### PR TITLE
fix(app): restore file tree, terminal and search buttons in V2 layout

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -158,6 +158,7 @@ export function SessionHeader() {
   const isV2 = settings.general.newLayoutDesigns
   const search = settings.visibility.search
   const status = settings.visibility.status
+  const fileTree = settings.visibility.fileTree
 
   const [exists, setExists] = createStore<Partial<Record<OpenApp, boolean>>>({
     finder: true,
@@ -238,6 +239,20 @@ export function SessionHeader() {
     reviewKeybind: command.keybind("review.toggle"),
     reviewOpened: view().reviewPanel.opened(),
     onReviewToggle: () => view().reviewPanel.toggle(),
+    searchVisible: search(),
+    searchLabel: language.t("session.header.searchFiles"),
+    searchKeybind: command.keybind("file.open"),
+    onSearchTrigger: () => command.trigger("file.open"),
+    fileTreeVisible: fileTree(),
+    fileTreeOpened: layout.fileTree.opened(),
+    fileTreeLabel: language.t("command.fileTree.toggle"),
+    fileTreeKeybind: command.keybind("fileTree.toggle"),
+    onFileTreeToggle: () => layout.fileTree.toggle(),
+    terminalVisible: settings.general.showTerminal(),
+    terminalOpened: view().terminal.opened(),
+    terminalLabel: language.t("command.terminal.toggle"),
+    terminalKeybind: command.keybind("terminal.toggle"),
+    onTerminalToggle: toggleTerminal,
   }))
 
   const selectApp = (app: OpenApp) => {
@@ -320,7 +335,7 @@ export function SessionHeader() {
         {(mount) => (
           <Portal mount={mount()}>
             <Show
-              when={isV2}
+              when={isV2()}
               fallback={
                 <div class="flex items-center gap-2">
                   <Show when={projectDirectory()}>
@@ -520,11 +535,70 @@ type SessionHeaderV2ActionsState = {
   reviewKeybind: string
   reviewOpened: boolean
   onReviewToggle: () => void
+  searchVisible: boolean
+  searchLabel: string
+  searchKeybind: string
+  onSearchTrigger: () => void
+  fileTreeVisible: boolean
+  fileTreeOpened: boolean
+  fileTreeLabel: string
+  fileTreeKeybind: string
+  onFileTreeToggle: () => void
+  terminalVisible: boolean
+  terminalOpened: boolean
+  terminalLabel: string
+  terminalKeybind: string
+  onTerminalToggle: () => void
 }
 
 function SessionHeaderV2Actions(props: { state: SessionHeaderV2ActionsState }) {
   return (
     <div class="flex items-center gap-2">
+      <Show when={props.state.searchVisible}>
+        <TooltipKeybind title={props.state.searchLabel} keybind={props.state.searchKeybind}>
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="!w-9 shrink-0"
+            onClick={props.state.onSearchTrigger}
+            aria-label={props.state.searchLabel}
+            icon={<IconV2 name="magnifying-glass" />}
+          />
+        </TooltipKeybind>
+      </Show>
+      <Show when={props.state.terminalVisible}>
+        <TooltipKeybind title={props.state.terminalLabel} keybind={props.state.terminalKeybind}>
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="!w-9 shrink-0"
+            state={props.state.terminalOpened ? "pressed" : undefined}
+            onClick={props.state.onTerminalToggle}
+            aria-label={props.state.terminalLabel}
+            aria-expanded={props.state.terminalOpened}
+            aria-controls="terminal-panel"
+            icon={<IconV2 name="terminal" />}
+          />
+        </TooltipKeybind>
+      </Show>
+      <Show when={props.state.fileTreeVisible}>
+        <TooltipKeybind title={props.state.fileTreeLabel} keybind={props.state.fileTreeKeybind}>
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="!w-9 shrink-0"
+            state={props.state.fileTreeOpened ? "pressed" : undefined}
+            onClick={props.state.onFileTreeToggle}
+            aria-label={props.state.fileTreeLabel}
+            aria-expanded={props.state.fileTreeOpened}
+            aria-controls="file-tree-panel"
+            icon={<IconV2 name="file-tree" />}
+          />
+        </TooltipKeybind>
+      </Show>
       <Show when={props.state.statusVisible}>
         <Tooltip placement="bottom" value={props.state.statusLabel}>
           <StatusPopoverV2 />

--- a/packages/ui/src/v2/components/icon.tsx
+++ b/packages/ui/src/v2/components/icon.tsx
@@ -65,6 +65,14 @@ const icons = {
     viewBox: "0 0 16 16",
     body: `<path d="M2.5 7.5H3.5V8.5H2.5V7.5Z" stroke="currentColor"/><path d="M7.5 7.5H8.5V8.5H7.5V7.5Z" stroke="currentColor"/><path d="M12.5 7.5H13.5V8.5H12.5V7.5Z" stroke="currentColor"/>`,
   },
+  terminal: {
+    viewBox: "0 0 20 20",
+    body: `<path d="M6.5 8L8.64286 10L6.5 12M10.9286 12H13.5M2 18H18V2H2V18Z" stroke="currentColor" stroke-linecap="square"/>`,
+  },
+  "file-tree": {
+    viewBox: "0 0 20 20",
+    body: `<path d="M18 18V5H9.5L7.5 2H2L2 18H5M18 18H5M18 18V8.5H5V18" stroke="currentColor" stroke-linecap="square"/>`,
+  },
 }
 
 const spriteID = "opencode-v2-icon-sprite"


### PR DESCRIPTION
Fixes two bugs in `session-header.tsx`:

1. **`isV2` gate broken**: `Show when={isV2}` passed a function reference (always truthy) instead of calling `isV2()`. The old layout fallback was **never** rendered — Settings > 'New layout designs' had no effect.

2. **Missing V2 buttons**: `SessionHeaderV2Actions` lacked buttons for file tree, terminal, and search even when their visibility settings were enabled. Added them with proper tooltips, pressed states, and aria attributes.

Also added `terminal` and `file-tree` SVG icons to the V2 icon set.

Fixes #29951