### PR TITLE
docs(ecosystem): add AION to plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [AION](https://github.com/ztxtech/aion)                                                           | Time-series harness for OpenCode: 4-layer (task/workspace/execution/review) multi-agent system with governance hierarchy, 17 skills, 8 protocols, and leakage prevention. Companion to arXiv:2605.25045 |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A - ecosystem listing addition.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [AION](https://github.com/ztxtech/aion) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

AION is a time-series harness for OpenCode: a 4-layer (task/workspace/execution/review) multi-agent system with a governance hierarchy, 17 skills, 8 coordination protocols, and leakage prevention. [Companion paper](https://arxiv.org/abs/2605.25045).

Only the English `ecosystem.mdx` is modified. The repo's `docs-locale-sync` workflow handles the 17 locale copies automatically.

### How did you verify your code works?

- Edited `packages/web/src/content/docs/ecosystem.mdx` and confirmed the new row matches the column format of the surrounding entries.
- Verified the GitHub link `https://github.com/ztxtech/aion` resolves to the plugin's repository.
- Plugin is published on GitHub with active releases (latest Jun 14 2026); it compiles to a self-contained `.opencode/plugins/aion.js` bundle that OpenCode auto-discovers.

### Screenshots / recordings

N/A - docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR