### PR TITLE
test(acp): make shell workdir location assertion windows-safe

### DIFF
--- a/packages/opencode/test/acp/tool.test.ts
+++ b/packages/opencode/test/acp/tool.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from "path"
 import { describe, expect, test } from "bun:test"
 import {
   completedToolContent,
@@ -38,8 +39,9 @@ describe("acp tool conversion", () => {
       { path: "/tmp/outside" },
     ])
     expect(toLocations("bash", { cmd: "pwd" }, "/workspace")).toEqual([{ path: "/workspace" }])
+    // Relative workdir resolves against cwd via the platform path resolver (backslashes on Windows).
     expect(toLocations("bash", { command: "pwd", workdir: "subdir" }, "/workspace")).toEqual([
-      { path: "/workspace/subdir" },
+      { path: resolve("/workspace", "subdir") },
     ])
     expect(toLocations("bash", { command: "pwd", workdir: "/abs/dir" }, "/workspace")).toEqual([{ path: "/abs/dir" }])
     expect(toLocations("bash", { command: "printf hello" })).toEqual([])


### PR DESCRIPTION
Follow-up to #32304.

The `toLocations` bash test hardcoded `/workspace/subdir`, but on the Windows unit-test runner `path.resolve()` produces backslash paths (`\workspace\subdir`), so the assertion failed there. Use the platform path resolver as the oracle instead — matching the `resolve()` call in `tool.ts` and the existing convention across the test suite.

Source behavior is unchanged; this is test-only.