### PR TITLE
fix(tui): match @ mention items by name, not description or uri

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -362,7 +362,8 @@ export function Autocomplete(props: {
       const text = `${res.name} (${res.uri})`
       options.push({
         display: Locale.truncateMiddle(text, width),
-        value: text,
+        // Match the name only; matching the URI caused unrelated fuzzy hits.
+        value: res.name,
         description: res.description,
         onSelect: () => {
           insertPart(res.name, {
@@ -492,7 +493,8 @@ export function Autocomplete(props: {
       .go(removeLineRange(searchValue), nonFileOptions, {
         keys: [
           (obj) => removeLineRange((obj.value ?? obj.display).trimEnd()),
-          "description",
+          // Match description for slash commands only; for "@" it surfaced unrelated items.
+          ...(store.visible === "/" ? ["description" as const] : []),
           (obj) => obj.aliases?.join(" ") ?? "",
         ],
         limit: 10,


### PR DESCRIPTION
## Problem

Typing `@<query>` in the prompt ranked unrelated skills, widgets, and MCP resources **above** real file matches. For example `@legal` surfaced `canonicalize-tailwind` and some `ui://widget/...` resources above `legal/`, and `@mcp` / `@dialog` surfaced unrelated Figma docs above the obvious file matches.

## Root cause

Non-file items (agents, references, MCP resources/skills/widgets) are fuzzy-matched with `fuzzysort` and concatenated **before** files (files come pre-ranked from fff and are intentionally not re-fuzzysorted, see #27802). Because the two lists are scored by separate systems and never merged, any non-file match jumps ahead of every file.

The matches themselves were spurious: non-files were matched against two permissive fields:
- `description` — `legal` matches as a scattered subsequence inside a long skill description.
- the full `name (uri)` string — `mcp` matches `fig`**`m`**`a/do`**`c`**`s/...`**`p`**, `dialog` matches a scatter across name + `file://...` URI.

## Fix

Match non-file items by **name only**:
- Scope `description` matching to slash commands (`/`), where it's useful and there are no files to bury.
- Match MCP resources on `res.name` instead of `name (uri)`. The URI is still shown in the list, just not matched.

fff file ranking is untouched.

## Result

- `@legal` / `@learn` → only the real path matches.
- `@dialog` → only `dialog-*.tsx` files (no resource name contains a `d-i-a-l-o-g` subsequence).
- `@mcp` → only genuinely `mcp`-named resources + `mcp` files; unrelated docs gone.

## Notes / follow-up

Non-files are still listed before files, so genuinely name-matched resources (e.g. `mcp-vs-agent`) still sort above similarly-named files (e.g. `mcp.ts`). That's defensible now that junk is filtered out. Flipping to files-first is a separate call with its own tradeoff (exact name matches like the `@ui` agent would then sink below `ui` files), so it's left out of this PR.

## Test plan

- `bun typecheck` (in `packages/tui`) passes.
- `prettier --check` passes.
- Manual: `@legal`, `@learn`, `@mcp`, `@dialog` no longer surface unrelated items; `@<agent>` / `@<reference>` / `/<command>` still work.