### PR TITLE
fix(opencode): harden experimental plan mode gating

### DIFF
--- a/packages/core/src/config/plugin/agent.ts
+++ b/packages/core/src/config/plugin/agent.ts
@@ -11,6 +11,8 @@ import { ModelV2 } from "../../model"
 import { PluginV2 } from "../../plugin"
 import { ConfigAgentV1 } from "../../v1/config/agent"
 import { ConfigMigrateV1 } from "../../v1/config/migrate"
+import { Location } from "../../location"
+import { planAgentRestrictions } from "../../plugin/agent"
 
 const legacySources = [
   { pattern: "{agent,agents}/**/*.md", primary: false },
@@ -39,6 +41,7 @@ export const Plugin = PluginV2.define({
     const agent = yield* AgentV2.Service
     const config = yield* Config.Service
     const fs = yield* FSUtil.Service
+    const location = yield* Location.Service
     const documents = yield* Effect.forEach(yield* config.entries(), (entry) => {
       if (entry.type === "document") return Effect.succeed([entry])
       return Effect.gen(function* () {
@@ -63,6 +66,10 @@ export const Plugin = PluginV2.define({
       for (const current of editor.list()) {
         editor.update(current.id, (agent) => agent.permissions.push(...global))
       }
+
+      editor.update(AgentV2.ID.make("plan"), (item) => {
+        item.permissions.push(...planAgentRestrictions(location.directory))
+      })
 
       for (const document of documents) {
         for (const [id, item] of Object.entries(document.info.agents ?? {})) {

--- a/packages/core/src/plugin/agent.ts
+++ b/packages/core/src/plugin/agent.ts
@@ -4,7 +4,6 @@ import path from "path"
 import { Effect } from "effect"
 import { AgentV2 } from "../agent"
 import { Global } from "../global"
-import { Location } from "../location"
 import { PermissionV2 } from "../permission"
 import { PluginV2 } from "../plugin"
 
@@ -97,12 +96,50 @@ Rules:
 - If the conversation ends with an unanswered question to the user, preserve that exact question
 - If the conversation ends with an imperative statement or request to the user (e.g. "Now please run the command and paste the console output"), always include that exact request in the summary`
 
+/** Read-only bash invocations allowed without prompt in plan mode. Use "cmd *" form (matches bare cmd too). */
+export const planModeBashReadonly = [
+  "pwd",
+  "ls *",
+  "cat *",
+  "head *",
+  "tail *",
+  "grep *",
+  "rg *",
+  "wc *",
+  "which *",
+  "tree *",
+  "git status *",
+  "git log *",
+  "git diff *",
+  "git show *",
+  "git blame *",
+] as const
+
+export function planAgentRestrictions(worktree: string): PermissionV2.Ruleset {
+  return [
+    { action: "plan_enter", resource: "*", effect: "deny" },
+    { action: "question", resource: "*", effect: "allow" },
+    { action: "plan_exit", resource: "*", effect: "allow" },
+    { action: "task", resource: "general", effect: "deny" },
+    { action: "external_directory", resource: path.join(Global.Path.data, "plans", "*"), effect: "allow" },
+    { action: "edit", resource: "*", effect: "deny" },
+    { action: "edit", resource: path.join(".opencode", "plans", "*.md"), effect: "allow" },
+    {
+      action: "edit",
+      resource: path.relative(worktree, path.join(Global.Path.data, "plans", "*.md")),
+      effect: "allow",
+    },
+    { action: "bash", resource: "*", effect: "ask" },
+    ...planModeBashReadonly.map(
+      (resource): PermissionV2.Rule => ({ action: "bash", resource, effect: "allow" }),
+    ),
+  ]
+}
+
 export const Plugin = PluginV2.define({
   id: PluginV2.ID.make("agent"),
   effect: Effect.gen(function* () {
     const agent = yield* AgentV2.Service
-    const location = yield* Location.Service
-    const worktree = location.directory
     const whitelistedDirs = [TRUNCATION_GLOB, path.join(Global.Path.tmp, "*")]
     const readonlyExternalDirectory: PermissionV2.Ruleset = [
       { action: "external_directory", resource: "*", effect: "ask" },
@@ -142,14 +179,6 @@ export const Plugin = PluginV2.define({
           ...PermissionV2.merge(defaults, [
             { action: "question", resource: "*", effect: "allow" },
             { action: "plan_exit", resource: "*", effect: "allow" },
-            { action: "external_directory", resource: path.join(Global.Path.data, "plans", "*"), effect: "allow" },
-            { action: "edit", resource: "*", effect: "deny" },
-            { action: "edit", resource: path.join(".opencode", "plans", "*.md"), effect: "allow" },
-            {
-              action: "edit",
-              resource: path.relative(worktree, path.join(Global.Path.data, "plans", "*.md")),
-              effect: "allow",
-            },
           ]),
         )
       })

--- a/packages/core/test/agent.test.ts
+++ b/packages/core/test/agent.test.ts
@@ -123,9 +123,13 @@ describe("AgentV2", () => {
         "summary",
         "title",
       ])
-      for (const item of agents) {
+      const otherAgents = agents.filter((item) => item.id !== AgentV2.ID.make("plan"))
+      for (const item of otherAgents) {
         expect(item.permissions.some((rule) => rule.action === "bash" && rule.effect !== "deny")).toBe(false)
       }
+
+      const plan = agents.find((item) => item.id === AgentV2.ID.make("plan"))!
+      expect(plan.permissions.some((rule) => rule.action === "bash")).toBe(false)
     }),
   )
 })

--- a/packages/core/test/config/agent.test.ts
+++ b/packages/core/test/config/agent.test.ts
@@ -5,16 +5,49 @@ import { Effect, Layer, Schema } from "effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigAgentPlugin } from "@opencode-ai/core/config/plugin/agent"
+import { AgentPlugin, planModeBashReadonly } from "@opencode-ai/core/plugin/agent"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Location } from "@opencode-ai/core/location"
 import { PermissionV2 } from "@opencode-ai/core/permission"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Project } from "@opencode-ai/core/project"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
+
+const testLocation = Location.Service.of({
+  directory: AbsolutePath.make("/tmp"),
+  project: { id: Project.ID.make("prj_test"), directory: AbsolutePath.make("/tmp") },
+})
 
 const it = testEffect(Layer.mergeAll(AgentV2.locationLayer, FSUtil.defaultLayer))
 const decode = Schema.decodeUnknownSync(Config.Info)
 
 describe("ConfigAgentPlugin.Plugin", () => {
+  it.effect("applies plan bash ask-default and readonly allows after plugin boot", () =>
+    Effect.gen(function* () {
+      const agents = yield* AgentV2.Service
+      const location = Location.Service.of(testLocation)
+
+      yield* AgentPlugin.Plugin.effect.pipe(Effect.provideService(Location.Service, location))
+      yield* ConfigAgentPlugin.Plugin.effect.pipe(
+        Effect.provideService(Config.Service, Config.Service.of({ entries: () => Effect.succeed([]) })),
+        Effect.provideService(AgentV2.Service, agents),
+        Effect.provideService(Location.Service, location),
+      )
+
+      const plan = yield* agents.get(AgentV2.ID.make("plan"))
+      if (!plan) throw new Error("expected plan agent")
+
+      const wildcard = plan.permissions.findLast((rule) => rule.action === "bash" && rule.resource === "*")
+      expect(wildcard?.effect).toBe("ask")
+      for (const resource of planModeBashReadonly) {
+        expect(plan.permissions).toContainEqual({ action: "bash", resource, effect: "allow" })
+      }
+      expect(PermissionV2.evaluate("bash", "ls -la", plan.permissions).effect).toBe("allow")
+      expect(PermissionV2.evaluate("bash", "lsof", plan.permissions).effect).toBe("ask")
+    }),
+  )
+
   it.effect("applies all global permissions before agent-specific permissions", () =>
     Effect.gen(function* () {
       const agents = yield* AgentV2.Service
@@ -71,6 +104,7 @@ describe("ConfigAgentPlugin.Plugin", () => {
       yield* ConfigAgentPlugin.Plugin.effect.pipe(
         Effect.provideService(Config.Service, config),
         Effect.provideService(AgentV2.Service, agents),
+        Effect.provideService(Location.Service, testLocation),
       )
 
       const buildAgent = yield* agents.get(build)
@@ -153,6 +187,7 @@ describe("ConfigAgentPlugin.Plugin", () => {
       yield* ConfigAgentPlugin.Plugin.effect.pipe(
         Effect.provideService(Config.Service, config),
         Effect.provideService(AgentV2.Service, agents),
+        Effect.provideService(Location.Service, testLocation),
       )
 
       const reviewer = yield* agents.get(AgentV2.ID.make("reviewer"))
@@ -193,6 +228,7 @@ describe("ConfigAgentPlugin.Plugin", () => {
       yield* ConfigAgentPlugin.Plugin.effect.pipe(
         Effect.provideService(Config.Service, config),
         Effect.provideService(AgentV2.Service, agents),
+        Effect.provideService(Location.Service, testLocation),
       )
 
       expect(yield* agents.get(build)).toBeUndefined()
@@ -254,6 +290,7 @@ Use native v2 fields.`,
           yield* ConfigAgentPlugin.Plugin.effect.pipe(
             Effect.provideService(Config.Service, config),
             Effect.provideService(AgentV2.Service, agents),
+            Effect.provideService(Location.Service, testLocation),
           )
 
           expect(yield* agents.get(AgentV2.ID.make("reviewer"))).toMatchObject({

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { ConfigPermissionV1 } from "@opencode-ai/core/v1/config/permission"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Config } from "@/config/config"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
@@ -31,6 +32,7 @@ import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { PluginBoot } from "@opencode-ai/core/plugin/boot"
 import { Reference } from "@opencode-ai/core/reference"
 import { Location } from "@opencode-ai/core/location"
+import { planModeBashReadonly } from "@opencode-ai/core/plugin/agent"
 
 export const Info = Schema.Struct({
   name: Schema.String,
@@ -54,6 +56,28 @@ export const Info = Schema.Struct({
   steps: Schema.optional(Schema.Finite),
 }).annotate({ identifier: "Agent" })
 export type Info = DeepMutable<Schema.Schema.Type<typeof Info>>
+
+// Global permission and session permission cannot relax plan caps; agent.plan.permission can (intentional opt-out).
+export function planRulesConfig(worktree: string): ConfigPermissionV1.Info {
+  return {
+    question: "allow",
+    plan_exit: "allow",
+    plan_enter: "deny",
+    task: { general: "deny" },
+    external_directory: {
+      [path.join(Global.Path.data, "plans", "*")]: "allow",
+    },
+    edit: {
+      "*": "deny",
+      [path.join(".opencode", "plans", "*.md")]: "allow",
+      [path.relative(worktree, path.join(Global.Path.data, "plans", "*.md"))]: "allow",
+    },
+    bash: {
+      "*": "ask",
+      ...Object.fromEntries(planModeBashReadonly.map((resource) => [resource, "allow"])),
+    },
+  }
+}
 
 const GeneratedAgent = Schema.Struct({
   identifier: Schema.String,
@@ -135,6 +159,8 @@ export const layer = Layer.effect(
 
         const user = Permission.fromConfig(cfg.permission ?? {})
 
+        const planRules = Permission.fromConfig(planRulesConfig(ctx.worktree))
+
         const agents: Record<string, Info> = {
           build: {
             name: "build",
@@ -155,25 +181,7 @@ export const layer = Layer.effect(
             name: "plan",
             description: "Plan mode. Disallows all edit tools.",
             options: {},
-            permission: Permission.merge(
-              defaults,
-              Permission.fromConfig({
-                question: "allow",
-                plan_exit: "allow",
-                task: {
-                  general: "deny",
-                },
-                external_directory: {
-                  [path.join(Global.Path.data, "plans", "*")]: "allow",
-                },
-                edit: {
-                  "*": "deny",
-                  [path.join(".opencode", "plans", "*.md")]: "allow",
-                  [path.relative(ctx.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
-                },
-              }),
-              user,
-            ),
+            permission: Permission.merge(defaults, user, planRules),
             mode: "primary",
             native: true,
           },

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -81,6 +81,12 @@ export const layer = Layer.effect(
       let needsAsk = false
 
       for (const pattern of request.patterns) {
+        const base = evaluate(request.permission, pattern, ruleset)
+        if (base.action === "deny") {
+          return yield* new PermissionV1.DeniedError({
+            ruleset: ruleset.filter((rule) => Wildcard.match(request.permission, rule.permission)),
+          })
+        }
         const rule = evaluate(request.permission, pattern, ruleset, approved)
         yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: rule })
         if (rule.action === "deny") {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -7,7 +7,7 @@ import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import { SessionRevert } from "./revert"
 import { Session } from "./session"
-import { Agent } from "../agent/agent"
+import { Agent, planRulesConfig } from "../agent/agent"
 import { Provider } from "@/provider/provider"
 
 import { type Tool as AITool, tool, jsonSchema } from "ai"
@@ -327,7 +327,13 @@ export const layer = Layer.effect(
               .ask({
                 ...req,
                 sessionID,
-                ruleset: Permission.merge(taskAgent.permission, session.permission ?? []),
+                ruleset: Permission.merge(
+                  taskAgent.permission,
+                  session.permission ?? [],
+                  taskAgent.name === "plan"
+                    ? Permission.fromConfig(planRulesConfig(ctx.worktree))
+                    : [],
+                ),
               })
               .pipe(Effect.orDie),
         })

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -8,6 +8,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import { Session } from "./session"
+import { Permission } from "@/permission"
 import PROMPT_PLAN from "./prompt/plan.txt"
 import BUILD_SWITCH from "./prompt/build-switch.txt"
 import PLAN_MODE from "./prompt/plan-mode.txt"
@@ -23,7 +24,12 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
   if (!userMessage) return input.messages
 
-  if (!flags.experimentalPlanMode) {
+  const planExitAvailable =
+    flags.client === "cli" &&
+    Permission.evaluate("plan_exit", "*", Permission.merge(input.agent.permission, input.session.permission ?? []))
+      .action !== "deny"
+
+  if (!flags.experimentalPlanMode || !planExitAvailable) {
     if (input.agent.name === "plan") {
       userMessage.parts.push({
         id: PartID.ascending(),

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -1,4 +1,4 @@
-import { Agent } from "@/agent/agent"
+import { Agent, planRulesConfig } from "@/agent/agent"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
@@ -18,6 +18,7 @@ import { Session } from "./session"
 import { SessionProcessor } from "./processor"
 import { PartID } from "./schema"
 import { EffectBridge } from "@/effect/bridge"
+import { InstanceState } from "@/effect/instance-state"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 
@@ -37,6 +38,13 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   const registry = yield* ToolRegistry.Service
   const mcp = yield* MCP.Service
   const truncate = yield* Truncate.Service
+  const instance = yield* InstanceState.context
+
+  const ruleset = (agent: Agent.Info) => {
+    const planCaps =
+      agent.name === "plan" ? Permission.fromConfig(planRulesConfig(instance.worktree)) : []
+    return Permission.merge(agent.permission, input.session.permission ?? [], planCaps)
+  }
 
   const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => ({
     sessionID: input.session.id,
@@ -66,7 +74,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           ...req,
           sessionID: input.session.id,
           tool: { messageID: input.processor.message.id, callID: options.toolCallId },
-          ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
+          ruleset: ruleset(input.agent),
         })
         .pipe(Effect.orDie),
   })

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -6,6 +6,7 @@ import { Question } from "../question"
 import { Session } from "@/session/session"
 import { MessageV2 } from "../session/message-v2"
 import { Provider } from "@/provider/provider"
+import { Agent } from "@/agent/agent"
 import { InstanceState } from "@/effect/instance-state"
 import { MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
@@ -18,6 +19,7 @@ export const PlanExitTool = Tool.define(
     const session = yield* Session.Service
     const question = yield* Question.Service
     const provider = yield* Provider.Service
+    const agents = yield* Agent.Service
 
     return {
       description: EXIT_DESCRIPTION,
@@ -47,15 +49,30 @@ export const PlanExitTool = Tool.define(
 
           const messages = yield* session.messages({ sessionID: ctx.sessionID }).pipe(Effect.orDie)
           const lastUser = messages.findLast((item) => item.info.role === "user" && item.info.model)
+          const target =
+            (yield* agents.get("build")) ??
+            (yield* agents.list()).find((a) => a.mode === "primary" && !a.hidden && a.name !== "plan")
+
+          if (!target) {
+            return {
+              title: "No build agent available",
+              output:
+                "No primary non-plan agent is configured. Stay with the plan agent or enable a build agent.",
+              metadata: {},
+            }
+          }
+
           const model =
-            lastUser?.info.role === "user" && lastUser.info.model ? lastUser.info.model : yield* provider.defaultModel()
+            target.model ??
+            (lastUser?.info.role === "user" ? lastUser.info.model : undefined) ??
+            (yield* provider.defaultModel())
 
           const msg: SessionV1.User = {
             id: MessageID.ascending(),
             sessionID: ctx.sessionID,
             role: "user",
             time: { created: Date.now() },
-            agent: "build",
+            agent: target.name,
             model,
           }
           yield* session.updateMessage(msg)

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -120,6 +120,51 @@ function source(node: Node) {
   return (node.parent?.type === "redirected_statement" ? node.parent.text : node.text).trim()
 }
 
+const WRITE_REDIRECT = new Set([">", ">>", "&>", "&>>", ">|", ">&"])
+
+function redirectDest(node: Node, ps: boolean) {
+  const parent = node.parent
+  if (!parent || parent.type !== "redirected_statement") return
+
+  for (let i = 0; i < parent.childCount; i++) {
+    const child = parent.child(i)
+    if (!child) continue
+    if (ps) {
+      if (child.type !== "file_redirect" && child.type !== "redirected_output") continue
+      const text = child.text.trim()
+      if (!/^(\*>>?|>>?)/.test(text)) continue
+      const dest = child.childForFieldName("destination")
+      if (dest) return dest.text
+      for (let j = child.childCount - 1; j >= 0; j--) {
+        const part = child.child(j)
+        if (!part) continue
+        if (part.type === "word" || part.type === "string" || part.type === "raw_string" || part.type === "concatenation")
+          return part.text
+      }
+      continue
+    }
+    if (child.type !== "file_redirect") continue
+    const text = child.text.trim()
+    if (/^<<</.test(text) || /^<</.test(text) || /^</.test(text)) continue
+    const operator = child.childForFieldName("operator")?.text ?? text.match(/^(\d*&?>|\d*>>&?|>>|>\||>&)/)?.[1]
+    if (!operator) continue
+    if (/^\d+>$/.test(operator) || /^\d+>>$/.test(operator)) continue
+    if (!WRITE_REDIRECT.has(operator) && operator !== ">" && operator !== ">>" && !/^\d*&>/.test(operator)) continue
+    const dest = child.childForFieldName("destination")
+    if (dest) return dest.text
+    for (let j = child.childCount - 1; j >= 0; j--) {
+      const part = child.child(j)
+      if (!part) continue
+      if (part.type === "word" || part.type === "string" || part.type === "raw_string" || part.type === "concatenation")
+        return part.text
+    }
+  }
+}
+
+function writeRedirect(node: Node, ps: boolean) {
+  return redirectDest(node, ps) !== undefined
+}
+
 function commands(node: Node) {
   return node.descendantsOfType("command").filter((child): child is Node => Boolean(child))
 }
@@ -410,7 +455,16 @@ export const ShellTool = Tool.define(
           }
         }
 
-        if (tokens.length && (!cmd || !CWD.has(cmd))) {
+        const redirect = redirectDest(node, ps)
+        if (redirect) {
+          const resolved = yield* argPath(redirect, cwd, ps, shell)
+          if (resolved) {
+            const dir = (yield* fs.isDir(resolved)) ? resolved : path.dirname(resolved)
+            scan.dirs.add(dir)
+          }
+        }
+
+        if (tokens.length && (!cmd || !CWD.has(cmd)) && !writeRedirect(node, ps)) {
           scan.patterns.add(source(node))
           scan.always.add(BashArity.prefix(tokens).join(" ") + " *")
         }

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -96,12 +96,12 @@ it.instance("plan agent denies the general subagent by default", () =>
 )
 
 it.instance(
-  "user permission can allow the general subagent from plan mode",
+  "user permission cannot relax plan agent task.general deny",
   () =>
     Effect.gen(function* () {
       const plan = yield* load((svc) => svc.get("plan"))
       expect(plan).toBeDefined()
-      expect(Permission.evaluate("task", "general", plan!.permission).action).toBe("allow")
+      expect(Permission.evaluate("task", "general", plan!.permission).action).toBe("deny")
     }),
   {
     config: {

--- a/packages/opencode/test/agent/plan-mode-gating.test.ts
+++ b/packages/opencode/test/agent/plan-mode-gating.test.ts
@@ -1,0 +1,430 @@
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { planAgentRestrictions } from "@opencode-ai/core/plugin/agent"
+import { PermissionV2 } from "@opencode-ai/core/permission"
+import { expect } from "bun:test"
+import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import { Agent, planRulesConfig } from "../../src/agent/agent"
+import { Auth } from "../../src/auth"
+import { Config } from "../../src/config/config"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin"
+import { Provider } from "../../src/provider/provider"
+import { Question } from "../../src/question"
+import { SessionReminders } from "../../src/session/reminders"
+import { Session } from "../../src/session/session"
+import { MessageID, SessionID } from "../../src/session/schema"
+import { PlanExitTool } from "../../src/tool/plan"
+import { Truncate } from "../../src/tool/truncate"
+import { Skill } from "../../src/skill"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { InstanceBootstrap } from "../../src/project/bootstrap-service"
+import { InstanceStore } from "../../src/project/instance-store"
+import { InstanceState } from "../../src/effect/instance-state"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Database } from "@opencode-ai/core/database/database"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { LocationServiceMap } from "@opencode-ai/core/location-layer"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { testEffect } from "../lib/effect"
+
+const agentLayer = (flags: Partial<RuntimeFlags.Info> = {}) =>
+  Agent.layer.pipe(
+    Layer.provide(Plugin.defaultLayer),
+    Layer.provide(Provider.defaultLayer),
+    Layer.provide(Auth.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+    Layer.provide(Skill.defaultLayer),
+    Layer.provide(LocationServiceMap.layer),
+    Layer.provide(RuntimeFlags.layer(flags)),
+  )
+
+const it = testEffect(agentLayer())
+
+const noopBootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+
+const permissionIt = testEffect(
+  Layer.mergeAll(
+    Permission.layer.pipe(
+      Layer.provide(Database.defaultLayer),
+      Layer.provide(EventV2Bridge.defaultLayer),
+    ),
+    EventV2Bridge.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    InstanceStore.defaultLayer.pipe(Layer.provide(noopBootstrap)),
+  ),
+)
+
+function reminderInput(input: {
+  agent: Agent.Info
+  sessionPermission?: PermissionV1.Ruleset
+}) {
+  const sessionID = SessionID.make("ses_reminder")
+  const user: SessionV1.User = {
+    id: MessageID.ascending(),
+    sessionID,
+    role: "user",
+    time: { created: Date.now() },
+    agent: "plan",
+    model: {
+      providerID: ProviderV2.ID.make("openai"),
+      modelID: ModelV2.ID.make("gpt-4"),
+    },
+  }
+  return {
+    agent: input.agent,
+    session: {
+      id: sessionID,
+      slug: "reminder",
+      projectID: ProjectV2.ID.make("prj_test"),
+      directory: "/tmp",
+      title: "test",
+      version: "test",
+      time: { created: Date.now(), updated: Date.now() },
+      permission: input.sessionPermission ? [...input.sessionPermission] : undefined,
+    } satisfies Session.Info,
+    messages: [{ info: user, parts: [] }],
+  }
+}
+
+it.instance(
+  "plan agent edit deny survives global permission edit allow",
+  () =>
+    Effect.gen(function* () {
+      const plan = yield* Agent.use.get("plan")
+      expect(Permission.evaluate("edit", "/src/foo.ts", plan!.permission).action).toBe("deny")
+      expect(Permission.evaluate("edit", ".opencode/plans/foo.md", plan!.permission).action).toBe("allow")
+    }),
+  {
+    config: {
+      permission: {
+        edit: "allow",
+      },
+    },
+  },
+)
+
+it.instance(
+  "plan agent edit deny survives global wildcard allow",
+  () =>
+    Effect.gen(function* () {
+      const plan = yield* Agent.use.get("plan")
+      expect(Permission.evaluate("edit", "/src/foo.ts", plan!.permission).action).toBe("deny")
+    }),
+  {
+    config: {
+      permission: {
+        "*": "allow",
+      },
+    },
+  },
+)
+
+it.instance("plan agent bash allows readonly commands and asks for mutating commands", () =>
+  Effect.gen(function* () {
+    const plan = yield* Agent.use.get("plan")
+    expect(Permission.evaluate("bash", "ls -la", plan!.permission).action).toBe("allow")
+    expect(Permission.evaluate("bash", "git status", plan!.permission).action).toBe("allow")
+    expect(Permission.evaluate("bash", "lsof", plan!.permission).action).toBe("ask")
+    expect(Permission.evaluate("bash", "lstmeval", plan!.permission).action).toBe("ask")
+    expect(Permission.evaluate("bash", "find . -delete", plan!.permission).action).toBe("ask")
+    expect(Permission.evaluate("bash", "git branch -D main", plan!.permission).action).toBe("ask")
+    expect(Permission.evaluate("bash", "rm -rf x", plan!.permission).action).toBe("ask")
+    expect(Permission.evaluate("bash", "npm install", plan!.permission).action).toBe("ask")
+    expect(Permission.evaluate("bash", "tee out", plan!.permission).action).toBe("ask")
+  }),
+)
+
+it.instance("plan agent bash allows cat without write redirect", () =>
+  Effect.gen(function* () {
+    const plan = yield* Agent.use.get("plan")
+    expect(Permission.evaluate("bash", "cat foo.txt", plan!.permission).action).toBe("allow")
+  }),
+)
+
+it.instance("V2 plan agent keeps plan_enter deny under global allow", () =>
+  Effect.sync(() => {
+    const merged = PermissionV2.merge(
+      [{ action: "*", resource: "*", effect: "allow" }],
+      planAgentRestrictions("/project"),
+    )
+    expect(PermissionV2.evaluate("plan_enter", "*", merged).effect).toBe("deny")
+  }),
+)
+
+it.instance(
+  "session permission edit allow does not relax plan edit deny",
+  () =>
+    Effect.gen(function* () {
+      const plan = yield* Agent.use.get("plan")
+      const instance = yield* InstanceState.context
+      const merged = Permission.merge(
+        plan!.permission,
+        Permission.fromConfig({ edit: "allow" }),
+        Permission.fromConfig(planRulesConfig(instance.worktree)),
+      )
+      expect(Permission.evaluate("edit", "/src/foo.ts", merged).action).toBe("deny")
+    }),
+  {
+    config: {
+      permission: {
+        edit: "allow",
+      },
+    },
+  },
+)
+
+it.instance(
+  "agent.plan.permission is the supported escape hatch for relaxing plan caps",
+  () =>
+    Effect.gen(function* () {
+      const plan = yield* Agent.use.get("plan")
+      expect(Permission.evaluate("edit", "/src/foo.ts", plan!.permission).action).toBe("allow")
+      expect(Permission.evaluate("bash", "npm install", plan!.permission).action).toBe("allow")
+    }),
+  {
+    config: {
+      agent: {
+        plan: {
+          permission: {
+            edit: "allow",
+            bash: "allow",
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "global permission still merges last for build agent",
+  () =>
+    Effect.gen(function* () {
+      const build = yield* Agent.use.get("build")
+      expect(Permission.evaluate("edit", "/src/foo.ts", build!.permission).action).toBe("allow")
+      expect(Permission.evaluate("bash", "npm install", build!.permission).action).toBe("deny")
+    }),
+  {
+    config: {
+      permission: {
+        bash: "deny",
+      },
+    },
+  },
+)
+
+permissionIt.instance(
+  "ask denies when ruleset denies even after always-allow approval",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const sessionID = SessionID.make("ses_plan_cap")
+      const askRuleset = Permission.fromConfig({ edit: "ask" })
+      const denyRuleset = Permission.fromConfig({ edit: "deny" })
+
+      const pending = yield* permission
+        .ask({
+          sessionID,
+          permission: "edit",
+          patterns: ["/src/foo.ts"],
+          metadata: {},
+          always: ["*"],
+          ruleset: askRuleset,
+        })
+        .pipe(Effect.forkScoped)
+
+      const requests = yield* Effect.gen(function* () {
+        while (true) {
+          const list = yield* permission.list()
+          if (list.length === 1) return list
+          yield* Effect.sleep("10 millis")
+        }
+      }).pipe(Effect.timeoutOrElse({ duration: "1 second", orElse: () => Effect.die("timed out waiting for permission ask") }))
+
+      expect(requests).toHaveLength(1)
+      yield* permission.reply({ requestID: requests[0]!.id, reply: "always" })
+      yield* Fiber.join(pending)
+
+      const exit = yield* permission
+        .ask({
+          sessionID,
+          permission: "edit",
+          patterns: ["/src/foo.ts"],
+          metadata: {},
+          always: ["*"],
+          ruleset: denyRuleset,
+        })
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(PermissionV1.DeniedError)
+    }) as Effect.Effect<void>,
+  { git: true },
+)
+
+const planExitCapture: { message?: SessionV1.User } = {}
+
+const planExitIt = testEffect(
+  Layer.mergeAll(
+    agentLayer(),
+    Provider.defaultLayer,
+    Truncate.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    Layer.mock(Session.Service, {
+      get: () =>
+        Effect.succeed({
+          id: SessionID.make("ses_plan_exit"),
+          slug: "plan-exit",
+          projectID: ProjectV2.ID.make("prj_test"),
+          directory: "/tmp",
+          title: "test",
+          version: "test",
+          time: { created: 1, updated: 1 },
+        } satisfies Session.Info),
+      messages: () =>
+        Effect.succeed([
+          {
+            info: {
+              id: MessageID.ascending(),
+              sessionID: SessionID.make("ses_plan_exit"),
+              role: "user",
+              agent: "plan",
+              model: {
+                providerID: ProviderV2.ID.make("openai"),
+                modelID: ModelV2.ID.make("gpt-4"),
+              },
+              time: { created: Date.now() },
+            } satisfies SessionV1.User,
+            parts: [],
+          },
+        ]),
+      updateMessage: (msg) =>
+        Effect.sync(() => {
+          planExitCapture.message = msg as SessionV1.User
+          return msg
+        }),
+      updatePart: (part) => Effect.succeed(part),
+    }),
+    Layer.mock(Question.Service, {
+      ask: () => Effect.succeed([["Yes"]]),
+    }),
+  ),
+)
+
+planExitIt.instance(
+  "plan_exit falls back when build agent is disabled",
+  () =>
+    Effect.gen(function* () {
+      const toolInfo = yield* PlanExitTool
+      const tool = yield* toolInfo.init()
+      yield* tool.execute(
+        {},
+        {
+          sessionID: SessionID.make("ses_plan_exit"),
+          messageID: MessageID.ascending(),
+          agent: "plan",
+          abort: AbortSignal.any([]),
+          callID: "call_plan_exit",
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      const message = planExitCapture.message
+      expect(message?.agent).toBe("implement")
+      expect(message?.agent).not.toBe("build")
+    }) as Effect.Effect<void>,
+  {
+    config: {
+      agent: {
+        build: { disable: true },
+        implement: {
+          mode: "primary",
+          description: "Implements approved plans",
+        },
+      },
+    },
+  },
+)
+
+planExitIt.instance(
+  "plan_exit handoff uses build agent configured model",
+  () =>
+    Effect.gen(function* () {
+      const build = yield* Agent.use.get("build")
+      const toolInfo = yield* PlanExitTool
+      const tool = yield* toolInfo.init()
+      yield* tool.execute(
+        {},
+        {
+          sessionID: SessionID.make("ses_plan_exit"),
+          messageID: MessageID.ascending(),
+          agent: "plan",
+          abort: AbortSignal.any([]),
+          callID: "call_plan_exit",
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(planExitCapture.message?.agent).toBe("build")
+      expect(planExitCapture.message?.model).toEqual(build?.model)
+    }) as Effect.Effect<void>,
+  {
+    config: {
+      agent: {
+        build: {
+          model: "anthropic/claude-3",
+        },
+      },
+    },
+  },
+)
+
+const reminderLayer = (flags: Partial<RuntimeFlags.Info>) =>
+  Layer.mergeAll(
+    agentLayer(flags),
+    RuntimeFlags.layer(flags),
+    FSUtil.defaultLayer,
+    Layer.mock(Session.Service, {
+      updatePart: (part) => Effect.succeed(part),
+    }),
+  )
+
+const reminderIt = testEffect(reminderLayer({ experimentalPlanMode: true, client: "app" }))
+
+reminderIt.instance(
+  "experimental plan reminder falls back when client is not cli",
+  () =>
+    Effect.gen(function* () {
+      const plan = yield* Agent.use.get("plan")
+      const result = yield* SessionReminders.apply(reminderInput({ agent: plan! }))
+      const text = result[0]?.parts.map((part) => (part.type === "text" ? part.text : "")).join("\n")
+      expect(text).toContain("# Plan Mode - System Reminder")
+      expect(text).not.toContain("call plan_exit")
+    }) as Effect.Effect<void>,
+)
+
+const deniedReminderIt = testEffect(reminderLayer({ experimentalPlanMode: true, client: "cli" }))
+
+deniedReminderIt.instance(
+  "experimental plan reminder falls back when plan_exit is denied",
+  () =>
+    Effect.gen(function* () {
+      const plan = yield* Agent.use.get("plan")
+      const result = yield* SessionReminders.apply(
+        reminderInput({
+          agent: plan!,
+          sessionPermission: Permission.fromConfig({ plan_exit: "deny" }),
+        }),
+      )
+      const text = result[0]?.parts.map((part) => (part.type === "text" ? part.text : "")).join("\n")
+      expect(text).toContain("# Plan Mode - System Reminder")
+      expect(text).not.toContain("call plan_exit")
+    }) as Effect.Effect<void>,
+)

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -10,6 +10,7 @@ import { ShellTool } from "../../src/tool/shell"
 import { Filesystem } from "@/util/filesystem"
 import { provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
 import type { Permission } from "../../src/permission"
+import { Permission as PermissionService } from "../../src/permission"
 import { Agent } from "../../src/agent/agent"
 import { Truncate } from "@/tool/truncate"
 import { SessionID, MessageID } from "../../src/session/schema"
@@ -996,7 +997,7 @@ describe("tool.shell permissions", () => {
     }),
   )
 
-  each("matches redirects in permission pattern", () =>
+  each("skips bash pattern for write redirects", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped()
       yield* runIn(
@@ -1011,8 +1012,104 @@ describe("tool.shell permissions", () => {
             ),
           ).toMatchObject({ message: err.message })
           const bashReq = requests.find((r) => r.permission === "bash")
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(bashReq).toBeUndefined()
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain(glob(path.join(tmp, "*")))
+        }),
+      )
+    }),
+  )
+
+  each("keeps bash pattern for read redirects", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* Effect.promise(() => Bun.write(path.join(tmp, "input.txt"), "x"))
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          yield* run(
+            {
+              command: "cat < input.txt",
+              description: "Read redirected input",
+            },
+            capture(requests),
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
           expect(bashReq).toBeDefined()
-          expect(bashReq!.patterns).toContain("echo test > output.txt")
+          expect(bashReq!.patterns).toContain("cat < input.txt")
+        }),
+      )
+    }),
+  )
+
+  each("skips bash auto-allow for append and stderr redirects", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          for (const command of ["ls > out", "echo x >> out", "echo x &> out"]) {
+            const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+            expect(
+              yield* fail({ command, description: command }, capture(requests, err)),
+            ).toMatchObject({ message: err.message })
+            expect(requests.find((r) => r.permission === "bash")).toBeUndefined()
+            expect(requests.find((r) => r.permission === "external_directory")).toBeDefined()
+          }
+        }),
+      )
+    }),
+  )
+
+  each("asks bash for tee in pipeline on plan agent", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* Effect.promise(() => Bun.write(path.join(tmp, "file"), "x"))
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const plan = yield* Agent.use.get("plan")
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          expect(
+            yield* fail(
+              { command: "cat file | tee out", description: "Tee output" },
+              { ...capture(requests, err), agent: "plan" },
+            ),
+          ).toMatchObject({ message: err.message })
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          expect(bashReq!.patterns.some((pattern) => pattern.includes("tee"))).toBe(true)
+          expect(
+            bashReq!.patterns.some(
+              (pattern) => PermissionService.evaluate("bash", pattern, plan!.permission).action === "ask",
+            ),
+          ).toBe(true)
+        }),
+      )
+    }),
+  )
+
+  each("allows readonly pipeline on plan agent", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const plan = yield* Agent.use.get("plan")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          yield* run(
+            { command: "ls -la | head", description: "Readonly pipeline" },
+            { ...capture(requests), agent: "plan" },
+          )
+          const bashReq = requests.find((r) => r.permission === "bash")
+          expect(bashReq).toBeDefined()
+          for (const pattern of bashReq!.patterns) {
+            expect(PermissionService.evaluate("bash", pattern, plan!.permission).action).toBe("allow")
+          }
         }),
       )
     }),


### PR DESCRIPTION
These changes ensure that "plan" mode is reliably enforced across the entire application, providing a safer and more predictable user experience.Ensure plan agents cannot bypass edit/bash restrictions via user config, shell redirects, or always-allow approvals while preserving plan-file writes.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
