### PR TITLE
fix: silence plugin spinner outside TTY

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -44,8 +44,18 @@ export type PlugCtx = {
   directory: string
 }
 
+const noopSpinner: Spin = {
+  start() {},
+  stop() {},
+}
+
+export function createPlugSpinner(isTTY = Boolean(process.stdout.isTTY)): Spin {
+  if (!isTTY) return noopSpinner
+  return spinner()
+}
+
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => createPlugSpinner(),
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises"
 import path from "path"
 import { parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "@/util/filesystem"
-import { createPlugTask, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
+import { createPlugSpinner, createPlugTask, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
 import { tmpdir } from "../fixture/fixture"
 
 function deps(global: string, target: string | Error): PlugDeps {
@@ -109,6 +109,24 @@ async function read(file: string) {
 }
 
 describe("plugin.install.task", () => {
+  test("uses a quiet spinner for non-TTY output", () => {
+    const writes: string[] = []
+    const original = process.stdout.write
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const spin = createPlugSpinner(false)
+      spin.start("Installing plugin package...")
+      spin.stop("Plugin package ready")
+    } finally {
+      process.stdout.write = original
+    }
+
+    expect(writes).toEqual([])
+  })
+
   test("writes both server and tui config entries", async () => {
     await using tmp = await tmpdir()
     const target = await plugin(tmp.path, ["server", "tui"])


### PR DESCRIPTION
### Issue for this PR

Closes #27908

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode plugin` currently creates the animated spinner even when stdout is not a TTY. In non-interactive output this can emit spinner control text instead of quiet command output.

This PR keeps the existing spinner behavior for interactive terminals, but uses a no-op spinner when stdout is not a TTY. The change is scoped to the plugin command spinner creation path and adds a regression test for the non-TTY case.

The duplicate check flagged related PRs. This PR specifically targets the plugin install spinner path and includes a focused regression test for non-TTY spinner start/stop output.

### How did you verify your code works?

- `bun test test/plugin/install.test.ts`

### Screenshots / recordings

Not applicable. This is a CLI output behavior fix covered by a regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR