### PR TITLE
fix: allow partial provider model limits

### DIFF
--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -40,9 +40,9 @@ export const Model = Schema.Struct({
   ),
   limit: Schema.optional(
     Schema.Struct({
-      context: Schema.Finite,
+      context: Schema.optional(Schema.Finite),
       input: Schema.optional(Schema.Finite),
-      output: Schema.Finite,
+      output: Schema.optional(Schema.Finite),
     }),
   ),
   modalities: Schema.optional(

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1339,6 +1339,40 @@ test("config parser preserves permission order while rejecting unknown top-level
   }
 })
 
+test("provider model limits can specify token fields independently", () => {
+  const config = ConfigParse.schema(
+    ConfigV1.Info,
+    {
+      provider: {
+        custom: {
+          models: {
+            "context-only": {
+              limit: {
+                context: 1_000_000,
+              },
+            },
+            "output-only": {
+              limit: {
+                output: 16_384,
+              },
+            },
+            "input-only": {
+              limit: {
+                input: 512_000,
+              },
+            },
+          },
+        },
+      },
+    },
+    "test",
+  )
+
+  expect(config.provider?.custom.models?.["context-only"]?.limit).toEqual({ context: 1_000_000 })
+  expect(config.provider?.custom.models?.["output-only"]?.limit).toEqual({ output: 16_384 })
+  expect(config.provider?.custom.models?.["input-only"]?.limit).toEqual({ input: 512_000 })
+})
+
 // MCP config merging tests
 
 it.instance("project config can override MCP server enabled status", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #31780

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Provider model `limit` config supports `input`, `context`, and `output`, but the schema required `context` and `output` together. That made valid partial overrides fail, such as setting only `context` for a model.

This PR makes each token limit field independent while preserving the same numeric validation. It also adds regression coverage for context-only, output-only, and input-only limit config.

The duplicate check found a related provider limit PR, but this PR is scoped to the existing schema behavior for partial model limits.

### How did you verify your code works?

- `bun test test/config/config.test.ts`

### Screenshots / recordings

Not applicable. This is a config schema fix covered by a regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR