### PR TITLE
feat(app): add session file list tab

### DIFF
--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -596,6 +596,7 @@ export const dict = {
   "session.tab.session": "Session",
   "session.tab.review": "Review",
   "session.tab.context": "Context",
+  "session.tab.files": "Files",
   "session.panel.reviewAndFiles": "Review and files",
   "session.review.filesChanged": "{{count}} Files Changed",
   "session.review.change.one": "Change",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -512,6 +512,7 @@ export const dict = {
   "session.tab.session": "会话",
   "session.tab.review": "审查",
   "session.tab.context": "上下文",
+  "session.tab.files": "文件列表",
   "session.panel.reviewAndFiles": "审查和文件",
   "session.review.filesChanged": "{{count}} 个文件变更",
   "session.review.change.one": "更改",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -497,6 +497,7 @@ export const dict = {
   "session.tab.session": "工作階段",
   "session.tab.review": "審查",
   "session.tab.context": "上下文",
+  "session.tab.files": "檔案列表",
   "session.panel.reviewAndFiles": "審查與檔案",
   "session.review.filesChanged": "{{count}} 個檔案變更",
   "session.review.change.one": "變更",

--- a/packages/app/src/pages/session/helpers.test.ts
+++ b/packages/app/src/pages/session/helpers.test.ts
@@ -186,4 +186,26 @@ describe("createSessionTabs", () => {
       dispose()
     })
   })
+
+  test("treats file list as a special session tab", () => {
+    createRoot((dispose) => {
+      const [state] = createStore({
+        active: "files" as string | undefined,
+        all: ["files", "file://src/a.ts"],
+      })
+      const tabs = createMemo(() => ({ active: () => state.active, all: () => state.all }))
+      const result = createSessionTabs({
+        tabs,
+        pathFromTab: (tab) => (tab.startsWith("file://") ? tab.slice("file://".length) : undefined),
+        normalizeTab: (tab) => (tab.startsWith("file://") ? `norm:${tab.slice("file://".length)}` : tab),
+      })
+
+      expect(result.filesOpen()).toBe(true)
+      expect(result.openedTabs()).toEqual(["norm:src/a.ts"])
+      expect(result.activeTab()).toBe("files")
+      expect(result.activeFileTab()).toBeUndefined()
+      expect(result.closableTab()).toBe("files")
+      dispose()
+    })
+  })
 })

--- a/packages/app/src/pages/session/helpers.ts
+++ b/packages/app/src/pages/session/helpers.ts
@@ -28,6 +28,7 @@ export const createSessionTabs = (input: TabsInput) => {
   const review = input.review ?? (() => false)
   const hasReview = input.hasReview ?? (() => false)
   const contextOpen = createMemo(() => input.tabs().active() === "context" || input.tabs().all().includes("context"))
+  const filesOpen = createMemo(() => input.tabs().active() === "files" || input.tabs().all().includes("files"))
   const openedTabs = createMemo(
     () => {
       const seen = new Set<string>()
@@ -35,7 +36,7 @@ export const createSessionTabs = (input: TabsInput) => {
         .tabs()
         .all()
         .flatMap((tab) => {
-          if (tab === "context" || tab === "review") return []
+          if (tab === "context" || tab === "files" || tab === "review") return []
           const value = input.pathFromTab(tab) ? input.normalizeTab(tab) : tab
           if (seen.has(value)) return []
           seen.add(value)
@@ -48,12 +49,14 @@ export const createSessionTabs = (input: TabsInput) => {
   const activeTab = createMemo(() => {
     const active = input.tabs().active()
     if (active === "context") return active
+    if (active === "files") return active
     if (active === "review" && review()) return active
     if (active && input.pathFromTab(active)) return input.normalizeTab(active)
 
     const first = openedTabs()[0]
     if (first) return first
     if (contextOpen()) return "context"
+    if (filesOpen()) return "files"
     if (review() && hasReview()) return "review"
     return "empty"
   })
@@ -65,12 +68,14 @@ export const createSessionTabs = (input: TabsInput) => {
   const closableTab = createMemo(() => {
     const active = activeTab()
     if (active === "context") return active
+    if (active === "files") return active
     if (!openedTabs().includes(active)) return
     return active
   })
 
   return {
     contextOpen,
+    filesOpen,
     openedTabs,
     activeTab,
     activeFileTab,

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -151,6 +151,7 @@ export function SessionSidePanel(props: {
     hasReview: props.canReview,
   })
   const contextOpen = tabState.contextOpen
+  const filesOpen = tabState.filesOpen
   const openedTabs = tabState.openedTabs
   const activeTab = tabState.activeTab
   const activeFileTab = tabState.activeFileTab
@@ -299,6 +300,9 @@ export function SessionSidePanel(props: {
                             </div>
                           </Tabs.Trigger>
                         </Show>
+                        <Tabs.Trigger value="files">
+                          <div>{language.t("session.tab.files")}</div>
+                        </Tabs.Trigger>
                         <SortableProvider ids={openedTabs()}>
                           <For each={openedTabs()}>{(tab) => <SortableTab tab={tab} onTabClose={tabs().close} />}</For>
                         </SortableProvider>
@@ -353,6 +357,25 @@ export function SessionSidePanel(props: {
                         </Show>
                       </Tabs.Content>
                     </Show>
+
+                    <Tabs.Content value="files" class="flex flex-col h-full overflow-hidden contain-strict">
+                      <Show when={activeTab() === "files" || filesOpen()}>
+                        <div class="relative flex-1 min-h-0 overflow-hidden bg-background-stronger px-3 py-0">
+                          <Switch>
+                            <Match when={nofiles()}>{empty(language.t("session.files.empty"))}</Match>
+                            <Match when={true}>
+                              <FileTree
+                                path=""
+                                class="pt-3"
+                                modified={diffFiles()}
+                                kinds={kinds()}
+                                onFileClick={(node) => openTab(file.tab(node.path))}
+                              />
+                            </Match>
+                          </Switch>
+                        </div>
+                      </Show>
+                    </Tabs.Content>
 
                     <Show when={activeFileTab()} keyed>
                       {(tab) => <FileTabContent tab={tab} />}


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a Files tab to the session side panel. The tab reuses the existing file tree and file tab opening flow, so users can browse workspace files from the session panel and open a selected file in the existing viewer.

The change treats `files` as a special session tab, similar to the existing non-file tabs, and adds locale labels for English, Simplified Chinese, and Traditional Chinese.

### How did you verify your code works?

- `bun test src/pages/session/helpers.test.ts src/i18n/parity.test.ts`
- `bun run build` from `packages/app`
- `OPENCODE_CHANNEL=prod bun run build` from `packages/desktop`
- `OPENCODE_CHANNEL=prod bun run package:win` from `packages/desktop`

### Screenshots / recordings

Not included. This is a small session side-panel tab addition that reuses the existing file tree UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR