### PR TITLE
docs: correct Kimi K2.7 Code model ID in Go docs

### DIFF
--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -166,7 +166,7 @@ You can also access Go models through the following API endpoints.
 | ----------------- | ----------------- | ------------------------------------------------ | --------------------------- |
 | GLM-5.1           | glm-5.1           | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | GLM-5             | glm-5             | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
-| Kimi K2.7         | kimi-k2.7         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
+| Kimi K2.7 Code    | kimi-k2.7-code    | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | Kimi K2.6         | kimi-k2.6         | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Pro   | deepseek-v4-pro   | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |
 | DeepSeek V4 Flash | deepseek-v4-flash | `https://opencode.ai/zen/go/v1/chat/completions` | `@ai-sdk/openai-compatible` |


### PR DESCRIPTION
### Issue for this PR

Closes #32196

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The OpenCode Go docs endpoint table listed Kimi K2.7 Code with the model ID `kimi-k2.7`, while the model list, config examples, and `/v1/models` endpoint use the canonical ID `kimi-k2.7-code`. This inconsistency made it unclear which ID to use when configuring OpenCode Go manually or from external clients.

This change updates the endpoint table row in the English Go docs (`packages/web/src/content/docs/go.mdx`) to use `Kimi K2.7 Code` and `kimi-k2.7-code`, matching the canonical model ID used everywhere else. Localized docs will be synced by the `docs-locale-sync` workflow.

### How did you verify your code works?

- Confirmed that the updated table row keeps the same cell widths as the original, so the markdown table alignment is preserved.
- Verified there are no remaining `kimi-k2.7` references (excluding the correct `kimi-k2.7-code`) in the English docs.

### Screenshots / recordings

N/A — this is a documentation text correction only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR