### PR TITLE
fix: include file content preview in oldString not found error

### DIFF
--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -163,9 +163,9 @@ export const layer = Layer.effectDiscard(
                 const newString = convertToLineEnding(input.newString, ending)
                 const replacements = countOccurrences(source.text, oldString)
                 if (replacements === 0) {
+                  const preview = source.text.length > 500 ? source.text.slice(0, 500) + "\n..." : source.text
                   return yield* new ToolFailure({
-                    message:
-                      "Could not find oldString in the file. It must match exactly, including whitespace and indentation.",
+                    message: `Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\n${preview}`,
                   })
                 }
                 if (replacements > 1 && input.replaceAll !== true) {

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -301,7 +301,7 @@ describe("EditTool", () => {
                 ).toEqual({
                   type: "error",
                   value:
-                    "Could not find oldString in the file. It must match exactly, including whitespace and indentation.",
+                    "Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\nsame same",
                 })
                 expect(
                   yield* executeTool(registry, call({ path: "matches.txt", oldString: "same", newString: "after" })),
@@ -309,6 +309,35 @@ describe("EditTool", () => {
                   type: "error",
                   value:
                     "Found multiple exact matches for oldString. Provide more surrounding context or set replaceAll to true.",
+                })
+                expect(writes).toEqual([])
+              }),
+            ),
+          ),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  it.live("truncates the file content preview in the oldString not found error to 500 characters", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const target = path.join(tmp.path, "long.txt")
+        const content = "a".repeat(600)
+        return Effect.promise(() => fs.writeFile(target, content)).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              Effect.gen(function* () {
+                const result = yield* executeTool(
+                  registry,
+                  call({ path: "long.txt", oldString: "not present", newString: "after" }),
+                )
+                expect(result).toEqual({
+                  type: "error",
+                  value: `Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\n${"a".repeat(500)}\n...`,
                 })
                 expect(writes).toEqual([])
               }),


### PR DESCRIPTION
## Issue for this PR

Closes #30863

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

## What does this PR do?

### Problem

`packages/core/src/tool/edit.ts:160` already loads the full file content into `source.text` before attempting the edit. However, when `oldString` is not found (`replacements === 0`), the error message at line 165-169 only returns the hardcoded string:

```ts
"Could not find oldString in the file. It must match exactly, including whitespace and indentation."
```

— discarding the file-state information the AI needs to correct its edit.

### Impact

The AI gets `"Could not find oldString"` with zero file-state context. It must blindly guess the correct `oldString`, wasting multiple turns. In complex files this often cascades into hitting `MAX_STEPS` and failing the task entirely.

### Fix

Slice up to 500 characters of the already-loaded `source.text` and append it to the error message:

```ts
if (replacements === 0) {
  const preview = source.text.length > 500 ? source.text.slice(0, 500) + "\n..." : source.text
  return yield* new ToolFailure({
    message: `Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\n${preview}`,
  })
}
```

The 500-char cap prevents flooding the AI context window for large files. No additional file reads or side effects — it is a pure `slice` of `source.text` that is already loaded for the edit itself.

### Relationship to #30912

This is a rebase of #30912 (closed). Upstream `dev` has since refactored `edit.ts` significantly (`ToolRegistry` → `Tools` + `Tool`, permission API rewritten, `parameters` → `input`), so the previous branch could not be merged as-is. The fix logic itself is unchanged; only the surrounding context moved.

## How did you verify your code works?

- Updated existing test `rejects no-op, empty, missing, and ambiguous exact replacements` in `packages/core/test/tool-edit.test.ts` to assert the new preview-containing message.
- Added new test `truncates the file content preview in the oldString not found error to 500 characters` covering the >500-char truncation path with a 600-char file.
- Ran `bun test test/tool-edit.test.ts` locally — **10 pass, 1 fail**.
- The single failure (`keeps the locked edit schema, semantics docstring, and deferred TODOs visible`) is **pre-existing on `dev`** and unrelated to this PR: that meta-test asserts the source contains the string `"Named project references\n * are read-oriented and deliberately are not accepted by mutation tools."`, which was removed during the upstream refactor (PRs #31545/#31539). Verified by running the same test against unmodified `origin/dev` — same failure.
- `bun run typecheck` in `packages/core` — clean (exit 0).

## Screenshots / recordings

N/A

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR