### PR TITLE
fix(tui): reset terminal modes on shutdown

### DIFF
--- a/packages/tui/src/util/renderer.ts
+++ b/packages/tui/src/util/renderer.ts
@@ -1,7 +1,38 @@
 import type { CliRenderer } from "@opentui/core"
 
-export function destroyRenderer(renderer: Pick<CliRenderer, "isDestroyed" | "setTerminalTitle" | "destroy">) {
+export const TERMINAL_MODE_RESETS = [
+  { name: "basicMouseTracking", sequence: "\x1b[?1000l" },
+  { name: "mouseButtonEventTracking", sequence: "\x1b[?1002l" },
+  { name: "mouseAnyEventTracking", sequence: "\x1b[?1003l" },
+  { name: "utf8MouseMode", sequence: "\x1b[?1005l" },
+  { name: "sgrMouseMode", sequence: "\x1b[?1006l" },
+  { name: "urxvtMouseMode", sequence: "\x1b[?1015l" },
+  { name: "focusEventTracking", sequence: "\x1b[?1004l" },
+  { name: "bracketedPaste", sequence: "\x1b[?2004l" },
+  { name: "alternateScreen", sequence: "\x1b[?1049l" },
+] as const
+
+export const TERMINAL_MODE_RESET_SEQUENCE = TERMINAL_MODE_RESETS.map((mode) => mode.sequence).join("")
+
+type TerminalCleanupWriter = {
+  write(data: string): unknown
+}
+
+function resetTerminalModes(writer: TerminalCleanupWriter) {
+  try {
+    writer.write(TERMINAL_MODE_RESET_SEQUENCE)
+  } catch {
+    // Do not let a failed best-effort terminal reset block renderer teardown.
+  }
+}
+
+export function destroyRenderer(
+  renderer: Pick<CliRenderer, "isDestroyed" | "setTerminalTitle" | "destroy">,
+  writer: TerminalCleanupWriter = process.stdout,
+) {
   renderer.setTerminalTitle("")
+  resetTerminalModes(writer)
   if (renderer.isDestroyed) return
   renderer.destroy()
+  resetTerminalModes(writer)
 }

--- a/packages/tui/test/util/renderer.test.ts
+++ b/packages/tui/test/util/renderer.test.ts
@@ -1,30 +1,82 @@
 import { expect, test } from "bun:test"
-import { destroyRenderer } from "../../src/util/renderer"
+import { destroyRenderer, TERMINAL_MODE_RESET_SEQUENCE, TERMINAL_MODE_RESETS } from "../../src/util/renderer"
 
-test("clears the terminal title before destroying the renderer", () => {
+test("resets terminal modes before and after destroying the renderer", () => {
   const calls: string[] = []
-  destroyRenderer({
-    isDestroyed: false,
-    setTerminalTitle(title) {
-      calls.push(`title:${title}`)
+  destroyRenderer(
+    {
+      isDestroyed: false,
+      setTerminalTitle(title) {
+        calls.push(`title:${title}`)
+      },
+      destroy() {
+        calls.push("destroy")
+      },
     },
-    destroy() {
-      calls.push("destroy")
+    {
+      write(data) {
+        calls.push(`write:${data}`)
+      },
     },
-  })
-  expect(calls).toEqual(["title:", "destroy"])
+  )
+  expect(calls).toEqual([
+    "title:",
+    `write:${TERMINAL_MODE_RESET_SEQUENCE}`,
+    "destroy",
+    `write:${TERMINAL_MODE_RESET_SEQUENCE}`,
+  ])
 })
 
-test("still clears the title after renderer destruction", () => {
+test("still resets terminal modes after renderer destruction", () => {
   const calls: string[] = []
-  destroyRenderer({
-    isDestroyed: true,
-    setTerminalTitle(title) {
-      calls.push(`title:${title}`)
+  destroyRenderer(
+    {
+      isDestroyed: true,
+      setTerminalTitle(title) {
+        calls.push(`title:${title}`)
+      },
+      destroy() {
+        calls.push("destroy")
+      },
     },
-    destroy() {
-      calls.push("destroy")
+    {
+      write(data) {
+        calls.push(`write:${data}`)
+      },
     },
-  })
-  expect(calls).toEqual(["title:"])
+  )
+  expect(calls).toEqual(["title:", `write:${TERMINAL_MODE_RESET_SEQUENCE}`])
+})
+
+test("still destroys the renderer when terminal reset writes fail", () => {
+  const calls: string[] = []
+  destroyRenderer(
+    {
+      isDestroyed: false,
+      setTerminalTitle(title) {
+        calls.push(`title:${title}`)
+      },
+      destroy() {
+        calls.push("destroy")
+      },
+    },
+    {
+      write(data) {
+        calls.push(`write:${data}`)
+        throw new Error("write failed")
+      },
+    },
+  )
+  expect(calls).toEqual([
+    "title:",
+    `write:${TERMINAL_MODE_RESET_SEQUENCE}`,
+    "destroy",
+    `write:${TERMINAL_MODE_RESET_SEQUENCE}`,
+  ])
+})
+
+test("terminal mode reset sequences are unique and generated from one registry", () => {
+  expect(new Set(TERMINAL_MODE_RESETS.map((mode) => mode.name)).size).toBe(TERMINAL_MODE_RESETS.length)
+  expect(new Set(TERMINAL_MODE_RESETS.map((mode) => mode.sequence)).size).toBe(TERMINAL_MODE_RESETS.length)
+  expect(TERMINAL_MODE_RESET_SEQUENCE).toBe(TERMINAL_MODE_RESETS.map((mode) => mode.sequence).join(""))
 })


### PR DESCRIPTION
### Issue for this PR

Closes #20458

Related: #11748, #32336

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`destroyRenderer()` cleared the terminal title and then delegated to OpenTUI teardown. In some shutdown paths, terminal private modes can survive exit, especially mouse reporting and bracketed paste, leaving the user's shell in a broken state.

This PR centralizes the terminal reset contract in one `TERMINAL_MODE_RESETS` registry and writes the joined reset sequence before and after `renderer.destroy()`. The reset is idempotent and best-effort: a failed stdout write does not block renderer destruction.

The covered shutdown cases are:

- normal renderer destruction
- already-destroyed renderer cleanup
- stdout write failure during cleanup
- mouse tracking modes: basic, button-event, any-event, UTF-8, SGR, and URXVT
- focus event reporting
- bracketed paste
- alternate screen
- shared lifecycle consumers, since `app.exit`, scoped release, and SIGHUP already call `destroyRenderer()`

### How did you verify your code works?

- `bun test test/util/renderer.test.ts`
- `bun run typecheck` from `packages/tui`
- `bunx oxlint packages/tui/src/util/renderer.ts packages/tui/test/util/renderer.test.ts`
- `git diff --check`

### Screenshots / recordings

Not applicable. This is terminal teardown behavior covered by unit tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
