### PR TITLE
fix: create worktrees from empty git repos

### DIFF
--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -128,6 +128,10 @@ function failedRemoves(...chunks: string[]) {
   )
 }
 
+function branchMissing(...chunks: string[]) {
+  return chunks.some((chunk) => /branch ['"].+['"] not found/i.test(chunk))
+}
+
 // ---------------------------------------------------------------------------
 // Effect service
 // ---------------------------------------------------------------------------
@@ -229,9 +233,11 @@ export const layer: Layer.Layer<
 
     const setup = Effect.fnUntraced(function* (info: Info) {
       const ctx = yield* InstanceState.context
+      const head = yield* git(["rev-parse", "--verify", "HEAD"], { cwd: ctx.worktree })
+      const hasHead = head.code === 0
       const created = yield* git(
         info.branch
-          ? ["worktree", "add", "--no-checkout", "-b", info.branch, info.directory]
+          ? ["worktree", "add", ...(hasHead ? ["--no-checkout"] : []), "-b", info.branch, info.directory]
           : ["worktree", "add", "--no-checkout", "--detach", info.directory, "HEAD"],
         { cwd: ctx.worktree },
       )
@@ -242,6 +248,7 @@ export const layer: Layer.Layer<
       }
 
       yield* project.addSandbox(ctx.project.id, info.directory).pipe(Effect.catch(() => Effect.void))
+      return undefined
     })
 
     const boot = Effect.fnUntraced(function* (info: Info, startCommand?: string) {
@@ -454,7 +461,7 @@ export const layer: Layer.Layer<
       const branch = entry.branch?.replace(/^refs\/heads\//, "")
       if (branch) {
         const deleted = yield* git(["branch", "-D", branch], { cwd: ctx.worktree })
-        if (deleted.code !== 0) {
+        if (deleted.code !== 0 && !branchMissing(deleted.stderr, deleted.text)) {
           return yield* new RemoveFailedError({
             message: deleted.stderr || deleted.text || "Failed to delete worktree branch",
           })
@@ -478,7 +485,7 @@ export const layer: Layer.Layer<
       function* (directory: string, cmd: string) {
         const [shell, args] = process.platform === "win32" ? ["cmd", ["/c", cmd]] : ["bash", ["-lc", cmd]]
         const result = yield* appProcess.run(
-          ChildProcess.make(shell, args as string[], { cwd: directory, extendEnv: true, stdin: "ignore" }),
+          ChildProcess.make(shell, args, { cwd: directory, extendEnv: true, stdin: "ignore" }),
         )
         return { code: result.exitCode, stderr: result.stderr.toString("utf8") }
       },

--- a/packages/opencode/test/project/worktree.test.ts
+++ b/packages/opencode/test/project/worktree.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect } from "bun:test"
+import { $ } from "bun"
 import path from "path"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -13,6 +14,15 @@ const it = testEffect(
   Layer.mergeAll(Worktree.defaultLayer, FSUtil.defaultLayer, CrossSpawnSpawner.defaultLayer, Git.defaultLayer),
 )
 const wintest = process.platform !== "win32" ? it.instance : it.instance.skip
+
+const initEmptyGitRepo = (directory: string) =>
+  Effect.promise(async () => {
+    await $`git init`.cwd(directory).quiet()
+    await $`git config core.fsmonitor false`.cwd(directory).quiet()
+    await $`git config commit.gpgsign false`.cwd(directory).quiet()
+    await $`git config user.email test@opencode.test`.cwd(directory).quiet()
+    await $`git config user.name Test`.cwd(directory).quiet()
+  })
 
 function normalize(input: string) {
   return input.replace(/\\/g, "/").toLowerCase()
@@ -41,6 +51,7 @@ const removeCreatedWorktree = (directory: string) =>
     const svc = yield* Worktree.Service
     const ok = yield* svc.remove({ directory })
     if (!ok) return yield* Effect.fail(new Error(`failed to remove worktree ${directory}`))
+    return undefined
   })
 
 const withCreatedWorktree = <A, E, R>(
@@ -174,6 +185,22 @@ describe("Worktree", () => {
   })
 
   describe("create + remove lifecycle", () => {
+    wintest(
+      "creates git worktree from empty repository",
+      () =>
+        withCreatedWorktree({ name: "empty-repo" }, ({ info, ready }) =>
+          Effect.gen(function* () {
+            const test = yield* TestInstance
+            const list = yield* git(test.directory, ["worktree", "list", "--porcelain"])
+
+            expect(normalize(list)).toContain(normalize(info.directory))
+            expect(info.branch).toBe("opencode/empty-repo")
+            expect(ready.branch).toBe(info.branch)
+          }),
+        ),
+      { init: initEmptyGitRepo },
+    )
+
     it.instance(
       "create returns worktree info and remove cleans up",
       () =>


### PR DESCRIPTION
### Issue for this PR

Fixes #20910

Related: #32341

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Creating an opencode worktree from a git repo with no commits currently fails because `git worktree add` infers `--orphan`, while opencode also passes `--no-checkout`. Git rejects that combination.

This PR keeps the existing `--no-checkout` path for normal repositories with a valid `HEAD`, but omits it when the source repository has an unborn `HEAD`. That lets Git create the orphan worktree branch for empty repos. It also treats a missing branch during cleanup as already clean, which can happen after removing an unborn worktree branch.

The covered cases are:

- empty git repo with no commits can create a named worktree
- normal worktree create/list/remove lifecycle still passes
- detached worktree creation from a normal repo still passes
- remove still preserves existing non-empty worktree behavior
- missing branch cleanup after an unborn worktree does not turn successful removal into an error

### How did you verify your code works?

- `bun test test/project/worktree.test.ts`
- `bun test test/project/worktree-remove.test.ts`
- `bunx oxlint packages/opencode/src/worktree/index.ts packages/opencode/test/project/worktree.test.ts`
- `git diff --check`

### Screenshots / recordings

Not applicable. This is git worktree lifecycle behavior covered by regression tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
