### PR TITLE
docs: add opencode-lens to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ar/ecosystem.mdx
+++ b/packages/web/src/content/docs/ar/ecosystem.mdx
@@ -63,6 +63,7 @@ description: مشاريع وتكاملات مبنية باستخدام OpenCode.
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | واجهة Neovim لـ opencode - وكيل برمجة بالذكاء الاصطناعي يعتمد على الطرفية |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | موفر Vercel AI SDK لاستخدام OpenCode عبر @opencode-ai/sdk                 |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | تطبيق ويب / سطح مكتب وامتداد VS Code لـ OpenCode                          |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | خادم MCP ومكوّن TUI يتيحان للوكلاء التحكم في جلسات OpenCode النشطة ومراقبتها |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | إضافة Obsidian تدمج OpenCode في واجهة مستخدم Obsidian                     |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | بديل مفتوح المصدر لـ Claude Cowork، مدعوم بواسطة OpenCode                 |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | مدير امتدادات OpenCode مع ملفات تعريف محمولة ومعزولة.                     |

--- a/packages/web/src/content/docs/bs/ecosystem.mdx
+++ b/packages/web/src/content/docs/bs/ecosystem.mdx
@@ -63,6 +63,7 @@ Također možete pogledati [awesome-opencode](https://github.com/awesome-opencod
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend za opencode - terminal baziran AI agent za kodiranje  |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK dobavljač za korištenje OpenCode putem @opencode-ai/sdk |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App i VS Code Extension za OpenCode                     |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP server i TUI dodatak koji agentima omogućavaju kontrolu i praćenje aktivnih OpenCode sesija |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian dodatak koji ugrađuje OpenCode u Obsidian-ov UI              |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Alternativa otvorenog koda Claudeu Coworku, pokretana pomoću OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode menadžer ekstenzija sa prenosivim, izolovanim profilima.     |

--- a/packages/web/src/content/docs/da/ecosystem.mdx
+++ b/packages/web/src/content/docs/da/ecosystem.mdx
@@ -63,6 +63,7 @@ Du kan også tjekke [awesome-opencode](https://github.com/awesome-opencode/aweso
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim-frontend til opencode - en terminalbaseret AI-kodningsagent     |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK udbyder til brug af OpenCode via @opencode-ai/sdk        |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App og VS Code udvidelse til OpenCode                    |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP-server og TUI-plugin, så agenter kan styre og overvåge aktive OpenCode-sessioner |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin, der integrerer OpenCode i Obsidians brugergrænseflade |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Et open source-alternativ til Claude Cowork, drevet af OpenCode        |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode udvidelsesmanager med bærbare, isolerede profiler.            |

--- a/packages/web/src/content/docs/de/ecosystem.mdx
+++ b/packages/web/src/content/docs/de/ecosystem.mdx
@@ -63,6 +63,7 @@ Sie können sich auch [awesome-opencode](https://github.com/awesome-opencode/awe
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim-Frontend für OpenCode – ein terminalbasierter AI-Coding-Agent         |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK Anbieter für die Verwendung von OpenCode über @opencode-ai/sdk |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web-/Desktop-App und VS Code-Erweiterung für OpenCode                        |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP-Server und TUI-Plugin, mit dem Agents laufende OpenCode-Sitzungen steuern und überwachen |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian-Plugin, das OpenCode in Obsidians UI einbettet                      |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Eine Open-Source-Alternative zu Claude Cowork, unterstützt von OpenCode      |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode Erweiterungsmanager mit portablen, isolierten Profilen.             |

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -68,6 +68,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim frontend for opencode - a terminal-based AI coding agent  |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK provider for using OpenCode via @opencode-ai/sdk   |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web / Desktop App and VS Code Extension for OpenCode             |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP server and TUI plugin for agents to control and monitor live OpenCode sessions |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian plugin that embeds OpenCode in Obsidian's UI            |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |

--- a/packages/web/src/content/docs/es/ecosystem.mdx
+++ b/packages/web/src/content/docs/es/ecosystem.mdx
@@ -63,6 +63,7 @@ También puedes consultar [awesome-opencode](https://github.com/awesome-opencode
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Interfaz de Neovim para opencode: un agente de codificación de IA basado en terminal |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Proveedor Vercel AI SDK para usar OpenCode a través de @opencode-ai/sdk              |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Aplicación web/de escritorio y extensión VS Code para OpenCode                       |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | Servidor MCP y plugin TUI para que los agentes controlen y supervisen sesiones de OpenCode en vivo |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Complemento de Obsidian que incorpora OpenCode en la interfaz de usuario de Obsidian |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Una alternativa de código abierto a Claude Cowork, impulsada por OpenCode            |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Administrador de extensiones OpenCode con perfiles portátiles y aislados.            |

--- a/packages/web/src/content/docs/fr/ecosystem.mdx
+++ b/packages/web/src/content/docs/fr/ecosystem.mdx
@@ -63,6 +63,7 @@ Vous pouvez également consulter [awesome-opencode](https://github.com/awesome-o
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Frontend Neovim pour opencode - un agent de codage IA basé sur terminal     |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Fournisseur Vercel AI SDK pour utiliser OpenCode via @opencode-ai/sdk       |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Application Web / Bureau et extension VS Code pour OpenCode                 |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | Serveur MCP et plugin TUI permettant aux agents de contrôler et surveiller les sessions OpenCode actives |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Plugin Obsidian qui intègre OpenCode dans l'interface d'Obsidian            |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Une alternative open-source à Claude Cowork, propulsée par OpenCode         |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gestionnaire d'extensions OpenCode avec profils portables et isolés.        |

--- a/packages/web/src/content/docs/it/ecosystem.mdx
+++ b/packages/web/src/content/docs/it/ecosystem.mdx
@@ -63,6 +63,7 @@ Puoi anche dare un'occhiata a [awesome-opencode](https://github.com/awesome-open
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Frontend Neovim per opencode: un agente di coding AI per terminale   |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Provider Vercel AI SDK per usare OpenCode tramite @opencode-ai/sdk   |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | App Web/Desktop ed estensione VS Code per OpenCode                   |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | Server MCP e plugin TUI per consentire agli agenti di controllare e monitorare sessioni OpenCode attive |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Plugin Obsidian che integra OpenCode nella UI di Obsidian            |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Alternativa open source a Claude Cowork, alimentata da OpenCode      |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gestore di estensioni OpenCode con profili portabili e isolati       |

--- a/packages/web/src/content/docs/ja/ecosystem.mdx
+++ b/packages/web/src/content/docs/ja/ecosystem.mdx
@@ -63,6 +63,7 @@ OpenCode 関連プロジェクトをこのリストに追加したいですか? 
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim OpenCode用フロントエンド - ターミナルベースの AI コーディングエージェント |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | @opencode-ai/sdk 経由で OpenCode を使用するための Vercel AI SDK プロバイダー     |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | OpenCode 用の Web/デスクトップアプリと VS Code 拡張機能                          |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | エージェントが実行中の OpenCode セッションを制御・監視できる MCP サーバーと TUI プラグイン |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian の UI に OpenCode を埋め込む Obsidian プラグイン                        |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode を利用した、Claude Cowork に代わるオープンソース                        |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | 移植可能な独立したプロファイルを備えた OpenCode 拡張機能マネージャー。           |

--- a/packages/web/src/content/docs/ko/ecosystem.mdx
+++ b/packages/web/src/content/docs/ko/ecosystem.mdx
@@ -63,6 +63,7 @@ OpenCode를 기반으로 만들어진 커뮤니티 프로젝트 모음입니다.
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | terminal 기반 AI 코딩 agent인 opencode용 Neovim frontend입니다.        |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | `@opencode-ai/sdk`로 OpenCode를 사용하는 Vercel AI SDK provider입니다. |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | OpenCode용 Web/Desktop App 및 VS Code Extension입니다.                 |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | 에이전트가 실행 중인 OpenCode 세션을 제어하고 모니터링할 수 있는 MCP 서버 및 TUI 플러그인입니다. |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian UI에 OpenCode를 내장하는 Obsidian plugin입니다.               |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode 기반의 Claude Cowork 대체 오픈소스 프로젝트입니다.            |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | 휴대형 격리 프로필을 지원하는 OpenCode extension manager입니다.        |

--- a/packages/web/src/content/docs/nb/ecosystem.mdx
+++ b/packages/web/src/content/docs/nb/ecosystem.mdx
@@ -63,6 +63,7 @@ Du kan også sjekke ut [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Neovim-grensesnitt for OpenCode - en terminalbasert AI-kodingsagent |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK leverandør for bruk av OpenCode via @opencode-ai/sdk  |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Web-/skrivebordsapp og VS Code-utvidelse for OpenCode               |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP-server og TUI-plugin som lar agenter styre og overvåke aktive OpenCode-økter |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Obsidian-plugin som bygger inn OpenCode i Obsidians UI              |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Et åpen kildekode-alternativ til Claude Cowork, drevet av OpenCode  |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode utvidelsesbehandler med bærbare, isolerte profiler.        |

--- a/packages/web/src/content/docs/pl/ecosystem.mdx
+++ b/packages/web/src/content/docs/pl/ecosystem.mdx
@@ -63,6 +63,7 @@ Możesz również sprawdzić [awesome-opencode](https://github.com/awesome-openc
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Frontend Neovim dla OpenCode - terminalowy agent kodujący AI            |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Dostawca Vercel AI SDK do używania OpenCode przez @opencode-ai/sdk      |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Aplikacja Web / Desktop i rozszerzenie VS Code dla OpenCode             |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | Serwer MCP i wtyczka TUI, dzięki którym agenci kontrolują i monitorują aktywne sesje OpenCode |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Wtyczka Obsidian osadzająca OpenCode w interfejsie Obsidian             |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Otwartoźródłowa alternatywa dla Claude Cowork, napędzana przez OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Menedżer rozszerzeń OpenCode z przenośnymi, izolowanymi profilami.      |

--- a/packages/web/src/content/docs/pt-br/ecosystem.mdx
+++ b/packages/web/src/content/docs/pt-br/ecosystem.mdx
@@ -63,6 +63,7 @@ Você também pode conferir [awesome-opencode](https://github.com/awesome-openco
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Frontend Neovim para OpenCode - um agente de codificação IA baseado em terminal |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Provedor Vercel AI SDK para usar OpenCode via @opencode-ai/sdk                  |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Aplicativo Web / Desktop e Extensão do VS Code para OpenCode                    |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | Servidor MCP e plugin TUI para agentes controlarem e monitorarem sessões OpenCode em execução |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Plugin Obsidian que incorpora OpenCode na UI do Obsidian                        |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Uma alternativa de código aberto ao Claude Cowork, alimentada pelo OpenCode     |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Gerenciador de extensões OpenCode com perfis portáteis e isolados.              |

--- a/packages/web/src/content/docs/ru/ecosystem.mdx
+++ b/packages/web/src/content/docs/ru/ecosystem.mdx
@@ -63,6 +63,7 @@ description: Проекты и интеграции, созданные с по�
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | Интерфейс Neovim для OpenCode - агент кодирования искусственного интеллекта на базе терминала |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Поставщик Vercel AI SDK для использования OpenCode через @opencode-ai/sdk                     |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | Веб-приложение или настольное приложение и расширение VS Code для OpenCode                    |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP-сервер и TUI-плагин, с помощью которых агенты управляют и отслеживают активные сессии OpenCode |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | Плагин Obsidian, встраивающий OpenCode в пользовательский интерфейс Obsidian                  |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Альтернатива Claude Cowork с открытым исходным кодом на базе OpenCode                         |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Менеджер расширений OpenCode с переносимыми изолированными профилями                          |

--- a/packages/web/src/content/docs/th/ecosystem.mdx
+++ b/packages/web/src/content/docs/th/ecosystem.mdx
@@ -63,6 +63,7 @@ description: โปรเจ็กต์และการผสานรวม�
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | ส่วนหน้า Neovim สำหรับ opencode - เอเจนต์การเข้ารหัส AI ที่ใช้ terminal   |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | ผู้ให้บริการ Vercel AI SDK สำหรับการใช้งาน OpenCode ผ่าน @opencode-ai/sdk |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | แอพเว็บ / เดสก์ท็อปและส่วนขยาย VS Code สำหรับ OpenCode                    |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | เซิร์ฟเวอร์ MCP และปลั๊กอิน TUI ที่ให้เอเจนต์ควบคุมและตรวจสอบเซสชัน OpenCode ที่กำลังทำงาน |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | ปลั๊กอิน Obsidian ที่ฝัง OpenCode ไว้ใน UI ของ Obsidian                   |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | ทางเลือกโอเพ่นซอร์สแทน Claude Cowork ซึ่งขับเคลื่อนโดย OpenCode           |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | ตัวจัดการส่วนขยาย OpenCode พร้อมโปรไฟล์แบบพกพาและแยกส่วน                  |

--- a/packages/web/src/content/docs/tr/ecosystem.mdx
+++ b/packages/web/src/content/docs/tr/ecosystem.mdx
@@ -63,6 +63,7 @@ Ayrıca ekosistemi ve topluluğu bir araya getiren [awesome-opencode](https://gi
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | opencode için Neovim ön yüzü - terminal tabanlı bir yapay zeka kodlama aracısı  |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | @opencode-ai/sdk aracılığıyla OpenCode kullanmak için Vercel AI SDK sağlayıcısı |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | OpenCode için Web / Masaüstü Uygulaması ve VS Code Uzantısı                     |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | Ajanların canlı OpenCode oturumlarını kontrol edip izlemesini sağlayan MCP sunucusu ve TUI eklentisi |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | OpenCode'u Obsidian arayüzüne gömen Obsidian eklentisi                          |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | OpenCode tarafından desteklenen, Claude Cowork'e açık kaynaklı bir alternatif   |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | Taşınabilir, izole profillere sahip OpenCode eklenti yöneticisi                 |

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -63,6 +63,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | OpenCode 的 Neovim 前端——基于终端的 AI 编码代理               |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK 提供商，用于通过 @opencode-ai/sdk 使用 OpenCode |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | OpenCode 的 Web / 桌面应用和 VS Code 扩展                     |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP 服务器和 TUI 插件，让代理控制并监控正在运行的 OpenCode 会话 |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | 将 OpenCode 嵌入 Obsidian UI 的 Obsidian 插件                 |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Claude Cowork 的开源替代方案，由 OpenCode 驱动                |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode 扩展管理器，支持可移植的隔离配置                     |

--- a/packages/web/src/content/docs/zh-tw/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-tw/ecosystem.mdx
@@ -63,6 +63,7 @@ description: 基於 OpenCode 建置的專案與整合。
 | [opencode.nvim](https://github.com/sudo-tee/opencode.nvim)                                 | OpenCode 的 Neovim 前端——基於終端機的 AI 編碼代理             |
 | [ai-sdk-provider-opencode-sdk](https://github.com/ben-vargas/ai-sdk-provider-opencode-sdk) | Vercel AI SDK 供應商，用於透過 @opencode-ai/sdk 使用 OpenCode |
 | [OpenChamber](https://github.com/btriapitsyn/openchamber)                                  | OpenCode 的 Web / 桌面應用程式和 VS Code 擴充功能             |
+| [opencode-lens](https://github.com/wuxiaoqiang12/opencode-lens)                            | MCP 伺服器和 TUI 外掛，讓代理控制並監控正在執行的 OpenCode 會話 |
 | [OpenCode-Obsidian](https://github.com/mtymek/opencode-obsidian)                           | 將 OpenCode 嵌入 Obsidian UI 的 Obsidian 外掛程式             |
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Claude Cowork 的開源替代方案，由 OpenCode 驅動                |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode 擴充功能管理器，支援可攜式的隔離設定                 |


### PR DESCRIPTION
## Summary\n- add opencode-lens to the ecosystem projects list\n- update the entry across all localized ecosystem pages\n\n## Verification\n- git diff --check\n- Confirmed opencode-lens appears in all 18 ecosystem.mdx files\n- Attempted `bun --cwd packages/web build`, but this fresh clone has no installed dependencies, so `astro` was not available