### PR TITLE
feat(workflow): engine-core (1/6) — modularized workflow engine, split from #29789

### DIFF
--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -81,6 +81,10 @@
       "entityType": "tables"
     },
     {
+      "name": "workflow_run",
+      "entityType": "tables"
+    },
+    {
       "type": "text",
       "notNull": false,
       "autoincrement": false,
@@ -1481,9 +1485,193 @@
       "table": "session_share"
     },
     {
-      "columns": ["project_id"],
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "''",
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "current_phase",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "args",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "definition",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "logs",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agents",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "result",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "resume_of",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_question",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "workflow_run"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1492,9 +1680,13 @@
       "table": "workspace"
     },
     {
-      "columns": ["active_account_id"],
+      "columns": [
+        "active_account_id"
+      ],
       "tableTo": "account",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "SET NULL",
       "nameExplicit": false,
@@ -1503,9 +1695,13 @@
       "table": "account_state"
     },
     {
-      "columns": ["aggregate_id"],
+      "columns": [
+        "aggregate_id"
+      ],
       "tableTo": "event_sequence",
-      "columnsTo": ["aggregate_id"],
+      "columnsTo": [
+        "aggregate_id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1514,9 +1710,13 @@
       "table": "event"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1525,9 +1725,13 @@
       "table": "permission"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1536,9 +1740,13 @@
       "table": "project_directory"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1547,9 +1755,13 @@
       "table": "message"
     },
     {
-      "columns": ["message_id"],
+      "columns": [
+        "message_id"
+      ],
       "tableTo": "message",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1558,9 +1770,13 @@
       "table": "part"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1569,9 +1785,13 @@
       "table": "session_context_epoch"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1580,9 +1800,13 @@
       "table": "session_input"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1591,9 +1815,13 @@
       "table": "session_message"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1602,9 +1830,13 @@
       "table": "session"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1613,9 +1845,13 @@
       "table": "todo"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1624,136 +1860,186 @@
       "table": "session_share"
     },
     {
-      "columns": ["email", "url"],
+      "columns": [
+        "email",
+        "url"
+      ],
       "nameExplicit": false,
       "name": "control_account_pk",
       "entityType": "pks",
       "table": "control_account"
     },
     {
-      "columns": ["project_id", "directory"],
+      "columns": [
+        "project_id",
+        "directory"
+      ],
       "nameExplicit": false,
       "name": "project_directory_pk",
       "entityType": "pks",
       "table": "project_directory"
     },
     {
-      "columns": ["session_id", "position"],
+      "columns": [
+        "session_id",
+        "position"
+      ],
       "nameExplicit": false,
       "name": "todo_pk",
       "entityType": "pks",
       "table": "todo"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "workspace_pk",
       "table": "workspace",
       "entityType": "pks"
     },
     {
-      "columns": ["name"],
+      "columns": [
+        "name"
+      ],
       "nameExplicit": false,
       "name": "data_migration_pk",
       "table": "data_migration",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "account_state_pk",
       "table": "account_state",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "account_pk",
       "table": "account",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "credential_pk",
       "table": "credential",
       "entityType": "pks"
     },
     {
-      "columns": ["aggregate_id"],
+      "columns": [
+        "aggregate_id"
+      ],
       "nameExplicit": false,
       "name": "event_sequence_pk",
       "table": "event_sequence",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "event_pk",
       "table": "event",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "permission_pk",
       "table": "permission",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "project_pk",
       "table": "project",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "message_pk",
       "table": "message",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "part_pk",
       "table": "part",
       "entityType": "pks"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "nameExplicit": false,
       "name": "session_context_epoch_pk",
       "table": "session_context_epoch",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_input_pk",
       "table": "session_input",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_message_pk",
       "table": "session_message",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_pk",
       "table": "session",
       "entityType": "pks"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "nameExplicit": false,
       "name": "session_share_pk",
       "table": "session_share",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "workflow_run_pk",
+      "table": "workflow_run",
       "entityType": "pks"
     },
     {
@@ -2065,6 +2351,38 @@
       "name": "todo_session_idx",
       "entityType": "indexes",
       "table": "todo"
+    },
+    {
+      "columns": [
+        {
+          "value": "started_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workflow_run_started_at_idx",
+      "entityType": "indexes",
+      "table": "workflow_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        },
+        {
+          "value": "started_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "workflow_run_status_started_at_idx",
+      "entityType": "indexes",
+      "table": "workflow_run"
     }
   ],
   "renames": []

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -37,6 +37,7 @@ export const migrations = (
     import("./migration/20260611035744_credential"),
     import("./migration/20260611192811_lush_chimera"),
     import("./migration/20260612174303_project_dir_strategy"),
+    import("./migration/20260615050011_real_rachel_grey"),
     import("./migration/20260622142730_simplify_session_context_epoch"),
     import("./migration/20260622170816_reset_v2_session_state"),
     import("./migration/20260622202450_simplify_session_input"),

--- a/packages/core/src/database/migration/20260615050011_real_rachel_grey.ts
+++ b/packages/core/src/database/migration/20260615050011_real_rachel_grey.ts
@@ -1,0 +1,34 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260615050011_real_rachel_grey",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`
+        CREATE TABLE \`workflow_run\` (
+          \`id\` text PRIMARY KEY,
+          \`session_id\` text,
+          \`directory\` text DEFAULT '' NOT NULL,
+          \`workflow\` text NOT NULL,
+          \`status\` text NOT NULL,
+          \`started_at\` integer NOT NULL,
+          \`completed_at\` integer,
+          \`current_phase\` text,
+          \`args\` text,
+          \`definition\` text,
+          \`logs\` text NOT NULL,
+          \`agents\` text NOT NULL,
+          \`result\` text,
+          \`error\` text,
+          \`resume_of\` text,
+          \`pending_question\` text,
+          \`time_created\` integer NOT NULL,
+          \`time_updated\` integer NOT NULL
+        );
+      `)
+      yield* tx.run(`CREATE INDEX \`workflow_run_started_at_idx\` ON \`workflow_run\` (\`started_at\`);`)
+      yield* tx.run(`CREATE INDEX \`workflow_run_status_started_at_idx\` ON \`workflow_run\` (\`status\`,\`started_at\`);`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -236,6 +236,28 @@ export default {
           CONSTRAINT \`fk_session_share_session_id_session_id_fk\` FOREIGN KEY (\`session_id\`) REFERENCES \`session\`(\`id\`) ON DELETE CASCADE
         );
       `)
+      yield* tx.run(`
+        CREATE TABLE \`workflow_run\` (
+          \`id\` text PRIMARY KEY,
+          \`session_id\` text,
+          \`directory\` text DEFAULT '' NOT NULL,
+          \`workflow\` text NOT NULL,
+          \`status\` text NOT NULL,
+          \`started_at\` integer NOT NULL,
+          \`completed_at\` integer,
+          \`current_phase\` text,
+          \`args\` text,
+          \`definition\` text,
+          \`logs\` text NOT NULL,
+          \`agents\` text NOT NULL,
+          \`result\` text,
+          \`error\` text,
+          \`resume_of\` text,
+          \`pending_question\` text,
+          \`time_created\` integer NOT NULL,
+          \`time_updated\` integer NOT NULL
+        );
+      `)
       yield* tx.run(`CREATE UNIQUE INDEX \`event_aggregate_seq_idx\` ON \`event\` (\`aggregate_id\`,\`seq\`);`)
       yield* tx.run(`CREATE INDEX \`event_aggregate_type_seq_idx\` ON \`event\` (\`aggregate_id\`,\`type\`,\`seq\`);`)
       yield* tx.run(
@@ -269,6 +291,10 @@ export default {
       yield* tx.run(`CREATE INDEX \`session_workspace_idx\` ON \`session\` (\`workspace_id\`);`)
       yield* tx.run(`CREATE INDEX \`session_parent_idx\` ON \`session\` (\`parent_id\`);`)
       yield* tx.run(`CREATE INDEX \`todo_session_idx\` ON \`todo\` (\`session_id\`);`)
+      yield* tx.run(`CREATE INDEX \`workflow_run_started_at_idx\` ON \`workflow_run\` (\`started_at\`);`)
+      yield* tx.run(
+        `CREATE INDEX \`workflow_run_status_started_at_idx\` ON \`workflow_run\` (\`status\`,\`started_at\`);`,
+      )
     })
   },
 } satisfies Omit<DatabaseMigration.Migration, "id">

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -163,6 +163,41 @@ export const Info = Schema.Struct({
       }),
     }),
   ),
+  workflows: Schema.optional(
+    Schema.Struct({
+      ultracode_keyword: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Detect the standalone `ultracode` keyword in the prompt and highlight it; on submit it opts the turn into workflow orchestration (default: true)",
+      }),
+      approval: Schema.optional(Schema.Literals(["always", "first-run", "never"])).annotate({
+        description:
+          "When to ask before an interactive workflow start. 'first-run' (default) asks once per workflow until approved, 'always' asks every time, 'never' starts without asking.",
+      }),
+      approved: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
+        description: "Workflow names that have been approved via 'Yes, always' in the interactive start dialog.",
+      }),
+      foreground_grace_ms: Schema.optional(NonNegativeInt).annotate({
+        description:
+          "How long a workflow start waits in the foreground before switching the run to the background (milliseconds, default 45000). Only applies when neither background nor timeout is set explicitly.",
+      }),
+      budget_directive: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Detect the `+$N` budget directive in the prompt and highlight it; on submit it reserves that budget for workflow orchestration in the turn (default: true)",
+      }),
+      shell_permission: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Gate workflow ctx.shell commands through the caller's bash permission ruleset, exactly like the bash tool (default: true). Set to false to restore the ungated behavior.",
+      }),
+      lint: Schema.optional(Schema.Literals(["off", "warn", "deny"])).annotate({
+        description:
+          "Static source lint for workflow scripts on create/inline start (node builtins, Bun.spawn, process.env, fetch, dynamic import). 'warn' (default) surfaces findings non-blocking, 'deny' fails create/start on findings, 'off' disables the lint.",
+      }),
+      lazy_mcp: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Load MCP tools lazily in workflow subagent sessions via the tool_search meta-tool instead of registering every MCP schema eagerly (default: true).",
+      }),
+    }),
+  ).annotate({ description: "Workflow orchestration options" }),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/core/src/workflow/sql.ts
+++ b/packages/core/src/workflow/sql.ts
@@ -1,0 +1,166 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
+import { Timestamps } from "../database/schema.sql"
+
+// The workflow_run table lives in core (not in the opencode engine that owns the
+// runtime logic) because migrations are applied by core: every Drizzle table must
+// be declared here so the schema/migration pipeline sees it (cf. AGENTS.md,
+// "migrations live in packages/core and are applied by core"). The engine in
+// `packages/opencode/src/workflow/workflow.ts` re-exports the table via a one-line
+// bridge and owns the Effect schemas that validate these shapes at runtime.
+//
+// These row types are the SINGLE SOURCE OF TRUTH for the JSON column payloads:
+// they are the persistence contract that defines the columns. The engine's Effect
+// schemas (the runtime validators) are asserted assignable to/from these row types
+// at compile time, so the two can never silently drift again — a field added,
+// removed, or retyped on either side fails the engine build. The dependency law
+// (core must not import the engine) means the canonical declaration has to live
+// here in core; the assertion lives in the engine, which legally imports core.
+
+export type WorkflowDefinitionRow = {
+  name: string
+  path: string
+  meta: {
+    name: string
+    description?: string
+    // Phases are persisted in their NORMALIZED (decoded) shape — always objects
+    // (`{ title, detail?, model? }`), never bare strings. The engine normalizes a
+    // workflow's authored phases (which may be strings OR objects on the public
+    // contract) the moment meta is decoded, and `mutableMeta` writes that decoded
+    // form into the definition JSON, so the row only ever holds objects.
+    phases?: { title: string; detail?: string; model?: string }[]
+    arguments?: Record<string, { type?: string; default?: unknown; description?: string }>
+  }
+  source?: string
+  temporary?: boolean
+}
+
+export type WorkflowLogRow = {
+  time: number
+  phase?: string
+  message: string
+}
+
+export type WorkflowAgentRow = {
+  id: string
+  // Agent NODES only ever carry these four ("skipped" = a human skipped the step
+  // via skipAgent, Item 15). The run-level `status` column below is widened to
+  // also include "cancelled"/"interrupted", but those are RUN lifecycle states
+  // only: on cancel/interrupt the engine rewrites a still-running agent node to
+  // "failed" (with an explanatory error), and the orphan sweep touches only the
+  // run row, never the agents JSON. Keep this union in lockstep with the
+  // engine's `AgentRun` schema (asserted at compile time over there).
+  status: "running" | "completed" | "failed" | "skipped"
+  started_at: number
+  completed_at?: number
+  phase?: string
+  agent?: string
+  // Per-call display name (Item 16), set from `ctx.agent({ label })`. Display-only
+  // (never part of the resume journal key). Keep in lockstep with the engine's
+  // `AgentRun` schema (asserted at compile time over there).
+  label?: string
+  model?: string
+  session_id?: string
+  message_id?: string
+  // Item 7: the isolated `git worktree` base directory this step ran in (only
+  // for isolation:"worktree" steps; preserved worktrees stay inspectable here).
+  // Keep in lockstep with the engine's `AgentRun` schema (asserted at compile
+  // time over there).
+  worktree?: string
+  prompt: string
+  output?: string
+  cost?: number
+  tokens?: {
+    total?: number
+    input: number
+    output: number
+    reasoning: number
+    cache: {
+      read: number
+      write: number
+    }
+  }
+  error?: string
+  // `true` when this agent node was replayed from a resumed run's persisted
+  // journal rather than executed live. Omitted for a live step. Keep this in
+  // lockstep with the engine's `AgentRun` schema (asserted at compile time).
+  cached?: boolean
+  // The journal node KIND (Tasks 12/13). `"agent"` (or undefined, for rows
+  // written before this field existed) is a normal LLM agent step; `"question"`
+  // is a human-in-the-loop `ctx.question` step whose `prompt` holds the question
+  // text and whose `answer` (below) is filled in once the user replies. Old rows
+  // decode with `kind` absent, which the engine reads as `"agent"`. Keep this in
+  // lockstep with the engine's `AgentRun` schema (asserted at compile time).
+  kind?: "agent" | "question"
+  // The answer recorded on a `kind:"question"` node once the question was
+  // answered (live) or replayed from a resumed run's journal. Omitted while the
+  // question is still open / for non-question nodes. Keep in lockstep with the
+  // engine's `AgentRun` schema.
+  answer?: string
+}
+
+export const WorkflowRunTable = sqliteTable(
+  "workflow_run",
+  {
+    id: text().primaryKey(),
+    session_id: text(),
+    // The workspace directory the run was started in (InstanceState.directory).
+    // The DB is process-global (one opencode.db under Global.Path.data) but the
+    // workflow endpoints are per-directory (WorkspaceRoutingMiddleware), so every
+    // read/delete/sweep is scoped to this column — a run started in directory A
+    // must never leak into / be deleted from directory B (Fund 6/17). Legacy rows
+    // written before this column existed get the `""` default and stay visible as
+    // "global/legacy" (no crash on old DBs); never NULL so the scoping equality
+    // comparison is total.
+    directory: text().notNull().default(""),
+    workflow: text().notNull(),
+    // `paused` is a non-terminal status: a run the user explicitly suspended via
+    // pause() (sessions aborted, scope closed, fiber interrupted — like cancel),
+    // but whose persisted agent journal is kept intact so a later resume can
+    // replay the completed agents instead of re-running them. Distinct from
+    // `cancelled`/`interrupted` (both terminal): a paused run is neither finished
+    // nor lost, it is parked. Keep this union in lockstep with the engine's
+    // `Status` schema (asserted assignable at compile time over there).
+    status: text().$type<"running" | "completed" | "failed" | "cancelled" | "interrupted" | "paused">().notNull(),
+    started_at: integer().notNull(),
+    completed_at: integer(),
+    current_phase: text(),
+    args: text({ mode: "json" }).$type<Record<string, unknown>>(),
+    definition: text({ mode: "json" }).$type<WorkflowDefinitionRow>(),
+    logs: text({ mode: "json" }).notNull().$type<WorkflowLogRow[]>(),
+    agents: text({ mode: "json" }).notNull().$type<WorkflowAgentRow[]>(),
+    // Plain `text` (NOT `mode: "json"`) on purpose (Fund 42): Drizzle's JSON mode
+    // decodes BOTH the SQL value NULL and the literal JSON text `"null"` to JS
+    // `null`, collapsing two distinct states — a result that was never recorded
+    // (column empty) vs. a workflow that genuinely returned `null`. The engine
+    // must tell them apart (empty → reported `undefined` / "No result recorded.";
+    // real null → reported `null`), so it owns the JSON serialization explicitly:
+    // it writes SQL NULL for an unset result and the text `"null"` for a real one,
+    // and parses the text back in `fromRow`. The on-disk type is unchanged (`text`
+    // either way), so no migration is required. JSON mode stays on logs/agents,
+    // which never carry that null/undefined ambiguity.
+    result: text(),
+    error: text(),
+    // Nullable back-reference to the run this run was resumed FROM (a previous
+    // paused/interrupted run id). When set, start() loaded the source run's
+    // persisted agent journal and replayed every completed agent it could match
+    // instead of re-prompting them — so a resume is cheap and cross-restart
+    // (the journal lives in the DB, not in memory). NULL for an ordinary
+    // (non-resume) start. Purely a provenance/audit field on the row; the engine
+    // reads it back as `resume_of` on the public Run.
+    resume_of: text(),
+    // The open human-in-the-loop question a running run is currently waiting on
+    // (Tasks 12/13). Set when `ctx.question` is awaited and the answer has not yet
+    // arrived; cleared the moment the answer lands (live) or the question node is
+    // replayed during a resume. A JSON object `{ question, options?, asked_at }` so
+    // a paused run that timed out keeps the open question persisted across restarts
+    // (the journal also keeps the matching `kind:"question"` agent node). NULL when
+    // no question is pending — the common case. Distinct from the agent journal:
+    // this is the SINGLE in-flight question, the journal is the audit trail.
+    pending_question: text({ mode: "json" }).$type<{ question: string; options?: string[]; asked_at: number }>(),
+    ...Timestamps,
+  },
+  (table) => [
+    index("workflow_run_started_at_idx").on(table.started_at),
+    index("workflow_run_status_started_at_idx").on(table.status, table.started_at),
+  ],
+)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1628,6 +1628,7 @@ const ModelRef = Schema.Struct({
 
 export const PromptInput = Schema.Struct({
   sessionID: SessionID,
+  permissionSessionID: Schema.optional(SessionID),
   messageID: Schema.optional(MessageID),
   model: Schema.optional(ModelRef),
   agent: Schema.optional(Schema.String),
@@ -1639,6 +1640,22 @@ export const PromptInput = Schema.Struct({
   format: Schema.optional(SessionV1.Format),
   system: Schema.optional(Schema.String),
   variant: Schema.optional(Schema.String),
+  // Item 24: optional shared TURN budget. When set, the prompt creates ONE
+  // TurnBudget.Pool for this turn: the main loop charges it directly (never
+  // gated) and every workflow run started by this turn reserves/settles
+  // against it — so multiple runs of one turn share a single cap. Non-negative
+  // finite, mirroring the workflow budget validation.
+  turnBudget: Schema.optional(
+    Schema.Struct({
+      usd: Schema.optional(Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0))),
+      tokens: Schema.optional(Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0))),
+    }),
+  ),
+  // Item 28: MCP tool loading mode for this session's loop. 'eager' (default)
+  // registers every MCP tool schema as before; 'lazy' starts with only the
+  // tool_search meta-tool and registers MCP tools on activation. Workflow
+  // subagent sessions are started lazy (config workflows.lazy_mcp).
+  mcp: Schema.optional(Schema.Literals(["eager", "lazy"])),
   parts: Schema.Array(
     Schema.Union([
       SessionV1.TextPartInput,

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -469,6 +469,15 @@ export interface Interface {
     metadata?: typeof Metadata.Type
     permission?: PermissionV1.Ruleset
     workspaceID?: WorkspaceV2.ID
+    /**
+     * Working directory recorded on the session row. Defaults to the instance
+     * directory (`ctx.directory`) — the prior, only behaviour. A caller may
+     * override it to record that the session ran somewhere else (e.g. a workflow
+     * subagent isolated inside a git worktree), so the dashboard reflects where
+     * the work happened. Purely a metadata override; it does NOT change where
+     * tools resolve their cwd (that follows the effective `InstanceRef`).
+     */
+    directory?: string
   }) => Effect.Effect<Info>
   readonly fork: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Info, NotFound>
   readonly touch: (sessionID: SessionID) => Effect.Effect<void>
@@ -714,12 +723,13 @@ export const layer: Layer.Layer<
       metadata?: typeof Metadata.Type
       permission?: PermissionV1.Ruleset
       workspaceID?: WorkspaceV2.ID
+      directory?: string
     }) {
       const ctx = yield* InstanceState.context
       const workspace = yield* InstanceState.workspaceID
       return yield* createNext({
         parentID: input?.parentID,
-        directory: ctx.directory,
+        directory: input?.directory ?? ctx.directory,
         path: sessionPath(ctx.worktree, ctx.directory),
         title: input?.title,
         agent: input?.agent,

--- a/packages/opencode/src/session/turn-budget.ts
+++ b/packages/opencode/src/session/turn-budget.ts
@@ -1,0 +1,108 @@
+// Item 24: shared per-TURN budget pool. ONE pool is created per prompt turn
+// (SessionPrompt.prompt) and shared by the main loop (chargeDirect on each
+// step-finish) and EVERY workflow run the turn starts (reserve/settle around
+// each ctx.agent step) — so two runs of the same turn compete for the same
+// USD headroom instead of each getting its own cap.
+//
+// The pool is turn-scoped and IN-MEMORY by design: it binds to exactly one
+// prompt turn, and plain object-reference sharing carries it everywhere it
+// needs to go (a background run keeps holding the reference past the turn's
+// end; the main loop simply stops charging once the turn finished). It is
+// deliberately NOT persisted (InstanceState/DB) — a resume turn brings its own
+// fresh pool.
+//
+// ATOMICITY: `reserve` is a synchronous check-and-set with no await in
+// between. Bun is single-threaded, so no other fiber can interleave between
+// the headroom check and the reservation — this closes the audited soft-cap
+// race of the per-run budget gate (N parallel steps could all pass a
+// check-only gate before any of them charged). The known residual: with
+// `avgStepUsd === 0` (no settled step yet) reservations are free, so the
+// FIRST parallel wave can still overspend bounded by its in-flight cost —
+// exactly the per-run soft cap's documented bound.
+//
+// The `tokens` limit is structurally prepared (Item 17 supplies the token
+// telemetry) but the reservation itself is USD-denominated; a tokens-only
+// pool gates on committed tokens at reserve time.
+
+export type Limit = { total: number; committed: number; reserved: number }
+
+export type Pool = {
+  id: string
+  usd?: Limit
+  tokens?: Limit
+  /**
+   * Rolling average USD cost of a settled step — the reservation ESTIMATE for
+   * the next step. Starts at 0 (free reservations until the first settlement;
+   * see the residual soft-cap note above).
+   */
+  avgStepUsd: number
+  /** Number of settled steps feeding `avgStepUsd`. */
+  steps: number
+}
+
+export type Reservation = { usd: number }
+
+let counter = 0
+
+export function make(input: { usd?: number; tokens?: number }): Pool {
+  counter += 1
+  return {
+    id: `turnpool_${counter}`,
+    usd: input.usd !== undefined ? { total: input.usd, committed: 0, reserved: 0 } : undefined,
+    tokens: input.tokens !== undefined ? { total: input.tokens, committed: 0, reserved: 0 } : undefined,
+    avgStepUsd: 0,
+    steps: 0,
+  }
+}
+
+/**
+ * SYNCHRONOUS check-and-set: refuses (returns undefined) when any configured
+ * limit is exhausted (committed + reserved >= total), otherwise reserves
+ * `estimateUsd` against the USD limit and returns the reservation the caller
+ * MUST later `settle` (ensuring-style, on every outcome) so reserved headroom
+ * can never leak.
+ */
+export function reserve(pool: Pool, estimateUsd: number): Reservation | undefined {
+  if (pool.usd !== undefined && pool.usd.committed + pool.usd.reserved >= pool.usd.total) return undefined
+  if (pool.tokens !== undefined && pool.tokens.committed + pool.tokens.reserved >= pool.tokens.total) return undefined
+  const usd = Math.max(0, estimateUsd)
+  if (pool.usd !== undefined) pool.usd.reserved += usd
+  return { usd }
+}
+
+/**
+ * Releases a reservation and commits the step's ACTUAL spend (0 for an
+ * aborted/cancelled step — the caller decides), advancing the rolling
+ * per-step average that prices the next reservation.
+ */
+export function settle(pool: Pool, reservation: Reservation, actual: { usd: number; tokens?: number }): void {
+  if (pool.usd !== undefined) {
+    pool.usd.reserved = Math.max(0, pool.usd.reserved - reservation.usd)
+    pool.usd.committed += actual.usd
+  }
+  if (pool.tokens !== undefined && actual.tokens !== undefined) pool.tokens.committed += actual.tokens
+  pool.steps += 1
+  pool.avgStepUsd = pool.avgStepUsd + (actual.usd - pool.avgStepUsd) / pool.steps
+}
+
+/**
+ * Main-loop charging: commits actual spend WITHOUT a reservation and is NEVER
+ * gated — the turn's own model loop must not be refused by its own pool; the
+ * pool throttles the workflow steps it spawned.
+ */
+export function chargeDirect(pool: Pool, actual: { usd: number; tokens?: number }): void {
+  if (pool.usd !== undefined) pool.usd.committed += actual.usd
+  if (pool.tokens !== undefined && actual.tokens !== undefined) pool.tokens.committed += actual.tokens
+}
+
+export function remaining(pool: Pool): { usd?: number; tokens?: number } {
+  return {
+    usd: pool.usd !== undefined ? Math.max(0, pool.usd.total - pool.usd.committed - pool.usd.reserved) : undefined,
+    tokens:
+      pool.tokens !== undefined
+        ? Math.max(0, pool.tokens.total - pool.tokens.committed - pool.tokens.reserved)
+        : undefined,
+  }
+}
+
+export * as TurnBudget from "./turn-budget"

--- a/packages/opencode/src/tool/catalog.ts
+++ b/packages/opencode/src/tool/catalog.ts
@@ -1,0 +1,427 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { httpClient } from "@opencode-ai/core/effect/layer-node-platform"
+import { Glob } from "@opencode-ai/core/util/glob"
+import { Database } from "@opencode-ai/core/database/database"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { FetchHttpClient } from "effect/unstable/http"
+import { Context, Effect, Layer, Schema } from "effect"
+import { Agent } from "@/agent/agent"
+import { BackgroundJob } from "@/background/job"
+import { Config } from "@/config/config"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Format } from "@/format"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Instruction } from "@/session/instruction"
+import { LSP } from "@/lsp/lsp"
+import { Permission } from "@/permission"
+import { Plugin } from "@/plugin"
+import { Provider } from "@/provider/provider"
+import { Question } from "@/question"
+import { Session } from "@/session/session"
+import { Skill } from "@/skill"
+import { Todo } from "@/session/todo"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Truncate } from "./truncate"
+import { ApplyPatchTool } from "./apply_patch"
+import { EditTool } from "./edit"
+import { GlobTool } from "./glob"
+import { GrepTool } from "./grep"
+import { InvalidTool } from "./invalid"
+import { LspTool } from "./lsp"
+import { PlanExitTool } from "./plan"
+import { QuestionTool } from "./question"
+import { ReadTool } from "./read"
+import { ShellTool } from "./shell"
+import { SkillTool } from "./skill"
+import { TaskTool } from "./task"
+import { TodoWriteTool } from "./todo"
+import { Tool } from "./tool"
+import { WebFetchTool } from "./webfetch"
+import { WebSearchTool } from "./websearch"
+import { WriteTool } from "./write"
+import { pathToFileURL } from "url"
+import path from "path"
+import type { JSONSchema7, JSONSchema7Definition } from "@ai-sdk/provider"
+import { type ToolContext as PluginToolContext, type ToolDefinition } from "@opencode-ai/plugin"
+import z from "zod"
+import { EffectBridge } from "@/effect/bridge"
+import { InstanceState } from "@/effect/instance-state"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+
+type TaskDef = Tool.InferDef<typeof TaskTool>
+type ReadDef = Tool.InferDef<typeof ReadTool>
+
+type State = {
+  custom: Tool.Def[]
+  builtin: Tool.Def[]
+  task: TaskDef
+  read: ReadDef
+}
+
+export interface Interface {
+  readonly all: () => Effect.Effect<Tool.Def[]>
+  readonly named: () => Effect.Effect<{ task: TaskDef; read: ReadDef }>
+  readonly tools: (input: {
+    providerID: ProviderV2.ID
+    modelID: ModelV2.ID
+    agent: Agent.Info
+    ultracode?: boolean
+  }) => Effect.Effect<Tool.Def[]>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/ToolCatalog") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const config = yield* Config.Service
+    const plugin = yield* Plugin.Service
+    const agents = yield* Agent.Service
+    const truncate = yield* Truncate.Service
+    const flags = yield* RuntimeFlags.Service
+    const agent = yield* Agent.Service
+
+    const invalid = yield* InvalidTool
+    const task = yield* TaskTool
+    const read = yield* ReadTool
+    const question = yield* QuestionTool
+    const todo = yield* TodoWriteTool
+    const lsptool = yield* LspTool
+    const plan = yield* PlanExitTool
+    const webfetch = yield* WebFetchTool
+    const websearch = yield* WebSearchTool
+    const shell = yield* ShellTool
+    const globtool = yield* GlobTool
+    const writetool = yield* WriteTool
+    const edit = yield* EditTool
+    const greptool = yield* GrepTool
+    const patchtool = yield* ApplyPatchTool
+    const skilltool = yield* SkillTool
+
+    const state = yield* InstanceState.make<State>(
+      Effect.fn("ToolCatalog.state")(function* (ctx) {
+        const custom: Tool.Def[] = []
+
+        function fromPlugin(id: string, def: ToolDefinition): Tool.Def {
+          const args = def.args ?? {}
+          const entries = Object.entries(args)
+          const allZod = entries.every((entry) => isZodType(entry[1]))
+          const zodParams = allZod ? z.object(args) : undefined
+          const jsonSchema = zodParams ? zodJsonSchema(zodParams) : legacyJsonSchema(entries)
+          const parameters = zodParams
+            ? Schema.declare<unknown>((u): u is unknown => zodParams.safeParse(u).success)
+            : Schema.Unknown
+          return {
+            id,
+            parameters,
+            jsonSchema,
+            description: def.description,
+            execute: (args, toolCtx) =>
+              Effect.gen(function* () {
+                const bridge = yield* EffectBridge.make()
+                const pluginCtx: PluginToolContext = {
+                  ...toolCtx,
+                  ask: (req) => bridge.promise(toolCtx.ask(req)),
+                  directory: ctx.directory,
+                  worktree: ctx.worktree,
+                }
+                const result = yield* Effect.promise(() => def.execute(args as never, pluginCtx))
+                const output = typeof result === "string" ? result : result.output
+                const metadata = typeof result === "string" ? {} : (result.metadata ?? {})
+                const attachments = typeof result === "string" ? undefined : result.attachments
+                const info = yield* agent.get(toolCtx.agent)
+                const out = yield* truncate.output(output, {}, info)
+                return {
+                  title: typeof result === "string" ? "" : (result.title ?? ""),
+                  output: out.truncated ? out.content : output,
+                  attachments,
+                  metadata: {
+                    ...metadata,
+                    truncated: out.truncated,
+                    ...(out.truncated && { outputPath: out.outputPath }),
+                  },
+                }
+              }).pipe(
+                Effect.withSpan("Tool.execute", {
+                  attributes: {
+                    "tool.name": id,
+                    "session.id": toolCtx.sessionID,
+                    "message.id": toolCtx.messageID,
+                    ...(toolCtx.callID ? { "tool.call_id": toolCtx.callID } : {}),
+                  },
+                }),
+              ),
+          }
+        }
+
+        const dirs = yield* config.directories()
+        const matches = dirs.flatMap((dir) =>
+          Glob.scanSync("{tool,tools}/*.{js,ts}", { cwd: dir, absolute: true, dot: true, symlink: true }),
+        )
+        if (matches.length) yield* config.waitForDependencies()
+        for (const match of matches) {
+          const namespace = path.basename(match, path.extname(match))
+          const mod = yield* Effect.promise(() => import(pathToFileURL(match).href))
+          for (const [id, def] of Object.entries(mod)) {
+            if (!isPluginTool(def)) continue
+            custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
+          }
+        }
+
+        const plugins = yield* plugin.list()
+        for (const p of plugins) {
+          for (const [id, def] of Object.entries(p.tool ?? {})) {
+            custom.push(fromPlugin(id, def))
+          }
+        }
+
+        yield* config.get()
+        const questionEnabled = ["app", "cli", "desktop"].includes(flags.client) || flags.enableQuestionTool
+
+        const tool = yield* Effect.all({
+          invalid: Tool.init(invalid),
+          shell: Tool.init(shell),
+          read: Tool.init(read),
+          glob: Tool.init(globtool),
+          grep: Tool.init(greptool),
+          edit: Tool.init(edit),
+          write: Tool.init(writetool),
+          task: Tool.init(task),
+          fetch: Tool.init(webfetch),
+          todo: Tool.init(todo),
+          search: Tool.init(websearch),
+          skill: Tool.init(skilltool),
+          patch: Tool.init(patchtool),
+          question: Tool.init(question),
+          lsp: Tool.init(lsptool),
+          plan: Tool.init(plan),
+        })
+
+        return {
+          custom,
+          builtin: [
+            tool.invalid,
+            ...(questionEnabled ? [tool.question] : []),
+            tool.shell,
+            tool.read,
+            tool.glob,
+            tool.grep,
+            tool.edit,
+            tool.write,
+            tool.task,
+            tool.fetch,
+            tool.todo,
+            tool.search,
+            tool.skill,
+            tool.patch,
+            ...(flags.experimentalLspTool ? [tool.lsp] : []),
+            ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),
+          ],
+          task: tool.task,
+          read: tool.read,
+        }
+      }),
+    )
+
+    const all: Interface["all"] = Effect.fn("ToolCatalog.all")(function* () {
+      const s = yield* InstanceState.get(state)
+      return [...s.builtin, ...s.custom] as Tool.Def[]
+    })
+
+    const describeTask = Effect.fn("ToolCatalog.describeTask")(function* (agent: Agent.Info) {
+      const items = (yield* agents.list()).filter((item) => item.mode !== "primary")
+      const filtered = items.filter(
+        (item) => Permission.evaluate("task", item.name, agent.permission).action !== "deny",
+      )
+      const list = filtered.toSorted((a, b) => a.name.localeCompare(b.name))
+      const description = list
+        .map(
+          (item) =>
+            `- ${item.name}: ${item.description ?? "This subagent should only be called manually by the user."}`,
+        )
+        .join("\n")
+      return ["Available agent types and the tools they have access to:", description].join("\n")
+    })
+
+    const tools: Interface["tools"] = Effect.fn("ToolCatalog.tools")(function* (input) {
+      const filtered = (yield* all()).filter((tool) => {
+        if (tool.id === WebSearchTool.id) {
+          return input.providerID === ProviderV2.ID.opencode || flags.enableExa || flags.enableParallel
+        }
+
+        const usePatch =
+          input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4")
+        if (tool.id === ApplyPatchTool.id) return usePatch
+        if (tool.id === EditTool.id || tool.id === WriteTool.id) return !usePatch
+
+        return true
+      })
+
+      return yield* Effect.forEach(
+        filtered,
+        Effect.fnUntraced(function* (tool: Tool.Def) {
+          const output = {
+            description: tool.description,
+            parameters: tool.parameters,
+            jsonSchema: tool.jsonSchema,
+          }
+          yield* plugin.trigger("tool.definition", { toolID: tool.id }, output)
+          const jsonSchema =
+            output.parameters === tool.parameters || output.jsonSchema !== tool.jsonSchema
+              ? output.jsonSchema
+              : undefined
+          return {
+            id: tool.id,
+            description: [output.description, tool.id === TaskTool.id ? yield* describeTask(input.agent) : undefined]
+              .filter(Boolean)
+              .join("\n"),
+            parameters: output.parameters,
+            jsonSchema,
+            execute: tool.execute,
+            formatValidationError: tool.formatValidationError,
+          }
+        }),
+        { concurrency: "unbounded" },
+      )
+    })
+
+    const named: Interface["named"] = Effect.fn("ToolCatalog.named")(function* () {
+      const s = yield* InstanceState.get(state)
+      return { task: s.task, read: s.read }
+    })
+
+    return Service.of({ all, named, tools })
+  }),
+)
+
+export const defaultLayer = Layer.suspend(() =>
+  layer
+    .pipe(
+      Layer.provide(Config.defaultLayer),
+      Layer.provide(Plugin.defaultLayer),
+      Layer.provide(Question.defaultLayer),
+      Layer.provide(Todo.defaultLayer),
+      Layer.provide(Skill.defaultLayer),
+      Layer.provide(Agent.defaultLayer),
+      Layer.provide(Session.defaultLayer),
+      Layer.provide(BackgroundJob.defaultLayer),
+      Layer.provide(Provider.defaultLayer),
+      Layer.provide(LSP.defaultLayer),
+      Layer.provide(Instruction.defaultLayer),
+      Layer.provide(FSUtil.defaultLayer),
+      Layer.provide(EventV2Bridge.defaultLayer),
+      Layer.provide(FetchHttpClient.layer),
+      Layer.provide(Format.defaultLayer),
+      Layer.provide(CrossSpawnSpawner.defaultLayer),
+      Layer.provide(Truncate.defaultLayer),
+      Layer.provide(Ripgrep.defaultLayer),
+    )
+    .pipe(
+      Layer.provide(Database.defaultLayer),
+      Layer.provide(RuntimeFlags.defaultLayer),
+    ),
+)
+
+export const node = LayerNode.make(layer.pipe(Layer.provide(Ripgrep.defaultLayer)), [
+  Config.node,
+  Plugin.node,
+  Question.node,
+  Todo.node,
+  Agent.node,
+  Skill.node,
+  Session.node,
+  BackgroundJob.node,
+  Provider.node,
+  LSP.node,
+  Instruction.node,
+  FSUtil.node,
+  EventV2Bridge.node,
+  httpClient,
+  CrossSpawnSpawner.node,
+  Format.node,
+  Truncate.node,
+  RuntimeFlags.node,
+  Database.node,
+])
+
+function isZodType(value: unknown): value is z.ZodType {
+  return typeof value === "object" && value !== null && "_zod" in value
+}
+
+function isPluginTool(value: unknown): value is ToolDefinition {
+  return typeof value === "object" && value !== null && "args" in value && "description" in value && "execute" in value
+}
+
+function isJsonSchemaDefinition(value: unknown): value is JSONSchema7Definition {
+  return typeof value === "boolean" || (typeof value === "object" && value !== null && !Array.isArray(value))
+}
+
+function legacyJsonSchema(entries: [string, unknown][]): JSONSchema7 {
+  const properties = Object.fromEntries(
+    entries.filter((entry): entry is [string, JSONSchema7Definition] => isJsonSchemaDefinition(entry[1])),
+  )
+  const required = Object.keys(properties)
+  return {
+    type: "object",
+    properties,
+    required: required.length ? required : undefined,
+    additionalProperties: true,
+  }
+}
+
+function zodJsonSchema(schema: z.ZodType): JSONSchema7 {
+  const result = normalizeZodJsonSchema(z.toJSONSchema(schema, { io: "input", metadata: zodMetadataRegistry(schema) }))
+  if (!isJsonSchemaObject(result)) throw new Error("plugin tool Zod schema produced a non-object JSON Schema")
+  const { $defs, ...rest } = result
+  return (
+    $defs && isJsonSchemaObject($defs) ? { ...rest, definitions: $defs as JSONSchema7["definitions"] } : rest
+  ) as JSONSchema7
+}
+
+function zodMetadataRegistry(schema: z.ZodType) {
+  const registry = z.registry<Record<string, unknown>>()
+  const seen = new WeakSet<object>()
+  const collect = (value: unknown) => {
+    if (typeof value !== "object" || value === null) return
+    if (seen.has(value)) return
+    seen.add(value)
+
+    if (isZodType(value)) {
+      const metadata = typeof value.meta === "function" ? value.meta() : undefined
+      const description = typeof value.description === "string" ? value.description : undefined
+      const merged = {
+        ...(metadata && typeof metadata === "object" ? metadata : {}),
+        ...(description ? { description } : {}),
+      }
+      if (Object.keys(merged).length) registry.add(value, merged)
+      collect(value._zod.def)
+      return
+    }
+
+    for (const item of Object.values(value)) collect(item)
+  }
+  collect(schema)
+  return registry
+}
+
+function normalizeZodJsonSchema(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => normalizeZodJsonSchema(item))
+  if (typeof value !== "object" || value === null) return value
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter((entry) =>
+        (entry[0] === "exclusiveMaximum" || entry[0] === "exclusiveMinimum") && typeof entry[1] === "boolean"
+          ? false
+          : true,
+      )
+      .map(([key, item]) => [key, normalizeZodJsonSchema(item)]),
+  )
+}
+
+function isJsonSchemaObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export * as ToolCatalog from "./catalog"

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -70,7 +70,9 @@ type Part = {
   text: string
 }
 
-type Scan = {
+// Exported for the workflow engine's ctx.shell gate (Item 23), which consumes
+// the same Scan shape `scanCommand` returns.
+export type Scan = {
   dirs: Set<string>
   patterns: Set<string>
   always: Set<string>
@@ -260,6 +262,115 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
   return tree
 })
 
+// Item 23: the path/pattern derivation, extracted from the ShellTool factory so
+// it can be shared with the exported `scanCommand` (the workflow engine's
+// ctx.shell gate). Pure relocation — the ShellTool factory builds the same
+// scanner from its own resolved services, so the bash tool's behavior is
+// byte-identical.
+function makeScanner(spawner: ChildProcessSpawner["Service"], fs: FSUtil.Interface) {
+  const cygpath = Effect.fn("ShellTool.cygpath")(function* (shell: string, text: string) {
+    const lines = yield* spawner
+      .lines(ChildProcess.make(shell, ["-lc", 'cygpath -w -- "$1"', "_", text]))
+      .pipe(Effect.catch(() => Effect.succeed([] as string[])))
+    const file = lines[0]?.trim()
+    if (!file) return
+    return FSUtil.normalizePath(file)
+  })
+
+  const resolvePath = Effect.fn("ShellTool.resolvePath")(function* (text: string, root: string, shell: string) {
+    if (process.platform === "win32") {
+      if (Shell.posix(shell) && text.startsWith("/") && FSUtil.windowsPath(text) === text) {
+        const file = yield* cygpath(shell, text)
+        if (file) return file
+      }
+      return FSUtil.normalizePath(path.resolve(root, FSUtil.windowsPath(text)))
+    }
+    return path.resolve(root, text)
+  })
+
+  const argPath = Effect.fn("ShellTool.argPath")(function* (arg: string, cwd: string, ps: boolean, shell: string) {
+    const text = ps ? expand(arg, cwd, shell) : home(unquote(arg))
+    const file = text && prefix(text)
+    if (!file || dynamic(file, ps)) return
+    const next = ps ? provider(file) : file
+    if (!next) return
+    return yield* resolvePath(next, cwd, shell)
+  })
+
+  const collect = Effect.fn("ShellTool.collect")(function* (
+    root: Node,
+    cwd: string,
+    ps: boolean,
+    shell: string,
+    instance: InstanceContext,
+  ) {
+    const scan: Scan = {
+      dirs: new Set<string>(),
+      patterns: new Set<string>(),
+      always: new Set<string>(),
+    }
+    const shellKind = ShellID.toKind(Shell.name(shell))
+
+    for (const node of commands(root)) {
+      const command = parts(node)
+      const tokens = command.map((item) => item.text)
+      const cmd = ps || shellKind === "cmd" ? tokens[0]?.toLowerCase() : tokens[0]
+
+      if (cmd && (FILES.has(cmd) || (shellKind === "cmd" && CMD_FILES.has(cmd)))) {
+        for (const arg of pathArgs(command, ps, shellKind === "cmd")) {
+          const resolved = yield* argPath(arg, cwd, ps, shell)
+          yield* Effect.logInfo("resolved path", { arg, resolved })
+          if (!resolved || containsPath(resolved, instance)) continue
+          const dir = (yield* fs.isDir(resolved)) ? resolved : path.dirname(resolved)
+          scan.dirs.add(dir)
+        }
+      }
+
+      if (tokens.length && (!cmd || !CWD.has(cmd))) {
+        scan.patterns.add(source(node))
+        scan.always.add(BashArity.prefix(tokens).join(" ") + " *")
+      }
+    }
+
+    return scan
+  })
+
+  return { cygpath, resolvePath, argPath, collect }
+}
+
+/**
+ * Item 23 (Stufe 1): the bash tool's permission-pattern derivation, exported so
+ * the workflow engine's `ctx.shell` gate asks with EXACTLY the same granularity
+ * as the bash tool — a user's `git status*` allow/deny rules apply identically.
+ * Parses the command (AST, never executes it) and returns the Scan
+ * (`patterns`/`always` for the bash permission, `dirs` for external_directory);
+ * a `cwd` outside the workspace is added to `dirs` like the bash tool does.
+ * `shellOverride` lets the caller scan with the shell that will actually
+ * execute the command (the workflow engine uses Shell.preferred); omitted, it
+ * resolves the configured shell exactly like the bash tool.
+ */
+export const scanCommand = Effect.fn("ShellTool.scanCommand")(function* (
+  command: string,
+  cwd: string,
+  instance: InstanceContext,
+  shellOverride?: string,
+) {
+  const spawner = yield* ChildProcessSpawner
+  const fs = yield* FSUtil.Service
+  const config = yield* Config.Service
+  const shell = shellOverride ?? Shell.acceptable((yield* config.get()).shell)
+  const scanner = makeScanner(spawner, fs)
+  const ps = Shell.ps(shell)
+  return yield* Effect.scoped(
+    Effect.gen(function* () {
+      const tree = yield* Effect.acquireRelease(parse(command, ps), (tree) => Effect.sync(() => tree.delete()))
+      const scan = yield* scanner.collect(tree.rootNode, cwd, ps, shell, instance)
+      if (!containsPath(cwd, instance)) scan.dirs.add(cwd)
+      return scan
+    }),
+  )
+})
+
 const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan, input: { command: string }) {
   if (scan.dirs.size > 0) {
     const directories = Array.from(scan.dirs)
@@ -346,72 +457,10 @@ export const ShellTool = Tool.define(
     const flags = yield* RuntimeFlags.Service
     const defaultTimeoutMs = flags.bashDefaultTimeoutMs ?? 2 * 60 * 1000
 
-    const cygpath = Effect.fn("ShellTool.cygpath")(function* (shell: string, text: string) {
-      const lines = yield* spawner
-        .lines(ChildProcess.make(shell, ["-lc", 'cygpath -w -- "$1"', "_", text]))
-        .pipe(Effect.catch(() => Effect.succeed([] as string[])))
-      const file = lines[0]?.trim()
-      if (!file) return
-      return FSUtil.normalizePath(file)
-    })
-
-    const resolvePath = Effect.fn("ShellTool.resolvePath")(function* (text: string, root: string, shell: string) {
-      if (process.platform === "win32") {
-        if (Shell.posix(shell) && text.startsWith("/") && FSUtil.windowsPath(text) === text) {
-          const file = yield* cygpath(shell, text)
-          if (file) return file
-        }
-        return FSUtil.normalizePath(path.resolve(root, FSUtil.windowsPath(text)))
-      }
-      return path.resolve(root, text)
-    })
-
-    const argPath = Effect.fn("ShellTool.argPath")(function* (arg: string, cwd: string, ps: boolean, shell: string) {
-      const text = ps ? expand(arg, cwd, shell) : home(unquote(arg))
-      const file = text && prefix(text)
-      if (!file || dynamic(file, ps)) return
-      const next = ps ? provider(file) : file
-      if (!next) return
-      return yield* resolvePath(next, cwd, shell)
-    })
-
-    const collect = Effect.fn("ShellTool.collect")(function* (
-      root: Node,
-      cwd: string,
-      ps: boolean,
-      shell: string,
-      instance: InstanceContext,
-    ) {
-      const scan: Scan = {
-        dirs: new Set<string>(),
-        patterns: new Set<string>(),
-        always: new Set<string>(),
-      }
-      const shellKind = ShellID.toKind(Shell.name(shell))
-
-      for (const node of commands(root)) {
-        const command = parts(node)
-        const tokens = command.map((item) => item.text)
-        const cmd = ps || shellKind === "cmd" ? tokens[0]?.toLowerCase() : tokens[0]
-
-        if (cmd && (FILES.has(cmd) || (shellKind === "cmd" && CMD_FILES.has(cmd)))) {
-          for (const arg of pathArgs(command, ps, shellKind === "cmd")) {
-            const resolved = yield* argPath(arg, cwd, ps, shell)
-            yield* Effect.logInfo("resolved path", { arg, resolved })
-            if (!resolved || containsPath(resolved, instance)) continue
-            const dir = (yield* fs.isDir(resolved)) ? resolved : path.dirname(resolved)
-            scan.dirs.add(dir)
-          }
-        }
-
-        if (tokens.length && (!cmd || !CWD.has(cmd))) {
-          scan.patterns.add(source(node))
-          scan.always.add(BashArity.prefix(tokens).join(" ") + " *")
-        }
-      }
-
-      return scan
-    })
+    // Item 23: the path/pattern derivation now lives in the module-level
+    // makeScanner (shared with the exported scanCommand); same services, same
+    // behavior.
+    const { resolvePath, collect } = makeScanner(spawner, fs)
 
     const shellEnv = Effect.fn("ShellTool.shellEnv")(function* (ctx: Tool.Context, cwd: string) {
       const extra = yield* plugin.trigger(

--- a/packages/opencode/src/workflow/builtin.ts
+++ b/packages/opencode/src/workflow/builtin.ts
@@ -1,0 +1,155 @@
+// Built-in workflows shipped with opencode. Each entry maps a workflow NAME to
+// its module SOURCE TEXT (a string, never a file on disk). This is the
+// binary-safe form: the source travels inside the compiled bundle as a plain
+// string constant, so there is no separate `.ts`/`.js` file that a packaged
+// binary would have to ship alongside itself and locate at runtime.
+//
+// INVARIANT: builtin sources must be SELF-CONTAINED — no imports. start()
+// materializes them as temp modules under the global workflows directory, so a
+// bare specifier would resolve through whatever node_modules sits above that
+// directory: the PUBLISHED `@opencode-ai/plugin` that config.ts installs there,
+// never a dev workspace checkout (PR #2 review: a contributor had to manually
+// link the workspace plugin globally before an import-using builtin would load).
+// Import-free sources load identically in dev, in tests, and in the compiled
+// binary. The wrapper-free `export default { meta, run }` shape is exactly what
+// the plugin's workflow() helper returns at runtime, and the static MetaReader
+// reads it natively (form 2) — the wrapper only ever added editor types, which a
+// string constant cannot benefit from anyway.
+//
+// Discovery treats these as the LOWEST-precedence root (project > global >
+// builtin): a builtin name is only ever surfaced when no project or global file
+// already claims that name (first-wins in `discover`). The static `MetaReader`
+// reads meta straight from the source string (it already takes `source`
+// directly), and `start()` loads the module from the source string via the same
+// temp-file import path that on-disk workflows use — so a builtin runs through
+// the identical permission gate and argument-coercion boundary as any file.
+//
+// The synthetic path marker for a builtin is `builtin:<name>` (see
+// BUILTIN_PATH_PREFIX); it is never a real filesystem path and is only used as a
+// stable identifier on the Info/Definition record.
+
+export const BUILTIN_PATH_PREFIX = "builtin:"
+
+export function builtinPath(name: string) {
+  return `${BUILTIN_PATH_PREFIX}${name}`
+}
+
+export function isBuiltinPath(path: string) {
+  return path.startsWith(BUILTIN_PATH_PREFIX)
+}
+
+// The synthetic path marker for an INLINE-source workflow is `inline:<metaName>`
+// (P3). Like `builtin:`, it is never a real filesystem path: an inline start
+// supplies the module source directly, loaded through the SAME source-string
+// import path builtins use (loadModule materializes a randomized temp module
+// under the global workflows dir). Discovery globs real `*.ts` files only, so an
+// `inline:` marker — exactly like `builtin:` — can never be picked up as a
+// discovered workflow.
+export const INLINE_PATH_PREFIX = "inline:"
+
+export function inlinePath(name: string) {
+  return `${INLINE_PATH_PREFIX}${name}`
+}
+
+export function isInlinePath(path: string) {
+  return path.startsWith(INLINE_PATH_PREFIX)
+}
+
+// deep-research: fan out a question into distinct search angles, research each
+// in parallel, adversarially verify every claim against its cited sources, then
+// synthesize a cited report from only the surviving claims. The meta fields are
+// LITERALS so the static meta reader can extract name/description/phases/
+// arguments without executing the module.
+const DEEP_RESEARCH = `export default {
+  meta: {
+    name: "deep-research",
+    description: "Research a question across angles with adversarial claim verification",
+    phases: ["plan", "research", "verify", "synthesize"],
+    arguments: { question: { type: "string" } },
+  },
+  async run(args, ctx) {
+    const question = String(args.question ?? "")
+    if (!question) throw new Error("deep-research needs args.question")
+
+    ctx.setPhase("plan")
+    const plan = await ctx.agent({
+      prompt: \`Break this research question into 3-5 distinct search angles. Question: \${question}. Respond ONLY via the schema.\`,
+      schema: {
+        type: "object",
+        required: ["angles"],
+        properties: { angles: { type: "array", minItems: 3, maxItems: 5, items: { type: "string" } } },
+      },
+    })
+
+    ctx.setPhase("research")
+    // ctx.parallel drops a rejecting/agent-erroring task to null at its position
+    // (P1 Claude parity) — filter before dereferencing the findings.
+    const findings = (await ctx.parallel(
+      plan.data.angles.map((angle) => () =>
+        ctx.agent({
+          prompt: \`Research this angle using your available web/search tools. If NO web/search tools are available, return {"claims": [], "no_web_tools": true} via the schema. Angle: \${angle}\\nFull question: \${question}\\nReturn findings with source URLs via the schema.\`,
+          schema: {
+            type: "object",
+            required: ["claims"],
+            properties: {
+              claims: {
+                type: "array",
+                items: {
+                  type: "object",
+                  required: ["claim", "sources"],
+                  properties: {
+                    claim: { type: "string" },
+                    sources: { type: "array", items: { type: "string" } },
+                  },
+                },
+              },
+              no_web_tools: { type: "boolean" },
+            },
+          },
+        }),
+      ),
+    )).filter((f) => f !== null)
+    // Gate via the structured schema (a forced-JSON schema makes the old plaintext
+    // sentinel unreachable — StructuredOutputError would fire before any reply
+    // text could carry it). An agent with no web/search tools instead sets the
+    // optional no_web_tools flag, which we surface as an honest hard failure.
+    if (findings.some((f) => (f.data as { no_web_tools?: boolean }).no_web_tools))
+      throw new Error("deep-research requires web/search tools to be available to agents")
+
+    const claims = findings.flatMap((f) => f.data.claims)
+
+    ctx.setPhase("verify")
+    // Same null-drop contract here — filter the verdicts before dereferencing.
+    const verified = (await ctx.parallel(
+      claims.map((c) => () =>
+        ctx
+          .agent({
+            prompt: \`Adversarially verify this claim against its sources (fetch them). Claim: \${c.claim}\\nSources: \${c.sources.join(", ")}\\nReply via schema: supported=true only if the sources actually back the claim.\`,
+            schema: {
+              type: "object",
+              required: ["supported", "reason"],
+              properties: { supported: { type: "boolean" }, reason: { type: "string" } },
+            },
+          })
+          .then((v) => ({ ...c, verdict: v.data })),
+      ),
+      { concurrencyLimit: 8 },
+    )).filter((v) => v !== null)
+    const surviving = verified.filter((c) => c.verdict.supported)
+    const rejected = verified.filter((c) => !c.verdict.supported)
+
+    ctx.setPhase("synthesize")
+    const report = await ctx.agent({
+      prompt: \`Write a cited research report answering: \${question}\\nUse ONLY these verified claims (cite their sources inline): \${JSON.stringify(surviving)}\\nList rejected claims briefly at the end: \${JSON.stringify(rejected.map((r) => ({ claim: r.claim, reason: r.verdict.reason })))}\`,
+    })
+
+    return { report: report.text, claims: { verified: surviving.length, rejected: rejected.length } }
+  },
+}
+`
+
+// name -> module source text. Keep insertion order stable; discovery sorts by
+// name so the order here is not load-bearing.
+export const BUILTIN_WORKFLOWS: Record<string, string> = {
+  "deep-research": DEEP_RESEARCH,
+}

--- a/packages/opencode/src/workflow/errors.ts
+++ b/packages/opencode/src/workflow/errors.ts
@@ -1,0 +1,103 @@
+// Workflow engine error classes, split out of workflow.ts so the engine, the
+// HTTP handlers, and the tests can share the exact same TaggedError tags without
+// pulling in the full engine module. The public `Workflow.<Error>` surface is
+// preserved by re-exporting every class from the workflow.ts barrel. The tag
+// strings ("WorkflowNotFoundError", "WorkflowSaveConflictError", …) are matched
+// on by HTTP handlers (e.g. SaveConflictError -> 409) and tests, so they MUST NOT
+// change.
+import { Schema } from "effect"
+
+export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("WorkflowNotFoundError", {
+  name: Schema.String,
+}) {}
+
+export class InvalidError extends Schema.TaggedErrorClass<InvalidError>()("WorkflowInvalidError", {
+  path: Schema.String,
+  message: Schema.String,
+}) {}
+
+// Raised by save() when a workflow file already exists at the resolved
+// destination. Save NEVER overwrites — it mirrors the create tool's behavior
+// (`Workflow already exists: …`), so an accidental re-save of a run cannot clobber
+// a hand-edited file. The HTTP handler maps this to a 409 ConflictError; `name` is
+// the workflow file base and `path` the colliding file so callers can surface both.
+export class SaveConflictError extends Schema.TaggedErrorClass<SaveConflictError>()("WorkflowSaveConflictError", {
+  name: Schema.String,
+  path: Schema.String,
+}) {}
+
+/**
+ * Raised by an agent step that requested structured output (a `schema` was
+ * passed to `ctx.agent`) when the session produced no parsed structured result —
+ * either because the underlying session set a `StructuredOutputError` on the
+ * assistant message, or because `structured` came back `undefined`. The engine
+ * MUST NOT silently fall back to plaintext when a schema was requested: a missing
+ * structured result is a genuine step failure, so this error propagates through
+ * the same agent-failure path as any other agent error (node `failed`, run
+ * `failed` unless the workflow module catches it).
+ */
+export class StructuredOutputError extends Schema.TaggedErrorClass<StructuredOutputError>()(
+  "WorkflowStructuredOutputError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+/**
+ * Raised at the top of `ctx.agent` (right after the abort-signal checkpoint)
+ * when the run was started with a budget and that budget is exhausted
+ * (`budgetRemaining <= 0`). The next agent step never starts: the engine
+ * refuses to spend past the cap. Propagates through the SAME agent-failure path
+ * as any other agent error (node `failed`, run `failed` unless the workflow
+ * module catches it). The message names both the configured budget and the
+ * amount already spent so the failure is self-explanatory.
+ *
+ * The cap is enforced PER STEP, best-effort: it is checked before each
+ * `ctx.agent` call and the spend is settled after each step. Steps launched
+ * concurrently via `ctx.parallel`/`ctx.pipeline` all pass the gate while the
+ * budget is still positive, so a run can overspend by up to the combined cost
+ * of the steps already in flight when the budget runs out. This is a soft cap,
+ * not a hard mid-step limit.
+ */
+export class BudgetExceededError extends Schema.TaggedErrorClass<BudgetExceededError>()("WorkflowBudgetExceededError", {
+  message: Schema.String,
+  budget: Schema.Finite,
+  spent: Schema.Finite,
+  // Item 17: which cap tripped — "usd" (cost) or "tokens" (output tokens).
+  // Optional for backward compatibility with errors persisted before the field.
+  unit: Schema.optional(Schema.Literals(["usd", "tokens"])),
+}) {}
+
+/**
+ * Raised at the top of `ctx.agent` once the run has already STARTED its
+ * lifetime-cap many agents (default 1.000). The cap is a per-run safety ceiling
+ * on the TOTAL number of agent dispatches a single workflow run may launch, so a
+ * pathological or runaway workflow (e.g. an unbounded loop of `ctx.agent`) cannot
+ * spawn unbounded subagent sessions. Like BudgetExceededError it propagates
+ * through the SAME agent-failure path as any other agent error (node `failed`,
+ * run `failed` unless the workflow module catches it). The message names both the
+ * limit and the count already started so the failure is self-explanatory.
+ */
+export class AgentLimitError extends Schema.TaggedErrorClass<AgentLimitError>()("WorkflowAgentLimitError", {
+  message: Schema.String,
+  limit: Schema.Finite,
+  started: Schema.Finite,
+}) {}
+
+/**
+ * Thrown by `checkpoint()` before the next `ctx.agent`/`ctx.parallel`/
+ * `ctx.pipeline` task/step once the run's abort signal has fired, so the
+ * follow-up step never starts. Detected in the run's failure branch and mapped
+ * to `cancelled` rather than `failed`.
+ *
+ * Deliberately a plain `Error` (not `Schema.TaggedErrorClass`): it is thrown
+ * synchronously from `checkpoint()`, a non-Effect JS callback invoked by the
+ * workflow module's own code, so it cannot yield an Effect error.
+ */
+export class CancelledError extends Error {
+  readonly _tag = "WorkflowCancelledError"
+  constructor() {
+    super("Workflow cancelled")
+    this.name = "WorkflowCancelledError"
+  }
+}

--- a/packages/opencode/src/workflow/meta-reader.ts
+++ b/packages/opencode/src/workflow/meta-reader.ts
@@ -1,0 +1,164 @@
+import ts from "typescript"
+import { Cause, Exit, Schema } from "effect"
+import { Meta } from "./meta"
+
+// The single error text every non-literal meta value maps to. Workflow discovery
+// (list/read/autocomplete/HTTP) must never EXECUTE a workflow module just to read
+// its meta — doing so runs untrusted top-level code before any permission gate
+// (the root cause this reader fixes). So meta is extracted purely from the AST:
+// only literal values are understood. Anything dynamic (a call, an identifier, a
+// member access like `process.env.X`, a template with substitutions, …) cannot
+// be known without running code, so it is rejected with this message rather than
+// throwing or evaluated.
+const NON_LITERAL_ERROR = "workflow meta must be statically analyzable (literal values only)"
+
+export type Result = { valid: true; meta: Meta } | { valid: false; error: string }
+
+const decodeMeta = Schema.decodeUnknownExit(Meta)
+
+/**
+ * Statically extracts a workflow module's meta from its SOURCE TEXT, without ever
+ * importing or executing the module. Supports the same module shapes the engine's
+ * `loadModule` accepts at runtime:
+ *   1. named exports — `export const meta = { … }` (+ `export … run`)
+ *   2. a default object literal — `export default { meta: { … }, run() {} }`
+ *   3. the plugin helper — `export default workflow({ name, description, … })`,
+ *      where the meta fields live at the top level of the call's object argument
+ *      (`run` is ignored).
+ * The extracted object is validated by the SAME `Meta` schema the engine uses, so
+ * a file that statically parses but is not a valid meta is reported invalid with
+ * the schema's own message. Non-literal values yield `NON_LITERAL_ERROR`. Never
+ * throws: every failure mode is returned as `{ valid: false, error }`.
+ */
+export function read(source: string, filePath: string): Result {
+  const file = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true)
+  // More than one `export default` is invalid TS and ambiguous to extract from —
+  // reject explicitly rather than silently picking the first one.
+  if (file.statements.filter((s) => ts.isExportAssignment(s) && !s.isExportEquals).length > 1)
+    return { valid: false, error: "Multiple default exports; cannot determine the workflow" }
+  const node = findMetaObject(file)
+  if (!node) return { valid: false, error: "Missing meta export (export const meta / export default)" }
+  const extracted = extractValue(node)
+  if (extracted.ok === false) return { valid: false, error: NON_LITERAL_ERROR }
+  const decoded = decodeMeta(extracted.value, { errors: "all", propertyOrder: "original" })
+  if (Exit.isFailure(decoded)) return { valid: false, error: Cause.pretty(decoded.cause) }
+  return { valid: true, meta: decoded.value }
+}
+
+// Strips the syntactic wrappers that carry no runtime value — `(expr)`,
+// `expr as T` / `as const`, and `expr satisfies T` — so idiomatic TS like
+// `{ … } as const` or `phases: [...] as const` is seen as the literal it wraps.
+function unwrap(node: ts.Expression): ts.Expression {
+  if (ts.isParenthesizedExpression(node) || ts.isAsExpression(node) || ts.isSatisfiesExpression(node))
+    return unwrap(node.expression)
+  return node
+}
+
+// Locates the object literal that carries the meta, matching the three accepted
+// module shapes. Returns the ObjectLiteral whose properties ARE the meta (forms 1
+// and 3 flatten to the same shape: `{ name, description, phases, arguments }`).
+function findMetaObject(file: ts.SourceFile): ts.ObjectLiteralExpression | undefined {
+  for (const statement of file.statements) {
+    // Form 1: `export const meta = { … }` (initializer may be `… as const`).
+    if (ts.isVariableStatement(statement) && hasExportModifier(statement)) {
+      for (const decl of statement.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.name.text === "meta" && decl.initializer) {
+          const initializer = unwrap(decl.initializer)
+          return ts.isObjectLiteralExpression(initializer) ? initializer : undefined
+        }
+      }
+    }
+    // Forms 2 & 3: `export default …` (expression may be `(…)`/`… as const`).
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
+      const expr = unwrap(statement.expression)
+      // Form 2: a default object literal — read its `meta` property's value.
+      if (ts.isObjectLiteralExpression(expr)) return metaPropertyObject(expr)
+      // Form 3: `workflow({ … })` — the call's first arg is the flat meta object
+      // (name/description/phases/arguments at the top level; `run` is ignored by
+      // the schema, which only reads the meta keys).
+      if (ts.isCallExpression(expr)) {
+        const arg = expr.arguments[0]
+        const unwrapped = arg ? unwrap(arg) : undefined
+        return unwrapped && ts.isObjectLiteralExpression(unwrapped) ? unwrapped : undefined
+      }
+    }
+  }
+  return undefined
+}
+
+function metaPropertyObject(object: ts.ObjectLiteralExpression): ts.ObjectLiteralExpression | undefined {
+  for (const property of object.properties) {
+    if (ts.isPropertyAssignment(property) && propertyKey(property.name) === "meta") {
+      const initializer = unwrap(property.initializer)
+      return ts.isObjectLiteralExpression(initializer) ? initializer : undefined
+    }
+  }
+  return undefined
+}
+
+function hasExportModifier(node: ts.HasModifiers) {
+  return node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false
+}
+
+function propertyKey(name: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text
+  return undefined
+}
+
+type Extracted = { ok: true; value: unknown } | { ok: false }
+
+const FAIL: Extracted = { ok: false }
+
+function isFunctionLike(node: ts.Expression) {
+  return ts.isArrowFunction(node) || ts.isFunctionExpression(node)
+}
+
+// Recursively converts a literal AST node into its plain JS value. Anything that
+// would require executing code to know its value (identifiers, calls, member
+// access, spreads, methods, computed keys, template substitutions) makes the
+// whole extraction fail — the caller turns that into the NON_LITERAL_ERROR.
+function extractValue(input: ts.Expression): Extracted {
+  // Transparent wrappers (`(expr)`, `as const`, `satisfies`) carry no value.
+  const node = unwrap(input)
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return { ok: true, value: node.text }
+  if (ts.isNumericLiteral(node)) return { ok: true, value: Number(node.text) }
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return { ok: true, value: true }
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return { ok: true, value: false }
+  if (node.kind === ts.SyntaxKind.NullKeyword) return { ok: true, value: null }
+  // Negative (and explicit positive) numeric literals: `-3`, `+1`.
+  if (ts.isPrefixUnaryExpression(node) && ts.isNumericLiteral(node.operand)) {
+    if (node.operator === ts.SyntaxKind.MinusToken) return { ok: true, value: -Number(node.operand.text) }
+    if (node.operator === ts.SyntaxKind.PlusToken) return { ok: true, value: Number(node.operand.text) }
+    return FAIL
+  }
+  if (ts.isArrayLiteralExpression(node)) {
+    const items: unknown[] = []
+    for (const element of node.elements) {
+      const extracted = extractValue(element)
+      if (extracted.ok === false) return FAIL
+      items.push(extracted.value)
+    }
+    return { ok: true, value: items }
+  }
+  if (ts.isObjectLiteralExpression(node)) {
+    const result: Record<string, unknown> = {}
+    for (const property of node.properties) {
+      // Method members (e.g. the `run(args, ctx) {}` carried by the `workflow({…})`
+      // helper form) are functions, never part of literal meta, and are ignored by
+      // the Meta schema — skip them rather than fail the whole extraction.
+      if (ts.isMethodDeclaration(property)) continue
+      if (!ts.isPropertyAssignment(property)) return FAIL
+      const key = propertyKey(property.name)
+      if (key === undefined) return FAIL
+      // A `run:` value that is itself a function is likewise ignored, not literal.
+      if (key === "run" && isFunctionLike(unwrap(property.initializer))) continue
+      const extracted = extractValue(property.initializer)
+      if (extracted.ok === false) return FAIL
+      result[key] = extracted.value
+    }
+    return { ok: true, value: result }
+  }
+  return FAIL
+}
+
+export * as MetaReader from "./meta-reader"

--- a/packages/opencode/src/workflow/meta.ts
+++ b/packages/opencode/src/workflow/meta.ts
@@ -1,0 +1,69 @@
+import { Schema, SchemaGetter } from "effect"
+
+// Workflow meta schemas live in their own leaf module (depending only on
+// `Schema`) so both the engine (`workflow.ts`) and the static meta reader
+// (`meta-reader.ts`) can import them without forming an import cycle: the engine
+// re-exports them so its public `Workflow.Meta` / `Workflow.Argument` API is
+// unchanged, while the reader can build its decoder at module scope.
+
+export const Argument = Schema.Struct({
+  type: Schema.optional(Schema.String),
+  default: Schema.optional(Schema.Unknown),
+  description: Schema.optional(Schema.String),
+}).annotate({ identifier: "WorkflowArgument" })
+export type Argument = Schema.Schema.Type<typeof Argument>
+
+// A structured phase. `title` is the phase name (required); `detail` is optional
+// human-readable copy; `model` is a per-phase DEFAULT model used by `ctx.agent`
+// calls made while this phase is active when the call gave no explicit model.
+export const Phase = Schema.Struct({
+  title: Schema.String,
+  detail: Schema.optional(Schema.String),
+  model: Schema.optional(Schema.String),
+}).annotate({ identifier: "WorkflowPhase" })
+export type Phase = Schema.Schema.Type<typeof Phase>
+
+// A phase entry as AUTHORED / as carried on the public (SDK/HTTP) contract: either
+// a plain string (the phase title) OR a structured `{ title, detail?, model? }`
+// object. Keeping the union on the ENCODED side is what makes the change
+// backward-compatible — existing string-phases workflows and the already-published
+// SDK shape (`phases?: string[]`) still validate unchanged.
+const PhaseEntry = Schema.Union([Schema.String, Phase])
+
+// Phases are NORMALIZED to ALWAYS objects internally (`{ title, detail?, model? }[]`)
+// the moment meta is decoded — both readers (the static `meta-reader.read` and the
+// engine's `finishModule`) go through this same `Meta` decode, so normalization
+// lives in exactly ONE place. A bare string `"plan"` becomes `{ title: "plan" }`;
+// an object phase is kept verbatim. The transform's ENCODE direction re-emits a
+// string for a title-only phase so the wire form stays the back-compatible union.
+const Phases = Schema.Array(PhaseEntry).pipe(
+  Schema.decodeTo(Schema.Array(Phase), {
+    decode: SchemaGetter.transform((entries) =>
+      entries.map((entry) => (typeof entry === "string" ? { title: entry } : entry)),
+    ),
+    encode: SchemaGetter.transform((phases) =>
+      phases.map((phase) => (phase.detail === undefined && phase.model === undefined ? phase.title : phase)),
+    ),
+  }),
+)
+
+export const Meta = Schema.Struct({
+  name: Schema.String,
+  description: Schema.optional(Schema.String),
+  whenToUse: Schema.optional(Schema.String),
+  phases: Schema.optional(Phases),
+  arguments: Schema.optional(Schema.Record(Schema.String, Argument)),
+}).annotate({ identifier: "WorkflowMeta" })
+export type Meta = Schema.Schema.Type<typeof Meta>
+
+// The same back-compat ENCODE rule the `Phases` schema applies, extracted as a
+// plain function so the persistence layer (`workflow.ts`) can re-emit a stored
+// definition's phases in the WIRE form (a title-only phase → the bare string,
+// a phase carrying detail/model → the object) WITHOUT round-tripping the whole
+// `Definition` through `Schema.encode` (which also touches `source`/`path` and
+// is needless risk for a field-local transform). DECODE normalizes every entry
+// to an object; ENCODE is the inverse for the back-compatible cross-version
+// shape. Kept here, beside the schema, so the rule lives in exactly ONE place.
+export function encodePhase(phase: Phase): string | Phase {
+  return phase.detail === undefined && phase.model === undefined ? phase.title : phase
+}

--- a/packages/opencode/src/workflow/schema.ts
+++ b/packages/opencode/src/workflow/schema.ts
@@ -1,0 +1,249 @@
+// Workflow data schemas (Zod/Effect-Schema), split out of workflow.ts so the
+// engine, the persistence layer, the meta reader, and the HTTP layer share one
+// definition of the run/log/agent shapes without pulling in the full engine.
+// Every symbol here is re-exported from the workflow.ts barrel, so the public
+// `Workflow.RunID` / `Workflow.Info` / `Workflow.Run` / … surface is unchanged.
+import { Schema } from "effect"
+import { EventV2 } from "@opencode-ai/core/event"
+import { type DeepMutable, withStatics } from "@opencode-ai/core/schema"
+import type { WorkflowAgentRow, WorkflowDefinitionRow, WorkflowLogRow } from "@opencode-ai/core/workflow/sql"
+import { Identifier } from "@/id/id"
+import { Meta } from "./meta"
+
+// Branded id for a workflow run. Follows the repo's ID convention (cf. SessionID
+// / MessageID in `session/schema.ts`): a `job_`-prefixed string carrying a
+// nominal brand so a run id can never be confused with any other string at the
+// type level. The brand is type-only — the `isStartsWith("job")` check is the
+// same shape SessionID uses, which the OpenAPI generator emits as a plain
+// `string`, so the SDK shape is unchanged. `make` mints a fresh ascending id
+// (the prefix the engine already used via `Identifier.ascending("job")`).
+export const RunID = Schema.String.check(Schema.isStartsWith("job")).pipe(
+  Schema.brand("WorkflowRunID"),
+  withStatics((schema) => ({
+    ascending: (id?: string) => schema.make(Identifier.ascending("job", id)),
+  })),
+)
+export type RunID = Schema.Schema.Type<typeof RunID>
+
+// Meta/Argument schemas live in `./meta` (a Schema-only leaf module) so the
+// static meta reader can share them without forming an import cycle. Re-exported
+// here so the engine's public `Workflow.Meta` / `Workflow.Argument` API is
+// unchanged.
+export { Argument, Meta, Phase } from "./meta"
+
+export const Info = Schema.Struct({
+  name: Schema.String,
+  path: Schema.String,
+  meta: Meta,
+  // `valid: false` marks a file that failed to load (bad meta / missing run /
+  // syntax error). It is still returned so a single broken file never makes the
+  // whole list fail; `error` carries the load failure as a human-readable
+  // string. Valid entries are explicitly `valid: true` (never omitted).
+  valid: Schema.Boolean,
+  error: Schema.optional(Schema.String),
+  // `source_kind: "builtin"` flags a workflow that ships INSIDE opencode (its
+  // module source is a bundled string, `path` is the synthetic `builtin:<name>`
+  // marker, not a real file). Omitted for the common case of an on-disk
+  // project/global file. Builtins are the lowest-precedence discovery root:
+  // a same-named project or global file shadows the builtin entirely.
+  source_kind: Schema.optional(Schema.Literals(["builtin"])),
+}).annotate({ identifier: "WorkflowInfo" })
+export type Info = Schema.Schema.Type<typeof Info>
+
+// The resolved module SOURCE of a single named workflow, returned by `read(name)`
+// / `GET /workflow/:name/source` for the pre-run approval preview. Kept SEPARATE
+// from `Info` (and off `list()`) on purpose: `list()` is hit for autocomplete and
+// the slash popover and returns EVERY workflow, so inlining each one's full module
+// text would bloat that hot, name+meta-only payload — whereas the source is only
+// needed lazily when an operator opens the "View script" preview for one workflow.
+// `source_kind: "builtin"` is mirrored from Info so a consumer can label a builtin.
+export const Source = Schema.Struct({
+  name: Schema.String,
+  path: Schema.String,
+  source: Schema.String,
+  source_kind: Schema.optional(Schema.Literals(["builtin"])),
+}).annotate({ identifier: "WorkflowSource" })
+export type Source = Schema.Schema.Type<typeof Source>
+
+export const Definition = Schema.Struct({
+  name: Schema.String,
+  path: Schema.String,
+  meta: Meta,
+  source: Schema.optional(Schema.String),
+  temporary: Schema.optional(Schema.Boolean),
+}).annotate({ identifier: "WorkflowDefinition" })
+export type Definition = DeepMutable<Schema.Schema.Type<typeof Definition>>
+
+// "interrupted" is a terminal status assigned to runs whose in-memory fiber was
+// lost (crash/process restart) while the DB row still said "running". The orphan
+// sweep on service start rewrites such zombie rows so the lifecycle stays honest.
+//
+// "paused" is the only NON-terminal status besides "running": a run the user
+// explicitly suspended via pause() (sessions aborted, scope closed, fiber
+// interrupted — exactly like cancel), but whose persisted agent journal is kept
+// intact so a later resume can replay the completed agents instead of re-running
+// them. The orphan sweep deliberately ignores paused rows (they have no live
+// fiber by design, but they are parked, not lost); cancel() on a paused run moves
+// it to the terminal "cancelled"; wait() on a paused run returns its snapshot at
+// once (timedOut:false) because there is no live fiber to await.
+export const Status = Schema.Literals(["running", "completed", "failed", "cancelled", "interrupted", "paused"])
+export type Status = Schema.Schema.Type<typeof Status>
+
+export const LogEntry = Schema.Struct({
+  // Epoch millis — always a finite number. `Schema.Finite` (not `Schema.Number`)
+  // so the generated SDK wire type is a plain `number`, not the dishonest
+  // `number | "NaN" | "Infinity" | …` union the OpenAPI generator emits for an
+  // unbounded `Schema.Number` (Fund 18). Same JS Type (`number`) as before, so
+  // the core row-type SSoT assertions stay valid.
+  time: Schema.Finite,
+  phase: Schema.optional(Schema.String),
+  message: Schema.String,
+}).annotate({ identifier: "WorkflowLogEntry" })
+export type LogEntry = DeepMutable<Schema.Schema.Type<typeof LogEntry>>
+
+export const AgentRun = Schema.Struct({
+  id: Schema.String,
+  // `skipped` (Item 15): a human skipped this step via skipAgent — the step's
+  // ctx.agent call resolved `null` and the run continued. Distinct from `failed`
+  // so run views can tell a deliberate skip apart from an error.
+  status: Schema.Literals(["running", "completed", "failed", "skipped"]),
+  // Epoch millis — always finite. `Schema.Finite` keeps the SDK wire type a
+  // plain `number` instead of the NaN/Infinity-string union (Fund 18).
+  started_at: Schema.Finite,
+  completed_at: Schema.optional(Schema.Finite),
+  phase: Schema.optional(Schema.String),
+  agent: Schema.optional(Schema.String),
+  // Per-call display name (Item 16): set from `ctx.agent({ label })` so run views
+  // can show an author-chosen step name instead of the agent name. Display-only —
+  // deliberately NOT part of the resume journal key (see journalKey).
+  label: Schema.optional(Schema.String),
+  model: Schema.optional(Schema.String),
+  session_id: Schema.optional(Schema.String),
+  message_id: Schema.optional(Schema.String),
+  // Item 7: the isolated `git worktree` base directory this step ran in (set
+  // only for `isolation: "worktree"` steps). Makes the step's work location
+  // inspectable (inspect/dashboard) and anchors the preserve log when the
+  // worktree is kept at run end (uncommitted changes / new commits).
+  worktree: Schema.optional(Schema.String),
+  prompt: Schema.String,
+  output: Schema.optional(Schema.String),
+  cost: Schema.optional(Schema.Finite),
+  tokens: Schema.optional(
+    Schema.Struct({
+      total: Schema.optional(Schema.Finite),
+      input: Schema.Finite,
+      output: Schema.Finite,
+      reasoning: Schema.Finite,
+      cache: Schema.Struct({
+        read: Schema.Finite,
+        write: Schema.Finite,
+      }),
+    }),
+  ),
+  error: Schema.optional(Schema.String),
+  // `true` when this agent node was NOT executed live but replayed verbatim from
+  // a resumed run's persisted journal (output/structured/cost/tokens copied from
+  // the source run's matching completed agent). Omitted (⇒ undefined) for a live
+  // step. Lets the dashboard mark a cheap, re-used step apart from a fresh one.
+  cached: Schema.optional(Schema.Boolean),
+  // The journal node KIND (Tasks 12/13). `"question"` marks a human-in-the-loop
+  // `ctx.question` step (its `prompt` is the question text, `answer` is filled in
+  // on reply); `"agent"` (or absent — old rows) is an ordinary LLM step. The field
+  // is optional so rows written before it existed decode cleanly (undefined ⇒ an
+  // agent node), which is the decode-tolerance the persistence contract relies on.
+  kind: Schema.optional(Schema.Literals(["agent", "question"])),
+  // The answer recorded on a `kind:"question"` node once the question is answered
+  // (live) or replayed from a resumed run's journal. Omitted while open / for an
+  // agent node. Resume replay matches a question node on [kind, question, phase]
+  // and copies this answer back to the body, mirroring the agent-journal replay.
+  answer: Schema.optional(Schema.String),
+}).annotate({ identifier: "WorkflowAgentRun" })
+export type AgentRun = DeepMutable<Schema.Schema.Type<typeof AgentRun>>
+
+// Compile-time SSoT bridge between the engine's runtime validators (the Effect
+// schemas above) and core's persistence contract (the row types that annotate the
+// workflow_run JSON columns). The engine keeps the Effect schemas as the runtime
+// validators; core keeps the row types as the canonical column shapes. These
+// bidirectional assignability checks fail the build the moment either side drifts
+// — a field added/removed/retyped, or the AgentRun status union widened — so the
+// silent drift that motivated this refactor cannot recur. Two directions are
+// needed because a one-way `extends` only catches a SUPERSET on one side; both
+// directions together pin the shapes to be mutually assignable (structurally
+// identical for these closed object types). `void` keeps the consts from being
+// reported as unused.
+const _defToRow: WorkflowDefinitionRow = {} as Definition
+const _defFromRow: Definition = {} as WorkflowDefinitionRow
+const _logToRow: WorkflowLogRow = {} as LogEntry
+const _logFromRow: LogEntry = {} as WorkflowLogRow
+const _agentToRow: WorkflowAgentRow = {} as AgentRun
+const _agentFromRow: AgentRun = {} as WorkflowAgentRow
+void _defToRow
+void _defFromRow
+void _logToRow
+void _logFromRow
+void _agentToRow
+void _agentFromRow
+
+export const Run = Schema.Struct({
+  id: RunID,
+  session_id: Schema.optional(Schema.String),
+  workflow: Schema.String,
+  args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  definition: Schema.optional(Definition),
+  status: Status,
+  started_at: Schema.Number,
+  completed_at: Schema.optional(Schema.Number),
+  current_phase: Schema.optional(Schema.String),
+  logs: Schema.Array(LogEntry),
+  agents: Schema.Array(AgentRun),
+  result: Schema.optional(Schema.Unknown),
+  error: Schema.optional(Schema.String),
+  // Set when this run was started as a resume of a previous (paused/interrupted)
+  // run: the id of that source run, whose persisted journal was replayed.
+  // Omitted for an ordinary (non-resume) run.
+  resume_of: Schema.optional(RunID),
+  // The open human-in-the-loop question this run is currently waiting on
+  // (Tasks 12/13). Set while `ctx.question` is awaited and not yet answered;
+  // cleared once the answer lands (live) or the question node is replayed during a
+  // resume. A timed-out question parks the run as `paused` with this still set, so
+  // the open question survives across restarts. Omitted when no question pends.
+  pending_question: Schema.optional(
+    Schema.Struct({
+      question: Schema.String,
+      options: Schema.optional(Schema.Array(Schema.String)),
+      asked_at: Schema.Number,
+    }),
+  ),
+}).annotate({ identifier: "WorkflowRun" })
+export type Run = DeepMutable<Schema.Schema.Type<typeof Run>>
+
+// Run-lifecycle bus events. Published from `persistRun` (the single choke-point
+// every state write goes through) AFTER the DB upsert commits, so a consumer
+// never observes a state that was not persisted. The payload is intentionally
+// SLIM — the metadata fields plus an `agents` COUNT object — so non-TUI
+// consumers (dashboard, plugins) can render run progress without the heavy
+// logs/agents/result blobs (those stay readable via `get()`). `updated` fires on
+// every non-terminal write; `finished` fires once on the terminal write.
+const RunEventData = {
+  id: Schema.String,
+  workflow: Schema.String,
+  status: Status,
+  current_phase: Schema.NullOr(Schema.String),
+  directory: Schema.String,
+  agents: Schema.Struct({
+    total: Schema.Number,
+    running: Schema.Number,
+    failed: Schema.Number,
+  }),
+  // `true` while this run is waiting on an open human-in-the-loop question
+  // (`ctx.question` awaited, not yet answered — Tasks 12/13), so a non-TUI
+  // consumer can surface the prompt without reading the full run. The detail
+  // (question text/options) stays on `get()`'s `pending_question`; the event
+  // only flags THAT one pends, keeping the payload slim.
+  pending_question: Schema.Boolean,
+  error: Schema.NullOr(Schema.String),
+}
+export const Event = {
+  Updated: EventV2.define({ type: "workflow.run.updated", schema: RunEventData }),
+  Finished: EventV2.define({ type: "workflow.run.finished", schema: RunEventData }),
+}

--- a/packages/opencode/src/workflow/source-lint.ts
+++ b/packages/opencode/src/workflow/source-lint.ts
@@ -1,0 +1,145 @@
+import ts from "typescript"
+
+// Item 23 (Stufe 2): static source lint for workflow scripts. Like the
+// MetaReader, this works purely on the AST (ts.createSourceFile) and NEVER
+// imports or executes the module — the whole point is to surface capability-
+// relevant constructs (process spawning, filesystem/network access, env reads)
+// BEFORE any code runs, so the create output and the start approval dialog can
+// show them to the human who decides. The lint is advisory by default
+// (config `workflows.lint: 'warn'`); `'deny'` makes create/start fail on
+// findings and `'off'` disables it. It is deliberately NOT a sandbox: a
+// determined script can evade a static lint (computed member access, eval-ish
+// tricks) — the runtime ctx.shell permission gate (Stufe 1) and the approval
+// visibility are the load-bearing controls; this narrows the casual/accidental
+// vector and labels the script honestly.
+
+export type Finding = { line: number; rule: string; text: string }
+
+// node:-builtins whose import/require flags a finding. Matched by the FIRST
+// path segment after stripping the optional `node:` prefix, so `fs/promises`
+// and `node:fs/promises` both resolve to `fs`.
+const FLAGGED_BUILTINS = new Set([
+  "fs",
+  "child_process",
+  "net",
+  "http",
+  "https",
+  "dns",
+  "os",
+  "worker_threads",
+  "vm",
+])
+
+// Bun.* members that reach the filesystem / spawn processes / run shell
+// commands. `$` is Bun's template shell.
+const FLAGGED_BUN_MEMBERS = new Set(["spawn", "spawnSync", "write", "file", "$"])
+
+function moduleRoot(specifier: string): string {
+  const stripped = specifier.startsWith("node:") ? specifier.slice("node:".length) : specifier
+  const slash = stripped.indexOf("/")
+  return slash === -1 ? stripped : stripped.slice(0, slash)
+}
+
+function isFlaggedModule(specifier: string): boolean {
+  return FLAGGED_BUILTINS.has(moduleRoot(specifier))
+}
+
+// A finding's `text` is the offending source snippet, truncated so a single
+// long line cannot blow up the tool output / approval metadata.
+function snippet(node: ts.Node, file: ts.SourceFile): string {
+  const text = node.getText(file).replace(/\s+/g, " ").trim()
+  return text.length > 120 ? text.slice(0, 117) + "..." : text
+}
+
+/**
+ * Statically lints a workflow module's SOURCE TEXT for capability-relevant
+ * constructs, without importing or executing it. Flagged (rule names in
+ * parentheses):
+ * - static `import`/`export … from` of a flagged node builtin (`node-builtin-import`)
+ * - `require("<builtin>")` of a flagged builtin (`node-builtin-require`)
+ * - dynamic `import("<builtin>")` of a flagged builtin (`node-builtin-import`)
+ * - dynamic `import(<non-literal>)` — unanalyzable target (`dynamic-import`)
+ * - `Bun.spawn`/`Bun.spawnSync`/`Bun.write`/`Bun.file`/`Bun.$` (`bun-api`)
+ * - `process.env` reads (`process-env`)
+ * - `fetch(...)` calls (`fetch`)
+ * Never throws; an unparseable file simply yields the findings the parser
+ * could still see (TS recovers aggressively).
+ */
+export function lint(source: string, filePath: string): { findings: Finding[] } {
+  const file = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true)
+  const findings: Finding[] = []
+  const add = (node: ts.Node, rule: string) => {
+    const { line } = file.getLineAndCharacterOfPosition(node.getStart(file))
+    findings.push({ line: line + 1, rule, text: snippet(node, file) })
+  }
+
+  const visit = (node: ts.Node): void => {
+    // `import … from "x"` / `import "x"` / `export … from "x"`.
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      isFlaggedModule(node.moduleSpecifier.text)
+    ) {
+      add(node, "node-builtin-import")
+    }
+    // `import x = require("y")` (TS import-equals form).
+    if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      ts.isStringLiteral(node.moduleReference.expression) &&
+      isFlaggedModule(node.moduleReference.expression.text)
+    ) {
+      add(node, "node-builtin-require")
+    }
+    if (ts.isCallExpression(node)) {
+      // Dynamic `import(...)`: a flagged-builtin literal is the builtin rule; a
+      // non-literal argument is unanalyzable and flagged as such.
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        const arg = node.arguments[0]
+        if (arg !== undefined && ts.isStringLiteral(arg)) {
+          if (isFlaggedModule(arg.text)) add(node, "node-builtin-import")
+        } else {
+          add(node, "dynamic-import")
+        }
+      }
+      // `require("x")`.
+      if (ts.isIdentifier(node.expression) && node.expression.text === "require") {
+        const arg = node.arguments[0]
+        if (arg !== undefined && ts.isStringLiteral(arg)) {
+          if (isFlaggedModule(arg.text)) add(node, "node-builtin-require")
+        } else {
+          add(node, "node-builtin-require")
+        }
+      }
+      // `fetch(...)`.
+      if (ts.isIdentifier(node.expression) && node.expression.text === "fetch") {
+        add(node, "fetch")
+      }
+    }
+    // `Bun.<member>` for the flagged members (covers `Bun.$\`…\`` too, whose
+    // tag is the property access).
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "Bun" &&
+      FLAGGED_BUN_MEMBERS.has(node.name.text)
+    ) {
+      add(node, "bun-api")
+    }
+    // `process.env` (property or element access on it both contain this node).
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "process" &&
+      node.name.text === "env"
+    ) {
+      add(node, "process-env")
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(file)
+  return { findings }
+}
+
+export * as SourceLint from "./source-lint"

--- a/packages/opencode/src/workflow/types.ts
+++ b/packages/opencode/src/workflow/types.ts
@@ -1,0 +1,433 @@
+// Public input/option/context TYPES for the workflow engine, split out of
+// workflow.ts. These are the start/wait/answer/save input shapes, the agent/tool
+// option shapes, the parallel/pipeline aliases (owned by @opencode-ai/plugin),
+// the `ContextApi` (engine-side `ctx` view), and the `Interface` service shape.
+// Re-exported from the workflow.ts barrel so the public `Workflow.StartInput` /
+// `Workflow.AgentInput` / `Workflow.ContextApi` / `Workflow.Interface` / … surface
+// is unchanged.
+import { Effect, Schema } from "effect"
+import type { SessionPrompt } from "@/session/prompt"
+import { SessionID } from "@/session/schema"
+import { TurnBudget } from "@/session/turn-budget"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import type {
+  WorkflowContext,
+  WorkflowParallelOptions,
+  WorkflowPipelineFn,
+  WorkflowPipelineOptions,
+  WorkflowPipelineStage,
+  WorkflowToolFn,
+} from "@opencode-ai/plugin/workflow"
+import type { Info, Run, RunID, Source } from "./schema"
+import type { InvalidError, NotFoundError, SaveConflictError } from "./errors"
+
+// Non-negative finite number — the only shape a budget cap may take: a
+// negative/NaN/Infinity cap is a validation error at the boundary, never a
+// confusing runtime budget failure.
+const NonNegFinite = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(0))
+
+// Item 17: the budget cap. A NAKED number stays USD (backward compatibility for
+// every existing caller); the struct form adds an independent output-TOKEN cap.
+// Both caps may be set — whichever exhausts first gates the next step.
+const BudgetInput = Schema.Union([
+  NonNegFinite,
+  Schema.Struct({
+    usd: Schema.optional(NonNegFinite),
+    tokens: Schema.optional(NonNegFinite),
+  }),
+])
+
+export const StartInput = Schema.Struct({
+  // Optional so an inline-source start can omit it: when `source` is supplied with
+  // no `name`, start() loads the module straight from the source string (the
+  // builtin source-string load path) and the run's name is the source's meta name.
+  // Every other start path supplies a name to select a discovered workflow.
+  name: Schema.optional(Schema.String),
+  args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  // Optional cost cap for the whole run: a naked number is USD (back-compat), the
+  // struct form is `{ usd?, tokens? }`. USD is gated against the per-agent cost
+  // telemetry the engine already records (`AgentRun.cost`); tokens against each
+  // step's output+reasoning tokens (Item 17). After each agent step the spend
+  // accumulators advance; before each `ctx.agent` call the engine fails the step
+  // with a BudgetExceededError once a set cap is exhausted. Omitted ⇒ unlimited.
+  budget: Schema.optional(BudgetInput),
+}).annotate({ identifier: "WorkflowStartInput" })
+export type StartInput = Schema.Schema.Type<typeof StartInput>
+
+export type PromptOps = {
+  prompt: (input: SessionPrompt.PromptInput) => Effect.Effect<SessionV1.WithParts, unknown>
+  /**
+   * Aborts a running agent session (the same path TUI Esc / `POST /:id/abort`
+   * use). The workflow engine calls this for every tracked child session when a
+   * run is cancelled so no tokens keep burning after cancel. Optional so callers
+   * that never start agents need not provide it.
+   */
+  cancel?: (sessionID: SessionID) => Effect.Effect<void>
+  /**
+   * The RESOLVED model of a session (session.model → last user-message model →
+   * provider default). The workflow tool reads the CALLER session's model
+   * through this before start so default-agent steps can inherit it (Item 12).
+   * Optional so existing prompt-ops stubs keep compiling.
+   */
+  currentModel?: (
+    sessionID: SessionID,
+  ) => Effect.Effect<{ providerID: string; modelID: string; variant?: string }, unknown>
+}
+
+export type StartOptions = StartInput & {
+  prompt?: PromptOps
+  source?: string
+  temporary?: boolean
+  permissionSessionID?: SessionID
+  /**
+   * Identity of the caller that started this run (the tool/session that asked).
+   * `sessionID` is used to derive the inherited `permission` ruleset for every
+   * subagent session the run spawns (parent-session deny/external_directory
+   * rules; since #31696 parent-AGENT restrictions are deliberately NOT
+   * inherited — plan mode is instead gated by the plan agent's `workflow`
+   * deny). This is distinct from `permissionSessionID`, which only controls
+   * WHERE interactive permission prompts surface, not WHICH rules apply.
+   * Absent on a purely programmatic/HTTP start with no session identity — the
+   * documented fallback (no inherited ruleset) preserves the prior behavior.
+   * `agent` is currently informational only.
+   */
+  caller?: { sessionID: SessionID; agent?: string }
+  /**
+   * Item 24: the caller TURN's shared budget pool — a live, shared mutable
+   * object (NOT a schema field; it is not serializable and binds to exactly
+   * one prompt turn). When set, every `ctx.agent` step must pass BOTH the
+   * per-run budget gate AND an atomic pool reservation; the main loop charges
+   * the same pool directly, so two runs of one turn compete for one cap.
+   * Absent on HTTP/programmatic starts and on resumes (a resume turn brings
+   * its own pool).
+   */
+  pool?: TurnBudget.Pool
+  /**
+   * The caller session's RESOLVED model at start time (Item 12), already parsed
+   * into `{ providerID, modelID }` — never re-parsed via Provider.parseModel.
+   * A `ctx.agent` step that uses the DEFAULT agent (no `agent:` override) and
+   * has no explicit/phase model resolves to this, so subagents follow the main
+   * loop's model (incl. a TUI model switch). An explicitly chosen agent is a
+   * deliberate authoring decision including its model, so it is unaffected.
+   * Absent on HTTP/programmatic starts with no session-model context.
+   */
+  caller_model?: { providerID: string; modelID: string }
+  /**
+   * Resume a previous (paused, interrupted, failed, or completed) run by id.
+   * When set, start() loads the SOURCE run's persisted agent journal
+   * (directory-scoped, like get()) and builds
+   * a replay map keyed by the agent's call shape + occurrence index. As the new
+   * run re-executes the SAME workflow body, each `ctx.agent` call first looks up
+   * the journal: a matching COMPLETED source agent (whose index is not in
+   * `invalidate_agents`) is replayed verbatim (output/structured/cost/tokens,
+   * `cached: true`) with NO prompt, and the replayed cost is charged once via the
+   * shared `ensuring` (post-step), just like a live step; a miss runs live. The
+   * budget gate before the lookup still fails honestly when exhausted. The resume
+   * is cross-restart because the journal lives in the DB, not in memory.
+   */
+  resume_of?: RunID
+  /**
+   * Replay strategy for the resume journal (Item 20). Only meaningful together
+   * with `resume_of`:
+   * - `"prefix"` (DEFAULT, the safe mode): the journal is the source run's
+   *   agents in ORIGINAL ORDER and replay stops PERMANENTLY at the first
+   *   mismatch (a changed call, a non-completed source node, or an
+   *   `invalidate_agents` index) — every later call runs live, even if its
+   *   shape is unchanged. Rationale: shape-matching would serve a LATER
+   *   unchanged call from the journal although its workspace side effects may
+   *   be stale after an earlier step changed.
+   * - `"keyed"`: the previous shape-matching behavior, kept 1:1 for read-only
+   *   workflows (and recommended for heavily parallel ones, where dispatch
+   *   order within a parallel batch is not deterministic and could spuriously
+   *   break a prefix — prefix then degrades safely to live: more expensive,
+   *   never wrong).
+   * The default flip from keyed to prefix is a deliberate behavior change.
+   */
+  replay?: "prefix" | "keyed"
+  /**
+   * Source-journal agent indices (0-based, in the source run's `agents[]` order)
+   * to FORCE live re-execution of during a resume, even if they completed. Only
+   * meaningful together with `resume_of`. An index here is excluded from journal
+   * replay, so its `ctx.agent` call runs live and re-prompts. In `prefix` replay
+   * mode (the default), everything AFTER the first invalidated agent re-runs
+   * live too — the invalidated index breaks the prefix permanently.
+   */
+  invalidate_agents?: number[]
+  /**
+   * Seeded answers for a resume that picks up a run parked on a `ctx.question`
+   * (Tasks 12/13). A map of question TEXT → answer. During the resume the engine
+   * builds a question journal from the source run's `kind:"question"` nodes; on
+   * reaching the matching `ctx.question` the body is served the seeded answer
+   * (and the node is marked `cached`) instead of asking the user again. Only
+   * meaningful together with `resume_of`. Set by `answer()` on a paused run;
+   * unused by an ordinary resume.
+   */
+  questionAnswers?: Record<string, string>
+}
+
+export type WaitInput = {
+  id: RunID
+  timeout?: number
+}
+
+export type WaitResult = {
+  run?: Run
+  timedOut: boolean
+}
+
+export type AnswerInput = {
+  id: RunID
+  answer: string
+  /**
+   * Execution options forwarded UNCHANGED into the resume that `answer()` starts
+   * when the target run is `paused` on a question (Tasks 12/13). These mirror the
+   * subset of `StartOptions` the resume path consumes, so a workflow that asks a
+   * question and then dispatches more `ctx.agent` steps can run those steps on the
+   * resumed run. Ignored on the live-answer path (no resume happens). All optional
+   * for backward compatibility:
+   * - `prompt`: the prompt-ops vector (dispatch + abort) the agent steps need.
+   * - `permissionSessionID`: where interactive permission prompts surface.
+   * - `caller`: identity used to derive each subagent's inherited permission ruleset.
+   * - `budget`: cost cap for the resumed run — naked number = USD (back-compat),
+   *   or `{ usd?, tokens? }` (Item 17), mirroring StartInput.budget.
+   */
+  prompt?: PromptOps
+  permissionSessionID?: SessionID
+  caller?: { sessionID: SessionID; agent?: string }
+  budget?: number | { usd?: number; tokens?: number }
+}
+
+// Where save() writes a workflow file. `project` (default) targets the workspace
+// `.opencode/workflows` dir discover() globs first; `global` targets the global
+// config `workflows` dir. Mirrors the TUI save dialog's project/global toggle.
+export type SaveScope = "project" | "global"
+
+export type SaveInput = {
+  name: string
+  source: string
+  scope?: SaveScope
+}
+
+export type AgentInput = {
+  agent?: string
+  prompt: string
+  model?: string
+  variant?: string
+  tools?: Record<string, boolean>
+  skills?: string[]
+  files?: string[]
+  schema?: Record<string, unknown>
+  permissionSessionID?: SessionID
+  /**
+   * Explicit progress group for THIS call (Item 16). Pins the step's node to the
+   * named phase regardless of where `ctx.setPhase` currently points — closing
+   * the race window when setPhase and agent() do not share a microtask under
+   * parallel/pipeline concurrency. A phase declared in `meta.phases` with a
+   * `model` activates that model as this call's default (explicit `model` still
+   * wins); the run's `current_phase` is NOT changed (no setPhase side effect).
+   */
+  phase?: string
+  /** Display name for this step in run views (defaults to the agent name). */
+  label?: string
+  /**
+   * Run this step's subagent in a FRESH `git worktree` instead of the run's
+   * workspace, so parallel agents that mutate files do not conflict. The
+   * worktree is created on first dispatch and auto-removed when the run finishes
+   * or is cancelled (registered on the run scope). Requires the workspace to be
+   * a git repository; otherwise the step fails with a WorkflowInvalidError.
+   */
+  isolation?: "worktree"
+  /**
+   * What a FAILING step resolves to (Item 15). Default `"fail"`: the error
+   * propagates (run fails unless caught). `"null"`: the step resolves `null`
+   * (the node stays `failed` with its error recorded) so the body can branch.
+   * Budget/lifetime gates and aborts are NEVER swallowed — they always throw.
+   */
+  onError?: "fail" | "null"
+}
+
+export type ToolInput = {
+  timeout?: number
+  onError?: "fail" | "null"
+}
+
+// Pipeline/parallel option and stage shapes are the public workflow-authoring
+// contract, owned by `@opencode-ai/plugin` (opencode depends on the plugin, so
+// the plugin is the single source of truth). The engine re-exports them under
+// its short names so workflow modules and the engine see the SAME types; any
+// drift in the plugin definitions is a compile error here.
+export type ParallelOptions = WorkflowParallelOptions
+export type PipelineOptions = WorkflowPipelineOptions
+export type PipelineStage<Prev, Item, Next> = WorkflowPipelineStage<Prev, Item, Next>
+export type PipelineFn = WorkflowPipelineFn
+
+export type ContextApi = {
+  /** @deprecated USD-only view; prefer `ctx.budget.remaining()` (and `tokensRemaining()` for the token cap). */
+  readonly budgetRemaining: number
+  /**
+   * Budget in Claude-Code API shape. USD: `total` (null when unlimited),
+   * `spent()` so far, `remaining()` (Infinity when unlimited). Tokens (Item 17):
+   * `tokensTotal`/`tokensSpent()`/`tokensRemaining()` — the same trio for the
+   * independent output-token cap.
+   */
+  readonly budget: {
+    readonly total: number | null
+    spent(): number
+    remaining(): number
+    readonly tokensTotal: number | null
+    tokensSpent(): number
+    tokensRemaining(): number
+  }
+  readonly setPhase: (phase: string) => void
+  readonly log: (message: string) => void
+  readonly parallel: <T>(tasks: readonly (() => Promise<T>)[], options?: ParallelOptions) => Promise<(T | null)[]>
+  readonly pipeline: PipelineFn
+  /**
+   * Resolves `null` when a human skips the step (skipAgent), or — with
+   * `onError: "null"` — when the step fails (Item 15). Guard the result before
+   * dereferencing (`if (!r) …`).
+   */
+  readonly agent: (input: AgentInput) => Promise<{ data: unknown; text: string } | null>
+  readonly tool: WorkflowToolFn
+  /**
+   * Deterministic non-LLM step: run a shell command in the run's workspace and
+   * resolve to `{ output, exitCode }`. Does NOT consume an LLM turn or the run's
+   * budget (`ctx.budget.spent()` is unaffected). A non-zero exit is mapped to the
+   * returned `exitCode`, NOT thrown.
+   */
+  readonly shell: (
+    command: string,
+    opts?: { timeout?: number; cwd?: string },
+  ) => Promise<{ output: string; exitCode: number }>
+  /**
+   * Run another DISCOVERED workflow inline under the SAME run (no separate run
+   * row), sharing this run's concurrency, budget, abort scope, and agent-lifetime
+   * cap. Returns the child workflow's `run()` result. Nesting is limited to depth
+   * 1: a workflow invoked via `ctx.workflow` cannot itself call `ctx.workflow`
+   * (the nested call throws a WorkflowInvalidError).
+   */
+  readonly workflow: (name: string, args?: Record<string, unknown>) => Promise<unknown>
+  /**
+   * Human-in-the-loop step (Tasks 12/13): persist a pending question on the run,
+   * emit a `workflow.run.updated` event carrying `pending_question: true`, then
+   * wait LIVE for an answer (a Deferred resolved by the service `answer()` method),
+   * racing a timeout (default 10 minutes). On answer it resolves to `{ answer }`
+   * and clears the pending question; the question is also recorded as a
+   * `kind:"question"` journal node so a resumed run can replay the answer instead
+   * of asking again. If the timeout elapses unanswered the run PARKS as `paused`
+   * (the same pause machinery), keeping the open question so a later `answer()`
+   * resumes it.
+   */
+  readonly question: (input: {
+    question: string
+    options?: readonly string[]
+    timeout?: number
+  }) => Promise<{ answer: string }>
+}
+
+// `ContextApi` is the engine-side view of the run context handed to a workflow
+// module; `WorkflowContext` (plugin) is the public authoring view. They must
+// stay structurally assignable so a value the engine builds is a valid argument
+// to a module typed against the plugin. This is asserted at compile time rather
+// than via a full SSoT import because the two differ intentionally: ContextApi
+// is `readonly` and is the runtime producer, WorkflowContext is the consumer
+// contract. Drift in either direction fails the build below.
+type _ContextApiSatisfiesWorkflowContext = ContextApi extends WorkflowContext ? true : never
+const _contextApiCheck: _ContextApiSatisfiesWorkflowContext = true
+void _contextApiCheck
+
+// The Workflow service shape. Kept here with the other public types; the
+// implementing `Service` class + engine `layer` live in engine.ts.
+export interface Interface {
+  // Never fails: a file that cannot be loaded is reported as an invalid Info
+  // entry rather than aborting the whole list.
+  readonly list: () => Effect.Effect<Info[]>
+  /**
+   * Resolves a single workflow's module SOURCE by name, for the pre-run approval
+   * preview (which has no run yet, so it cannot read `run.definition.source`).
+   * Returns the file text for an on-disk workflow or the bundled string for a
+   * builtin — WITHOUT a raw `file.read({path})` (which failed for an absolute path
+   * and returned "" for a synthetic `builtin:`/`inline:` marker). `list()` stays
+   * lean (name + meta only); the heavier source is fetched on-demand only when the
+   * operator actually opens the source view. Returns `undefined` for an unknown
+   * name (the HTTP handler maps that to 404).
+   */
+  readonly read: (name: string) => Effect.Effect<Source | undefined>
+  readonly runs: () => Effect.Effect<Run[]>
+  readonly get: (id: RunID) => Effect.Effect<Run | undefined>
+  readonly start: (input: StartOptions) => Effect.Effect<Run, InvalidError | NotFoundError>
+  readonly wait: (input: WaitInput) => Effect.Effect<WaitResult>
+  readonly cancel: (id: RunID) => Effect.Effect<Run | undefined>
+  /**
+   * Suspends a running run: aborts every tracked child agent session, closes the
+   * run scope, and interrupts the run fiber (exactly like cancel), but finishes
+   * the run with the non-terminal status `paused` instead of `cancelled` — the
+   * persisted agent journal is kept intact so the run can later be resumed. Like
+   * cancel, returns the run's snapshot, or `undefined` for a genuinely unknown id
+   * (which the HTTP handler maps to 404). A run that is already terminal/paused is
+   * returned as-is (idempotent); a non-live but persisted row is returned verbatim.
+   */
+  readonly pause: (id: RunID) => Effect.Effect<Run | undefined>
+  /**
+   * Skips ONE in-flight agent step of a LIVE run (Item 15): the step's
+   * `ctx.agent` call resolves `null`, the node finishes `skipped` (no budget
+   * charge), and the run continues. Returns `undefined` for an id unknown to
+   * this workspace (HTTP → 404); fails with InvalidError when the run is not
+   * live (no registry entry — a persisted/terminal run has nothing to skip),
+   * the node does not exist, the node is a `question`, or the node is not
+   * `running` (HTTP → 409). The skip request is recorded BEFORE the node's
+   * session is aborted, mirroring cancel's request-flag-first ordering.
+   */
+  readonly skipAgent: (input: { id: RunID; agentId: string }) => Effect.Effect<Run | undefined, InvalidError>
+  /**
+   * Answers the open human-in-the-loop question on a run (Tasks 12/13):
+   * - a LIVE run waiting in `ctx.question` → resolve the Deferred so the body
+   *   receives `{ answer }`, clear the pending question, persist, and return the
+   *   updated run.
+   * - a `paused` run with a persisted `pending_question` → START a resume
+   *   (`resume_of`) whose journal replay serves this answer to the question node
+   *   instead of asking again, and return the NEW run.
+   * - an unknown id, or a run with no open question → `undefined` (the HTTP
+   *   mapping is a later track).
+   */
+  readonly answer: (input: AnswerInput) => Effect.Effect<Run | undefined, InvalidError | NotFoundError>
+  /**
+   * Persists a workflow SOURCE string to disk as a discoverable workflow file
+   * (the dashboard's "save a run as a command"). Resolves the destination from
+   * `scope`: `project` writes `<worktree|directory>/.opencode/workflows/<name>.ts`
+   * (the same root discover() globs first), `global` writes
+   * `<config>/workflows/<name>.ts`. The name is sanitized to a single safe path
+   * segment (letters/digits/_/-) and the source is statically validated with the
+   * SAME MetaReader the create tool uses (AST-only, never imports/executes the
+   * module). NEVER overwrites: an existing file at the destination fails with
+   * SaveConflictError. A bad name or invalid meta fails with InvalidError. Returns
+   * the absolute path of the written file. Mirrors the create tool's write logic,
+   * minus the tool-context permission ask (the HTTP route is gated by the auth
+   * middleware; the engine method is the shared write seam for both surfaces).
+   */
+  readonly save: (input: SaveInput) => Effect.Effect<{ path: string }, InvalidError | SaveConflictError>
+  /**
+   * Exports a run's transcripts as hand-readable files under
+   * `<data>/workflow/<runId>/transcripts/` (Item 27): `run.json` (the run
+   * snapshot, 2-space) plus one `<agent-id>.jsonl` per agent node — each line
+   * `{ info, parts }` for a message of the node's session, or a single
+   * fallback line `{ node }` when the node has no readable session (a
+   * replayed/cached node, a question node, or a deleted session), so the
+   * export is always COMPLETE across all nodes. Idempotently overwrites on
+   * re-export. Returns the directory and the written file names, or
+   * `undefined` for a run unknown to this workspace (directory-scoped like
+   * `get()`; the HTTP handler maps that to 404). A still-running run exports
+   * its current snapshot. The JSONL line shape is a debug/hand format, NOT an
+   * API contract — no schema is exported for it.
+   */
+  readonly export: (id: RunID) => Effect.Effect<{ path: string; files: string[] } | undefined>
+  readonly remove: (id: RunID) => Effect.Effect<boolean>
+  /**
+   * Marks every `running` DB row that has no live registry entry as
+   * `interrupted`. Runs automatically when the per-instance registry is first
+   * created (process start → registry empty → all `running` rows are zombies),
+   * and is exposed so callers/tests can trigger it explicitly. Paused rows are
+   * deliberately left untouched (parked by design, not lost).
+   */
+  readonly sweep: () => Effect.Effect<void>
+}

--- a/packages/opencode/src/workflow/workflow.sql.ts
+++ b/packages/opencode/src/workflow/workflow.sql.ts
@@ -1,0 +1,1 @@
+export { WorkflowRunTable } from "@opencode-ai/core/workflow/sql"

--- a/packages/opencode/src/workflow/workflow.ts
+++ b/packages/opencode/src/workflow/workflow.ts
@@ -1,0 +1,4147 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Config } from "@/config/config"
+import { Agent } from "@/agent/agent"
+import { deriveSubagentSessionPermission } from "@/agent/subagent-permissions"
+import { EffectBridge } from "@/effect/bridge"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceState } from "@/effect/instance-state"
+import { InstanceRef } from "@/effect/instance-ref"
+import { Provider } from "@/provider/provider"
+import { Session } from "@/session/session"
+import { SessionID, MessageID, PartID } from "@/session/schema"
+import { Database } from "@opencode-ai/core/database/database"
+import { Global } from "@opencode-ai/core/global"
+import { Permission } from "@/permission"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import { scanCommand } from "@/tool/shell"
+import { ShellID } from "@/tool/shell/id"
+import { TurnBudget } from "@/session/turn-budget"
+import { ToolCatalog } from "@/tool/catalog"
+import { MCP } from "@/mcp"
+import { Plugin } from "@/plugin"
+import { Truncate } from "@/tool/truncate"
+import { Tool } from "@/tool/tool"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import type { WorkflowDefinitionRow } from "@opencode-ai/core/workflow/sql"
+import { Glob } from "@opencode-ai/core/util/glob"
+import { and, desc, eq, isNotNull, notInArray } from "drizzle-orm"
+import { APICallError } from "ai"
+import { spawnSync } from "child_process"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { pathToFileURL } from "url"
+import {
+  Cause,
+  Clock,
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Scope,
+  Schema,
+  Semaphore,
+  SynchronizedRef,
+} from "effect"
+import type { Hooks } from "@opencode-ai/plugin"
+import type { WorkflowDefinition, WorkflowToolFn, WorkflowToolResult } from "@opencode-ai/plugin/workflow"
+import { WorkflowRunTable } from "./workflow.sql"
+import { MetaReader } from "./meta-reader"
+import { Meta } from "./meta"
+import { BUILTIN_WORKFLOWS, builtinPath, inlinePath } from "./builtin"
+import { Process } from "@/util/process"
+import { Shell } from "@opencode-ai/core/shell"
+
+// ---------------------------------------------------------------------------
+// Public surface re-exports. workflow.ts is now a THIN BARREL: the data schemas
+// live in ./schema, the error classes in ./errors, the input/option/context
+// types + the service Interface in ./types. Re-exported here so the public
+// `Workflow.*` namespace surface (the `export * as Workflow` at the bottom) is
+// byte-for-byte identical to before the split — every external `import { Workflow }
+// from "@/workflow/workflow"` and every `Workflow.RunID` / `Workflow.Info` /
+// `Workflow.NotFoundError` / `Workflow.StartInput` / `Workflow.Interface` member
+// access keeps resolving. No exported symbol was dropped.
+// ---------------------------------------------------------------------------
+export {
+  RunID,
+  Argument,
+  Meta,
+  Phase,
+  Info,
+  Source,
+  Definition,
+  Status,
+  LogEntry,
+  AgentRun,
+  Run,
+  Event,
+} from "./schema"
+export {
+  NotFoundError,
+  InvalidError,
+  SaveConflictError,
+  StructuredOutputError,
+  BudgetExceededError,
+  AgentLimitError,
+  CancelledError,
+} from "./errors"
+export {
+  StartInput,
+  type PromptOps,
+  type StartOptions,
+  type WaitInput,
+  type WaitResult,
+  type AnswerInput,
+  type SaveScope,
+  type SaveInput,
+  type AgentInput,
+  type ToolInput,
+  type ParallelOptions,
+  type PipelineOptions,
+  type PipelineStage,
+  type PipelineFn,
+  type ContextApi,
+  type Interface,
+} from "./types"
+
+// Engine-internal imports of the split-out symbols. The engine body below
+// references these schemas/types/errors/values directly, so they are imported
+// (in addition to the re-exports above) for the implementation's own use.
+import {
+  AgentRun,
+  Definition,
+  Event,
+  Info,
+  Run,
+  RunID,
+  Source,
+  Status,
+} from "./schema"
+import {
+  AgentLimitError,
+  BudgetExceededError,
+  CancelledError,
+  InvalidError,
+  NotFoundError,
+  SaveConflictError,
+  StructuredOutputError,
+} from "./errors"
+import type {
+  AgentInput,
+  AnswerInput,
+  ContextApi,
+  Interface,
+  PipelineOptions,
+  PromptOps,
+  SaveInput,
+  SaveScope,
+  StartOptions,
+  ToolInput,
+  WaitInput,
+  WaitResult,
+} from "./types"
+import { StartInput } from "./types"
+// `encodePhase` (and the `Phase` type) are engine-body helpers from ./meta; the
+// public `Phase` re-export above comes from ./schema (which re-exports ./meta).
+import { type Phase, encodePhase } from "./meta"
+
+// The default lifetime cap: the maximum number of agent dispatches a single run
+// may start before `ctx.agent` refuses with AgentLimitError. Overridable per
+// process by the `__testHooks.agentLimit` seam (a small value keeps the lifetime
+// test fast); inert at the default in production.
+const DEFAULT_AGENT_LIMIT = 1_000
+
+// The per-call batch cap for `ctx.parallel`/`ctx.pipeline` (Claude parity): a
+// single call may carry at most this many tasks/items. Enforced with an explicit
+// InvalidError AT THE CALL SITE so the author gets actionable feedback naming the
+// offending call, instead of the batch silently degrading into a mass of `null`
+// drops against the per-run lifetime cap above.
+const MAX_BATCH_ITEMS = 4_096
+
+// Framing directive prepended to every NON-schema agent step's prompt (Claude
+// parity): a workflow step's final message is consumed by a PROGRAM (the step's
+// resolved value), not by a human, so the subagent is told to output only the
+// requested data. Prepended onto the prompt text exactly like the skills
+// directive (PromptInput.system exists but the run loop's system-prompt assembly
+// does not read it, so a prompt prepend is the supported mechanism). Schema steps
+// are NOT framed: the StructuredOutput tool call enforces the shape already, and
+// an extra "output only data" line could compete with the structured-output
+// system prompt. Exported for tests asserting the dispatched prompt text.
+export const STEP_FRAMING_DIRECTIVE =
+  "You are one step of an automated workflow. Your final message is returned verbatim as this step's value to a program — output only the requested data, no preamble, no human-directed summary."
+
+// Legitimate resume sources for `start({ resume_of })`. Beyond paused/interrupted,
+// a FAILED source carries the core iteration loop (run fails → edit the script →
+// replay the completed prefix live-free) and a COMPLETED source is the
+// 100%-cache-hit re-run. `running` stays excluded (stop the source run first) and
+// `cancelled` stays excluded (the cancel-of-a-paused-run race protection — see the
+// status guard in start()).
+const RESUMABLE: ReadonlySet<Status> = new Set(["paused", "interrupted", "failed", "completed"])
+
+// The run-wide concurrency cap: the maximum number of `ctx.agent` dispatches that
+// may run simultaneously within a single run, regardless of any (looser) per-call
+// `concurrencyLimit`. Derived from the host's CPU count, clamped to [2, 16] so a
+// tiny box never serializes to 1 and a huge box never fans out unbounded.
+const agentConcurrencyCap = () => Math.min(16, Math.max(2, os.cpus().length - 2))
+
+// Item 15: sentinel resolved through the agent dispatch when a human skipped the
+// step (skipAgent). The success settlement maps it to `null` WITHOUT touching
+// the node — its `skipped` state was already persisted inside the dispatch gen.
+// A module-scoped symbol so it can never collide with a real step result.
+const SKIPPED = Symbol("workflow-agent-skipped")
+
+type Module = {
+  meta: Meta
+  run: (args: Record<string, unknown>, ctx: ContextApi) => Promise<unknown>
+  // The RESOLVED module source string this module was loaded from — the file text
+  // for an on-disk workflow, the bundled/inline string for a builtin/inline start.
+  // loadModule already reads this to materialize the import; threading it out lets
+  // start() stamp `definition.source` for EVERY run (not just inline starts), which
+  // is what powers save-as-command and the run-detail source view.
+  source: string
+}
+
+type Active = {
+  run: Run
+  /**
+   * The workspace directory (InstanceState.directory) this run was started in.
+   * Persisted to the `directory` column so every read/delete/sweep can be scoped
+   * to the owning workspace (Fund 6/17): the DB is process-global but the
+   * workflow endpoints are per-directory, so a run started in A must never leak
+   * into / be swept from B. Not surfaced on the public `Run` schema — it is a
+   * persistence/routing concern, not part of the run's reported shape.
+   */
+  directory: string
+  done: Deferred.Deferred<Run>
+  fiber?: Fiber.Fiber<void, unknown>
+  /**
+   * Per-run scope into which EVERY agent/parallel/pipeline effect is forked
+   * (via `Effect.forkIn(runScope)`), instead of running as a detached root
+   * fiber through `Effect.runPromise`. This makes all dispatched agent work a
+   * tracked child of the run: closing `runScope` on cancel/remove propagates
+   * Interrupt down to in-flight agent fibers (Fund 14), including ones that
+   * started but had not yet registered their child session (Fund 16), and ones
+   * that would otherwise re-INSERT a deleted row after delete (Fund 3). The
+   * scope is forked from the instance scope, so an instance teardown also
+   * closes it.
+   */
+  runScope: Scope.Closeable
+  /** Child agent sessions currently in flight; aborted on cancel/remove. */
+  sessions: Set<string>
+  /** Session-abort vector for this run (the prompt-ops `cancel`); undefined when no prompt-ops were supplied. */
+  cancelSession?: (sessionID: SessionID) => Effect.Effect<void>
+  /** Set once a cancel/remove has been requested so the run finishes as `cancelled`, never `failed`. */
+  cancelling?: boolean
+  /**
+   * Tombstone set by `remove()` BEFORE the row is deleted. `persistRun` reads
+   * it inside its `Effect.suspend` and NO-OPs for a removed run, so a settlement
+   * write racing the delete can never re-INSERT (resurrect) the deleted row
+   * (Fund 3).
+   */
+  removed?: boolean
+  /**
+   * Original cost cap (USD) the run was started with, or `Infinity` when no
+   * budget was set. Kept alongside `budgetRemaining` purely so the
+   * BudgetExceededError can report how much was budgeted vs. spent.
+   */
+  budget: number
+  /**
+   * Live remaining budget (USD). Starts at `budget` and is decremented after
+   * each agent step by that step's `AgentRun.cost`. `Infinity` ⇒ unlimited.
+   * Read by `ctx.budgetRemaining`; gated against in `ctx.agent`.
+   */
+  budgetRemaining: number
+  /**
+   * Original cost cap (USD) the run was started with, or `undefined` when no
+   * budget was set. Distinct from `budget` (which coerces "unset" to `Infinity`
+   * for the gate): this keeps the unset case as `undefined` so `ctx.budget.total`
+   * can report `null`. Read-only after `start()`.
+   */
+  budgetTotal?: number
+  /**
+   * Total cost (USD) actually spent so far, accumulated at the same site that
+   * decrements `budgetRemaining` — but ALWAYS, even with no budget set, so
+   * `ctx.budget.spent()` works regardless. Starts at 0. Read by `ctx.budget`.
+   */
+  costSpent: number
+  /**
+   * Output-token cap (Item 17), or `undefined` when no token budget was set
+   * (unlimited). Gated in `ctx.agent` exactly like the USD cap — a soft cap with
+   * the same audited parallel-overspend bound (comment T5).
+   */
+  tokensBudgetTotal?: number
+  /**
+   * Output tokens (output + reasoning; reasoning is output-billed) actually
+   * spent so far. Accumulated at the SAME settlement site (and under the same
+   * guards) as `costSpent` — ALWAYS, even with no token budget, so
+   * `ctx.budget.tokensSpent()` works regardless. Starts at 0.
+   */
+  tokensSpent: number
+  /**
+   * Run-wide concurrency gate over EVERY `ctx.agent` dispatch (agent/parallel/
+   * pipeline all funnel through ctx.agent). Sized to the host CPU count clamped
+   * to [2, 16] at run start. A per-call `concurrencyLimit` still applies on top
+   * (the narrower limit wins); this is the global ceiling for one run.
+   */
+  agentSemaphore: Semaphore.Semaphore
+  /**
+   * Count of agent dispatches STARTED by this run. Incremented at the top of
+   * `ctx.agent`; once it would exceed `agentLimit` the call fails with
+   * AgentLimitError so a runaway workflow cannot spawn unbounded subagents.
+   */
+  agentStarted: number
+  /** Per-run lifetime ceiling (DEFAULT_AGENT_LIMIT unless overridden by the test seam). */
+  agentLimit: number
+  /** Set once pause() has requested suspension so the run finishes as `paused`, not `cancelled`/`failed`. */
+  pausing?: boolean
+  /**
+   * Resume journal: when this run was started with `resume_of`, the source run's
+   * completed agents keyed by call shape. Each `ctx.agent` consumes the next
+   * unused entry for its key (occurrence order), so two identical calls resolve
+   * to distinct journal entries. Absent on a non-resume run.
+   */
+  journal?: Map<string, AgentRun[]>
+  /** Per-key consumption cursor into `journal`, advanced as each occurrence is replayed. */
+  journalCursor?: Map<string, number>
+  /**
+   * Replay strategy of this resume (Item 20): `"prefix"` (default) walks
+   * `journalSeq` in order and breaks permanently at the first mismatch;
+   * `"keyed"` is the previous shape-matching behavior over `journal`/
+   * `journalCursor`. Absent on a non-resume run.
+   */
+  journalMode?: "prefix" | "keyed"
+  /**
+   * Prefix-mode journal (Item 20): the source run's agents in ORIGINAL order
+   * (questions filtered out — question replay stays on `questionJournal`),
+   * INCLUDING non-completed nodes, which BREAK the prefix instead of being
+   * invisibly absent. `index` is the node's position in the source `agents[]`
+   * so `invalidate_agents` can be checked at replay time. Absent in keyed mode.
+   */
+  journalSeq?: { node: AgentRun; index: number }[]
+  /** Consumption cursor into `journalSeq`, advanced on each prefix replay hit. */
+  journalSeqCursor: number
+  /**
+   * Set once a prefix replay missed (changed call, non-completed source node,
+   * invalidated index, or a schema parse failure). From then on EVERY
+   * `ctx.agent` call runs live — the prefix is broken permanently (Item 20).
+   */
+  replayBroken: boolean
+  /**
+   * Prefix-mode view of `invalidate_agents` (source `agents[]` indices forced
+   * live). Checked at replay time against `journalSeq[cursor].index`; a hit
+   * breaks the prefix. Keyed mode filters these out at seed time instead.
+   */
+  invalidateSet?: Set<number>
+  /** Id of the source run this run resumed from; mirrored onto `run.resume_of` and the row. */
+  resumeOf?: RunID
+  /**
+   * The open human-in-the-loop question this run is currently parked on inside
+   * `ctx.question` (Tasks 12/13). `deferred` is resolved by `answer()` on a LIVE
+   * run to hand the reply back to the body; `node` is the `kind:"question"`
+   * journal node so `answer()` can stamp the answer onto it. Set while a question
+   * is awaited, cleared the instant it resolves (live) or times out (park).
+   */
+  pendingQuestion?: { deferred: Deferred.Deferred<{ answer: string }>; node: AgentRun }
+  /**
+   * Resume answer journal (Tasks 12/13): when this run resumed a source run that
+   * was parked on a question, the answer supplied to `answer()` keyed by the
+   * question node's call shape ([question, phase]). On reaching the matching
+   * `ctx.question` the body is served this answer from the journal instead of
+   * asking again — the SAME journal-replay seam the agent journal uses. Absent on
+   * a run that did not resume a question.
+   */
+  questionJournal?: Map<string, string>
+  /**
+   * Per-phase DEFAULT model (Task 15). Resolved AT `setPhase` time from the
+   * workflow's declared phases (`run.definition.meta.phases`) — the matched
+   * phase's `model`, or `undefined` when the phase is undeclared or declares no
+   * model. Stored here rather than re-parsed from `run.current_phase` so a nested
+   * workflow's prefixed phase string never needs decoding: the value is set by the
+   * SAME context's `setPhase`, and `ctx.agent` reads it as the middle tier of model
+   * resolution (explicit input.model > this phase model > selected agent's model).
+   */
+  currentPhaseModel?: string
+  /**
+   * The caller session's RESOLVED model at start time (Item 12), captured by the
+   * workflow tool via promptOps.currentModel. A DEFAULT-agent `ctx.agent` step
+   * (no `agent:` override) with no explicit/phase model resolves to it, so
+   * subagents follow the main loop's model. Absent on starts with no
+   * session-model context (HTTP/programmatic). Shared by ctx.workflow children
+   * automatically (same `active`).
+   */
+  callerModel?: { providerID: string; modelID: string }
+  /**
+   * Node IDs a human asked to skip via `skipAgent` (Item 15). Added BEFORE the
+   * node's session is aborted (the same request-flag-first ordering cancel uses,
+   * Fund 16) so the abort settlement can tell a skip apart from a cancel. The
+   * step's ctx.agent call resolves `null` and the node finishes `skipped`.
+   */
+  skipRequests: Set<string>
+  /**
+   * Item 23 (Stufe 1): the bash permission ruleset every `ctx.shell` ask of
+   * this run is evaluated against — the CALLER session's rules (deny/allow/
+   * external_directory), inherited with the same logic as the subagent asks.
+   * Computed once in start(); `[]` when there is no caller identity (HTTP/
+   * headless start) — asks then fall through to the interactive default.
+   */
+  shellRuleset: PermissionV1.Rule[]
+  /**
+   * Item 24: the caller turn's shared budget pool (StartOptions.pool).
+   * ctx.workflow children share `active`, so the pool is automatically shared;
+   * a background run holds the reference past the turn's end. Per-step
+   * reservations live in the step closure (not a map) — the step's `ensuring`
+   * always settles them, so a reservation can never leak.
+   */
+  pool?: TurnBudget.Pool
+}
+
+type State = {
+  runs: SynchronizedRef.SynchronizedRef<Map<string, Active>>
+  scope: Scope.Scope
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Workflow") {}
+
+const decodeMeta = Schema.decodeUnknownExit(Meta)
+
+// Cross-version phases compatibility (@VasyaYovbak). The `definition` JSON column
+// is the one place the phases shape drifted between branches: an older branch
+// stored `meta.phases` as bare strings (`["setup"]`), a newer one as normalized
+// objects (`[{title:"setup"}]`). Switching branches leaves the OTHER shape's rows
+// in the shared local DB. Two halves close the gap, both routed through the SAME
+// `Definition`/`Meta` schema whose `phases` union (`string | object`) already
+// accepts BOTH shapes:
+//
+// (A) PERSIST writes the back-compat ENCODED form. `encodeDefinitionForRow`
+//     re-emits a title-only phase as the bare STRING (a structured phase stays an
+//     object) so an OLDER reader expecting `phases: string[]` can still decode our
+//     plain-phase rows. Only `meta.phases` is rewritten — a targeted, total
+//     transform — instead of a full `Schema.encode(Definition)` round-trip, which
+//     would needlessly re-run the codec over `source`/`path` and risk throwing on
+//     a definition that drifted; the bytes for every OTHER field are untouched.
+//
+// (B) READ normalizes back to the canonical OBJECT form. `decodeDefinition` runs
+//     the stored definition through the schema decode (the union accepts strings
+//     OR objects), so the in-memory `Run` is ALWAYS object-phased and the public
+//     `Run` encode (the HTTP response) never trips over a string phase producing
+//     an `undefined` title — the exact failure the reviewer reported.
+const decodeDefinition = Schema.decodeUnknownExit(Definition)
+
+// (A) Persist-time encode: return a row-shaped definition whose `meta.phases` is
+// the back-compat WIRE form. Total and field-local — we touch only `meta.phases`
+// and leave every other field (name/path/source/temporary, all other meta keys)
+// byte-identical, so this can never throw on a well-formed in-memory definition.
+function encodeDefinitionForRow(definition: Definition): Definition {
+  if (!definition.meta.phases) return definition
+  return {
+    ...definition,
+    meta: { ...definition.meta, phases: definition.meta.phases.map(encodePhase) as Definition["meta"]["phases"] },
+  }
+}
+
+// (C) De-dupe seam: a persistently-bad row would otherwise re-warn on EVERY
+// runs()/get() (every dashboard poll re-reads it), so a single foreign row would
+// spam the log forever. Warn at most ONCE per row id per process — a plain
+// module-level Set keyed by id, which is total and never unbounded in practice
+// (one entry per distinct bad row, which is a tiny finite set). Lives at module
+// scope (not per-instance) deliberately: the warn is a developer diagnostic, not
+// per-workspace state, so once-per-process is the right granularity.
+const warnedBadDefinitionRows = new Set<string>()
+
+// (B)+(C) Read-time normalize with per-row resilience. Decode the stored
+// definition so its phases land in the canonical object form regardless of
+// whether the row holds strings (old/encoded) or objects (older un-encoded
+// rows). A row whose definition the schema REJECTS (a foreign/malformed shape
+// from some other branch) is COERCED — not dropped — to a safe definition with
+// EMPTY phases: a corrupt phases blob must never blank a user's run out of the
+// history list, so we degrade that one field and keep the row's id/status/logs
+// visible. (Skipping the row was the alternative; coercing is the friendlier
+// graceful-degradation choice — the run still shows up, just without phases.)
+//
+// `runId` is threaded in only to de-dupe the warn (see above); it is not part of
+// the normalization itself, so it is optional (a caller without a row id — none
+// today — simply warns every time, which is the old behavior).
+function normalizeDefinition(definition: Definition | undefined, runId?: string): Definition | undefined {
+  if (definition === undefined) return undefined
+  const decoded = decodeDefinition(definition)
+  if (Exit.isSuccess(decoded)) return decoded.value as Definition
+  // Diagnostic only — never rethrow: the whole point of (C) is that ONE bad row
+  // cannot fail the list/get response; we COERCE the row (keep it, degrade its
+  // phases to empty) rather than drop it. `console.warn` (not an Effect logger)
+  // because this is a pure, synchronous row-mapping helper outside any fiber.
+  // De-duped per row id so a persistently-bad row warns once, not on every poll.
+  if (runId === undefined || !warnedBadDefinitionRows.has(runId)) {
+    if (runId !== undefined) warnedBadDefinitionRows.add(runId)
+    console.warn(
+      `[workflow] coercing un-decodable definition phases to empty for "${definition.name}": ${Cause.pretty(decoded.cause)}`,
+    )
+  }
+  return { ...definition, meta: { ...definition.meta, phases: [] } }
+}
+
+// N13: the public `Run` projection of a live run. The spread copies ONLY the
+// `Run` fields (`active.run` is exactly the `Run` shape — the engine-internal
+// fields like `directory`/`runScope`/`budget` live on `Active`, never on
+// `active.run`), so no internal state leaks. But a shallow spread still ALIASES
+// the live nested values, so a caller mutating `snapshot(active).args.x` /
+// `.definition` / `.result` / a `logs`/`agents`/`agents[].tokens` entry would
+// mutate the running engine's own state. Defensively deep-copy every nested
+// value so the returned run is a detached projection (matching `fromRow`, which
+// already returns a fresh DB-parsed run).
+//
+// The clone goes through the JSON codec (`JSON.parse(JSON.stringify(x))`) — the
+// SAME serializability semantics as `persistRun`/`fromRow`, which round-trip the
+// JSON columns. structuredClone (the previous approach) was wrong: it THROWS on
+// functions/symbols/class instances (`DOMException: object can not be cloned`),
+// which a workflow can return via `result` (e.g. `return { cb: () => {} }`), so
+// it stranded every no-timeout `wait()` and blocked the terminal persist (N2
+// regression). The JSON codec instead drops those values silently, exactly as
+// the DB persist does, keeping the live snapshot and the DB row identical.
+//
+// This is total — it cannot throw — for every reachable engine state: `args`/
+// `definition` are `mode: "json"` columns (a non-JSON value would already have
+// died at the persist that ran on `start`), and `result` is JSON-normalized at
+// the single point it enters the engine (the `finish` boundary, see below), so
+// by the time it lands on `active.run.result` it is guaranteed JSON-safe. The
+// per-entry JSON clone of `agents` also severs the `tokens`/`cache` aliasing
+// (those are plain numbers, never throw).
+function jsonClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value))
+}
+
+function snapshot(active: Active): Run {
+  return {
+    ...active.run,
+    args: active.run.args === undefined ? undefined : jsonClone(active.run.args),
+    definition: active.run.definition === undefined ? undefined : jsonClone(active.run.definition),
+    result: active.run.result === undefined ? undefined : jsonClone(active.run.result),
+    logs: active.run.logs.map((item) => ({ ...item })),
+    agents: active.run.agents.map((item) => jsonClone(item)),
+    // Detach the pending question from the live run so a caller mutating the
+    // returned snapshot cannot reach into engine state (mirrors the nested-value
+    // defensiveness above). `options` is a plain string array, JSON-safe.
+    pending_question: active.run.pending_question === undefined ? undefined : jsonClone(active.run.pending_question),
+  }
+}
+
+type Row = typeof WorkflowRunTable.$inferSelect
+
+function fromRow(row: Row): Run {
+  return {
+    // DB->engine brand boundary: the row id is an opaque `text` column in core
+    // (which cannot import the engine's brand), so it is re-branded here.
+    id: RunID.make(row.id),
+    session_id: row.session_id ?? undefined,
+    workflow: row.workflow,
+    args: row.args ?? undefined,
+    // (B)+(C): normalize the stored definition's phases to the canonical OBJECT
+    // form (the row may hold the old string shape from another branch) and
+    // coerce — never throw — if the definition is foreign/un-decodable, so one
+    // bad row never blanks the whole list/get response (@VasyaYovbak). The row id
+    // is passed so a persistently-bad row's coerce-warn is de-duped per id.
+    definition: normalizeDefinition(row.definition ?? undefined, row.id),
+    status: row.status,
+    started_at: row.started_at,
+    completed_at: row.completed_at ?? undefined,
+    current_phase: row.current_phase ?? undefined,
+    logs: row.logs.map((item) => ({ ...item })),
+    agents: row.agents.map((item) => ({ ...item })),
+    // Fund 42: the `result` column is plain JSON text (the engine owns the codec,
+    // see persistRun). SQL NULL means the result was never recorded → `undefined`;
+    // any stored text is JSON-parsed, so the literal `"null"` decodes back to the
+    // real `null` a workflow returned rather than being flattened to `undefined`.
+    result: row.result === null ? undefined : JSON.parse(row.result),
+    error: row.error ?? undefined,
+    // DB->engine brand boundary: the source-run id is an opaque `text` column in
+    // core; re-brand it here like the row id above. Nullable column → undefined.
+    resume_of: row.resume_of ? RunID.make(row.resume_of) : undefined,
+    // The open question (Tasks 12/13). A `mode: "json"` column, so the driver has
+    // already parsed it to an object (or SQL NULL → JS null → undefined here). The
+    // shape mirrors the engine schema; `options` is copied so the engine value is
+    // detached from the row's array.
+    pending_question: row.pending_question
+      ? {
+          question: row.pending_question.question,
+          options: row.pending_question.options ? [...row.pending_question.options] : undefined,
+          asked_at: row.pending_question.asked_at,
+        }
+      : undefined,
+  }
+}
+
+// Test seam (N2): when set, the NEXT terminal persist (the awaited write in
+// `finish`) fails once, simulating a DB error on the terminal write. Used only
+// by the workflow test to prove that a failing terminal persist never strands
+// the run's `done` deferred (waiters must still observe the terminal state).
+// A module-level one-shot flag is the minimal seam that does not require
+// threading a fake DB through the whole layer graph; it is inert in production.
+let failNextTerminalPersist = false
+// Test seam: overrides the per-run agent lifetime cap (DEFAULT_AGENT_LIMIT) for
+// runs started AFTER this is called, so the lifetime test can prove the gate with
+// a tiny limit (e.g. 5) instead of dispatching 1.000 agents. `undefined` ⇒ the
+// default. Inert in production (never called). Captured per-run at start().
+let agentLimitOverride: number | undefined
+// Instance-aware test seam (Finding 10): set inside the layer once `state` exists.
+// Lets a test flip a live run's `pausing` flag exactly as `abortRun(active,"pause")`
+// does synchronously — reproducing the narrow window where a run is unwinding to
+// paused but its open question is still live — without racing the real scope close.
+let setPausingHook: ((id: string) => Effect.Effect<boolean>) | undefined
+// Finding 4 test seam: an Effect the question() dispatch runs the instant the
+// timeout wins (`None`) but BEFORE the park decision — while `pendingQuestion` is
+// still live — so a test can deterministically land an answer() in the
+// timeout-vs-answer race window. `Effect.void` in production (no-op).
+let questionTimeoutParkHook: Effect.Effect<unknown> = Effect.void
+// Finding 2 test seam: records the live spend accumulators (`budgetRemaining` /
+// `costSpent`) of each run AS IT REACHES its terminal transition in finish().
+// These are in-memory `active` fields that are never persisted to the row, so a
+// test cannot read them back after the run is evicted; this captures them at the
+// exact moment the run settles. Inert in production (never set).
+let captureSpendHook: ((id: string, spend: { budgetRemaining: number; costSpent: number }) => void) | undefined
+export const __testHooks = {
+  failNextTerminalPersist: () => {
+    failNextTerminalPersist = true
+  },
+  agentLimit: (limit: number) => {
+    agentLimitOverride = limit
+  },
+  /**
+   * Flip the live registry entry's `pausing` flag for `id`, mirroring the first
+   * synchronous step of `pause()`/`abortRun`. Returns `true` if a live entry was
+   * found and flipped. Used to deterministically drive Finding 10's race.
+   */
+  setPausing: (id: string): Effect.Effect<boolean> => (setPausingHook ? setPausingHook(id) : Effect.succeed(false)),
+  /**
+   * Register an Effect to run once inside the question() timeout-park window
+   * (Finding 4). It fires while the open question is still live in-memory, so a
+   * test can call answer() there to reproduce the timeout-vs-answer race
+   * deterministically. The hook auto-clears after firing so it runs at most once.
+   */
+  runOnQuestionTimeoutPark: (effect: Effect.Effect<unknown>) => {
+    questionTimeoutParkHook = effect.pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          questionTimeoutParkHook = Effect.void
+        }),
+      ),
+    )
+  },
+  /**
+   * Capture the live spend accumulators (`budgetRemaining`/`costSpent`) of each
+   * run as it settles in finish(). Used by Finding 2's test to prove an
+   * externally-aborted subagent's abort-artifact cost is NOT charged to the
+   * budget even though the run terminates `cancelled`.
+   */
+  captureSpend: (sink: (id: string, spend: { budgetRemaining: number; costSpent: number }) => void) => {
+    captureSpendHook = sink
+  },
+  /**
+   * Run the startup worktree sweep against `directory` (Item 7). Lets a test
+   * prove the preserved-marker / dirty-tree skip directly, without forcing a
+   * full instance-state re-materialization.
+   */
+  sweepWorktrees: (directory: string): Promise<void> => sweepWorktrees(directory),
+}
+
+class TerminalPersistTestError extends Error {
+  constructor() {
+    super("injected terminal persist failure (test seam)")
+  }
+}
+
+// The terminal run statuses: a run in one of these has settled and will never
+// transition again, so its persist emits `workflow.run.finished` instead of
+// `workflow.run.updated`. `running`/`paused` are the only non-terminal statuses
+// (a paused run can still resume), so they emit `updated`. This mirrors the
+// terminal/non-terminal split documented on the `Status` literal above.
+const TERMINAL_STATUSES = ["completed", "failed", "cancelled", "interrupted"] as const
+function isTerminalStatus(status: string): boolean {
+  return (TERMINAL_STATUSES as readonly string[]).includes(status)
+}
+
+function persistRun(
+  db: Database.Interface["db"],
+  events: EventV2Bridge.Service["Service"],
+  active: Active,
+  options?: { terminal?: boolean },
+) {
+  // The snapshot MUST be built at execution time (inside Effect.suspend), not
+  // at effect-construction time: progress writes are forked into the run scope
+  // and may execute AFTER the awaited terminal write in `finish`. A snapshot
+  // captured at construction would then revert the row to a stale state
+  // (live-found regression: a completed run's row flipped back to `running`).
+  // Reading `active.run` at execution time makes every write a full snapshot of
+  // the CURRENT state, so any write ordering converges on the final row.
+  return Effect.suspend(() => {
+    // Fund 3: once a run is removed, NO write may re-create its row. A late
+    // settlement write (a detached agent that settles after `remove` deleted
+    // the row) would otherwise re-INSERT a zombie row, only swept to
+    // `interrupted` on the next restart. The tombstone is checked at execution
+    // time so it covers writes already queued before the delete.
+    if (active.removed) return Effect.void
+    // Test seam (N2): fail exactly the terminal write once, to prove the
+    // `done` deferred still resolves around a failing terminal persist.
+    if (options?.terminal && failNextTerminalPersist) {
+      failNextTerminalPersist = false
+      return Effect.fail(new TerminalPersistTestError())
+    }
+    const data = {
+      id: active.run.id,
+      session_id: active.run.session_id ?? null,
+      directory: active.directory,
+      workflow: active.run.workflow,
+      status: active.run.status,
+      started_at: active.run.started_at,
+      completed_at: active.run.completed_at ?? null,
+      current_phase: active.run.current_phase ?? null,
+      args: active.run.args ?? null,
+      // (A): persist the definition with its phases in the back-compat WIRE form
+      // (a title-only phase → the bare string), so an OLDER reader whose schema
+      // expects `phases: string[]` can still decode our rows (@VasyaYovbak). Only
+      // `meta.phases` is rewritten; `snapshot()` still returns the normalized
+      // OBJECT form, so only the PERSISTED bytes change. The cast threads the
+      // back-compat string|object phases past the row type (whose `phases` is
+      // typed as objects only); on READ `normalizeDefinition` decodes it back.
+      definition: active.run.definition
+        ? (encodeDefinitionForRow(active.run.definition) as unknown as WorkflowDefinitionRow)
+        : null,
+      logs: active.run.logs,
+      agents: active.run.agents,
+      // Fund 42: the `result` column is plain text and the engine owns its JSON
+      // codec, so a real `null` result survives the roundtrip distinct from an
+      // unset one. An unset result (`undefined`) is stored as SQL NULL; any other
+      // value — including the literal `null` a workflow may return — is stringified
+      // to JSON text (a `null` result becomes the text `"null"`, NOT SQL NULL).
+      result: active.run.result === undefined ? null : JSON.stringify(active.run.result),
+      error: active.run.error ?? null,
+      resume_of: active.run.resume_of ?? null,
+      // The open question (Tasks 12/13). Persisted as a JSON object so a paused
+      // run that timed out keeps it across restarts; `undefined` ⇒ SQL NULL (no
+      // pending question). `options` is normalized to a mutable array for the row
+      // type (the engine schema declares it `readonly`).
+      pending_question: active.run.pending_question
+        ? {
+            question: active.run.pending_question.question,
+            options: active.run.pending_question.options ? [...active.run.pending_question.options] : undefined,
+            asked_at: active.run.pending_question.asked_at,
+          }
+        : null,
+    }
+    return db
+      .insert(WorkflowRunTable)
+      .values(data)
+      .onConflictDoUpdate({
+        target: WorkflowRunTable.id,
+        set: { ...data, time_updated: Date.now() },
+      })
+      .run()
+      .pipe(
+        // Publish the run-lifecycle event ONLY after the upsert commits, so a
+        // consumer never observes a state that was not persisted. Sits inside the
+        // write path so it inherits the `active.removed` tombstone and the failing
+        // terminal-persist seam above (both return before reaching here ⇒ no
+        // publish). The event is chosen by terminal status, never by the caller's
+        // `terminal` flag, so any persist that happens to carry a terminal status
+        // (e.g. a forked progress write that races the awaited terminal one) still
+        // reports `finished` consistently. Slim payload — counts, not the arrays.
+        Effect.tap(() =>
+          events.publish(isTerminalStatus(active.run.status) ? Event.Finished : Event.Updated, {
+            id: active.run.id,
+            workflow: active.run.workflow,
+            status: active.run.status,
+            current_phase: active.run.current_phase ?? null,
+            directory: active.directory,
+            agents: {
+              total: active.run.agents.length,
+              running: active.run.agents.filter((a) => a.status === "running").length,
+              failed: active.run.agents.filter((a) => a.status === "failed").length,
+            },
+            pending_question: active.run.pending_question !== undefined,
+            error: active.run.error ?? null,
+          }),
+        ),
+      )
+  }).pipe(Effect.orDie)
+}
+
+/**
+ * Forks a progress-snapshot write as a child of the run scope, so the fiber is
+ * tracked and torn down with the run (and, transitively, the instance) instead
+ * of leaking as a detached root fiber. Interrupt-on-dispose is safe for these
+ * writes: every `persistRun` is an idempotent full-state upsert that NO-OPs for
+ * a removed run, the terminal write in `finish` is awaited inline, and the
+ * startup orphan sweep heals any run whose last progress snapshot was cut short.
+ */
+function persistInScope(
+  active: Active,
+  bridge: EffectBridge.Shape,
+  db: Database.Interface["db"],
+  events: EventV2Bridge.Service["Service"],
+) {
+  bridge.fork(persistRun(db, events, active).pipe(Effect.forkIn(active.runScope)))
+}
+
+/**
+ * Rewrites every `running` row whose id is not in `liveIds` to `interrupted`
+ * with a completion timestamp, AND normalizes any still-`running` agent node in
+ * those rows to `failed` (Fund 15). Used by the startup sweep (liveIds empty) and
+ * the exposed `sweep()` method (liveIds = currently active runs); genuinely-
+ * running rows owned by a live fiber are left untouched.
+ *
+ * Fund 15: a swept orphan has no live registry entry, so the only node-closeout
+ * (in finish()) never runs for it — the row used to keep agents with status
+ * `running`, no completed_at, no error, and the TUI then rendered a live agent
+ * icon forever on a terminal run. The sweep now patches the agents JSON too: each
+ * `running` node becomes `failed` with the sweep time and an explanatory error.
+ *
+ * The run-level flip is no longer a single bulk UPDATE because the agents JSON is
+ * per-row (each row's array is patched in JS), so the bulk write degrades to a
+ * select + per-row update. Both the read and the writes run inside ONE
+ * transaction so the orphan set the sweep acts on cannot change underneath it
+ * (a row flipping to running/terminal between the read and the write) and the
+ * whole heal commits atomically.
+ *
+ * `directory` scopes the sweep to the calling workspace (Fund 17): the DB is
+ * process-global but every per-directory registry only knows its OWN runs, so a
+ * sweep keyed off another directory's (empty) registry must NOT flip a run that
+ * is genuinely live in a different workspace. Without the scope, the first
+ * Workflow operation in a second directory B — whose fresh registry is empty —
+ * would stamp every `running` row of every directory (including a run currently
+ * executing in A) to `interrupted`.
+ */
+function sweepOrphans(db: Database.Interface["db"], liveIds: ReadonlySet<string>, now: number, directory: string) {
+  const where = and(
+    eq(WorkflowRunTable.status, "running"),
+    eq(WorkflowRunTable.directory, directory),
+    liveIds.size ? notInArray(WorkflowRunTable.id, [...liveIds]) : undefined,
+  )
+  return db
+    .transaction((tx) =>
+      Effect.gen(function* () {
+        const orphans = yield* tx
+          .select({ id: WorkflowRunTable.id, agents: WorkflowRunTable.agents })
+          .from(WorkflowRunTable)
+          .where(where)
+          .all()
+        yield* Effect.forEach(
+          orphans,
+          (orphan) =>
+            tx
+              .update(WorkflowRunTable)
+              .set({
+                status: "interrupted",
+                completed_at: now,
+                time_updated: now,
+                agents: orphan.agents.map((node) =>
+                  node.status === "running"
+                    ? { ...node, status: "failed", completed_at: now, error: "interrupted: process restarted" }
+                    : node,
+                ),
+              })
+              .where(eq(WorkflowRunTable.id, orphan.id))
+              .run(),
+          { discard: true },
+        )
+      }),
+    )
+    .pipe(Effect.orDie, Effect.asVoid)
+}
+
+function errorText(error: unknown) {
+  if (APICallError.isInstance(error)) {
+    return [error.message, error.statusCode ? `status: ${error.statusCode}` : undefined, error.responseBody]
+      .filter(Boolean)
+      .join("\n")
+  }
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+function isInvalidError(error: unknown): error is InvalidError {
+  return typeof error === "object" && error !== null && Reflect.get(error, "_tag") === "WorkflowInvalidError"
+}
+
+function isCancelled(value: unknown): boolean {
+  return (
+    value instanceof CancelledError ||
+    (typeof value === "object" && value !== null && Reflect.get(value, "_tag") === "WorkflowCancelledError")
+  )
+}
+
+// Fund 4: the production session runner RESOLVES a prompt on abort (it returns
+// the last assistant message rather than rejecting), and that message carries
+// an abort marker — either an `aborted` flag or a `MessageAbortedError` error
+// (see message-v2.ts `fromError` / v1 `AbortedError`). An agent step whose
+// prompt came back abort-marked did NOT succeed and must be treated as
+// cancelled, never flipped to `completed`. Tolerant of the loose `WithParts`
+// shape the engine sees (it only reads `info`).
+function isAbortedMessage(message: SessionV1.WithParts): boolean {
+  const info = message.info as { aborted?: boolean; error?: { name?: string } } | undefined
+  if (!info) return false
+  if (info.aborted === true) return true
+  const name = info.error?.name
+  return name === "MessageAbortedError" || name === "AbortError"
+}
+
+// Enforces the workflow's DECLARED argument contract (meta.arguments) at the
+// single engine entry point — `start()`, before `module.run` — so every start
+// path (HTTP JSON args, the workflow tool, the TUI) gets identical, authoritative
+// behavior regardless of what the UI did upstream. Two concerns, in order:
+//
+//   1. Defaults: a declared `default` fills in any argument the caller omitted.
+//      An explicitly supplied value always wins over the default. Either way the
+//      value (supplied OR default) is run through the SAME coercion below, so a
+//      `default: "7"` for a number-declared arg reaches run() as the number 7,
+//      consistent with the authoritative type contract.
+//   2. Coercion to the declared `type`:
+//      - number: a numeric string ("42") becomes the number 42; the result must
+//        be finite, so "abc"/"Infinity" and a non-string/non-number (null,
+//        object, boolean) fail with InvalidError. Strings are trimmed first and
+//        an empty / whitespace-only string is rejected — `Number("")` and
+//        `Number("  ")` are 0 (finite!), which would silently swallow a missing
+//        value as 0; we treat those as InvalidError instead. We deliberately keep
+//        the full `Number()` parse semantics for the remaining strings, which
+//        means hex ("0x10" -> 16) and exponent ("1e3" -> 1000) are accepted; for
+//        JSON/HTTP-shaped numbers this is the least-surprising choice and stays
+//        consistent with the rest of the numeric path. A value already a number
+//        is kept as-is.
+//      - boolean: only the strings "true"/"false" (or an actual boolean) are
+//        accepted; anything else fails with InvalidError.
+//      - string: a primitive non-string (number/boolean) is coerced via
+//        String(...). A non-primitive (object/array) is left UNCHANGED — there is
+//        no honest String() for it and forcing "[object Object]" would hide a
+//        caller mistake.
+//
+// An argument with NO declared type, or one not declared in meta.arguments at
+// all, is passed through verbatim. Returns the coerced map (or undefined when
+// the caller passed none and there are no defaults to apply), or an InvalidError
+// naming the offending argument.
+function coerceArgs(
+  args: Record<string, unknown> | undefined,
+  declared: Meta["arguments"],
+  path: string,
+): Record<string, unknown> | undefined | InvalidError {
+  if (!declared) return args
+  const supplied = args ?? {}
+  const result: Record<string, unknown> = { ...supplied }
+  for (const [name, argument] of Object.entries(declared)) {
+    // Supplied value wins; otherwise fall back to the declared default. Both go
+    // through the identical coercion below — a value present at all (supplied or
+    // defaulted) is coerced to the declared type before run() ever sees it.
+    const hasValue = name in supplied
+    if (!hasValue && argument.default === undefined) continue
+    const value = hasValue ? supplied[name] : argument.default
+    if (argument.type === "number") {
+      // Trim strings first, then reject the empty trim explicitly: `Number("")`
+      // and `Number("  ")` are 0 (finite) and would otherwise swallow a blank
+      // input as 0. Non-string/non-number values short-circuit to NaN -> error.
+      const trimmed = typeof value === "string" ? value.trim() : value
+      const coerced =
+        typeof trimmed === "number" ? trimmed : typeof trimmed === "string" && trimmed !== "" ? Number(trimmed) : NaN
+      if (!Number.isFinite(coerced))
+        return new InvalidError({
+          path,
+          message: `argument "${name}" must be a finite number, got ${JSON.stringify(value)}`,
+        })
+      result[name] = coerced
+      continue
+    }
+    if (argument.type === "boolean") {
+      const coerced =
+        typeof value === "boolean" ? value : value === "true" ? true : value === "false" ? false : undefined
+      if (coerced === undefined)
+        return new InvalidError({
+          path,
+          message: `argument "${name}" must be a boolean ("true"/"false"), got ${JSON.stringify(value)}`,
+        })
+      result[name] = coerced
+      continue
+    }
+    if (argument.type === "string" && typeof value !== "string") {
+      // Only primitive non-strings get a String() coercion; objects/arrays are
+      // left untouched (no honest string form — see the doc comment above).
+      if (typeof value === "number" || typeof value === "boolean") result[name] = String(value)
+      continue
+    }
+    // No declared type, or value already matches it: pass through unchanged.
+    // (Default-only path still records the default verbatim here.)
+    if (!hasValue) result[name] = value
+  }
+  return result
+}
+
+function mutableMeta(meta: Meta): Definition["meta"] {
+  return {
+    name: meta.name,
+    description: meta.description,
+    // Phases are normalized objects (Task 15); deep-copy each so the mutable
+    // Definition does not alias the (readonly) decoded meta's phase objects.
+    phases: meta.phases ? meta.phases.map((phase) => ({ ...phase })) : undefined,
+    arguments: meta.arguments
+      ? Object.fromEntries(Object.entries(meta.arguments).map(([name, argument]) => [name, { ...argument }]))
+      : undefined,
+  }
+}
+
+// Resume journal key: identifies a `ctx.agent` call by its dispatch shape so the
+// same call in a resumed run lands on the same source-run agent. A stable JSON
+// tuple with `null` for absent fields, so calls differing only in (say) phase get
+// distinct keys. Two IDENTICAL calls produce the SAME key; the occurrence cursor
+// (journalCursor) then keeps them separate in call order — the first such call
+// replays the first matching source agent, the second the next one.
+//
+// Built from the RESOLVED agent name (not the raw `AgentInput.agent`) on both
+// sides: a source agent's persisted `node.agent` is the engine-normalized
+// `selected.name`, so the lookup must resolve the live call the SAME way (default
+// agent → its name) to match. `model` and `schema` are deliberately NOT part of
+// the key: the persisted node normalizes `model` to the actually-used model id
+// (which a fresh resolve cannot reproduce) and never stores the requested
+// `schema` at all, so including either would make a default-model or structured
+// call fail to match and re-run live. The key therefore matches on the stable,
+// reconstructible fields [prompt, resolvedAgent, phase]; the lookup's own schema
+// presence still drives how the replayed output is interpreted at replay time.
+//
+// `label` (Item 16) is deliberately NOT part of the key: it is display-only, so
+// relabeling a step between runs must not invalidate its journal entry. A per-call
+// `phase` (Item 16) needs no special handling — both the seed side and the live
+// lookup key on `node.phase`, which carries the (prefixed) per-call phase, so a
+// pinned step is automatically resume-stable.
+function journalKey(parts: { prompt: string; agent?: string; phase?: string }): string {
+  return JSON.stringify([parts.prompt, parts.agent ?? null, parts.phase ?? null])
+}
+
+// Resume journal key for a `ctx.question` node (Tasks 12/13). The question has no
+// agent/model/schema, so it keys purely on [kind:"question", question, phase] —
+// the question text plus the phase it was asked in. The literal "question" tag
+// keeps the namespace disjoint from agent keys even if a prompt happened to equal
+// a question. Built identically on the seed side (from the source run's question
+// node) and the live side (the re-asked question), so a resumed run resolves the
+// answer from the journal instead of asking again.
+function questionJournalKey(parts: { question: string; phase?: string }): string {
+  return JSON.stringify(["question", parts.question, parts.phase ?? null])
+}
+
+// The default wait for a `ctx.question` with no explicit `timeout` (Tasks 12/13):
+// 10 minutes. Once it elapses with no answer the run PARKS as `paused` (existing
+// pause machinery) with the open question persisted, so a later `answer()` can
+// resume it. Tests pass a tiny timeout to exercise the park path quickly.
+const DEFAULT_QUESTION_TIMEOUT_MS = 10 * 60 * 1000
+
+// loadModule writes a transient import copy ALONGSIDE the source file (same
+// directory) on purpose: relative imports and the workflow module's
+// node_modules resolution are anchored on the source directory, so moving the
+// copy to os.tmpdir() would break module resolution. The trade-off is that a
+// process killed mid-import can leave the temp copy behind — hence the orphan
+// filter + sweep in discover() below, which keys off TEMP_FILE_RE.
+//
+// The name shape is `.<base>.<ts>.<rand>.<mts|mjs>`: a leading dot (hidden),
+// the original base name, a millisecond timestamp (used by the sweep to age the
+// file out), a random suffix (collision-free concurrent loads), and an .mts/.mjs
+// extension that is deliberately NOT one of the discovered globs (`*.ts`/`*.js`),
+// so a temp copy can never be picked up as a workflow even before the sweep runs.
+const TEMP_FILE_RE = /^\.(.+)\.(\d+)\.[0-9a-f]+\.(mts|mjs)$/
+const TEMP_FILE_MAX_AGE_MS = 60 * 60 * 1000
+
+// Finding 3: per-step worktree isolation mints a private base dir via
+// `fs.mkdtemp(os.tmpdir()/oc-wf-…)`. The run-scope finalizer removes it on a
+// normal finish/cancel, but a SIGKILL/crash mid-run never fires that finalizer,
+// leaking the checked-out repo content (and any secrets the subagent wrote) into
+// tmp indefinitely. A best-effort startup sweep (mirroring sweepTempFiles)
+// reclaims stale `oc-wf-*` worktrees older than the cutoff so a crashed process
+// does not leave repo content behind. The prefix is shared with the creation site
+// so the sweep matches exactly the dirs the engine mints.
+const WORKTREE_PREFIX = "oc-wf-"
+const WORKTREE_MAX_AGE_MS = 60 * 60 * 1000
+// Item 7: marker file the run-scope finalizer writes into a worktree it
+// deliberately PRESERVES (uncommitted changes / new commits). The startup sweep
+// skips dirs carrying it — otherwise a preserved worktree would be silently
+// deleted one hour later by the orphan sweep.
+const WORKTREE_PRESERVED_MARKER = ".oc-wf-preserved"
+
+function tempFileName(file: string): string {
+  const ext = path.extname(file)
+  return `.${path.basename(file, ext)}.${Date.now()}.${Math.random().toString(16).slice(2)}${ext === ".js" ? ".mjs" : ".mts"}`
+}
+
+// Each call imports the file fresh through a unique temp-file copy, so a
+// workflow edited between calls is always reloaded. We deliberately do NOT keep
+// a cross-call module cache, and we do not rely on a `?mtime=` query either:
+// Bun's module cache is not reliably invalidated by a query string alone, so a
+// cached or query-busted import can serve a stale `run`/`meta` after an edit
+// (the realtime-update bug). Correctness over micro-optimization — the
+// double-load that motivated the original finding is already gone because
+// start() now loads only the target module instead of calling list().
+// `inlineSource`, when given, is the module SOURCE of a workflow that has no real
+// file on disk — its `file` is a synthetic scheme marker (`builtin:<name>` for a
+// bundled builtin, `inline:<metaName>` for a P3 inline-source start), not a real
+// path. The marker has no source directory, so the temp copy is written into the
+// GLOBAL workflows directory (`<Global.Path.config>/workflows`) rather than
+// `import.meta.dir`: in a compiled Bun binary `import.meta.dir` is `/$bunfs/root`
+// (read-only — writing there throws ENOENT), whereas the global config dir is
+// a binary-proven writable location where normal global workflows already load
+// from. Builtin sources are SELF-CONTAINED by invariant (no imports — see
+// builtin.ts); an inline source is authored by the model/user and likewise
+// materialized here, so the temp copy depends on no node_modules above it and
+// loads identically in dev and in the binary. The directory is ensured (the
+// workflows subdir may not exist on a cold system) and the temp file keeps
+// TEMP_FILE_RE's name shape so the per-directory sweep in discover() cleans up any
+// orphan; the random temp suffix means two concurrent inline starts never collide.
+// A write failure is a hard error (there is no original file to fall back to).
+async function loadModule(file: string, inlineSource?: string): Promise<Module> {
+  const source = inlineSource ?? (await fs.readFile(file, "utf8"))
+  if (inlineSource !== undefined) {
+    const configDir = path.join(Global.Path.config, "workflows")
+    await fs.mkdir(configDir, { recursive: true })
+    // Resolve the dir to its REALPATH before writing+importing. On macOS the temp
+    // root is `/var/folders/...` (a symlink to `/private/var/...`); Bun's dynamic
+    // `import()` resolves the `file://` URL through the realpath, so after the first
+    // temp module in this dir is imported-then-deleted, a SECOND import of a new
+    // file under the symlinked path fails with "Cannot find module … from ''" (a
+    // stale per-directory resolver entry). Writing+importing via the realpath keeps
+    // both starts consistent so repeated source-string loads (two builtins, two
+    // inline starts, or the same one twice) all succeed.
+    const workflowsDir = await fs.realpath(configDir)
+    // Strip the synthetic `<scheme>:` marker prefix (builtin:/inline:) so the temp
+    // file name is just a sanitized basename, not a path with a colon in it.
+    const cachePath = path.join(workflowsDir, tempFileName(`${file.replace(/^[a-z]+:/, "")}.ts`))
+    await fs.writeFile(cachePath, source)
+    const imported = (await import(pathToFileURL(cachePath).href).finally(() =>
+      fs.rm(cachePath, { force: true }),
+    )) as Record<string, unknown>
+    return finishModule(imported, file, source)
+  }
+  const dir = path.dirname(file)
+  const cachePath = path.join(dir, tempFileName(file))
+  // Fund 40 (b): the temp copy must live in the source directory so relative
+  // imports / node_modules resolution still work. If that directory is not
+  // writable (read-only or external mount), fall back to importing the original
+  // file directly instead of hard-failing. Caveat: a direct import is subject to
+  // the runtime's module cache, so an edit between two starts of a workflow in a
+  // read-only dir may serve a stale module — acceptable, since a read-only dir
+  // is not being edited in place anyway.
+  let importPath = cachePath
+  let cleanup = () => fs.rm(cachePath, { force: true })
+  const wrote = await fs.writeFile(cachePath, source).then(
+    () => true,
+    () => false,
+  )
+  if (!wrote) {
+    importPath = file
+    cleanup = () => Promise.resolve()
+  }
+  const imported = (await import(pathToFileURL(importPath).href).finally(cleanup)) as Record<string, unknown>
+  return finishModule(imported, file, source)
+}
+
+// Unwraps the imported module (default-object vs named exports), validates its
+// meta against the same `Meta` schema, and asserts a `run` function — shared by
+// the file and built-in load paths so both fail identically (InvalidError naming
+// the source) when meta is bad or `run` is missing.
+function finishModule(imported: Record<string, unknown>, file: string, source: string): Module {
+  const module = (
+    typeof imported.default === "object" && imported.default !== null ? imported.default : imported
+  ) as Record<string, unknown>
+  const parsed = decodeMeta(module.meta, { errors: "all", propertyOrder: "original" })
+  if (Exit.isFailure(parsed)) throw new InvalidError({ path: file, message: Cause.pretty(parsed.cause) })
+  if (typeof module.run !== "function") throw new InvalidError({ path: file, message: "Missing run(args, ctx) export" })
+  return {
+    meta: parsed.value,
+    run: module.run as Module["run"],
+    source,
+  }
+}
+
+function assistantText(message: SessionV1.WithParts) {
+  return message.parts
+    .filter((part): part is SessionV1.TextPart => part.type === "text" && part.text.trim().length > 0)
+    .map((part) => part.text)
+    .join("\n")
+}
+
+// Fund 40: opportunistically remove orphaned loadModule temp copies (left
+// behind by a process killed mid-import) from a workflows directory, but only
+// when they are older than TEMP_FILE_MAX_AGE_MS so a temp copy of a CURRENTLY
+// loading workflow is never deleted out from under it. Best-effort: any error
+// (missing dir, race, permission) is swallowed — a stale temp file is harmless
+// since it is never discovered as a workflow (wrong extension + filter below).
+async function sweepTempFiles(workflowsDir: string) {
+  const names = await fs.readdir(workflowsDir).catch(() => [] as string[])
+  const cutoff = Date.now() - TEMP_FILE_MAX_AGE_MS
+  await Promise.all(
+    names
+      .filter((name) => TEMP_FILE_RE.test(name))
+      .map(async (name) => {
+        const full = path.join(workflowsDir, name)
+        const stat = await fs.stat(full).catch(() => undefined)
+        if (stat && stat.mtimeMs < cutoff) await fs.rm(full, { force: true }).catch(() => undefined)
+      }),
+  )
+}
+
+// Finding 3: best-effort startup sweep of orphaned per-step worktree base dirs
+// (`<tmp>/oc-wf-*`) left behind by a SIGKILLed/crashed run whose run-scope remove
+// finalizer never fired. Only dirs older than WORKTREE_MAX_AGE_MS are touched so a
+// worktree of a CURRENTLY running sibling process is never removed out from under
+// it. Each stale dir is detached as a git worktree first (so the source repo's
+// worktree list does not keep a dangling registration) and then removed, and a
+// final `git worktree prune` reclaims any other stale registrations. Best-effort:
+// every error (missing dir, race, permission, non-git, locked tree) is swallowed.
+async function sweepWorktrees(directory: string) {
+  const tmp = os.tmpdir()
+  const names = await fs.readdir(tmp).catch(() => [] as string[])
+  const cutoff = Date.now() - WORKTREE_MAX_AGE_MS
+  await Promise.all(
+    names
+      .filter((name) => name.startsWith(WORKTREE_PREFIX))
+      .map(async (name) => {
+        const full = path.join(tmp, name)
+        const stat = await fs.stat(full).catch(() => undefined)
+        if (!stat || !stat.isDirectory() || stat.mtimeMs >= cutoff) return
+        // Item 7: a worktree the run finalizer deliberately preserved carries the
+        // marker — never sweep it, no matter how old.
+        const preserved = await fs
+          .stat(path.join(full, WORKTREE_PRESERVED_MARKER))
+          .then(() => true)
+          .catch(() => false)
+        if (preserved) return
+        // Fallback for a preserve whose marker write failed (or a crashed run
+        // with real work in flight): the same dirty check the finalizer uses. A
+        // non-git/leaked dir fails git-status and is swept as before.
+        const status = spawnSync("git", ["status", "--porcelain"], { cwd: full })
+        if (status.status === 0 && status.stdout.toString().trim().length > 0) return
+        // Detach the registration from the owning repo (best-effort), then remove
+        // the leaked dir. `remove --force` covers the common case; the explicit rm
+        // is the backstop for a dir git no longer recognizes as a worktree.
+        spawnSync("git", ["worktree", "remove", "--force", full], { cwd: directory })
+        await fs.rm(full, { recursive: true, force: true }).catch(() => undefined)
+      }),
+  )
+  // Reclaim any dangling worktree registrations whose dir is already gone.
+  spawnSync("git", ["worktree", "prune"], { cwd: directory })
+}
+
+// Fund 2: a discovered file must really live inside its workflows directory.
+// We glob WITHOUT following symlinks, but a symlinked file entry can still be
+// returned, so we additionally resolve the realpath of both the file and the
+// workflows directory and require the file to stay within it. A symlink that
+// escapes the directory (e.g. -> /tmp/payload.ts) is dropped, so it can never
+// be listed/started — a reviewer eyeballing the directory only sees the harmless
+// link, never the external target. Returns true when the file is safe to keep.
+async function withinWorkflowsDir(file: string, workflowsDir: string): Promise<boolean> {
+  const [realFile, realDir] = await Promise.all([
+    fs.realpath(file).catch(() => undefined),
+    fs.realpath(workflowsDir).catch(() => undefined),
+  ])
+  if (!realFile || !realDir) return false
+  const prefix = realDir.endsWith(path.sep) ? realDir : realDir + path.sep
+  return realFile.startsWith(prefix)
+}
+
+// `directories` is ordered by precedence (project before global, see
+// discoverWorkflows): the first directory that contributes a given workflow
+// NAME wins, so a project workflow shadows a same-named global one. Plugin
+// workflows are appended after project/global files and before builtins; if
+// multiple plugins register the same name, the first loaded plugin wins.
+type Discovered = { name: string; path: string; source?: string; kind?: "builtin" | "plugin"; error?: string }
+
+const PLUGIN_PATH_PREFIX = "plugin:"
+
+function pluginPath(name: string) {
+  return `${PLUGIN_PATH_PREFIX}${name}`
+}
+
+async function discover(directories: readonly string[], pluginWorkflows: readonly Discovered[]) {
+  const seen = new Set<string>()
+  const result: Discovered[] = []
+  for (const dir of directories) {
+    const workflowsDir = path.join(dir, "workflows")
+    // Fire-and-forget sweep of stale temp copies in this directory.
+    await sweepTempFiles(workflowsDir)
+    const files = (
+      await Promise.all(
+        ["workflows/*.ts", "workflows/*.js"].map((pattern) =>
+          Glob.scan(pattern, { cwd: dir, absolute: true, dot: true, symlink: false }),
+        ),
+      )
+    )
+      .flat()
+      .filter((file) => !TEMP_FILE_RE.test(path.basename(file)))
+    const kept = await Promise.all(
+      files.map(async (file) => ((await withinWorkflowsDir(file, workflowsDir)) ? file : undefined)),
+    )
+    for (const file of kept) {
+      if (!file) continue
+      const name = path.basename(file, path.extname(file))
+      if (seen.has(name)) continue
+      seen.add(name)
+      result.push({ name, path: file })
+    }
+  }
+  // Plugin workflows sit between project/global files and builtins. Hook order is
+  // deterministic from plugin loading; first plugin wins on duplicate names.
+  for (const workflow of pluginWorkflows) {
+    if (seen.has(workflow.name)) continue
+    seen.add(workflow.name)
+    result.push(workflow)
+  }
+  // Built-in workflows are the LOWEST-precedence root: appended after every
+  // project/global/plugin source so a same-named earlier entry shadows the builtin
+  // (first-wins). A builtin carries its module SOURCE inline and a synthetic
+  // `builtin:<name>` path marker — list() reads meta from that source string and
+  // start() loads the module from it, neither touching the filesystem.
+  for (const [name, source] of Object.entries(BUILTIN_WORKFLOWS)) {
+    if (seen.has(name)) continue
+    seen.add(name)
+    result.push({ name, path: builtinPath(name), source, kind: "builtin" })
+  }
+  return result.toSorted((a, b) => a.name.localeCompare(b.name))
+}
+
+function registeredPluginWorkflows(hooks: readonly Hooks[]): Discovered[] {
+  return hooks.flatMap((hook) =>
+    Object.entries(hook.workflow ?? {}).map(([name, definition]) => {
+      const path = pluginPath(name)
+      if (!SAVE_NAME_PATTERN.test(name)) {
+        return {
+          name,
+          path,
+          kind: "plugin" as const,
+          error: "Workflow names may only contain letters, numbers, underscores, and dashes",
+        }
+      }
+      const source = pluginWorkflowSource(name, definition)
+      return source.ok ? { name, path, source: source.source, kind: "plugin" as const } : { name, path, kind: "plugin" as const, error: source.error }
+    }),
+  )
+}
+
+function pluginWorkflowSource(name: string, definition: WorkflowDefinition | string) {
+  if (typeof definition === "string") return { ok: true as const, source: definition }
+  if (!isRecord(definition) || !isRecord(definition.meta) || typeof definition.run !== "function")
+    return { ok: false as const, error: `Plugin workflow ${name} must be a source string or workflow definition` }
+  const meta = JSON.stringify(definition.meta)
+  if (!meta) return { ok: false as const, error: `Plugin workflow ${name} meta must be JSON serializable` }
+  return {
+    ok: true as const,
+    source: [`export const meta = ${meta}`, `export const run = ${workflowRunSource(definition.run)}`].join("\n"),
+  }
+}
+
+function workflowRunSource(run: WorkflowDefinition["run"]) {
+  const source = Function.prototype.toString.call(run).trim()
+  return source.replace(/^(async\s+)?([A-Za-z_$][\w$]*)\s*\(/, "$1function $2(")
+}
+
+function pluginWorkflowMismatch(workflow: Discovered, meta: Meta) {
+  return workflow.kind === "plugin" && meta.name !== workflow.name
+    ? `Plugin workflow ${workflow.name} meta.name must match the registered workflow name`
+    : undefined
+}
+
+function projectConfigDir(ctx: { directory: string; worktree: string }) {
+  return path.join(ctx.worktree === "/" ? ctx.directory : ctx.worktree, ".opencode")
+}
+
+// The legal workflow-file basename charset, identical to the workflow tool's
+// WORKFLOW_NAME_PATTERN (tool/workflow.ts) and the discover()-time name shape: a
+// discovered name is just a file basename, so save() must accept exactly the same
+// shape it writes. Rejecting anything else keeps a save() name from escaping the
+// workflows dir (a `/`/`..` segment) or carrying glob metacharacters.
+const SAVE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/
+
+// Resolves the absolute destination file for save(): `project` → the workspace
+// `.opencode/workflows/<name>.ts` (the dir discover() globs FIRST, so a saved
+// project workflow is immediately discoverable and shadows a same-named global
+// one); `global` → `<config>/workflows/<name>.ts` (where discover() globs global
+// workflows from, via config.directories()). The name is already sanitized by the
+// caller against SAVE_NAME_PATTERN.
+function saveTargetPath(ctx: { directory: string; worktree: string }, scope: SaveScope, name: string) {
+  const base = scope === "global" ? path.join(Global.Path.config) : projectConfigDir(ctx)
+  return path.join(base, "workflows", `${name}.ts`)
+}
+
+function createContext(input: {
+  active: Active
+  agent: (input: AgentInput, callOpts?: { phaseModel?: string }) => Promise<{ data: unknown; text: string } | null>
+  tool: WorkflowToolFn
+  shell: ContextApi["shell"]
+  question: ContextApi["question"]
+  workflow: ContextApi["workflow"]
+  permissionSessionID?: SessionID
+  persist: () => void
+  /** AbortSignal of the run fiber; fires when the run is interrupted/cancelled. */
+  signal: () => AbortSignal | undefined
+  /**
+   * Run-relative prefix for `ctx.log`/`ctx.setPhase` messages. Empty for the
+   * top-level run; set to `"<child-name>: "` for a depth-1 nested workflow so its
+   * logs/phases are attributable to the child without a second run row.
+   */
+  logPrefix?: string
+  /**
+   * The NORMALIZED declared phases of THIS context's module (Task 15) — the
+   * top-level run's `module.meta.phases` or, for a nested ctx.workflow child, the
+   * CHILD module's phases. `setPhase` resolves a phase's default model and detects
+   * an undeclared phase against THIS list, so a nested child looks up its OWN
+   * phases (not the parent's), and the prefixed `current_phase` string never needs
+   * decoding. Omitted ⇒ no declared phases (every setPhase is "undeclared").
+   */
+  phases?: readonly Phase[]
+  /**
+   * Runs the parallel/pipeline task graph as a child of the run scope (not as a
+   * detached root fiber): closing the run scope on cancel/remove propagates
+   * Interrupt into the in-flight graph. An interrupted graph rejects as
+   * CancelledError so the workflow body unwinds as `cancelled`.
+   */
+  dispatch: <A>(effect: Effect.Effect<A, unknown>) => Promise<A>
+}): ContextApi {
+  const checkpoint = () => {
+    // Also treat a landed cancel/pause as an abort even before the run fiber's
+    // signal has been observed, so a follow-up step is gated the moment cancel or
+    // pause started.
+    if (input.signal()?.aborted || input.active.cancelling || input.active.pausing) throw new CancelledError()
+  }
+  return {
+    // Live remaining budget (USD), read on every access so a workflow can
+    // observe the value shrink across agent steps. `Infinity` when the run was
+    // started without a budget (unchanged default).
+    get budgetRemaining() {
+      return input.active.budgetRemaining
+    },
+    // Claude-Code API-shape view over the same spend the run tracks. `total` is
+    // the cap (null when unlimited), `spent()` the running total charged so far,
+    // `remaining()` the headroom (Infinity when unlimited). All read live so a
+    // workflow sees them change across agent steps, mirroring `budgetRemaining`.
+    budget: {
+      get total() {
+        // Item 24: with a shared turn pool and NO run budget, the pool's cap
+        // is the reported total (Claude-Code semantics — the turn's budget).
+        // A run budget keeps the run-scoped view.
+        if (input.active.budgetTotal === undefined && input.active.pool?.usd) return input.active.pool.usd.total
+        return input.active.budgetTotal ?? null
+      },
+      spent: () => {
+        // Item 24: pool view = the TURN's total committed spend, INCLUDING the
+        // main loop's chargeDirect share — only when no run budget keeps the
+        // run-scoped view.
+        if (input.active.budgetTotal === undefined && input.active.pool?.usd) return input.active.pool.usd.committed
+        return input.active.costSpent
+      },
+      remaining: () => {
+        // Item 24: the tighter of run headroom and pool headroom wins; either
+        // absent contributes Infinity, so the prior single-budget behavior is
+        // preserved exactly.
+        const pool = input.active.pool?.usd
+        const poolRemaining = pool ? Math.max(0, pool.total - pool.committed - pool.reserved) : Infinity
+        const runRemaining =
+          input.active.budgetTotal === undefined
+            ? Infinity
+            : Math.max(0, input.active.budgetTotal - input.active.costSpent)
+        return Math.min(runRemaining, poolRemaining)
+      },
+      // Item 17: the token trio, mirroring the USD trio above 1:1 (live reads,
+      // null/Infinity for an unset cap).
+      get tokensTotal() {
+        return input.active.tokensBudgetTotal ?? null
+      },
+      tokensSpent: () => input.active.tokensSpent,
+      tokensRemaining: () =>
+        input.active.tokensBudgetTotal === undefined
+          ? Infinity
+          : Math.max(0, input.active.tokensBudgetTotal - input.active.tokensSpent),
+    },
+    setPhase(phase: string) {
+      input.active.run.current_phase = (input.logPrefix ?? "") + phase
+      // Task 15: resolve this phase against THIS context's declared phases (the
+      // raw `phase` name, never the prefixed string), keyed by `title`. A declared
+      // phase's `model` becomes the active per-phase default model that ctx.agent
+      // uses when a call gives no explicit model; an undeclared phase clears the
+      // default AND logs a warning (never an error — an undeclared phase is allowed,
+      // it simply has no default model). The lookup uses the SAME context's phases
+      // so a nested child resolves against its own declarations and the parent's
+      // restored on return (runNested snapshots/restores currentPhaseModel too).
+      const declared = input.phases?.find((entry) => entry.title === phase)
+      if (declared) {
+        input.active.currentPhaseModel = declared.model
+      } else {
+        input.active.currentPhaseModel = undefined
+        input.active.run.logs.push({
+          time: Date.now(),
+          phase: input.active.run.current_phase,
+          message: `${input.logPrefix ?? ""}phase "${phase}" is not declared`,
+        })
+      }
+      input.persist()
+    },
+    log(message: string) {
+      input.active.run.logs.push({
+        time: Date.now(),
+        phase: input.active.run.current_phase,
+        message: (input.logPrefix ?? "") + message,
+      })
+      input.persist()
+    },
+    parallel<T>(tasks: readonly (() => Promise<T>)[], options?: { concurrencyLimit?: number }) {
+      checkpoint()
+      // Batch cap AFTER checkpoint() (abort wins, matching ctx.agent's gate
+      // order): an oversized batch is an authoring error reported at the call
+      // site. The synchronous throw propagates like any body error — run failed
+      // unless the author catches it.
+      if (tasks.length > MAX_BATCH_ITEMS)
+        throw new InvalidError({
+          path: input.active.run.workflow,
+          message: `ctx.parallel supports at most ${MAX_BATCH_ITEMS} tasks, got ${tasks.length}`,
+        })
+      const concurrency = Math.max(1, options?.concurrencyLimit ?? 20)
+      // Each task is gated by the run's abort signal via checkpoint() before it
+      // starts: once cancel has fired, not-yet-started tasks throw CancelledError
+      // and never run. The whole batch runs as a child of the run scope (via
+      // dispatch), so a cancel/remove that closes the run scope ALSO interrupts
+      // tasks already in flight — and each agent task additionally aborts its
+      // child session for real via PromptOps.cancel.
+      return input.dispatch(
+        Effect.forEach(
+          tasks,
+          (task, index) =>
+            Effect.promise(() => {
+              checkpoint()
+              // P1 (Claude parity): a rejecting task resolves to `null` at its
+              // position instead of failing the whole batch. CancelledError stays
+              // fatal (an abort is not a task failure). The drop is logged — never
+              // silent.
+              return task().then(
+                (value) => value as T | null,
+                (error) => {
+                  if (error instanceof CancelledError) throw error
+                  input.active.run.logs.push({
+                    time: Date.now(),
+                    phase: input.active.run.current_phase,
+                    message: `parallel task ${index + 1} dropped: ${error instanceof Error ? error.message : String(error)}`,
+                  })
+                  input.persist()
+                  return null
+                },
+              )
+            }),
+          { concurrency },
+        ),
+      )
+    },
+    // Real per-item pipeline (heterogeneous stages). The public type is the
+    // precise overloaded `PipelineFn`; internally we plumb `unknown` because the
+    // variadic stage chain cannot be expressed in a single impl signature. The
+    // last argument is an optional `{ concurrencyLimit }` object (a plain object,
+    // never a function) — everything before it is a stage.
+    pipeline: ((items: readonly unknown[], ...rest: unknown[]) => {
+      checkpoint()
+      const last = rest[rest.length - 1]
+      const hasOptions = typeof last === "object" && last !== null
+      const options = (hasOptions ? last : undefined) as PipelineOptions | undefined
+      const stages = (hasOptions ? rest.slice(0, -1) : rest) as ReadonlyArray<
+        (prev: unknown, item: unknown, index: number) => Promise<unknown>
+      >
+      // Same batch cap as parallel() (after checkpoint() and options parsing):
+      // an oversized item list is an authoring error reported at the call site.
+      if (items.length > MAX_BATCH_ITEMS)
+        throw new InvalidError({
+          path: input.active.run.workflow,
+          message: `ctx.pipeline supports at most ${MAX_BATCH_ITEMS} items, got ${items.length}`,
+        })
+      // Same clamp as parallel(): an explicit limit ≤0 is floored to 1, matching
+      // parallel's `Math.max(1, …)`. Only an UNSET limit means "unbounded".
+      const concurrency = options?.concurrencyLimit === undefined ? "unbounded" : Math.max(1, options.concurrencyLimit)
+      // No barrier between stages: each ITEM runs the full stage SEQUENCE as its
+      // own Effect, and items run under Effect.forEach concurrency — so item B may
+      // be in stage 2 while item A is still in stage 1. checkpoint() gates before
+      // each stage so the next stage never starts after cancel. The whole graph
+      // runs as a child of the run scope (via dispatch), so a cancel/remove that
+      // closes the run scope interrupts stages already in flight too; agent
+      // stages additionally abort their child session for real via PromptOps.cancel.
+      return input.dispatch(
+        Effect.forEach(
+          items,
+          (item, index) =>
+            Effect.promise(async () => {
+              let current: unknown = item
+              try {
+                for (const stage of stages) {
+                  checkpoint()
+                  // Every stage receives the item's position in the ORIGINAL items
+                  // array as its third argument (Effect.forEach supplies it, same
+                  // as parallel() above) so a stage can address per-item state.
+                  current = await stage(current, item, index)
+                }
+                return current
+              } catch (error) {
+                // P2: a throwing stage drops ONLY this item (null) and skips its
+                // remaining stages; other items keep running. Abort stays fatal.
+                // The drop log uses the forEach `index` (not items.indexOf), so
+                // duplicate items report their TRUE position, not the first
+                // occurrence's.
+                if (error instanceof CancelledError) throw error
+                input.active.run.logs.push({
+                  time: Date.now(),
+                  phase: input.active.run.current_phase,
+                  message: `pipeline item ${index + 1} dropped: ${error instanceof Error ? error.message : String(error)}`,
+                })
+                input.persist()
+                return null
+              }
+            }),
+          { concurrency },
+        ),
+      )
+    }) as ContextApi["pipeline"],
+    // Item 16: a per-call `phase` is resolved HERE because only createContext
+    // knows this context's logPrefix and declared phases. The phase reaching the
+    // engine closure is already PREFIXED (consistent with setPhase above), so a
+    // nested ctx.workflow child's per-call phase is attributed to the child; the
+    // declared phase's default `model` rides along as a per-call option. No
+    // global state moves: current_phase/currentPhaseModel are untouched.
+    agent: (ai) => {
+      if (ai.phase === undefined) return input.agent(ai)
+      const declared = input.phases?.find((entry) => entry.title === ai.phase)
+      return input.agent({ ...ai, phase: (input.logPrefix ?? "") + ai.phase }, { phaseModel: declared?.model })
+    },
+    tool: input.tool,
+    shell: input.shell,
+    question: input.question,
+    workflow: input.workflow,
+  }
+}
+
+function mcpOutput(result: unknown) {
+  if (!isRecord(result)) return { output: String(result), metadata: {} }
+  const content = Array.isArray(result.content) ? result.content : []
+  const output = content
+    .flatMap((item) => {
+      if (!isRecord(item)) return []
+      if (item.type === "text" && typeof item.text === "string") return [item.text]
+      if (item.type === "resource" && isRecord(item.resource)) {
+        if (typeof item.resource.text === "string") return [item.resource.text]
+        if (typeof item.resource.blob === "string") return [item.resource.blob]
+      }
+      return []
+    })
+    .join("\n\n")
+  return {
+    output,
+    metadata: isRecord(result.metadata) ? result.metadata : {},
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function fmt(list: Info[]) {
+  const described = list.filter((workflow) => workflow.meta.description !== undefined)
+  if (described.length === 0) return "No workflows are currently available."
+  return [
+    "<available_workflows>",
+    ...described
+      .toSorted((a, b) => a.name.localeCompare(b.name))
+      .flatMap((workflow) => [
+        "  <workflow>",
+        `    <name>${workflow.name}</name>`,
+        `    <description>${workflow.meta.description}</description>`,
+        ...(workflow.meta.whenToUse ? [`    <when_to_use>${workflow.meta.whenToUse}</when_to_use>`] : []),
+        `    <path>${pathToFileURL(workflow.path).href}</path>`,
+        ...(workflow.meta.phases?.length
+          ? [`    <phases>${workflow.meta.phases.map((phase) => phase.title).join(", ")}</phases>`]
+          : []),
+        ...(workflow.meta.arguments
+          ? [
+              "    <arguments>",
+              ...Object.entries(workflow.meta.arguments).map(
+                ([name, arg]) =>
+                  `      <argument name="${name}" type="${arg.type ?? "string"}">${arg.description ?? ""}</argument>`,
+              ),
+              "    </arguments>",
+            ]
+          : []),
+        "  </workflow>",
+      ]),
+    "</available_workflows>",
+  ].join("\n")
+}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const config = yield* Config.Service
+    const agents = yield* Agent.Service
+    const sessions = yield* Session.Service
+    const providers = yield* Provider.Service
+    const { db } = yield* Database.Service
+    const events = yield* EventV2Bridge.Service
+    // Item 23 (Stufe 1): the permission service gates ctx.shell; FSUtil and the
+    // spawner feed the bash tool's scanCommand (path/pattern derivation), which
+    // is provided these explicitly at the call site inside ctx.shell.
+    const permission = yield* Permission.Service
+    const fsUtil = yield* FSUtil.Service
+    const spawner = yield* ChildProcessSpawner
+    const catalog = yield* ToolCatalog.Service
+    const mcp = yield* MCP.Service
+    const plugin = yield* Plugin.Service
+    const truncate = yield* Truncate.Service
+    const state = yield* InstanceState.make<State>(
+      Effect.fn("Workflow.state")(function* (ctx) {
+        const runs = yield* SynchronizedRef.make(new Map<string, Active>())
+        // The registry is freshly empty here: any row still marked `running`
+        // belongs to a fiber that did not survive into this process, so sweep
+        // every one of them to `interrupted` (honest orphan recovery on start).
+        // Scoped to THIS workspace directory (Fund 17): this state is created
+        // per-directory, so the startup sweep must heal only its OWN zombie rows
+        // — a sibling directory's live run shares the global DB and must be left
+        // running.
+        yield* sweepOrphans(db, new Set(), yield* Clock.currentTimeMillis, ctx.directory)
+        // Finding 3: reclaim stale per-step worktree base dirs (`<tmp>/oc-wf-*`)
+        // leaked by a crashed run whose remove finalizer never fired, so a
+        // SIGKILLed run does not leave repo content + secrets in tmp. Bounded
+        // (a single tmp readdir + rm of only aged dirs) and best-effort: any error
+        // is swallowed, and it runs inline alongside the DB orphan sweep so it
+        // cannot be interrupted by an instance teardown mid-sweep.
+        yield* Effect.promise(() => sweepWorktrees(ctx.directory)).pipe(Effect.ignore)
+        return {
+          runs,
+          scope: yield* Scope.Scope,
+        }
+      }),
+    )
+
+    // Wire the instance-aware test seam now that `state` exists (Finding 10).
+    setPausingHook = (id: string) =>
+      Effect.gen(function* () {
+        const active = (yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)).get(id)
+        if (!active) return false
+        active.pausing = true
+        return true
+      })
+
+    const readRuns = Effect.fn("Workflow.readRuns")(function* () {
+      const active = yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)
+      // Scope the listing to the calling workspace (Fund 6): the DB is global,
+      // so without the directory filter `GET /workflow/run?directory=A` would
+      // leak runs started in directory B.
+      const directory = yield* InstanceState.directory
+      const rows = yield* db
+        .select()
+        .from(WorkflowRunTable)
+        .where(eq(WorkflowRunTable.directory, directory))
+        .orderBy(desc(WorkflowRunTable.started_at))
+        .all()
+        .pipe(Effect.orDie)
+      return rows
+        .map(fromRow)
+        .map((run) => {
+          const live = active.get(run.id)
+          return live ? snapshot(live) : run
+        })
+        .toSorted((a, b) => b.started_at - a.started_at)
+    })
+
+    // Shared discovery for list() and start(): resolves the config + project
+    // directories and globs them into a sorted `{ name, path }[]`. No module is
+    // loaded here — loading is the caller's concern (list loads all per-file,
+    // start loads only the target).
+    //
+    // N4 (precedence, behavior change): the project config dir is placed FIRST,
+    // ahead of config.directories() (which leads with the GLOBAL ~/.config
+    // dir). discover() dedups by NAME with first-wins, so a project workflow now
+    // shadows a same-named global one — previously the global file won, which
+    // meant create "validated" / start ran the wrong file when both existed.
+    const discoverWorkflows = Effect.fn("Workflow.discover")(function* () {
+      const ctx = yield* InstanceState.context
+      const directories = [...new Set([projectConfigDir(ctx), ...(yield* config.directories())])]
+      const hooks = yield* plugin.list()
+      return yield* Effect.promise(() => discover(directories, registeredPluginWorkflows(hooks)))
+    })
+
+    const list: Interface["list"] = Effect.fn("Workflow.list")(function* () {
+      const workflows = yield* discoverWorkflows()
+      // Discovery NEVER executes workflow module code: meta is extracted purely
+      // from each file's source text via the static AST reader. `loadModule` (a
+      // real dynamic import that runs the module's top-level code) is reserved for
+      // start(), AFTER the permission gate. This closes the root cause where merely
+      // listing/reading/autocompleting workflows in a cloned workspace ran foreign
+      // code before any prompt. Per-file error isolation is kept: a file whose meta
+      // is missing, dynamic (not statically analyzable), or schema-invalid becomes
+      // an `{ valid: false, error }` entry instead of aborting the whole list.
+      return yield* Effect.forEach(
+        workflows,
+        (workflow) =>
+          // A builtin carries its module source inline (no file to read); an
+          // on-disk workflow's source comes from its file. MetaReader.read takes
+          // the source string directly either way, so a builtin is meta-extracted
+          // through the identical static (never-executed) path. `source_kind` is
+          // stamped only on builtins so consumers can tell them apart.
+          workflow.error
+            ? Effect.succeed<Info>({
+                name: workflow.name,
+                path: workflow.path,
+                meta: { name: workflow.name },
+                valid: false,
+                error: workflow.error,
+              })
+            : Effect.promise(() =>
+                workflow.source !== undefined ? Promise.resolve(workflow.source) : fs.readFile(workflow.path, "utf8"),
+              ).pipe(
+                Effect.map((source): Info => {
+                  const kind = workflow.kind === "builtin" ? ({ source_kind: "builtin" } as const) : {}
+                  const result = MetaReader.read(source, workflow.path)
+                  const mismatch = result.valid ? pluginWorkflowMismatch(workflow, result.meta) : undefined
+                  return result.valid && !mismatch
+                    ? { name: workflow.name, path: workflow.path, meta: result.meta, valid: true, ...kind }
+                    : // Synthesize a minimal meta so the schema stays satisfied and
+                      // consumers can still show the file's name; `valid: false`
+                      // signals the entry is not runnable.
+                      {
+                        name: workflow.name,
+                        path: workflow.path,
+                        meta: { name: workflow.name },
+                        valid: false,
+                        error: mismatch ?? (result.valid ? "invalid workflow" : result.error),
+                        ...kind,
+                      }
+                }),
+              ),
+        { concurrency: "unbounded" },
+      )
+    })
+
+    const read: Interface["read"] = Effect.fn("Workflow.read")(function* (name) {
+      // Resolve the single named target through the SAME discovery precedence
+      // start() uses (project > global > builtin), so the preview shows exactly the
+      // source that would run. A builtin carries its module string inline
+      // (workflow.source); an on-disk workflow's source is its file text. Neither
+      // executes the module — this is a pure source read, like list()'s meta pass.
+      const discovered = yield* discoverWorkflows()
+      const found = discovered.find((item) => item.name === name)
+      if (!found) return undefined
+      const source =
+        found.source !== undefined ? found.source : yield* Effect.promise(() => fs.readFile(found.path, "utf8"))
+      return {
+        name: found.name,
+        path: found.path,
+        source,
+        ...(found.kind === "builtin" ? ({ source_kind: "builtin" } as const) : {}),
+      }
+    })
+
+    const runs: Interface["runs"] = Effect.fn("Workflow.runs")(function* () {
+      return yield* readRuns()
+    })
+
+    const get: Interface["get"] = Effect.fn("Workflow.get")(function* (id) {
+      const active = (yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)).get(id)
+      if (active) return snapshot(active)
+      // Cold DB read is scoped to the calling workspace (Fund 6): `get(id)` from
+      // directory B must not see a run that belongs to directory A even though
+      // both share the global DB. The in-memory branch above is already scoped
+      // because the registry is per-directory.
+      const directory = yield* InstanceState.directory
+      const row = yield* db
+        .select()
+        .from(WorkflowRunTable)
+        .where(and(eq(WorkflowRunTable.id, id), eq(WorkflowRunTable.directory, directory)))
+        .get()
+        .pipe(Effect.orDie)
+      if (!row) return
+      return fromRow(row)
+    })
+
+    const finish = Effect.fn("Workflow.finish")(function* (
+      id: RunID,
+      status: Exclude<Status, "running">,
+      data?: { result?: unknown; error?: string },
+    ) {
+      const completed_at = yield* Clock.currentTimeMillis
+      const active = (yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)).get(id)
+      if (!active) return
+      if (active.run.status !== "running") return snapshot(active)
+      active.run.status = status
+      active.run.completed_at = completed_at
+      // N2/N13: a workflow's return value reaches `finish` 1:1 from `module.run`
+      // (`Promise<unknown>`) and is otherwise unvalidated. Normalize it ONCE here —
+      // the single point an untrusted result enters the engine — through the SAME
+      // JSON codec the persist uses (`JSON.stringify` then re-parse), so the value
+      // stored on `active.run.result` matches exactly what the DB round-trips:
+      // functions/symbols/class instances are dropped silently (as the persist's
+      // `JSON.stringify` already does), not left to crash `snapshot`/the persist.
+      // `JSON.stringify` itself can still throw on circular references or BigInt,
+      // so the normalization is guarded with `Effect.try` captured as an
+      // `Effect.exit` (no try/catch per the engine style; same fail-soft posture as
+      // the terminal persist's `Effect.exit` guard below — waiters always observe a
+      // terminal state). On failure the run still finishes honestly with a result of
+      // `{ $unserializable: "<message>" }` rather than hanging the run or losing the
+      // terminal transition.
+      const normalized = yield* Effect.try({
+        try: () => (data?.result === undefined ? undefined : (JSON.parse(JSON.stringify(data.result)) as unknown)),
+        catch: (error) => (error instanceof Error ? error.message : String(error)),
+      }).pipe(Effect.exit)
+      active.run.result =
+        normalized._tag === "Success" ? normalized.value : { $unserializable: String(Cause.squash(normalized.cause)) }
+      active.run.error = data?.error
+      active.fiber = undefined
+      // Close out EVERY agent node still marked `running` at the terminal
+      // transition — for ALL terminal statuses, completed included (N11). A run
+      // can reach `completed` while an agent node is still running without any
+      // author error: a fire-and-forget `ctx.agent` whose promise settles after
+      // the body returns, or a settlement race. Gating this on the non-completed
+      // statuses left such a node persisted as `running` forever (TUI live icon),
+      // and its detached child session kept burning tokens. Now the node always
+      // gets a terminal status + completed_at + an explanatory error, and the
+      // still-open child sessions are aborted below.
+      const lingering = active.run.agents.filter((node) => node.status === "running")
+      for (const node of lingering) {
+        node.status = "failed"
+        node.completed_at = completed_at
+        node.error ??=
+          status === "cancelled"
+            ? "Cancelled"
+            : status === "paused"
+              ? "Paused"
+              : status === "completed"
+                ? "agent step never settled before the run completed"
+                : "Workflow failed"
+      }
+      // Stop the run-scoped agent fibers before collecting session ids to abort.
+      // A fire-and-forget ctx.agent can register its child session after `lingering`
+      // is collected but before the old cancel list was evaluated. Closing the
+      // run scope first prevents new work from progressing and lets a session_id
+      // that was registered just before interruption become visible on the same
+      // node objects in `lingering`. Then the explicit prompt cancel below aborts
+      // every lingering child session that actually exists, without touching
+      // already-completed agent sessions.
+      yield* Scope.close(active.runScope, Exit.void).pipe(Effect.ignore)
+      if (active.cancelSession) {
+        const cancelSession = active.cancelSession
+        yield* Effect.forEach(
+          lingering.flatMap((node) => (node.session_id ? [node.session_id] : [])),
+          (sessionID) => cancelSession(SessionID.make(sessionID)),
+          { concurrency: "unbounded", discard: true },
+        ).pipe(Effect.ignore)
+      }
+      // N2: a failing terminal persist must NEVER strand the `done` deferred —
+      // `persistRun` is `orDie`, so a DB error on the terminal write used to kill
+      // the finish fiber and the deferred was never resolved, hanging every
+      // no-timeout `wait()` (and background jobs) forever. `Effect.exit` captures
+      // ANY outcome of the persist (success, failure, or the `orDie` defect) as a
+      // value, so execution ALWAYS continues to the resolve below — the persist
+      // can fail and waiters still observe the terminal state (a cut-short write
+      // is healed by the startup orphan sweep on next restart).
+      //
+      // Fund 42: the persist runs BEFORE the resolve so a successful terminal
+      // write is already committed by the time a waiter wakes — a direct DB read
+      // right after `wait()` sees the final row (incl. a `null` result serialized
+      // as the text `"null"`) instead of racing an in-flight progress write. The
+      // `Effect.exit` guard keeps this ordering safe for the failing-persist case.
+      const result = snapshot(active)
+      // Finding 2 test seam: surface the in-memory spend accumulators at the
+      // terminal transition (never persisted, so otherwise unobservable post-run).
+      if (captureSpendHook)
+        captureSpendHook(id, { budgetRemaining: active.budgetRemaining, costSpent: active.costSpent })
+      yield* persistRun(db, events, active, { terminal: true }).pipe(Effect.exit)
+      yield* Deferred.succeed(active.done, result).pipe(Effect.ignore)
+      // N1: evict the terminal run from the in-memory registry so the map does not
+      // grow unbounded for a long-lived instance, and so a dead run's heavy
+      // in-memory snapshot (full logs/agents/result) is no longer pinned ahead of
+      // its DB row by get()/readRuns() (a divergence once the row is later edited
+      // out-of-band, e.g. by a sweep). ORDER is critical (3e/N2): the eviction runs
+      // only AFTER (a) the terminal persist above committed the DB row — so get()
+      // after evict reads a real row through fromRow, never a hole — and AFTER (b)
+      // `Deferred.succeed`, so a waiter already holds the terminal snapshot from the
+      // resolved deferred even if it wakes exactly at the eviction; a subsequent
+      // get() then falls back to that committed DB row. Safe even when the terminal
+      // persist FAILED (the `Effect.exit` above): the startup orphan sweep heals a
+      // cut-short row, and an evicted-but-unpersisted run is simply no longer
+      // readable until then — strictly better than a forever-pinned stale snapshot.
+      const inst = yield* InstanceState.get(state)
+      yield* SynchronizedRef.update(inst.runs, (runs) => {
+        if (!runs.has(id)) return runs
+        const next = new Map(runs)
+        next.delete(id)
+        return next
+      })
+      // The run scope was closed above before terminal persistence so no detached
+      // agent fiber can write after the final row. A second close would be a no-op,
+      // but keeping one close point makes the terminal ordering easier to reason about.
+      return result
+    })
+
+    const start: Interface["start"] = Effect.fn("Workflow.start")(function* (input) {
+      // Item 17: normalize the budget ONCE — a naked number is USD (back-compat
+      // for every existing caller), the struct form carries independent usd/token
+      // caps; unset ⇒ both unlimited.
+      const budget = typeof input.budget === "number" ? { usd: input.budget } : (input.budget ?? {})
+      // Resolve the start TARGET — `{ name, path, source? }` — either by discovery
+      // (a named workflow: project/global file or bundled builtin) or, when an
+      // inline `source` is supplied WITHOUT a name (P3), as a synthetic inline
+      // target that is never discovered and never written to the project. Both
+      // feed the SAME source-string/file load path below, so the run lifecycle,
+      // permission boundary, and argument coercion are source-agnostic.
+      let target: { name: string; path: string; source?: string }
+      if (input.source !== undefined && input.name === undefined) {
+        // Inline-source start: read the meta STATICALLY from the source (AST-only,
+        // never executes the module). The tool already pre-validates before its
+        // permission ask; the engine validates again defensively so a programmatic
+        // caller still fails cleanly (InvalidError) instead of defecting deep in
+        // the module load. The run's name is the source's meta name.
+        const read = MetaReader.read(input.source, inlinePath("inline"))
+        if (read.valid === false) return yield* new InvalidError({ path: inlinePath("inline"), message: read.error })
+        target = { name: read.meta.name, path: inlinePath(read.meta.name), source: input.source }
+      } else {
+        // Resolve the single target by name without loading every workflow: a
+        // broken sibling file must not block starting a valid one. Only the target
+        // module is imported, and a broken target fails precisely (InvalidError
+        // naming the file) rather than as part of a whole-list failure.
+        const discovered = yield* discoverWorkflows()
+        const found = discovered.find((item) => item.name === input.name)
+        if (!found) return yield* new NotFoundError({ name: input.name ?? "" })
+        if (found.error) return yield* new InvalidError({ path: found.path, message: found.error })
+        target = { name: found.name, path: found.path, source: found.source }
+        // Static meta gate, IDENTICAL to the inline path above: validate the
+        // source AST-only (never executing the module) BEFORE loadModule imports
+        // it. The tool pre-checks via list(), but that is only ONE surface — a
+        // name start via HTTP/programmatic callers/answer()-resume reached
+        // loadModule ungated, letting computed meta (e.g. `name: process.env.X`)
+        // slip past the pure-literal requirement. Builtins pass trivially (their
+        // meta is literal by invariant). A file deleted between discovery and
+        // here fails as a clean InvalidError (ENOENT text) instead of a
+        // loadModule defect. The gate's file read is deliberately SEPARATE from
+        // loadModule's (the TOCTOU between the two reads is accepted: the gate
+        // is defense-in-depth for the permission-dialog guarantee, not a
+        // security boundary against racing writers) — passing the read text as
+        // inlineSource would move the module load to the global config dir and
+        // break relative imports.
+        const sourceText =
+          target.source !== undefined
+            ? target.source
+            : yield* Effect.tryPromise({
+                try: () => fs.readFile(target.path, "utf8"),
+                catch: (error) => new InvalidError({ path: target.path, message: errorText(error) }),
+              })
+        const gate = MetaReader.read(sourceText, target.path)
+        if (gate.valid === false) return yield* new InvalidError({ path: target.path, message: gate.error })
+        const mismatch = pluginWorkflowMismatch(target, gate.meta)
+        if (mismatch) return yield* new InvalidError({ path: target.path, message: mismatch })
+      }
+      // tryPromise so a load failure (bad meta / missing run / syntax error)
+      // surfaces as a typed InvalidError naming the file, not as an unhandled
+      // defect (Effect.promise would treat a rejection as a die).
+      const module = yield* Effect.tryPromise({
+        // A builtin/inline target carries its module source inline (`target.source`);
+        // an on-disk workflow loads from its file. Both go through loadModule's
+        // temp-file import so every source runs the IDENTICAL load + validation path.
+        try: () => loadModule(target.path, target.source),
+        catch: (error) =>
+          isInvalidError(error) ? error : new InvalidError({ path: target.path, message: errorText(error) }),
+      })
+      // Enforce the declared argument contract HERE — the single engine boundary
+      // before the body runs — so coercion + defaults apply identically on every
+      // start path (HTTP/Tool/TUI). A non-coercible value fails the start as an
+      // InvalidError; nothing reaches `module.run` until the args are authoritative.
+      const coerced = coerceArgs(input.args, module.meta.arguments, target.path)
+      if (coerced instanceof InvalidError) return yield* coerced
+      const args = coerced
+      const inst = yield* InstanceState.get(state)
+      // The workspace this run belongs to. Persisted to the `directory` column so
+      // every later read/delete/sweep can be scoped to it (Fund 6/17).
+      const directory = yield* InstanceState.directory
+      // Resume journal: when `resume_of` is supplied, load the SOURCE run's
+      // completed agents (directory-scoped, exactly like get()) and group them by
+      // call key in occurrence order. A `ctx.agent` call in the new run consumes
+      // the next unused entry for its key — replaying it verbatim instead of
+      // re-prompting. Indices listed in `invalidate_agents` are excluded so they
+      // re-run live. An unknown/foreign source id yields an empty journal (every
+      // call then runs live), so a stale resume id degrades to a normal run rather
+      // than failing the start.
+      const journal = new Map<string, AgentRun[]>()
+      // Item 20: the replay strategy. Default `prefix` (the safe mode): replay
+      // stops permanently at the first mismatch instead of shape-matching later
+      // calls whose workspace side effects may be stale. `keyed` keeps the
+      // previous occurrence-cursor behavior 1:1 for read-only workflows.
+      const replayMode: "prefix" | "keyed" = input.replay ?? "prefix"
+      // Prefix-mode journal: the source agents in ORIGINAL order (questions
+      // filtered out), INCLUDING non-completed nodes so they BREAK the prefix
+      // rather than being invisibly absent.
+      const journalSeq: { node: AgentRun; index: number }[] = []
+      // Question replay journal (Tasks 12/13): when this resume seeds answers
+      // (answer() on a paused run), map the source run's `kind:"question"` nodes to
+      // their provided answer keyed by [question, phase] — the SAME shape the live
+      // `ctx.question` will rebuild. On reaching that question the body is served
+      // the answer from here instead of asking again.
+      const questionJournal = new Map<string, string>()
+      if (input.resume_of) {
+        const sourceRow = yield* db
+          .select()
+          .from(WorkflowRunTable)
+          .where(and(eq(WorkflowRunTable.id, input.resume_of), eq(WorkflowRunTable.directory, directory)))
+          .get()
+          .pipe(Effect.orDie)
+        if (sourceRow) {
+          // Status guard: paused, interrupted, FAILED, and COMPLETED runs are
+          // legitimate resume sources. failed-resume carries the original core
+          // iteration loop — the run fails, the author edits the script and
+          // replays the completed prefix from the journal (the failed node never
+          // entered the journal, so it runs live); completed-resume is the
+          // 100%-cache-hit re-run of an identical script. Still forbidden:
+          // `running` (the original precondition — stop the source run first) and
+          // `cancelled` (the cancel-of-a-paused-run race protection: a cancelled
+          // source could otherwise be re-resumed via a direct DB UPDATE to
+          // `cancelled`). HTTP maps WorkflowInvalidError to 400. An unknown id
+          // leaves `sourceRow` undefined and still degrades to a normal run
+          // (every call runs live), unchanged.
+          if (!RESUMABLE.has(sourceRow.status)) {
+            return yield* new InvalidError({
+              path: target.path,
+              message: `Cannot resume run ${input.resume_of}: status is ${sourceRow.status} (running runs must be stopped first; cancelled runs cannot be resumed)`,
+            })
+          }
+          // Finding 11: identity guard. The HTTP start route lets the caller choose
+          // the workflow NAME (path param) and the resume source (`resume_of` body)
+          // INDEPENDENTLY. Without this check, POST /workflow/B/start with
+          // {resume_of: <paused run of A>} would run B but replay A's journaled
+          // agent output/cost/answers wherever a journal key collides — silently
+          // serving one workflow's recorded results to a different workflow's steps,
+          // and recording resume_of pointing at an unrelated workflow. Require the
+          // source run's workflow to MATCH the workflow being started. The answer()
+          // resume path satisfies this by construction (name/source come from the
+          // same source row). HTTP maps WorkflowInvalidError to 400.
+          if (sourceRow.workflow !== target.name) {
+            return yield* new InvalidError({
+              path: target.path,
+              message: `Cannot resume run ${input.resume_of}: it belongs to workflow "${sourceRow.workflow}", not "${target.name}"`,
+            })
+          }
+          const invalidate = new Set(input.invalidate_agents ?? [])
+          sourceRow.agents.forEach((node, index) => {
+            // A `kind:"question"` node is replayed from the SEEDED answer (not the
+            // agent journal): match it on [question, phase] and record the supplied
+            // answer. The source node may be `failed`/"Paused" (a timed-out park
+            // flips the still-open node), so — unlike the agent journal — we do NOT
+            // gate on `completed`; the seed answer is what makes the replay valid.
+            if (node.kind === "question") {
+              const seeded = input.questionAnswers?.[node.prompt]
+              if (seeded !== undefined) {
+                questionJournal.set(questionJournalKey({ question: node.prompt, phase: node.phase }), seeded)
+              }
+              return
+            }
+            // Item 20 (prefix mode): keep the source agents as an ORDERED
+            // sequence instead of the keyed map. Non-completed nodes are
+            // INCLUDED — they break the prefix at their position rather than
+            // being invisibly absent; `invalidate_agents` is checked at replay
+            // time against the carried index (a hit breaks the prefix too).
+            if (replayMode === "prefix") {
+              journalSeq.push({ node: { ...node }, index })
+              return
+            }
+            if (node.status !== "completed") return
+            if (invalidate.has(index)) return
+            const key = journalKey({ prompt: node.prompt, agent: node.agent, phase: node.phase })
+            const bucket = journal.get(key) ?? []
+            bucket.push({ ...node })
+            journal.set(key, bucket)
+          })
+        }
+      }
+      const id = RunID.ascending()
+      const started_at = yield* Clock.currentTimeMillis
+      // Item 23 (Stufe 1): the ctx.shell asks of this run are evaluated against
+      // the CALLER session's permission rules — the same inheritance the
+      // subagent asks derive from. No caller identity (HTTP/headless) ⇒ empty
+      // ruleset ⇒ asks fall through to the interactive default, exactly like a
+      // subagent tool ask today.
+      const shellCallerSession = input.caller
+        ? yield* sessions.get(input.caller.sessionID).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
+        : undefined
+      const shellRuleset = Permission.merge(shellCallerSession?.permission ?? [], [])
+      const session = yield* sessions.create({ title: `Workflow: ${module.meta.name}` })
+      const done = yield* Deferred.make<Run>()
+      // Per-run scope forked from the instance scope. ALL agent/parallel/pipeline
+      // work and all progress writes are forked into it (not into a detached
+      // root fiber), so closing it on cancel/remove propagates Interrupt to the
+      // in-flight agent graph; the instance teardown closes it transitively.
+      const runScope = yield* Scope.fork(inst.scope)
+      // Run-wide concurrency gate over every ctx.agent dispatch. Created here (at
+      // run start) so it is shared by the whole run; a per-call concurrencyLimit
+      // still applies on top, the narrower limit winning. The override seam is
+      // captured per run so a test's tiny limit only affects runs started after it.
+      const agentSemaphore = yield* Semaphore.make(agentConcurrencyCap())
+      const active: Active = {
+        run: {
+          id,
+          session_id: session.id,
+          workflow: target.name,
+          args: args ?? undefined,
+          definition: {
+            name: target.name,
+            path: target.path,
+            meta: mutableMeta(module.meta),
+            // The RESOLVED module source for EVERY run, not just inline starts:
+            // `module.source` is the file text for an on-disk workflow and the
+            // bundled/inline string for a builtin/inline start (it equals
+            // input.source on the inline path, so this is a strict superset of the
+            // old `source: input.source`). Carrying it makes save-as-command and the
+            // run-detail source view work for named/on-disk and builtin runs too,
+            // which previously got `source: undefined`.
+            source: module.source,
+            temporary: input.temporary,
+          },
+          status: "running",
+          started_at,
+          logs: [],
+          agents: [],
+          resume_of: input.resume_of,
+        },
+        directory,
+        done,
+        runScope,
+        sessions: new Set<string>(),
+        cancelSession: input.prompt?.cancel,
+        // Unset budget ⇒ Infinity ⇒ the gate never trips and the decrement is a
+        // no-op, preserving the previous unlimited behavior exactly.
+        budget: budget.usd ?? Number.POSITIVE_INFINITY,
+        budgetRemaining: budget.usd ?? Number.POSITIVE_INFINITY,
+        // Kept as the raw validated budget (undefined ⇒ no budget) so
+        // `ctx.budget.total` reports `null` rather than coercing to Infinity.
+        budgetTotal: budget.usd,
+        costSpent: 0,
+        // Item 17: independent output-token cap; undefined ⇒ unlimited.
+        tokensBudgetTotal: budget.tokens,
+        tokensSpent: 0,
+        agentSemaphore,
+        agentStarted: 0,
+        agentLimit: agentLimitOverride ?? DEFAULT_AGENT_LIMIT,
+        journal: input.resume_of && replayMode === "keyed" ? journal : undefined,
+        journalCursor: input.resume_of && replayMode === "keyed" ? new Map<string, number>() : undefined,
+        // Item 20: prefix-mode replay state. journalSeq is the ordered source
+        // sequence; the cursor advances on each hit; replayBroken flips
+        // permanently on the first mismatch; invalidateSet carries the
+        // invalidate_agents indices for the at-replay-time check.
+        journalMode: input.resume_of ? replayMode : undefined,
+        journalSeq: input.resume_of && replayMode === "prefix" ? journalSeq : undefined,
+        journalSeqCursor: 0,
+        replayBroken: false,
+        invalidateSet:
+          input.resume_of && replayMode === "prefix" ? new Set(input.invalidate_agents ?? []) : undefined,
+        resumeOf: input.resume_of,
+        questionJournal: input.resume_of && questionJournal.size > 0 ? questionJournal : undefined,
+        // Item 12: the caller session's resolved model — default-agent steps
+        // without an explicit/phase model inherit it (see the chain in agent()).
+        callerModel: input.caller_model,
+        // Item 15: node ids a human asked to skip.
+        skipRequests: new Set<string>(),
+        // Item 23 (Stufe 1): the caller-inherited bash ruleset for ctx.shell.
+        shellRuleset,
+        // Item 24: the caller turn's shared budget pool (absent ⇒ no pool gate).
+        pool: input.pool,
+      }
+      yield* SynchronizedRef.update(inst.runs, (runs) => new Map(runs).set(id, active))
+      yield* persistRun(db, events, active)
+      if (input.prompt) {
+        yield* input.prompt
+          .prompt({
+            sessionID: session.id,
+            noReply: true,
+            parts: [
+              {
+                type: "text",
+                text: [
+                  `Workflow started: ${module.meta.name}`,
+                  `Run ID: ${id}`,
+                  "",
+                  module.meta.description ?? "Use the workflow dashboard to inspect phases, agent runs, and results.",
+                ].join("\n"),
+              },
+            ],
+          })
+          .pipe(Effect.ignore)
+      }
+      const bridge = yield* EffectBridge.make()
+      // AbortSignal of the run fiber; set inside Effect.promise below and fired
+      // on Fiber.interrupt. Read by ctx.agent/parallel/pipeline for gating.
+      let runSignal: AbortSignal | undefined
+
+      // Runs an effect as a CHILD of the run scope and awaits it as a promise.
+      // Unlike `bridge.promise` (a detached root fiber via Effect.runPromise),
+      // the work is forked into `runScope`, so closing the scope on cancel/remove
+      // interrupts it. An interrupt-only outcome (the scope was closed) is
+      // surfaced as a CancelledError rejection so the workflow body unwinds as
+      // `cancelled`; any other failure is rejected with its representative error.
+      const dispatch = <A>(effect: Effect.Effect<A, unknown>): Promise<A> =>
+        bridge.promise(
+          Effect.gen(function* () {
+            const fiber = yield* Effect.forkIn(effect, runScope)
+            const exit = yield* Fiber.await(fiber)
+            if (Exit.isSuccess(exit)) return exit.value
+            if (Cause.hasInterruptsOnly(exit.cause)) return yield* Effect.die(new CancelledError())
+            return yield* Effect.failCause(exit.cause)
+          }),
+        )
+
+      const agentStep = async (agentInput: AgentInput, callOpts?: { phaseModel?: string }) => {
+        // Gate the step: a fired run signal OR a landed cancel/pause all mean the
+        // run is unwinding, so refuse to start another agent step (Fund 5/4).
+        if (runSignal?.aborted || active.cancelling || active.pausing || active.removed) throw new CancelledError()
+        // Budget gate — ordered right AFTER the abort-signal checkpoint so a
+        // cancelled run still unwinds as `cancelled` (not `failed`) before any
+        // budget verdict is reached. `Infinity` (no budget set) never trips.
+        // Once the prior steps have consumed the whole budget we refuse to spend
+        // again: fail the step with a BudgetExceededError, which propagates like
+        // any other agent failure (node `failed`, run `failed` unless caught).
+        // AUDITED soft cap (T5): this gate + the post-step spend (ensuring, below)
+        // run on SEPARATE turns, so N parallel ctx.parallel tasks can all pass this
+        // synchronous check before any of them charges ⇒ a run may overspend by the
+        // combined cost of the steps already in flight. That overspend is BOUNDED
+        // (the next step after exhaustion is refused here), so it is best-effort by
+        // design, not an unbounded leak — no atomic reservation is needed. Pinned by
+        // "budget-race audit: 2 parallel agents with budget for 1 …".
+        if (active.budgetRemaining <= 0) {
+          const spent = active.budget - active.budgetRemaining
+          throw new BudgetExceededError({
+            message: `Workflow budget exhausted: spent ${spent} of ${active.budget} (USD) budget; refusing to start another agent step`,
+            budget: active.budget,
+            spent,
+            unit: "usd",
+          })
+        }
+        // Item 17: second gate for the independent output-TOKEN cap. Same
+        // soft-cap semantics as the USD gate above (comment T5 applies to both:
+        // parallel steps already in flight may push past the cap; the NEXT step
+        // is refused). Checked after the USD gate, so with both caps exhausted
+        // the USD verdict reports first.
+        if (active.tokensBudgetTotal !== undefined && active.tokensSpent >= active.tokensBudgetTotal) {
+          throw new BudgetExceededError({
+            message: `Workflow token budget exhausted: spent ${active.tokensSpent} of ${active.tokensBudgetTotal} output tokens; refusing to start another agent step`,
+            budget: active.tokensBudgetTotal,
+            spent: active.tokensSpent,
+            unit: "tokens",
+          })
+        }
+        // Lifetime gate — ordered after the abort + budget gates so a cancelled
+        // or over-budget run reports those first. A run may START at most
+        // `agentLimit` agent dispatches; the (limit+1)-th call refuses with a
+        // tagged AgentLimitError (same failure path as the budget gate: node
+        // `failed`, run `failed` unless caught). Counts every dispatch attempt
+        // (including journal replays) so a runaway loop cannot spin unbounded.
+        if (active.agentStarted >= active.agentLimit) {
+          throw new AgentLimitError({
+            message: `Workflow agent lifetime limit reached: ${active.agentStarted} of ${active.agentLimit} agents started; refusing to start another agent step`,
+            limit: active.agentLimit,
+            started: active.agentStarted,
+          })
+        }
+        // Moved ABOVE the pool reservation (Item 24): every throw-point between
+        // the reservation and the dispatched effect's `ensuring` would leak the
+        // reserved headroom, so the only remaining code on that path must be
+        // non-throwing straight-line work.
+        const prompt = input.prompt
+        if (!prompt) throw new Error("Workflow agent execution requires prompt operations")
+        // Item 24: shared turn-pool gate, AFTER every other gate (so a refusal
+        // can never leak a reservation past an abort/budget/limit throw) and
+        // BEFORE the node is recorded. `TurnBudget.reserve` is a SYNCHRONOUS
+        // check-and-set — no await separates the headroom check from the
+        // reservation, which closes the audited per-run soft-cap race (T5) for
+        // the pool: of N parallel steps with priced reservations, only the ones
+        // the pool can still cover pass. Per-run budget AND pool must BOTH
+        // pass. The reservation is priced at the pool's rolling per-step
+        // average (0 before the first settlement — the documented residual
+        // soft cap for the first parallel wave). Journal replays reserve and
+        // settle like live steps, mirroring the run-budget parity. The
+        // matching settle lives in the step's `ensuring` below and runs on
+        // EVERY outcome, so a reservation can never leak.
+        const poolReservation = active.pool ? TurnBudget.reserve(active.pool, active.pool.avgStepUsd) : undefined
+        if (active.pool && !poolReservation) {
+          throw new BudgetExceededError({
+            message: `Turn budget exhausted: spent ${active.pool.usd?.committed ?? 0} of ${active.pool.usd?.total ?? 0} (USD) shared turn pool; refusing to start another agent step`,
+            budget: active.pool.usd?.total ?? 0,
+            spent: active.pool.usd?.committed ?? 0,
+            unit: "usd",
+          })
+        }
+        active.agentStarted += 1
+        // Task 15: snapshot the active per-phase default model SYNCHRONOUSLY here
+        // (alongside `node.phase`), not inside the dispatched gen — concurrent
+        // parallel/pipeline steps may move the phase before this fiber runs, so
+        // capturing it at call time keeps each step bound to the phase it was
+        // dispatched under (matching how `node.phase` snapshots current_phase).
+        //
+        // Item 16: an EXPLICIT per-call phase uses ITS declared model (or none) —
+        // never the global current phase's model: the author pinned this step to a
+        // phase, so the global default would be the wrong phase's model.
+        const phaseModel = agentInput.phase !== undefined ? callOpts?.phaseModel : active.currentPhaseModel
+        const node: AgentRun = {
+          id: `${active.run.agents.length + 1}`,
+          status: "running",
+          started_at: Date.now(),
+          // Item 16: a per-call phase (already logPrefix-ed by createContext) pins
+          // the node; otherwise the node snapshots the run's current phase.
+          phase: agentInput.phase ?? active.run.current_phase,
+          agent: agentInput.agent,
+          label: agentInput.label,
+          model: agentInput.model,
+          prompt: agentInput.prompt,
+        }
+        active.run.agents.push(node)
+        persistInScope(active, bridge, db, events)
+        // Finding 2: an externally-aborted subagent (a session abort/timeout that is
+        // NOT a run-level cancel/pause) RESOLVES with an abort-marked assistant
+        // message that carries the abort-artifact cost. That cost must NOT be charged
+        // to the budget/costSpent (the comment in the `ensuring` below says so), but
+        // the run-level flags it gated on (cancelling/removed/pausing) are all false
+        // in this case. We capture `aborted` at the abort-detection point so the
+        // `ensuring` settlement can skip the charge for it too. Lives in the handler
+        // scope (shared by the gen and its `ensuring`).
+        let aborted = false
+        return dispatch(
+          Effect.gen(function* () {
+            const selected = agentInput.agent ? yield* agents.get(agentInput.agent) : yield* agents.defaultInfo()
+            // Model resolution (precedence, highest first):
+            //   1. EXPLICIT per-call `agentInput.model` — including the magic
+            //      `model: "small"`, which routes to the configured `small_model`
+            //      (read from the already-injected Config.Service). Requesting
+            //      "small" with no `small_model` configured is an authoring error
+            //      (fail the step, never silently fall back).
+            //   2. The active PHASE'S default `model` (Task 15) — captured at call
+            //      time as `phaseModel`; used only when the call gave no explicit
+            //      model, so an explicit model always wins over the phase default.
+            //   3. The CALLER session's resolved model (Item 12) — DEFAULT-agent
+            //      steps only (`!agentInput.agent`): an explicitly chosen agent is
+            //      a deliberate authoring decision including its model, while the
+            //      default-agent step should follow the main loop's model.
+            //      `caller_model` arrives pre-parsed ({providerID, modelID}), so it
+            //      is used as-is, never re-run through Provider.parseModel.
+            //   4. The selected agent's own model.
+            const smallModel = agentInput.model === "small" ? (yield* config.get()).small_model : undefined
+            if (agentInput.model === "small" && !smallModel) {
+              return yield* new InvalidError({
+                path: active.run.workflow,
+                message: 'ctx.agent({ model: "small" }) requires "small_model" to be configured',
+              })
+            }
+            const modelInfo = smallModel
+              ? Provider.parseModel(smallModel)
+              : agentInput.model
+                ? Provider.parseModel(agentInput.model)
+                : phaseModel
+                  ? Provider.parseModel(phaseModel)
+                  : !agentInput.agent && active.callerModel
+                    ? // Pre-parsed components are only re-BRANDED here (plain
+                      // brands, no refinement): model ids legitimately contain
+                      // slashes, so the joined string must never go back through
+                      // Provider.parseModel.
+                      {
+                        providerID: ProviderV2.ID.make(active.callerModel.providerID),
+                        modelID: ModelV2.ID.make(active.callerModel.modelID),
+                      }
+                    : selected.model
+            // OTel: enrich the enclosing `workflow.agent` span with the RESOLVED
+            // agent name and model now that both are known (the boundary above set
+            // only the static/requested attributes). Purely observational.
+            yield* Effect.annotateCurrentSpan({
+              "workflow.agent.name": selected.name,
+              ...(modelInfo ? { "workflow.agent.model": `${modelInfo.providerID}/${modelInfo.modelID}` } : {}),
+            })
+            // Per-step model reasoning variant (e.g. "max"). opencode keeps the
+            // variant SEPARATE from the model ref (model ids legitimately contain
+            // slashes, so it is never peeled from the model string here — that is
+            // the registry-aware job of the model picker); it rides alongside the
+            // model into both the child session and the prompt run.
+            const variant = agentInput.variant
+            // Per-step skills (Task 9). opencode has NO structured "give this
+            // session these skills" field: skills are only loadable at runtime via
+            // the `skill` tool (which asks for the `skill` permission and injects
+            // the skill content into the conversation). So the supported mechanism
+            // is a documented prompt convention — prepend a directive naming the
+            // requested skills and ENABLE the `skill` tool for the step (folded
+            // into the per-step tools scoping above). The directive precedes the
+            // author's prompt so the model loads the skills before starting.
+            const skills = agentInput.skills?.filter((s) => s.length > 0) ?? []
+            // Prompt assembly (in order): the step-framing directive (NON-schema
+            // steps only — see STEP_FRAMING_DIRECTIVE), the skills directive, then
+            // the author's prompt. Only the DISPATCHED text is framed: `node.prompt`
+            // keeps the raw `agentInput.prompt` (set at node creation above), and
+            // the resume journalKey builds on agentInput.prompt too — so framing
+            // never breaks existing resume journals or the journal shape match
+            // (the skills directive has relied on the same split all along).
+            const promptText = [
+              agentInput.schema ? undefined : STEP_FRAMING_DIRECTIVE,
+              skills.length > 0 ? `Load these skills before starting: ${skills.join(", ")}.` : undefined,
+              agentInput.prompt,
+            ]
+              .filter(Boolean)
+              .join("\n\n")
+            const tools = skills.length > 0 ? { ...(agentInput.tools ?? {}), skill: true } : agentInput.tools
+            // Declarative file attachments (Task 10). Each path is resolved
+            // RELATIVE TO the run's workspace directory (`active.directory`, the
+            // InstanceState directory the run was started in) and must exist —
+            // a missing attachment is an authoring error, so fail the step with a
+            // clear WorkflowInvalidError naming the file (before any prompt is
+            // dispatched) rather than sending a broken prompt. Each resolved file
+            // becomes a `text/plain` FilePartInput whose `url` is the absolute
+            // `file://` URL; the prompt loop reads `file://` parts off disk (via
+            // the Read tool) exactly like a TUI-attached file. Built here so the
+            // parts can be appended AFTER the text part below.
+            const fileParts: { type: "file"; mime: string; filename: string; url: string }[] = []
+            for (const file of agentInput.files ?? []) {
+              if (file.length === 0) continue
+              const resolved = path.isAbsolute(file) ? file : path.resolve(active.directory, file)
+              // Must exist AND be a regular file: a directory is not an attachable
+              // source, so it fails here cleanly rather than being sent as a broken
+              // `file://` part (matches the prior `Bun.file(dir).exists()` -> false).
+              const exists = yield* Effect.promise(() =>
+                fs
+                  .stat(resolved)
+                  .then((s) => s.isFile())
+                  .catch(() => false),
+              )
+              if (!exists) {
+                return yield* new InvalidError({
+                  path: active.run.workflow,
+                  message: `ctx.agent file attachment not found: ${file} (resolved to ${resolved})`,
+                })
+              }
+              fileParts.push({
+                type: "file",
+                mime: "text/plain",
+                filename: path.basename(resolved),
+                url: pathToFileURL(resolved).href,
+              })
+            }
+            // Resume replay: when this run has a journal (started with
+            // resume_of), consume the next unused source agent for this call's
+            // key (occurrence order) and replay it verbatim — NO session, NO
+            // prompt. The node adopts the source output/cost/tokens, is marked
+            // `cached`, and the replayed cost is charged once via the shared
+            // `ensuring` (post-step) — the SAME decrement the live-step path uses;
+            // the budget gate before this lookup still fails honestly when
+            // exhausted. `structured` is re-parsed from the stored output when a
+            // schema was requested so `result.data` stays the parsed object,
+            // identical to a live structured step. A miss falls through to the
+            // live path below. The agent name is resolved (`selected.name`)
+            // exactly like the seed side, so a default-agent call still matches.
+            // Item 20: both replay modes resolve a CANDIDATE here and share the
+            // verbatim-replay block below; `commitReplay` advances the mode's
+            // own cursor only once the hit is final (the schema parse guard may
+            // still veto it).
+            // - prefix (default): the next entry of the ORDERED source sequence
+            //   must match this call — entry exists, source node completed, its
+            //   index not invalidated, and the journal key equal. ANY mismatch
+            //   breaks the prefix PERMANENTLY (replayBroken): every later call
+            //   runs live, even an unchanged one, because its workspace side
+            //   effects may be stale after the changed step.
+            // - keyed: the previous shape-matching behavior 1:1 (occurrence
+            //   cursor per key; a miss falls through to live without breaking
+            //   anything).
+            let replayCached: AgentRun | undefined
+            let commitReplay: (() => void) | undefined
+            if (active.journalMode === "prefix" && active.journalSeq && !active.replayBroken) {
+              const entry = active.journalSeq[active.journalSeqCursor]
+              const liveKey = journalKey({ prompt: agentInput.prompt, agent: selected.name, phase: node.phase })
+              const matches =
+                entry !== undefined &&
+                entry.node.status === "completed" &&
+                !(active.invalidateSet?.has(entry.index) ?? false) &&
+                journalKey({ prompt: entry.node.prompt, agent: entry.node.agent, phase: entry.node.phase }) === liveKey
+              if (matches) {
+                replayCached = entry.node
+                commitReplay = () => {
+                  active.journalSeqCursor += 1
+                }
+              } else {
+                active.replayBroken = true
+              }
+            } else if (active.journal && active.journalCursor) {
+              const key = journalKey({ prompt: agentInput.prompt, agent: selected.name, phase: node.phase })
+              const bucket = active.journal.get(key)
+              const cursor = active.journalCursor.get(key) ?? 0
+              const cached = bucket?.[cursor]
+              if (cached) {
+                replayCached = cached
+                commitReplay = () => {
+                  active.journalCursor!.set(key, cursor + 1)
+                }
+              }
+            }
+            if (replayCached !== undefined && commitReplay !== undefined) {
+              const cached = replayCached
+              // A schema was requested ⇒ the replayed output must parse as JSON
+              // to satisfy `result.data`. The source node may be a PLAINTEXT
+              // agent whose journal key happens to match this schema call (the
+              // workflow FILE drifted between the original run and the resume:
+              // same prompt/agent/phase, but the agent now asks for a schema).
+              // `JSON.parse` on that plaintext would throw SYNCHRONOUSLY and
+              // turn into a defect. Guard it with `Effect.try` captured as an
+              // `Effect.exit` (engine style; no try/catch). On a parse FAILURE
+              // we treat the lookup as a cache MISS — semantically correct: the
+              // cache cannot serve this schema, so we DON'T consume the journal
+              // entry, fall through, and let the agent run live (which yields a
+              // real structured result). Only commit the cache hit once we know
+              // the parse succeeded. Item 20: in PREFIX mode a parse failure
+              // additionally breaks the prefix permanently (the cache no longer
+              // fits this call semantically — the script drifted), instead of a
+              // silent per-call fall-through.
+              const parsedExit =
+                agentInput.schema && cached.output !== undefined
+                  ? yield* Effect.try({
+                      try: () => JSON.parse(cached.output!) as unknown,
+                      catch: (error) => (error instanceof Error ? error.message : String(error)),
+                    }).pipe(Effect.exit)
+                  : undefined
+              const parseFailed = parsedExit !== undefined && Exit.isFailure(parsedExit)
+              if (parseFailed && active.journalMode === "prefix") {
+                active.replayBroken = true
+              }
+              if (!parseFailed) {
+                commitReplay()
+                node.agent = selected.name
+                node.status = "completed"
+                node.completed_at = Date.now()
+                node.output = cached.output
+                node.cost = cached.cost
+                node.tokens = cached.tokens
+                node.model = cached.model
+                node.cached = true
+                // The budget decrement is left to the shared `ensuring` below
+                // (node.cost is set), so a cache hit is charged exactly once.
+                yield* persistRun(db, events, active)
+                const structured = parsedExit !== undefined ? parsedExit.value : undefined
+                return {
+                  data: structured !== undefined ? structured : (cached.output ?? ""),
+                  text: cached.output ?? "",
+                }
+              }
+            }
+            // Security (#26514 regression, Fund N9): a workflow subagent MUST
+            // inherit the caller's deny/external_directory rules — exactly like
+            // the task tool derives a subagent's ruleset (since #31696 parent
+            // AGENT restrictions are deliberately NOT inherited; the subagent's
+            // own permissions determine its capabilities). Without the caller's
+            // identity (a purely programmatic/HTTP start with no session) we fall
+            // back to the prior behavior: no inherited ruleset (the engine still
+            // defaults task/todowrite denies for any non-permitting subagent via
+            // the normal session permission path).
+            const callerSession = input.caller
+              ? yield* sessions.get(input.caller.sessionID).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
+              : undefined
+            // The inherited subagent ruleset: parent session denies/external_directory,
+            // default task/todowrite denies. Absent a caller identity there is
+            // nothing to inherit (prior fallback).
+            const derivedPermission = callerSession
+              ? deriveSubagentSessionPermission({
+                  parentSessionPermission: callerSession.permission ?? [],
+                  subagent: selected,
+                })
+              : undefined
+            // Security (compose, never override): per-step tool scoping must NEVER
+            // re-grant a tool the inherited ruleset denies. The Record→rules
+            // conversion mirrors the prompt loop's (PromptInput.tools handler):
+            // each entry → `{ permission, action: allow|deny, pattern: "*" }`.
+            // When an inherited ruleset exists we MUST NOT route `tools` through
+            // PromptInput.tools, whose handler does a FULL ASSIGNMENT
+            // (`session.permission = [tools→rules]`) that would clobber the derived
+            // denies for the step. Instead we COMPOSE: the per-step rules go FIRST,
+            // the derived ruleset LAST. The permission engine is last-match-wins
+            // (`evaluate` = `.flat().findLast(...)`), so an inherited deny always
+            // beats a per-step grant of the same permission, while a per-step DENY
+            // (scoping down) and grants of non-denied tools still take effect. When
+            // there is no inherited ruleset there is nothing to clobber, so we keep
+            // routing `tools` through PromptInput.tools below (createPermission stays
+            // undefined and `tools` is passed to prompt.prompt).
+            const toolRules = Object.entries(tools ?? {}).map(([t, enabled]) => ({
+              permission: t,
+              action: enabled ? ("allow" as const) : ("deny" as const),
+              pattern: "*" as const,
+            }))
+            const composeTools = derivedPermission !== undefined && toolRules.length > 0
+            const createPermission = composeTools ? [...toolRules, ...derivedPermission!] : derivedPermission
+            // Per-step git-worktree isolation (Task 11). When requested, run the
+            // subagent inside a FRESH `git worktree` so parallel agents that
+            // mutate files cannot conflict. The worktree is created off the run's
+            // workspace (`active.directory`) and removed when the run finishes or
+            // is cancelled — the remove finalizer is registered on the RUN scope
+            // (this effect runs via dispatch → `Effect.forkIn(effect, runScope)`,
+            // so the finalizer attaches there, survives parallel steps, and fires
+            // on cancel). A non-git workspace cannot host a worktree, so the step
+            // fails with a clear WorkflowInvalidError instead of crashing.
+            //
+            // The isolation is load-bearing via the `InstanceRef` override below,
+            // NOT the session's `directory` field: the subagent's file tools
+            // (bash/edit/write/read) and the prompt loop resolve their cwd from
+            // the effective `InstanceState.context` (the `InstanceRef`), not from
+            // `session.directory`. So we both (a) override `InstanceRef` for the
+            // prompt run (what actually redirects the tools) and (b) record the
+            // worktree as the session's `directory` so the dashboard reflects
+            // where the work happened.
+            const instanceCtx = yield* InstanceState.context
+            let promptInstanceCtx = instanceCtx
+            let sessionDirectory = instanceCtx.directory
+            if (agentInput.isolation === "worktree") {
+              // Finding 3: do NOT use a predictable, world-readable path under the
+              // shared tmp root (`os.tmpdir()/oc-wf-<runid>-<nodeid>`). Both run.id
+              // (monotonic, returned verbatim by the API/events) and node.id (a
+              // sequential counter) are guessable, so on a multi-user host any local
+              // user could read the full checkout + any secrets the subagent writes.
+              // Mint a private base via `fs.mkdtemp` (random, unguessable suffix) and
+              // chmod it 0700 so only the running user can traverse it; the empty
+              // mkdtemp dir is a valid `git worktree add` target. The `WORKTREE_PREFIX`
+              // is shared with the startup orphan sweep so a SIGKILLed run's leaked
+              // worktree is reclaimed on next start.
+              const base = yield* Effect.promise(() => fs.mkdtemp(path.join(os.tmpdir(), WORKTREE_PREFIX)))
+              yield* Effect.promise(() => fs.chmod(base, 0o700)).pipe(Effect.ignore)
+              const res = spawnSync("git", ["worktree", "add", "--detach", base], { cwd: instanceCtx.directory })
+              if (res.status !== 0) {
+                // node's spawnSync reports the exit code on `status` (not `exitCode`);
+                // on a spawn failure (e.g. git not on PATH) `status` is null and the
+                // reason is on `res.error`, with `stderr` possibly null — surface
+                // whichever is present so the message is never empty.
+                const detail = res.stderr ? new TextDecoder().decode(res.stderr) : (res.error?.message ?? "")
+                // The mkdtemp dir is orphaned when `git worktree add` fails (e.g. a
+                // non-git workspace); remove it so a failed isolation request does
+                // not leak an empty private dir into tmp.
+                yield* Effect.promise(() => fs.rm(base, { recursive: true, force: true })).pipe(Effect.ignore)
+                return yield* new InvalidError({
+                  path: active.run.workflow,
+                  message: `ctx.agent isolation:"worktree" requires a git repository (${detail.trim()})`,
+                })
+              }
+              // Item 7: capture the worktree's base commit so the finalizer can
+              // tell "new commits were made here" apart from "unchanged". A
+              // rev-parse failure leaves baseRef undefined — then only the dirty
+              // check decides.
+              const baseHead = spawnSync("git", ["rev-parse", "HEAD"], { cwd: base })
+              const baseRef = baseHead.status === 0 ? baseHead.stdout.toString().trim() : undefined
+              // Cleanup on the RUN scope: survives parallel steps, fires on
+              // cancel/finish. Register EXPLICITLY on `active.runScope` rather
+              // than via `Effect.addFinalizer` (which targets the ambient Scope):
+              // this effect is forked via `Effect.forkIn(effect, runScope)`, which
+              // SUPERVISES the fiber under the run scope but does NOT provide that
+              // scope as the `Scope` service in context — so an ambient
+              // `addFinalizer` would attach to the wrong (or no) scope. Targeting
+              // the run scope object directly guarantees the finalizer runs
+              // exactly once when the run terminates (finish closes runScope) or
+              // is cancelled/removed (abortRun closes it), never per step.
+              //
+              // Item 7: only an UNCHANGED worktree is removed. A worktree with
+              // uncommitted changes OR new commits (not merged back to the main
+              // tree) is PRESERVED — including its git registration, so
+              // `git worktree list` still shows it — and the preserve is logged
+              // with the path. A git-status failure is conservatively treated as
+              // dirty (better to preserve than to lose data).
+              yield* Scope.addFinalizer(
+                active.runScope,
+                Effect.gen(function* () {
+                  const status = spawnSync("git", ["status", "--porcelain"], { cwd: base })
+                  const dirty = status.status !== 0 || status.stdout.toString().trim().length > 0
+                  const head = spawnSync("git", ["rev-parse", "HEAD"], { cwd: base })
+                  const moved = baseRef !== undefined && head.status === 0 && head.stdout.toString().trim() !== baseRef
+                  if (!dirty && !moved) {
+                    spawnSync("git", ["worktree", "remove", "--force", base], { cwd: instanceCtx.directory })
+                    // `git worktree remove` deletes the worktree dir on success;
+                    // force a recursive rm as a backstop so the private base never
+                    // lingers even if the git removal was partial. Runs ONLY on the
+                    // unchanged branch — a preserved worktree is never rm'd.
+                    yield* Effect.promise(() => fs.rm(base, { recursive: true, force: true })).pipe(Effect.ignore)
+                    return
+                  }
+                  // Marker file so the startup orphan sweep (sweepWorktrees) skips
+                  // this deliberately-preserved dir even past its age cutoff.
+                  yield* Effect.promise(() => fs.writeFile(path.join(base, WORKTREE_PRESERVED_MARKER), "")).pipe(
+                    Effect.ignore,
+                  )
+                  active.run.logs.push({
+                    time: Date.now(),
+                    message: `worktree preserved at ${base}: ${dirty ? "uncommitted changes" : "new commits"}`,
+                  })
+                  // On the normal finish path the runScope closes AFTER the
+                  // terminal persist, so this write emits a SECOND finished event
+                  // (persistRun picks the event by status). The TUI notification
+                  // dedupes per run id and the app merely refetches — accepted.
+                  // On cancel, abortRun closes the scope BEFORE finish, so the log
+                  // rides the regular terminal persist. For a removed run,
+                  // persistRun no-ops (tombstone) — the worktree stays preserved
+                  // anyway (files > run row).
+                  yield* persistRun(db, events, active).pipe(Effect.ignore)
+                }),
+              )
+              // A fresh worktree is a self-contained working tree, so both the
+              // working directory AND the worktree root point at `base`.
+              promptInstanceCtx = { ...instanceCtx, directory: base, worktree: base }
+              sessionDirectory = base
+              // Item 7: record the work location on the node (persisted by the
+              // existing persistRun after session creation below).
+              node.worktree = base
+            }
+            const session = yield* sessions.create({
+              parentID: active.run.session_id ? SessionID.make(active.run.session_id) : undefined,
+              title: `${active.run.workflow} ${node.id} (@${selected.name} subagent)`,
+              agent: selected.name,
+              model: modelInfo ? { id: modelInfo.modelID, providerID: modelInfo.providerID, variant } : undefined,
+              permission: createPermission,
+              directory: sessionDirectory,
+            })
+            node.agent = selected.name
+            if (modelInfo) node.model = `${modelInfo.providerID}/${modelInfo.modelID}`
+            node.session_id = session.id
+            // Track the child session so cancel()/remove() can abort it.
+            active.sessions.add(session.id)
+            // Fund 16: a cancel may have landed in the window between the start
+            // gate above and registering this session. Self-abort the freshly
+            // created session if so, instead of relying on a one-shot snapshot
+            // in abortRun that could miss it. The scope-close path will also
+            // interrupt this fiber, but aborting the session here stops the
+            // model spend deterministically and is idempotent.
+            if (active.cancelling || active.removed) {
+              if (active.cancelSession) yield* active.cancelSession(session.id).pipe(Effect.ignore)
+            }
+            yield* persistRun(db, events, active)
+            // Item 15: a skip that landed BEFORE this step's session was
+            // registered (skipAgent had no session_id to abort yet) is caught
+            // here, right before the prompt would dispatch — the step never
+            // spends and resolves null via the SKIPPED settlement below.
+            if (active.skipRequests.has(node.id)) {
+              node.status = "skipped"
+              node.completed_at = Date.now()
+              yield* persistRun(db, events, active)
+              return SKIPPED
+            }
+            // Item 28: subagent sessions load MCP tools LAZILY by default —
+            // they start with only the tool_search meta-tool instead of every
+            // MCP schema, the context-economy win for short-lived workflow
+            // steps. Configurable off via workflows.lazy_mcp=false; the main
+            // session loop stays eager (no `mcp` field there).
+            const lazyMcp = (yield* config.get()).workflows?.lazy_mcp !== false
+            const message = yield* prompt
+              .prompt({
+                sessionID: session.id,
+                permissionSessionID: agentInput.permissionSessionID ?? input.permissionSessionID,
+                agent: selected.name,
+                model: modelInfo,
+                variant,
+                mcp: lazyMcp ? ("lazy" as const) : undefined,
+                // Per-step tool scoping: opencode's `Record<string, boolean>`
+                // whitelist/blacklist (glob-able keys, e.g. `{ webfetch: false }`)
+                // lives on PromptInput.tools (NOT sessions.create — that only takes a
+                // permission Ruleset). The prompt loop folds each entry into an
+                // allow/deny session permission rule, so threading it here scopes the
+                // child session's tools for this step. `tools` already merges the
+                // step's own scoping with the `skill: true` enablement that the
+                // skills directive (above) requires.
+                //
+                // BUT the prompt loop's handler does a FULL ASSIGNMENT that would
+                // clobber an inherited subagent ruleset. So when we already composed
+                // the per-step rules INTO the child session's permission at creation
+                // (an inherited ruleset existed — `composeTools`), we must NOT pass
+                // `tools` here, or it would overwrite that composed ruleset and drop
+                // the inherited denies. Only route through PromptInput.tools when there
+                // was nothing to inherit/clobber.
+                tools: composeTools ? undefined : tools,
+                format: agentInput.schema ? { type: "json_schema", schema: agentInput.schema } : undefined,
+                // `promptText` is the author's prompt, optionally prefixed with the
+                // per-step skill-load directive (see the `skills` resolution above).
+                // Declarative file attachments (Task 10) follow the text part, in the
+                // order they were declared.
+                parts: [{ type: "text", text: promptText }, ...fileParts],
+                // Worktree isolation (Task 11): override the effective InstanceRef
+                // for the subagent's prompt run so its file tools resolve cwd
+                // against the worktree, not the run's workspace. `InstanceRef` is a
+                // Context.Reference (innermost-wins), so this local provide beats
+                // the run-level one attached at the dispatch boundary. When isolation
+                // is off, `promptInstanceCtx === instanceCtx` so this is the prior
+                // (effectively no-op) provide of the same ref value.
+              })
+              .pipe(Effect.provideService(InstanceRef, promptInstanceCtx))
+            node.message_id = message.info.id
+            if (message.info.role === "assistant") {
+              node.model = `${message.info.providerID}/${message.info.modelID}`
+              // `prompt.prompt` is an agentic while(true) loop (SessionPrompt.runLoop):
+              // a single ctx.agent step that uses tools persists MANY assistant
+              // messages (one per turn), each with its own per-turn `cost`/`tokens`,
+              // but only ever RETURNS the LAST one. Charging just `message.info.cost`
+              // therefore discards every intermediate turn's spend — the dashboard
+              // under-reports and the budget under-counts massively (Fund N12). Sum
+              // cost/tokens over ALL assistant messages of this child session instead.
+              // `sessions.messages` returns the raw per-message list (NOT a cumulative
+              // pre-aggregate), so summing it cannot double-count; the returned
+              // `message` is itself one of those persisted rows, so it is NOT added on
+              // top. A single-turn session yields exactly one assistant message ⇒ the
+              // sum equals that message ⇒ identical to the prior single-message read.
+              const assistants = (yield* sessions.messages({ sessionID: session.id }).pipe(Effect.orDie))
+                .map((m) => m.info)
+                .filter((info) => info.role === "assistant")
+              node.cost = assistants.reduce((sum, info) => sum + info.cost, 0)
+              // Keep `total` optional exactly as the per-message tokens schema has it:
+              // only emit a summed total when at least one message actually carried one,
+              // otherwise leave it `undefined` so a single-message session is byte-for-byte
+              // identical to the prior `node.tokens = message.info.tokens` assignment.
+              const totals = assistants.map((info) => info.tokens.total).filter((t) => t !== undefined)
+              node.tokens = assistants.reduce(
+                (acc, info) => ({
+                  total: acc.total,
+                  input: acc.input + info.tokens.input,
+                  output: acc.output + info.tokens.output,
+                  reasoning: acc.reasoning + info.tokens.reasoning,
+                  cache: {
+                    read: acc.cache.read + info.tokens.cache.read,
+                    write: acc.cache.write + info.tokens.cache.write,
+                  },
+                }),
+                {
+                  total: totals.length > 0 ? totals.reduce((sum, t) => sum + t, 0) : undefined,
+                  input: 0,
+                  output: 0,
+                  reasoning: 0,
+                  cache: { read: 0, write: 0 },
+                } as NonNullable<AgentRun["tokens"]>,
+              )
+            }
+            // Fund 4: the production runner RESOLVES (does not reject) when a
+            // session is aborted — it returns the last assistant message, which
+            // carries an abort/cancelled error. If the run is cancelling/removed
+            // OR the message itself is abort-marked, this step did not succeed:
+            // fail it as cancelled so the body unwinds as `cancelled` and the
+            // settlement callbacks below never flip the node to `completed`.
+            aborted = isAbortedMessage(message)
+            // Item 15: an abort caused by a SKIP request (skipAgent aborted this
+            // node's session, no run-level cancel/pause in flight) settles the
+            // step as `skipped` and resolves null — checked BEFORE the cancel
+            // branch below. A prompt that resolved NORMALLY before the abort
+            // landed (aborted === false) keeps its result: the skip came too
+            // late. Budget: aborted === true ⇒ the ensuring below skips the
+            // charge, so skip-artifact cost is never billed.
+            if (
+              aborted &&
+              active.skipRequests.has(node.id) &&
+              !active.cancelling &&
+              !active.removed &&
+              !active.pausing
+            ) {
+              node.status = "skipped"
+              node.completed_at = Date.now()
+              node.output = undefined
+              yield* persistRun(db, events, active)
+              return SKIPPED
+            }
+            if (active.cancelling || active.removed || aborted) {
+              return yield* Effect.die(new CancelledError())
+            }
+            const structured = message.info.role === "assistant" ? message.info.structured : undefined
+            // A schema was requested ⇒ a structured result is mandatory. When the
+            // session produced none (it set a StructuredOutputError on the message
+            // and/or `structured` came back undefined) we MUST fail the step rather
+            // than silently fall back to plaintext: a missing structured result is
+            // a genuine step failure that has to surface (node `failed`, run fails
+            // unless the module catches it). Non-schema agents are unaffected.
+            if (agentInput.schema && structured === undefined) {
+              const sessionMessage =
+                message.info.role === "assistant" && message.info.error?.name === "StructuredOutputError"
+                  ? message.info.error.data.message
+                  : undefined
+              node.output = assistantText(message)
+              const schemaText = JSON.stringify(agentInput.schema)
+              return yield* new StructuredOutputError({
+                message: [
+                  "Agent was asked for structured output but produced none",
+                  sessionMessage ? `(${sessionMessage})` : undefined,
+                  `expected a result matching the requested schema (${schemaText.length > 200 ? schemaText.slice(0, 200) + "…" : schemaText})`,
+                ]
+                  .filter(Boolean)
+                  .join(" "),
+              })
+            }
+            node.output = structured !== undefined ? JSON.stringify(structured, null, 2) : assistantText(message)
+            return {
+              data: structured !== undefined ? structured : node.output,
+              text: node.output,
+            }
+          }).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                if (node.session_id) active.sessions.delete(node.session_id)
+                // Item 24: settle the pool reservation FIRST — before the
+                // cancelled/paused early-return below — because settle must run
+                // on EVERY outcome (ensuring semantics): it releases the
+                // reserved headroom even when the charge is skipped, so a
+                // reservation can never leak. An aborted/cancelled/paused step
+                // settles with 0 (its cost is the abort artifact, not real
+                // spend — same rule as the run-budget charge below); any other
+                // outcome commits the step's actual cost/tokens and advances
+                // the rolling per-step estimate.
+                if (poolReservation && active.pool) {
+                  const skipCharge = active.cancelling || active.removed || active.pausing || aborted
+                  TurnBudget.settle(active.pool, poolReservation, {
+                    usd: skipCharge ? 0 : (node.cost ?? 0),
+                    tokens: skipCharge ? 0 : node.tokens ? node.tokens.output + node.tokens.reasoning : 0,
+                  })
+                }
+                // Decrement the live budget by whatever this step ACTUALLY cost
+                // — the SAME `cost` (USD) the dashboard shows, set on the node
+                // from the assistant message above. Done in `ensuring` (not the
+                // success branch) so failed-but-paid steps (e.g. a structured-
+                // output failure that still incurred model cost) are charged too.
+                // EXCEPT a cancelled run: an abort-resolved step did not produce
+                // a real result and must not be charged (Fund 4) — and any cost
+                // on an aborted message is the abort artifact, not real spend.
+                // A step with no cost leaves the budget untouched; unset stays Infinity.
+                // A pausing run is treated like a cancelling one: an interrupted
+                // step did not really spend, so it must not be charged.
+                // Finding 2: ALSO skip when the resolved message was abort-marked
+                // (`aborted`), even with NO run-level flag set — an externally
+                // aborted subagent's cost is the abort artifact, not real spend, so
+                // charging it would leave a `cancelled` run with a debited budget.
+                if (active.cancelling || active.removed || active.pausing || aborted) return
+                // Charge the SAME cost to BOTH the live remaining budget (gated)
+                // and the lifetime spend accumulator. costSpent accrues regardless
+                // of whether a budget was set, so `ctx.budget.spent()` works without
+                // a budget; keeping it on the same guard/cost as `budgetRemaining`
+                // makes `spent()`/`remaining()`/`total` mutually consistent.
+                active.budgetRemaining -= node.cost ?? 0
+                active.costSpent += node.cost ?? 0
+                // Item 17: token accounting at the SAME site, under the SAME
+                // guards. Counted: output + reasoning (reasoning is output-billed
+                // — the original counts the turn's output tokens); input/cache
+                // deliberately NOT counted. Journal replays charge automatically
+                // (node.tokens is copied on a cache hit before this runs).
+                active.tokensSpent += node.tokens ? node.tokens.output + node.tokens.reasoning : 0
+              }),
+            ),
+            // Run-wide concurrency cap (Spec §5.1): acquire one permit around
+            // the whole dispatch so at most `agentConcurrencyCap()` ctx.agent
+            // steps run at once across the entire run, no matter how generous a
+            // per-call `concurrencyLimit` is. The permit is released on success,
+            // failure, OR interruption (withPermits semantics), so a cancelled
+            // step never leaks a permit. A journal replay returns early and so
+            // holds the permit only momentarily.
+            active.agentSemaphore.withPermits(1),
+            // OTel: each ctx.agent dispatch gets a `workflow.agent` span (the
+            // engine had no agent-level spans before). Static attributes are set
+            // here at construction time; the RESOLVED agent name and model are
+            // only known once `selected`/`modelInfo` are computed inside the gen,
+            // so they are added there via `Effect.annotateCurrentSpan`. Dotted
+            // lowercase keys match the repo convention (tool.name/session.id …);
+            // the span is purely observational and changes no behavior.
+            Effect.withSpan("workflow.agent", {
+              attributes: {
+                "workflow.run_id": active.run.id,
+                "workflow.agent.id": node.id,
+                "workflow.phase": node.phase ?? undefined,
+                // Requested (pre-resolution) agent/model, useful even on a step
+                // that fails before resolution. The resolved values are annotated
+                // onto this same span once known (see the gen body above).
+                ...(agentInput.agent ? { "workflow.agent.requested": agentInput.agent } : {}),
+                ...(agentInput.model ? { "workflow.agent.model_requested": agentInput.model } : {}),
+              },
+            }),
+          ),
+        ).then(
+          (result) => {
+            // Item 15: a skipped step resolves `null` — BEFORE the terminal
+            // settlement guard below (the run may legitimately finish while the
+            // skip settles) and without a second persist (the dispatch gen
+            // already persisted the node's `skipped` state).
+            if (result === SKIPPED) return null
+            // Settlement guard (Fund 4): once the run is cancelling/pausing/
+            // removed or already terminal, the success branch is a NO-OP for the
+            // node and emits NO further write. Otherwise a resolve-on-abort step
+            // (the production runner resolves on abort) would flip a cancelled/
+            // paused node to `completed` and re-persist after the terminal write.
+            if (active.cancelling || active.pausing || active.removed || active.run.status !== "running") {
+              throw new CancelledError()
+            }
+            node.status = "completed"
+            node.completed_at = Date.now()
+            node.output = result.text
+            persistInScope(active, bridge, db, events)
+            return result
+          },
+          (error) => {
+            // Same guard on the failure path: do not mutate/persist the node
+            // for a run that has already moved to (or is moving to) terminal/
+            // paused — finish() owns the node's terminal state in that case.
+            if (active.cancelling || active.pausing || active.removed || active.run.status !== "running") {
+              return Promise.reject(error)
+            }
+            node.status = "failed"
+            node.completed_at = Date.now()
+            node.error = errorText(error)
+            persistInScope(active, bridge, db, events)
+            return Promise.reject(error)
+          },
+        )
+      }
+
+      // Item 15 (onError:"null"): the public agent vector. A FINAL catch over the
+      // whole step (gates included — the failure settlement above has already
+      // recorded the node as `failed` with its error by the time it fires):
+      // with `onError: "null"` a failing step resolves `null` so the body can
+      // branch instead of unwinding. Budget/lifetime gates and aborts are NEVER
+      // swallowed (excluded below) — silently nulling those inside a while-loop
+      // would spin forever against an exhausted budget or a cancelled run.
+      const agent = (agentInput: AgentInput, callOpts?: { phaseModel?: string }) =>
+        agentStep(agentInput, callOpts).catch((error) => {
+          if (
+            agentInput.onError === "null" &&
+            !(error instanceof CancelledError) &&
+            !(error instanceof BudgetExceededError) &&
+            !(error instanceof AgentLimitError)
+          ) {
+            return null
+          }
+          throw error
+        })
+
+      const tool: WorkflowToolFn = ((name: string, args?: Record<string, unknown>, options?: ToolInput) => {
+        if (runSignal?.aborted || active.cancelling || active.pausing || active.removed) throw new CancelledError()
+        const toolArgs = args ?? {}
+        active.run.logs.push({
+          time: Date.now(),
+          phase: active.run.current_phase,
+          message: `tool ${name} started`,
+        })
+        persistInScope(active, bridge, db, events)
+
+        return dispatch(
+          Effect.gen(function* () {
+            const selected = input.caller?.agent
+              ? yield* agents.get(input.caller.agent).pipe(Effect.catchCause(() => agents.defaultInfo()))
+              : yield* agents.defaultInfo()
+            const modelInfo = active.callerModel
+              ? {
+                  providerID: ProviderV2.ID.make(active.callerModel.providerID),
+                  modelID: ModelV2.ID.make(active.callerModel.modelID),
+                }
+              : (selected.model ?? (yield* providers.defaultModel()))
+            const model = yield* providers.getModel(modelInfo.providerID, modelInfo.modelID)
+            const messageID = MessageID.ascending()
+            const callID = `workflow_${active.run.id}_${name}_${Date.now()}`
+            const controller = new AbortController()
+            const sessionID = SessionID.make(active.run.session_id!)
+            const ruleset = Permission.merge(selected.permission, active.shellRuleset)
+            const ctx: Tool.Context = {
+              sessionID,
+              messageID,
+              callID,
+              agent: selected.name,
+              abort: controller.signal,
+              messages: [],
+              extra: {
+                model,
+                promptOps: input.prompt,
+                turnBudget: active.pool,
+              },
+              metadata: (val) =>
+                Effect.sync(() => {
+                  active.run.logs.push({
+                    time: Date.now(),
+                    phase: active.run.current_phase,
+                    message: `tool ${name} metadata${val.title ? `: ${val.title}` : ""}`,
+                  })
+                  persistInScope(active, bridge, db, events)
+                }),
+              ask: (req) =>
+                permission
+                  .ask({
+                    ...req,
+                    sessionID: input.permissionSessionID ?? sessionID,
+                    tool: { messageID, callID },
+                    ruleset,
+                  })
+                  .pipe(Effect.orDie),
+            }
+
+            const native = (
+              yield* catalog.tools({
+                providerID: model.providerID,
+                modelID: ModelV2.ID.make(model.id),
+                agent: selected,
+                ultracode: false,
+              })
+            ).find((tool) => tool.id === name)
+            if (native) {
+              yield* plugin.trigger(
+                "tool.execute.before",
+                { tool: name, sessionID: ctx.sessionID, callID: ctx.callID },
+                { args: toolArgs },
+              )
+              const result = yield* native.execute(toolArgs, ctx).pipe(
+                Effect.onInterrupt(() => Effect.sync(() => controller.abort())),
+              )
+              const output = {
+                ...result,
+                attachments: result.attachments?.map((attachment) => ({
+                  ...attachment,
+                  id: PartID.ascending(),
+                  sessionID: ctx.sessionID,
+                  messageID,
+                })),
+              }
+              yield* plugin.trigger(
+                "tool.execute.after",
+                { tool: name, sessionID: ctx.sessionID, callID: ctx.callID, args: toolArgs },
+                output,
+              )
+              return { output: output.output, metadata: output.metadata } satisfies WorkflowToolResult
+            }
+
+            const mcpTool = (yield* mcp.tools())[name]
+            const execute = mcpTool?.execute
+            if (!execute) {
+              const available = [
+                ...(yield* catalog.tools({
+                  providerID: model.providerID,
+                  modelID: ModelV2.ID.make(model.id),
+                  agent: selected,
+                  ultracode: false,
+                })).map((tool) => tool.id),
+                ...Object.keys(yield* mcp.tools()),
+              ].toSorted()
+              return yield* Effect.fail(
+                new Error(`ctx.tool unknown tool: ${name}. Available tools: ${available.join(", ")}`),
+              )
+            }
+
+            yield* ctx.ask({ permission: name, metadata: {}, patterns: ["*"], always: ["*"] })
+            yield* plugin.trigger(
+              "tool.execute.before",
+              { tool: name, sessionID: ctx.sessionID, callID: ctx.callID },
+              { args: toolArgs },
+            )
+            const result = yield* Effect.tryPromise(() =>
+              Promise.resolve(
+                execute(toolArgs, {
+                  toolCallId: callID,
+                  messages: [],
+                  abortSignal: controller.signal,
+                }),
+              ),
+            ).pipe(Effect.onInterrupt(() => Effect.sync(() => controller.abort())))
+            yield* plugin.trigger(
+              "tool.execute.after",
+              { tool: name, sessionID: ctx.sessionID, callID, args: toolArgs },
+              result,
+            )
+            const output = mcpOutput(result)
+            const truncated = yield* truncate.output(output.output, {}, selected)
+            return {
+              output: truncated.content,
+              metadata: {
+                ...output.metadata,
+                truncated: truncated.truncated,
+                ...(truncated.truncated && { outputPath: truncated.outputPath }),
+              },
+            } satisfies WorkflowToolResult
+          }).pipe(
+            options?.timeout
+              ? Effect.timeoutOrElse({
+                  duration: options.timeout,
+                  orElse: () => Effect.fail(new Error(`ctx.tool ${name} timed out after ${options.timeout}ms`)),
+                })
+              : (effect) => effect,
+          ),
+        ).then(
+          (result) => {
+            active.run.logs.push({
+              time: Date.now(),
+              phase: active.run.current_phase,
+              message: `tool ${name} completed`,
+            })
+            persistInScope(active, bridge, db, events)
+            return result
+          },
+          (error) => {
+            active.run.logs.push({
+              time: Date.now(),
+              phase: active.run.current_phase,
+              message: `tool ${name} failed: ${errorText(error)}`,
+            })
+            persistInScope(active, bridge, db, events)
+            if (options?.onError === "null" && !(error instanceof CancelledError)) return null
+            throw error
+          },
+        )
+      }) as WorkflowToolFn
+
+      // Deterministic non-LLM step. Runs a shell command in the run's workspace
+      // (or an explicit `cwd`) and resolves to `{ output, exitCode }` WITHOUT
+      // touching `costSpent`/budget or starting an agent — it deliberately does
+      // NOT go through `agent()`, the budget gate, or the lifetime cap. The work
+      // runs as a child of the run scope (via `dispatch`), so a cancel/remove that
+      // closes the run scope interrupts an in-flight shell; a `checkpoint()`-style
+      // guard before dispatch refuses to start a new shell once a cancel/pause has
+      // landed. A non-zero exit is returned (`nothrow`), never thrown.
+      const shell: ContextApi["shell"] = (command, opts) => {
+        if (runSignal?.aborted || active.cancelling || active.pausing || active.removed) throw new CancelledError()
+        const cwd = opts?.cwd ?? active.directory
+        return dispatch(
+          Effect.gen(function* () {
+            const cfg = yield* config.get()
+            const sh = Shell.preferred(cfg.shell)
+            // Item 23 (Stufe 1): permission gate, the FIRST step inside the
+            // dispatched effect (so a cancel/pause that closes the run scope
+            // interrupts an OPEN ask cleanly — same unwind as a hung agent).
+            // The scan reuses the bash tool's exact pattern derivation
+            // (scanCommand), so the user's `bash` allow/deny rules (e.g.
+            // 'git status*') apply identically; out-of-workspace paths get the
+            // same external_directory ask the bash tool raises. The asks are
+            // evaluated against the run's caller-inherited ruleset and surface
+            // on permissionSessionID (or the run's own session for headless
+            // starts, identical to subagent tool asks). Kill-switch: config
+            // workflows.shell_permission=false restores the ungated behavior.
+            // A deny/reject propagates like a step failure — mapped to a clear
+            // error naming the command, so the run's error is self-explanatory.
+            // ctx.shell is not journaled, so the gate fires again on every
+            // resume.
+            if (cfg.workflows?.shell_permission !== false) {
+              const instanceCtx = yield* InstanceState.context
+              const scan = yield* scanCommand(command, cwd, instanceCtx, sh).pipe(
+                Effect.provideService(ChildProcessSpawner, spawner),
+                Effect.provideService(FSUtil.Service, fsUtil),
+                Effect.provideService(Config.Service, config),
+              )
+              // The run's own session is always set at start; the fallback
+              // mirrors the subagent parentID branding (SessionID.make).
+              const askSessionID = input.permissionSessionID ?? SessionID.make(active.run.session_id!)
+              const denied = (error: PermissionV1.Error) =>
+                new InvalidError({
+                  path: active.run.workflow,
+                  message: `ctx.shell permission denied for command: ${command} (${error.message})`,
+                })
+              if (scan.dirs.size > 0) {
+                const directories = Array.from(scan.dirs)
+                const globs = directories.map((dir) =>
+                  process.platform === "win32" ? FSUtil.normalizePathPattern(path.join(dir, "*")) : path.join(dir, "*"),
+                )
+                yield* permission
+                  .ask({
+                    permission: "external_directory",
+                    patterns: globs,
+                    always: globs,
+                    sessionID: askSessionID,
+                    ruleset: active.shellRuleset,
+                    metadata: {
+                      command,
+                      cwd,
+                      workflow: active.run.workflow,
+                      source: "workflow.shell",
+                      directories,
+                      patterns: globs,
+                    },
+                  })
+                  .pipe(Effect.mapError(denied))
+              }
+              if (scan.patterns.size > 0) {
+                yield* permission
+                  .ask({
+                    permission: ShellID.ToolID,
+                    patterns: Array.from(scan.patterns),
+                    always: Array.from(scan.always),
+                    sessionID: askSessionID,
+                    ruleset: active.shellRuleset,
+                    metadata: { command, cwd, workflow: active.run.workflow, source: "workflow.shell" },
+                  })
+                  .pipe(Effect.mapError(denied))
+              }
+            }
+            // Finding 5: Process.run only kills the child when its `abort` signal
+            // fires. Closing the run scope (cancel/pause/remove) INTERRUPTS this
+            // Effect fiber, but `Effect.tryPromise` does NOT abort the underlying
+            // promise — so without wiring the interrupt to an AbortController, a
+            // no-timeout shell (e.g. `sleep 600`) was orphaned and kept running
+            // after the run was cancelled/paused. ALWAYS create the controller and
+            // fire it on BOTH (a) the optional wall-clock timeout AND (b) fiber
+            // interruption (the scope-close path), so a cancel/pause actually
+            // SIGTERMs/SIGKILLs the OS child. The controller is created OUTSIDE
+            // tryPromise so `Effect.onInterrupt` can reach it.
+            const controller = new AbortController()
+            const result = yield* Effect.tryPromise(() => {
+              const timer = opts?.timeout ? setTimeout(() => controller.abort(), opts.timeout) : undefined
+              return Process.run([sh, ...Shell.args(sh, command, cwd)], {
+                cwd,
+                nothrow: true,
+                abort: controller.signal,
+                timeout: opts?.timeout,
+              }).finally(() => {
+                if (timer) clearTimeout(timer)
+              })
+            }).pipe(
+              // Reap the OS child on fiber interruption: aborting the controller
+              // makes Process.run SIGTERM the child (then SIGKILL after its grace),
+              // so a scope-close cancel/pause no longer leaks the process.
+              Effect.onInterrupt(() => Effect.sync(() => controller.abort())),
+              Effect.orDie,
+            )
+            const output = Buffer.concat([result.stdout, result.stderr]).toString()
+            return { output, exitCode: result.code }
+          }),
+        )
+      }
+
+      // Human-in-the-loop step (Tasks 12/13). Persists a pending question on the
+      // run, records it as a `kind:"question"` journal node, and waits LIVE for an
+      // answer (a Deferred resolved by the service `answer()` method) racing a
+      // timeout (default 10 minutes). It deliberately does NOT consume an agent
+      // dispatch, the budget, or the lifetime cap — a question is not an LLM step.
+      const question: ContextApi["question"] = (questionInput) => {
+        // Gate exactly like ctx.agent/ctx.shell: a fired signal or a landed
+        // cancel/pause means the run is unwinding, so refuse to ask.
+        if (runSignal?.aborted || active.cancelling || active.pausing || active.removed) throw new CancelledError()
+        const phase = active.run.current_phase
+        const node: AgentRun = {
+          id: `${active.run.agents.length + 1}`,
+          status: "running",
+          started_at: Date.now(),
+          phase,
+          kind: "question",
+          // The question text rides on `prompt` so it shares the journal-node
+          // shape (and the resume key is built from it, like an agent prompt).
+          prompt: questionInput.question,
+        }
+        active.run.agents.push(node)
+        // Resume replay: a resumed run that was parked on this exact question
+        // ([question, phase]) is served the SEEDED answer from the question journal
+        // — no live ask, no pending_question. Mirrors the agent-journal replay:
+        // mark the node completed + cached, record the answer, return it.
+        const replayKey = questionJournalKey({ question: questionInput.question, phase })
+        const seeded = active.questionJournal?.get(replayKey)
+        if (seeded !== undefined) {
+          node.status = "completed"
+          node.completed_at = Date.now()
+          node.answer = seeded
+          node.cached = true
+          persistInScope(active, bridge, db, events)
+          return Promise.resolve({ answer: seeded })
+        }
+        // Live path: persist the open question (emits workflow.run.updated with
+        // pending_question:true) and park on a Deferred + timeout race. The wait
+        // runs through `dispatch` (forked into the run scope) so an external
+        // pause()/cancel() that closes the run scope interrupts it — exactly like
+        // a hung ctx.agent. `answer()` resolves the Deferred to wake it live.
+        const timeout = questionInput.timeout ?? DEFAULT_QUESTION_TIMEOUT_MS
+        const options = questionInput.options ? [...questionInput.options] : undefined
+        return dispatch(
+          Effect.gen(function* () {
+            const deferred = yield* Deferred.make<{ answer: string }>()
+            // Publish the open question and register the Deferred so answer() can
+            // find + resolve it. Set BEFORE persist so a concurrent answer() that
+            // observes the persisted pending_question also sees the live Deferred.
+            active.pendingQuestion = { deferred, node }
+            active.run.pending_question = { question: questionInput.question, options, asked_at: node.started_at }
+            yield* persistRun(db, events, active)
+            // Race the answer against the timeout. `timeoutOption` is interruptible,
+            // so a run-scope close (external pause/cancel) unwinds this wait too.
+            const result = yield* Deferred.await(deferred).pipe(Effect.timeoutOption(timeout))
+            // Finding 4 (test seam): when the timeout won (`None`), fire the hook
+            // HERE — `active.pendingQuestion` is still set, so a test's answer() can
+            // take the live-answer branch and complete the node, deterministically
+            // reproducing the timeout-vs-answer race the `.then` below must survive.
+            // No-op in production (the hook is `Effect.void`).
+            if (result._tag === "None") yield* questionTimeoutParkHook.pipe(Effect.ignore)
+            return result
+          }),
+        ).then(
+          (result) => {
+            // Resolve (answer landed) or park (timeout). Either way the question is no
+            // longer pending in-memory.
+            active.pendingQuestion = undefined
+            if (result._tag === "Some") {
+              // Live answer. `answer()` is the authoritative writer (it completes the
+              // node + clears pending_question + persists before resolving the
+              // Deferred), so this branch only needs to hand the reply back to the
+              // body. Idempotently close the node if it was somehow left open, so the
+              // body never proceeds with a still-`running` question node.
+              if (node.status === "running") {
+                active.run.pending_question = undefined
+                node.status = "completed"
+                node.completed_at = Date.now()
+                node.answer = result.value.answer
+                persistInScope(active, bridge, db, events)
+              }
+              return result.value
+            }
+            // Timeout fired at the Effect level (`None`). Finding 4: a concurrent
+            // answer() can land in the window between the timeout resolving and this
+            // continuation running — it completes the question node + clears
+            // pending_question + persists, then its Deferred.succeed is a no-op
+            // (the timeout already completed the Deferred). If we parked
+            // unconditionally here we would discard that recorded answer AND park as
+            // paused, leaving the caller with a success snapshot while the run is
+            // actually paused. So re-read the node: if a racing answer() already
+            // closed it (status flipped to `completed`), hand that answer back to
+            // the body instead of parking. Only park when the node is still open.
+            if (node.status === "completed") {
+              return { answer: node.answer! }
+            }
+            // PARK the run as `paused` via the existing pause machinery. Keep
+            // `pending_question` AND the open question node intact (do NOT complete
+            // the node) so a later answer() can resume. Setting `pausing` makes the
+            // body's matchCauseEffect map this unwind to `paused`, racing pause()'s
+            // own finish idempotently. Throwing CancelledError unwinds the body the
+            // same way an interrupt-driven pause does.
+            active.pausing = true
+            throw new CancelledError()
+          },
+          (error) => {
+            // An external pause()/cancel() that closed the run scope rejects the
+            // dispatched wait with CancelledError. Drop the dangling in-memory
+            // pending-question reference (the run is unwinding to paused/cancelled via
+            // abortRun's own finish) and let the rejection propagate so the body
+            // unwinds consistently with the rest of the engine.
+            active.pendingQuestion = undefined
+            throw error
+          },
+        )
+      }
+
+      // Build the run context for the top-level body OR a depth-1 nested workflow.
+      // Captured here so `ctx.workflow` (below) can re-enter it with a bumped
+      // `depth` and a `logPrefix`, sharing the SAME `active` — and thus the same
+      // concurrency semaphore, budget, abort scope, and agent-lifetime cap.
+      const buildContext = (ctxInput: { depth: number; logPrefix?: string; phases?: readonly Phase[] }): ContextApi =>
+        createContext({
+          active,
+          agent,
+          tool,
+          shell,
+          question,
+          workflow: (name, childArgs) => runNested(ctxInput.depth, name, childArgs),
+          logPrefix: ctxInput.logPrefix,
+          // Task 15: each context carries ITS OWN module's declared phases so
+          // setPhase resolves the per-phase default model (and undeclared warning)
+          // against the right list — the top-level run's phases, or a nested
+          // child's own phases.
+          phases: ctxInput.phases,
+          persist: () => void persistInScope(active, bridge, db, events),
+          signal: () => runSignal,
+          dispatch,
+        })
+
+      // Depth-1 nesting: run another DISCOVERED workflow inline under the SAME run
+      // (no second run row). It shares this run's `active`, so the concurrency
+      // semaphore, budget, abort scope, and agent-lifetime cap all carry over
+      // automatically — the child's `ctx.agent` dispatches funnel through the same
+      // `agent` closure and count against the same gates. The parent run was
+      // already approved (its own start went through the permission gate), so the
+      // child loads with NO additional permission ask. A nested call (the child
+      // itself calling ctx.workflow) is refused: nesting is limited to depth 1.
+      //
+      // A hoisted `function` declaration (not a `const` arrow) so `buildContext`
+      // above can reference it without a temporal-dead-zone smell, even though
+      // the reference is only invoked lazily once `ctx.workflow` is called.
+      async function runNested(parentDepth: number, name: string, childArgs?: Record<string, unknown>) {
+        if (parentDepth >= 1) {
+          throw new InvalidError({
+            path: active.run.workflow,
+            message: "ctx.workflow nesting is limited to depth 1",
+          })
+        }
+        // Load the named workflow via the existing discovery + loadModule path
+        // (discoverWorkflows reads InstanceState, so run it through `dispatch`).
+        // No permission ask: the parent run is already approved.
+        const discovered = await dispatch(discoverWorkflows())
+        const target = discovered.find((item) => item.name === name)
+        if (!target) {
+          throw new InvalidError({ path: active.run.workflow, message: `Workflow not found: ${name}` })
+        }
+        if (target.error) throw new InvalidError({ path: target.path, message: target.error })
+        // Static meta gate, same as start()'s name branch: a nested child module
+        // is validated AST-only BEFORE loadModule imports (and thereby executes)
+        // it, so computed meta cannot slip in through the ctx.workflow seam
+        // either. A read failure or non-literal meta throws a clean InvalidError
+        // naming the child's file. (Same accepted TOCTOU between the gate read
+        // and loadModule's own read as in start() — defense-in-depth, not a
+        // security boundary.)
+        const childSource =
+          target.source !== undefined
+            ? target.source
+            : await fs.readFile(target.path, "utf8").then(
+                (text) => text,
+                (error) => {
+                  throw new InvalidError({ path: target.path, message: errorText(error) })
+                },
+              )
+        const childGate = MetaReader.read(childSource, target.path)
+        if (childGate.valid === false) throw new InvalidError({ path: target.path, message: childGate.error })
+        const childMismatch = pluginWorkflowMismatch(target, childGate.meta)
+        if (childMismatch) throw new InvalidError({ path: target.path, message: childMismatch })
+        const childModule = await loadModule(target.path, target.source)
+        const coerced = coerceArgs(childArgs, childModule.meta.arguments, target.path)
+        if (coerced instanceof InvalidError) throw coerced
+        // Child context shares `active`; depth+1 closes the nesting at 1 and the
+        // logPrefix attributes the child's logs/phases without a second run row.
+        const childCtx = buildContext({
+          depth: parentDepth + 1,
+          logPrefix: `${name}: `,
+          phases: childModule.meta.phases,
+        })
+        // The child writes its (prefixed) phase into the SHARED
+        // `active.run.current_phase` and its per-phase default model into the SHARED
+        // `active.currentPhaseModel`. Snapshot BOTH parent values and restore them
+        // after the child returns (resolve OR throw) so a parent log/agent dispatched
+        // after the nested call is attributed to the parent's phase AND resolves the
+        // parent's phase-default model, not the child's leftover ones.
+        const parentPhase = active.run.current_phase
+        const parentPhaseModel = active.currentPhaseModel
+        try {
+          return await childModule.run(coerced ?? {}, childCtx)
+        } finally {
+          active.run.current_phase = parentPhase
+          active.currentPhaseModel = parentPhaseModel
+        }
+      }
+
+      // Fund 5 (TOCTOU): a cancel/remove can land during the startup window —
+      // after the run was registered but before the body fiber exists. In that
+      // window abortRun set `cancelling`/closed the run scope and finish() already
+      // moved the row to `cancelled`. Forking the body anyway would run the whole
+      // workflow (burning tokens) under a row that already reports `cancelled`.
+      // Re-check here and skip the fork entirely if a cancel has landed: the run
+      // stays cancelled and the body never runs.
+      if (active.cancelling || active.removed || active.run.status !== "running") {
+        yield* Deferred.succeed(active.done, snapshot(active)).pipe(Effect.ignore)
+        return snapshot(active)
+      }
+
+      active.fiber = yield* Effect.promise((signal) => {
+        runSignal = signal
+        return module.run(args ?? {}, buildContext({ depth: 0, phases: module.meta.phases }))
+      }).pipe(
+        Effect.matchCauseEffect({
+          onSuccess: (result) => finish(id, "completed", { result }),
+          onFailure: (cause) =>
+            // A workflow module throwing CancelledError surfaces as a failure or
+            // a defect depending on the path; squash returns the representative
+            // error either way, so `isCancelled(squash)` catches both. A pausing
+            // run interrupts the body the SAME way a cancel does, so it would map
+            // to `cancelled` here — check `pausing` FIRST so a pause finishes as
+            // the non-terminal `paused` (the journal is then kept for resume),
+            // racing pause()'s own `finish(id, "paused")` idempotently.
+            finish(
+              id,
+              active.pausing
+                ? "paused"
+                : active.cancelling ||
+                    active.removed ||
+                    Cause.hasInterruptsOnly(cause) ||
+                    isCancelled(Cause.squash(cause))
+                  ? "cancelled"
+                  : "failed",
+              active.pausing ? undefined : { error: errorText(Cause.squash(cause)) },
+            ),
+        }),
+        Effect.asVoid,
+        // OTel: wrap the whole run body in a `workflow.run` span so HTTP/CI/server
+        // operators get observability for a run (the engine had ZERO spans before;
+        // only the generic Tool.execute span wrapped a subagent's tool calls). The
+        // span is purely observational — it sits AFTER matchCauseEffect/asVoid so it
+        // never alters the run's success/cancel/fail mapping. Attribute style mirrors
+        // the repo convention (dotted lowercase keys, e.g. tool.name/session.id).
+        Effect.withSpan("workflow.run", {
+          attributes: { "workflow.run_id": id, "workflow.name": active.run.workflow },
+        }),
+        // Fork lazily (no `startImmediately`) so this returns the fiber handle
+        // immediately. With `startImmediately` the runtime drives the run body
+        // synchronously into the first agent step, blocking `start` and leaving
+        // `active.fiber` unassigned (which would make cancel a no-op).
+        Effect.forkIn(inst.scope),
+      )
+      return snapshot(active)
+    })
+
+    const wait: Interface["wait"] = Effect.fn("Workflow.wait")(function* (input) {
+      const run = yield* get(input.id)
+      if (!run) return { timedOut: false }
+      // Terminal runs (completed/failed/cancelled/interrupted) resolve at once —
+      // there is no fiber left to wait on, so never report a timeout for them.
+      if (run.status !== "running") return { run, timedOut: false }
+
+      const live = yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)
+      const active = live.get(input.id)
+      // DB still says `running` but no live fiber owns it: an orphan. Sweep it to
+      // `interrupted` and report that honestly instead of a misleading timeout.
+      // Pass the live registry keys so genuinely-running siblings are untouched.
+      if (!active) {
+        yield* sweepOrphans(db, new Set(live.keys()), yield* Clock.currentTimeMillis, yield* InstanceState.directory)
+        return { run: yield* get(input.id), timedOut: false }
+      }
+      if (input.timeout === undefined) return { run: yield* Deferred.await(active.done), timedOut: false }
+      if (input.timeout <= 0) return { run: snapshot(active), timedOut: true }
+
+      const done = yield* Deferred.await(active.done).pipe(Effect.timeoutOption(input.timeout))
+      if (done._tag === "Some") return { run: done.value, timedOut: false }
+      return { run: snapshot(active), timedOut: true }
+    })
+
+    // Race-free cancel. The order matters and every step is idempotent.
+    // (0) Set `cancelling` FIRST — unconditionally, even when there is no fiber
+    //     yet (startup window, Fund 5): the gates in agent()/checkpoint() and the
+    //     settlement guards all key off it, and start() re-checks it before
+    //     forking the body, so a cancel that lands during startup still wins.
+    // (1) Abort every tracked child agent session via PromptOps.cancel from a
+    //     LIVE view of `active.sessions` (not a one-shot snapshot, Fund 16): this
+    //     is what actually stops the in-flight agent (same path as TUI Esc / HTTP
+    //     abort); the production runner then RESOLVES the prompt and the agent
+    //     step is recognised as cancelled. Sessions registered during this window
+    //     additionally self-abort in agent() because `cancelling` is already set.
+    // (2) Close the run scope: this propagates Interrupt into EVERY agent/parallel/
+    //     pipeline fiber forked into it (Fund 14) — including ones started but not
+    //     yet session-registered (Fund 16) and ones that have no cancel vector
+    //     (Fund 50, where the scope close is the only thing that stops them).
+    // (3) Interrupt the run fiber so checkpoint() unwinds the body, then await it.
+    //
+    // `mode` selects which suspension flag the gates key off: "cancel" sets
+    // `cancelling` (run will finish `cancelled`), "pause" sets `pausing` (run will
+    // finish the non-terminal `paused`, journal kept). The mechanics are identical
+    // — the only difference is the terminal status finish() assigns.
+    const abortRun = Effect.fn("Workflow.abortRun")(function* (active: Active, mode: "cancel" | "pause" = "cancel") {
+      if (mode === "pause") active.pausing = true
+      else active.cancelling = true
+      const cancelSession = active.cancelSession
+      if (cancelSession) {
+        yield* Effect.forEach([...active.sessions], (sessionID) => cancelSession(SessionID.make(sessionID)), {
+          concurrency: "unbounded",
+          discard: true,
+        }).pipe(Effect.ignore)
+      }
+      // Closing the run scope interrupts all dispatched agent work; it is safe to
+      // close even with no live fiber (startup window). Forked so a slow finalizer
+      // cannot wedge cancel.
+      const scope = (yield* InstanceState.get(state)).scope
+      const closed = yield* Scope.close(active.runScope, Exit.void).pipe(Effect.ignore, Effect.forkIn(scope))
+      const interrupted = active.fiber ? yield* Fiber.interrupt(active.fiber).pipe(Effect.forkIn(scope)) : undefined
+      if (interrupted) yield* Fiber.await(interrupted).pipe(Effect.ignore)
+      yield* Fiber.await(closed).pipe(Effect.ignore)
+      if (active.fiber) yield* Fiber.await(active.fiber).pipe(Effect.ignore)
+    })
+
+    const cancel: Interface["cancel"] = Effect.fn("Workflow.cancel")(function* (id) {
+      const active = (yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)).get(id)
+      // N16: a run that is not in the live registry is NOT automatically "not
+      // found" — every persisted run after a restart, and every terminal run
+      // evicted by N1, lives only in the DB. Consult the (directory-scoped) DB
+      // row, exactly like get()/remove() do, so cancel never confuses
+      // "found-but-not-cancellable" with "absent". A found-but-non-live run is
+      // already terminal/orphaned (no live fiber to interrupt), so it is returned
+      // honestly as its persisted snapshot rather than rewritten — but it is
+      // returned, NOT undefined. undefined is reserved for a genuinely unknown id
+      // (which the HTTP handler in Task 3h maps to 404). The scoping mirrors get():
+      // a foreign-directory row is invisible here and so reports undefined too. The
+      // same lookup also rescues a cancel that LOSES the race against the run's own
+      // natural completion (below): the body fiber's `finish(id, "completed")` can
+      // persist the terminal row and N1-evict it between this registry read and our
+      // own `finish` — leaving our `finish` to return undefined for a run that very
+      // much exists and is terminal. Both paths resolve to the persisted snapshot.
+      const persisted = Effect.fn("Workflow.cancel.persisted")(function* () {
+        const directory = yield* InstanceState.directory
+        const row = yield* db
+          .select()
+          .from(WorkflowRunTable)
+          .where(and(eq(WorkflowRunTable.id, id), eq(WorkflowRunTable.directory, directory)))
+          .get()
+          .pipe(Effect.orDie)
+        return row ? fromRow(row) : undefined
+      })
+      if (!active) {
+        // No live fiber. A paused run lives only in the DB (finish evicted it):
+        // cancelling it transitions the non-terminal `paused` row to the terminal
+        // `cancelled` directly (Spec §5.3). Any other persisted status (already
+        // terminal) is returned verbatim, and an unknown id stays undefined.
+        const row = yield* persisted()
+        if (row?.status === "paused") {
+          const completed_at = yield* Clock.currentTimeMillis
+          const directory = yield* InstanceState.directory
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "cancelled", completed_at, time_updated: completed_at })
+            .where(and(eq(WorkflowRunTable.id, id), eq(WorkflowRunTable.directory, directory)))
+            .run()
+            .pipe(Effect.orDie)
+          return yield* persisted()
+        }
+        return row
+      }
+      if (active.run.status !== "running") return snapshot(active)
+      yield* abortRun(active)
+      // Lost-race fallback: `finish` returns undefined only when the run was already
+      // evicted (the body fiber completed and ran finish()'s N1 eviction first). The
+      // run is terminal and gone from the registry — return its persisted snapshot
+      // showing the TRUE terminal status (completed, NOT rewritten to cancelled),
+      // never undefined. remove() already tolerates the same idempotent `finish`
+      // here via `Effect.ignore`; cancel must additionally surface the snapshot.
+      const finished = yield* finish(id, "cancelled")
+      return finished ?? (yield* persisted())
+    })
+
+    const pause: Interface["pause"] = Effect.fn("Workflow.pause")(function* (id) {
+      const active = (yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)).get(id)
+      // Mirror cancel's directory-scoped DB fallback: a run not in the live
+      // registry is consulted in the DB (after a restart / N1 eviction), so pause
+      // never confuses "found-but-not-live" with "absent". undefined ⇒ genuinely
+      // unknown id (HTTP → 404).
+      const persisted = Effect.fn("Workflow.pause.persisted")(function* () {
+        const directory = yield* InstanceState.directory
+        const row = yield* db
+          .select()
+          .from(WorkflowRunTable)
+          .where(and(eq(WorkflowRunTable.id, id), eq(WorkflowRunTable.directory, directory)))
+          .get()
+          .pipe(Effect.orDie)
+        return row ? fromRow(row) : undefined
+      })
+      if (!active) return yield* persisted()
+      // Only a genuinely running run can be paused; an already-terminal/paused run
+      // is returned as-is (idempotent).
+      if (active.run.status !== "running") return snapshot(active)
+      yield* abortRun(active, "pause")
+      // finish maps to `paused` (the body's interrupt-driven finish also keys off
+      // `pausing`; both are idempotent). On the lost race against natural
+      // completion `finish` returns undefined — surface the persisted snapshot,
+      // whose TRUE status (completed) is reported, never rewritten.
+      const finished = yield* finish(id, "paused")
+      return finished ?? (yield* persisted())
+    })
+
+    // Item 15: skip ONE in-flight agent step of a LIVE run. Only live runs are
+    // skippable (a persisted/terminal run has no step to resolve); the skip
+    // request is recorded BEFORE the node's session is aborted (the Fund-16
+    // request-flag-first ordering cancel uses), so the abort settlement in
+    // agent() reliably reads it even when the abort lands instantly.
+    const skipAgent: Interface["skipAgent"] = Effect.fn("Workflow.skipAgent")(function* (input) {
+      const active = (yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)).get(input.id)
+      if (!active) {
+        // Distinguish 404 (unknown to this workspace) from 409 (known but not
+        // live) via the directory-scoped row, mirroring cancel/pause.
+        const directory = yield* InstanceState.directory
+        const row = yield* db
+          .select()
+          .from(WorkflowRunTable)
+          .where(and(eq(WorkflowRunTable.id, input.id), eq(WorkflowRunTable.directory, directory)))
+          .get()
+          .pipe(Effect.orDie)
+        if (!row) return undefined
+        return yield* new InvalidError({
+          path: row.workflow,
+          message: `Workflow run is not live: ${input.id} (${row.status})`,
+        })
+      }
+      const node = active.run.agents.find((agent) => agent.id === input.agentId)
+      if (!node) {
+        return yield* new InvalidError({
+          path: active.run.workflow,
+          message: `Workflow agent run not found: ${input.agentId}`,
+        })
+      }
+      // A question step is answered, never skipped — skipping it would strand
+      // the body's ctx.question await without an answer.
+      if (node.kind === "question") {
+        return yield* new InvalidError({
+          path: active.run.workflow,
+          message: `Workflow agent run is a question; answer it instead of skipping: ${input.agentId}`,
+        })
+      }
+      if (node.status !== "running") {
+        return yield* new InvalidError({
+          path: active.run.workflow,
+          message: `Workflow agent run is not running: ${input.agentId} (${node.status})`,
+        })
+      }
+      // Request flag FIRST (race window — see Fund 16), THEN abort the step's
+      // session so the in-flight prompt resolves abort-marked and settles as
+      // `skipped`. A node without a session yet is caught by the pre-prompt
+      // check in agent() instead.
+      active.skipRequests.add(node.id)
+      if (node.session_id && active.cancelSession) {
+        yield* active.cancelSession(SessionID.make(node.session_id)).pipe(Effect.ignore)
+      }
+      return snapshot(active)
+    })
+
+    const answer: Interface["answer"] = Effect.fn("Workflow.answer")(function* (input) {
+      const id = input.id
+      const active = (yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)).get(id)
+      // LIVE run waiting in ctx.question: this is the authoritative writer. Complete
+      // the question node + clear the persisted pending_question + persist, THEN
+      // resolve the Deferred so the parked ctx.question wakes and hands { answer }
+      // to the body. The returned snapshot already reflects the cleared question.
+      //
+      // Finding 10: refuse the live branch when the run is ALREADY unwinding to
+      // paused/cancelled/removed (`pausing`/`cancelling`/`removed` set). An in-flight
+      // pause() sets `active.pausing` synchronously and only LATER clears
+      // `pendingQuestion` (via the scope-close → question reject). In that window the
+      // live branch would otherwise clear+persist `pending_question` on a run that
+      // then finishes `paused`, stranding an un-resumable paused row (no
+      // pending_question). Mirrors the gate used by agent()/shell()/question(): a run
+      // that is suspending does not have its open question consumed mid-abort. The
+      // caller gets `undefined` (HTTP → 409) so it does not believe the answer stuck;
+      // once the run settles `paused`, a subsequent answer() resumes it normally.
+      if (
+        active &&
+        active.run.status === "running" &&
+        active.pendingQuestion &&
+        !active.pausing &&
+        !active.cancelling &&
+        !active.removed
+      ) {
+        const { deferred, node } = active.pendingQuestion
+        active.pendingQuestion = undefined
+        active.run.pending_question = undefined
+        node.status = "completed"
+        node.completed_at = yield* Clock.currentTimeMillis
+        node.answer = input.answer
+        yield* persistRun(db, events, active)
+        yield* Deferred.succeed(deferred, { answer: input.answer }).pipe(Effect.ignore)
+        return snapshot(active)
+      }
+      // No live open question. Consult the (directory-scoped) DB row: a `paused` run
+      // with a persisted `pending_question` is resumed — start a NEW run keyed off
+      // the source, seeding the answer into the question journal so the replayed
+      // ctx.question returns it instead of asking again. Any other state (no pending
+      // question, terminal, unknown id, foreign directory) ⇒ undefined.
+      const directory = yield* InstanceState.directory
+      const row = yield* db
+        .select()
+        .from(WorkflowRunTable)
+        .where(and(eq(WorkflowRunTable.id, id), eq(WorkflowRunTable.directory, directory)))
+        .get()
+        .pipe(Effect.orDie)
+      if (!row || row.status !== "paused" || !row.pending_question) return undefined
+      // Capture the question text BEFORE consuming the row (the seed key) so the
+      // claim's clearing of pending_question cannot lose it.
+      const question = row.pending_question.question
+      // Finding 1 (consume-once): atomically CLAIM the source row before starting
+      // the resume so a repeated/concurrent answer() cannot spawn a SECOND resume run
+      // (which would re-replay the journal and burn budget twice). A single
+      // conditional UPDATE clears `pending_question` only while the row is still
+      // `paused` with an open question; `.returning()` reports whether THIS call won
+      // the claim. A losing second answer() gets 0 rows back → undefined, mirroring
+      // cancel()'s consume-once on a paused row. Status stays `paused` so the resume
+      // start() below still passes its paused/interrupted source-status guard, and
+      // the journal replay reads `agents` (the question node), not this column.
+      const now = yield* Clock.currentTimeMillis
+      const claimed = yield* db
+        .update(WorkflowRunTable)
+        .set({ pending_question: null, time_updated: now })
+        .where(
+          and(
+            eq(WorkflowRunTable.id, id),
+            eq(WorkflowRunTable.directory, directory),
+            eq(WorkflowRunTable.status, "paused"),
+            isNotNull(WorkflowRunTable.pending_question),
+          ),
+        )
+        .returning({ id: WorkflowRunTable.id })
+        .all()
+        .pipe(Effect.orDie)
+      if (claimed.length === 0) return undefined
+      // Resume: re-run the SAME workflow, replaying the agent journal AND serving
+      // the seeded answer to the question node. The caller's execution options
+      // (prompt-ops vector, permissionSessionID, caller, budget) are forwarded
+      // UNCHANGED so a workflow that asks a question and then dispatches more
+      // `ctx.agent` steps can run those steps live on the resumed run — without
+      // them the post-question agent step would fail ("requires prompt operations").
+      //
+      // Finding 9: an INLINE-source run persists its module body on
+      // definition.source and its NAME is never discoverable. Thread the persisted
+      // source (and `temporary`) back so start() takes the inline-source LOAD path
+      // and re-runs the SAME module — otherwise the named-discovery branch would
+      // fail NotFound (or worse, load a foreign same-named workflow). Pass `name`
+      // ONLY when there is no inline source (start()'s inline branch requires
+      // `name === undefined`).
+      const inlineSource = row.definition?.source
+      return yield* start({
+        name: inlineSource !== undefined ? undefined : row.workflow,
+        source: inlineSource,
+        temporary: row.definition?.temporary,
+        args: row.args ?? undefined,
+        resume_of: id,
+        questionAnswers: { [question]: input.answer },
+        prompt: input.prompt,
+        permissionSessionID: input.permissionSessionID,
+        caller: input.caller,
+        budget: input.budget,
+      })
+    })
+
+    const save: Interface["save"] = Effect.fn("Workflow.save")(function* (input) {
+      // Sanitize the name to a single safe path segment BEFORE it becomes a path:
+      // a `/`/`..` segment could escape the workflows dir, and a glob metacharacter
+      // would later distort discovery/permission matching. Same shape the create
+      // tool writes, so a saved file is discoverable/startable identically.
+      if (!SAVE_NAME_PATTERN.test(input.name))
+        return yield* Effect.fail(
+          new InvalidError({
+            path: input.name,
+            message: "Workflow names may only contain letters, numbers, underscores, and dashes",
+          }),
+        )
+      const ctx = yield* InstanceState.context
+      const filepath = saveTargetPath(ctx, input.scope ?? "project", input.name)
+      // Validate the source STATICALLY via the meta-reader (AST-only meta
+      // extraction) BEFORE any write — identical to the create tool's gate. This
+      // never imports/executes the module, so saving a run's source can never run
+      // attacker-authored top-level code. A bad meta is a precise InvalidError.
+      const validated = MetaReader.read(input.source, filepath)
+      if (validated.valid === false)
+        return yield* Effect.fail(new InvalidError({ path: filepath, message: validated.error }))
+      // NEVER overwrite: a collision is a hard SaveConflictError (mirrors the create
+      // tool's "Workflow already exists"), so a re-save can't clobber a hand-edited
+      // file. The existence check + write are not atomic, but a save() is a
+      // deliberate single-user action, so a TOCTOU race here is not a real concern.
+      const exists = yield* Effect.promise(() =>
+        fs
+          .access(filepath)
+          .then(() => true)
+          .catch(() => false),
+      )
+      if (exists) return yield* Effect.fail(new SaveConflictError({ name: input.name, path: filepath }))
+      yield* Effect.promise(async () => {
+        await fs.mkdir(path.dirname(filepath), { recursive: true })
+        await fs.writeFile(filepath, input.source)
+      })
+      return { path: filepath }
+    })
+
+    // Item 27: transcript export. Writes the run snapshot + one JSONL per agent
+    // node under `<data>/workflow/<runId>/transcripts/` (the same per-run data
+    // dir Item 18 uses for the persisted script.ts), so a human (or a manual
+    // continuation script) can read the whole run off disk. All data already
+    // exists in the DB row + the session store; this only materializes it.
+    // The JSONL line shape ({ info, parts } per message / { node } fallback) is
+    // a hand/debug format, deliberately NOT a schema-backed API contract.
+    const exportRun: Interface["export"] = Effect.fn("Workflow.export")(function* (id) {
+      // Directory-scoped exactly like get(): a run from another workspace (or
+      // an unknown id) yields undefined → the HTTP handler maps it to 404.
+      const run = yield* get(id)
+      if (!run) return undefined
+      const dir = path.join(Global.Path.data, "workflow", id, "transcripts")
+      yield* Effect.promise(() => fs.mkdir(dir, { recursive: true }))
+      const files: string[] = []
+      const write = (name: string, content: string) =>
+        Effect.promise(() => fs.writeFile(path.join(dir, name), content)).pipe(
+          Effect.tap(() => Effect.sync(() => files.push(name))),
+        )
+      // (a) run.json: the full run snapshot (a still-running run exports its
+      // current state). Re-export overwrites deterministically (same names).
+      yield* write("run.json", JSON.stringify(run, null, 2))
+      // (b) one <agent-id>.jsonl per node. Agent ids are engine-generated
+      // counters ("1", "2", …) but are encodeURIComponent-ed anyway so a node
+      // id can never traverse the directory. A node with a readable session
+      // exports one line per message; a session-less or unreadable node
+      // (replayed/cached, question, deleted session) exports a single fallback
+      // line carrying the journal node — the export is always COMPLETE across
+      // all nodes, never holey.
+      for (const node of run.agents) {
+        const name = `${encodeURIComponent(node.id)}.jsonl`
+        const msgs = node.session_id
+          ? yield* sessions
+              .messages({ sessionID: SessionID.make(node.session_id) })
+              .pipe(Effect.catchCause(() => Effect.succeed([] as SessionV1.WithParts[])))
+          : []
+        const lines =
+          msgs.length > 0 ? msgs.map((m) => JSON.stringify({ info: m.info, parts: m.parts })) : [JSON.stringify({ node })]
+        yield* write(name, lines.join("\n") + "\n")
+      }
+      return { path: dir, files }
+    })
+
+    const remove: Interface["remove"] = Effect.fn("Workflow.remove")(function* (id) {
+      const inst = yield* InstanceState.get(state)
+      const active = (yield* SynchronizedRef.get(inst.runs)).get(id)
+      // A registered run is cancelled first (abort agent sessions + close the run
+      // scope + interrupt the fiber) so delete cannot block on in-flight work and
+      // no agent keeps running.
+      if (active) {
+        // Fund 3: set the tombstone BEFORE the delete. abortRun closes the run
+        // scope, which interrupts dispatched agent fibers; their settlement
+        // writes are forked into that same scope and may run AFTER the delete.
+        // `persistRun` checks `removed` at execution time and NO-OPs, so a late
+        // write can never re-INSERT (resurrect) the row.
+        active.removed = true
+        yield* abortRun(active)
+        yield* finish(id, "cancelled").pipe(Effect.ignore)
+      }
+      yield* SynchronizedRef.update(inst.runs, (runs) => {
+        const next = new Map(runs)
+        next.delete(id)
+        return next
+      })
+      // Scope both the existence probe and the delete to the calling workspace
+      // (Fund 6): `DELETE …?directory=B` must NEVER delete a row owned by A and
+      // report success. The `id` predicate alone would delete across directories
+      // because the DB is global; adding the directory equality makes the delete
+      // a no-op for a foreign row, and `row` (the scoped probe) stays undefined so
+      // a cross-directory remove honestly reports `false`.
+      const directory = yield* InstanceState.directory
+      const scope = and(eq(WorkflowRunTable.id, id), eq(WorkflowRunTable.directory, directory))
+      const row = yield* db.select().from(WorkflowRunTable).where(scope).get().pipe(Effect.orDie)
+      yield* db.delete(WorkflowRunTable).where(scope).run().pipe(Effect.orDie)
+      return !!row || !!active
+    })
+
+    const sweep: Interface["sweep"] = Effect.fn("Workflow.sweep")(function* () {
+      const live = yield* SynchronizedRef.get((yield* InstanceState.get(state)).runs)
+      yield* sweepOrphans(db, new Set(live.keys()), yield* Clock.currentTimeMillis, yield* InstanceState.directory)
+    })
+
+    return Service.of({
+      list,
+      read,
+      runs,
+      get,
+      start,
+      wait,
+      cancel,
+      pause,
+      skipAgent,
+      answer,
+      save,
+      export: exportRun,
+      remove,
+      sweep,
+    })
+  }),
+)
+
+export const defaultLayer = layer.pipe(
+  Layer.provide(Database.defaultLayer),
+  Layer.provide(Session.defaultLayer),
+  Layer.provide(Agent.defaultLayer),
+  Layer.provide(Provider.defaultLayer),
+  Layer.provide(Config.defaultLayer),
+  Layer.provide(EventV2Bridge.defaultLayer),
+  // Item 23 (Stufe 1): Permission gates ctx.shell; FSUtil + the spawner feed
+  // the bash tool's scanCommand the gate reuses.
+  Layer.provide(Permission.defaultLayer),
+  Layer.provide(FSUtil.defaultLayer),
+  Layer.provide(CrossSpawnSpawner.defaultLayer),
+  Layer.provide(ToolCatalog.defaultLayer),
+  Layer.provide(MCP.defaultLayer),
+  Layer.provide(Plugin.defaultLayer),
+  Layer.provide(Truncate.defaultLayer),
+)
+
+export const node = LayerNode.make(layer, [
+  Database.node,
+  Session.node,
+  Agent.node,
+  Provider.node,
+  Config.node,
+  EventV2Bridge.node,
+  // Item 23 (Stufe 1): see defaultLayer.
+  Permission.node,
+  FSUtil.node,
+  CrossSpawnSpawner.node,
+  ToolCatalog.node,
+  MCP.node,
+  Plugin.node,
+  Truncate.node,
+])
+
+export * as Workflow from "./workflow"

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -6,6 +6,33 @@ import fs from "fs/promises"
 import { setTimeout as sleep } from "node:timers/promises"
 import { afterAll } from "bun:test"
 
+// Best-effort sweep of stale per-test tmpdirs (`opencode-test-*`) left behind by
+// PRIOR runs whose process was killed mid-test (timeout/crash/CI cancel) before
+// the scoped fixture finalizers could rm them. The in-run teardown
+// (tmpdirScoped's Effect.addFinalizer / tmpdir's Symbol.asyncDispose) fires
+// correctly on a normal scope close, but a SIGKILL skips every JS finalizer, so
+// orphans accumulate across runs. This is purely defensive: it is AGE-GATED
+// (older than 1h) so it can never race a live sibling test process's just-created
+// dir, and it swallows every error. Failure here must not affect tests.
+const STALE_MS = 60 * 60 * 1000
+try {
+  const root = os.tmpdir()
+  const now = Date.now()
+  const entries = await fs.readdir(root).catch(() => [] as string[])
+  await Promise.all(
+    entries
+      .filter((name) => name.startsWith("opencode-test-"))
+      .map(async (name) => {
+        const full = path.join(root, name)
+        const stat = await fs.stat(full).catch(() => undefined)
+        if (!stat || now - stat.mtimeMs < STALE_MS) return
+        await fs.rm(full, { recursive: true, force: true }).catch(() => undefined)
+      }),
+  )
+} catch {
+  // never fail preload on cleanup
+}
+
 // Set XDG env vars FIRST, before any src/ imports
 const dir = path.join(os.tmpdir(), "opencode-test-data-" + process.pid)
 await fs.mkdir(dir, { recursive: true })

--- a/packages/opencode/test/workflow/meta-reader.test.ts
+++ b/packages/opencode/test/workflow/meta-reader.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import path from "path"
+import { MetaReader } from "@/workflow/meta-reader"
+
+const FAKE_PATH = path.join(os.tmpdir(), "fake-workflow.ts")
+
+describe("MetaReader", () => {
+  test("extracts literal meta from named exports (export const meta / export function run)", () => {
+    const source = `export const meta = {
+  name: "Hello",
+  description: "Test workflow",
+  phases: ["start", "end"],
+  arguments: { value: { type: "number", description: "A value" } }
+}
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.name).toBe("Hello")
+    expect(result.meta.description).toBe("Test workflow")
+    // Phases normalize to the internal object shape (Task 15): strings → { title }.
+    expect(result.meta.phases).toEqual([{ title: "start" }, { title: "end" }])
+    expect(result.meta.arguments).toEqual({ value: { type: "number", description: "A value" } })
+  })
+
+  test("extracts whenToUse from literal meta (QW4)", () => {
+    const source = `export const meta = {
+  name: "Deploy",
+  description: "Deploy the app.",
+  whenToUse: "When the user explicitly asks to ship to production."
+}
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.whenToUse).toBe("When the user explicitly asks to ship to production.")
+  })
+
+  test("extracts literal meta from a default object literal (export default { meta, run })", () => {
+    const source = `export default {
+  meta: { name: "Typed Workflow", phases: ["run"] },
+  async run(args, ctx) { return { ok: true } }
+}
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.name).toBe("Typed Workflow")
+    expect(result.meta.phases).toEqual([{ title: "run" }])
+  })
+
+  test("extracts literal meta from an export default workflow({ ... }) call", () => {
+    const source = `import { workflow } from "@opencode-ai/plugin/workflow"
+export default workflow({
+  name: "Called",
+  description: "Built via helper",
+  phases: ["one"],
+  arguments: { x: { type: "string" } },
+  async run(args, ctx) { return { ok: true } }
+})
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.name).toBe("Called")
+    expect(result.meta.description).toBe("Built via helper")
+    expect(result.meta.phases).toEqual([{ title: "one" }])
+    expect(result.meta.arguments).toEqual({ x: { type: "string" } })
+  })
+
+  test("does NOT execute module top-level code (no import, no side effects)", async () => {
+    const marker = path.join(os.tmpdir(), `meta-reader-marker-${Math.random().toString(16).slice(2)}`)
+    // Top-level await with a real side effect: if the reader were to import/run
+    // the module, this marker file would be written. Static extraction must not.
+    const source = `await Bun.write(${JSON.stringify(marker)}, "executed")
+export const meta = { name: "SideEffect" }
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.name).toBe("SideEffect")
+    // The marker must NOT exist: top-level code was never run.
+    expect(await Bun.file(marker).exists()).toBe(false)
+  })
+
+  test("non-statically-analyzable meta is reported invalid (no throw)", () => {
+    const source = `export const meta = { name: process.env.SECRET_NAME }
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toContain("statically analyzable")
+  })
+
+  test("computed property name (name: someFn()) is reported invalid", () => {
+    const source = `function compute() { return "x" }
+export const meta = { name: compute() }
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toContain("statically analyzable")
+  })
+
+  test("meta that fails the schema (missing name) is reported invalid", () => {
+    const source = `export const meta = { description: "no name here" }
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toBeTruthy()
+  })
+
+  test("a file with no default export and no meta export is reported invalid", () => {
+    const source = `export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toBeTruthy()
+  })
+
+  test("negative and boolean literals are extracted faithfully", () => {
+    const source = `export const meta = {
+  name: "Literals",
+  arguments: { flag: { type: "boolean", default: false }, n: { type: "number", default: -3 } }
+}
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.arguments).toEqual({
+      flag: { type: "boolean", default: false },
+      n: { type: "number", default: -3 },
+    })
+  })
+
+  test("`as const` on the whole meta and on a nested array is extracted (idiomatic TS)", () => {
+    const source = `export const meta = {
+  name: "Const",
+  phases: ["a", "b"] as const,
+  arguments: { x: { type: "string" } }
+} as const
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.name).toBe("Const")
+    expect(result.meta.phases).toEqual([{ title: "a" }, { title: "b" }])
+    expect(result.meta.arguments).toEqual({ x: { type: "string" } })
+  })
+
+  test("`satisfies` and parenthesized expressions are unwrapped transparently", () => {
+    const source = `export const meta = ({
+  name: "Sat",
+  phases: (["one"]) satisfies readonly string[]
+}) satisfies Record<string, unknown>
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    expect(result.meta.name).toBe("Sat")
+    expect(result.meta.phases).toEqual([{ title: "one" }])
+  })
+
+  test("more than one default export is reported invalid (ambiguous)", () => {
+    const source = `export default { meta: { name: "First" }, run() {} }
+export default { meta: { name: "Second" }, run() {} }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toBeTruthy()
+  })
+
+  test("a syntax-error file is reported invalid, never crashes", () => {
+    const source = `export const meta = {`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toBeTruthy()
+  })
+
+  test("a template string WITH substitution in meta is reported invalid", () => {
+    const source = `const suffix = "x"
+export const meta = { name: \`Hello-\${suffix}\` }
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toContain("statically analyzable")
+  })
+
+  // Task 15: structured phases. A phase entry may be an object literal
+  // `{ title, detail?, model? }` alongside plain strings. The reader extracts it
+  // statically (object literals only — same static-analyzability rule) and the
+  // schema NORMALIZES every phase to the internal object shape on decode, so a
+  // string phase reads back as `{ title }` and an object phase keeps its fields.
+  test("structured phase objects are read statically and normalized to objects", () => {
+    const source = `export const meta = {
+  name: "Structured",
+  phases: ["plan", { title: "verify", detail: "x", model: "stub/mini" }]
+}
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(true)
+    if (!result.valid) throw new Error("expected valid")
+    // Always objects internally: the string "plan" normalizes to { title: "plan" },
+    // and the object phase keeps title/detail/model.
+    expect(result.meta.phases?.[0]).toEqual({ title: "plan" })
+    expect(result.meta.phases?.[1].title).toBe("verify")
+    expect(result.meta.phases?.[1]).toEqual({ title: "verify", detail: "x", model: "stub/mini" })
+  })
+
+  // A phase OBJECT missing the required `title` is invalid meta. The rule is
+  // statically analyzable (the object literal is read, then rejected by the same
+  // Meta schema the engine uses), so it reports invalid rather than throwing.
+  test("a phase object without a title is reported invalid meta", () => {
+    const source = `export const meta = {
+  name: "BadPhase",
+  phases: ["ok", { detail: "no title here", model: "x/y" }]
+}
+export async function run(args, ctx) { return { ok: true } }
+`
+    const result = MetaReader.read(source, FAKE_PATH)
+    expect(result.valid).toBe(false)
+    if (result.valid) throw new Error("expected invalid")
+    expect(result.error).toBeTruthy()
+  })
+})

--- a/packages/opencode/test/workflow/source-lint.test.ts
+++ b/packages/opencode/test/workflow/source-lint.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import path from "path"
+import { SourceLint } from "@/workflow/source-lint"
+
+const FAKE_PATH = path.join(os.tmpdir(), "fake-workflow.ts")
+
+// Item 23 (Stufe 2): the static source lint runs purely on the AST (like the
+// MetaReader) and never executes the module. These tests pin the rule set:
+// node builtins via import/require/dynamic import, Bun.* capability members,
+// process.env reads, fetch calls, and non-literal dynamic imports.
+describe("SourceLint", () => {
+  test("flags a static node:fs import with its line", () => {
+    const source = `import fs from "node:fs"
+export const meta = { name: "x" }
+export async function run(args, ctx) { return {} }
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("node-builtin-import")
+    expect(findings[0].line).toBe(1)
+    expect(findings[0].text).toContain("node:fs")
+  })
+
+  test("flags bare and subpath builtin specifiers (fs/promises, child_process)", () => {
+    const source = `import { readFile } from "fs/promises"
+import { spawn } from "child_process"
+export const meta = { name: "x" }
+export async function run(args, ctx) { return {} }
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    expect(findings.map((f) => f.rule)).toEqual(["node-builtin-import", "node-builtin-import"])
+  })
+
+  test("flags child_process via require", () => {
+    const source = `export const meta = { name: "x" }
+export async function run(args, ctx) {
+  const cp = require("child_process")
+  return {}
+}
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].rule).toBe("node-builtin-require")
+    expect(findings[0].line).toBe(3)
+  })
+
+  test("flags a dynamic import of a builtin and a non-literal dynamic import", () => {
+    const source = `export const meta = { name: "x" }
+export async function run(args, ctx) {
+  const vm = await import("node:vm")
+  const dyn = await import(args.module)
+  return {}
+}
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    expect(findings.map((f) => f.rule)).toEqual(["node-builtin-import", "dynamic-import"])
+    expect(findings[0].line).toBe(3)
+    expect(findings[1].line).toBe(4)
+  })
+
+  test("flags fetch calls and Bun capability members (spawn/write/file/$)", () => {
+    const source = `export const meta = { name: "x" }
+export async function run(args, ctx) {
+  const res = await fetch("https://example.com")
+  Bun.spawn(["ls"])
+  await Bun.write("out.txt", "data")
+  const f = Bun.file("in.txt")
+  await Bun.$\`ls\`
+  return {}
+}
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    expect(findings.map((f) => f.rule).toSorted()).toEqual(["bun-api", "bun-api", "bun-api", "bun-api", "fetch"])
+  })
+
+  test("flags process.env reads (property and element access)", () => {
+    const source = `export const meta = { name: "x" }
+export async function run(args, ctx) {
+  const a = process.env.SECRET
+  const b = process.env["TOKEN"]
+  return {}
+}
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    // Each access contains exactly one process.env node.
+    expect(findings.map((f) => f.rule)).toEqual(["process-env", "process-env"])
+    expect(findings[0].line).toBe(3)
+    expect(findings[1].line).toBe(4)
+  })
+
+  test("a clean script using only the ctx API yields zero findings", () => {
+    const source = `export const meta = { name: "clean", description: "No capabilities.", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.agent({ prompt: "do work" })
+  const sh = await ctx.shell("git status")
+  ctx.log("done")
+  return { a: a.text, code: sh.exitCode }
+}
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    expect(findings).toHaveLength(0)
+  })
+
+  test("non-flagged imports (relative, npm package, node:path) are not flagged", () => {
+    const source = `import helper from "./helper"
+import lodash from "lodash"
+import path from "node:path"
+export const meta = { name: "x" }
+export async function run(args, ctx) { return {} }
+`
+    const { findings } = SourceLint.lint(source, FAKE_PATH)
+    expect(findings).toHaveLength(0)
+  })
+})

--- a/packages/opencode/test/workflow/workflow.test.ts
+++ b/packages/opencode/test/workflow/workflow.test.ts
@@ -1,0 +1,8602 @@
+import { describe, expect, test } from "bun:test"
+import { Workflow } from "@/workflow/workflow"
+import { BUILTIN_WORKFLOWS } from "@/workflow/builtin"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Session } from "@/session/session"
+import { Permission } from "@/permission"
+import { Agent } from "@/agent/agent"
+import { SessionID } from "@/session/schema"
+import type { SessionPrompt } from "@/session/prompt"
+import { TurnBudget } from "@/session/turn-budget"
+import type { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Database } from "@opencode-ai/core/database/database"
+import { WorkflowRunTable } from "@opencode-ai/core/workflow/sql"
+import { MessageTable } from "@opencode-ai/core/session/sql"
+import { MessageID } from "@opencode-ai/core/v1/session"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { eq, sql } from "drizzle-orm"
+import { TestInstance, provideInstance, tmpdirScoped, reloadInstance, testInstanceStoreLayer } from "../fixture/fixture"
+import { InstanceState } from "@/effect/instance-state"
+import { awaitWithTimeout, pollWithTimeout, testEffect } from "../lib/effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema } from "effect"
+import { Global } from "@opencode-ai/core/global"
+import { spawnSync } from "child_process"
+import fs from "fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
+
+// Database.defaultLayer is merged so the orphan-sweep tests can seed a row
+// directly through the same in-memory SQLite connection the engine uses.
+// Session/Agent.defaultLayer are merged so the subagent-permission-inheritance
+// tests can create a caller session (with a deny ruleset) and read back the
+// child session the engine spawns — through the SAME memoised services the
+// engine resolves (Effect dedupes shared layer builds, exactly as for Database).
+const it = testEffect(
+  Layer.mergeAll(
+    Workflow.defaultLayer,
+    Database.defaultLayer,
+    Session.defaultLayer,
+    Agent.defaultLayer,
+    CrossSpawnSpawner.defaultLayer,
+    // EventV2Bridge.defaultLayer is merged so a test can subscribe to the SAME bus
+    // instance the engine publishes run-lifecycle events on. It is the identical
+    // exported const reference the Workflow layer provides internally, so Effect's
+    // layer memoisation resolves both to ONE instance (exactly as for Database).
+    EventV2Bridge.defaultLayer,
+    // Item 23: Permission.defaultLayer is merged so the ctx.shell gate tests can
+    // observe/reply to the SAME permission instance the engine asks through
+    // (identical const reference ⇒ one memoised instance, as above).
+    Permission.defaultLayer,
+  ),
+)
+
+const HELLO_FIXTURE = "hello"
+
+// Seeds a workflow_run row in status="running" with NO live registry entry,
+// the exact shape an orphaned (crashed/restarted) run leaves behind. The row is
+// owned by the calling workspace `directory` so the directory-scoped sweep/get
+// (Fund 6/17) recognises it as a local zombie rather than a foreign run.
+function seedRunningRow(id: string, directory: string) {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    yield* db
+      .insert(WorkflowRunTable)
+      .values({
+        id,
+        workflow: HELLO_FIXTURE,
+        status: "running",
+        started_at: Date.now(),
+        directory,
+        logs: [],
+        agents: [],
+      })
+      .run()
+      .pipe(Effect.orDie)
+  })
+}
+
+// Seeds a `running` row that ALSO carries a still-`running` agent node — the
+// shape an orphaned run leaves behind once it had dispatched an agent. The sweep
+// must normalise BOTH the run row (→ interrupted) and the zombie agent node
+// (→ failed with completed_at + error), so the TUI never renders a live agent
+// icon on a terminal run (Fund 15).
+function seedRunningRowWithAgent(id: string, directory: string) {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    const now = Date.now()
+    yield* db
+      .insert(WorkflowRunTable)
+      .values({
+        id,
+        workflow: HELLO_FIXTURE,
+        status: "running",
+        started_at: now,
+        directory,
+        current_phase: "run",
+        logs: [],
+        agents: [
+          { id: "1", status: "running", started_at: now, phase: "run", prompt: "hang" },
+          { id: "2", status: "completed", started_at: now, completed_at: now, phase: "run", prompt: "done" },
+        ],
+      })
+      .run()
+      .pipe(Effect.orDie)
+  })
+}
+
+function fetchRunRow(id: string) {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    const row = yield* db.select().from(WorkflowRunTable).where(eq(WorkflowRunTable.id, id)).get().pipe(Effect.orDie)
+    return row ?? (yield* Effect.fail(new Error(`row ${id} not found`)))
+  })
+}
+
+// Reads the RAW `result` column text (bypassing any json decode) so a test can
+// prove how the engine serialised it: SQL-NULL (never set) vs the literal JSON
+// text `"null"` (a real null result) — the distinction Fund 42 turns on.
+function fetchRawResult(id: string) {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    const row = yield* db
+      .select({ raw: sql<string | null>`${WorkflowRunTable.result}` })
+      .from(WorkflowRunTable)
+      .where(eq(WorkflowRunTable.id, id))
+      .get()
+      .pipe(Effect.orDie)
+    return row?.raw ?? null
+  })
+}
+
+// Seeds a completed run whose persisted `definition.meta` is supplied RAW —
+// bypassing the engine so a test can pin EXACTLY how an older/foreign branch
+// would have left the row's phases on disk (bare strings, malformed shapes,
+// etc.). The `as never` casts thread an arbitrary on-disk JSON shape past the
+// strongly-typed `WorkflowDefinitionRow` column type — the whole point is to
+// reproduce a row the current row-type would never WRITE but might still READ.
+function seedRowWithRawMeta(id: string, directory: string, meta: unknown) {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    const now = Date.now()
+    yield* db
+      .insert(WorkflowRunTable)
+      .values({
+        id,
+        workflow: HELLO_FIXTURE,
+        status: "completed",
+        started_at: now,
+        completed_at: now,
+        directory,
+        logs: [],
+        agents: [],
+        definition: { name: HELLO_FIXTURE, path: "/p/.opencode/workflows/hello.js", meta } as never,
+      })
+      .run()
+      .pipe(Effect.orDie)
+  })
+}
+
+// Seeds a fully finished run (with log + agent telemetry) straight into the DB.
+// Because it never went through start(), it has NO live registry entry, so
+// get() is forced through the DB->fromRow path — no test-only seam required.
+function seedCompletedRow(id: string, directory: string) {
+  return Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    const now = Date.now()
+    yield* db
+      .insert(WorkflowRunTable)
+      .values({
+        id,
+        workflow: HELLO_FIXTURE,
+        status: "completed",
+        started_at: now,
+        completed_at: now,
+        directory,
+        current_phase: "run",
+        logs: [{ time: now, phase: "run", message: "running" }],
+        agents: [
+          {
+            id: "1",
+            status: "completed",
+            started_at: now,
+            completed_at: now,
+            phase: "run",
+            // Item 16: the per-call display label must survive the DB→fromRow
+            // roundtrip like the rest of the node's telemetry.
+            label: "seeded label",
+            // Item 7: the isolated-worktree location must survive the roundtrip
+            // so a preserved worktree stays inspectable.
+            worktree: "/tmp/oc-wf-seeded",
+            prompt: "do the thing",
+            output: "did the thing",
+            // Fund 51: per-agent telemetry (cost USD + tokens incl. `total`) must
+            // survive the DB→fromRow roundtrip, not just status/output. Seeded with
+            // non-zero values so a roundtrip that drops them would be observable.
+            cost: 0.42,
+            tokens: { total: 99, input: 11, output: 22, reasoning: 33, cache: { read: 44, write: 55 } },
+          },
+        ],
+        // The `result` column is plain text and the engine owns its JSON codec
+        // (Fund 42), so a seed must serialize exactly like persistRun does — a raw
+        // object would fail the bind. The roundtrip test reads this back through
+        // fromRow, which JSON-parses it.
+        result: JSON.stringify({ ok: true }),
+      })
+      .run()
+      .pipe(Effect.orDie)
+  })
+}
+
+async function writeWorkflow(dir: string, name: string, body: string, ext = "js") {
+  await Bun.write(path.join(dir, ".opencode", "workflows", `${name}.${ext}`), body)
+}
+
+import os from "os"
+
+// A workflow whose TOP-LEVEL body writes a marker file the moment the module is
+// imported and executed. list()/discover() must NEVER produce this marker
+// (static meta extraction only); start() must, because it really imports the
+// target module after the permission gate.
+const SIDE_EFFECT_FIXTURE = "side-effect"
+function sideEffectWorkflow(markerPath: string) {
+  return `await Bun.write(${JSON.stringify(markerPath)}, "executed")
+export const meta = { name: "SideEffect", description: "writes a marker on import" }
+export async function run(args, ctx) { return { ok: true } }
+`
+}
+
+const STEP2_MARKER = "step-2-reached"
+const SLOW_FIXTURE = "slow"
+
+// Fixture-Workflow: ein absichtlich blockierender Agent-Schritt, danach ein
+// zweiter Schritt (STEP2_MARKER), der bei korrekter Cancellation NIE läuft.
+const SLOW_WORKFLOW = `export const meta = { name: "${SLOW_FIXTURE}", phases: ["agent", "after"] }
+export async function run(args, ctx) {
+  ctx.setPhase("agent")
+  ctx.log("step-1-started")
+  await ctx.agent({ prompt: "hang" })
+  ctx.setPhase("after")
+  ctx.log("${STEP2_MARKER}")
+  return { ok: true }
+}
+`
+
+// Subagent-permission-inheritance fixture (#26514 regression / Fund N9): a
+// single agent step that completes. The engine must spawn its child session
+// with a derived `permission` ruleset when a `caller` context is supplied.
+const SINGLE_AGENT_FIXTURE = "single-agent"
+const SINGLE_AGENT_WORKFLOW = `export const meta = { name: "${SINGLE_AGENT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "do the thing" })
+  return { ok: true }
+}
+`
+
+// Per-step reasoning variant fixture (Task 6): a single agent step that passes a
+// `variant` through to the engine. The engine must thread that variant into the
+// underlying prompt run (PromptInput.variant) unchanged.
+const VARIANT_FIXTURE = "variant-step"
+const VARIANT_WORKFLOW = `export const meta = { name: "${VARIANT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", variant: "max" })
+  return { ok: true }
+}
+`
+
+// model:"small" fixture (Task 7): a single agent step that requests the magic
+// "small" model. The engine must resolve this to the configured small_model and
+// dispatch the prompt against that provider/model.
+const SMALL_MODEL_FIXTURE = "small-model-step"
+const SMALL_MODEL_WORKFLOW = `export const meta = { name: "${SMALL_MODEL_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", model: "small" })
+  return { ok: true }
+}
+`
+
+// Per-phase default model fixture (Task 15): a structured phase declares a
+// default `model`. The first ctx.agent call (no explicit model) must resolve to
+// that phase default; the second call passes an EXPLICIT model that must win over
+// the phase default.
+const PHASE_MODEL_FIXTURE = "phase-model"
+const PHASE_MODEL_WORKFLOW = `export const meta = {
+  name: "${PHASE_MODEL_FIXTURE}",
+  phases: ["plan", { title: "verify", model: "stub/mini" }]
+}
+export async function run(args, ctx) {
+  ctx.setPhase("verify")
+  await ctx.agent({ prompt: "hi" })
+  await ctx.agent({ prompt: "hi", model: "other/explicit" })
+  return { ok: true }
+}
+`
+
+// Item 16 (a): a per-call `phase` pins the step's node to that phase regardless
+// of where setPhase has moved the run's current phase in the meantime — the
+// deterministic core of the parallel/pipeline race the option closes.
+const PERCALL_PHASE_FIXTURE = "percall-phase"
+const PERCALL_PHASE_WORKFLOW = `export const meta = { name: "${PERCALL_PHASE_FIXTURE}", phases: ["a", "b"] }
+export async function run(args, ctx) {
+  ctx.setPhase("a")
+  ctx.setPhase("b")
+  await ctx.agent({ prompt: "pinned", phase: "a" })
+  await ctx.agent({ prompt: "unpinned" })
+  return { ok: true }
+}
+`
+
+// Item 16 (b): a per-call phase that is DECLARED with a model resolves that model
+// as the call's default; an explicit model still wins; and a per-call phase
+// WITHOUT a declared model never inherits the global current phase's model.
+const PERCALL_PHASE_MODEL_FIXTURE = "percall-phase-model"
+const PERCALL_PHASE_MODEL_WORKFLOW = `export const meta = {
+  name: "${PERCALL_PHASE_MODEL_FIXTURE}",
+  phases: ["x", { title: "y", model: "stub/mini" }]
+}
+export async function run(args, ctx) {
+  await ctx.agent({ prompt: "a", phase: "y" })
+  await ctx.agent({ prompt: "b", phase: "y", model: "other/explicit" })
+  ctx.setPhase("y")
+  await ctx.agent({ prompt: "c", phase: "x" })
+  return { ok: true }
+}
+`
+
+// Item 16 (c): `label` is a per-call display name persisted on the agent node.
+const LABEL_FIXTURE = "label-step"
+const LABEL_WORKFLOW = `export const meta = { name: "${LABEL_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", label: "Find the bug" })
+  return { ok: true }
+}
+`
+
+// Item 16 (d): a nested ctx.workflow child's per-call phase is logPrefix-ed
+// exactly like its setPhase would be.
+const PERCALL_CHILD_FIXTURE = "percall-child"
+const PERCALL_CHILD_WORKFLOW = `export const meta = { name: "${PERCALL_CHILD_FIXTURE}", phases: ["p"] }
+export async function run(args, ctx) {
+  await ctx.agent({ prompt: "child step", phase: "p" })
+  return { ok: true }
+}
+`
+const PERCALL_PARENT_FIXTURE = "percall-parent"
+const PERCALL_PARENT_WORKFLOW = `export const meta = { name: "${PERCALL_PARENT_FIXTURE}", description: "pp" }
+export async function run(_a, ctx) {
+  return await ctx.workflow("${PERCALL_CHILD_FIXTURE}", {})
+}
+`
+
+// Item 12 fixtures: model inheritance from the caller session. A DEFAULT-agent
+// step (no `agent:` override) with no explicit/phase model resolves to the
+// run's caller_model; an explicitly chosen agent does NOT inherit it.
+const CALLER_MODEL_FIXTURE = "caller-model"
+const CALLER_MODEL_WORKFLOW = `export const meta = { name: "${CALLER_MODEL_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "default-step" })
+  await ctx.agent({ prompt: "explicit-agent-step", agent: "general" })
+  return { ok: true }
+}
+`
+// A declared phase model must still WIN over the caller model (the new tier
+// sits between phase model and the agent's own model).
+const CALLER_PHASE_FIXTURE = "caller-phase-model"
+const CALLER_PHASE_WORKFLOW = `export const meta = {
+  name: "${CALLER_PHASE_FIXTURE}",
+  phases: [{ title: "verify", model: "stub/mini" }]
+}
+export async function run(args, ctx) {
+  ctx.setPhase("verify")
+  await ctx.agent({ prompt: "hi" })
+  return { ok: true }
+}
+`
+
+// Item 15 fixtures: a human skip resolves the in-flight ctx.agent call to null.
+const SKIP_FIXTURE = "skip-step"
+const SKIP_WORKFLOW = `export const meta = { name: "${SKIP_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const r = await ctx.agent({ prompt: "hang" })
+  return { skipped: r === null }
+}
+`
+
+// Item 15 (pre-dispatch skip): args.count parallel agent steps. With count =
+// run-concurrency-cap + 1 the LAST step's node exists while its dispatch still
+// waits for a semaphore permit — the deterministic window for a skip that lands
+// BEFORE the step's prompt dispatches.
+const SKIP_PARALLEL_FIXTURE = "skip-parallel"
+const SKIP_PARALLEL_WORKFLOW = `export const meta = { name: "${SKIP_PARALLEL_FIXTURE}", phases: ["run"], arguments: { count: { type: "number" } } }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const tasks = []
+  for (let i = 0; i < args.count; i++) tasks.push(() => ctx.agent({ prompt: "hang " + i }))
+  const results = await ctx.parallel(tasks)
+  return { allNull: results.every((r) => r === null) }
+}
+`
+
+// Item 15 (onError:"null"): a failing step resolves null; the body branches.
+const ONERROR_NULL_FIXTURE = "onerror-null"
+const ONERROR_NULL_WORKFLOW = `export const meta = { name: "${ONERROR_NULL_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const r = await ctx.agent({ prompt: "boom", onError: "null" })
+  return { isNull: r === null }
+}
+`
+
+// Item 15 (budget carve-out): onError:"null" must NOT swallow budget exhaustion.
+const ONERROR_BUDGET_FIXTURE = "onerror-budget"
+const ONERROR_BUDGET_WORKFLOW = `export const meta = { name: "${ONERROR_BUDGET_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "gated", onError: "null" })
+  return { ok: true }
+}
+`
+
+// Undeclared-phase fixture (Task 15): setPhase on a phase NOT in meta.phases is
+// allowed (no error) but logs a warning. The run still completes.
+const UNDECLARED_PHASE_FIXTURE = "undeclared-phase"
+const UNDECLARED_PHASE_WORKFLOW = `export const meta = { name: "${UNDECLARED_PHASE_FIXTURE}", phases: ["plan"] }
+export async function run(args, ctx) {
+  ctx.setPhase("undeclared")
+  return { ok: true }
+}
+`
+
+// Per-step tools-scoping fixture (Task 8): a single agent step that passes a
+// `tools` whitelist/blacklist. The engine must thread that Record<string,boolean>
+// through to the prompt run (PromptInput.tools) unchanged so the session scopes
+// its tools accordingly.
+const TOOLS_FIXTURE = "tools-step"
+const TOOLS_WORKFLOW = `export const meta = { name: "${TOOLS_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", tools: { webfetch: false } })
+  return { ok: true }
+}
+`
+
+// Security-compose fixture: a single agent step that tries to RE-GRANT a tool
+// (\`edit\`) the inherited caller permission denies (Plan Mode). The per-step
+// grant must NOT override the inherited deny — the composed child-session
+// ruleset must still deny \`edit\`.
+const TOOLS_REGRANT_FIXTURE = "tools-regrant-step"
+const TOOLS_REGRANT_WORKFLOW = `export const meta = { name: "${TOOLS_REGRANT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", tools: { edit: true } })
+  return { ok: true }
+}
+`
+
+// Per-step skills fixture (Task 9): a single agent step that requests specific
+// skills. opencode only loads skills via the runtime \`skill\` tool, so the engine
+// prepends a load directive to the prompt and enables the skill tool for the step.
+const SKILLS_FIXTURE = "skills-step"
+const SKILLS_WORKFLOW = `export const meta = { name: "${SKILLS_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "do it", skills: ["pdf", "xlsx"] })
+  return { ok: true }
+}
+`
+
+// Declarative file-attachments fixture (Task 10): a single agent step that
+// attaches an existing file by path. The engine must resolve the path relative
+// to the run's workspace directory and append a file part after the text part.
+const FILES_FIXTURE = "files-step"
+const FILES_WORKFLOW = `export const meta = { name: "${FILES_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", files: ["./ATTACH.md"] })
+  return { ok: true }
+}
+`
+
+// Missing-file variant of the Task 10 fixture: a non-existent attachment must
+// fail the run with a WorkflowInvalidError naming the missing file.
+const FILES_MISSING_FIXTURE = "files-missing-step"
+const FILES_MISSING_WORKFLOW = `export const meta = { name: "${FILES_MISSING_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", files: ["./DOES_NOT_EXIST.md"] })
+  return { ok: true }
+}
+`
+
+// Directory variant of the Task 10 fixture: an attachment path that resolves to a
+// DIRECTORY (not a regular file) must fail the run the same way a missing file
+// does. This pins the corrected portable `exists` check (fs.stat().isFile()),
+// which preserves the prior `Bun.file(dir).exists()` -> false semantics — a
+// directory is never an attachable source.
+const FILES_DIR_FIXTURE = "files-dir-step"
+const FILES_DIR_WORKFLOW = `export const meta = { name: "${FILES_DIR_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", files: ["./ATTACH_DIR"] })
+  return { ok: true }
+}
+`
+
+// Task 11: a single agent step requesting worktree isolation. When the workspace
+// is a git repository the engine runs the subagent inside a fresh `git worktree`
+// (auto-cleaned on the run scope); a non-git workspace fails the step with a
+// WorkflowInvalidError naming the missing git repository.
+const ISOLATION_FIXTURE = "isolation-step"
+const ISOLATION_WORKFLOW = `export const meta = { name: "${ISOLATION_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hi", isolation: "worktree" })
+  return { ok: true }
+}
+`
+
+// Task 11a (deterministic non-LLM shell step): ctx.shell runs a command in the
+// run's workspace and returns { output, exitCode } WITHOUT consuming an LLM turn
+// or budget. A non-zero exit is mapped to the return value (never thrown), and
+// ctx.budget.spent() stays 0 because shell never touches the cost accumulator.
+const SHELL_FIXTURE = "shell-step"
+const SHELL_WORKFLOW = `export const meta = { name: "${SHELL_FIXTURE}", phases: ["run"] }
+export async function run(_args, ctx) {
+  ctx.setPhase("run")
+  const ok = await ctx.shell("echo hello-workflow")
+  const fail = await ctx.shell("exit 3")
+  return { out: ok.output.trim(), okCode: ok.exitCode, failCode: fail.exitCode, spent: ctx.budget.spent() }
+}
+`
+
+// Task 11a (real timeout): ctx.shell with a short timeout kills a hung command and
+// resolves PROMPTLY with a non-zero exitCode (not a hang, not a throw). The fixture
+// records elapsed wall-clock so the test can prove the timeout fired well before
+// the command's natural duration.
+const SHELL_TIMEOUT_FIXTURE = "shell-timeout-step"
+const SHELL_TIMEOUT_WORKFLOW = `export const meta = { name: "${SHELL_TIMEOUT_FIXTURE}", phases: ["run"] }
+export async function run(_args, ctx) {
+  ctx.setPhase("run")
+  const started = Date.now()
+  const r = await ctx.shell("sleep 5", { timeout: 100 })
+  const elapsed = Date.now() - started
+  return { exitCode: r.exitCode, elapsed }
+}
+`
+
+// Finding 5: a ctx.shell with NO timeout must have its OS child reaped when the
+// run is cancelled/paused (the scope-close path). The shell command writes a
+// "running" marker immediately so the test can synchronize on the child being
+// live, then sleeps, then writes a "leaked" marker. If the child were orphaned on
+// cancel (the bug), the leaked marker would appear ~after the sleep; with the fix
+// the child is SIGTERMed on interruption so the leaked marker is NEVER written.
+// The markers' paths come from args so the test controls them.
+const SHELL_LEAK_FIXTURE = "shell-leak-step"
+const SHELL_LEAK_WORKFLOW = `export const meta = { name: "${SHELL_LEAK_FIXTURE}", phases: ["run"], arguments: { running: { type: "string" }, leaked: { type: "string" } } }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  // No timeout: only a scope-close interrupt (cancel/pause) can stop this.
+  await ctx.shell("touch '" + args.running + "'; sleep 3; touch '" + args.leaked + "'")
+  return { ok: true }
+}
+`
+
+// Item 23 (Stufe 1): ctx.shell under the permission gate. The command (`rm
+// <target>`) targets a RELATIVE path inside the workspace so no
+// external_directory ask fires — only the bash permission, evaluated against
+// the caller session's ruleset.
+const SHELL_GATE_FIXTURE = "shell-gate"
+const SHELL_GATE_WORKFLOW = `export const meta = { name: "${SHELL_GATE_FIXTURE}", phases: ["run"], arguments: { command: { type: "string" } } }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const r = await ctx.shell(args.command)
+  return { code: r.exitCode, out: r.output.trim() }
+}
+`
+
+// Task 11b (depth-1 nesting): a parent workflow runs a DISCOVERED child workflow
+// inline via ctx.workflow under the SAME run (no second run row). The child's
+// logs are prefixed (`child: ...`) and its result flows back to the parent.
+const NEST_CHILD_FIXTURE = "child"
+const NEST_CHILD_WORKFLOW = `export const meta = { name: "${NEST_CHILD_FIXTURE}", description: "c" }
+export async function run(args, ctx) {
+  ctx.log("child-ran")
+  return { doubled: Number(args.n) * 2 }
+}
+`
+const NEST_PARENT_FIXTURE = "parent"
+const NEST_PARENT_WORKFLOW = `export const meta = { name: "${NEST_PARENT_FIXTURE}", description: "p" }
+export async function run(_a, ctx) {
+  const r = await ctx.workflow("child", { n: 21 })
+  return { fromChild: r.doubled }
+}
+`
+
+// Task 11b (phase restore): a child that sets its own phase must NOT leak it back
+// to the parent. The parent sets "plan", runs a child that sets "research", then
+// logs again — that final parent log must carry the parent's "plan" phase, not the
+// child's leftover "child-phase: research".
+const NEST_PHASE_CHILD_FIXTURE = "phase-child"
+const NEST_PHASE_CHILD_WORKFLOW = `export const meta = { name: "${NEST_PHASE_CHILD_FIXTURE}", description: "pc" }
+export async function run(args, ctx) {
+  ctx.setPhase("research")
+  ctx.log("inside-child")
+  return { ok: true }
+}
+`
+const NEST_PHASE_PARENT_FIXTURE = "phase-parent"
+const NEST_PHASE_PARENT_WORKFLOW = `export const meta = { name: "${NEST_PHASE_PARENT_FIXTURE}", description: "pp" }
+export async function run(_a, ctx) {
+  ctx.setPhase("plan")
+  await ctx.workflow("phase-child", {})
+  ctx.log("after-nested")
+  return { ok: true }
+}
+`
+
+// Task 11b (depth guard): a child that ITSELF calls ctx.workflow must be refused —
+// nesting is limited to depth 1, so the nested call throws a WorkflowInvalidError
+// and the run fails with that error.
+const NEST_GRANDCHILD_FIXTURE = "grandchild"
+const NEST_GRANDCHILD_WORKFLOW = `export const meta = { name: "${NEST_GRANDCHILD_FIXTURE}", description: "gc" }
+export async function run(args, ctx) { return { ok: true } }
+`
+const NEST_DEEP_CHILD_FIXTURE = "deep-child"
+const NEST_DEEP_CHILD_WORKFLOW = `export const meta = { name: "${NEST_DEEP_CHILD_FIXTURE}", description: "dc" }
+export async function run(args, ctx) {
+  // depth-2 attempt: this nested ctx.workflow must throw.
+  return await ctx.workflow("grandchild", {})
+}
+`
+const NEST_DEEP_PARENT_FIXTURE = "deep-parent"
+const NEST_DEEP_PARENT_WORKFLOW = `export const meta = { name: "${NEST_DEEP_PARENT_FIXTURE}", description: "dp" }
+export async function run(_a, ctx) {
+  return await ctx.workflow("deep-child", {})
+}
+`
+
+// Task 11b (c) (shared agent-lifetime cap): a parent that dispatches one agent and
+// then runs a child that dispatches more — collectively exceeding the run's
+// (test-lowered) agent-lifetime cap. The cap is shared via the SAME run, so the
+// over-cap dispatch (inside the child) fails the WHOLE run with AgentLimitError.
+const NEST_AGENT_CHILD_FIXTURE = "agent-child"
+const NEST_AGENT_CHILD_WORKFLOW = `export const meta = { name: "${NEST_AGENT_CHILD_FIXTURE}", description: "ac" }
+export async function run(args, ctx) {
+  for (let i = 0; i < args.count; i++) await ctx.agent({ prompt: "child step " + i })
+  return { ok: true }
+}
+`
+const NEST_AGENT_PARENT_FIXTURE = "agent-parent"
+const NEST_AGENT_PARENT_WORKFLOW = `export const meta = { name: "${NEST_AGENT_PARENT_FIXTURE}", description: "ap" }
+export async function run(_a, ctx) {
+  await ctx.agent({ prompt: "parent step" })
+  return await ctx.workflow("agent-child", { count: 10 })
+}
+`
+
+// Prompt-ops that resolve every agent prompt immediately (no hang), so the run
+// reaches `completed` and the child session is fully created/projected.
+function immediatePromptOps() {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: () => Effect.succeed(assistantReply()),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Capturing prompt-ops: resolve every agent prompt immediately (like
+// immediatePromptOps) but capture each real (non-noReply) PromptInput so a test
+// can assert on what the engine actually dispatched (e.g. its resolved `variant`
+// or `model`). The initial "Workflow started" noReply message is skipped so only
+// genuine ctx.agent dispatches are recorded. Named distinctly from the journal
+// `recordingPromptOps` below so the two never collide via function hoisting.
+function capturingPromptOps() {
+  const inputs: SessionPrompt.PromptInput[] = []
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.sync(() => {
+        if (!input.noReply) inputs.push(input)
+        return assistantReply()
+      }),
+    cancel: () => Effect.void,
+  }
+  return { ops, inputs }
+}
+
+// Directory-capturing prompt-ops: like capturingPromptOps, but for each real
+// (non-noReply) dispatch it ALSO records the EFFECTIVE instance directory the
+// prompt runs under (`InstanceState.directory`). This is the directory the
+// subagent's file tools (bash/edit/write/read) resolve their cwd against — so
+// recording it from INSIDE the prompt-op Effect proves whether worktree
+// isolation actually redirects the child (the assertion target for Task 11),
+// not merely that a worktree was created.
+function directoryCapturingPromptOps() {
+  const inputs: SessionPrompt.PromptInput[] = []
+  const directories: string[] = []
+  // Whether the captured directory contained a `.git` entry AT DISPATCH TIME
+  // (i.e. while the worktree was still live) — proving it was a real git
+  // worktree, observed before the run-scope finalizer removes it.
+  const wasGitWorktree: boolean[] = []
+  // The directory's permission bits (mode & 0o777) AT DISPATCH TIME — used by
+  // Finding 3 to prove the private worktree base is 0700, not world-readable.
+  const modes: number[] = []
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (!input.noReply) {
+          inputs.push(input)
+          const dir = yield* InstanceState.directory
+          directories.push(dir)
+          wasGitWorktree.push(
+            yield* Effect.promise(() =>
+              fs
+                .stat(path.join(dir, ".git"))
+                .then(() => true)
+                .catch(() => false),
+            ),
+          )
+          modes.push(
+            yield* Effect.promise(() =>
+              fs
+                .stat(dir)
+                .then((s) => s.mode & 0o777)
+                .catch(() => -1),
+            ),
+          )
+        }
+        return assistantReply()
+      }),
+    cancel: () => Effect.void,
+  }
+  return { ops, inputs, directories, wasGitWorktree, modes }
+}
+
+// Item 15: prompt-ops whose agent prompts FAIL (the noReply start banner still
+// succeeds so the run gets going). Drives the onError:"null" settlement.
+function failingPromptOps() {
+  const ops: Workflow.PromptOps = {
+    prompt: (input) => (input.noReply ? Effect.succeed(assistantReply()) : Effect.fail(new Error("boom"))),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Item 7: like directoryCapturingPromptOps, but each real dispatch ALSO writes
+// an (uncommitted) file into the effective directory — making an isolated
+// worktree DIRTY so the run finalizer must preserve it instead of removing it.
+function dirtyingPromptOps() {
+  const directories: string[] = []
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (!input.noReply) {
+          const dir = yield* InstanceState.directory
+          directories.push(dir)
+          yield* Effect.promise(() => fs.writeFile(path.join(dir, "UNCOMMITTED.txt"), "dirty"))
+        }
+        return assistantReply()
+      }),
+    cancel: () => Effect.void,
+  }
+  return { ops, directories }
+}
+
+// N11-Fixture: Der Body startet einen Agenten OHNE ihn zu awaiten (fire-and-
+// forget) — der hängende ctx.agent-Promise settelt nie vor Body-Ende — und
+// returnt sofort. Die Pause gibt dem dispatchten Agent-Fiber Zeit, seine
+// Child-Session zu erzeugen/registrieren und am hängenden Prompt zu blockieren,
+// BEVOR der Body zurückkehrt und der Run als `completed` finished. So bleibt ein
+// Agent-Node beim Terminal-Übergang noch `running` OHNE Autor-Fehlverhalten.
+//
+// Die Session-Erzeugung läuft als geforkter Fiber im run-Scope (asynchron, NACH
+// dem synchronen Node-Push). Unter Last (volle Suite parallel) kann ein zu
+// kurzes Fenster diesen Fiber verhungern lassen, bevor node.session_id gesetzt
+// ist — dann fände finish() den Node zwar noch `running`, aber ohne Session zum
+// Abbrechen, und die Session-Assertion des Tests flackerte. 400ms gibt dem Fork
+// auch unter Contention zuverlässig Zeit; der hängende Prompt (30s-Race im Fake)
+// stellt sicher, dass der Node beim Body-Ende dennoch `running` ist.
+const DETACHED_AGENT_FIXTURE = "detached-agent"
+const DETACHED_AGENT_WORKFLOW = `export const meta = { name: "${DETACHED_AGENT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  // Bewusst NICHT awaiten: der Promise hängt am Prompt, der Body returnt davor.
+  void ctx.agent({ prompt: "hang" }).catch(() => {})
+  await new Promise((resolve) => setTimeout(resolve, 400))
+  return { ok: true }
+}
+`
+
+// Fund 42-Fixtures: ein Workflow, der explizit `null` returnt, und einer, der
+// gar nichts returnt (undefined). Beide müssen den DB-Roundtrip unterscheidbar
+// überleben: null bleibt null, undefined bleibt undefined.
+const NULL_RESULT_FIXTURE = "null-result"
+const NULL_RESULT_WORKFLOW = `export const meta = { name: "${NULL_RESULT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) { ctx.setPhase("run"); return null }
+`
+const VOID_RESULT_FIXTURE = "void-result"
+const VOID_RESULT_WORKFLOW = `export const meta = { name: "${VOID_RESULT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) { ctx.setPhase("run") }
+`
+
+// A minimal single-phase, zero-agent workflow used by the bus-event test: it sets
+// the phase and returns a value, so the run goes running -> completed through the
+// same persistRun choke-point every state write uses — no provider stubbing needed.
+const EVENTS_FIXTURE = "events"
+const EVENTS_WORKFLOW = `export const meta = { name: "${EVENTS_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) { ctx.setPhase("run"); return { ok: true } }
+`
+
+// Finding 15: a fixture that dispatches TWO agents — one that COMPLETES (plaintext)
+// and one with a schema that FAILS (no structured output, caught by the body) — so
+// the run still ends `completed` but with a NON-trivial agents split: total 2,
+// failed 1, running 0. This makes the slim-payload `agents` COUNT object falsifiable
+// (the zero-agent EVENTS fixture could not distinguish a swapped running/failed
+// filter from the all-zero case).
+const EVENTS_AGENTS_FIXTURE = "events-agents"
+const EVENTS_AGENTS_WORKFLOW = `export const meta = { name: "${EVENTS_AGENTS_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "completes" })
+  try {
+    await ctx.agent({ prompt: "fails", schema: { type: "object" } })
+  } catch (e) {}
+  return { ok: true }
+}
+`
+
+// Finding 15 prompt-ops: a schema request (input.format set) returns a message
+// with NO structured output → the engine fails that node (failed). A plain request
+// returns a normal reply → that node completes. Net: one completed + one failed
+// agent node on a run the body still completes.
+function eventsAgentsPromptOps(db: Database.Interface["db"]) {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        const wantsSchema = input.format?.type === "json_schema"
+        const last = yield* persistTurns(db, input.sessionID, [
+          { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+        ])
+        // Schema agent: no `structured` → engine marks the node failed. Plain agent:
+        // a text part → node completes.
+        const parts = wantsSchema ? [] : [{ type: "text", text: "done" }]
+        return { info: last.info, parts } as unknown as SessionV1.WithParts
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// N2/N13-Fixture: ein Workflow, dessen Rückgabewert NICHT strukturell klonbar ist
+// (eine Funktion ist weder JSON-serialisierbar noch structuredClone-fähig). Der
+// frühere structuredClone-Snapshot warf hier (DOMException) und strandete jeden
+// no-timeout-wait() / verhinderte den Terminal-Persist. Der Engine normalisiert
+// das result jetzt über denselben JSON-Codec wie der Persist: Funktionen werden
+// (wie bei JSON.stringify) still verworfen, der Run schließt sauber ab, und
+// Live-Snapshot wie DB-Row tragen dieselbe (entfunktionalisierte) Form.
+const UNSERIALIZABLE_RESULT_FIXTURE = "unserializable-result"
+const UNSERIALIZABLE_RESULT_WORKFLOW = `export const meta = { name: "${UNSERIALIZABLE_RESULT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) { ctx.setPhase("run"); return { kept: 1, cb: () => {} } }
+`
+
+// N2/N13-Fixture: ein Workflow, dessen Rückgabewert eine ZIRKULÄRE Referenz hat —
+// JSON.stringify wirft darauf (TypeError). Der mit Effect.try abgesicherte
+// Normalisierungspfad muss den Run dennoch terminal abschließen und das result
+// auf den $unserializable-Platzhalter setzen, statt zu hängen.
+const CIRCULAR_RESULT_FIXTURE = "circular-result"
+const CIRCULAR_RESULT_WORKFLOW = `export const meta = { name: "${CIRCULAR_RESULT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) { ctx.setPhase("run"); const r = { a: 1 }; r.self = r; return r }
+`
+
+function assistantReply(): SessionV1.WithParts {
+  return { info: { role: "assistant" }, parts: [] } as unknown as SessionV1.WithParts
+}
+
+// Deterministic concurrency barrier shared with a workflow module's body.
+// `loadModule` imports the workflow into the SAME process, and Bun shares
+// `globalThis` across dynamically imported modules (verified), so a barrier
+// registered here under a unique token is reachable from the workflow body via
+// `globalThis.__workflowTestBarriers[token]`. Every task entering the barrier
+// bumps a live `active` counter (tracking `peak`) and then parks on a single
+// shared gate Promise until the test releases it. This replaces wall-clock
+// `setTimeout` windows (Fund 48): a task's overlap is observed by polling the
+// `active` counter for a CONDITION (e.g. "20 tasks parked"), never by sleeping a
+// fixed duration and hoping the tasks happened to overlap. The gate keeps every
+// in-flight task suspended until the test has observed the peak, so the measured
+// concurrency is exactly the engine's scheduling decision, not a timing artifact.
+type TestBarrier = {
+  active: number
+  peak: number
+  /** Resolves when the test releases the gate; tasks await this before exiting. */
+  gate: Promise<void>
+  release: () => void
+  /** Per-key ordered markers a task can push (used by the no-barrier pipeline proof). */
+  order: string[]
+}
+
+declare global {
+  // `var` (not `const`) is required for a writable global so the body and the
+  // test can assign `globalThis.__workflowTestBarriers`.
+  var __workflowTestBarriers: Record<string, TestBarrier> | undefined
+}
+
+// Installs a fresh barrier under a unique token and returns the token plus an
+// Effect that polls until at least `count` tasks are simultaneously parked on the
+// gate (the deterministic "tasks have overlapped" condition) and reports the peak.
+function installBarrier() {
+  const token = `barrier_${Math.random().toString(16).slice(2)}`
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const barrier: TestBarrier = { active: 0, peak: 0, gate, release, order: [] }
+  ;(globalThis.__workflowTestBarriers ??= {})[token] = barrier
+  return {
+    token,
+    barrier,
+    // Waits until `peak` has reached `count` (i.e. that many tasks have been
+    // simultaneously parked at the gate at some point), then yields the barrier.
+    awaitPeak: (count: number) =>
+      pollWithTimeout(
+        Effect.sync(() => (barrier.peak >= count ? barrier : undefined)),
+        `barrier never reached peak ${count}`,
+      ),
+    // Waits until an exact ordered marker has been recorded by a task.
+    awaitOrder: (marker: string) =>
+      pollWithTimeout(
+        Effect.sync(() => (barrier.order.includes(marker) ? barrier : undefined)),
+        `barrier never recorded order marker ${marker}`,
+      ),
+  }
+}
+
+// The body-side latch helper, inlined as source text into every barrier fixture
+// (the workflow module runs in its own import; it cannot import test helpers).
+// A task: bumps active/peak, parks on the gate, then decrements active on the way
+// out. `enter`/`leave` are split so a pipeline stage can record order between them.
+const BARRIER_PRELUDE = `
+  const __b = globalThis.__workflowTestBarriers[args.__barrier]
+  const __enter = () => { __b.active++; __b.peak = Math.max(__b.peak, __b.active) }
+  const __leave = () => { __b.active-- }
+  const __park = async () => { await __b.gate }
+`
+
+// Parallel barrier fixture: N tasks (count from args), each parks on the shared
+// gate so the test can observe the true peak concurrency deterministically. The
+// concurrencyLimit is passed through from args (omitted ⇒ engine default).
+const PARALLEL_BARRIER_FIXTURE = "parallel-barrier"
+const PARALLEL_BARRIER_WORKFLOW = `export const meta = { name: "${PARALLEL_BARRIER_FIXTURE}", phases: ["parallel"] }
+export async function run(args, ctx) {
+  ctx.setPhase("parallel")${BARRIER_PRELUDE}
+  const tasks = Array.from({ length: args.count }, (_, i) => async () => {
+    __enter()
+    await __park()
+    __leave()
+    return i
+  })
+  const options = args.concurrencyLimit === undefined ? undefined : { concurrencyLimit: args.concurrencyLimit }
+  const result = await ctx.parallel(tasks, options)
+  return { peak: __b.peak, result }
+}
+`
+
+// P1 (Claude parity): a rejecting task in ctx.parallel must NOT kill the whole
+// batch — it resolves to `null` at its position, the surviving tasks keep their
+// values, and the drop is LOGGED (never silent). Module uses `export default`
+// so the resolved-object load path is exercised too.
+const PARALLEL_ERROR_FIXTURE = "par-err"
+const PARALLEL_ERROR_WORKFLOW = `export default {
+  meta: { name: "${PARALLEL_ERROR_FIXTURE}", description: "parallel error tolerance" },
+  async run(_args, ctx) {
+    const out = await ctx.parallel([
+      () => Promise.resolve("ok-1"),
+      () => Promise.reject(new Error("boom")),
+      () => Promise.resolve("ok-3"),
+    ])
+    return { out }
+  },
+}
+`
+
+// P2 (Claude parity): a throwing stage in ctx.pipeline must NOT kill the whole
+// pipeline — it drops ONLY that item to `null` at its position and skips that
+// item's remaining stages, while the other items run every stage to completion;
+// the drop is LOGGED (never silent). Module uses `export default` so the
+// resolved-object load path is exercised too.
+const PIPELINE_ERROR_FIXTURE = "pipe-err"
+const PIPELINE_ERROR_WORKFLOW = `export default {
+  meta: { name: "${PIPELINE_ERROR_FIXTURE}", description: "pipeline per-item drop" },
+  async run(_args, ctx) {
+    const calls: string[] = []
+    const out = await ctx.pipeline(
+      [1, 2, 3],
+      async (prev) => { if (prev === 2) throw new Error("stage1-boom"); calls.push("s1:" + prev); return prev * 10 },
+      async (prev, item) => { calls.push("s2:" + item); return prev + 1 },
+    )
+    return { out, calls }
+  },
+}
+`
+
+// Item-cap fixtures (MAX_BATCH_ITEMS = 4096): trivial non-agent thunks/items so
+// the boundary tests stay fast. `count` is an argument so one fixture covers both
+// the rejection (4097) and the boundary (4096) case.
+const PARALLEL_CAP_FIXTURE = "par-cap"
+const PARALLEL_CAP_WORKFLOW = `export const meta = { name: "${PARALLEL_CAP_FIXTURE}", description: "parallel item cap", arguments: { count: { type: "number" } } }
+export async function run(args, ctx) {
+  const tasks = Array.from({ length: args.count }, (_, i) => () => Promise.resolve(i))
+  const out = await ctx.parallel(tasks)
+  return { length: out.length }
+}
+`
+const PIPELINE_CAP_FIXTURE = "pipe-cap"
+const PIPELINE_CAP_WORKFLOW = `export const meta = { name: "${PIPELINE_CAP_FIXTURE}", description: "pipeline item cap", arguments: { count: { type: "number" } } }
+export async function run(args, ctx) {
+  const items = Array.from({ length: args.count }, (_, i) => i)
+  const out = await ctx.pipeline(items, async (prev) => prev)
+  return { length: out.length }
+}
+`
+
+// Pipeline index fixtures (stage third parameter): stage 1 returns its `index`,
+// stage 2 proves it sees the SAME index for the item (prev === index from stage 1).
+const PIPELINE_INDEX_FIXTURE = "pipe-index"
+const PIPELINE_INDEX_WORKFLOW = `export const meta = { name: "${PIPELINE_INDEX_FIXTURE}", description: "pipeline stage index" }
+export async function run(_args, ctx) {
+  const out = await ctx.pipeline(
+    ["x", "y"],
+    async (_prev, _item, i) => i,
+    async (prev, _item, i) => ({ first: prev, second: i }),
+  )
+  return { out }
+}
+`
+// Duplicate items: the stage throws ONLY for the second occurrence (told apart by
+// index, the items are identical), so the drop log must name item 2 — the old
+// items.indexOf(item) logging always reported the FIRST occurrence (item 1).
+const PIPELINE_DUP_FIXTURE = "pipe-dup"
+const PIPELINE_DUP_WORKFLOW = `export const meta = { name: "${PIPELINE_DUP_FIXTURE}", description: "pipeline duplicate-item drop index" }
+export async function run(_args, ctx) {
+  const out = await ctx.pipeline(["a", "a"], async (prev, _item, i) => {
+    if (i === 1) throw new Error("dup-boom")
+    return prev
+  })
+  return { out }
+}
+`
+
+// Pipeline barrier fixture: N items, ONE stage that parks every item on the gate,
+// so the test can observe how many items run that stage concurrently (the
+// pipeline concurrency default / clamp).
+const PIPELINE_BARRIER_FIXTURE = "pipeline-barrier"
+const PIPELINE_BARRIER_WORKFLOW = `export const meta = { name: "${PIPELINE_BARRIER_FIXTURE}", phases: ["pipeline"] }
+export async function run(args, ctx) {
+  ctx.setPhase("pipeline")${BARRIER_PRELUDE}
+  const items = Array.from({ length: args.count }, (_, i) => i)
+  const stage = async (item) => { __enter(); await __park(); __leave(); return item }
+  // Pass the options object ONLY when a limit is set: the engine treats a trailing
+  // object as { concurrencyLimit }, so a trailing undefined would be parsed as a
+  // (missing) stage. No-options ⇒ pipeline runs items unbounded.
+  const result = args.concurrencyLimit === undefined
+    ? await ctx.pipeline(items, stage)
+    : await ctx.pipeline(items, stage, { concurrencyLimit: args.concurrencyLimit })
+  return { peak: __b.peak, result }
+}
+`
+
+// No-barrier pipeline ordering fixture (deterministic replacement for the
+// setTimeout-based PIPELINE_WORKFLOW ordering proof, Fund 48): item "A" parks in
+// stage 1 on the shared gate; item "B" passes stage 1 unparked and records that it
+// REACHED stage 2 while A is still held in stage 1. Stage 2 also changes the type
+// (string -> { a, b }), proving heterogeneous stages. The test waits for B's
+// stage-2 marker (a condition, no wall clock) BEFORE releasing A, so the ordering
+// claim "B reaches stage 2 before A leaves stage 1" is guaranteed, not timed.
+const PIPELINE_ORDER_FIXTURE = "pipeline-order"
+const PIPELINE_ORDER_WORKFLOW = `export const meta = { name: "${PIPELINE_ORDER_FIXTURE}", phases: ["pipeline"] }
+export async function run(args, ctx) {
+  ctx.setPhase("pipeline")${BARRIER_PRELUDE}
+  const result = await ctx.pipeline(
+    ["A", "B"],
+    async (item) => {
+      __b.order.push(item + ":stage1:start")
+      // Item A is held in stage 1 on the gate until the test releases it; item B
+      // proceeds immediately, so B can reach stage 2 before A leaves stage 1.
+      if (item === "A") await __park()
+      __b.order.push(item + ":stage1:done")
+      return { item, n: item === "A" ? 1 : 2 }
+    },
+    async (prev, item) => {
+      __b.order.push(item + ":stage2")
+      return { a: prev.n, b: prev.item === "A" ? "x" : "y" }
+    },
+  )
+  return { order: __b.order, result }
+}
+`
+
+// Telemetry shape of a single assistant turn — exactly the fields the engine reads
+// off a persisted assistant message when it sums per-agent cost/tokens.
+type AssistantTurn = {
+  cost: number
+  tokens: { total?: number; input: number; output: number; reasoning: number; cache: { read: number; write: number } }
+  structured?: unknown
+  error?: unknown
+}
+
+// Faithfully mirrors the production session layer: SessionPrompt.runLoop is a
+// while(true) loop that PERSISTS one assistant message per turn (queryable via
+// Session.messages) and RETURNS only the last one. The prompt fakes are given the
+// engine's child sessionID, so they write each turn into the SAME MessageTable the
+// engine's `sessions.messages(sessionID)` sum reads from, then resolve with a
+// WithParts carrying the LAST turn's info (the engine still uses that single
+// message for message_id / output / abort + structured-output detection). A fake
+// with a single turn persists exactly one row ⇒ the summed result equals that row,
+// identical to the previous single-message behaviour. The captured Database.Service
+// is the same in-memory connection the engine uses (memoised in the merged layer).
+function persistTurns(db: Database.Interface["db"], sessionID: string, turns: AssistantTurn[]) {
+  return Effect.gen(function* () {
+    let last: SessionV1.WithParts | undefined
+    for (const turn of turns) {
+      const id = MessageID.ascending()
+      const data = {
+        role: "assistant",
+        providerID: "test",
+        modelID: "test-model",
+        cost: turn.cost,
+        tokens: turn.tokens,
+        ...("structured" in turn ? { structured: turn.structured } : {}),
+        ...(turn.error ? { error: turn.error } : {}),
+      }
+      yield* db
+        .insert(MessageTable)
+        .values({
+          id,
+          session_id: sessionID,
+          time_created: Date.now(),
+          time_updated: Date.now(),
+          data,
+        } as unknown as typeof MessageTable.$inferInsert)
+        .run()
+        .pipe(Effect.orDie)
+      last = {
+        info: { id, sessionID, ...data },
+        parts: [{ type: "text", text: "ok" }],
+      } as unknown as SessionV1.WithParts
+    }
+    return last!
+  })
+}
+
+// Startup-Fenster-Fixture: schreibt eine Marker-Datei, SOBALD der Body läuft.
+// Wird der Run im Startup-Fenster (vor dem Body-Fork) gecancelt, darf dieser
+// Marker NIE erscheinen — der Body läuft dann nie.
+const STARTUP_FIXTURE = "startup-window"
+function startupWorkflow(markerPath: string) {
+  return `export const meta = { name: "${STARTUP_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  await Bun.write(${JSON.stringify(markerPath)}, "body-ran")
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "hang" })
+  return { ok: true }
+}
+`
+}
+
+// Parallel-Hang-Fixture: drei parallele Agent-Tasks, jede startet einen Agenten
+// (eigene Child-Session). Ein vierter, SEQUENTIELLER Step nach dem Batch
+// schreibt einen Marker, der bei korrektem Cancel nie laufen darf.
+const PARALLEL_HANG_FIXTURE = "parallel-hang"
+const PARALLEL_HANG_MARKER = "parallel-after-reached"
+const PARALLEL_HANG_WORKFLOW = `export const meta = { name: "${PARALLEL_HANG_FIXTURE}", phases: ["fan-out", "after"] }
+export async function run(args, ctx) {
+  ctx.setPhase("fan-out")
+  ctx.log("fan-out-started")
+  await ctx.parallel([
+    () => ctx.agent({ prompt: "task A" }),
+    () => ctx.agent({ prompt: "task B" }),
+    () => ctx.agent({ prompt: "task C" }),
+  ])
+  ctx.setPhase("after")
+  ctx.log("${PARALLEL_HANG_MARKER}")
+  return { ok: true }
+}
+`
+
+// Test-Prompt-Ops, die das echte Session-Abort-Verhalten nachbilden:
+// - die initiale "Workflow started"-Nachricht (noReply) wird sofort beantwortet,
+//   damit start() zurückkehrt;
+// - jeder Agent-Prompt blockiert (langer, unterbrechbarer Lauf), bis cancel()
+//   die Session abbricht; cancel() protokolliert die abgebrochene Child-Session
+//   und unterbricht den laufenden Prompt (wie SessionPrompt.cancel -> Abort).
+function hangingPromptOps() {
+  const aborted = new Set<string>()
+  const started = new Set<string>()
+  const gates = new Map<string, Deferred.Deferred<void>>()
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        const gate = yield* Deferred.make<void>()
+        gates.set(input.sessionID, gate)
+        started.add(input.sessionID)
+        // Läuft, bis die Session per cancel() abgebrochen wird (Gate -> Interrupt)
+        // oder der lange Lauf endet. Der Timer hält die Suspension unterbrechbar.
+        yield* Effect.race(
+          Effect.sleep("30 seconds"),
+          Deferred.await(gate).pipe(Effect.flatMap(() => Effect.interrupt)),
+        )
+        return assistantReply()
+      }),
+    cancel: (sessionID) =>
+      Effect.gen(function* () {
+        aborted.add(sessionID)
+        const gate = gates.get(sessionID)
+        if (gate) yield* Deferred.succeed(gate, undefined)
+      }),
+  }
+  return { ops, aborted, started }
+}
+
+// Resolve-on-abort-Prompt-Ops: bilden den ECHTEN Produktions-Runner nach.
+// Wird eine laufende Agent-Session abgebrochen (cancel -> Abort), RESOLVED der
+// Prompt mit dem letzten Assistant-Stand (eine WithParts, deren info.error ein
+// abgebrochenes Ergebnis markiert) — er REJECTED NICHT. Genau dieses Verhalten
+// (session/prompt.ts: Effect.onInterrupt -> lastAssistant) ist der Kern mehrerer
+// Cancel-Bugs: die Erfolgsverzweigung der Settlement-Callbacks lief sonst und
+// flippte cancelled->completed.
+//
+// `delayMs` verzögert die Beantwortung der initialen noReply-Nachricht, damit
+// Tests im Startup-Fenster (vor dem Body-Fork) cancellen können.
+function resolveOnAbortPromptOps(options?: { delayMs?: number }) {
+  const aborted = new Set<string>()
+  const started = new Set<string>()
+  const gates = new Map<string, Deferred.Deferred<void>>()
+  const abortedReply = (): SessionV1.WithParts =>
+    ({
+      info: { role: "assistant", error: { name: "MessageAbortedError", data: {} } },
+      parts: [],
+    }) as unknown as SessionV1.WithParts
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) {
+          if (options?.delayMs) yield* Effect.sleep(options.delayMs)
+          return assistantReply()
+        }
+        const gate = yield* Deferred.make<void>()
+        gates.set(input.sessionID, gate)
+        started.add(input.sessionID)
+        // Race: entweder der lange Lauf endet, oder cancel() öffnet das Gate ->
+        // der Prompt RESOLVED (nicht interrupt!) mit dem abort-Assistant-Stand,
+        // wie der echte Runner. Der Timer hält die Suspension unterbrechbar, so
+        // dass ein Scope-Close die Session-Fiber dennoch hart interrupten kann.
+        return yield* Effect.race(
+          Effect.sleep("30 seconds").pipe(Effect.map(() => assistantReply())),
+          Deferred.await(gate).pipe(Effect.map(() => abortedReply())),
+        )
+      }),
+    cancel: (sessionID) =>
+      Effect.gen(function* () {
+        aborted.add(sessionID)
+        const gate = gates.get(sessionID)
+        if (gate) yield* Deferred.succeed(gate, undefined)
+      }),
+  }
+  return { ops, aborted, started }
+}
+
+// N13-Fixture (tokens-Alias): der Agent-Prompt RESOLVED sofort mit echter
+// Token-Telemetrie (nicht-null, damit eine Mutation beobachtbar ist), so dass
+// der Engine den Node mit `tokens`/`cache` befüllt. Danach hält der Body den Run
+// LIVE (langer, unterbrechbarer Timer), so dass get() einen Live-Snapshot liefert
+// (nicht den fromRow-Pfad nach der N1-Eviction). cancel() bricht den Timer ab.
+function tokensPromptOps(db: Database.Interface["db"]) {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        return yield* persistTurns(db, input.sessionID, [
+          { cost: 0, tokens: { input: 11, output: 22, reasoning: 0, cache: { read: 33, write: 44 } } },
+        ])
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Body: ein Agent-Step (setzt tokens) und danach ein langer Timer, der den Run
+// LIVE in der Registry hält, bis der Test cancelt.
+const AGENT_THEN_HANG_FIXTURE = "agent-then-hang"
+const AGENT_THEN_HANG_WORKFLOW = `export const meta = { name: "${AGENT_THEN_HANG_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "produce tokens" })
+  await new Promise((resolve) => setTimeout(resolve, 30000))
+  return { ok: true }
+}
+`
+
+// Schema-Fixtures: Workflows, deren run(ctx) den Agenten MIT Schema aufruft
+// (strukturierte Ausgabe angefordert). Der Promtp-Ops-Fake (unten) steuert, ob
+// die Session strukturierte Daten, undefined oder einen StructuredOutputError
+// liefert. Jeder gibt das geparste Objekt im Ergebnis zurück, damit der
+// Positivpfad das Objekt durchreichen kann.
+const SCHEMA_SUCCESS_FIXTURE = "schema-success"
+const SCHEMA_UNDEFINED_FIXTURE = "schema-undefined"
+const SCHEMA_FAILING_FIXTURE = "schema-failing"
+const SCHEMA_OBJECT = { value: 123 }
+
+function schemaWorkflow(name: string) {
+  return `export const meta = { name: "${name}", phases: ["agent"] }
+export async function run(args, ctx) {
+  ctx.setPhase("agent")
+  const result = await ctx.agent({ prompt: "produce structured", schema: { type: "object" } })
+  return { data: result.data }
+}
+`
+}
+
+// Prompt-Ops-Fake, der die SESSION-Schicht nachbildet (nicht die Engine): die
+// initiale noReply-Nachricht wird sofort beantwortet; der Agent-Prompt liefert
+// eine Assistant-Nachricht, deren `structured`/`error`-Feld der Modus bestimmt:
+// - "structured": message.info.structured ist gesetzt (Erfolgspfad);
+// - "undefined": structured fehlt trotz angefordertem Schema (stiller Fallback,
+//   der jetzt scheitern muss);
+// - "error": die Session hat einen StructuredOutputError auf message.info.error
+//   gesetzt (genau wie packages/opencode/src/session/prompt.ts es tut), gibt aber
+//   weiterhin erfolgreich eine WithParts zurück.
+// `cost` mirrors the real telemetry (`message.info.cost`, USD) so a step that
+// FAILS structured-output can still report what it actually cost — exactly the
+// failed-but-paid case the budget must charge for. Defaults to 0 to leave the
+// existing structured-output callers unchanged.
+function structuredPromptOps(db: Database.Interface["db"], mode: "structured" | "undefined" | "error", cost = 0) {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        const turn: AssistantTurn = {
+          cost,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        }
+        if (mode === "structured") turn.structured = SCHEMA_OBJECT
+        if (mode === "error")
+          turn.error = {
+            name: "StructuredOutputError",
+            data: { message: "Model did not produce structured output", retries: 0 },
+          }
+        const last = yield* persistTurns(db, input.sessionID, [turn])
+        const parts = mode === "undefined" || mode === "error" ? [{ type: "text", text: "here is some plaintext" }] : []
+        return { info: last.info, parts } as unknown as SessionV1.WithParts
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Budget-Fixtures. Der Engine liest die Agent-Kosten aus `message.info.cost`
+// (USD) — exakt wie der echte Session-Pfad und das TUI-Dashboard. Dieser Fake
+// bildet GENAU diese Telemetrie-Form nach: jede beantwortete Agent-Nachricht
+// trägt `cost` (und `tokens`, wie die echte Session), sodass der Engine pro
+// Step das Restbudget korrekt dekrementieren kann.
+function costPromptOps(db: Database.Interface["db"], cost: number) {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        return yield* persistTurns(db, input.sessionID, [
+          { cost, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+        ])
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Item 17: prompt-ops whose telemetry carries TOKENS (with deliberately non-zero
+// input/cache numbers, which must NOT count toward the token budget — only
+// output + reasoning do). Cost stays 0 so the USD path is provably untouched.
+// (Distinct from the aliasing-test `tokensPromptOps` above, which pins a fixed
+// token shape — this one parameterizes the budget-relevant output/reasoning.)
+function tokenBudgetPromptOps(db: Database.Interface["db"], output: number, reasoning = 0) {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        return yield* persistTurns(db, input.sessionID, [
+          { cost: 0, tokens: { input: 11, output, reasoning, cache: { read: 7, write: 3 } } },
+        ])
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Finding 2 fake: an externally-aborted subagent. The prompt RESOLVES (does not
+// reject) with an abort-marked assistant message that ALSO carries a real cost —
+// exactly what the production runner returns when a child session is aborted out
+// of band (POST /session/:id/abort, internal session timeout) while the workflow
+// run itself is NOT cancelling/pausing/removed. The cost is persisted into the
+// MessageTable (where the engine's per-session cost sum reads from) so the abort
+// artifact carries a charge, and the returned WithParts is abort-marked
+// (MessageAbortedError) so `isAbortedMessage` fires with no run-level flag set.
+// No cancel() is wired — the abort is purely message-level.
+function abortedCostPromptOps(db: Database.Interface["db"], cost: number) {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        return yield* persistTurns(db, input.sessionID, [
+          {
+            cost,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            error: { name: "MessageAbortedError", data: {} },
+          },
+        ])
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Multi-turn fake (Fund N12): a SINGLE ctx.agent step whose underlying session
+// runs several provider turns (the normal case when the subagent uses tools),
+// each persisting its own assistant message with its own cost/tokens. Production
+// returns only the LAST turn, so charging that one alone discards every
+// intermediate turn. The engine must instead sum cost/tokens across ALL persisted
+// assistant messages of the child session.
+function multiTurnPromptOps(db: Database.Interface["db"], turns: AssistantTurn[]) {
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        return yield* persistTurns(db, input.sessionID, turns)
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Fund 23 (budget soft-cap under parallelism): prompt-ops that hold EVERY agent
+// prompt at a shared latch until `expected` prompts have arrived, then resolve all
+// of them with the given per-step `cost`. The engine checks the budget gate at the
+// TOP of `ctx.agent`, BEFORE calling the prompt — so by the time a prompt arrives
+// here its step has already passed the gate. Gating the resolution until all
+// `expected` prompts have arrived therefore GUARANTEES, deterministically (a
+// Deferred barrier, not a timing window), that all parallel in-flight steps passed
+// the gate while the budget was still positive. They then all settle and charge,
+// documenting the best-effort overspend. Returns the latch arrival promise so the
+// test can also await the barrier shape if needed.
+function budgetBarrierPromptOps(db: Database.Interface["db"], cost: number, expected: number) {
+  const gates: Deferred.Deferred<void>[] = []
+  let arrived = 0
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        // Park until all `expected` parallel prompts have arrived: each opens its
+        // own gate, and the LAST arrival releases every gate at once.
+        const gate = yield* Deferred.make<void>()
+        gates.push(gate)
+        arrived += 1
+        if (arrived >= expected) for (const g of gates) yield* Deferred.succeed(g, undefined)
+        yield* Deferred.await(gate)
+        return yield* persistTurns(db, input.sessionID, [
+          { cost, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+        ])
+      }),
+    cancel: () => Effect.void,
+  }
+  return ops
+}
+
+// Fund 23: N parallel agent steps, then a SEQUENTIAL step after the batch. With a
+// budget that each parallel step's cost overshoots in aggregate, all N parallel
+// steps pass the gate (budget still positive when each is checked) and all are
+// charged — the documented soft-cap overspend. The follow-up sequential step then
+// hits an exhausted budget and fails. The workflow catches that failure and reports
+// how far the budget was overspent and that the post-batch step did NOT run.
+const BUDGET_PARALLEL_FIXTURE = "budget-parallel"
+const BUDGET_PARALLEL_WORKFLOW = `export const meta = { name: "${BUDGET_PARALLEL_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const tasks = Array.from({ length: args.count }, (_, i) => () => ctx.agent({ prompt: "parallel " + i }))
+  await ctx.parallel(tasks)
+  const overspent = ctx.budgetRemaining
+  let nextStarted = false
+  let nextFailed = false
+  try {
+    nextStarted = true
+    await ctx.agent({ prompt: "after the batch" })
+  } catch (e) {
+    nextFailed = true
+  }
+  return { overspent, nextStarted, nextFailed }
+}
+`
+
+// Zwei sequentielle ctx.agent-Aufrufe; bei kleinem Budget muss der zweite
+// Aufruf am Budget-Gate scheitern (Restbudget <= 0 nach dem ersten Step).
+const BUDGET_FIXTURE = "budget-two-steps"
+const BUDGET_WORKFLOW = `export const meta = { name: "${BUDGET_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.agent({ prompt: "step one" })
+  await ctx.agent({ prompt: "step two" })
+  return { ok: true }
+}
+`
+
+// Item 24 (Turn-Pool): zwei PARALLELE Steps gegen einen Pool mit Headroom für
+// genau einen (gepreiste Reservierung via vorab gesettletem Step). Die
+// synchrone Check-and-Set-Reservierung lässt exakt EINEN passieren — der
+// andere wird VOR der Node-Erzeugung refused (kein Soft-Cap-Overspend mehr).
+const POOL_PARALLEL_FIXTURE = "pool-parallel"
+const POOL_PARALLEL_WORKFLOW = `export const meta = { name: "${POOL_PARALLEL_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  await ctx.parallel([
+    () => ctx.agent({ prompt: "pool A" }),
+    () => ctx.agent({ prompt: "pool B" }),
+  ])
+  return { ok: true }
+}
+`
+
+// Item 24: macht die ctx.budget-Pool-Sicht beobachtbar (total/spent vor und
+// nach einem Step plus remaining) — ohne Run-Budget leitet sie aus dem Pool ab.
+const POOL_SPENT_FIXTURE = "pool-spent"
+const POOL_SPENT_WORKFLOW = `export const meta = { name: "${POOL_SPENT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const before = ctx.budget.spent()
+  const total = ctx.budget.total
+  await ctx.agent({ prompt: "spend" })
+  return { before, total, after: ctx.budget.spent(), remaining: ctx.budget.remaining() }
+}
+`
+
+// Schreibt ctx.budgetRemaining vor und nach einem Agent-Step ins Resultat,
+// damit der Test die Live-Dekrementierung beobachten kann.
+const BUDGET_REMAINING_FIXTURE = "budget-remaining"
+const BUDGET_REMAINING_WORKFLOW = `export const meta = { name: "${BUDGET_REMAINING_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const before = ctx.budgetRemaining
+  await ctx.agent({ prompt: "spend" })
+  const after = ctx.budgetRemaining
+  return { before, after }
+}
+`
+
+// Liest ctx.budgetRemaining OHNE gesetztes Budget — muss Infinity sein.
+const BUDGET_UNLIMITED_FIXTURE = "budget-unlimited"
+const BUDGET_UNLIMITED_WORKFLOW = `export const meta = { name: "${BUDGET_UNLIMITED_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const remaining = ctx.budgetRemaining
+  await ctx.agent({ prompt: "spend" })
+  return { unlimited: remaining === Infinity }
+}
+`
+
+// Failed-but-paid-Fixture: ein Agent MIT Schema, der scheitert (kein
+// strukturiertes Ergebnis), aber laut Telemetrie echte Kosten verursacht hat.
+// Der Workflow fängt den Fehler ab und gibt das Restbudget zurück, damit der
+// Test beweisen kann, dass das Budget TROTZ des Fehlers belastet wurde.
+const BUDGET_FAILED_PAID_FIXTURE = "budget-failed-paid"
+const BUDGET_FAILED_PAID_WORKFLOW = `export const meta = { name: "${BUDGET_FAILED_PAID_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  let failed = false
+  try {
+    await ctx.agent({ prompt: "produce structured", schema: { type: "object" } })
+  } catch (e) {
+    failed = true
+  }
+  return { failed, remaining: ctx.budgetRemaining }
+}
+`
+
+// ctx.budget (Claude-Code-Parität) MIT gesetztem Budget: liest total/spent()/
+// remaining() OHNE Agent-Step, sodass spent()===0 und remaining()===total gilt.
+const BUDGET_API_FIXTURE = "budget-api"
+const BUDGET_API_WORKFLOW = `export const meta = { name: "${BUDGET_API_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  return { total: ctx.budget.total, spent: ctx.budget.spent(), remaining: ctx.budget.remaining() }
+}
+`
+
+// ctx.budget OHNE Budget: total ist null und remaining() ist Infinity. Infinity
+// überlebt JSON nicht, daher gibt das Fixture stattdessen einen Booleschen zurück.
+const BUDGET_API_UNLIMITED_FIXTURE = "budget-api-unlimited"
+const BUDGET_API_UNLIMITED_WORKFLOW = `export const meta = { name: "${BUDGET_API_UNLIMITED_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  return { total: ctx.budget.total, remainingFinite: Number.isFinite(ctx.budget.remaining()) }
+}
+`
+
+// Item 17: ctx.budget token trio MIT Token-Budget — liest tokensTotal/
+// tokensSpent()/tokensRemaining() vor und nach einem Agent-Step, damit der Test
+// die Live-Verbuchung (output+reasoning, NICHT input/cache) beobachten kann.
+const TOKEN_API_FIXTURE = "token-budget-api"
+const TOKEN_API_WORKFLOW = `export const meta = { name: "${TOKEN_API_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const beforeSpent = ctx.budget.tokensSpent()
+  const beforeRemaining = ctx.budget.tokensRemaining()
+  await ctx.agent({ prompt: "spend tokens" })
+  return {
+    total: ctx.budget.tokensTotal,
+    beforeSpent,
+    beforeRemaining,
+    afterSpent: ctx.budget.tokensSpent(),
+    afterRemaining: ctx.budget.tokensRemaining(),
+  }
+}
+`
+
+// Item 17: ohne Token-Budget ist tokensTotal null und tokensRemaining()
+// Infinity (nicht endlich; Boolean wegen JSON).
+const TOKEN_API_UNLIMITED_FIXTURE = "token-budget-unlimited"
+const TOKEN_API_UNLIMITED_WORKFLOW = `export const meta = { name: "${TOKEN_API_UNLIMITED_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  return { tokensTotal: ctx.budget.tokensTotal, remainingFinite: Number.isFinite(ctx.budget.tokensRemaining()) }
+}
+`
+
+// Fund 18/19/20 (Argument-Koerzierung & Defaults): ein Workflow, der die
+// deklarierten args UND deren JS-Laufzeittypen 1:1 ins Resultat zurückgibt.
+// Über `typeof` kann der Test beweisen, dass die Engine String-eingehende args
+// (z. B. JSON-args über HTTP) gemäß dem deklarierten `type` koerziert hat, bevor
+// `run` sie sieht — und dass nicht deklarierte args unverändert durchgereicht
+// werden.
+const COERCE_FIXTURE = "coerce-args"
+const COERCE_WORKFLOW = `export const meta = {
+  name: "${COERCE_FIXTURE}",
+  arguments: {
+    count: { type: "number" },
+    flag: { type: "boolean" },
+    label: { type: "string" },
+    bare: {},
+  },
+}
+export async function run(args, ctx) {
+  return {
+    count: args.count,
+    countType: typeof args.count,
+    flag: args.flag,
+    flagType: typeof args.flag,
+    label: args.label,
+    labelType: typeof args.label,
+    bare: args.bare,
+    bareType: typeof args.bare,
+  }
+}
+`
+
+// Fund 20 (Defaults): deklarierte Defaults für jeden Typ. Werden die args nicht
+// übergeben, MUSS run() den (typ-korrekten) Default sehen; ein explizit
+// übergebener Wert gewinnt über den Default.
+const DEFAULT_FIXTURE = "default-args"
+const DEFAULT_WORKFLOW = `export const meta = {
+  name: "${DEFAULT_FIXTURE}",
+  arguments: {
+    name: { type: "string", default: "x" },
+    count: { type: "number", default: 7 },
+    flag: { type: "boolean", default: true },
+  },
+}
+export async function run(args, ctx) {
+  return {
+    name: args.name,
+    nameType: typeof args.name,
+    count: args.count,
+    countType: typeof args.count,
+    flag: args.flag,
+    flagType: typeof args.flag,
+  }
+}
+`
+
+// Review-Fund 3i.3 (LOW): ein deklarierter Default wird selbst durch den
+// Koerzierungspfad geschickt, bevor er run() erreicht. Ein STRING-Default "7"
+// für ein number-Argument muss run() als die Zahl 7 erreichen — nicht als der
+// rohe String "7". Bewusst getrennt von DEFAULT_WORKFLOW (dessen Default schon
+// die Zahl 7 ist und den rohen Durchschlupf daher NICHT aufdecken würde).
+const STRING_DEFAULT_FIXTURE = "string-default-args"
+const STRING_DEFAULT_WORKFLOW = `export const meta = {
+  name: "${STRING_DEFAULT_FIXTURE}",
+  arguments: {
+    count: { type: "number", default: "7" },
+    flag: { type: "boolean", default: "true" },
+  },
+}
+export async function run(args, ctx) {
+  return {
+    count: args.count,
+    countType: typeof args.count,
+    flag: args.flag,
+    flagType: typeof args.flag,
+  }
+}
+`
+
+// Track B — Cap-Fixture: N parallele ctx.agent-Aufrufe, jeder am Barrier-Gate
+// geparkt (über die Prompt-Ops, nicht im Body), damit der Test den ECHTEN Peak
+// gleichzeitig laufender Agent-Dispatches misst. Die Run-weite Semaphore deckelt
+// diesen Peak auf min(16, max(2, cpus-2)). Anders als PARALLEL_BARRIER (das
+// schlichte Tasks parkt und so NUR die parallel-Concurrency misst), parkt diese
+// Fixture innerhalb von ctx.agent — genau der Pfad, den die Semaphore deckelt.
+const AGENT_CAP_FIXTURE = "agent-cap"
+const AGENT_CAP_WORKFLOW = `export const meta = { name: "${AGENT_CAP_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const tasks = Array.from({ length: args.count }, (_, i) => () => ctx.agent({ prompt: "cap " + i }))
+  const result = await ctx.parallel(tasks, { concurrencyLimit: args.count })
+  return { result: result.length }
+}
+`
+
+// Lifetime-Fixture: ruft ctx.agent in einer Schleife N-mal SEQUENTIELL auf, fängt
+// einen geworfenen Fehler ab und meldet, wie viele Aufrufe gelangen, bevor das
+// Lifetime-Limit zugeschlagen hat.
+const LIFETIME_FIXTURE = "agent-lifetime"
+const LIFETIME_WORKFLOW = `export const meta = { name: "${LIFETIME_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  for (let i = 0; i < args.count; i++) {
+    await ctx.agent({ prompt: "step " + i })
+  }
+  return { ok: true }
+}
+`
+
+// Pause-Fixture: ein Agent-Step, der am Gate hängt (über hangingPromptOps), danach
+// ein zweiter Step, der bei korrekter Pause NIE läuft (PAUSE_AFTER_MARKER).
+const PAUSE_FIXTURE = "pause-hang"
+const PAUSE_AFTER_MARKER = "pause-after-reached"
+const PAUSE_WORKFLOW = `export const meta = { name: "${PAUSE_FIXTURE}", phases: ["run", "after"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  ctx.log("pause-started")
+  await ctx.agent({ prompt: "hang" })
+  ctx.setPhase("after")
+  ctx.log("${PAUSE_AFTER_MARKER}")
+  return { ok: true }
+}
+`
+
+// Resume-Fixture: zwei sequentielle ctx.agent-Aufrufe (A, dann B). Beim ersten
+// Lauf wird A completed, B durch die Pause unterbrochen. Beim Resume muss A aus
+// dem Journal kommen (KEIN neuer Prompt), B live laufen. Der Body gibt beide
+// Outputs zurück, damit der Test die Werte prüfen kann.
+const RESUME_FIXTURE = "resume-two-agents"
+const RESUME_WORKFLOW = `export const meta = { name: "${RESUME_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.agent({ prompt: "agent A" })
+  const b = await ctx.agent({ prompt: "agent B" })
+  return { a: a.text, b: b.text }
+}
+`
+
+// Occurrence-Fixture: ZWEI identische Prompts hintereinander. Beim Resume müssen
+// beide getrennt aus dem Journal aufgelöst werden (Occurrence-Index), nicht beide
+// auf denselben Journal-Eintrag.
+const RESUME_DUP_FIXTURE = "resume-dup-prompts"
+const RESUME_DUP_WORKFLOW = `export const meta = { name: "${RESUME_DUP_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const first = await ctx.agent({ prompt: "same prompt" })
+  const second = await ctx.agent({ prompt: "same prompt" })
+  return { first: first.text, second: second.text }
+}
+`
+
+// Item 20 (prefix-Replay): drei sequentielle Agenten. Mit invalidate_agents:[0]
+// bricht der Präfix im Default-Modus ab Index 0 DAUERHAFT — B und C laufen
+// ebenfalls live, obwohl sie unverändert sind (Original-Semantik). Im keyed-
+// Modus cachen B/C trotz des Invalidates (Shape-Match).
+const PREFIX_FIXTURE = "prefix-three-agents"
+const PREFIX_WORKFLOW = `export const meta = { name: "${PREFIX_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.agent({ prompt: "agent A" })
+  const b = await ctx.agent({ prompt: "agent B" })
+  const c = await ctx.agent({ prompt: "agent C" })
+  return { a: a.text, b: b.text, c: c.text }
+}
+`
+
+// Item 20 (Schema-Drift bricht den Präfix dauerhaft): V1 hat einen Plaintext-
+// Agenten plus einen unveränderten zweiten Agenten; V2 fordert für Call 1 ein
+// Schema an. Der Parse-Fehler am Plaintext-Journal-Node bricht im prefix-Modus
+// den Präfix — der UNVERÄNDERTE Call 2 läuft ebenfalls live. Im keyed-Modus
+// bleibt Call 2 gecacht (Shape-Match, per-Call-MISS für den Drift).
+const DRIFT2_FIXTURE = "resume-schema-drift-two"
+const DRIFT2_WORKFLOW_PLAINTEXT = `export const meta = { name: "${DRIFT2_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const r = await ctx.agent({ prompt: "drift agent" })
+  const s = await ctx.agent({ prompt: "stable agent" })
+  return { value: r.text, stable: s.text }
+}
+`
+const DRIFT2_WORKFLOW_SCHEMA = `export const meta = { name: "${DRIFT2_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const r = await ctx.agent({ prompt: "drift agent", schema: { type: "object" } })
+  const s = await ctx.agent({ prompt: "stable agent" })
+  return { value: r.data, stable: s.text }
+}
+`
+
+// Drift-Fixture (Fund: ungeschütztes JSON.parse auf einem Plaintext-Journal-Node).
+// Der Journal-Key ist NUR { prompt, agent, phase } — das Schema gehört NICHT dazu.
+// Eine V1-Datei mit einem PLAINTEXT-Agenten (kein Schema) erzeugt einen Journal-
+// Node, dessen output kein gültiges JSON ist. Wird die SELBE Datei (gleicher Name
+// → gleiche path/journalKey) zwischen Lauf und Resume zu V2 überschrieben — jetzt
+// fordert derselbe Agent-Call ein Schema an — matcht der Plaintext-Node die Schema-
+// Anfrage. Das alte JSON.parse(cached.output) würde synchron werfen (Defect). Der
+// Resume MUSS das stattdessen als Cache-MISS behandeln und den Agenten LIVE laufen
+// lassen. Beide Versionen teilen Name/Phase/Prompt, damit der Key identisch ist.
+const DRIFT_FIXTURE = "resume-schema-drift"
+const DRIFT_WORKFLOW_PLAINTEXT = `export const meta = { name: "${DRIFT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const r = await ctx.agent({ prompt: "drift agent" })
+  return { value: r.text }
+}
+`
+const DRIFT_WORKFLOW_SCHEMA = `export const meta = { name: "${DRIFT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const r = await ctx.agent({ prompt: "drift agent", schema: { type: "object" } })
+  return { value: r.data }
+}
+`
+
+// Tasks 12/13 (ctx.question): ein Workflow, der EINE Frage stellt und die Antwort
+// zurückgibt. Wird live beantwortet (Deferred), bevor das Timeout feuert. Der
+// Question-Node landet als Journal-Step (kind:"question"), so dass ein Resume die
+// Antwort aus dem Journal serviert statt erneut zu fragen.
+const QUESTION_FIXTURE = "ask-question"
+const QUESTION_WORKFLOW = `export const meta = { name: "${QUESTION_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.question({ question: "deploy?", options: ["yes", "no"] })
+  return { answer: a.answer }
+}
+`
+// Timeout-Variante: dieselbe Frage, aber mit winzigem Timeout. Wird sie nicht
+// rechtzeitig beantwortet, PARKT der Run als `paused` über die bestehende
+// Pause-Maschinerie, die offene Question wird persistiert (pending_question).
+const QUESTION_TIMEOUT_FIXTURE = "ask-question-timeout"
+const QUESTION_TIMEOUT_WORKFLOW = `export const meta = { name: "${QUESTION_TIMEOUT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.question({ question: "deploy?", options: ["yes", "no"], timeout: 50 })
+  return { answer: a.answer }
+}
+`
+// Finding 4 (timeout-park races answer): a question with a very short timeout,
+// answered the instant its pending_question is published. The engine must NOT
+// both record the answer AND park as paused — exactly one of {answer, park}
+// wins. The fix makes the timeout-park branch re-read node.status, so an answer()
+// that completed the node mid-race returns the answer instead of parking.
+const QUESTION_TINY_TIMEOUT_FIXTURE = "ask-question-tiny-timeout"
+const QUESTION_TINY_TIMEOUT_WORKFLOW = `export const meta = { name: "${QUESTION_TINY_TIMEOUT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.question({ question: "deploy?", options: ["yes", "no"], timeout: 1 })
+  return { answer: a.answer }
+}
+`
+
+// Question-then-agent: asks a question that times out (parks as paused), then
+// dispatches a real ctx.agent step that depends on the answer. The resume that
+// answer() triggers must thread the prompt-ops vector so this agent step can run
+// LIVE on the resumed run (the question is replayed from the journal).
+const QUESTION_AGENT_FIXTURE = "q-then-agent"
+const QUESTION_AGENT_WORKFLOW = `export const meta = { name: "${QUESTION_AGENT_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.question({ question: "go?", timeout: 50 })
+  const r = await ctx.agent({ prompt: "after-" + a.answer })
+  return { answer: a.answer, agentText: r.text }
+}
+`
+
+// T5 gap (mixed cached replay): a workflow that asks a question THEN dispatches
+// an agent. On the first run both complete (question answered live, agent
+// prompted live). On a resume of the parked/paused run, BOTH must come from the
+// journal: the question is NOT re-asked (no pending_question) and the agent is
+// NOT re-prompted (recordingPromptOps records nothing).
+const MIXED_REPLAY_FIXTURE = "mixed-question-agent"
+const MIXED_REPLAY_WORKFLOW = `export const meta = { name: "${MIXED_REPLAY_FIXTURE}", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.question({ question: "ship?", options: ["yes", "no"] })
+  const r = await ctx.agent({ prompt: "do-" + a.answer })
+  return { answer: a.answer, work: r.text }
+}
+`
+
+// Prompt-Ops für den Drift-Test: zählt jeden GEFEUERTEN (live) Prompt und liefert,
+// wenn ein Schema angefordert wurde (input.format gesetzt), eine strukturierte
+// Antwort (message.info.structured) — sonst PLAINTEXT, dessen Text KEIN gültiges
+// JSON ist. So beweist der Resume: matcht die Schema-Anfrage den Plaintext-Journal-
+// Node, läuft der Agent live (count +1) und liefert ein echtes structured-Ergebnis,
+// statt am JSON.parse des Plaintext-Outputs zu defecten.
+function driftPromptOps(db: Database.Interface["db"]) {
+  const state = { count: 0 }
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        state.count++
+        const wantsSchema = input.format?.type === "json_schema"
+        const turn: AssistantTurn = {
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        }
+        if (wantsSchema) turn.structured = SCHEMA_OBJECT
+        const last = yield* persistTurns(db, input.sessionID, [turn])
+        // Plaintext-Pfad: ein Text, der bewusst KEIN gültiges JSON ist.
+        const parts = wantsSchema ? [] : [{ type: "text", text: "not json at all" }]
+        return { info: last.info, parts } as unknown as SessionV1.WithParts
+      }),
+    cancel: () => Effect.void,
+  }
+  return { ops, state }
+}
+
+// Prompt-Ops, die jeden Agent-Prompt SOFORT mit einem PROMPT-spezifischen Output
+// beantworten und (a) jeden gestarteten Prompt-Text protokollieren sowie (b) echte
+// Kosten verbuchen. So kann der Resume-Test beweisen, dass für gecachte Agenten
+// KEIN neuer Prompt gefeuert wird (Prompt-Text fehlt in `prompted`) und der Output
+// aus dem Journal stammt. Der Output ist `"out:" + prompt-text` damit identische
+// Prompts dennoch denselben Output liefern (die Occurrence-Trennung wird über die
+// Zähl-Logik geprüft, nicht über unterschiedliche Outputs).
+// Entfernt die vom Engine vorangestellte Step-Framing-Direktive (Item 6: jeder
+// Nicht-Schema-Agent-Prompt wird damit geframt), sodass Prompt-matchende Ops und
+// Assertions weiterhin auf dem AUTOREN-Prompt operieren. Schema-Prompts (und der
+// rohe node.prompt) tragen das Präfix nie.
+function authorPrompt(text: string) {
+  const prefix = Workflow.STEP_FRAMING_DIRECTIVE + "\n\n"
+  return text.startsWith(prefix) ? text.slice(prefix.length) : text
+}
+
+function recordingPromptOps(db: Database.Interface["db"], cost = 0) {
+  const prompted: string[] = []
+  const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+    prompt: (input) =>
+      Effect.gen(function* () {
+        if (input.noReply) return assistantReply()
+        const text = authorPrompt(input.parts?.[0]?.type === "text" ? input.parts[0].text : "")
+        prompted.push(text)
+        const last = yield* persistTurns(db, input.sessionID, [
+          { cost, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+        ])
+        return {
+          info: last.info,
+          parts: [{ type: "text", text: "out:" + text }],
+        } as unknown as SessionV1.WithParts
+      }),
+    cancel: () => Effect.void,
+  }
+  return { ops, prompted }
+}
+
+describe("Workflow", () => {
+  // The engine must publish run-lifecycle bus events from persistRun so non-TUI
+  // consumers (dashboard, plugins) can observe a run instead of polling. A run
+  // crosses persistRun at least once while `running` and once at its terminal
+  // transition, so a subscriber must see >=1 `workflow.run.updated` (running)
+  // and a final `workflow.run.finished` (completed). The payload is the SLIM
+  // shape: `agents` is a COUNT object, never the full array.
+  it.instance("publishes workflow.run.updated/finished bus events with a slim payload", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, EVENTS_FIXTURE, EVENTS_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const events = yield* EventV2Bridge.Service
+      const seen: Array<{ type: string; data: Record<string, unknown> }> = []
+      const unsub = yield* events.listen((event) =>
+        Effect.sync(() => {
+          if (event.type === "workflow.run.updated" || event.type === "workflow.run.finished")
+            seen.push({ type: event.type, data: event.data as Record<string, unknown> })
+        }),
+      )
+      yield* Effect.addFinalizer(() => unsub)
+
+      const started = yield* workflow.start({ name: EVENTS_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("events workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      // At least one `running` update was seen during the run.
+      const running = seen.filter((e) => e.type === "workflow.run.updated" && e.data["status"] === "running")
+      expect(running.length).toBeGreaterThanOrEqual(1)
+
+      // The final event is the terminal `finished` with status completed.
+      const last = seen.at(-1) ?? (yield* Effect.fail(new Error("no workflow.run events seen")))
+      expect(last.type).toBe("workflow.run.finished")
+      expect(last.data["status"]).toBe("completed")
+
+      // Slim payload: the metadata fields plus an `agents` COUNT object (never the
+      // full agents array).
+      expect(last.data["id"]).toBe(started.id)
+      expect(last.data["workflow"]).toBe(EVENTS_FIXTURE)
+      expect(last.data["current_phase"]).toBe("run")
+      expect(last.data["directory"]).toBe(test.directory)
+      expect(last.data["agents"]).toEqual({ total: 0, running: 0, failed: 0 })
+      expect(Array.isArray(last.data["agents"])).toBe(false)
+      // The slim payload carries a `pending_question` flag (false for a run with
+      // no open human-in-the-loop question — Tasks 12/13).
+      expect(last.data["pending_question"]).toBe(false)
+    }),
+  )
+
+  // Finding 15: the zero-agent fixture above only ever asserts the slim-payload
+  // `agents` count in its trivial all-zero state, so a regression that swapped the
+  // `running`/`failed` filters or always emitted zeros would still pass. Drive a run
+  // that dispatches TWO agents — one completed, one failed (caught) — and assert the
+  // emitted `agents` object carries the real NON-zero split, so the count
+  // COMPUTATION (not just the "it's a count object" shape) is falsifiable.
+  it.instance("the slim-payload agents count reflects a real non-zero total/running/failed split", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, EVENTS_AGENTS_FIXTURE, EVENTS_AGENTS_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const events = yield* EventV2Bridge.Service
+      const { db } = yield* Database.Service
+      const seen: Array<{ type: string; data: Record<string, unknown> }> = []
+      const unsub = yield* events.listen((event) =>
+        Effect.sync(() => {
+          if (event.type === "workflow.run.updated" || event.type === "workflow.run.finished")
+            seen.push({ type: event.type, data: event.data as Record<string, unknown> })
+        }),
+      )
+      yield* Effect.addFinalizer(() => unsub)
+
+      const started = yield* workflow.start({
+        name: EVENTS_AGENTS_FIXTURE,
+        args: {},
+        prompt: eventsAgentsPromptOps(db),
+      })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("events-agents workflow did not finish")))
+      // The body caught the schema failure, so the run completes...
+      expect(done.status).toBe("completed")
+      // ...with exactly one completed and one failed agent node.
+      expect(done.agents.length).toBe(2)
+      expect(done.agents.filter((a) => a.status === "completed").length).toBe(1)
+      expect(done.agents.filter((a) => a.status === "failed").length).toBe(1)
+
+      // The terminal slim payload's `agents` COUNT reflects that real split — a
+      // swapped running/failed filter or an always-zero emitter would fail here.
+      const last = seen.at(-1) ?? (yield* Effect.fail(new Error("no workflow.run events seen")))
+      expect(last.type).toBe("workflow.run.finished")
+      expect(last.data["agents"]).toEqual({ total: 2, running: 0, failed: 1 })
+      expect(Array.isArray(last.data["agents"])).toBe(false)
+
+      // The `running` filter is also exercised live: at least one mid-run `updated`
+      // event must have carried a running agent count >= 1 (a dispatched agent is
+      // `running` until it settles), so swapping running<->failed would be caught
+      // both at the terminal event AND on a live update.
+      const runningCounts = seen
+        .filter((e) => e.type === "workflow.run.updated")
+        .map((e) => (e.data["agents"] as { running: number }).running)
+      expect(runningCounts.some((n) => n >= 1)).toBe(true)
+    }),
+  )
+
+  // Fund 48 (deterministic ordering): the pipeline runs each item's stage SEQUENCE
+  // independently — there is NO barrier between stages, so item B can be in stage 2
+  // while item A is still in stage 1. Previously proven by sleeping item A 80ms in
+  // stage 1 (wall-clock flake); now item A parks on a shared gate in stage 1 and
+  // the test waits for B's stage-2 marker (a CONDITION) before releasing A, so the
+  // ordering is guaranteed regardless of scheduling speed. Stage 2 also changes the
+  // type (string -> { a, b }), proving heterogeneous stages.
+  it.instance("pipeline runs stages per item without a barrier and supports heterogeneous types", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PIPELINE_ORDER_FIXTURE, PIPELINE_ORDER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sync = installBarrier()
+      const run = yield* workflow.start({ name: PIPELINE_ORDER_FIXTURE, args: { __barrier: sync.token } })
+      // Deterministic proof: wait until B has REACHED stage 2 (while A is still
+      // parked in stage 1), then release A so the run can finish.
+      yield* sync.awaitOrder("B:stage2")
+      sync.barrier.release()
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("pipeline did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as { order: string[]; result: Array<{ a: number; b: string }> }
+      // No barrier between stages: B reached stage 2 before A left stage 1.
+      expect(result.order.indexOf("B:stage2")).toBeLessThan(result.order.indexOf("A:stage1:done"))
+      // Stage 2 changes the type; results stay in item order.
+      expect(result.result).toEqual([
+        { a: 1, b: "x" },
+        { a: 2, b: "y" },
+      ])
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  // Fund 48/49 (deterministic peak): an explicit concurrencyLimit caps the number
+  // of simultaneously-running parallel tasks. Previously proven by 6 tasks à ~40ms
+  // hoping they overlap; now every task parks on a shared gate and the test polls
+  // the live `active` counter, so the measured peak is the engine's real scheduling
+  // decision, not a timing window. With limit 2 and 6 tasks exactly 2 tasks are
+  // ever parked at once (peak === 2): a lower peak would mean over-clamping, a
+  // higher one would mean the limit was ignored.
+  it.instance("parallel respects concurrencyLimit", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_BARRIER_FIXTURE, PARALLEL_BARRIER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sync = installBarrier()
+      const run = yield* workflow.start({
+        name: PARALLEL_BARRIER_FIXTURE,
+        args: { __barrier: sync.token, count: 6, concurrencyLimit: 2 },
+      })
+      // Wait until the limit (2) tasks are simultaneously parked, then release the
+      // gate so the whole batch can drain.
+      yield* sync.awaitPeak(2)
+      sync.barrier.release()
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("parallel did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as { peak: number; result: number[] }
+      expect(result.result).toHaveLength(6)
+      // Exactly the limit: never above (limit honored) and never below 2 (no
+      // accidental over-clamp to 1).
+      expect(result.peak).toBe(2)
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  // P1 (Claude parity): a rejecting parallel task must not fail the whole batch.
+  // It resolves to `null` at its position, the surviving tasks keep their values,
+  // and the drop is logged (never silent). Before this change the first rejection
+  // killed the batch and the run ended `failed`.
+  it.instance("parallel drops a rejecting task to null and logs it instead of failing the batch", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_ERROR_FIXTURE, PARALLEL_ERROR_WORKFLOW, "ts"))
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: PARALLEL_ERROR_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("par-err did not finish")))
+      // The batch survives the rejection.
+      expect(run.status).toBe("completed")
+      expect((run.result as { out: unknown[] }).out).toEqual(["ok-1", null, "ok-3"])
+      // The drop is logged, never silent — and carries the rejection's message.
+      const dropLog = run.logs.find((l) => l.message.includes("parallel task 2 dropped"))
+      expect(dropLog?.message).toContain("boom")
+    }),
+  )
+
+  // P2 (Claude parity): a throwing stage in ctx.pipeline must not fail the whole
+  // pipeline — it drops ONLY that item to `null` at its position and skips that
+  // item's remaining stages; the other items run every stage to completion, and
+  // the drop is logged (never silent). Before this change the first throwing item
+  // aborted the whole pipeline and the run ended `failed`.
+  it.instance("pipeline drops only the throwing item to null and skips its remaining stages", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PIPELINE_ERROR_FIXTURE, PIPELINE_ERROR_WORKFLOW, "ts"))
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: PIPELINE_ERROR_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("pipe-err did not finish")))
+      expect(run.status).toBe("completed")
+      const r = run.result as { out: unknown[]; calls: string[] }
+      expect(r.out).toEqual([11, null, 31]) // only item 2 dropped
+      expect(r.calls).not.toContain("s2:2") // item 2's remaining stages skipped
+      expect(
+        run.logs.some((l) => l.message.includes("pipeline item 2 dropped") && l.message.includes("stage1-boom")),
+      ).toBe(true)
+    }),
+  )
+
+  // Pipeline stages receive the item's index as their third parameter — the same
+  // index in EVERY stage the item flows through (stage 2's `prev` is stage 1's
+  // returned index, and stage 2's own `i` must match it).
+  it.instance("pipeline stage receives the item index in every stage", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PIPELINE_INDEX_FIXTURE, PIPELINE_INDEX_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: PIPELINE_INDEX_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("pipe-index did not finish")))
+      expect(run.status).toBe("completed")
+      expect((run.result as { out: unknown[] }).out).toEqual([
+        { first: 0, second: 0 },
+        { first: 1, second: 1 },
+      ])
+    }),
+  )
+
+  // Duplicate-items log bug: the drop log uses the forEach index, so the SECOND
+  // occurrence of an identical item reports "item 2" — the old items.indexOf
+  // logging always named the first occurrence ("item 1").
+  it.instance("duplicate items log the true index on drop", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PIPELINE_DUP_FIXTURE, PIPELINE_DUP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: PIPELINE_DUP_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("pipe-dup did not finish")))
+      expect(run.status).toBe("completed")
+      // Only the second occurrence dropped, at its true position.
+      expect((run.result as { out: unknown[] }).out).toEqual(["a", null])
+      const dropLog = run.logs.find((l) => l.message.includes("dropped"))
+      expect(dropLog?.message).toContain("pipeline item 2 dropped")
+      expect(dropLog?.message).toContain("dup-boom")
+      expect(run.logs.some((l) => l.message.includes("pipeline item 1 dropped"))).toBe(false)
+    }),
+  )
+
+  // Item cap (Claude parity): a single ctx.parallel call may carry at most 4096
+  // tasks. One past the cap fails the run with an explicit InvalidError naming the
+  // limit at the call site — never a silent mass of null drops.
+  it.instance("parallel rejects more than 4096 tasks with an explicit error", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_CAP_FIXTURE, PARALLEL_CAP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: PARALLEL_CAP_FIXTURE, args: { count: 4097 } })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("par-cap did not finish")))
+      expect(run.status).toBe("failed")
+      expect(run.error).toContain("at most 4096")
+      expect(run.error).toContain("4097")
+    }),
+  )
+
+  // Same cap for ctx.pipeline, with the pipeline-specific wording.
+  it.instance("pipeline rejects more than 4096 items with an explicit error", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PIPELINE_CAP_FIXTURE, PIPELINE_CAP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: PIPELINE_CAP_FIXTURE, args: { count: 4097 } })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("pipe-cap did not finish")))
+      expect(run.status).toBe("failed")
+      expect(run.error).toContain("ctx.pipeline supports at most 4096")
+    }),
+  )
+
+  // Boundary: EXACTLY 4096 items pass the gate (only > caps) and the batch runs
+  // through with the default concurrency clamp.
+  it.instance("parallel allows exactly 4096 tasks", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_CAP_FIXTURE, PARALLEL_CAP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: PARALLEL_CAP_FIXTURE, args: { count: 4096 } })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("par-cap boundary did not finish")))
+      expect(run.status).toBe("completed")
+      expect((run.result as { length: number }).length).toBe(4096)
+    }),
+  )
+
+  // Fund 49 (default parallel concurrency): `ctx.parallel` WITHOUT an explicit
+  // concurrencyLimit clamps to the documented default of 20
+  // (`Math.max(1, options?.concurrencyLimit ?? 20)` in createContext). With 25
+  // tasks all parked on the gate, exactly 20 run at once — peak === 20, never 25
+  // (would mean unbounded) and never 1 (would mean over-clamped). Deterministic via
+  // the parked-task counter, no timing window.
+  it.instance("parallel without an explicit limit defaults to a peak concurrency of 20", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_BARRIER_FIXTURE, PARALLEL_BARRIER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sync = installBarrier()
+      // 25 tasks, NO concurrencyLimit ⇒ engine default 20.
+      const run = yield* workflow.start({
+        name: PARALLEL_BARRIER_FIXTURE,
+        args: { __barrier: sync.token, count: 25 },
+      })
+      // Exactly the default (20) tasks become parked simultaneously; the remaining
+      // 5 wait for a slot. Wait for that peak, then drain.
+      yield* sync.awaitPeak(20)
+      // The peak must not climb past the default even given a moment to settle: a
+      // 21st parked task would mean the default cap was not applied.
+      expect(sync.barrier.active).toBe(20)
+      sync.barrier.release()
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("parallel did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as { peak: number; result: number[] }
+      expect(result.result).toHaveLength(25)
+      expect(result.peak).toBe(20)
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  // Fund 49 (parallel limit floor): an explicit concurrencyLimit of 0 (and any
+  // negative value) is floored to 1 — `Math.max(1, …)` — so the batch runs strictly
+  // sequentially (peak === 1) rather than degenerating into "no tasks run" or
+  // unbounded. Consistency guard for the clamp.
+  it.instance("parallel concurrencyLimit 0 and negative are clamped to a peak of 1", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_BARRIER_FIXTURE, PARALLEL_BARRIER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      for (const limit of [0, -5]) {
+        const sync = installBarrier()
+        const run = yield* workflow.start({
+          name: PARALLEL_BARRIER_FIXTURE,
+          args: { __barrier: sync.token, count: 4, concurrencyLimit: limit },
+        })
+        // Only ONE task is ever parked at a time; release it so the next can run.
+        yield* sync.awaitPeak(1)
+        expect(sync.barrier.active).toBe(1)
+        sync.barrier.release()
+        const waited = yield* workflow.wait({ id: run.id })
+        const done = waited.run ?? (yield* Effect.fail(new Error(`parallel(${limit}) did not finish`)))
+        expect(done.status).toBe("completed")
+        const result = done.result as { peak: number; result: number[] }
+        expect(result.result).toHaveLength(4)
+        expect(result.peak).toBe(1)
+        delete globalThis.__workflowTestBarriers![sync.token]
+      }
+    }),
+  )
+
+  // Fund 49 (default pipeline concurrency): `ctx.pipeline` WITHOUT options runs its
+  // items UNBOUNDED (the pipeline default differs from parallel's 20 — see
+  // createContext: `options?.concurrencyLimit === undefined ? "unbounded" : …`). With
+  // 25 items all parked in the single stage, ALL 25 run concurrently — peak === 25.
+  it.instance("pipeline without options runs items unbounded", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PIPELINE_BARRIER_FIXTURE, PIPELINE_BARRIER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sync = installBarrier()
+      const run = yield* workflow.start({
+        name: PIPELINE_BARRIER_FIXTURE,
+        args: { __barrier: sync.token, count: 25 },
+      })
+      // Unbounded ⇒ every item parks at once; the peak equals the item count.
+      yield* sync.awaitPeak(25)
+      expect(sync.barrier.active).toBe(25)
+      sync.barrier.release()
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("pipeline did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as { peak: number; result: number[] }
+      expect(result.result).toHaveLength(25)
+      expect(result.peak).toBe(25)
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  // Fund 49 (pipeline limit floor): a pipeline concurrencyLimit of 0 is floored to 1
+  // (same `Math.max(1, …)` clamp as parallel), so items run strictly one at a time
+  // (peak === 1) instead of unbounded — only an UNSET limit means unbounded.
+  it.instance("pipeline concurrencyLimit 0 is clamped to a peak of 1", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PIPELINE_BARRIER_FIXTURE, PIPELINE_BARRIER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sync = installBarrier()
+      const run = yield* workflow.start({
+        name: PIPELINE_BARRIER_FIXTURE,
+        args: { __barrier: sync.token, count: 4, concurrencyLimit: 0 },
+      })
+      yield* sync.awaitPeak(1)
+      expect(sync.barrier.active).toBe(1)
+      sync.barrier.release()
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("pipeline did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as { peak: number; result: number[] }
+      expect(result.result).toHaveLength(4)
+      expect(result.peak).toBe(1)
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  it.instance("discovers workflow files", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "hello",
+          `export const meta = { name: "Hello", description: "Test workflow", phases: ["start"] }
+export async function run(args, ctx) { ctx.setPhase("start"); ctx.log("hello"); return { ok: true } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      expect(list.map((item) => item.name)).toContain("hello")
+      expect(list.find((item) => item.name === "hello")?.meta.name).toBe("Hello")
+    }),
+  )
+
+  it.instance("list() statically extracts meta and never executes module top-level code; start() does", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const marker = path.join(os.tmpdir(), `workflow-side-effect-${Math.random().toString(16).slice(2)}`)
+      yield* Effect.promise(() => writeWorkflow(test.directory, SIDE_EFFECT_FIXTURE, sideEffectWorkflow(marker)))
+      const workflow = yield* Workflow.Service
+
+      const list = yield* workflow.list()
+      const info = list.find((item) => item.name === SIDE_EFFECT_FIXTURE)
+      // Meta was extracted statically (valid + literal values present)...
+      expect(info?.valid).toBe(true)
+      expect(info?.meta.name).toBe("SideEffect")
+      expect(info?.meta.description).toBe("writes a marker on import")
+      // ...but the module's top-level code was NEVER executed: no marker file.
+      expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
+
+      // start() really imports the target module, so now the marker appears.
+      const run = yield* workflow.start({ name: SIDE_EFFECT_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: run.id })
+      expect(waited.run?.status).toBe("completed")
+      expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(true)
+    }),
+  )
+
+  it.instance("non-statically-analyzable meta is reported invalid without running the file", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const marker = path.join(os.tmpdir(), `workflow-dynamic-meta-${Math.random().toString(16).slice(2)}`)
+      // Dynamic meta value (process.env) plus a top-level side effect: the file
+      // must be reported invalid AND never executed during list().
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "dynamic-meta",
+          `await Bun.write(${JSON.stringify(marker)}, "executed")
+export const meta = { name: process.env.SECRET }
+export async function run(args, ctx) { return { ok: true } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      const info = list.find((item) => item.name === "dynamic-meta")
+      expect(info?.valid).toBe(false)
+      expect(info?.error).toContain("statically analyzable")
+      expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
+    }),
+  )
+
+  it.instance("a broken workflow file does not break list(); it is reported invalid", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          HELLO_FIXTURE,
+          `export const meta = { name: "Hello", description: "Test workflow", phases: ["start"] }
+export async function run(args, ctx) { ctx.setPhase("start"); ctx.log("hello"); return { ok: true } }
+`,
+        ),
+      )
+      // Syntaxfehler: unvollständiges Objektliteral -> Modul-Load schlägt fehl.
+      yield* Effect.promise(() => writeWorkflow(test.directory, "broken", "export const meta = {"))
+      const workflow = yield* Workflow.Service
+
+      const all = yield* workflow.list()
+      const broken = all.find((item) => item.name === "broken")
+      expect(broken?.valid).toBe(false)
+      expect(broken?.error).toBeTruthy()
+      // Die gute Datei bleibt trotz der kaputten weiterhin gelistet und gültig.
+      expect(all.some((item) => item.name === HELLO_FIXTURE && item.valid !== false)).toBe(true)
+    }),
+  )
+
+  it.instance("start loads only the target module and fails precisely for broken target", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          HELLO_FIXTURE,
+          `export const meta = { name: "Hello" }
+export async function run(args, ctx) { ctx.setPhase("run"); ctx.log("running"); return { ok: true } }
+`,
+        ),
+      )
+      yield* Effect.promise(() => writeWorkflow(test.directory, "broken", "export const meta = {"))
+      const workflow = yield* Workflow.Service
+
+      // Ein kaputtes Ziel scheitert präzise (InvalidError, der die Datei/den Namen nennt).
+      const failed = yield* workflow.start({ name: "broken", args: {} }).pipe(Effect.flip)
+      expect(failed._tag).toBe("WorkflowInvalidError")
+      // Narrow the start() error union (InvalidError | NotFoundError) to the
+      // precise InvalidError so its `path` is accessible and typed.
+      const invalid =
+        failed instanceof Workflow.InvalidError ? failed : yield* Effect.fail(new Error("expected InvalidError"))
+      expect(invalid.path).toContain("broken")
+
+      // Die gültige Datei ist trotz broken.ts startbar (kein voller list()-Abbruch).
+      const ok = yield* workflow.start({ name: HELLO_FIXTURE, args: {} })
+      expect(ok.id).toBeTruthy()
+    }),
+  )
+
+  it.instance("starts and records a workflow run", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "hello",
+          `export const meta = { name: "Hello" }
+export async function run(args, ctx) { ctx.setPhase("run"); ctx.log("running"); return { value: args.value } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "hello", args: { value: 42 } })
+      expect(run.status).toBe("running")
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("workflow did not finish")))
+      expect(done.current_phase).toBe("run")
+      expect(done.logs.map((item) => item.message)).toContain("running")
+      expect(done.args).toEqual({ value: 42 })
+      expect(done.definition?.name).toBe("hello")
+      expect(done.definition?.path.endsWith("hello.js")).toBe(true)
+      expect(done.result).toEqual({ value: 42 })
+    }),
+  )
+
+  // Race-regression: cancel() must never report a run as "not found" (undefined →
+  // HTTP 404) when it LOSES the race against the run's own natural completion. In
+  // the live engine the body fiber's finish("completed") persists the terminal row
+  // AND N1-evicts the run from the registry between cancel's registry read and its
+  // own finish("cancelled") — leaving that finish to return undefined for a run
+  // that exists and is terminal. cancel must then fall back to the persisted
+  // snapshot showing the TRUE terminal status (completed), NOT undefined and NOT
+  // rewritten to cancelled.
+  //
+  // Deterministic coverage of the FIX SEMANTICS (the observable contract), not of
+  // the exact lost-race code line: complete the run first (await its terminal state
+  // via wait, which resolves at finish's Deferred — committed terminal row, but the
+  // subsequent N1-evict may or may not have run yet), THEN cancel. The cancel then
+  // takes one of the two non-undefined branches — `snapshot(active)` if still
+  // registered, or the persisted-DB fallback once evicted — both returning the TRUE
+  // terminal status. The pre-fix code returned undefined on the evicted branch.
+  // The precise finish-undefined window (cancel's OWN finish returning undefined
+  // mid-eviction, the named `finished ?? persisted()` line) is exercised end-to-end
+  // by script/httpapi-exercise.ts (workflow.start), whose fixture completes
+  // synchronously fast; this unit test pins the contract those branches must honor.
+  it.instance("cancel of an already-completed (evicted) run returns the completed snapshot, never undefined", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "instant",
+          `export const meta = { name: "Instant" }
+export async function run(args, ctx) { ctx.setPhase("run"); return { value: args.value } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "instant", args: { value: 7 } })
+      // Drive to terminal: wait resolves only after finish() committed the terminal
+      // row, and finish() then evicts the run from the live registry (N1).
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("workflow did not finish")))
+      expect(done.status).toBe("completed")
+      // Cancel after completion: the run is terminal and (being) evicted, so cancel
+      // either snapshots the still-registered terminal run or, once evicted, takes
+      // the new finish-undefined fallback to the persisted row. Both must return a
+      // non-undefined run whose status is the TRUE terminal status, never cancelled.
+      const cancelled = yield* workflow.cancel(run.id)
+      expect(cancelled).toBeDefined()
+      expect(cancelled?.status).toBe("completed")
+      expect(cancelled?.result).toEqual({ value: 7 })
+      // Reserved meaning preserved: a genuinely unknown id still reports undefined.
+      expect(yield* workflow.cancel(Workflow.RunID.make("job_unknown_id"))).toBeUndefined()
+    }),
+  )
+
+  it.instance("preserves temporary workflow source in run definition", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const source = `export const meta = { name: "Temporary" }
+export async function run(args, ctx) { ctx.setPhase("run"); return { value: args.value } }
+`
+      yield* Effect.promise(() => writeWorkflow(test.directory, "temporary", source))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "temporary", args: { value: 99 }, source, temporary: true })
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("workflow did not finish")))
+      expect(done.definition?.temporary).toBe(true)
+      expect(done.definition?.source).toBe(source)
+      expect(done.result).toEqual({ value: 99 })
+    }),
+  )
+
+  // Inline-source start (P3): start({ source, temporary: true }) with NO name loads
+  // the module straight from the source string via the builtin source-string load
+  // path under a synthetic `inline:<metaName>` marker — never written to the
+  // project, never discovered. The run completes, the definition carries the
+  // source, list() does NOT surface it, and a second identical start works (the
+  // temp-file name randomizes, so no collision).
+  it.instance("starts an inline source as a temporary run without discovery", () =>
+    Effect.gen(function* () {
+      const source = `export const meta = { name: "InlineEngine", description: "Inline." }
+export async function run(args, ctx) { ctx.setPhase("run"); return { value: args.value } }
+`
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ args: { value: 7 }, source, temporary: true })
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("inline workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect(done.workflow).toBe("InlineEngine")
+      expect(done.definition?.temporary).toBe(true)
+      expect(done.definition?.source).toBe(source)
+      expect(done.result).toEqual({ value: 7 })
+      // Never discovered: list() does not surface an inline run's workflow.
+      const listed = yield* workflow.list()
+      expect(listed.some((item) => item.name === "InlineEngine")).toBe(false)
+      // A second identical inline start works (no temp-file collision).
+      const run2 = yield* workflow.start({ args: { value: 8 }, source, temporary: true })
+      const done2 =
+        (yield* workflow.wait({ id: run2.id })).run ??
+        (yield* Effect.fail(new Error("second inline workflow did not finish")))
+      expect(done2.status).toBe("completed")
+      expect(done2.result).toEqual({ value: 8 })
+    }),
+  )
+
+  // A NAMED on-disk run must carry its module SOURCE in `definition.source` (not
+  // just inline starts). The dashboard's save-as-command and any run-detail source
+  // view read `run.definition.source`; before the fix only inline starts populated
+  // it (`source: input.source`), so a named/on-disk run had `source: undefined` and
+  // "save as command" / source view were blank for every real workflow.
+  it.instance("a named on-disk run carries its file source in definition.source", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const source = `export const meta = { name: "SourceCarry" }
+export async function run(args, ctx) { ctx.setPhase("run"); return { value: args.value } }
+`
+      yield* Effect.promise(() => writeWorkflow(test.directory, "source-carry", source))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "source-carry", args: { value: 5 } })
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("workflow did not finish")))
+      expect(done.definition?.source).toBe(source)
+    }),
+  )
+
+  // A BUILTIN run must carry the bundled module string in `definition.source` so
+  // save-as-command works for a builtin too (its `path` is a synthetic marker, not
+  // a readable file).
+  it.instance("a builtin run carries the bundled source in definition.source", () =>
+    Effect.gen(function* () {
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "deep-research", args: { question: "x" } })
+      // The builtin body needs no model to populate definition at START time — the
+      // run's definition.source is set synchronously by start(), so cancel and
+      // assert without waiting for the (model-dependent) body to finish.
+      yield* workflow.cancel(run.id)
+      expect(run.definition?.source).toBe(BUILTIN_WORKFLOWS["deep-research"])
+    }),
+  )
+
+  // Source-availability read seam (Vasya's "CODE PREVIEW shows nothing"): the
+  // pre-run approval preview has no run yet, so it cannot read run.definition.source.
+  // workflow.read(name) returns the resolved module source for a NAME — file text
+  // for an on-disk workflow, the bundled string for a builtin — without a raw
+  // file.read({absolutePath}) (which failed for absolute paths and returned "" for
+  // synthetic builtin markers).
+  it.instance("read() returns the file source for an on-disk workflow", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const source = `export const meta = { name: "ReadSeam" }
+export async function run() { return {} }
+`
+      yield* Effect.promise(() => writeWorkflow(test.directory, "read-seam", source))
+      const workflow = yield* Workflow.Service
+      const read = yield* workflow.read("read-seam")
+      expect(read?.source).toBe(source)
+    }),
+  )
+
+  it.instance("read() returns the bundled source for a builtin", () =>
+    Effect.gen(function* () {
+      const workflow = yield* Workflow.Service
+      const read = yield* workflow.read("deep-research")
+      expect(read?.source).toBe(BUILTIN_WORKFLOWS["deep-research"])
+    }),
+  )
+
+  it.instance("read() returns undefined for an unknown workflow name", () =>
+    Effect.gen(function* () {
+      const workflow = yield* Workflow.Service
+      expect(yield* workflow.read("does-not-exist-xyz")).toBeUndefined()
+    }),
+  )
+
+  // Inline-source start with an INVALID source (non-literal meta name → MetaReader
+  // rejects it statically) fails the start as a WorkflowInvalidError, never a
+  // defect — the engine validates the source defensively even though the tool also
+  // pre-validates before its permission ask.
+  it.instance("inline source with invalid meta fails the start as InvalidError", () =>
+    Effect.gen(function* () {
+      const workflow = yield* Workflow.Service
+      const source = `export const meta = { name: someVar }
+export async function run() {}
+`
+      const exit = yield* Effect.exit(workflow.start({ source, temporary: true }))
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(Exit.isFailure(exit) ? Cause.pretty(exit.cause) : "").toContain("WorkflowInvalidError")
+    }),
+  )
+
+  // Static meta gate on the NAME start path: a name start (HTTP/programmatic)
+  // previously imported the module directly — only the inline path validated
+  // statically. Now the same MetaReader gate runs BEFORE loadModule, so computed
+  // meta fails the start as an InvalidError AND the module's top-level code is
+  // never executed (no marker file — the gate fired before any import).
+  it.instance("start by NAME rejects computed meta statically, before the module is imported", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const marker = path.join(os.tmpdir(), `workflow-name-gate-${Math.random().toString(16).slice(2)}`)
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "computed-meta-name",
+          `await Bun.write(${JSON.stringify(marker)}, "executed")
+export const meta = { name: globalThis.__wfName ?? "computed" }
+export async function run(args, ctx) { return { ok: true } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const failed = yield* workflow.start({ name: "computed-meta-name", args: {} }).pipe(Effect.flip)
+      expect(failed._tag).toBe("WorkflowInvalidError")
+      const invalid =
+        failed instanceof Workflow.InvalidError ? failed : yield* Effect.fail(new Error("expected InvalidError"))
+      expect(invalid.message).toContain("statically analyzable")
+      // The gate fired BEFORE the import: the top-level marker was never written.
+      expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
+    }),
+  )
+
+  // Same gate on the SECOND ungated seam: a nested ctx.workflow child module is
+  // statically validated before loadModule imports it, so a computed-meta child
+  // fails the parent run without ever executing the child's top-level code.
+  it.instance("nested ctx.workflow rejects a computed-meta child before import", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const marker = path.join(os.tmpdir(), `workflow-nested-gate-${Math.random().toString(16).slice(2)}`)
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "bad-child",
+          `await Bun.write(${JSON.stringify(marker)}, "executed")
+export const meta = { name: globalThis.__wfName ?? "bad-child" }
+export async function run(args, ctx) { return { ok: true } }
+`,
+        ),
+      )
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "gate-parent",
+          `export const meta = { name: "gate-parent" }
+export async function run(_args, ctx) { return await ctx.workflow("bad-child") }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const started = yield* workflow.start({ name: "gate-parent", args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const run = waited.run ?? (yield* Effect.fail(new Error("gate-parent did not finish")))
+      expect(run.status).toBe("failed")
+      expect(run.error).toContain("statically analyzable")
+      // The child's top-level marker was never written: gate before import.
+      expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
+    }),
+  )
+
+  it.instance("loads TypeScript workflow default exports", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "typed",
+          `export default {
+  meta: { name: "Typed Workflow", phases: ["run"] },
+  async run(args, ctx) { ctx.setPhase("run"); ctx.log("typed"); return { value: args.value } }
+}
+`,
+          "ts",
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      expect(list.map((item) => item.name)).toContain("typed")
+      const run = yield* workflow.start({ name: "typed", args: { value: 7 } })
+
+      const done = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current?.status === "completed" ? current : undefined
+        }),
+        "workflow never completed",
+      )
+      expect(done.result).toEqual({ value: 7 })
+    }),
+  )
+
+  it.instance("cancel interrupts a running workflow and aborts its agent sessions", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SLOW_FIXTURE, SLOW_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, aborted, started } = hangingPromptOps()
+
+      const run = yield* workflow.start({ name: SLOW_FIXTURE, args: {}, prompt: ops })
+
+      // Warten bis der erste Agent läuft und seine Child-Session erzeugt hat.
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+      expect(live.agents.some((a) => a.status === "running")).toBe(true)
+
+      yield* workflow.cancel(run.id)
+
+      const after = yield* workflow.get(run.id)
+      const done = after ?? (yield* Effect.fail(new Error("run vanished")))
+      expect(done.status).toBe("cancelled")
+      // Kein Agent darf nach Cancel noch laufen.
+      expect(done.agents.every((a) => a.status !== "running")).toBe(true)
+      // Folge-Step darf nie gestartet sein.
+      expect(done.logs.some((l) => l.message?.includes(STEP2_MARKER))).toBe(false)
+      // Kern-Assertion: die Child-Session wurde echt abgebrochen.
+      const childSession = done.agents[0]?.session_id
+      expect(childSession).toBeDefined()
+      expect(started.has(childSession!)).toBe(true)
+      expect(aborted.has(childSession!)).toBe(true)
+    }),
+  )
+
+  // Fund 4 (HIGH): Mit dem REALEN resolve-on-abort-Runner RESOLVED der Agent-
+  // Prompt bei Abort (statt zu rejecten). Die Settlement-Erfolgsverzweigung darf
+  // den abort-resolved Step NICHT auf `completed` flippen, keinen Write nach dem
+  // Terminal-Write absetzen und das Budget nicht fälschlich belasten.
+  it.instance("cancel with a resolve-on-abort runner never flips the agent node to completed", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SLOW_FIXTURE, SLOW_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, aborted, started } = resolveOnAbortPromptOps()
+
+      const run = yield* workflow.start({ name: SLOW_FIXTURE, args: {}, prompt: ops, budget: 5 })
+
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+      const childSession = live.agents[0]?.session_id
+      expect(childSession).toBeDefined()
+
+      yield* workflow.cancel(run.id)
+
+      const after = yield* workflow.get(run.id)
+      const done = after ?? (yield* Effect.fail(new Error("run vanished")))
+      expect(done.status).toBe("cancelled")
+      // Der abort-resolved Agent darf NICHT als completed verbucht sein.
+      expect(done.agents.every((a) => a.status !== "completed")).toBe(true)
+      expect(done.agents.every((a) => a.status !== "running")).toBe(true)
+      // Folge-Step lief nie.
+      expect(done.logs.some((l) => l.message?.includes(STEP2_MARKER))).toBe(false)
+      expect(started.has(childSession!)).toBe(true)
+      expect(aborted.has(childSession!)).toBe(true)
+
+      // KEIN Write nach dem Terminal-Write: ein kalter DB-Read (umgeht den
+      // In-Memory-Snapshot) muss cancelled zeigen, nicht completed.
+      const row = yield* fetchRunRow(run.id)
+      expect(row.status).toBe("cancelled")
+      expect(row.agents.every((a) => a.status !== "completed")).toBe(true)
+    }),
+  )
+
+  // N11 (HIGH): Ein Run, der als `completed` endet, während ein Agent-Node noch
+  // `running` ist (fire-and-forget ctx.agent, dessen Settlement nach Body-Ende
+  // käme). finish('completed') MUSS den noch laufenden Node terminal schließen
+  // (failed mit erklärendem error + completed_at) UND die offene Child-Session
+  // wirklich abbrechen, sonst verbrennt die detached Session weiter Tokens.
+  it.instance("completed run closes a still-running detached agent node and aborts its session", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, DETACHED_AGENT_FIXTURE, DETACHED_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, aborted, started } = hangingPromptOps()
+
+      const run = yield* workflow.start({ name: DETACHED_AGENT_FIXTURE, args: {}, prompt: ops })
+
+      // Auf den vollständig settled Endzustand warten (der Body returnt, während
+      // der detached Agent noch am Prompt hängt). Statt nur auf `completed` zu
+      // pollen und dann zu hoffen, dass die Terminalisierung des Nodes UND die
+      // Abort-Kaskade bereits durchgelaufen sind (das rennt unter CPU-Last gegen
+      // den fire-and-forget-Settlement-Pfad), wird hier auf die echte Bedingung
+      // gewartet: Run `completed`, der noch laufende Node terminal als `failed`
+      // geschlossen (Grund + Zeit). If a child session was registered before
+      // terminalization, it must also be aborted; if no child session was ever
+      // created, there is nothing that can keep spending.
+      const done = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          if (current?.status !== "completed") return undefined
+          if (current.agents.length === 0) return undefined
+          if (current.agents.some((a) => a.status === "running")) return undefined
+          const closed = current.agents.find((a) => a.status === "failed")
+          if (!closed || !((closed.completed_at ?? 0) > 0) || !closed.error) return undefined
+          if (Array.from(started).some((sessionID) => !aborted.has(sessionID))) return undefined
+          return current
+        }),
+        "workflow never settled (completed + node closed + no un-aborted child sessions)",
+        // Großzügiges Poll-Budget (unter dem 30s-Bun-Test-Timeout): der Settle
+        // (completed -> Node terminal -> optional Abort-Kaskade beim Kind) ist
+        // eine echte, letztlich wahre Bedingung; unter CPU-Last dauert die
+        // Propagation nur länger als die Default-5s. Wir warten auf die
+        // Bedingung, raten nicht.
+        "25 seconds",
+      )
+      expect(done.status).toBe("completed")
+      // Der noch laufende Node ist terminal geschlossen (failed + Grund + Zeit).
+      expect(done.agents.length).toBeGreaterThan(0)
+      expect(done.agents.every((a) => a.status !== "running")).toBe(true)
+      const closed = done.agents.find((a) => a.status === "failed")
+      expect(closed).toBeDefined()
+      expect(closed!.completed_at).toBeGreaterThan(0)
+      expect(closed!.error).toBeTruthy()
+
+      // Kalt-Read beweist die Terminalisierung über den DB-Roundtrip.
+      const row = yield* fetchRunRow(run.id)
+      expect(row.status).toBe("completed")
+      expect(row.agents.every((a) => a.status !== "running")).toBe(true)
+
+      // Kern: keine hängende Child-Session darf weiterlaufen. Je nach Scheduler
+      // kann der fire-and-forget-Agent vor finish() noch gar keine Session erzeugt
+      // haben; wenn doch, muss diese Session explizit abgebrochen worden sein.
+      for (const sessionID of started) {
+        expect(aborted.has(sessionID)).toBe(true)
+      }
+    }),
+  )
+
+  // Fund 5 (HIGH): Cancel im Startup-Fenster — start() registriert den Run,
+  // beantwortet aber die Initial-Phase verzögert; ein Cancel landet, BEVOR der
+  // Body geforkt wird. Der Body darf NIE laufen (kein Marker) und der Run muss
+  // als cancelled enden (nicht voll durchlaufen).
+  it.instance("cancel during the startup window prevents the body from ever running", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const marker = path.join(os.tmpdir(), `workflow-startup-${Math.random().toString(16).slice(2)}`)
+      yield* Effect.promise(() => writeWorkflow(test.directory, STARTUP_FIXTURE, startupWorkflow(marker)))
+      const workflow = yield* Workflow.Service
+      // Die Initial-noReply-Antwort wird ~150ms verzögert: start() hängt im
+      // Initial-Prompt, der Run ist aber bereits registriert (status running).
+      const { ops } = resolveOnAbortPromptOps({ delayMs: 150 })
+
+      // start() forken, damit wir parallel im Startup-Fenster cancellen können.
+      const startFiber = yield* Effect.forkScoped(workflow.start({ name: STARTUP_FIXTURE, args: {}, prompt: ops }))
+
+      // Warten bis der Run registriert ist (running, noch kein Body).
+      const id = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const all = yield* workflow.runs()
+          const found = all.find((r) => r.workflow === STARTUP_FIXTURE)
+          return found?.id
+        }),
+        "run never registered",
+      )
+
+      // Cancel im Fenster vor dem Body-Fork.
+      yield* workflow.cancel(id)
+      yield* Fiber.await(startFiber).pipe(Effect.ignore)
+      // Settle-Zeit: falls der Body fälschlich geforkt würde, hätte er hier
+      // längst Zeit gehabt, den Marker zu schreiben (Bug-Modell läuft voll durch).
+      yield* Effect.sleep("300 millis")
+
+      const done = yield* workflow.get(id)
+      expect(done?.status).toBe("cancelled")
+      // Der Body lief NIE: kein Marker.
+      expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
+    }),
+  )
+
+  it.instance("remove on a running run cancels it first, then deletes", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SLOW_FIXTURE, SLOW_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, aborted } = hangingPromptOps()
+
+      const run = yield* workflow.start({ name: SLOW_FIXTURE, args: {}, prompt: ops })
+
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+      const childSession = live.agents[0]?.session_id
+      expect(childSession).toBeDefined()
+
+      yield* workflow.remove(run.id)
+
+      // Run ist gelöscht.
+      const gone = yield* workflow.get(run.id)
+      expect(gone).toBeUndefined()
+      // Und die Child-Session wurde vor dem Löschen abgebrochen.
+      expect(aborted.has(childSession!)).toBe(true)
+    }),
+  )
+
+  // Fund 3 (HIGH): Mit dem resolve-on-abort-Runner laufen die detached Agent-
+  // Fibers über bridge.promise NACH dem db.delete weiter und re-INSERTen die
+  // gelöschte Row (Zombie). Nach Settlement muss die Row GELÖSCHT bleiben.
+  it.instance("remove keeps the row deleted even when the agent settles after delete", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SLOW_FIXTURE, SLOW_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops } = resolveOnAbortPromptOps()
+
+      const run = yield* workflow.start({ name: SLOW_FIXTURE, args: {}, prompt: ops })
+
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+
+      yield* workflow.remove(run.id)
+
+      // Ein paar Ticks für ggf. nachlaufende detached Settlement-Fibers.
+      yield* Effect.sleep("200 millis")
+
+      // Kalt-Read: kein Re-INSERT, die Row bleibt weg.
+      const { db } = yield* Database.Service
+      const row = yield* db
+        .select()
+        .from(WorkflowRunTable)
+        .where(eq(WorkflowRunTable.id, run.id))
+        .get()
+        .pipe(Effect.orDie)
+      expect(row).toBeUndefined()
+      expect(yield* workflow.get(run.id)).toBeUndefined()
+    }),
+  )
+
+  // Fund 24/16 (parallel): ein parallel-Batch mit drei hängenden Agenten +
+  // Cancel mitten drin. ALLE registrierten Child-Sessions müssen abgebrochen
+  // werden; der sequentielle Folge-Step darf nie laufen; Status cancelled.
+  it.instance("cancel during a parallel batch aborts every started child session", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_HANG_FIXTURE, PARALLEL_HANG_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, aborted, started } = resolveOnAbortPromptOps()
+
+      const run = yield* workflow.start({ name: PARALLEL_HANG_FIXTURE, args: {}, prompt: ops })
+
+      // Warten bis alle drei parallelen Agenten ihre Child-Session registriert haben.
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          const running = current?.agents.filter((a) => a.status === "running" && a.session_id) ?? []
+          return running.length >= 3 ? current : undefined
+        }),
+        "parallel agents never all started",
+      )
+      const sessions = live!.agents.map((a) => a.session_id!).filter(Boolean)
+      expect(sessions.length).toBeGreaterThanOrEqual(3)
+
+      yield* workflow.cancel(run.id)
+
+      const done = yield* workflow.get(run.id)
+      expect(done?.status).toBe("cancelled")
+      // Jede gestartete Child-Session wurde echt abgebrochen.
+      for (const s of started) expect(aborted.has(s)).toBe(true)
+      // Der Folge-Step lief nie.
+      expect(done?.logs.some((l) => l.message?.includes(PARALLEL_HANG_MARKER))).toBe(false)
+      // Kein Agent bleibt running, keiner wird als completed verbucht.
+      expect(done?.agents.every((a) => a.status !== "running")).toBe(true)
+      expect(done?.agents.every((a) => a.status !== "completed")).toBe(true)
+    }),
+  )
+
+  // Fund 50 (low): PromptOps OHNE cancel-Vektor. cancel() muss den Run trotzdem
+  // als cancelled markieren und den Folge-Step gaten. Dokumentierter Gap: die
+  // in-flight Child-Session wird NICHT abgebrochen (sie läuft aus) — nur die
+  // Run-Fiber/der Run-Scope wird beendet.
+  it.instance("cancel without a PromptOps.cancel vector still ends the run as cancelled", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SLOW_FIXTURE, SLOW_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      // PromptOps OHNE cancel: der Agent-Prompt hängt (resolved nie von selbst).
+      const ops: { prompt: SessionPrompt.Interface["prompt"] } = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            // Hängt unterbrechbar; nur ein Scope-Close (Run-Scope) kann sie beenden.
+            yield* Effect.never
+            return assistantReply()
+          }),
+      }
+
+      const run = yield* workflow.start({ name: SLOW_FIXTURE, args: {}, prompt: ops })
+
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running") ? current : undefined
+        }),
+        "agent never started",
+      )
+
+      yield* workflow.cancel(run.id)
+
+      const done = yield* workflow.get(run.id)
+      expect(done?.status).toBe("cancelled")
+      // Folge-Step lief nie.
+      expect(done?.logs.some((l) => l.message?.includes(STEP2_MARKER))).toBe(false)
+    }),
+  )
+
+  // Orphan-Mechanismus: Die In-Memory-Test-DB (OPENCODE_DB=:memory:) überlebt
+  // keine frische Layer-Instanz, daher wird der Orphan simuliert, indem wir eine
+  // running-Zeile OHNE Registry-Eintrag direkt über die SQL-Schicht einfügen und
+  // anschließend NUR den Sweep auslösen (engine.sweep()), so wie er beim
+  // Service-Start läuft (leere Registry -> alle running-Zeilen werden gefegt).
+  it.instance("orphaned running rows are marked interrupted on service start", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const orphanId = "job_orphan_sweep"
+      yield* seedRunningRow(orphanId, test.directory)
+
+      yield* workflow.sweep()
+
+      const row = yield* fetchRunRow(orphanId)
+      expect(row.status).toBe("interrupted")
+      expect(row.completed_at).toBeGreaterThan(0)
+    }),
+  )
+
+  // Fund 15 (medium): Der Sweep schrieb bisher nur Run-Level-Spalten um, nie das
+  // agents-JSON. Ein gesweepter Orphan trug daher permanent einen Agent mit
+  // status `running` ohne completed_at/error → das TUI rendert ewig ein Live-
+  // Icon. Nach dem Sweep MUSS auch jeder noch laufende Agent-Node terminal sein.
+  it.instance("orphan sweep normalizes still-running agent nodes to failed", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const orphanId = "job_orphan_agent"
+      yield* seedRunningRowWithAgent(orphanId, test.directory)
+
+      yield* workflow.sweep()
+
+      const row = yield* fetchRunRow(orphanId)
+      expect(row.status).toBe("interrupted")
+      // Der laufende Node ist terminal geschlossen (failed + Grund + Zeit).
+      const closed = row.agents.find((a) => a.id === "1")
+      expect(closed?.status).toBe("failed")
+      expect(closed?.completed_at).toBeGreaterThan(0)
+      expect(closed?.error).toBeTruthy()
+      // Ein bereits abgeschlossener Node bleibt unberührt.
+      const intact = row.agents.find((a) => a.id === "2")
+      expect(intact?.status).toBe("completed")
+      // Kein Node bleibt `running`.
+      expect(row.agents.every((a) => a.status !== "running")).toBe(true)
+    }),
+  )
+
+  it.instance("persisted run round-trips through fromRow", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const persistedId = Workflow.RunID.make("job_roundtrip")
+      // Persist a finished run directly via the SQL layer (no live registry
+      // entry), so get() must read it back through DB->fromRow.
+      yield* seedCompletedRow(persistedId, test.directory)
+
+      const viaDb = yield* workflow.get(persistedId)
+      const persisted = viaDb ?? (yield* Effect.fail(new Error("run not persisted")))
+      expect(persisted).toMatchObject({ id: persistedId, status: "completed" })
+      // Telemetrie überlebt den Roundtrip durch fromRow.
+      expect(persisted.logs.map((item) => item.message)).toContain("running")
+      expect(persisted.agents.length).toBeGreaterThan(0)
+      expect(persisted.agents[0]?.output).toBe("did the thing")
+      // Fund 51: per-agent cost/tokens (incl. the optional `total`) survive the
+      // DB→fromRow roundtrip intact — not just output/status.
+      expect(persisted.agents[0]?.cost).toBe(0.42)
+      expect(persisted.agents[0]?.tokens).toEqual({
+        total: 99,
+        input: 11,
+        output: 22,
+        reasoning: 33,
+        cache: { read: 44, write: 55 },
+      })
+      // N20: das geseedete result überlebt den Roundtrip (wurde bisher nie asserted).
+      expect(persisted.result).toEqual({ ok: true })
+    }),
+  )
+
+  // N1 (medium): Ein terminaler Run muss nach finish() aus der In-Memory-Registry
+  // evictet sein, sonst wächst die Map unbeschränkt UND get()/runs() pinnen für
+  // immer den In-Memory-Snapshot eines toten Runs statt der DB-Row (gepinnte
+  // Divergenz). Seam (ohne neuen Produktions-Export): nach Abschluss die DB-Row
+  // direkt über die SQL-Schicht mutieren und get() lesen. Hielte die Registry den
+  // Run noch, läse get() den (stale) In-Memory-Snapshot und ignorierte die
+  // Mutation; nach Eviction fällt get() auf fromRow → die Mutation ist sichtbar.
+  it.instance("a finished run is evicted from the in-memory registry (get falls back to the DB row)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "hello",
+          `export const meta = { name: "Hello" }
+export async function run(args, ctx) { ctx.setPhase("run"); ctx.log("running"); return { value: args.value } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "hello", args: { value: 42 } })
+      const waited = yield* workflow.wait({ id: run.id })
+      expect(waited.run?.status).toBe("completed")
+      expect(waited.run?.result).toEqual({ value: 42 })
+
+      // Direkt die DB-Row mutieren (umgeht die Engine vollständig) UND innerhalb
+      // der Poll-Schleife re-applizieren: eine zuletzt noch geforkte Progress-
+      // Schreibung (aus ctx.setPhase/log) kann unmittelbar nach wait() einmalig
+      // current_phase auf "run" zurückschreiben — das Re-Apply macht den Test
+      // robust gegen dieses kurze Fenster. Hielte die Registry den Run dagegen
+      // noch, läse get() den gepinnten In-Memory-Snapshot (current_phase === "run")
+      // und die DB-Mutation bliebe — egal wie oft geschrieben — für immer
+      // unsichtbar. Nach Eviction (Designreihenfolge 3e/N2: NACH dem Deferred-
+      // Resolve) fällt get() auf die DB-Row zurück → die Mutation wird sichtbar.
+      const { db } = yield* Database.Service
+      const after = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ current_phase: "db-mutated" })
+            .where(eq(WorkflowRunTable.id, run.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(run.id)
+          return current?.current_phase === "db-mutated" ? current : undefined
+        }),
+        "finished run was never evicted from the registry (get stayed pinned to the in-memory snapshot)",
+      )
+      expect(after.current_phase).toBe("db-mutated")
+      // Der Terminalstand bleibt sonst korrekt (kein Stale-Verlust).
+      expect(after.status).toBe("completed")
+      expect(after.result).toEqual({ value: 42 })
+      expect(after.logs.map((l) => l.message)).toContain("running")
+    }),
+  )
+
+  // N1 (medium) — Reihenfolge-Sicherung gegen 3e/N2: ein wait()-Warter, der GENAU
+  // um den finish()-Übergang aufwacht, muss noch den Terminalzustand erhalten —
+  // die Eviction darf den Waiter nicht entwerten (der Run kommt aus dem resolved
+  // done-Deferred; ein get() danach liest die DB-Row, die der Terminal-Persist
+  // VOR der Eviction geschrieben hat).
+  it.instance("a waiter receives the terminal state across eviction; the DB row is present afterwards", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "hello",
+          `export const meta = { name: "Hello" }
+export async function run(args, ctx) { ctx.setPhase("run"); return { value: args.value } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "hello", args: { value: 7 } })
+      // wait() ohne Timeout hängt am done-Deferred und wacht beim Terminal-Übergang
+      // auf — nach Persist + Deferred.succeed, danach folgt die Eviction.
+      const waited = yield* workflow.wait({ id: run.id })
+      expect(waited.run?.status).toBe("completed")
+      expect(waited.run?.result).toEqual({ value: 7 })
+      // Der Terminal-Persist lief VOR der Eviction: die DB-Row existiert (kein
+      // Read-after-Evict-Loch).
+      const row = yield* fetchRunRow(run.id)
+      expect(row.status).toBe("completed")
+      // Und get() nach Abschluss liefert exakt den persistierten Stand.
+      const got = yield* workflow.get(run.id)
+      expect(got?.status).toBe("completed")
+      expect(got?.result).toEqual({ value: 7 })
+    }),
+  )
+
+  // N16 (medium): cancel() auf einen persistierten, NICHT-live Run (geseedet, kein
+  // Registry-Eintrag — der Zustand nach Neustart/Eviction) darf NICHT undefined
+  // liefern. Konsistent mit get()/remove() konsultiert cancel() die (gescopte)
+  // DB-Row: gefunden → ehrlich den Run-Snapshot zurückgeben (ein bereits
+  // terminaler Run wird nicht „gecancelt", aber zurückgegeben). undefined NUR bei
+  // echtem not-found.
+  it.instance("cancel falls back to the persisted row for a non-live run; undefined only for unknown ids", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const persistedId = Workflow.RunID.make("job_cancel_nonlive")
+      // Fertiger Run direkt geseedet → kein Registry-Eintrag (nicht live).
+      yield* seedCompletedRow(persistedId, test.directory)
+
+      // cancel() findet ihn über die DB und liefert den Snapshot, nicht undefined.
+      const cancelled = yield* workflow.cancel(persistedId)
+      expect(cancelled).toBeDefined()
+      expect(cancelled?.id).toBe(persistedId)
+      // Ein bereits terminaler Run wird nicht in cancelled umgeschrieben.
+      expect(cancelled?.status).toBe("completed")
+
+      // Eine völlig unbekannte id liefert undefined (→ HTTP 404 in 3h).
+      const unknown = yield* workflow.cancel(Workflow.RunID.make("job_cancel_unknown"))
+      expect(unknown).toBeUndefined()
+    }),
+  )
+
+  // N16 — Cross-Directory: cancel() ist auf das aufrufende Verzeichnis gescoped
+  // (wie get()/remove()). Eine fremde Row darf NICHT als gefunden gelten.
+  it.instance(
+    "cancel from another directory cannot see a foreign run",
+    () =>
+      Effect.gen(function* () {
+        const a = yield* TestInstance
+        const b = yield* tmpdirScoped({ git: true })
+        const workflow = yield* Workflow.Service
+        const idA = Workflow.RunID.make("job_cancel_scoped_A")
+        yield* seedCompletedRow(idA, a.directory)
+
+        // B sieht ihn nicht → undefined (nicht „found-but-not-cancellable").
+        expect(yield* workflow.cancel(idA).pipe(provideInstance(b))).toBeUndefined()
+        // A findet ihn weiterhin.
+        expect((yield* workflow.cancel(idA))?.id).toBe(idA)
+      }),
+    { git: true },
+  )
+
+  // N13 (low): snapshot()/die öffentliche Run-Ausgabe darf KEINE internen
+  // Zusatzfelder (directory/done/runScope/fiber/budget …) tragen und KEINE
+  // Live-Referenzen aliasen — Mutieren des zurückgegebenen Objekts (inkl. der
+  // verschachtelten args/definition/result) darf den internen Zustand nicht
+  // verändern (defensive Projektion).
+  it.instance("public run output is a defensive projection with no internal fields or live aliases", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "hello",
+          `export const meta = { name: "Hello" }
+export async function run(args, ctx) { ctx.setPhase("run"); ctx.log("running"); return { nested: { ok: true } } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "hello", args: { nested: { value: 1 } } })
+
+      // Live-Snapshot (Run ist noch in der Registry): keine internen Felder.
+      const live = yield* workflow.get(run.id)
+      const liveAny = live as unknown as Record<string, unknown>
+      for (const internal of [
+        "directory",
+        "done",
+        "runScope",
+        "fiber",
+        "sessions",
+        "cancelSession",
+        "cancelling",
+        "removed",
+        "budget",
+        "budgetRemaining",
+      ]) {
+        expect(internal in liveAny).toBe(false)
+      }
+      // Exakt die deklarierten Run-Schlüssel (Teilmenge: optionale können fehlen).
+      const allowed = new Set([
+        "id",
+        "session_id",
+        "workflow",
+        "args",
+        "definition",
+        "status",
+        "started_at",
+        "completed_at",
+        "current_phase",
+        "logs",
+        "agents",
+        "result",
+        "error",
+        "resume_of",
+        "pending_question",
+      ])
+      for (const key of Object.keys(liveAny))
+        expect(allowed.has(key)).toBe(true)
+
+        // Defensive Projektion: das verschachtelte args mutieren darf den internen
+        // Zustand NICHT beeinflussen.
+      ;(live!.args as { nested: { value: number } }).nested.value = 999
+      const again = yield* workflow.get(run.id)
+      expect((again!.args as { nested: { value: number } }).nested.value).toBe(1)
+
+      // Nach Abschluss kommt der Run NICHT mehr aus dem Live-Snapshot: finish()
+      // evictet den terminalen Run aus der Registry (N1), so dass jeder folgende
+      // get() ihn frisch aus der DB-Row über fromRow rekonstruiert. Eine Mutation
+      // an `done.result` und ein erneuter get() würden hier also nur die (ohnehin
+      // garantierte) fromRow-Frische prüfen — NICHT die Alias-Trennung des
+      // Live-Snapshots. Die result-Alias-Trennung am LIVEN Run ist daher in
+      // "snapshot severs agents[].tokens aliasing on a live run" abgedeckt; hier
+      // verifizieren wir nur ehrlich, dass das result den DB-Roundtrip überlebt.
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("workflow did not finish")))
+      expect((done.result as { nested: { ok: boolean } }).nested.ok).toBe(true)
+    }),
+  )
+
+  // N13 (spec): die öffentliche Run-Projektion darf das verschachtelte
+  // `agents[].tokens` (inkl. des weiter genesteten `cache`) NICHT aliasen. Der
+  // frühere snapshot kopierte agents nur flach (`{ ...item }`), so dass ein
+  // Verbraucher über `snapshot.agents[0].tokens.input` den internen Engine-State
+  // mutieren konnte. Geprüft am LIVEN Run (Run noch in der Registry, Agent-Node
+  // mit echter Token-Telemetrie), damit get() einen Live-Snapshot liefert und
+  // NICHT den ohnehin frischen fromRow-Pfad.
+  it.instance("snapshot severs agents[].tokens aliasing on a live run", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, AGENT_THEN_HANG_FIXTURE, AGENT_THEN_HANG_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({ name: AGENT_THEN_HANG_FIXTURE, args: {}, prompt: tokensPromptOps(db) })
+
+      // Warten, bis der Agent-Step gesettlet ist (tokens befüllt) und der Run
+      // dabei NOCH läuft (Body hängt am 30s-Timer) — get() liefert dann live.
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current?.status === "running" && current.agents[0]?.tokens ? current : undefined
+        }),
+        "agent tokens never populated on a live run",
+      )
+      const tokens = live.agents[0]!.tokens!
+      expect(tokens.input).toBe(11)
+      expect(tokens.cache.read).toBe(33)
+
+      // Über den Snapshot in den verschachtelten tokens/cache schreiben …
+      tokens.input = 999
+      tokens.cache.read = 888
+
+      // … darf den internen Engine-State NICHT verändern: ein zweiter Live-Snapshot
+      // zeigt die Originalwerte.
+      const again = yield* workflow.get(run.id)
+      expect(again?.status).toBe("running")
+      expect(again!.agents[0]!.tokens!.input).toBe(11)
+      expect(again!.agents[0]!.tokens!.cache.read).toBe(33)
+
+      // Aufräumen: den hängenden Run abbrechen, damit der 30s-Timer den Test nicht hält.
+      yield* workflow.cancel(run.id)
+    }),
+  )
+
+  // N2/N13 (regression): ein Workflow, der einen NICHT strukturell klonbaren Wert
+  // zurückgibt (`{ kept: 1, cb: () => {} }`), darf weder den no-timeout-wait()
+  // strandlassen noch den Terminal-Persist verhindern. Der frühere
+  // structuredClone-Snapshot warf darauf (DOMException) und hing. Der Engine
+  // normalisiert das result jetzt über denselben JSON-Codec wie der Persist:
+  // Funktionen werden (wie JSON.stringify) still verworfen, der Run schließt
+  // sauber als `completed` ab, und Live-Snapshot wie DB-Row tragen dieselbe Form.
+  it.instance("a non-cloneable workflow result never hangs wait(); JSON-normalized like the persist", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, UNSERIALIZABLE_RESULT_FIXTURE, UNSERIALIZABLE_RESULT_WORKFLOW),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: UNSERIALIZABLE_RESULT_FIXTURE, args: {} })
+
+      // wait() OHNE timeout: kommt terminal zurück (kein Hang) und meldet keinen Timeout.
+      const waited = yield* workflow.wait({ id: run.id })
+      expect(waited.timedOut).toBe(false)
+      const done = waited.run ?? (yield* Effect.fail(new Error("workflow did not finish")))
+      expect(done.status).toBe("completed")
+      // Funktionen werden (wie bei JSON.stringify) verworfen, serialisierbare
+      // Felder bleiben erhalten.
+      expect(done.result).toEqual({ kept: 1 })
+
+      // DB-Row und Live-Verhalten konsistent: ein kalter Spalten-Read zeigt
+      // dieselbe entfunktionalisierte Form.
+      expect(yield* fetchRawResult(run.id)).toBe(JSON.stringify({ kept: 1 }))
+      const persisted = yield* workflow.get(run.id)
+      expect(persisted?.status).toBe("completed")
+      expect(persisted?.result).toEqual({ kept: 1 })
+    }),
+  )
+
+  // N2/N13 (regression): ein result mit ZIRKULÄRER Referenz lässt JSON.stringify
+  // selbst werfen (TypeError). Der mit Effect.try abgesicherte
+  // Normalisierungspfad muss den Run dennoch terminal als `completed` abschließen
+  // (kein Hang, kein verlorener Terminal-Übergang) und das result auf den
+  // $unserializable-Platzhalter setzen.
+  it.instance("a circular workflow result finishes with the $unserializable placeholder", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, CIRCULAR_RESULT_FIXTURE, CIRCULAR_RESULT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: CIRCULAR_RESULT_FIXTURE, args: {} })
+
+      const waited = yield* workflow.wait({ id: run.id })
+      expect(waited.timedOut).toBe(false)
+      const done = waited.run ?? (yield* Effect.fail(new Error("workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect((done.result as { $unserializable: string }).$unserializable).toBeDefined()
+
+      // Konsistent in der DB-Row.
+      const persisted = yield* workflow.get(run.id)
+      expect((persisted?.result as { $unserializable: string }).$unserializable).toBeDefined()
+    }),
+  )
+
+  // Fund 42 / N20 (low): result === null darf im DB-Roundtrip NICHT zu undefined
+  // ("No result recorded.") werden. Drei Fälle, end-to-end durch den echten
+  // Engine-Persist getrieben: ein echtes result, result === null und nie gesetzt.
+  // Geprüft wird BEIDE Richtungen: die rohe Spalten-Serialisierung (write) und
+  // die Decodierung durch fromRow (read), inkl. der Unterscheidung SQL-NULL
+  // (nie gesetzt → undefined) vs. JSON-Text "null" (echtes null → null).
+  it.instance("null and undefined workflow results survive persistence distinctly", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          HELLO_FIXTURE,
+          `export const meta = { name: "Hello" }
+export async function run(args, ctx) { ctx.setPhase("run"); return { value: args.value } }
+`,
+        ),
+      )
+      yield* Effect.promise(() => writeWorkflow(test.directory, NULL_RESULT_FIXTURE, NULL_RESULT_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, VOID_RESULT_FIXTURE, VOID_RESULT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const finishRun = (name: string, args?: Record<string, unknown>) =>
+        Effect.gen(function* () {
+          const run = yield* workflow.start({ name, args: args ?? {} })
+          const waited = yield* workflow.wait({ id: run.id })
+          const done = waited.run ?? (yield* Effect.fail(new Error(`${name} did not finish`)))
+          expect(done.status).toBe("completed")
+          return run.id
+        })
+
+      // (a) echtes result.
+      const realId = yield* finishRun(HELLO_FIXTURE, { value: 42 })
+      expect((yield* workflow.get(realId))?.result).toEqual({ value: 42 })
+      expect(yield* fetchRawResult(realId)).toBe(JSON.stringify({ value: 42 }))
+
+      // (b) result === null: roh als JSON-Text "null" persistiert, NICHT SQL-NULL.
+      const nullId = yield* finishRun(NULL_RESULT_FIXTURE)
+      expect((yield* workflow.get(nullId))?.result).toBeNull()
+      expect(yield* fetchRawResult(nullId)).toBe("null")
+
+      // (c) nie gesetzt: roh SQL-NULL, liest als undefined zurück.
+      const voidId = yield* finishRun(VOID_RESULT_FIXTURE)
+      expect((yield* workflow.get(voidId))?.result).toBeUndefined()
+      expect(yield* fetchRawResult(voidId)).toBeNull()
+
+      // Kalt-Read durch fromRow (frische Rows, kein Registry-Eintrag): die drei
+      // rohen Spalten-Zustände dekodieren exakt zu value / null / undefined.
+      const { db } = yield* Database.Service
+      const now = Date.now()
+      // Raw INSERT so the `result` column holds the EXACT bytes under test (the
+      // text `"null"` vs SQL NULL) — a Drizzle insert would route through the
+      // engine's codec and hide the distinction. time_created/time_updated are
+      // NOT NULL with no SQL-level default (the default lives in the Drizzle
+      // Timestamps helper, which a raw INSERT bypasses), so they must be set here.
+      const seedRaw = (id: string, raw: string | null) =>
+        db
+          .run(
+            sql`INSERT INTO ${WorkflowRunTable} (id, workflow, directory, status, started_at, completed_at, logs, agents, result, time_created, time_updated)
+              VALUES (${id}, ${HELLO_FIXTURE}, ${test.directory}, 'completed', ${now}, ${now}, '[]', '[]', ${raw}, ${now}, ${now})`,
+          )
+          .pipe(Effect.orDie)
+      yield* seedRaw("job_result_real", JSON.stringify({ value: 7 }))
+      yield* seedRaw("job_result_null", "null")
+      yield* seedRaw("job_result_void", null)
+      expect((yield* workflow.get(Workflow.RunID.make("job_result_real")))?.result).toEqual({ value: 7 })
+      expect((yield* workflow.get(Workflow.RunID.make("job_result_null")))?.result).toBeNull()
+      expect((yield* workflow.get(Workflow.RunID.make("job_result_void")))?.result).toBeUndefined()
+    }),
+  )
+
+  it.instance("wait on interrupted run resolves immediately as interrupted (not timedOut)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const orphanId = Workflow.RunID.make("job_orphan_wait")
+      yield* seedRunningRow(orphanId, test.directory)
+      yield* workflow.sweep()
+
+      const res = yield* workflow.wait({ id: orphanId, timeout: 50 })
+      expect(res.run?.status).toBe("interrupted")
+      expect(res.timedOut).not.toBe(true)
+    }),
+  )
+
+  // Fund 25 (a): wait() on a still-RUNNING run with a small timeout times out
+  // honestly — `timedOut: true`, the snapshot status stays `running`, and the run
+  // is NOT mutated by the timeout. Deterministic: the run is parked on a barrier
+  // (genuinely live in the registry, never released until after the assertion), so
+  // the timeout is the ONLY thing that ends the wait — no race with the body
+  // completing. The barrier is released afterwards so the run can drain.
+  it.instance("wait with a small timeout on a hanging run returns timedOut with status still running", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_BARRIER_FIXTURE, PARALLEL_BARRIER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sync = installBarrier()
+      const run = yield* workflow.start({ name: PARALLEL_BARRIER_FIXTURE, args: { __barrier: sync.token, count: 1 } })
+      // Ensure the run is genuinely live and parked (the single task is at the gate)
+      // before testing the timeout, so wait() cannot resolve via completion.
+      yield* sync.awaitPeak(1)
+
+      const res = yield* workflow.wait({ id: run.id, timeout: 50 })
+      expect(res.timedOut).toBe(true)
+      // The snapshot reports the live status (still running); the timeout did not
+      // flip or finish the run.
+      expect(res.run?.status).toBe("running")
+      // The run is still live and running afterwards (the timeout is observation-only).
+      const stillLive = yield* workflow.get(run.id)
+      expect(stillLive?.status).toBe("running")
+
+      // Release the gate so the run finishes, then drain it.
+      sync.barrier.release()
+      const waited = yield* workflow.wait({ id: run.id })
+      expect(waited.timedOut).toBe(false)
+      expect(waited.run?.status).toBe("completed")
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  // Fund 25 (b): wait() with timeout <= 0 returns an IMMEDIATE snapshot
+  // (`timedOut: true`) without ever suspending on the run's done deferred — a
+  // zero/negative timeout must not hang on a still-running run. Proven by parking
+  // the run on a barrier (so it is genuinely running) and asserting wait({timeout:0})
+  // returns at once with the running snapshot; a hung implementation would never
+  // return because the gate is still closed.
+  it.instance("wait with timeout <= 0 returns an immediate running snapshot without hanging", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PARALLEL_BARRIER_FIXTURE, PARALLEL_BARRIER_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sync = installBarrier()
+      const run = yield* workflow.start({ name: PARALLEL_BARRIER_FIXTURE, args: { __barrier: sync.token, count: 1 } })
+      yield* sync.awaitPeak(1)
+
+      for (const timeout of [0, -10]) {
+        // awaitWithTimeout proves the call RETURNS promptly (no hang on the closed
+        // gate); a non-short-circuiting implementation would block here forever.
+        const res = yield* awaitWithTimeout(
+          workflow.wait({ id: run.id, timeout }),
+          `wait({timeout:${timeout}}) hung on a still-running run`,
+          "2 seconds",
+        )
+        expect(res.timedOut).toBe(true)
+        expect(res.run?.status).toBe("running")
+      }
+
+      sync.barrier.release()
+      yield* workflow.wait({ id: run.id })
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  it.instance("schema agent failure is recorded as failed, never silently completed", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, SCHEMA_FAILING_FIXTURE, schemaWorkflow(SCHEMA_FAILING_FIXTURE)),
+      )
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: SCHEMA_FAILING_FIXTURE,
+        args: {},
+        prompt: structuredPromptOps(db, "error"),
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("failed")
+      expect(done.run?.agents.some((a) => a.status === "failed")).toBe(true)
+      // Kein stiller Plaintext-Fallback: der Agent darf NICHT completed sein.
+      expect(done.run?.agents.some((a) => a.status === "completed")).toBe(false)
+    }),
+  )
+
+  it.instance("schema agent with undefined structured result fails instead of plaintext fallback", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, SCHEMA_UNDEFINED_FIXTURE, schemaWorkflow(SCHEMA_UNDEFINED_FIXTURE)),
+      )
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: SCHEMA_UNDEFINED_FIXTURE,
+        args: {},
+        prompt: structuredPromptOps(db, "undefined"),
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("failed")
+      expect(done.run?.agents.some((a) => a.status === "failed")).toBe(true)
+    }),
+  )
+
+  it.instance("schema agent success returns the parsed object and completes", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, SCHEMA_SUCCESS_FIXTURE, schemaWorkflow(SCHEMA_SUCCESS_FIXTURE)),
+      )
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: SCHEMA_SUCCESS_FIXTURE,
+        args: {},
+        prompt: structuredPromptOps(db, "structured"),
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      // Positivpfad: das geparste Objekt wird durch ctx.agent (result.data) und
+      // damit das Workflow-Resultat hindurchgereicht.
+      expect(done.run?.result).toEqual({ data: SCHEMA_OBJECT })
+      expect(done.run?.agents.every((a) => a.status === "completed")).toBe(true)
+    }),
+  )
+
+  it.instance("agent calls beyond exhausted budget fail the run with a budget error", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_FIXTURE, BUDGET_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      // Budget 1.0 USD, jeder Step kostet 1.0 — nach Step 1 ist das Budget
+      // erschöpft (Rest 0), also scheitert der zweite ctx.agent am Gate.
+      const run = yield* workflow.start({
+        name: BUDGET_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 1),
+        budget: 1,
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("failed")
+      expect(done.run?.error ?? "").toMatch(/budget/i)
+      // Das Gate verhindert, dass der zweite Step überhaupt STARTET: nur der
+      // erste Agent läuft (und wird completed); für den geblockten zweiten Step
+      // wird kein Node angelegt — die Engine weigert sich, weiter zu spenden.
+      expect(done.run?.agents.filter((a) => a.status === "completed").length).toBe(1)
+      expect(done.run?.agents.length).toBe(1)
+    }),
+  )
+
+  // Fund 23 (best-effort soft cap under parallelism): the budget is enforced PER
+  // STEP, checked BEFORE each ctx.agent and settled AFTER it. Steps launched
+  // together via ctx.parallel all pass the gate while the budget is still positive,
+  // so a run can OVERSPEND by the combined cost of the steps already in flight when
+  // the budget runs out — documented soft-cap behavior, not a hard mid-step limit.
+  // Deterministic proof: a Deferred barrier holds all 3 parallel prompts until ALL
+  // have passed the gate, then releases them so they all charge. With budget 1.0 and
+  // 3 parallel steps à 0.5 (total 1.5), the budget overspends to -0.5; the NEXT
+  // (sequential) step then fails the exhausted-budget gate.
+  it.instance("parallel steps all pass the gate and overspend; the next step fails (soft cap)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_PARALLEL_FIXTURE, BUDGET_PARALLEL_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      // 3 parallel agents à 0.5 USD, budget 1.0. All 3 pass the gate while the
+      // budget is positive (the barrier holds them until all 3 have arrived), so
+      // all 3 charge ⇒ overspend to -0.5.
+      const run = yield* workflow.start({
+        name: BUDGET_PARALLEL_FIXTURE,
+        args: { count: 3 },
+        prompt: budgetBarrierPromptOps(db, 0.5, 3),
+        budget: 1,
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      // The run COMPLETES — the workflow body catches the post-batch budget failure.
+      expect(done.run?.status).toBe("completed")
+      const result = done.run?.result as { overspent: number; nextStarted: boolean; nextFailed: boolean }
+      // Soft-cap overspend: all 3 parallel steps charged, driving the budget below 0.
+      expect(result.overspent).toBeCloseTo(-0.5, 10)
+      // All 3 parallel steps were charged (completed) — the documented overspend.
+      const completed = done.run?.agents.filter((a) => a.status === "completed") ?? []
+      expect(completed.length).toBe(3)
+      const totalCost = completed.reduce((sum, a) => sum + (a.cost ?? 0), 0)
+      expect(totalCost).toBeCloseTo(1.5, 10)
+      // The NEXT (sequential) step after exhaustion hits the gate and fails.
+      expect(result.nextStarted).toBe(true)
+      expect(result.nextFailed).toBe(true)
+      // The blocked 4th step never created a node (refused before dispatch).
+      expect(done.run?.agents.length).toBe(3)
+    }),
+  )
+
+  // T5 budget-race AUDIT (verdict: benign soft cap, no fix). The review asked
+  // specifically: "2 parallel agents, budget for exactly 1 — does the second
+  // double-spend BEYOND the documented soft cap?" Deterministic proof via the
+  // same Deferred barrier as the Fund-23 test: 2 agents à 1.0, budget 1.0. The
+  // barrier holds BOTH until both have passed the synchronous gate, so both
+  // charge ⇒ overspend to -1.0 (exactly one extra step's worth, the cost already
+  // in flight). This is the DOCUMENTED soft cap — NOT an unbounded race: the gate
+  // refuses any FURTHER step once the budget is non-positive. This test pins that
+  // boundary so a future refactor that turns the soft cap into either a hard limit
+  // OR an unbounded leak fails here.
+  it.instance(
+    "budget-race audit: 2 parallel agents with budget for 1 overspend by exactly one step (soft cap, bounded)",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_PARALLEL_FIXTURE, BUDGET_PARALLEL_WORKFLOW))
+        const workflow = yield* Workflow.Service
+        const { db } = yield* Database.Service
+        const run = yield* workflow.start({
+          name: BUDGET_PARALLEL_FIXTURE,
+          args: { count: 2 },
+          prompt: budgetBarrierPromptOps(db, 1, 2),
+          budget: 1,
+        })
+        const done = yield* workflow.wait({ id: run.id })
+        expect(done.run?.status).toBe("completed")
+        const result = done.run?.result as { overspent: number; nextStarted: boolean; nextFailed: boolean }
+        // Exactly one extra step's worth of overspend: 2 * 1.0 charged against a 1.0
+        // budget ⇒ remaining -1.0. Bounded, not unbounded.
+        expect(result.overspent).toBeCloseTo(-1, 10)
+        // Both parallel steps charged (the in-flight cost), and exactly two nodes
+        // exist — no third step slipped past the gate.
+        const completed = done.run?.agents.filter((a) => a.status === "completed") ?? []
+        expect(completed.length).toBe(2)
+        expect(done.run?.agents.length).toBe(2)
+        // The NEXT sequential step after exhaustion is refused (bounded soft cap).
+        expect(result.nextStarted).toBe(true)
+        expect(result.nextFailed).toBe(true)
+      }),
+  )
+
+  // Item 24 Test (1): two runs share ONE turn pool. Run A's two steps charge
+  // the whole pool; Run B (same pool) is refused at its FIRST ctx.agent with
+  // 'Turn budget exhausted' — the cross-run gate the per-run budget never had.
+  it.instance("two runs share one turn pool: the second run fails with 'Turn budget exhausted'", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_FIXTURE, BUDGET_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const pool = TurnBudget.make({ usd: 1 })
+
+      // Run A: 2 steps à 0.6 — passes (reserve sees headroom before each) but
+      // commits 1.2, exhausting the pool past its 1.0 cap.
+      const first = yield* workflow.start({ name: BUDGET_FIXTURE, args: {}, prompt: costPromptOps(db, 0.6), pool })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("run A did not settle")))
+      expect(firstDone.status).toBe("completed")
+      expect(pool.usd!.committed).toBeCloseTo(1.2, 10)
+
+      // Run B on the SAME pool: its first agent is refused before any node is
+      // recorded — no spend, run failed with the pool verdict.
+      const second = yield* workflow.start({ name: BUDGET_FIXTURE, args: {}, prompt: costPromptOps(db, 0.6), pool })
+      const secondDone =
+        (yield* workflow.wait({ id: second.id })).run ?? (yield* Effect.fail(new Error("run B did not settle")))
+      expect(secondDone.status).toBe("failed")
+      expect(secondDone.error ?? "").toMatch(/Turn budget exhausted/)
+      expect(secondDone.agents).toHaveLength(0)
+      // Nothing further charged, nothing left reserved.
+      expect(pool.usd!.committed).toBeCloseTo(1.2, 10)
+      expect(pool.usd!.reserved).toBe(0)
+    }),
+  )
+
+  // Item 24 Test (2): the reservation closes the documented soft-cap race.
+  // After ONE settled step the pool prices reservations at its rolling average
+  // (1.0); with 0.5 headroom left, of two PARALLEL steps exactly one passes —
+  // the other is refused synchronously, before any node exists (contrast the
+  // per-run 'budget-race audit' above, where both passed and overspent).
+  it.instance("a priced pool reservation lets exactly one of two parallel steps pass", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_REMAINING_FIXTURE, BUDGET_REMAINING_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, POOL_PARALLEL_FIXTURE, POOL_PARALLEL_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const pool = TurnBudget.make({ usd: 1.5 })
+
+      // Prime: one settled step à 1.0 sets avgStepUsd = 1.0, committed = 1.0.
+      const prime = yield* workflow.start({
+        name: BUDGET_REMAINING_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 1),
+        pool,
+      })
+      const primed =
+        (yield* workflow.wait({ id: prime.id })).run ?? (yield* Effect.fail(new Error("prime run did not settle")))
+      expect(primed.status).toBe("completed")
+      expect(pool.avgStepUsd).toBeCloseTo(1, 10)
+
+      // Two parallel steps, 0.5 headroom, 1.0 reservations: exactly ONE passes.
+      // The refused one resolves to null at its position (the P1 parallel drop
+      // semantics), so the run COMPLETES — but only one node was ever created
+      // (the refusal precedes node recording) and the drop log carries the
+      // pool verdict.
+      const race = yield* workflow.start({
+        name: POOL_PARALLEL_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 0.1),
+        pool,
+      })
+      const raced =
+        (yield* workflow.wait({ id: race.id })).run ?? (yield* Effect.fail(new Error("race run did not settle")))
+      expect(raced.status).toBe("completed")
+      expect(raced.agents.length).toBe(1)
+      expect(raced.logs.some((l) => l.message.includes("dropped") && l.message.includes("Turn budget exhausted"))).toBe(
+        true,
+      )
+      // The passed step's reservation settled (committed its 0.1), the refused
+      // one never reserved: nothing leaks.
+      expect(pool.usd!.committed).toBeCloseTo(1.1, 10)
+      expect(pool.usd!.reserved).toBe(0)
+    }),
+  )
+
+  // Item 24 Test (3): a FAILED step releases its reservation — committed stays
+  // untouched, reserved returns to 0 (the ensuring settles on every outcome).
+  it.instance("a failed step releases its pool reservation without committing spend", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_REMAINING_FIXTURE, BUDGET_REMAINING_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const pool = TurnBudget.make({ usd: 2 })
+
+      // Prime a settled step so the next reservation is non-zero (0.5).
+      const prime = yield* workflow.start({
+        name: BUDGET_REMAINING_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 0.5),
+        pool,
+      })
+      yield* workflow.wait({ id: prime.id })
+      expect(pool.usd!.committed).toBeCloseTo(0.5, 10)
+
+      // Failing run: the step reserves 0.5, the prompt fails — the ensuring
+      // settles with 0: committed unchanged, reserved back to 0.
+      const failingOps: Workflow.PromptOps = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            return yield* Effect.fail(new Error("agent exploded"))
+          }),
+        cancel: () => Effect.void,
+      }
+      const failed = yield* workflow.start({ name: BUDGET_REMAINING_FIXTURE, args: {}, prompt: failingOps, pool })
+      const failedDone =
+        (yield* workflow.wait({ id: failed.id })).run ?? (yield* Effect.fail(new Error("failing run did not settle")))
+      expect(failedDone.status).toBe("failed")
+      expect(pool.usd!.committed).toBeCloseTo(0.5, 10)
+      expect(pool.usd!.reserved).toBe(0)
+    }),
+  )
+
+  // Item 24 Test (4): the ctx.budget pool view. Without a run budget, total/
+  // spent()/remaining() derive from the pool — spent() includes the main
+  // loop's chargeDirect share (Claude-Code semantics: the TURN's spend).
+  it.instance("ctx.budget reflects the pool including chargeDirect spend when no run budget is set", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, POOL_SPENT_FIXTURE, POOL_SPENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const pool = TurnBudget.make({ usd: 10 })
+      // Simulate the main loop's direct charge before the run starts.
+      TurnBudget.chargeDirect(pool, { usd: 0.3 })
+
+      const run = yield* workflow.start({ name: POOL_SPENT_FIXTURE, args: {}, prompt: costPromptOps(db, 0.25), pool })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("run did not settle")))
+      expect(done.status).toBe("completed")
+      const result = done.result as { before: number; total: number; after: number; remaining: number }
+      expect(result.total).toBe(10)
+      expect(result.before).toBeCloseTo(0.3, 10)
+      expect(result.after).toBeCloseTo(0.55, 10)
+      expect(result.remaining).toBeCloseTo(10 - 0.55, 10)
+    }),
+  )
+
+  // Item 24 Test (5): journal REPLAYS charge the pool too (parity with the
+  // run-budget charge — node.cost is copied on the cache hit and settled).
+  it.instance("a journal replay charges the shared turn pool", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_FIXTURE, BUDGET_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Source run (NO pool): two steps à 0.5 complete.
+      const first = yield* workflow.start({ name: BUDGET_FIXTURE, args: {}, prompt: costPromptOps(db, 0.5) })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("source run did not settle")))
+      expect(firstDone.status).toBe("completed")
+
+      // Resume with a pool: full cache hit, yet the pool is charged 1.0.
+      const pool = TurnBudget.make({ usd: 10 })
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: BUDGET_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        pool,
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not settle")))
+      expect(done.status).toBe("completed")
+      expect(prompted).toHaveLength(0)
+      expect(done.agents.every((a) => a.cached === true)).toBe(true)
+      expect(pool.usd!.committed).toBeCloseTo(1, 10)
+      expect(pool.usd!.reserved).toBe(0)
+    }),
+  )
+
+  it.instance("budgetRemaining reflects real spend during the run", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_REMAINING_FIXTURE, BUDGET_REMAINING_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: BUDGET_REMAINING_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 0.25),
+        budget: 1,
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      const result = done.run?.result as { before: number; after: number }
+      expect(result.before).toBe(1)
+      // Nach einem Step à 0.25 USD bleibt 0.75 übrig.
+      expect(result.after).toBe(0.75)
+      expect(result.after).toBeLessThan(result.before)
+    }),
+  )
+
+  // Fund N12 (high): a single ctx.agent step whose child session runs SEVERAL
+  // provider turns (the normal case once the subagent uses tools) persists one
+  // assistant message per turn, each with its own cost/tokens, but the runner
+  // RETURNS only the last. Charging that last message alone discarded every
+  // intermediate turn — under-reporting per-agent telemetry AND under-counting the
+  // budget. The engine must sum cost/tokens across ALL assistant messages of the
+  // child session: cost 0.01 + 0.02 + 0.03 = 0.06 (not just the final 0.03), tokens
+  // summed field-wise, and the budget decremented by the full 0.06.
+  it.instance("a multi-turn agent step charges the SUM of all turns, not just the last", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_REMAINING_FIXTURE, BUDGET_REMAINING_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: BUDGET_REMAINING_FIXTURE,
+        args: {},
+        prompt: multiTurnPromptOps(db, [
+          { cost: 0.01, tokens: { input: 1, output: 2, reasoning: 3, cache: { read: 4, write: 5 } } },
+          { cost: 0.02, tokens: { input: 10, output: 20, reasoning: 30, cache: { read: 40, write: 50 } } },
+          { cost: 0.03, tokens: { input: 100, output: 200, reasoning: 300, cache: { read: 400, write: 500 } } },
+        ]),
+        budget: 1,
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      // Per-agent telemetry reflects the FULL multi-turn spend (0.06), not 0.03.
+      const node = done.run!.agents[0]!
+      expect(node.cost).toBeCloseTo(0.06, 10)
+      expect(node.tokens).toEqual({ input: 111, output: 222, reasoning: 333, cache: { read: 444, write: 555 } })
+      // Budget decremented by the SUM (1 - 0.06 = 0.94), observed live mid-run.
+      const result = done.run?.result as { before: number; after: number }
+      expect(result.before).toBe(1)
+      expect(result.after).toBeCloseTo(0.94, 10)
+    }),
+  )
+
+  // Fund 51 (telemetry populated from the assistant message): an agent step whose
+  // session returns NON-null cost/tokens (including the optional `tokens.total`)
+  // must have that telemetry copied onto the agent node — `run.agents[0].cost` and
+  // `run.agents[0].tokens` (with `total`) reflect exactly what the assistant message
+  // carried. A single-turn session yields exactly one assistant message, so the
+  // node equals that message's telemetry verbatim (no summing artifact).
+  it.instance("agent telemetry (cost + tokens incl. total) is populated from the assistant message", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: SINGLE_AGENT_FIXTURE,
+        args: {},
+        // A single turn with non-null cost AND a non-null tokens.total so a dropped
+        // field would be observable.
+        prompt: multiTurnPromptOps(db, [
+          { cost: 0.17, tokens: { total: 60, input: 10, output: 20, reasoning: 30, cache: { read: 5, write: 7 } } },
+        ]),
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      const node = done.run!.agents[0]!
+      expect(node.cost).toBeCloseTo(0.17, 10)
+      // The whole tokens shape, including the summed-but-single `total`, is carried.
+      expect(node.tokens).toEqual({ total: 60, input: 10, output: 20, reasoning: 30, cache: { read: 5, write: 7 } })
+    }),
+  )
+
+  // Item 28: subagent sessions load MCP lazily by default — the engine stamps
+  // mcp:"lazy" on the subagent PromptInput (observed via the capture seam).
+  it.instance("a subagent PromptInput carries mcp:'lazy' by default", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+      const run = yield* workflow.start({ name: SINGLE_AGENT_FIXTURE, args: {}, prompt: ops })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      expect(inputs).toHaveLength(1)
+      expect(inputs[0].mcp).toBe("lazy")
+    }),
+  )
+
+  // Item 28: config workflows.lazy_mcp=false restores eager subagents (no mcp
+  // field on the PromptInput ⇒ the loop's eager default).
+  it.instance(
+    "workflows.lazy_mcp=false keeps subagent PromptInputs eager",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+        const workflow = yield* Workflow.Service
+        const { ops, inputs } = capturingPromptOps()
+        const run = yield* workflow.start({ name: SINGLE_AGENT_FIXTURE, args: {}, prompt: ops })
+        const done = yield* workflow.wait({ id: run.id })
+        expect(done.run?.status).toBe("completed")
+        expect(inputs).toHaveLength(1)
+        expect(inputs[0].mcp).toBeUndefined()
+      }),
+    { config: { workflows: { lazy_mcp: false } } },
+  )
+
+  it.instance("no budget set means unlimited (Infinity) — unchanged default", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_UNLIMITED_FIXTURE, BUDGET_UNLIMITED_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: BUDGET_UNLIMITED_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 5),
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      expect((done.run?.result as { unlimited: boolean }).unlimited).toBe(true)
+    }),
+  )
+
+  // ctx.budget (Claude-Code-Parität) neben ctx.budgetRemaining: mit gesetztem
+  // Budget liefert total den Startwert, spent() den bisher ausgegebenen Betrag
+  // (0 ohne Agent-Step) und remaining() den Rest (== total bei spent()===0).
+  it.instance("ctx.budget exposes total/spent()/remaining() when started with a budget", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_API_FIXTURE, BUDGET_API_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: BUDGET_API_FIXTURE, args: {}, budget: 5 })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      const result = done.run?.result as { total: number; spent: number; remaining: number }
+      expect(result.total).toBe(5)
+      expect(result.spent).toBe(0)
+      expect(result.remaining).toBe(5)
+    }),
+  )
+
+  // Ohne Budget: ctx.budget.total ist null und remaining() ist Infinity (nicht
+  // endlich). Infinity überlebt JSON nicht, deshalb prüft das Fixture per Boolean.
+  it.instance("ctx.budget.total is null and remaining() is Infinity without a budget", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, BUDGET_API_UNLIMITED_FIXTURE, BUDGET_API_UNLIMITED_WORKFLOW),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: BUDGET_API_UNLIMITED_FIXTURE, args: {} })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      const result = done.run?.result as { total: number | null; remainingFinite: boolean }
+      expect(result.total).toBe(null)
+      expect(result.remainingFinite).toBe(false)
+    }),
+  )
+
+  // Item 17: budget {tokens} gates the next step once the accumulated
+  // output+reasoning tokens reach the cap — same two-step shape as the USD gate.
+  it.instance("a token budget gates the next step once exhausted", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_FIXTURE, BUDGET_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      // Step 1 spends exactly the cap (40 output + 10 reasoning = 50) ⇒ step 2
+      // must be refused at the token gate.
+      const run = yield* workflow.start({
+        name: BUDGET_FIXTURE,
+        args: {},
+        prompt: tokenBudgetPromptOps(db, 40, 10),
+        budget: { tokens: 50 },
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("failed")
+      expect(done.run?.error ?? "").toMatch(/token budget exhausted/i)
+      // Step one really completed; step two was REFUSED at the gate (the throw
+      // happens before node creation, exactly like the USD gate).
+      const one = done.run?.agents.find((a) => a.prompt === "step one")
+      expect(one?.status).toBe("completed")
+      expect(done.run?.agents.length).toBe(1)
+    }),
+  )
+
+  // Item 17: ctx.budget's token trio reads live across steps; only
+  // output+reasoning count (the fake carries non-zero input/cache tokens).
+  it.instance("ctx.budget exposes tokensTotal/tokensSpent()/tokensRemaining() live across steps", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, TOKEN_API_FIXTURE, TOKEN_API_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: TOKEN_API_FIXTURE,
+        args: {},
+        prompt: tokenBudgetPromptOps(db, 30, 20),
+        budget: { tokens: 100 },
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      const result = done.run?.result as {
+        total: number
+        beforeSpent: number
+        beforeRemaining: number
+        afterSpent: number
+        afterRemaining: number
+      }
+      expect(result.total).toBe(100)
+      expect(result.beforeSpent).toBe(0)
+      expect(result.beforeRemaining).toBe(100)
+      // 30 output + 20 reasoning = 50; input (11) and cache (7/3) do NOT count.
+      expect(result.afterSpent).toBe(50)
+      expect(result.afterRemaining).toBe(50)
+    }),
+  )
+
+  // Item 17: without a token budget, tokensTotal is null and tokensRemaining()
+  // is Infinity — mirroring the USD trio's unlimited shape.
+  it.instance("ctx.budget.tokensTotal is null and tokensRemaining() is Infinity without a token budget", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, TOKEN_API_UNLIMITED_FIXTURE, TOKEN_API_UNLIMITED_WORKFLOW),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: TOKEN_API_UNLIMITED_FIXTURE, args: {} })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      const result = done.run?.result as { tokensTotal: number | null; remainingFinite: boolean }
+      expect(result.tokensTotal).toBe(null)
+      expect(result.remainingFinite).toBe(false)
+    }),
+  )
+
+  // Item 17 (back-compat pin): the struct form {usd} behaves exactly like the
+  // naked-number budget (which the existing USD tests keep pinning).
+  it.instance("budget {usd} behaves like the naked-number USD budget", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_FIXTURE, BUDGET_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const run = yield* workflow.start({
+        name: BUDGET_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 2),
+        budget: { usd: 1 },
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("failed")
+      expect(done.run?.error ?? "").toMatch(/budget exhausted.*USD/i)
+    }),
+  )
+
+  // Item 17: a resume's journal REPLAYS charge their token cost too (node.tokens
+  // is copied on the cache hit and settled like a live step), so a tight token
+  // budget gates a later step even when the earlier one never re-prompted.
+  it.instance("a resume charges replayed token cost against the token budget", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, BUDGET_FIXTURE, BUDGET_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // First run: both steps complete, 30 output tokens each.
+      const first = yield* workflow.start({ name: BUDGET_FIXTURE, args: {}, prompt: tokenBudgetPromptOps(db, 30) })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      // completed → paused so it is a legitimate resume source (journal kept).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      // Resume with tokens:30 — step one REPLAYS (no prompt) but charges its 30
+      // journal tokens, so step two trips the token gate.
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: BUDGET_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        budget: { tokens: 30 },
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("failed")
+      expect(done.error ?? "").toMatch(/token budget exhausted/i)
+      // Step one was never re-prompted — it came from the journal.
+      expect(prompted).not.toContain("step one")
+      const one = done.agents.find((a) => a.prompt === "step one")
+      expect(one?.cached).toBe(true)
+    }),
+  )
+
+  it.instance("a failed-but-paid step still charges the budget by its actual cost", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, BUDGET_FAILED_PAID_FIXTURE, BUDGET_FAILED_PAID_WORKFLOW),
+      )
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      // Schema-Agent scheitert (kein strukturiertes Ergebnis), hat aber 0.3 USD
+      // gekostet. Der Workflow fängt den Fehler ab und läuft weiter.
+      const run = yield* workflow.start({
+        name: BUDGET_FAILED_PAID_FIXTURE,
+        args: {},
+        prompt: structuredPromptOps(db, "error", 0.3),
+        budget: 1,
+      })
+      const done = yield* workflow.wait({ id: run.id })
+      expect(done.run?.status).toBe("completed")
+      const result = done.run?.result as { failed: boolean; remaining: number }
+      // Der Step ist wirklich gescheitert ...
+      expect(result.failed).toBe(true)
+      // ... wurde aber trotzdem mit seinen echten Kosten (0.3) belastet.
+      expect(result.remaining).toBe(0.7)
+      // Und der Agent-Node ist als failed verbucht.
+      expect(done.run?.agents.some((a) => a.status === "failed")).toBe(true)
+    }),
+  )
+
+  // Finding 2 (HIGH): an externally-aborted subagent — a session abort/timeout that
+  // is NOT a run-level cancel/pause — RESOLVES with an abort-marked assistant message
+  // that carries the abort-artifact cost (0.4 USD here). The run itself never enters
+  // cancelling/pausing/removed, so the spend-skip guard used to charge that cost,
+  // leaving a `cancelled` run whose budget/costSpent were debited (an internally
+  // inconsistent terminal state the comment explicitly forbids). The fix adds the
+  // message-level `aborted` flag to the spend-skip guard. We capture the live spend
+  // accumulators at the terminal transition (they are never persisted) via the
+  // captureSpend seam: the run finishes `cancelled` (the abort propagates) but its
+  // budget must be UNTOUCHED (full 1.0 remaining, 0 spent). The per-node telemetry
+  // cost is still recorded — only the budget charge is skipped.
+  it.instance("an externally-aborted subagent does not charge its abort-artifact cost to the budget", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const spend = new Map<string, { budgetRemaining: number; costSpent: number }>()
+      Workflow.__testHooks.captureSpend((id, s) => spend.set(id, s))
+      try {
+        const run = yield* workflow.start({
+          name: SINGLE_AGENT_FIXTURE,
+          args: {},
+          prompt: abortedCostPromptOps(db, 0.4),
+          budget: 1,
+        })
+        const done = yield* workflow.wait({ id: run.id })
+        // The abort propagates: the run finishes `cancelled` (not completed).
+        expect(done.run?.status).toBe("cancelled")
+        const captured = spend.get(run.id)
+        expect(captured).toBeDefined()
+        // The abort-artifact cost was NOT charged: budget intact, nothing spent.
+        expect(captured!.budgetRemaining).toBe(1)
+        expect(captured!.costSpent).toBe(0)
+      } finally {
+        Workflow.__testHooks.captureSpend(() => {})
+      }
+    }),
+  )
+
+  // N2 (medium): finish() persistet (orDie) den Terminalzustand. Schlägt dieser
+  // Terminal-Write fehl, darf das done-Deferred NICHT verloren gehen — sonst
+  // hängt jedes wait() ohne Timeout ewig. Wir injizieren genau eine fehlschlagende
+  // Terminal-Persistenz über einen minimalen, klar dokumentierten Test-Seam und
+  // verlangen, dass wait() trotzdem mit dem Terminalzustand resolved.
+  it.instance("finish resolves waiters even when the terminal persist fails", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "hello",
+          `export const meta = { name: "Hello" }
+export async function run(args, ctx) { ctx.setPhase("run"); return { value: args.value } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      // Seam: der NÄCHSTE Terminal-Persist (in finish) wirft einmalig.
+      Workflow.__testHooks.failNextTerminalPersist()
+      const run = yield* workflow.start({ name: "hello", args: { value: 1 } })
+      // wait() OHNE Timeout: darf nicht hängen, sondern muss den Terminalzustand
+      // liefern, obwohl der Terminal-DB-Write fehlgeschlagen ist.
+      const waited = yield* awaitWithTimeout(
+        workflow.wait({ id: run.id }),
+        "wait hung after a failing terminal persist",
+        "5 seconds",
+      )
+      expect(waited.run?.status).toBe("completed")
+      expect(waited.run?.result).toEqual({ value: 1 })
+    }),
+  )
+
+  it.instance("reloads workflow implementation after file changes", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "reload",
+          `export const meta = { name: "Reload One" }
+export async function run() { return { value: "one" } }
+`,
+          "ts",
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const first = yield* workflow.start({ name: "reload" })
+      const firstWaited = yield* workflow.wait({ id: first.id })
+      const firstDone = firstWaited.run ?? (yield* Effect.fail(new Error("first workflow did not finish")))
+      expect(firstDone.definition?.meta.name).toBe("Reload One")
+      expect(firstDone.result).toEqual({ value: "one" })
+
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "reload",
+          `export const meta = { name: "Reload Two" }
+export async function run() { return { value: "two" } }
+`,
+          "ts",
+        ),
+      )
+
+      const second = yield* workflow.start({ name: "reload" })
+      const secondWaited = yield* workflow.wait({ id: second.id })
+      const secondDone = secondWaited.run ?? (yield* Effect.fail(new Error("second workflow did not finish")))
+      expect(secondDone.definition?.meta.name).toBe("Reload Two")
+      expect(secondDone.result).toEqual({ value: "two" })
+    }),
+  )
+
+  // Fund 2 (Symlink-Boundary): Ein Symlink in workflows/ -> externes Ziel darf
+  // NIE als Workflow erscheinen. Sonst sieht ein Reviewer nur den harmlosen
+  // Symlink, während start() das externe Ziel (z. B. /tmp/payload.ts) lädt.
+  it.instance("a symlink in workflows/ pointing outside the directory is not discovered", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      // Externes Ziel außerhalb des workflows-Verzeichnisses.
+      const external = path.join(os.tmpdir(), `workflow-symlink-payload-${Math.random().toString(16).slice(2)}.js`)
+      yield* Effect.promise(() =>
+        Bun.write(
+          external,
+          `export const meta = { name: "Payload" }
+export async function run() { return { ok: true } }
+`,
+        ),
+      )
+      // Reguläre Datei als Regressions-Guard: muss weiterhin gefunden werden.
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "regular",
+          `export const meta = { name: "Regular" }
+export async function run() { return { ok: true } }
+`,
+        ),
+      )
+      const workflowsDir = path.join(test.directory, ".opencode", "workflows")
+      const link = path.join(workflowsDir, "evil.js")
+      yield* Effect.promise(() => fs.symlink(external, link))
+
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      // Der Symlink-Eintrag darf NICHT als gültiger Workflow erscheinen.
+      const evil = list.find((item) => item.name === "evil")
+      expect(evil?.valid).not.toBe(true)
+      // Die reguläre Datei bleibt auffindbar (Regressions-Guard).
+      expect(list.some((item) => item.name === "regular" && item.valid === true)).toBe(true)
+
+      yield* Effect.promise(() => fs.rm(external, { force: true }))
+    }),
+  )
+
+  // Fund 40 (Temp-Cleanup): Eine verwaiste loadModule-Tempdatei (Namensmuster
+  // `.<base>.<ts>.<rand>.mts`) im workflows-Verzeichnis darf NIE als Workflow
+  // gelistet werden und wird beim Discovery-Lauf opportunistisch gelöscht, wenn
+  // sie alt ist (> ~1h).
+  it.instance("an orphaned loadModule temp file is never listed and old ones are swept", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "hello",
+          `export const meta = { name: "Hello" }
+export async function run() { return { ok: true } }
+`,
+        ),
+      )
+      const workflowsDir = path.join(test.directory, ".opencode", "workflows")
+      // Exaktes Namensmuster, das loadModule erzeugt: `.<base>.<ts>.<rand>.mts`.
+      const orphan = path.join(workflowsDir, `.hello.${Date.now()}.abc123.mts`)
+      yield* Effect.promise(() =>
+        Bun.write(
+          orphan,
+          `export const meta = { name: "Orphan" }
+export async function run() { return { ok: true } }
+`,
+        ),
+      )
+      // Alt machen (2h zurück), damit der Sweep sie löscht.
+      const old = new Date(Date.now() - 2 * 60 * 60 * 1000)
+      yield* Effect.promise(() => fs.utimes(orphan, old, old))
+
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      // Die Tempdatei darf in keiner Form als Workflow auftauchen.
+      expect(list.some((item) => item.name.includes("hello.") || item.meta.name === "Orphan")).toBe(false)
+      // Die echte Datei bleibt gelistet.
+      expect(list.some((item) => item.name === "hello" && item.valid === true)).toBe(true)
+      // Die alte verwaiste Tempdatei wurde beim Discovery-Lauf gelöscht.
+      expect(yield* Effect.promise(() => Bun.file(orphan).exists())).toBe(false)
+    }),
+  )
+
+  // N4 (Projekt-Vorrang): Ein gleichnamiger Workflow im Projekt- UND im
+  // Global-Config-Verzeichnis muss zur PROJEKT-Datei auflösen — sonst schattet
+  // die globale Datei die Projektdatei und start()/find() trifft die falsche.
+  it.instance("a project workflow takes precedence over a same-named global workflow", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      // Projekt-Datei.
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "shared",
+          `export const meta = { name: "ProjectShared" }
+export async function run() { return { from: "project" } }
+`,
+        ),
+      )
+      // Gleichnamige Datei im globalen Config-Verzeichnis (~/.config/opencode).
+      const globalWorkflows = path.join(Global.Path.config, "workflows")
+      const globalFile = path.join(globalWorkflows, "shared.js")
+      yield* Effect.promise(() => fs.mkdir(globalWorkflows, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          globalFile,
+          `export const meta = { name: "GlobalShared" }
+export async function run() { return { from: "global" } }
+`,
+        ),
+      )
+
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      const shared = list.filter((item) => item.name === "shared")
+      // Genau ein Eintrag (dedupliziert nach Name)...
+      expect(shared.length).toBe(1)
+      // ... und es ist die PROJEKT-Datei.
+      const projectWorkflows = path.join(test.directory, ".opencode", "workflows")
+      expect(shared[0]?.path.startsWith(projectWorkflows)).toBe(true)
+      expect(shared[0]?.meta.name).toBe("ProjectShared")
+
+      // start() löst denselben Namen ebenfalls zur Projekt-Datei auf.
+      const run = yield* workflow.start({ name: "shared" })
+      const done = (yield* workflow.wait({ id: run.id })).run
+      expect(done?.result).toEqual({ from: "project" })
+      expect(done?.definition?.path.startsWith(projectWorkflows)).toBe(true)
+
+      yield* Effect.promise(() => fs.rm(globalFile, { force: true }))
+    }),
+  )
+
+  // Fund 6 (HIGH) — Cross-Directory-Leak. Zwei Verzeichnisse A/B teilen sich
+  // dieselbe (prozess-globale) DB. runs() von B darf As Run NICHT enthalten:
+  // jeder Run ist auf das Verzeichnis gescoped, in dem er gestartet wurde.
+  it.instance(
+    "runs() does not leak runs started in another directory",
+    () =>
+      Effect.gen(function* () {
+        const a = yield* TestInstance
+        const b = yield* tmpdirScoped({ git: true })
+        yield* Effect.promise(() =>
+          writeWorkflow(
+            a.directory,
+            "hello",
+            `export const meta = { name: "Hello" }
+export async function run() { return { ok: true } }
+`,
+          ),
+        )
+        const workflow = yield* Workflow.Service
+        const runA = yield* workflow.start({ name: "hello" })
+        yield* workflow.wait({ id: runA.id })
+
+        // B's Liste enthält As Run NICHT.
+        const fromB = yield* workflow.runs().pipe(provideInstance(b))
+        expect(fromB.some((r) => r.id === runA.id)).toBe(false)
+        // A sieht den eigenen Run weiterhin (Regression).
+        const fromA = yield* workflow.runs()
+        expect(fromA.some((r) => r.id === runA.id)).toBe(true)
+      }),
+    { git: true },
+  )
+
+  // Fund 6 (HIGH) — get()/remove() aus dem fremden Verzeichnis dürfen As Row
+  // weder lesen noch löschen. Kalt-Read (kein Registry-Eintrag, nur DB).
+  it.instance(
+    "get()/remove() from another directory cannot see or delete a foreign run",
+    () =>
+      Effect.gen(function* () {
+        const a = yield* TestInstance
+        const b = yield* tmpdirScoped({ git: true })
+        const workflow = yield* Workflow.Service
+        // As Run direkt als Row seeden, mit As directory.
+        const idA = Workflow.RunID.make("job_dir_scoped_A")
+        const { db } = yield* Database.Service
+        const now = Date.now()
+        yield* db
+          .insert(WorkflowRunTable)
+          .values({
+            id: idA,
+            workflow: HELLO_FIXTURE,
+            status: "completed",
+            started_at: now,
+            completed_at: now,
+            directory: a.directory,
+            logs: [],
+            agents: [],
+          })
+          .run()
+          .pipe(Effect.orDie)
+
+        // B sieht ihn nicht.
+        expect(yield* workflow.get(idA).pipe(provideInstance(b))).toBeUndefined()
+        // remove aus B meldet false und lässt As Row unangetastet.
+        const removed = yield* workflow.remove(idA).pipe(provideInstance(b))
+        expect(removed).toBe(false)
+        const row = yield* fetchRunRow(idA)
+        expect(row.status).toBe("completed")
+        // A findet seinen Run weiterhin.
+        const fromA = yield* workflow.get(idA)
+        expect(fromA?.id).toBe(idA)
+      }),
+    { git: true },
+  )
+
+  // Fund 17 (medium) — Startup-Sweep cross-directory. Ein Sweep aus B (leere
+  // liveIds-Registry, frische InstanceState) darf NUR Bs eigene Zombie-Rows
+  // heilen — As running-Row im anderen Verzeichnis bleibt unangetastet.
+  it.instance(
+    "sweep from another directory leaves foreign running rows untouched",
+    () =>
+      Effect.gen(function* () {
+        const a = yield* TestInstance
+        const b = yield* tmpdirScoped({ git: true })
+        const workflow = yield* Workflow.Service
+        const { db } = yield* Database.Service
+        const now = Date.now()
+        // As running-Row (gehört Verzeichnis A).
+        yield* db
+          .insert(WorkflowRunTable)
+          .values({
+            id: "job_sweep_A",
+            workflow: HELLO_FIXTURE,
+            status: "running",
+            started_at: now,
+            directory: a.directory,
+            logs: [],
+            agents: [],
+          })
+          .run()
+          .pipe(Effect.orDie)
+        // Bs eigene Zombie-Row.
+        yield* db
+          .insert(WorkflowRunTable)
+          .values({
+            id: "job_sweep_B",
+            workflow: HELLO_FIXTURE,
+            status: "running",
+            started_at: now,
+            directory: b,
+            logs: [],
+            agents: [],
+          })
+          .run()
+          .pipe(Effect.orDie)
+
+        // Sweep aus B: heilt nur Bs Zombie, nicht As running-Row.
+        yield* workflow.sweep().pipe(provideInstance(b))
+        expect((yield* fetchRunRow("job_sweep_A")).status).toBe("running")
+        expect((yield* fetchRunRow("job_sweep_B")).status).toBe("interrupted")
+
+        // As eigener Sweep heilt dann As Zombie.
+        yield* workflow.sweep()
+        expect((yield* fetchRunRow("job_sweep_A")).status).toBe("interrupted")
+      }),
+    { git: true },
+  )
+
+  // Fund 19 (medium): deklarierte Argument-Typen werden an der Engine-Grenze
+  // erzwungen, VOR module.run. Ein String-Wert "42" für ein als `number`
+  // deklariertes Argument erreicht run() als die Zahl 42; "true" für ein als
+  // `boolean` deklariertes Argument als der Boolean true. Das deckt ALLE
+  // Start-Pfade ab (HTTP-JSON-args, Tool, TUI), weil die Koerzierung zentral in
+  // start() sitzt. Nicht deklarierte args (`bare`) bleiben unverändert.
+  it.instance("declared number/boolean argument types are coerced from strings before run()", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, COERCE_FIXTURE, COERCE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({
+        name: COERCE_FIXTURE,
+        // String-eingehende args, wie sie über HTTP-JSON oder die TUI ankommen.
+        args: { count: "42", flag: "true", label: 99, bare: { keep: 1 } },
+      })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as Record<string, unknown>
+      // number-Deklaration: "42" -> 42 (echte Zahl).
+      expect(result.count).toBe(42)
+      expect(result.countType).toBe("number")
+      // boolean-Deklaration: "true" -> true (echter Boolean).
+      expect(result.flag).toBe(true)
+      expect(result.flagType).toBe("boolean")
+      // string-Deklaration: ein primitiver Nicht-String (99) wird via String(...)
+      // zu "99" koerziert.
+      expect(result.label).toBe("99")
+      expect(result.labelType).toBe("string")
+      // Nicht deklariertes Argument bleibt unverändert durchgereicht.
+      expect(result.bare).toEqual({ keep: 1 })
+      expect(result.bareType).toBe("object")
+    }),
+  )
+
+  // Fund 19 (medium): ein als `number` deklariertes Argument mit einem nicht
+  // konvertierbaren String ("abc") scheitert mit einem InvalidError an der
+  // Engine-Grenze — der Run startet NICHT (kein verwirrender NaN, der erst im
+  // Workflow-Body auffliegt).
+  it.instance("an unconvertible value for a declared number argument fails with InvalidError", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, COERCE_FIXTURE, COERCE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const failed = yield* workflow.start({ name: COERCE_FIXTURE, args: { count: "abc" } }).pipe(Effect.flip)
+      expect(failed._tag).toBe("WorkflowInvalidError")
+      const invalid =
+        failed instanceof Workflow.InvalidError ? failed : yield* Effect.fail(new Error("expected InvalidError"))
+      expect(invalid.message).toMatch(/count/)
+    }),
+  )
+
+  // Fund 19 (medium): ein als `boolean` deklariertes Argument akzeptiert nur
+  // "true"/"false"; alles andere scheitert mit InvalidError.
+  it.instance("an unconvertible value for a declared boolean argument fails with InvalidError", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, COERCE_FIXTURE, COERCE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const failed = yield* workflow.start({ name: COERCE_FIXTURE, args: { flag: "maybe" } }).pipe(Effect.flip)
+      expect(failed._tag).toBe("WorkflowInvalidError")
+    }),
+  )
+
+  // Review-Fund 3i.1 (IMPORTANT): ein leerer / nur aus Whitespace bestehender
+  // String darf für ein number-Argument NICHT still zu 0 koerzieren
+  // (`Number("") === 0`, `Number("  ") === 0` — beide finite und würden sonst
+  // durchschlüpfen). Beide müssen wie "abc" mit InvalidError scheitern.
+  it.instance("empty / whitespace-only string for a declared number argument fails with InvalidError", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, COERCE_FIXTURE, COERCE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      for (const bad of ["", "  ", "\t\n"]) {
+        const failed = yield* workflow.start({ name: COERCE_FIXTURE, args: { count: bad } }).pipe(Effect.flip)
+        expect(failed._tag).toBe("WorkflowInvalidError")
+        const invalid =
+          failed instanceof Workflow.InvalidError ? failed : yield* Effect.fail(new Error("expected InvalidError"))
+        expect(invalid.message).toMatch(/count/)
+      }
+    }),
+  )
+
+  // Review-Fund 3i.1 (IMPORTANT): non-string, non-number Werte (null, ein Objekt,
+  // ein Boolean) für ein number-Argument dürfen nicht als NaN/true durchschlüpfen
+  // — sie müssen sauber mit InvalidError scheitern, bevor run() startet.
+  it.instance("non-string non-number value for a declared number argument fails with InvalidError", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, COERCE_FIXTURE, COERCE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      for (const bad of [null, {}, [], true] as const) {
+        const failed = yield* workflow.start({ name: COERCE_FIXTURE, args: { count: bad } }).pipe(Effect.flip)
+        expect(failed._tag).toBe("WorkflowInvalidError")
+      }
+    }),
+  )
+
+  // Review-Fund 3i.4 (LOW): wir akzeptieren bewusst die volle `Number()`-Semantik
+  // inkl. Hex ("0x10" -> 16) und Exponent ("1e3" -> 1000) — siehe Doc-Kommentar
+  // an coerceArgs. Das ist die geringste Überraschung für JSON/HTTP-Zahlen und
+  // konsistent mit dem Rest der numerischen Koerzierung.
+  it.instance("hex and exponent numeric strings are accepted via Number() for a declared number argument", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, COERCE_FIXTURE, COERCE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: COERCE_FIXTURE, args: { count: "0x10" } })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as Record<string, unknown>
+      expect(result.count).toBe(16)
+      expect(result.countType).toBe("number")
+    }),
+  )
+
+  // Review-Fund 3i.3 (LOW): ein deklarierter STRING-Default ("7") für ein
+  // number-Argument wird durch denselben Koerzierungspfad geschickt — run() sieht
+  // die Zahl 7, nicht den rohen String "7". Gleiches für den boolean-Default.
+  it.instance("declared string-shaped defaults are coerced to their declared type before run()", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, STRING_DEFAULT_FIXTURE, STRING_DEFAULT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: STRING_DEFAULT_FIXTURE, args: {} })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as Record<string, unknown>
+      expect(result.count).toBe(7)
+      expect(result.countType).toBe("number")
+      expect(result.flag).toBe(true)
+      expect(result.flagType).toBe("boolean")
+    }),
+  )
+
+  // Fund 20 (medium): deklarierte Defaults greifen, wenn ein Argument NICHT
+  // übergeben wird — run() sieht den typ-korrekten Default.
+  it.instance("declared defaults are applied when an argument is not supplied", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, DEFAULT_FIXTURE, DEFAULT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      // Gar keine args übergeben: alle drei Defaults müssen einspringen.
+      const run = yield* workflow.start({ name: DEFAULT_FIXTURE, args: {} })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as Record<string, unknown>
+      expect(result.name).toBe("x")
+      expect(result.nameType).toBe("string")
+      expect(result.count).toBe(7)
+      expect(result.countType).toBe("number")
+      expect(result.flag).toBe(true)
+      expect(result.flagType).toBe("boolean")
+    }),
+  )
+
+  // Fund 20 (medium): ein explizit übergebener Wert gewinnt über den Default und
+  // wird dabei dennoch gemäß dem deklarierten Typ koerziert.
+  it.instance("an explicitly supplied argument wins over its declared default (and is still coerced)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, DEFAULT_FIXTURE, DEFAULT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      // count explizit als String "3" übergeben: gewinnt über default 7 und wird
+      // zu 3 koerziert. name/flag fallen auf ihre Defaults zurück.
+      const run = yield* workflow.start({ name: DEFAULT_FIXTURE, args: { count: "3" } })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as Record<string, unknown>
+      expect(result.count).toBe(3)
+      expect(result.countType).toBe("number")
+      // Die nicht übergebenen behalten ihre Defaults.
+      expect(result.name).toBe("x")
+      expect(result.flag).toBe(true)
+    }),
+  )
+
+  // #26514 regression / Fund N9 (security): a workflow subagent MUST inherit the
+  // caller SESSION's deny/external_directory rules — the same ruleset the task
+  // tool derives. (Parent-AGENT denies are deliberately not inherited since
+  // #31696; plan mode is instead gated by the plan agent's `workflow` deny.)
+  // Before the fix the engine spawned the child session with NO `permission`,
+  // so a parent session `edit: deny` or `external_directory` confinement
+  // silently leaked.
+  it.instance("workflow subagent inherits the caller session's deny/external_directory rules", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sessions = yield* Session.Service
+
+      // The caller session carries the exact rules a Plan-Mode / confined parent
+      // would: an edit deny and an external_directory rule. The fix must forward
+      // both onto every subagent session the run spawns.
+      const caller = yield* sessions.create({
+        title: "Caller",
+        permission: [
+          { permission: "edit", pattern: "**", action: "deny" },
+          { permission: "external_directory", pattern: "/outside/**", action: "allow" },
+        ],
+      })
+
+      const run = yield* workflow.start({
+        name: SINGLE_AGENT_FIXTURE,
+        args: {},
+        prompt: immediatePromptOps(),
+        caller: { sessionID: caller.id, agent: "build" },
+      })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+
+      const childSessionID = done.agents[0]?.session_id
+      expect(childSessionID).toBeDefined()
+      // The projector persists the session row off the Created event, so poll the
+      // read until the row (and its derived permission) is visible. A not-yet-
+      // projected row fails get() with NotFound → map to undefined to keep polling.
+      const child = yield* pollWithTimeout(
+        sessions.get(SessionID.make(childSessionID!)).pipe(
+          Effect.map((s) => (s.permission ? s : undefined)),
+          Effect.catchCause(() => Effect.succeed(undefined)),
+        ),
+        "child session permission never populated",
+      )
+      const rules = child.permission ?? []
+      // Core security assertion: the caller's deny + external_directory rules are
+      // present on the child (regression of #26514 would leave these absent).
+      expect(rules).toContainEqual({ permission: "edit", pattern: "**", action: "deny" })
+      expect(rules).toContainEqual({ permission: "external_directory", pattern: "/outside/**", action: "allow" })
+    }),
+  )
+
+  // Security (compose, never override): per-step tool scoping must NEVER re-grant
+  // a tool the inherited subagent permission denies. A caller in Plan Mode denies
+  // `edit`; the step passes `tools: { edit: true }`.
+  //
+  // Before the fix, per-step tools were routed ONLY through PromptInput.tools,
+  // whose prompt-loop handler does a FULL ASSIGNMENT `session.permission =
+  // [tools→rules]` — clobbering the derived ruleset and re-enabling `edit` for the
+  // step. After the fix, when a caller-derived permission exists the per-step
+  // tools are instead COMPOSED into the child session's `permission` at creation,
+  // placed BEFORE the derived denies so (under last-match-wins evaluation) an
+  // inherited deny always beats a per-step grant — and the tools are NO LONGER
+  // passed to prompt.prompt (so the clobbering assignment can't fire).
+  //
+  // Observability: the workflow tests inject fake prompt-ops, so the regression's
+  // runtime clobber can't be seen via the prompt loop. We instead assert the two
+  // fix-visible facts directly: (1) the composed child-session `permission`
+  // CONTAINS the per-step edit grant yet still evaluates `edit` to deny (the
+  // inherited deny wins by ordering); (2) the captured PromptInput carries NO
+  // `tools` for this step (the engine stopped routing through the clobber path).
+  // Both are FALSE before the fix: (1) the create permission never held the
+  // per-step rule, and (2) `tools` was passed straight to prompt.prompt.
+  it.instance("per-step tools cannot re-grant an inherited-denied tool (deny wins)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, TOOLS_REGRANT_FIXTURE, TOOLS_REGRANT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sessions = yield* Session.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      // A Plan-Mode-style caller: edit is denied on the parent session.
+      const caller = yield* sessions.create({
+        title: "Caller",
+        permission: [{ permission: "edit", pattern: "**", action: "deny" }],
+      })
+
+      const run = yield* workflow.start({
+        name: TOOLS_REGRANT_FIXTURE,
+        args: {},
+        prompt: ops,
+        caller: { sessionID: caller.id, agent: "build" },
+      })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+
+      const childSessionID = done.agents[0]?.session_id
+      expect(childSessionID).toBeDefined()
+      const child = yield* pollWithTimeout(
+        sessions.get(SessionID.make(childSessionID!)).pipe(
+          Effect.map((s) => (s.permission ? s : undefined)),
+          Effect.catchCause(() => Effect.succeed(undefined)),
+        ),
+        "child session permission never populated",
+      )
+      const rules = child.permission ?? []
+      // The inherited edit deny is still present...
+      expect(rules).toContainEqual({ permission: "edit", pattern: "**", action: "deny" })
+      // ...the per-step grant was COMPOSED into the SAME ruleset (proving tools
+      // were folded into sessions.create, not routed to the clobbering prompt path)...
+      const grantIdx = rules.findIndex((r) => r.permission === "edit" && r.action === "allow")
+      const denyIdx = rules.findIndex((r) => r.permission === "edit" && r.action === "deny")
+      expect(grantIdx).toBeGreaterThanOrEqual(0)
+      // ...ordered BEFORE the inherited deny (last-match-wins ⇒ deny is later ⇒ deny wins)...
+      expect(grantIdx).toBeLessThan(denyIdx)
+      // ...so `edit` evaluates to deny despite the per-step `tools: { edit: true }`.
+      expect(Permission.evaluate("edit", "anything.ts", rules).action).toBe("deny")
+      // And the per-step tools were NOT routed to prompt.prompt (no clobber path).
+      expect(inputs.length).toBe(1)
+      expect(inputs[0]?.tools).toBeUndefined()
+    }),
+  )
+
+  // Fallback (documented behavior): a programmatic start with NO caller context
+  // keeps the prior behavior — the child session carries no derived `permission`.
+  it.instance("workflow subagent has no inherited ruleset when no caller context is supplied", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sessions = yield* Session.Service
+
+      const run = yield* workflow.start({
+        name: SINGLE_AGENT_FIXTURE,
+        args: {},
+        prompt: immediatePromptOps(),
+      })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("completed")
+
+      const childSessionID = done.agents[0]?.session_id
+      expect(childSessionID).toBeDefined()
+      // No caller ⇒ no derived ruleset. The session row exists (the run created
+      // it), but its `permission` column stays unset (fromRow → undefined). Poll
+      // until the row is visible (NotFound → undefined keeps polling), then assert
+      // no permission was stored.
+      const child = yield* pollWithTimeout(
+        sessions.get(SessionID.make(childSessionID!)).pipe(Effect.catchCause(() => Effect.succeed(undefined))),
+        "child session never created",
+      )
+      expect(child.permission).toBeUndefined()
+    }),
+  )
+
+  // Fund 18 (medium): die drei Workflow-Zeitfelder (LogEntry.time,
+  // AgentRun.started_at/completed_at) sind Epoch-Millis und damit IMMER endlich.
+  // Als `Schema.Number` erzeugte der SDK-Generator für sie eine NaN/Infinity-
+  // String-Union (`number | "NaN" | "Infinity" | ...`), ein unehrlicher
+  // Wire-Typ. Nach der Umstellung auf `Schema.Finite` dürfen die generierten
+  // SDK-Typen für diese Felder KEINE String-Varianten mehr tragen — sie sind
+  // schlicht `number`. Wir greppen die erzeugte types.gen.ts (statisch, kein
+  // Laufzeit-Roundtrip nötig).
+  test("generated SDK types for workflow time fields are plain numbers, no NaN-string variants", async () => {
+    const source = await Bun.file(
+      path.join(import.meta.dir, "..", "..", "..", "sdk", "js", "src", "v2", "gen", "types.gen.ts"),
+    ).text()
+    // Hilfsextraktor: die Zeile, die ein Feld innerhalb eines benannten Typs
+    // deklariert, anhand des Typ-Headers + Feldnamens.
+    const fieldLine = (typeName: string, field: string) => {
+      const block = source.slice(source.indexOf(`export type ${typeName} = {`))
+      const line = block
+        .split("\n")
+        .find((l) => l.trimStart().startsWith(`${field}:`) || l.trimStart().startsWith(`${field}?:`))
+      return line ?? ""
+    }
+    for (const [typeName, field] of [
+      ["WorkflowLogEntry", "time"],
+      ["WorkflowAgentRun", "started_at"],
+      ["WorkflowAgentRun", "completed_at"],
+    ] as const) {
+      const line = fieldLine(typeName, field)
+      expect(line).toContain("number")
+      // Keine NaN/Infinity-String-Variante mehr.
+      expect(line).not.toContain('"NaN"')
+      expect(line).not.toContain('"Infinity"')
+    }
+  })
+
+  // Track C: Builtin-Workflows als niedrigste Präzedenz-Wurzel (Projekt > Global >
+  // Builtin). Ohne gleichnamige Projekt-/Global-Datei MUSS der gebündelte
+  // deep-research-Workflow auftauchen, statisch lesbare Meta tragen und als
+  // `source_kind: "builtin"` markiert sein. Sein `path` ist ein synthetischer
+  // Marker (`builtin:deep-research`), kein echter Dateipfad.
+  it.instance("the bundled deep-research workflow is discovered as a builtin with static meta", () =>
+    Effect.gen(function* () {
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      const info = list.find((item) => item.name === "deep-research")
+      if (!info) return yield* Effect.fail(new Error("deep-research builtin not discovered"))
+      expect(info.valid).toBe(true)
+      expect(info.source_kind).toBe("builtin")
+      expect(info.path).toBe("builtin:deep-research")
+      // Meta wurde rein statisch (ohne Modul-Ausführung) gelesen.
+      expect(info.meta.name).toBe("deep-research")
+      // Phases normalize to the internal object shape (Task 15): strings → { title }.
+      expect(info.meta.phases).toEqual([
+        { title: "plan" },
+        { title: "research" },
+        { title: "verify" },
+        { title: "synthesize" },
+      ])
+      expect(info.meta.arguments?.question?.type).toBe("string")
+    }),
+  )
+
+  // Track C: first-wins-Präzedenz — eine gleichnamige Projektdatei beschattet den
+  // gleichnamigen Builtin vollständig (genau EIN Eintrag, und es ist die Datei,
+  // KEIN Builtin).
+  it.instance("a project workflow takes precedence over a same-named builtin", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "deep-research",
+          `export const meta = { name: "ProjectDeepResearch" }
+export async function run() { return { from: "project" } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      const matches = list.filter((item) => item.name === "deep-research")
+      expect(matches.length).toBe(1)
+      // Es ist die Projektdatei (kein Builtin-Marker, kein source_kind).
+      const projectWorkflows = path.join(test.directory, ".opencode", "workflows")
+      expect(matches[0]?.path.startsWith(projectWorkflows)).toBe(true)
+      expect(matches[0]?.source_kind).toBeUndefined()
+      expect(matches[0]?.meta.name).toBe("ProjectDeepResearch")
+      // start() löst denselben Namen ebenfalls zur Projektdatei auf.
+      const run = yield* workflow.start({ name: "deep-research" })
+      const done = (yield* workflow.wait({ id: run.id })).run
+      expect(done?.result).toEqual({ from: "project" })
+    }),
+  )
+
+  // Track C: ein gleichnamiger GLOBALER Workflow beschattet den Builtin ebenfalls
+  // (Global > Builtin). Genau ein Eintrag, und es ist die globale Datei.
+  it.instance("a global workflow takes precedence over a same-named builtin", () =>
+    Effect.gen(function* () {
+      const globalWorkflows = path.join(Global.Path.config, "workflows")
+      const globalFile = path.join(globalWorkflows, "deep-research.js")
+      yield* Effect.promise(() => fs.mkdir(globalWorkflows, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          globalFile,
+          `export const meta = { name: "GlobalDeepResearch" }
+export async function run() { return { from: "global" } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const list = yield* workflow.list()
+      const matches = list.filter((item) => item.name === "deep-research")
+      expect(matches.length).toBe(1)
+      expect(matches[0]?.path.startsWith(globalWorkflows)).toBe(true)
+      expect(matches[0]?.source_kind).toBeUndefined()
+      expect(matches[0]?.meta.name).toBe("GlobalDeepResearch")
+      yield* Effect.promise(() => fs.rm(globalFile, { force: true }))
+    }),
+  )
+
+  // Track C: der Builtin-Source kompiliert real und lädt über denselben
+  // loadModule-Pfad — `run` ist eine Funktion und die Meta ist nach dem echten
+  // Import konsistent. KEIN Live-Lauf (deep-research braucht Web-Tools); nur die
+  // Lade-Integrität wird geprüft, indem der Builtin-Source via Datei real
+  // importiert wird (identische loadModule-Mechanik wie zur Laufzeit).
+  test("the deep-research builtin source compiles and exports a real run() via loadModule", async () => {
+    const { BUILTIN_WORKFLOWS } = await import("@/workflow/builtin")
+    const source = BUILTIN_WORKFLOWS["deep-research"]
+    expect(typeof source).toBe("string")
+    // INVARIANTE (PR #2 review): Builtin-Sources sind SELF-CONTAINED — keine
+    // Imports. Der Temp-Copy wird unter dem GLOBALEN workflows-Verzeichnis
+    // materialisiert; ein bare specifier würde dort über `<config>/node_modules`
+    // aufgelöst — die PUBLIZIERTE @opencode-ai/plugin, die config.ts installiert,
+    // nie der Dev-Workspace (der Reviewer musste das Workspace-Plugin manuell
+    // global verlinken, bevor der Builtin lud). Import-frei lädt der Source
+    // identisch in Dev, Tests und kompilierter Binary.
+    expect(source).not.toMatch(/^\s*import\b/m)
+    // Realer Import: in eine Temp-Datei schreiben und dynamisch laden (identisch
+    // zur loadModule-Mechanik: GLOBALES workflows-Verzeichnis — der in der
+    // kompilierten Bun-Binary beschreibbare Ort, anders als `import.meta.dir`
+    // (/$bunfs/root, read-only) — mit TEMP_FILE_RE-Namensschema, laden, danach
+    // löschen. Das Modul-Top-Level wird ausgeführt, also deckt dies
+    // Syntax-/Compile-Fehler im Source-Literal auf.
+    const configDir = path.join(Global.Path.config, "workflows")
+    await fs.mkdir(configDir, { recursive: true })
+    // Mirror loadModule: resolve to the realpath before writing+importing so the
+    // import is consistent with Bun's realpath resolution (the /var → /private/var
+    // symlink otherwise breaks a second source-string import in the same dir).
+    const workflowsDir = await fs.realpath(configDir)
+    const file = path.join(workflowsDir, `.deep-research.${Date.now()}.${Math.random().toString(16).slice(2)}.mts`)
+    await Bun.write(file, source)
+    try {
+      const imported = (await import(pathToFileURL(file).href)) as {
+        default?: { meta?: { name?: string }; run?: unknown }
+      }
+      const mod = imported.default ?? (imported as never)
+      expect(mod.meta?.name).toBe("deep-research")
+      expect(typeof mod.run).toBe("function")
+    } finally {
+      await Bun.file(file)
+        .delete()
+        .catch(() => {})
+    }
+    // Temp-Datei wurde im globalen workflows-Verzeichnis geladen und ist danach
+    // wieder weg (kein Orphan zurückgelassen).
+    expect(await Bun.file(file).exists()).toBe(false)
+  })
+
+  // P1 (Claude parity): ctx.parallel now resolves a dropped (rejecting/agent-
+  // erroring) task to `null` at its position, so the deep-research builtin MUST
+  // filter the parallel results before dereferencing them (research findings and
+  // verify verdicts). Source-string assertion only — a live run needs web tools.
+  test("the deep-research builtin filters dropped parallel results before dereferencing", async () => {
+    const { BUILTIN_WORKFLOWS } = await import("@/workflow/builtin")
+    const src = BUILTIN_WORKFLOWS["deep-research"]
+    expect(src).toContain(".filter((f) => f !== null)")
+    expect(src).toContain(".filter((v) => v !== null)")
+  })
+  // ===========================================================================
+  // Track B — Run-Caps (Concurrency + Lifetime) und Pause/Resume
+  // ===========================================================================
+
+  // Spec §5.1 (Concurrency-Cap): eine Run-weite Semaphore deckelt ALLE
+  // ctx.agent-Dispatches auf min(16, max(2, cpus-2)) — unabhängig von einem
+  // großzügigeren per-call concurrencyLimit. 30 parallele Quick-Agents, jeder am
+  // Barrier-Gate über die Prompt-Ops geparkt, dürfen daher höchstens cap viele
+  // gleichzeitig laufen lassen. Der Peak wird deterministisch über den Barrier-
+  // Counter gemessen (wie die Fund-49-Tests), nicht über eine Timing-Window.
+  it.instance("run-wide cap bounds concurrent ctx.agent dispatches regardless of per-call limit", () =>
+    Effect.gen(function* () {
+      const cap = Math.min(16, Math.max(2, os.cpus().length - 2))
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, AGENT_CAP_FIXTURE, AGENT_CAP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const sync = installBarrier()
+      // Prompt-Ops, die jeden Agent-Prompt am Barrier-Gate parken (Peak messbar)
+      // und ihn dann mit Telemetrie beantworten.
+      const capOps: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            const barrier = globalThis.__workflowTestBarriers![sync.token]
+            barrier.active++
+            barrier.peak = Math.max(barrier.peak, barrier.active)
+            yield* Effect.promise(() => barrier.gate)
+            barrier.active--
+            return yield* persistTurns(db, input.sessionID, [
+              { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+            ])
+          }),
+        cancel: () => Effect.void,
+      }
+      // 30 parallele Agenten, per-call-Limit 30 (>> cap): die Run-weite Semaphore
+      // muss dennoch greifen.
+      const run = yield* workflow.start({
+        name: AGENT_CAP_FIXTURE,
+        args: { count: 30 },
+        prompt: capOps,
+      })
+      // Warten bis cap viele Agenten gleichzeitig am Gate parken.
+      yield* sync.awaitPeak(cap)
+      // Selbst nach einer Settle-Pause darf der Peak NIE über den Cap klettern:
+      // ein (cap+1)-ter gleichzeitiger Dispatch würde die Semaphore verletzen.
+      yield* Effect.sleep("200 millis")
+      expect(sync.barrier.active).toBe(cap)
+      expect(sync.barrier.peak).toBe(cap)
+      // Gate öffnen, alle 30 abarbeiten lassen.
+      sync.barrier.release()
+      const waited = yield* workflow.wait({ id: run.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("cap run did not finish")))
+      expect(done.status).toBe("completed")
+      expect((done.result as { result: number }).result).toBe(30)
+      delete globalThis.__workflowTestBarriers![sync.token]
+    }),
+  )
+
+  // Spec §5.2 (Lifetime-Cap): ab 1.000 gestarteten Agenten wirft ctx.agent einen
+  // WorkflowAgentLimitError. Über den Test-Seam __testHooks.agentLimit wird das
+  // Limit auf 5 gesetzt: der 6. ctx.agent-Aufruf scheitert mit _tag
+  // "WorkflowAgentLimitError", der Run failt EHRLICH, und genau 5 Agenten sind
+  // sichtbar (completed).
+  it.instance("agent lifetime limit fails the run at the configured ceiling with a tagged error", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, LIFETIME_FIXTURE, LIFETIME_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      Workflow.__testHooks.agentLimit(5)
+      const run = yield* workflow.start({
+        name: LIFETIME_FIXTURE,
+        args: { count: 10 },
+        prompt: costPromptOps(db, 0),
+      })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("did not finish")))
+      expect(done.status).toBe("failed")
+      expect(done.error ?? "").toMatch(/WorkflowAgentLimitError|agent.*limit/i)
+      // Genau 5 Agenten gelangen; der 6. wird vom Lifetime-Gate geblockt (kein
+      // Node für den geblockten Aufruf).
+      expect(done.agents.filter((a) => a.status === "completed").length).toBe(5)
+      expect(done.agents.length).toBe(5)
+    }),
+  )
+
+  // Spec §5.3 (pause): ein am Agent-Gate hängender Run wird pausiert — die
+  // Sessions werden abgebrochen (Recorder), der Scope geschlossen, der Fiber
+  // unterbrochen, aber der Run finished mit Status `paused` (NICHT cancelled) und
+  // das Journal (agents[]) bleibt erhalten. wait() liefert sofort den
+  // paused-Snapshot (timedOut:false). Der Folge-Step läuft nie.
+  it.instance("pause suspends a running run as paused, aborts sessions, keeps the journal", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PAUSE_FIXTURE, PAUSE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, aborted } = hangingPromptOps()
+      const run = yield* workflow.start({ name: PAUSE_FIXTURE, args: {}, prompt: ops })
+
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+      const childSession = live.agents[0]?.session_id
+      expect(childSession).toBeDefined()
+
+      const paused = yield* workflow.pause(run.id)
+      expect(paused?.status).toBe("paused")
+      // Die Child-Session wurde abgebrochen (wie cancel).
+      expect(aborted.has(childSession!)).toBe(true)
+
+      // Persistierte Row trägt paused; das Journal bleibt erhalten.
+      const row = yield* fetchRunRow(run.id)
+      expect(row.status).toBe("paused")
+      expect(row.agents.length).toBeGreaterThanOrEqual(1)
+
+      // wait() auf einen paused Run liefert sofort den paused-Snapshot (kein Timeout).
+      const waited = yield* workflow.wait({ id: run.id })
+      expect(waited.timedOut).toBe(false)
+      expect(waited.run?.status).toBe("paused")
+
+      // Der Folge-Step lief nie.
+      const after = yield* workflow.get(run.id)
+      expect(after?.logs.some((l) => l.message?.includes(PAUSE_AFTER_MARKER))).toBe(false)
+    }),
+  )
+
+  // Spec §5.3 (Sweep lässt paused in Ruhe): der Orphan-Sweep darf NUR running-Rows
+  // ohne Live-Fiber zu interrupted machen — paused-Rows bleiben unangetastet.
+  it.instance("sweep leaves paused rows untouched", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const pausedId = "job_paused_sweep"
+      const now = Date.now()
+      yield* db
+        .insert(WorkflowRunTable)
+        .values({
+          id: pausedId,
+          workflow: HELLO_FIXTURE,
+          status: "paused",
+          started_at: now,
+          directory: test.directory,
+          logs: [],
+          agents: [{ id: "1", status: "completed", started_at: now, completed_at: now, prompt: "done", output: "x" }],
+        })
+        .run()
+        .pipe(Effect.orDie)
+      yield* workflow.sweep()
+      const row = yield* fetchRunRow(pausedId)
+      expect(row.status).toBe("paused")
+    }),
+  )
+
+  // T5 gap (sweep vs parked question): the existing "leaves paused rows untouched"
+  // test uses a paused row WITHOUT a pending_question. A run parked by an
+  // unanswered ctx.question carries a persisted pending_question; the sweep must
+  // leave BOTH the paused status AND the question intact so a later answer() can
+  // still resume it.
+  it.instance("sweep leaves a paused run that carries a pending_question untouched (status + question preserved)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const pausedId = "job_paused_pending_question"
+      const now = Date.now()
+      yield* db
+        .insert(WorkflowRunTable)
+        .values({
+          id: pausedId,
+          workflow: HELLO_FIXTURE,
+          status: "paused",
+          started_at: now,
+          directory: test.directory,
+          logs: [],
+          agents: [
+            {
+              id: "1",
+              status: "completed",
+              started_at: now,
+              completed_at: now,
+              kind: "question",
+              prompt: "deploy?",
+              answer: undefined,
+            },
+          ],
+          pending_question: { question: "deploy?", options: ["yes", "no"], asked_at: now },
+        })
+        .run()
+        .pipe(Effect.orDie)
+
+      yield* workflow.sweep()
+
+      const row = yield* fetchRunRow(pausedId)
+      expect(row.status).toBe("paused")
+      // The persisted question survives the sweep.
+      expect(row.pending_question?.question).toBe("deploy?")
+      expect(row.pending_question?.options).toEqual(["yes", "no"])
+      // The open question node is not flipped to failed (it is a parked question,
+      // not a lost running agent).
+      const qnode = row.agents.find((a) => a.kind === "question")
+      expect(qnode?.status).not.toBe("failed")
+    }),
+  )
+
+  // T5 gap (sweep vs live-waiting question): a run blocked LIVE on ctx.question
+  // has a real fiber by design — the sweep (which only heals fiber-less zombie
+  // running rows) must NOT interrupt it. Start the question run, wait until its
+  // pending_question is live, sweep, and assert it is still running and still
+  // answerable.
+  it.instance("sweep does not interrupt a run waiting live on a question", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, QUESTION_FIXTURE, QUESTION_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const run = yield* workflow.start({ name: QUESTION_FIXTURE, args: {}, prompt: immediatePromptOps() })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current?.pending_question?.question === "deploy?" ? current : undefined
+        }),
+        "pending question never appeared",
+      )
+
+      // sweep() keys off the live-id set; the live-waiting run must be protected.
+      yield* workflow.sweep()
+
+      const afterSweep = yield* workflow.get(run.id)
+      expect(afterSweep?.status).toBe("running")
+      expect(afterSweep?.pending_question?.question).toBe("deploy?")
+      // The DB row itself must NOT have been flipped to interrupted (get() reads the
+      // live registry snapshot, so assert the persisted row directly — this is what
+      // bites if sweepOrphans were called with an empty/incorrect live-id set).
+      const rowAfterSweep = yield* fetchRunRow(run.id)
+      expect(rowAfterSweep.status).toBe("running")
+
+      // Still answerable: the live fiber resolves and the run completes.
+      yield* workflow.answer({ id: run.id, answer: "yes" })
+      const done =
+        (yield* workflow.wait({ id: run.id })).run ??
+        (yield* Effect.fail(new Error("live question run did not finish")))
+      expect(done.status).toBe("completed")
+      expect((done.result as { answer: string }).answer).toBe("yes")
+    }),
+  )
+
+  // Spec §5.3 (cancel auf paused → cancelled): ein cancel auf einen pausierten Run
+  // überführt ihn in den terminalen Status cancelled.
+  it.instance("cancel on a paused run transitions it to cancelled", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PAUSE_FIXTURE, PAUSE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops } = hangingPromptOps()
+      const run = yield* workflow.start({ name: PAUSE_FIXTURE, args: {}, prompt: ops })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+      const paused = yield* workflow.pause(run.id)
+      expect(paused?.status).toBe("paused")
+      const cancelled = yield* workflow.cancel(run.id)
+      expect(cancelled?.status).toBe("cancelled")
+      const after = yield* workflow.get(run.id)
+      expect(after?.status).toBe("cancelled")
+    }),
+  )
+
+  // Spec §5.4 (Resume-Journal): ein Run mit Agent A (completed) + B (durch pause
+  // unterbrochen). Ein resume-Start mit resume_of übernimmt A aus dem Journal
+  // (KEIN neuer Prompt für A, output/cost übernommen, cached:true), B läuft live;
+  // das Budget des neuen Runs wird um As Kosten vor-dekrementiert.
+  it.instance("resume replays the completed agent from the journal and runs the rest live", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_FIXTURE, RESUME_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Erster Lauf: A completed sofort, B hängt → pause unterbricht B.
+      const firstAborted = new Set<string>()
+      const firstGates = new Map<string, Deferred.Deferred<void>>()
+      let promptCount = 0
+      const firstOps: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            promptCount++
+            const text = authorPrompt(input.parts?.[0]?.type === "text" ? input.parts[0].text : "")
+            // Agent A beantwortet sofort mit Kosten 0.25; Agent B hängt.
+            if (text === "agent A") {
+              const last = yield* persistTurns(db, input.sessionID, [
+                { cost: 0.25, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+              ])
+              return { info: last.info, parts: [{ type: "text", text: "out:A" }] } as unknown as SessionV1.WithParts
+            }
+            const gate = yield* Deferred.make<void>()
+            firstGates.set(input.sessionID, gate)
+            yield* Effect.race(
+              Effect.sleep("30 seconds"),
+              Deferred.await(gate).pipe(Effect.flatMap(() => Effect.interrupt)),
+            )
+            return assistantReply()
+          }),
+        cancel: (sessionID) =>
+          Effect.gen(function* () {
+            firstAborted.add(sessionID)
+            const gate = firstGates.get(sessionID)
+            if (gate) yield* Deferred.succeed(gate, undefined)
+          }),
+      }
+      const first = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: firstOps })
+      // Warten bis A completed und B running ist.
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(first.id)
+          const completed = current?.agents.filter((a) => a.status === "completed") ?? []
+          const running = current?.agents.filter((a) => a.status === "running" && a.session_id) ?? []
+          return completed.length >= 1 && running.length >= 1 ? current : undefined
+        }),
+        "first run did not reach A-completed + B-running",
+      )
+      const pausedFirst = yield* workflow.pause(first.id)
+      expect(pausedFirst?.status).toBe("paused")
+      const firstPromptCount = promptCount
+
+      // Zweiter Lauf (resume): recordingPromptOps protokolliert jeden GEFEUERTEN
+      // Prompt. A muss aus dem Journal kommen (NICHT in prompted), B live.
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0.5)
+      const resumed = yield* workflow.start({
+        name: RESUME_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        budget: 10,
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      // A kam aus dem Journal: KEIN neuer Prompt "agent A" wurde gefeuert.
+      expect(prompted).not.toContain("agent A")
+      // B lief live.
+      expect(prompted).toContain("agent B")
+      // Das resume hat den Quell-Run NICHT erneut geprompt (firstPromptCount fix).
+      expect(firstPromptCount).toBeGreaterThanOrEqual(1)
+      // A's Output (aus dem Journal) und B's Live-Output sind im Resultat.
+      const result = done.result as { a: string; b: string }
+      expect(result.a).toBe("out:A")
+      expect(result.b).toBe("out:agent B")
+      // Agent-Node A ist als cached markiert, B nicht.
+      const agentA = done.agents.find((a) => a.output === "out:A")
+      expect(agentA?.cached).toBe(true)
+      const agentB = done.agents.find((a) => a.output === "out:agent B")
+      expect(agentB?.cached).not.toBe(true)
+      // resume_of ist auf der Row vermerkt.
+      const row = yield* fetchRunRow(resumed.id)
+      expect(row.resume_of).toBe(first.id)
+      // Item 6 Regressionsschutz: node.prompt bleibt der ROHE Autoren-Prompt —
+      // die Step-Framing-Direktive wird nur auf den DISPATCHTEN Text geprependet,
+      // nie auf den Node (und damit nie in den Journal-Key).
+      expect(done.agents.every((a) => !a.prompt.includes(Workflow.STEP_FRAMING_DIRECTIVE))).toBe(true)
+    }),
+  )
+
+  // Spec §5.4 (Occurrence-Index): zwei identische Prompts müssen beim Resume
+  // getrennt aus dem Journal aufgelöst werden (je nach Aufruf-Reihenfolge), nicht
+  // beide auf denselben Eintrag. Beide A-Agenten kommen aus dem Journal, also wird
+  // KEIN Prompt erneut gefeuert. Item 20: das pinnt die KEYED-Occurrence-Semantik
+  // (Map + Cursor pro Key) — seit dem prefix-Default explizit mit replay:"keyed";
+  // der prefix-Zwilling (Sequenz-Cursor löst Duplikate genauso) steht darunter.
+  it.instance("resume caches two identical prompts separately by occurrence (keyed)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_DUP_FIXTURE, RESUME_DUP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Erster Lauf: beide identischen Prompts completen sofort mit
+      // UNTERSCHEIDBAREN Outputs (out:0, out:1), damit der Test beweisen kann, dass
+      // die zwei Journal-Einträge getrennt aufgelöst werden.
+      let counter = 0
+      const firstOps: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            const idx = counter++
+            const last = yield* persistTurns(db, input.sessionID, [
+              { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+            ])
+            return { info: last.info, parts: [{ type: "text", text: "out:" + idx }] } as unknown as SessionV1.WithParts
+          }),
+        cancel: () => Effect.void,
+      }
+      const first = yield* workflow.start({ name: RESUME_DUP_FIXTURE, args: {}, prompt: firstOps })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first dup run did not finish")))
+      expect(firstDone.status).toBe("completed")
+      expect(firstDone.result).toEqual({ first: "out:0", second: "out:1" })
+
+      // Dieser Test pinnt die Occurrence-Index-Auflösung aus einer PAUSED Quelle
+      // (completed wäre seit der Guard-Erweiterung zwar auch direkt resumebar, aber
+      // paused ist der historische Kernfall). Der erste Lauf completed mit beiden
+      // Journal-Einträgen; wir versetzen die Row auf `paused` (Journal/agents
+      // bleiben erhalten), um diese Resume-Quelle zu erhalten. Das Update
+      // wird im Poll wiederholt, bis es sichtbar `paused` ist (der terminale Run wird
+      // ASYNCHRON aus der Registry evictet — bis dahin könnte ein letzter Snapshot die
+      // DB-Mutation überschreiben; nach Eviction fällt get() auf die Row zurück).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      // Resume: beide identischen Prompts müssen aus dem Journal kommen (kein neuer
+      // Prompt), und zwar getrennt: first→out:0, second→out:1 (Occurrence-Reihenfolge).
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: RESUME_DUP_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        replay: "keyed",
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume dup did not finish")))
+      expect(done.status).toBe("completed")
+      // Kein Prompt wurde gefeuert: beide kamen aus dem Journal.
+      expect(prompted).toHaveLength(0)
+      // Getrennt aufgelöst, in Occurrence-Reihenfolge.
+      expect(done.result).toEqual({ first: "out:0", second: "out:1" })
+    }),
+  )
+
+  // Item 20 (prefix-Zwilling des Occurrence-Tests): im Default-Modus 'prefix'
+  // löst der Sequenz-Cursor zwei identische Prompts genauso getrennt auf — der
+  // erste Call trifft Eintrag 0, der zweite Eintrag 1, in Original-Reihenfolge.
+  it.instance("prefix replay resolves two identical prompts separately in order", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_DUP_FIXTURE, RESUME_DUP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      let counter = 0
+      const firstOps: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            const idx = counter++
+            const last = yield* persistTurns(db, input.sessionID, [
+              { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+            ])
+            return { info: last.info, parts: [{ type: "text", text: "out:" + idx }] } as unknown as SessionV1.WithParts
+          }),
+        cancel: () => Effect.void,
+      }
+      const first = yield* workflow.start({ name: RESUME_DUP_FIXTURE, args: {}, prompt: firstOps })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first dup run did not finish")))
+      expect(firstDone.status).toBe("completed")
+      expect(firstDone.result).toEqual({ first: "out:0", second: "out:1" })
+
+      // completed ist seit Item 2 direkt resumebar; explizites replay:"prefix"
+      // pinnt das Options-Feld (Default wäre identisch).
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: RESUME_DUP_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        replay: "prefix",
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume dup did not finish")))
+      expect(done.status).toBe("completed")
+      expect(prompted).toHaveLength(0)
+      expect(done.result).toEqual({ first: "out:0", second: "out:1" })
+    }),
+  )
+
+  // Spec §5.4 (invalidate_agents): mit invalidate_agents:[0] läuft Agent #0 live
+  // neu, alle anderen cachen. Item 20: das ist KEYED-Semantik (Shape-Match
+  // bedient spätere unveränderte Calls trotz früherem Invalidate) — seit dem
+  // prefix-Default deshalb explizit mit replay:"keyed" gepinnt; das prefix-
+  // Gegenstück ("alles nach dem Invalidate läuft live") steht unten.
+  it.instance("resume with invalidate_agents reruns the named index live and caches the rest (keyed)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_FIXTURE, RESUME_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Erster Lauf: beide Agenten completen sofort.
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      // Status-Guard: nur paused/interrupted Runs sind gültige Resume-Quellen. Die
+      // completed-Row auf `paused` versetzen (Journal bleibt), damit der Resume die
+      // invalidate_agents-Semantik prüfen kann. Im Poll wiederholt, bis sichtbar
+      // `paused` (asynchrone Eviction des terminalen Runs — siehe oben).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      // Resume mit invalidate_agents:[0] → Agent #0 (A) läuft live neu, B cacht
+      // (keyed: der Shape-Match bedient B trotz des früheren Invalidates).
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: RESUME_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        invalidate_agents: [0],
+        replay: "keyed",
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      // Nur Agent A (#0) lief live neu; B kam aus dem Journal.
+      expect(prompted).toContain("agent A")
+      expect(prompted).not.toContain("agent B")
+      const agentA = done.agents.find((a) => a.prompt === "agent A")
+      expect(agentA?.cached).not.toBe(true)
+      const agentB = done.agents.find((a) => a.prompt === "agent B")
+      expect(agentB?.cached).toBe(true)
+    }),
+  )
+
+  // T5 gap (invalidate_agents positional): the existing invalidate test only
+  // rebuilds index [0]. Pin that a NON-zero index reruns ONLY that agent live
+  // while the EARLIER agent stays cached — proving the index is honored
+  // positionally, not "always rerun the first". RESUME_WORKFLOW dispatches A
+  // (index 0) then B (index 1); invalidate_agents:[1] must rerun B live, cache A.
+  it.instance("resume with invalidate_agents reruns a NON-zero index live and caches the earlier agent", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_FIXTURE, RESUME_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      // completed → paused so it is a legitimate resume source (journal kept).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: RESUME_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        invalidate_agents: [1],
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      // Only B (index 1) reran live; A (index 0) came from the journal.
+      expect(prompted).toContain("agent B")
+      expect(prompted).not.toContain("agent A")
+      const agentA = done.agents.find((a) => a.prompt === "agent A")
+      expect(agentA?.cached).toBe(true)
+      const agentB = done.agents.find((a) => a.prompt === "agent B")
+      expect(agentB?.cached).not.toBe(true)
+    }),
+  )
+
+  // Item 20 Test (1): 'prefix replay stops at the first changed call'. Quelllauf
+  // A,B,C sequenziell completed; Resume (Default 'prefix') mit
+  // invalidate_agents:[0] ⇒ der Präfix bricht ab Index 0 DAUERHAFT — A, B UND C
+  // laufen live, obwohl B/C unverändert sind. Das ist die Original-Semantik:
+  // nach dem ersten Mismatch wird nichts mehr aus dem Journal bedient, weil die
+  // Workspace-Seiteneffekte späterer Steps stale sein können.
+  it.instance("prefix replay stops at the first changed call: invalidate_agents:[0] reruns everything live", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PREFIX_FIXTURE, PREFIX_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: PREFIX_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      // completed ist seit Item 2 direkt resumebar; kein replay gesetzt ⇒ der
+      // DEFAULT ist prefix (genau das pinnt dieser Test mit).
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: PREFIX_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        invalidate_agents: [0],
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      // ALLES lief live: A (invalidiert) und die unveränderten B/C dahinter.
+      expect(prompted).toEqual(["agent A", "agent B", "agent C"])
+      expect(done.agents.every((a) => a.cached !== true)).toBe(true)
+    }),
+  )
+
+  // Item 20 keyed-Gegentest zur 3-Agenten-Fixture: replay:"keyed" stellt das
+  // alte Verhalten exakt wieder her — nur A (invalidiert) läuft live, B und C
+  // werden trotz des früheren Invalidates aus dem Journal bedient.
+  it.instance("keyed replay after invalidate_agents:[0] serves the unchanged later calls from the journal", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PREFIX_FIXTURE, PREFIX_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: PREFIX_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: PREFIX_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        invalidate_agents: [0],
+        replay: "keyed",
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      // Nur A lief live; B/C kamen aus dem Journal (keyed-Shape-Match).
+      expect(prompted).toEqual(["agent A"])
+      const agentB = done.agents.find((a) => a.prompt === "agent B")
+      expect(agentB?.cached).toBe(true)
+      const agentC = done.agents.find((a) => a.prompt === "agent C")
+      expect(agentC?.cached).toBe(true)
+    }),
+  )
+
+  // Item 20 Test (2): 'prefix replay serves an unchanged full prefix'. Ein
+  // identisches Script (kein Invalidate, kein Drift) ist unter explizitem
+  // replay:"prefix" ein voller Cache-Hit — kein Prompt, alle Nodes cached.
+  it.instance("prefix replay serves an unchanged full prefix as a complete cache hit", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PREFIX_FIXTURE, PREFIX_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: PREFIX_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: PREFIX_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        replay: "prefix",
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      expect(prompted).toHaveLength(0)
+      expect(done.agents).toHaveLength(3)
+      expect(done.agents.every((a) => a.cached === true)).toBe(true)
+      expect(done.result).toEqual(firstDone.result)
+    }),
+  )
+
+  // Item 27 (Transcript-Export): export(id) schreibt run.json plus eine
+  // <agent-id>.jsonl pro Agent-Node unter <data>/workflow/<runId>/transcripts.
+  // Live-Nodes (mit Session) exportieren eine {info,parts}-Zeile pro Message;
+  // ein gecachter (session-loser) Node erzeugt GENAU die Fallback-Zeile {node}
+  // — der Export ist immer vollständig über alle Nodes, jede Zeile valides JSON.
+  it.instance("export writes run.json plus one parseable JSONL per agent node (incl. cached fallback)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_FIXTURE, RESUME_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      const exported = yield* workflow.export(first.id)
+      expect(exported).toBeDefined()
+      expect(exported!.path).toBe(path.join(Global.Path.data, "workflow", first.id, "transcripts"))
+      expect(exported!.files).toContain("run.json")
+      // run.json ist parsebar und trägt die Run-ID.
+      const runJson = JSON.parse(
+        yield* Effect.promise(() => fs.readFile(path.join(exported!.path, "run.json"), "utf8")),
+      ) as { id: string }
+      expect(runJson.id).toBe(first.id)
+      // Je Agent-Node eine .jsonl; jede Zeile besteht JSON.parse. Live-Nodes
+      // tragen Session-Messages ({info,parts}).
+      expect(firstDone.agents).toHaveLength(2)
+      for (const node of firstDone.agents) {
+        const file = `${node.id}.jsonl`
+        expect(exported!.files).toContain(file)
+        const lines = (yield* Effect.promise(() => fs.readFile(path.join(exported!.path, file), "utf8")))
+          .split("\n")
+          .filter((line) => line.length > 0)
+        expect(lines.length).toBeGreaterThanOrEqual(1)
+        for (const line of lines) {
+          const parsed = JSON.parse(line) as Record<string, unknown>
+          expect("info" in parsed || "node" in parsed).toBe(true)
+        }
+      }
+
+      // Resume der completed-Quelle: voller Cache-Hit ⇒ session-lose cached-
+      // Nodes. Deren Export ist die einzelne Fallback-Zeile {node}.
+      const resumeOps = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: RESUME_FIXTURE,
+        args: {},
+        prompt: resumeOps.ops,
+        resume_of: first.id,
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      const exported2 = yield* workflow.export(resumed.id)
+      expect(exported2).toBeDefined()
+      const cached = done.agents.find((a) => a.cached === true)
+      expect(cached).toBeDefined()
+      const fallbackLines = (yield* Effect.promise(() =>
+        fs.readFile(path.join(exported2!.path, `${cached!.id}.jsonl`), "utf8"),
+      ))
+        .split("\n")
+        .filter((line) => line.length > 0)
+      expect(fallbackLines).toHaveLength(1)
+      const parsedFallback = JSON.parse(fallbackLines[0]) as { node?: { id?: string; cached?: boolean } }
+      expect(parsedFallback.node?.id).toBe(cached!.id)
+      expect(parsedFallback.node?.cached).toBe(true)
+
+      // Re-Export überschreibt deterministisch (gleiche Namen, kein Fehler).
+      const again = yield* workflow.export(first.id)
+      expect(again!.files.toSorted()).toEqual(exported!.files.toSorted())
+
+      // Aufräumen: die Export-Verzeichnisse beider Runs entfernen (das Test-
+      // Datadir wird zwar am Prozessende gelöscht; lokal trotzdem nichts liegen
+      // lassen).
+      yield* Effect.promise(() =>
+        fs.rm(path.join(Global.Path.data, "workflow", first.id), { recursive: true, force: true }),
+      )
+      yield* Effect.promise(() =>
+        fs.rm(path.join(Global.Path.data, "workflow", resumed.id), { recursive: true, force: true }),
+      )
+    }),
+  )
+
+  // Item 27: export() ist directory-scoped wie get() — eine dem Workspace
+  // fremde Run-ID liefert undefined (HTTP → 404) und schreibt nichts; eine
+  // völlig unbekannte ID ebenso.
+  it.instance(
+    "export of an unknown or foreign-directory run returns undefined",
+    () =>
+      Effect.gen(function* () {
+        const b = yield* tmpdirScoped({ git: true })
+        const workflow = yield* Workflow.Service
+        const idA = Workflow.RunID.make("job_export_foreign_A")
+        // As Run direkt als Row seeden, mit As (Test-)directory.
+        yield* seedCompletedRow(idA, (yield* TestInstance).directory)
+        // B sieht ihn nicht — kein Export, kein Verzeichnis.
+        expect(yield* workflow.export(idA).pipe(provideInstance(b))).toBeUndefined()
+        const foreignDir = path.join(Global.Path.data, "workflow", idA, "transcripts")
+        expect(yield* Effect.promise(() => fs.stat(foreignDir).then(() => true).catch(() => false))).toBe(false)
+        // Unbekannte ID ⇒ undefined.
+        expect(yield* workflow.export(Workflow.RunID.make("job_export_unknown"))).toBeUndefined()
+        // A selbst kann exportieren (der geseedete Node hat keine Session ⇒
+        // Fallback-Zeile), danach aufräumen.
+        const exported = yield* workflow.export(idA)
+        expect(exported).toBeDefined()
+        expect(exported!.files.toSorted()).toEqual(["1.jsonl", "run.json"])
+        yield* Effect.promise(() =>
+          fs.rm(path.join(Global.Path.data, "workflow", idA), { recursive: true, force: true }),
+        )
+      }),
+    { git: true },
+  )
+
+  // T5 gap (mixed journal: agent cached, question re-asked on an ORDINARY resume).
+  // A workflow that asks a question THEN dispatches an agent. On the first run the
+  // question is answered live and the agent runs live. On an ORDINARY resume
+  // (resume_of only — no answer()-seed), the engine replays the completed AGENT
+  // node from the journal (cached, NOT re-prompted) but DELIBERATELY does NOT
+  // journal-replay the question: question replay is the answer()-seeded path only
+  // (workflow.ts ~1967 + q-then-agent test). So the question re-asks LIVE and we
+  // answer it live again; the cached agent proves the agent-journal replay works
+  // alongside a question node, and the live re-ask pins the documented boundary.
+  it.instance("ordinary resume of a mixed journal caches the agent and re-asks the question live", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, MIXED_REPLAY_FIXTURE, MIXED_REPLAY_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // First run: answer the question live, agent runs live with a recorded prompt.
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: MIXED_REPLAY_FIXTURE, args: {}, prompt: firstOps.ops })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(first.id)
+          return current?.pending_question?.question === "ship?" ? current : undefined
+        }),
+        "pending question never appeared",
+      )
+      yield* workflow.answer({ id: first.id, answer: "yes" })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ??
+        (yield* Effect.fail(new Error("first mixed run did not finish")))
+      expect(firstDone.status).toBe("completed")
+      expect(firstOps.prompted).toContain("do-yes")
+      const firstResult = firstDone.result as { answer: string; work: string }
+      expect(firstResult.answer).toBe("yes")
+
+      // completed → paused so it is a legitimate resume source (journal kept).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      // Ordinary resume: the agent is served from the journal; the question
+      // re-asks live (no seed), so we answer it live once it appears.
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: MIXED_REPLAY_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+      })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(resumed.id)
+          return current?.pending_question?.question === "ship?" ? current : undefined
+        }),
+        "resumed run never re-asked the question",
+      )
+      yield* workflow.answer({ id: resumed.id, answer: "yes" })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("mixed resume did not finish")))
+      expect(done.status).toBe("completed")
+      // The agent step came from the journal — it was NOT re-prompted on the resume.
+      expect(prompted).not.toContain("do-yes")
+      const anode = done.agents.find((a) => a.prompt === "do-yes")
+      expect(anode?.cached).toBe(true)
+      // The question was re-asked live and answered; no lingering pending_question.
+      expect(done.pending_question).toBeUndefined()
+      const qnode = done.agents.find((a) => a.kind === "question")
+      expect(qnode?.answer).toBe("yes")
+      // Replayed-agent result still matches the first run's structured result.
+      expect(done.result).toEqual(firstResult)
+    }),
+  )
+
+  // T5 gap (resume after engine restart): the resume path is proven within ONE
+  // service lifetime; here we PROVE it survives a process restart. A run parks as
+  // paused (its journal persisted in SQLite, which lives at the test-layer scope —
+  // NOT per-instance), then we reload the instance via the SAME test-layer
+  // InstanceStore (reloadInstance → runDisposers invalidates Workflow's
+  // per-directory InstanceState ScopedCache, so the next access rebuilds a FRESH
+  // runs registry and re-runs the startup orphan sweep over the same DB). The
+  // reload must NOT touch the paused row (it has no live fiber by design but is
+  // parked, not lost), and answer() on the fresh service must still resume and
+  // replay the journaled question from disk.
+  // NOTE (execution-time reconciliation): the plan suggested `reloadTestInstance`,
+  // but that bridges through the process-global AppRuntime's InstanceStore — a
+  // DIFFERENT registry than this test layer's. The faithful in-layer restart is the
+  // test-layer `reloadInstance` (InstanceStore.reload), which disposes+rebuilds the
+  // cached per-directory state. testInstanceStoreLayer supplies InstanceStore.Service
+  // for both provideInstance and reloadInstance.
+  it.live("a resume after an engine restart (instance reload) replays the journaled question from disk", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped({ git: true })
+      yield* Effect.promise(() => writeWorkflow(directory, QUESTION_TIMEOUT_FIXTURE, QUESTION_TIMEOUT_WORKFLOW))
+
+      // Lifetime 1: start the run; its 50ms-timeout question parks it as paused
+      // with the open question persisted on the row.
+      const pausedId = yield* Effect.gen(function* () {
+        const workflow = yield* Workflow.Service
+        const run = yield* workflow.start({ name: QUESTION_TIMEOUT_FIXTURE, args: {}, prompt: immediatePromptOps() })
+        const paused =
+          (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("timeout run did not settle")))
+        expect(paused.status).toBe("paused")
+        expect(paused.pending_question?.question).toBe("deploy?")
+        return run.id
+      }).pipe(provideInstance(directory))
+
+      // Restart: dispose+rebuild the instance over the SAME directory (invalidates
+      // Workflow's per-directory InstanceState → fresh runs registry + startup sweep).
+      yield* reloadInstance({ directory })
+
+      // Lifetime 2: the fresh service ran its startup sweep. The paused row must be
+      // intact (not swept to interrupted), and answer() must start a resume that
+      // replays the question from disk and completes.
+      yield* Effect.gen(function* () {
+        const workflow = yield* Workflow.Service
+        const reloaded = yield* workflow.get(pausedId)
+        expect(reloaded?.status).toBe("paused")
+        expect(reloaded?.pending_question?.question).toBe("deploy?")
+        const resumed = yield* workflow.answer({ id: pausedId, answer: "no" })
+        expect(resumed).toBeDefined()
+        expect(resumed!.resume_of).toBe(pausedId)
+        const done =
+          (yield* workflow.wait({ id: resumed!.id })).run ??
+          (yield* Effect.fail(new Error("post-restart resume did not finish")))
+        expect(done.status).toBe("completed")
+        expect((done.result as { answer: string }).answer).toBe("no")
+        const replayed = done.agents.find((a) => a.kind === "question")
+        expect(replayed?.answer).toBe("no")
+      }).pipe(provideInstance(directory))
+    }).pipe(Effect.provide(testInstanceStoreLayer)),
+  )
+
+  // Status-Guard (erweitert): ein COMPLETED Quell-Run ist eine gültige Resume-
+  // Quelle — der Re-Run eines identischen Scripts ist ein 100%-Cache-Hit: KEIN
+  // Prompt wird gefeuert, beide Agent-Nodes kommen als cached:true aus dem
+  // Journal, der Run endet sofort completed mit demselben Resultat.
+  it.instance("resume of a COMPLETED run is a full cache hit", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_FIXTURE, RESUME_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Quell-Run läuft regulär bis completed.
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      // Resume der completed-Quelle: vollständiger Cache-Hit.
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: resumeOps, resume_of: first.id })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ??
+        (yield* Effect.fail(new Error("completed-resume did not finish")))
+      expect(done.status).toBe("completed")
+      // KEIN Prompt wurde gefeuert — beide Agenten kamen aus dem Journal.
+      expect(prompted).toHaveLength(0)
+      expect(done.agents).toHaveLength(2)
+      expect(done.agents.every((a) => a.cached === true)).toBe(true)
+      // Das Resultat ist identisch zum Erstlauf; resume_of ist vermerkt.
+      expect(done.result).toEqual(firstDone.result)
+      const row = yield* fetchRunRow(resumed.id)
+      expect(row.resume_of).toBe(first.id)
+    }),
+  )
+
+  // Status-Guard (erweitert): ein FAILED Quell-Run ist eine gültige Resume-Quelle —
+  // das trägt die Kerniterationsschleife (Run failt → Script editieren → Präfix
+  // replayen). Der completed-Präfix (Agent A) kommt aus dem Journal (KEIN neuer
+  // Prompt); der gefailte Agent B steht NICHT im Journal (nur completed-Nodes
+  // landen dort) und läuft live — diesmal erfolgreich, der Run endet completed.
+  it.instance("resume of a FAILED run replays the completed prefix and reruns the failed step live", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_FIXTURE, RESUME_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Erster Lauf: Agent A antwortet, Agent B's Prompt schlägt fehl → Run failed.
+      // Als Workflow.PromptOps typisiert (Error-Kanal `unknown`), damit der
+      // gewollte Effect.fail(Error) den Prompt-Typ nicht verengt.
+      const failingOps: Workflow.PromptOps = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            const text = authorPrompt(input.parts?.[0]?.type === "text" ? input.parts[0].text : "")
+            if (text === "agent A") {
+              const last = yield* persistTurns(db, input.sessionID, [
+                { cost: 0, tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } } },
+              ])
+              return { info: last.info, parts: [{ type: "text", text: "out:A" }] } as unknown as SessionV1.WithParts
+            }
+            return yield* Effect.fail(new Error("B exploded"))
+          }),
+        cancel: () => Effect.void,
+      }
+      const first = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: failingOps })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("failed")
+
+      // Resume des failed-Runs: A aus dem Journal (NICHT erneut geprompt), B live
+      // (jetzt erfolgreiche Ops) → Run completed.
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: resumeOps, resume_of: first.id })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ??
+        (yield* Effect.fail(new Error("failed-resume did not finish")))
+      expect(done.status).toBe("completed")
+      expect(prompted).not.toContain("agent A")
+      expect(prompted).toContain("agent B")
+      const result = done.result as { a: string; b: string }
+      expect(result.a).toBe("out:A")
+      expect(result.b).toBe("out:agent B")
+      // A ist als cached markiert (Journal-Replay), B nicht (lief live).
+      const agentA = done.agents.find((a) => a.output === "out:A")
+      expect(agentA?.cached).toBe(true)
+      const agentB = done.agents.find((a) => a.output === "out:agent B")
+      expect(agentB?.cached).not.toBe(true)
+    }),
+  )
+
+  // Status-Guard (unverändert verboten): ein noch RUNNING Quell-Run darf nicht
+  // resumt werden — die Original-Voraussetzung bleibt: erst stoppen. Erwartung:
+  // WorkflowInvalidError mit der neuen Fehlermeldung.
+  it.instance("resume from a running source run still fails with WorkflowInvalidError", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PAUSE_FIXTURE, PAUSE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Hängenden Run starten (bleibt running am Agent-Gate).
+      const { ops } = hangingPromptOps()
+      const run = yield* workflow.start({ name: PAUSE_FIXTURE, args: {}, prompt: ops })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+
+      const { ops: resumeOps } = recordingPromptOps(db, 0)
+      const failed = yield* workflow
+        .start({ name: PAUSE_FIXTURE, args: {}, prompt: resumeOps, resume_of: run.id })
+        .pipe(Effect.flip)
+      expect(failed._tag).toBe("WorkflowInvalidError")
+      const invalid =
+        failed instanceof Workflow.InvalidError ? failed : yield* Effect.fail(new Error("expected InvalidError"))
+      expect(invalid.message).toContain("status is running")
+      expect(invalid.message).toContain("stopped first")
+      expect(invalid.message).toContain(run.id)
+
+      // Cleanup: die hängende Quelle canceln, damit kein Fiber den Test überlebt.
+      const cancelled = yield* workflow.cancel(run.id)
+      expect(cancelled?.status).toBe("cancelled")
+    }),
+  )
+
+  // Finding 11 (cross-workflow resume): the start route accepts the workflow NAME
+  // and the resume source `resume_of` INDEPENDENTLY. Resuming a paused run of
+  // workflow A while requesting a DIFFERENT workflow B must be rejected — otherwise
+  // B would replay A's journaled agent output/cost wherever a journal key collides,
+  // and record resume_of pointing at an unrelated workflow. We start A
+  // (RESUME_FIXTURE), park it as `paused` (a VALID resume status, so only the
+  // identity guard can reject), then attempt to resume it under name B
+  // (SINGLE_AGENT_FIXTURE). Expectation: WorkflowInvalidError naming BOTH workflows.
+  // The status guard alone would NOT catch this (the source is a legitimate paused
+  // resume source). This guards both the HTTP and tool start paths.
+  it.instance("resume of workflow A's run while requesting workflow B fails with WorkflowInvalidError", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, RESUME_FIXTURE, RESUME_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Start A and let it complete, then park it as `paused` so it is a valid
+      // resume source (only the workflow-identity guard should reject the resume).
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: RESUME_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      // Resume A's run while requesting workflow B → cross-workflow, must fail.
+      const { ops: resumeOps } = recordingPromptOps(db, 0)
+      const failed = yield* workflow
+        .start({ name: SINGLE_AGENT_FIXTURE, args: {}, prompt: resumeOps, resume_of: first.id })
+        .pipe(Effect.flip)
+      expect(failed._tag).toBe("WorkflowInvalidError")
+      const invalid =
+        failed instanceof Workflow.InvalidError ? failed : yield* Effect.fail(new Error("expected InvalidError"))
+      // The message names BOTH the source workflow (A) and the requested one (B).
+      expect(invalid.message).toContain(RESUME_FIXTURE)
+      expect(invalid.message).toContain(SINGLE_AGENT_FIXTURE)
+      expect(invalid.message).toContain(first.id)
+    }),
+  )
+
+  // Status-Guard / cancel-paused-Race: ein CANCELLED Quell-Run (hier: hängender Run
+  // → pause → cancel, exakt die cancel-of-a-paused-run-Semantik) darf AUCH nach der
+  // Erweiterung des Guards (failed/completed sind jetzt erlaubt) NICHT resumt
+  // werden. Ein direkter DB-UPDATE auf cancelled (die Race) wäre sonst re-resumebar.
+  // Erwartung: WorkflowInvalidError, der den Status `cancelled` nennt.
+  it.instance("resume from a cancelled source run fails with WorkflowInvalidError", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PAUSE_FIXTURE, PAUSE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      // Hängenden Run starten, pausieren, dann cancellen → terminal cancelled.
+      const { ops } = hangingPromptOps()
+      const run = yield* workflow.start({ name: PAUSE_FIXTURE, args: {}, prompt: ops })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running" && a.session_id) ? current : undefined
+        }),
+        "agent never started",
+      )
+      const paused = yield* workflow.pause(run.id)
+      expect(paused?.status).toBe("paused")
+      const cancelled = yield* workflow.cancel(run.id)
+      expect(cancelled?.status).toBe("cancelled")
+
+      // Resume von einer cancelled-Quelle MUSS scheitern.
+      const { ops: resumeOps } = recordingPromptOps(db, 0)
+      const failed = yield* workflow
+        .start({ name: PAUSE_FIXTURE, args: {}, prompt: resumeOps, resume_of: run.id })
+        .pipe(Effect.flip)
+      expect(failed._tag).toBe("WorkflowInvalidError")
+      const invalid =
+        failed instanceof Workflow.InvalidError ? failed : yield* Effect.fail(new Error("expected InvalidError"))
+      expect(invalid.message).toContain("status is cancelled")
+      expect(invalid.message).toContain("cancelled runs cannot be resumed")
+      expect(invalid.message).toContain(run.id)
+    }),
+  )
+
+  // Finding 1 (consume-once): answer() on a PAUSED run with a persisted
+  // pending_question must consume the source row exactly once — a second answer()
+  // with the same id must NOT spawn a duplicate resume run (which would re-replay
+  // the journal and burn budget twice). The first answer() starts the resume; the
+  // second finds the source no longer has an open pending_question and returns
+  // undefined. Only ONE resume run is ever created.
+  it.instance("answer() on a paused run consumes the source once: a second answer() spawns no duplicate resume", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, QUESTION_TIMEOUT_FIXTURE, QUESTION_TIMEOUT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      // Park the run as paused with an open pending_question (50ms timeout).
+      const run = yield* workflow.start({ name: QUESTION_TIMEOUT_FIXTURE, args: {}, prompt: immediatePromptOps() })
+      const paused =
+        (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("timeout run did not park")))
+      expect(paused.status).toBe("paused")
+      expect(paused.pending_question?.question).toBe("deploy?")
+
+      // First answer() resumes (consumes the source).
+      const firstResume = yield* workflow.answer({ id: run.id, answer: "yes" })
+      expect(firstResume).toBeDefined()
+      expect(firstResume!.resume_of).toBe(run.id)
+
+      // Second answer() must find the source already consumed → undefined, NO
+      // second resume run.
+      const secondResume = yield* workflow.answer({ id: run.id, answer: "yes" })
+      expect(secondResume).toBeUndefined()
+
+      // Exactly ONE resume run exists for this source (plus the source itself).
+      const allRuns = yield* workflow.runs()
+      const resumes = allRuns.filter((r) => r.resume_of === run.id)
+      expect(resumes.length).toBe(1)
+    }),
+  )
+
+  // Finding 9 (inline-source resume): a paused run that was started via the
+  // INLINE-source path (start({ source }) with no name) persists its module body
+  // ONLY on definition.source — its workflow NAME is never written to disk and is
+  // not discoverable. answer() must thread that source back into the resume start
+  // so it re-runs the SAME module, instead of taking the named-discovery branch
+  // and failing NotFound (or running a foreign same-named workflow).
+  it.instance("answer() resume of a paused INLINE-source workflow threads the source and resumes", () =>
+    Effect.gen(function* () {
+      yield* TestInstance
+      const workflow = yield* Workflow.Service
+      // Inline workflow whose meta NAME is deliberately NOT on disk anywhere, so a
+      // named-discovery resume would NotFound. 50ms-timeout question parks it.
+      const source = `export const meta = { name: "InlineQ", phases: ["run"] }
+export async function run(args, ctx) {
+  ctx.setPhase("run")
+  const a = await ctx.question({ question: "deploy?", options: ["yes", "no"], timeout: 50 })
+  return { answer: a.answer }
+}
+`
+      const run = yield* workflow.start({ source, args: {}, prompt: immediatePromptOps() })
+      const paused =
+        (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("inline run did not park")))
+      expect(paused.status).toBe("paused")
+      expect(paused.pending_question?.question).toBe("deploy?")
+
+      // answer() must resume the inline workflow (threading the persisted source).
+      const resumed = yield* workflow.answer({ id: run.id, answer: "no" })
+      expect(resumed).toBeDefined()
+      expect(resumed!.resume_of).toBe(run.id)
+      const done =
+        (yield* workflow.wait({ id: resumed!.id })).run ??
+        (yield* Effect.fail(new Error("inline resume did not finish")))
+      expect(done.status).toBe("completed")
+      expect((done.result as { answer: string }).answer).toBe("no")
+    }),
+  )
+
+  // Finding 10 (live answer loses to an in-flight pause): answer()'s live-writer
+  // branch must NOT consume the open question of a run that is already unwinding
+  // to paused (active.pausing set). Otherwise it clears+persists pending_question
+  // on a run that finishes `paused`, leaving a paused row with NO pending_question
+  // that can never be resumed via answer(). Drive it deterministically by setting
+  // active.pausing on the live registry entry while the run is parked on the
+  // question, then calling answer().
+  it.instance("answer() declines a live run that is already pausing, leaving it resumable", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, QUESTION_FIXTURE, QUESTION_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const run = yield* workflow.start({ name: QUESTION_FIXTURE, args: {}, prompt: immediatePromptOps() })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current?.pending_question?.question === "deploy?" ? current : undefined
+        }),
+        "pending question never appeared",
+      )
+
+      // Simulate an in-flight pause(): flip the live registry entry's pausing flag
+      // exactly as abortRun(active,"pause") does synchronously, BEFORE the scope
+      // close clears pendingQuestion — the precise window Finding 10 describes.
+      yield* Workflow.__testHooks.setPausing(run.id)
+
+      // answer() must DECLINE (not consume the open question) because the run is
+      // unwinding to paused.
+      const answered = yield* workflow.answer({ id: run.id, answer: "yes" })
+      expect(answered).toBeUndefined()
+
+      // Now finish the pause for real and assert the run is paused WITH its
+      // pending_question intact (so it is still resumable via answer()).
+      const paused = yield* workflow.pause(run.id)
+      expect(paused?.status).toBe("paused")
+      expect(paused?.pending_question?.question).toBe("deploy?")
+    }),
+  )
+
+  // Finding 4 (timeout-park races answer): a live answer() that completes the
+  // question node in the window between the timeout firing and the park decision
+  // must WIN — the run completes with the answer rather than parking as paused
+  // with the answer silently discarded. The race is driven deterministically via
+  // the __testHooks.runOnQuestionTimeoutPark seam, which fires answer() exactly in
+  // that window (the open question is still live in-memory there). On broken code
+  // the run parks as paused (answer lost); on fixed code the timeout branch
+  // re-reads the now-completed node and returns the answer.
+  it.instance("a live answer() that lands as the question times out wins over the park (no lost answer)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, QUESTION_TINY_TIMEOUT_FIXTURE, QUESTION_TINY_TIMEOUT_WORKFLOW),
+      )
+      const workflow = yield* Workflow.Service
+
+      // The run id is only known after start(); capture it so the hook can answer
+      // the right run. The hook fires INSIDE the timeout-park window (question still
+      // live), so this answer() takes the authoritative live-writer branch.
+      let runId: Workflow.RunID | undefined
+      Workflow.__testHooks.runOnQuestionTimeoutPark(
+        Effect.suspend(() => (runId ? workflow.answer({ id: runId, answer: "yes" }).pipe(Effect.ignore) : Effect.void)),
+      )
+
+      const started = yield* workflow.start({
+        name: QUESTION_TINY_TIMEOUT_FIXTURE,
+        args: {},
+        prompt: immediatePromptOps(),
+      })
+      runId = started.id
+
+      const done =
+        (yield* workflow.wait({ id: started.id })).run ??
+        (yield* Effect.fail(new Error("tiny-timeout question run did not settle")))
+      // The answer won: the run completed with it, NOT parked as paused.
+      expect(done.status).toBe("completed")
+      expect((done.result as { answer: string }).answer).toBe("yes")
+      expect(done.pending_question).toBeUndefined()
+      const qnode = done.agents.find((a) => a.kind === "question")
+      expect(qnode?.status).toBe("completed")
+      expect(qnode?.answer).toBe("yes")
+    }),
+  )
+
+  // Schema/Journal-Drift (Fund: ungeschütztes JSON.parse(cached.output)): der
+  // Journal-Key ignoriert das Schema. Ein PLAINTEXT-Quell-Node kann beim Resume
+  // eine Schema-Anfrage matchen, wenn die Workflow-Datei zwischen Lauf und Resume
+  // driftet (gleicher Name/Prompt/Phase, jetzt mit schema im agent-Call). Statt am
+  // JSON.parse des Plaintext-Outputs zu defecten, MUSS der Resume das als Cache-MISS
+  // behandeln und den Agenten LIVE laufen lassen (PromptOps-Zähler +1, Run completed).
+  // Item 20: der Per-Call-MISS-ohne-Konsum ist KEYED-Semantik — seit dem
+  // prefix-Default explizit mit replay:"keyed" gepinnt; der prefix-Zwilling
+  // (Drift bricht den Präfix DAUERHAFT) steht darunter.
+  it.instance("a schema call matching a plaintext journal node runs live instead of defecting (keyed)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      // V1: Plaintext-Agent (kein Schema) → Journal-Node mit nicht-JSON-Output.
+      yield* Effect.promise(() => writeWorkflow(test.directory, DRIFT_FIXTURE, DRIFT_WORKFLOW_PLAINTEXT))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const { ops: firstOps, state: firstState } = driftPromptOps(db)
+      const first = yield* workflow.start({ name: DRIFT_FIXTURE, args: {}, prompt: firstOps })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+      // Der Quell-Node trägt Plaintext (kein gültiges JSON).
+      expect(firstDone.result).toEqual({ value: "not json at all" })
+      expect(firstState.count).toBe(1)
+
+      // Quell-Row auf `paused` versetzen → legitime Resume-Quelle (Journal bleibt).
+      // Im Poll wiederholt, bis sichtbar `paused` (asynchrone Eviction, siehe oben).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      // Drift: SELBE Datei (gleicher Name → gleicher path/journalKey) wird zu V2
+      // überschrieben — derselbe Agent-Call fordert jetzt ein Schema an.
+      yield* Effect.promise(() => writeWorkflow(test.directory, DRIFT_FIXTURE, DRIFT_WORKFLOW_SCHEMA))
+
+      // Resume: die Schema-Anfrage matcht den Plaintext-Journal-Node. Kein Defect —
+      // der Agent läuft LIVE und liefert ein echtes structured-Ergebnis.
+      const { ops: resumeOps, state: resumeState } = driftPromptOps(db)
+      const resumed = yield* workflow.start({
+        name: DRIFT_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        replay: "keyed",
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      // Kein Defect: der Run completed sauber.
+      expect(done.status).toBe("completed")
+      // Der Agent lief LIVE (Zähler +1), NICHT aus dem Journal repliziert.
+      expect(resumeState.count).toBe(1)
+      // Das Live-Ergebnis ist das geparste Schema-Objekt, nicht der Plaintext.
+      expect(done.result).toEqual({ value: SCHEMA_OBJECT })
+      // Der Agent-Node ist NICHT als cached markiert (Cache-MISS → Live-Lauf).
+      const node = done.agents.find((a) => a.prompt === "drift agent")
+      expect(node?.cached).not.toBe(true)
+    }),
+  )
+
+  // Item 20 Test (4): 'schema drift breaks the prefix permanently'. Wie der
+  // Drift-Test, aber mit einem UNVERÄNDERTEN zweiten Agenten: im Default-Modus
+  // 'prefix' bricht der Parse-Fehler an Call 1 den Präfix dauerhaft — auch der
+  // unveränderte Call 2 läuft live (Zähler 2, kein cached-Node).
+  it.instance("schema drift breaks the prefix permanently: the unchanged second call runs live too", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, DRIFT2_FIXTURE, DRIFT2_WORKFLOW_PLAINTEXT))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const { ops: firstOps, state: firstState } = driftPromptOps(db)
+      const first = yield* workflow.start({ name: DRIFT2_FIXTURE, args: {}, prompt: firstOps })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+      expect(firstState.count).toBe(2)
+
+      // Drift: dieselbe Datei wird zu V2 überschrieben (Call 1 fordert jetzt ein
+      // Schema an, Call 2 bleibt unverändert). completed ist direkt resumebar.
+      yield* Effect.promise(() => writeWorkflow(test.directory, DRIFT2_FIXTURE, DRIFT2_WORKFLOW_SCHEMA))
+
+      const { ops: resumeOps, state: resumeState } = driftPromptOps(db)
+      const resumed = yield* workflow.start({
+        name: DRIFT2_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      // BEIDE Calls liefen live: der Drift brach den Präfix, der unveränderte
+      // zweite Call wurde NICHT mehr aus dem Journal bedient.
+      expect(resumeState.count).toBe(2)
+      expect(done.agents.every((a) => a.cached !== true)).toBe(true)
+      const stable = done.agents.find((a) => a.prompt === "stable agent")
+      expect(stable?.cached).not.toBe(true)
+    }),
+  )
+
+  // Item 20 keyed-Gegentest zum Drift-Zwilling: unter replay:"keyed" bleibt der
+  // Drift ein Per-Call-MISS — Call 1 läuft live, der unveränderte Call 2 wird
+  // weiterhin aus dem Journal bedient (Zähler 1, stable-Node cached).
+  it.instance("schema drift under keyed replay misses only the drifted call and keeps the second cached", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, DRIFT2_FIXTURE, DRIFT2_WORKFLOW_PLAINTEXT))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const { ops: firstOps } = driftPromptOps(db)
+      const first = yield* workflow.start({ name: DRIFT2_FIXTURE, args: {}, prompt: firstOps })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+
+      yield* Effect.promise(() => writeWorkflow(test.directory, DRIFT2_FIXTURE, DRIFT2_WORKFLOW_SCHEMA))
+
+      const { ops: resumeOps, state: resumeState } = driftPromptOps(db)
+      const resumed = yield* workflow.start({
+        name: DRIFT2_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+        replay: "keyed",
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      // Nur der Drift-Call lief live; der unveränderte zweite kam aus dem Journal.
+      expect(resumeState.count).toBe(1)
+      const stable = done.agents.find((a) => a.prompt === "stable agent")
+      expect(stable?.cached).toBe(true)
+    }),
+  )
+
+  // TASK 12/13 — TEST A (live answer): ctx.question persists a pending question on
+  // the run (pending_question + a kind:"question" journal node), emits a
+  // workflow.run.updated event carrying pending_question:true, and waits LIVE for
+  // an answer. workflow.answer({ id, answer }) resolves the Deferred → the body
+  // gets { answer }, the run completes, pending_question is cleared, and the
+  // question node carries the answer.
+  it.instance("ctx.question waits live for an answer, records it on the journal node, clears pending_question", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, QUESTION_FIXTURE, QUESTION_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const events = yield* EventV2Bridge.Service
+      const seenPending: boolean[] = []
+      const unsub = yield* events.listen((event) =>
+        Effect.sync(() => {
+          if (event.type === "workflow.run.updated")
+            seenPending.push((event.data as Record<string, unknown>)["pending_question"] === true)
+        }),
+      )
+      yield* Effect.addFinalizer(() => unsub)
+
+      const run = yield* workflow.start({ name: QUESTION_FIXTURE, args: {}, prompt: immediatePromptOps() })
+
+      // Poll until the pending question is persisted/visible on the run.
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current?.pending_question?.question === "deploy?" ? current : undefined
+        }),
+        "pending question never appeared",
+      )
+      expect(live.pending_question?.options).toEqual(["yes", "no"])
+      expect(live.status).toBe("running")
+
+      // Answer it live.
+      const answered = yield* workflow.answer({ id: run.id, answer: "yes" })
+      expect(answered?.id).toBe(run.id)
+
+      const done =
+        (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("question run did not finish")))
+      expect(done.status).toBe("completed")
+      expect((done.result as { answer: string }).answer).toBe("yes")
+      // pending_question cleared after the answer.
+      expect(done.pending_question).toBeUndefined()
+      // The journal carries a kind:"question" node with the answer.
+      const qnode = done.agents.find((a) => a.kind === "question")
+      expect(qnode).toBeDefined()
+      expect(qnode?.prompt).toBe("deploy?")
+      expect(qnode?.answer).toBe("yes")
+      expect(qnode?.status).toBe("completed")
+      // At least one workflow.run.updated event carried pending_question:true.
+      expect(seenPending.some((p) => p === true)).toBe(true)
+    }),
+  )
+
+  // TASK 12/13 — TEST B (park + resume): a question with a tiny timeout that goes
+  // unanswered PARKS the run as `paused` (existing pause machinery), keeping the
+  // journal (incl. the open question node) and the persisted pending_question.
+  // workflow.answer on the paused run starts a RESUME (resume_of) whose journal
+  // replay serves the answer to the question node WITHOUT asking again.
+  it.instance("an unanswered ctx.question times out, parks as paused, and answer() resumes serving the reply", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, QUESTION_TIMEOUT_FIXTURE, QUESTION_TIMEOUT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const run = yield* workflow.start({ name: QUESTION_TIMEOUT_FIXTURE, args: {}, prompt: immediatePromptOps() })
+
+      // The timeout (50ms) fires → the run parks as paused.
+      const paused =
+        (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("timeout run did not settle")))
+      expect(paused.status).toBe("paused")
+      // The open question node + persisted pending_question survive the park.
+      expect(paused.pending_question?.question).toBe("deploy?")
+      const openNode = paused.agents.find((a) => a.kind === "question")
+      expect(openNode).toBeDefined()
+      expect(openNode?.answer).toBeUndefined()
+
+      // answer() on the paused run starts a NEW resume run.
+      const resumed = yield* workflow.answer({ id: run.id, answer: "no" })
+      expect(resumed).toBeDefined()
+      expect(resumed!.id).not.toBe(run.id)
+      expect(resumed!.resume_of).toBe(run.id)
+
+      const done =
+        (yield* workflow.wait({ id: resumed!.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      expect((done.result as { answer: string }).answer).toBe("no")
+      // No second live ask on the resumed run: the question node carries the
+      // replayed answer and there is no open pending_question.
+      expect(done.pending_question).toBeUndefined()
+      const replayed = done.agents.find((a) => a.kind === "question")
+      expect(replayed?.answer).toBe("no")
+      expect(replayed?.status).toBe("completed")
+    }),
+  )
+
+  // TASK 12/13 follow-up: answer() must forward the SAME execution options start()
+  // accepts for a resume (at minimum the prompt-ops vector), so a workflow that
+  // asks a question and THEN dispatches ctx.agent steps can complete on the resume.
+  // The question times out → parks paused; answer({..., prompt}) starts a resume
+  // that replays the question from the journal AND runs the live agent step.
+  it.instance("answer() forwards prompt ops so a resumed run can dispatch agents after the question", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, QUESTION_AGENT_FIXTURE, QUESTION_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const run = yield* workflow.start({ name: QUESTION_AGENT_FIXTURE, args: {}, prompt: immediatePromptOps() })
+
+      // Unanswered question times out → run parks as paused.
+      const paused =
+        (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("q-then-agent did not settle")))
+      expect(paused.status).toBe("paused")
+      expect(paused.pending_question?.question).toBe("go?")
+
+      // answer() with prompt ops → resume that runs the live agent step.
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.answer({ id: run.id, answer: "yes", prompt: resumeOps })
+      expect(resumed).toBeDefined()
+      expect(resumed!.resume_of).toBe(run.id)
+
+      const done =
+        (yield* workflow.wait({ id: resumed!.id })).run ?? (yield* Effect.fail(new Error("resume did not finish")))
+      expect(done.status).toBe("completed")
+      const result = done.result as { answer: string; agentText: string }
+      // The question was replayed (answer served) AND the agent step ran live on
+      // the resumed run, prompted with the answer-dependent text.
+      expect(result.answer).toBe("yes")
+      expect(prompted).toContain("after-yes")
+      expect(result.agentText).toBe("out:after-yes")
+      // The resumed run carries both the (replayed) question node and the live
+      // agent node; no second pending_question.
+      expect(done.pending_question).toBeUndefined()
+      expect(done.agents.find((a) => a.kind === "question")?.answer).toBe("yes")
+      expect(done.agents.some((a) => a.kind !== "question" && a.output === "out:after-yes")).toBe(true)
+    }),
+  )
+
+  // Task 6: a per-step reasoning `variant` passed to ctx.agent must be threaded
+  // verbatim into the underlying prompt run. The recording prompt-ops capture the
+  // real PromptInput, so the dispatched `variant` is asserted directly — proving
+  // ctx.agent({ prompt, variant }) reaches SessionPrompt.prompt as input.variant.
+  it.instance("ctx.agent variant is threaded into the prompt run", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, VARIANT_FIXTURE, VARIANT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: VARIANT_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("variant workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      // Exactly one real agent dispatch, carrying the requested variant.
+      expect(inputs.length).toBe(1)
+      expect(inputs[0]?.variant).toBe("max")
+    }),
+  )
+
+  // Task 7: ctx.agent({ model: "small" }) must resolve to the configured
+  // small_model and dispatch the prompt against that provider/model. The
+  // capturing prompt-ops record the real PromptInput, so the resolved model is
+  // asserted directly against the configured small_model's providerID/modelID.
+  it.instance(
+    'ctx.agent model:"small" routes to the configured small_model',
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, SMALL_MODEL_FIXTURE, SMALL_MODEL_WORKFLOW))
+        const workflow = yield* Workflow.Service
+        const { ops, inputs } = capturingPromptOps()
+
+        const started = yield* workflow.start({ name: SMALL_MODEL_FIXTURE, args: {}, prompt: ops })
+        const waited = yield* workflow.wait({ id: started.id })
+        const done = waited.run ?? (yield* Effect.fail(new Error("small-model workflow did not finish")))
+        expect(done.status).toBe("completed")
+
+        // The dispatch resolved to the configured small_model, not the default agent model.
+        expect(inputs.length).toBe(1)
+        expect(String(inputs[0]?.model?.providerID)).toBe("smallprov")
+        expect(String(inputs[0]?.model?.modelID)).toBe("small-model")
+      }),
+    { config: { small_model: "smallprov/small-model" } },
+  )
+
+  // Task 7 (error path): requesting model:"small" with NO small_model configured
+  // is an authoring error. The agent step must fail with a clear message rather
+  // than silently falling back; the prompt is never dispatched.
+  it.instance('ctx.agent model:"small" fails clearly when no small_model is configured', () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SMALL_MODEL_FIXTURE, SMALL_MODEL_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: SMALL_MODEL_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("small-model workflow did not finish")))
+
+      // The run failed because the only agent step could not resolve a model.
+      expect(done.status).toBe("failed")
+      const node = done.agents[0]
+      expect(node?.status).toBe("failed")
+      expect(node?.error).toContain("small_model")
+      // The prompt was never dispatched (no model to run against).
+      expect(inputs.length).toBe(0)
+    }),
+  )
+
+  // Task 8: a per-step `tools` whitelist/blacklist passed to ctx.agent must be
+  // threaded verbatim into the underlying prompt run. opencode's tool-scoping
+  // mechanism is PromptInput.tools (a Record<string,boolean> with glob-able
+  // keys), which the prompt loop turns into session permission rules — so the
+  // capturing prompt-ops record it directly and the dispatched object is
+  // asserted unchanged.
+  it.instance("ctx.agent tools scoping is threaded into the prompt run", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, TOOLS_FIXTURE, TOOLS_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: TOOLS_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("tools workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      // Exactly one real agent dispatch, carrying the requested tools object unchanged.
+      expect(inputs.length).toBe(1)
+      expect(inputs[0]?.tools).toEqual({ webfetch: false })
+    }),
+  )
+
+  // Task 9: a per-step `skills` array passed to ctx.agent must be honoured.
+  // opencode only loads skills via the runtime `skill` tool (no structured
+  // create/prompt field), so the engine prepends a load directive naming the
+  // skills to the prompt text and enables the `skill` tool for the step. Both
+  // are asserted on the captured PromptInput.
+  it.instance("ctx.agent skills are loaded via a prompt directive and the enabled skill tool", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SKILLS_FIXTURE, SKILLS_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: SKILLS_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("skills workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      expect(inputs.length).toBe(1)
+      // The skill tool is enabled for this step.
+      expect(inputs[0]?.tools?.skill).toBe(true)
+      // The text part carries a directive naming both skills, ahead of the prompt.
+      const textPart = inputs[0]?.parts.find((p) => p.type === "text")
+      expect(textPart?.type).toBe("text")
+      const text = textPart?.type === "text" ? textPart.text : ""
+      expect(text).toContain("pdf")
+      expect(text).toContain("xlsx")
+      expect(text).toContain("do it")
+      // Directive comes BEFORE the author's prompt.
+      expect(text.indexOf("pdf")).toBeLessThan(text.indexOf("do it"))
+    }),
+  )
+
+  // Item 6 (Subagenten-Framing): a NON-schema agent step's dispatched prompt is
+  // prepended with the step-framing directive (the step's final message is a
+  // program's value, not a human reply). node.prompt keeps the RAW author prompt
+  // so the resume journal key is untouched.
+  it.instance("a non-schema agent step prepends the framing directive to the dispatched prompt", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: SINGLE_AGENT_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("framing workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      expect(inputs.length).toBe(1)
+      const textPart = inputs[0]?.parts.find((p) => p.type === "text")
+      const text = textPart?.type === "text" ? textPart.text : ""
+      // Framing first, author's prompt last — nothing else in between.
+      expect(text).toBe(`${Workflow.STEP_FRAMING_DIRECTIVE}\n\ndo the thing`)
+      // The node carries the RAW prompt (journal-key stability).
+      expect(done.agents[0]?.prompt).toBe("do the thing")
+    }),
+  )
+
+  // Item 6: a SCHEMA step is NOT framed — the StructuredOutput tool call enforces
+  // the shape already, and an extra "output only data" line could compete with
+  // the structured-output system prompt. The dispatched text is the author's
+  // prompt verbatim.
+  it.instance("a schema agent step does NOT get the framing directive", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, SCHEMA_SUCCESS_FIXTURE, schemaWorkflow(SCHEMA_SUCCESS_FIXTURE)),
+      )
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      // Structured-answering ops that ALSO capture the dispatched prompt text.
+      const texts: string[] = []
+      const ops: { prompt: SessionPrompt.Interface["prompt"]; cancel: SessionPrompt.Interface["cancel"] } = {
+        prompt: (input) =>
+          Effect.gen(function* () {
+            if (input.noReply) return assistantReply()
+            const part = input.parts?.[0]
+            texts.push(part?.type === "text" ? part.text : "")
+            const turn: AssistantTurn = {
+              cost: 0,
+              tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+              structured: SCHEMA_OBJECT,
+            }
+            const last = yield* persistTurns(db, input.sessionID, [turn])
+            return { info: last.info, parts: [] } as unknown as SessionV1.WithParts
+          }),
+        cancel: () => Effect.void,
+      }
+
+      const started = yield* workflow.start({ name: SCHEMA_SUCCESS_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("schema framing workflow did not finish")))
+      expect(done.status).toBe("completed")
+      // The dispatched prompt is the author's text VERBATIM — no framing.
+      expect(texts).toEqual(["produce structured"])
+    }),
+  )
+
+  // Item 6: framing composes with the skills directive — framing first, then the
+  // skills line, then the author's prompt.
+  it.instance("the framing directive composes with the skills directive ahead of the author's prompt", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SKILLS_FIXTURE, SKILLS_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: SKILLS_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("skills framing workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      expect(inputs.length).toBe(1)
+      const textPart = inputs[0]?.parts.find((p) => p.type === "text")
+      const text = textPart?.type === "text" ? textPart.text : ""
+      expect(text).toBe(`${Workflow.STEP_FRAMING_DIRECTIVE}\n\nLoad these skills before starting: pdf, xlsx.\n\ndo it`)
+    }),
+  )
+
+  // Task 10: a per-step `files` array passed to ctx.agent attaches files
+  // declaratively. Each path resolves relative to the run's workspace directory;
+  // the engine appends a file part (after the text part) whose URL is the
+  // absolute file:// URL of the attachment.
+  it.instance("ctx.agent files are resolved against the workspace and appended as file parts", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "ATTACH.md"), "# attached\n"))
+      yield* Effect.promise(() => writeWorkflow(test.directory, FILES_FIXTURE, FILES_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: FILES_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("files workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      expect(inputs.length).toBe(1)
+      const parts = inputs[0]?.parts ?? []
+      // Text part first, file part appended after it.
+      expect(parts[0]?.type).toBe("text")
+      const filePart = parts.find((p) => p.type === "file")
+      expect(filePart?.type).toBe("file")
+      // The file part resolves to the absolute attachment in the workspace directory.
+      const expectedUrl = pathToFileURL(path.join(test.directory, "ATTACH.md")).href
+      expect(filePart?.type === "file" ? filePart.url : undefined).toBe(expectedUrl)
+    }),
+  )
+
+  // Task 10 (error path): a non-existent attachment is an authoring error. The
+  // agent step must fail with a WorkflowInvalidError naming the missing file
+  // rather than dispatching a broken prompt.
+  it.instance("ctx.agent files fails clearly when an attachment does not exist", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, FILES_MISSING_FIXTURE, FILES_MISSING_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: FILES_MISSING_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("files-missing workflow did not finish")))
+
+      expect(done.status).toBe("failed")
+      const node = done.agents[0]
+      expect(node?.status).toBe("failed")
+      expect(node?.error).toContain("DOES_NOT_EXIST.md")
+      // The prompt was never dispatched (the attachment could not be resolved).
+      expect(inputs.length).toBe(0)
+    }),
+  )
+
+  // Task 10 (directory path): an attachment that resolves to a directory is NOT a
+  // regular file and must fail the step cleanly — same as a missing file — instead
+  // of being dispatched as a broken file:// part. Pins the corrected portable
+  // existence check: fs.stat().isFile() (a directory -> false), matching the prior
+  // Bun.file(dir).exists() behaviour. A naive fs.access() would WRONGLY pass here.
+  it.instance("ctx.agent files fails clearly when an attachment is a directory", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => fs.mkdir(path.join(test.directory, "ATTACH_DIR"), { recursive: true }))
+      yield* Effect.promise(() => writeWorkflow(test.directory, FILES_DIR_FIXTURE, FILES_DIR_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: FILES_DIR_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("files-dir workflow did not finish")))
+
+      expect(done.status).toBe("failed")
+      const node = done.agents[0]
+      expect(node?.status).toBe("failed")
+      expect(node?.error).toContain("ATTACH_DIR")
+      // The prompt was never dispatched (the directory is not an attachable file).
+      expect(inputs.length).toBe(0)
+    }),
+  )
+
+  // Task 11: ctx.agent({ isolation: "worktree" }) runs the subagent inside a
+  // FRESH git worktree so parallel agents that mutate files do not conflict. The
+  // load-bearing assertion is that the EFFECTIVE instance directory the prompt
+  // runs under (what the subagent's file tools resolve cwd against) is the
+  // worktree path — NOT the run's workspace directory. The directory-capturing
+  // prompt-ops read InstanceState.directory from inside the dispatch, so we can
+  // assert real isolation rather than merely "a worktree was created". After the
+  // run finishes the worktree must be gone (run-scope finalizer cleaned it up).
+  it.instance(
+    'ctx.agent isolation:"worktree" runs the subagent in a fresh git worktree and cleans it up',
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, ISOLATION_FIXTURE, ISOLATION_WORKFLOW))
+        const workflow = yield* Workflow.Service
+        const { ops, inputs, directories, wasGitWorktree } = directoryCapturingPromptOps()
+
+        const started = yield* workflow.start({ name: ISOLATION_FIXTURE, args: {}, prompt: ops })
+        const waited = yield* workflow.wait({ id: started.id })
+        const done = waited.run ?? (yield* Effect.fail(new Error("isolation workflow did not finish")))
+        expect(done.status).toBe("completed")
+
+        // Exactly one real agent dispatch.
+        expect(inputs.length).toBe(1)
+        const effectiveDir = directories[0]
+        // The subagent ran under a DIFFERENT directory than the workspace — this
+        // is the load-bearing proof of real isolation: the prompt run (and so the
+        // subagent's file tools) resolves cwd against the worktree, not the
+        // workspace. Before the InstanceRef override this was the workspace dir.
+        expect(effectiveDir).toBeDefined()
+        expect(effectiveDir).not.toBe(test.directory)
+        // It was a real git worktree at dispatch time: it had a `.git` entry (a
+        // worktree's `.git` is a file pointing at the parent's gitdir), observed
+        // live before the finalizer removed it.
+        expect(wasGitWorktree[0]).toBe(true)
+        // The worktree lived OUTSIDE the workspace (a sibling temp dir), so it can
+        // never collide with the workspace or another step's worktree.
+        expect(effectiveDir!.startsWith(test.directory)).toBe(false)
+
+        // Run-scope finalizer cleans up the worktree. On a normal finish the run
+        // scope is closed fire-and-forget (so the terminal return is never delayed
+        // by a finalizer), meaning cleanup is async relative to wait() — poll for
+        // the directory to disappear rather than asserting it synchronously.
+        yield* pollWithTimeout(
+          Effect.promise(() =>
+            fs
+              .stat(effectiveDir!)
+              .then(() => undefined)
+              .catch(() => true as const),
+          ),
+          `worktree ${effectiveDir} was not cleaned up after the run finished`,
+        )
+      }),
+    { git: true },
+  )
+
+  // Finding 3: the per-step worktree base must NOT be a predictable, world-readable
+  // path under the shared tmp root (`<tmp>/oc-wf-<runid>-<nodeid>`, both segments
+  // guessable). It must be minted via `fs.mkdtemp` (random suffix) AND chmod 0700,
+  // so on a multi-user host no other local user can read the checkout or any secrets
+  // the subagent writes. We observe the worktree directory live at dispatch time
+  // (the directory-capturing prompt-ops record its mode then) and assert: it lives
+  // under tmpdir with the `oc-wf-` prefix, it is NOT the predictable
+  // `oc-wf-<runid>-<nodeid>` name, and its mode is exactly 0700.
+  it.instance(
+    'ctx.agent isolation:"worktree" mints a private (0700) worktree under an unguessable mkdtemp path',
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, ISOLATION_FIXTURE, ISOLATION_WORKFLOW))
+        const workflow = yield* Workflow.Service
+        const { ops, inputs, directories, modes } = directoryCapturingPromptOps()
+
+        const started = yield* workflow.start({ name: ISOLATION_FIXTURE, args: {}, prompt: ops })
+        const waited = yield* workflow.wait({ id: started.id })
+        const done = waited.run ?? (yield* Effect.fail(new Error("isolation workflow did not finish")))
+        expect(done.status).toBe("completed")
+        expect(inputs.length).toBe(1)
+
+        const worktree = directories[0]!
+        expect(worktree).toBeDefined()
+        const tmp = yield* Effect.promise(() => fs.realpath(os.tmpdir()))
+        const realWorktree = yield* Effect.promise(() => fs.realpath(worktree).catch(() => worktree))
+        // It lives under the shared tmp root with the shared `oc-wf-` prefix.
+        const name = path.basename(realWorktree)
+        expect(path.dirname(realWorktree)).toBe(tmp)
+        expect(name.startsWith("oc-wf-")).toBe(true)
+        // But it is NOT the OLD predictable `oc-wf-<runid>-<nodeid>` path: an
+        // attacker who knows the run id + node id could no longer guess it.
+        const node = done.agents[0]!
+        expect(name).not.toBe(`oc-wf-${started.id}-${node.id}`)
+        expect(name.includes(started.id)).toBe(false)
+        // And it was 0700 at dispatch time — only the running user may traverse it.
+        expect(modes[0]).toBe(0o700)
+      }),
+    { git: true },
+  )
+
+  // Finding 3 (orphan sweep): a SIGKILLed/crashed run never fires its run-scope
+  // remove finalizer, leaking its `<tmp>/oc-wf-*` worktree (with checked-out repo
+  // content + any agent-written secrets) into tmp indefinitely. The startup sweep
+  // must reclaim a STALE such dir on the next instance start, while leaving a FRESH
+  // one (a currently-running sibling's worktree) untouched. We plant one aged dir
+  // and one new dir, reload the instance (re-runs the startup sweep), and assert the
+  // stale one is gone and the fresh one survives.
+  it.live("startup sweep removes a stale orphaned oc-wf-* worktree but spares a fresh one", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped({ git: true })
+      const tmp = os.tmpdir()
+      // A stale leaked worktree dir, aged well past the 1h cutoff.
+      const stale = yield* Effect.promise(() => fs.mkdtemp(path.join(tmp, "oc-wf-")))
+      yield* Effect.promise(() => fs.writeFile(path.join(stale, "leaked-secret"), "shh"))
+      const old = Date.now() - 3 * 60 * 60 * 1000
+      yield* Effect.promise(() => fs.utimes(stale, old / 1000, old / 1000))
+      // A fresh worktree dir (mtime now) — represents a sibling process's live run.
+      const fresh = yield* Effect.promise(() => fs.mkdtemp(path.join(tmp, "oc-wf-")))
+
+      try {
+        // Bring an instance up over the directory and touch an operation that
+        // MATERIALIZES the per-directory InstanceState (a ScopedCache value whose
+        // factory runs the startup sweep). `runs()` reads the registry, forcing
+        // materialization → the sweep runs.
+        yield* Effect.gen(function* () {
+          const workflow = yield* Workflow.Service
+          yield* workflow.runs()
+        }).pipe(provideInstance(directory))
+        // Reload to force a fresh state materialization (and a second sweep), proving
+        // the sweep is wired to startup regardless of first-vs-subsequent access.
+        yield* reloadInstance({ directory })
+        yield* Effect.gen(function* () {
+          const workflow = yield* Workflow.Service
+          yield* workflow.runs()
+        }).pipe(provideInstance(directory))
+
+        // The sweep is forked (best-effort, non-blocking); poll for its effect.
+        yield* pollWithTimeout(
+          Effect.promise(() =>
+            fs
+              .stat(stale)
+              .then(() => undefined)
+              .catch(() => true as const),
+          ),
+          `stale orphaned worktree ${stale} was not swept`,
+        )
+        // The fresh dir (a live sibling's worktree) must NOT be touched.
+        const freshAlive = yield* Effect.promise(() =>
+          fs
+            .stat(fresh)
+            .then(() => true)
+            .catch(() => false),
+        )
+        expect(freshAlive).toBe(true)
+      } finally {
+        yield* Effect.promise(() => fs.rm(stale, { recursive: true, force: true }).catch(() => {}))
+        yield* Effect.promise(() => fs.rm(fresh, { recursive: true, force: true }).catch(() => {}))
+      }
+    }).pipe(Effect.provide(testInstanceStoreLayer)),
+  )
+
+  // Item 7: an isolated worktree with UNCOMMITTED changes is PRESERVED at run
+  // end (git registration intact), the preserve is logged with the path, and
+  // the node records its work location (`worktree`).
+  it.instance(
+    "a dirty isolated worktree survives the run",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, ISOLATION_FIXTURE, ISOLATION_WORKFLOW))
+        const workflow = yield* Workflow.Service
+        const { ops, directories } = dirtyingPromptOps()
+
+        const started = yield* workflow.start({ name: ISOLATION_FIXTURE, args: {}, prompt: ops })
+        const waited = yield* workflow.wait({ id: started.id })
+        const done = waited.run ?? (yield* Effect.fail(new Error("isolation workflow did not finish")))
+        expect(done.status).toBe("completed")
+        const worktree = directories[0]!
+        expect(worktree).toBeDefined()
+        // The node records where the step worked (Item 7).
+        expect(done.agents[0]?.worktree).toBe(worktree)
+
+        try {
+          // The preserve runs in the run-scope finalizer (async relative to
+          // wait()); poll the persisted run for the preserve log.
+          const preserved = yield* pollWithTimeout(
+            Effect.gen(function* () {
+              const current = yield* workflow.get(started.id)
+              return current?.logs.some((l) => l.message.includes("worktree preserved at")) ? current : undefined
+            }),
+            "preserve log never appeared on the run",
+          )
+          const log = preserved.logs.find((l) => l.message.includes("worktree preserved at"))
+          expect(log?.message).toContain(worktree)
+          expect(log?.message).toContain("uncommitted changes")
+          // The worktree (with the uncommitted file) is still on disk…
+          const file = yield* Effect.promise(() =>
+            fs.readFile(path.join(worktree, "UNCOMMITTED.txt"), "utf8").catch(() => undefined),
+          )
+          expect(file).toBe("dirty")
+          // …and carries the sweep-skip marker.
+          const marker = yield* Effect.promise(() =>
+            fs
+              .stat(path.join(worktree, ".oc-wf-preserved"))
+              .then(() => true)
+              .catch(() => false),
+          )
+          expect(marker).toBe(true)
+        } finally {
+          // Cleanup: detach + remove the deliberately preserved worktree.
+          yield* Effect.promise(async () => {
+            spawnSync("git", ["worktree", "remove", "--force", worktree], { cwd: test.directory })
+            await fs.rm(worktree, { recursive: true, force: true }).catch(() => {})
+            spawnSync("git", ["worktree", "prune"], { cwd: test.directory })
+          })
+        }
+      }),
+    { git: true },
+  )
+
+  // Item 7 (sweep protection): the startup worktree sweep must skip BOTH a
+  // marker-carrying preserved worktree and (fallback) a marker-less but DIRTY
+  // git worktree, while still reclaiming a plain aged leak.
+  it.live("sweepWorktrees skips preserved and dirty worktrees but reclaims plain leaks", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped({ git: true })
+      const tmp = os.tmpdir()
+      const old = Date.now() - 3 * 60 * 60 * 1000
+      const age = (dir: string) => Effect.promise(() => fs.utimes(dir, old / 1000, old / 1000))
+
+      // (a) An aged dir WITH the preserve marker — must survive.
+      const preserved = yield* Effect.promise(() => fs.mkdtemp(path.join(tmp, "oc-wf-")))
+      yield* Effect.promise(() => fs.writeFile(path.join(preserved, ".oc-wf-preserved"), ""))
+      // (b) An aged REAL worktree, marker-less but dirty — fallback skip.
+      const dirty = yield* Effect.promise(() => fs.mkdtemp(path.join(tmp, "oc-wf-")))
+      spawnSync("git", ["worktree", "add", "--detach", dirty], { cwd: directory })
+      yield* Effect.promise(() => fs.writeFile(path.join(dirty, "WORK.txt"), "in flight"))
+      // (c) An aged plain (non-git) leak — must be reclaimed as before.
+      const leak = yield* Effect.promise(() => fs.mkdtemp(path.join(tmp, "oc-wf-")))
+      yield* age(preserved)
+      yield* age(dirty)
+      yield* age(leak)
+
+      try {
+        yield* Effect.promise(() => Workflow.__testHooks.sweepWorktrees(directory))
+        const exists = (dir: string) =>
+          Effect.promise(() =>
+            fs
+              .stat(dir)
+              .then(() => true)
+              .catch(() => false),
+          )
+        expect(yield* exists(preserved)).toBe(true)
+        expect(yield* exists(dirty)).toBe(true)
+        expect(yield* exists(leak)).toBe(false)
+      } finally {
+        yield* Effect.promise(async () => {
+          spawnSync("git", ["worktree", "remove", "--force", dirty], { cwd: directory })
+          for (const dir of [preserved, dirty, leak]) {
+            await fs.rm(dir, { recursive: true, force: true }).catch(() => {})
+          }
+          spawnSync("git", ["worktree", "prune"], { cwd: directory })
+        })
+      }
+    }).pipe(Effect.provide(testInstanceStoreLayer)),
+  )
+
+  // Task 11 (error path): isolation:"worktree" in a NON-git workspace is an
+  // authoring/environment error. The step must fail with a clear
+  // WorkflowInvalidError naming the missing git repository rather than crashing,
+  // and the prompt is never dispatched.
+  it.instance('ctx.agent isolation:"worktree" fails clearly outside a git repository', () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, ISOLATION_FIXTURE, ISOLATION_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: ISOLATION_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("isolation workflow did not finish")))
+
+      expect(done.status).toBe("failed")
+      expect(done.error ?? "").toContain("requires a git repository")
+      const node = done.agents[0]
+      expect(node?.status).toBe("failed")
+      // The prompt was never dispatched (no worktree to run in).
+      expect(inputs.length).toBe(0)
+    }),
+  )
+
+  // Task 11a: ctx.shell runs a real command in the run's workspace and returns
+  // { output, exitCode } without an LLM turn. A successful command reports
+  // exitCode 0 and its stdout; a non-zero exit is returned (failCode === 3), never
+  // thrown; and ctx.budget.spent() is 0 because shell never touches the budget.
+  // Item 23: runs with the kill-switch (workflows.shell_permission=false) so
+  // this test keeps pinning the UNGATED behavior — a headless run with no
+  // ruleset would otherwise park on the interactive ask. The kill-switch path
+  // is itself the documented regression guard for the pre-gate semantics.
+  it.instance(
+    "ctx.shell runs a deterministic non-LLM step returning output + exitCode without touching budget",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, SHELL_FIXTURE, SHELL_WORKFLOW))
+        const workflow = yield* Workflow.Service
+
+        const started = yield* workflow.start({ name: SHELL_FIXTURE, args: {} })
+        const waited = yield* workflow.wait({ id: started.id })
+        const done = waited.run ?? (yield* Effect.fail(new Error("shell workflow did not finish")))
+
+        expect(done.status).toBe("completed")
+        const result = done.result as { out: string; okCode: number; failCode: number; spent: number }
+        expect(result.out).toBe("hello-workflow")
+        expect(result.okCode).toBe(0)
+        // A non-zero exit is mapped to the return value, NOT a throw.
+        expect(result.failCode).toBe(3)
+        // Shell does not touch the budget — spend stays at 0.
+        expect(result.spent).toBe(0)
+      }),
+    { config: { workflows: { shell_permission: false } } },
+  )
+
+  // Task 11b (a): a parent runs a DISCOVERED child inline via ctx.workflow under
+  // the SAME run. The parent completes, the child's result flows back
+  // (fromChild === 42), exactly ONE run row exists for this start (no separate
+  // child run row), and the parent's logs include the child's prefixed log entry.
+  it.instance("ctx.workflow runs a discovered child inline under the same run with prefixed logs", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_CHILD_FIXTURE, NEST_CHILD_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_PARENT_FIXTURE, NEST_PARENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const started = yield* workflow.start({ name: NEST_PARENT_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("parent workflow did not finish")))
+
+      expect(done.status).toBe("completed")
+      expect((done.result as { fromChild: number }).fromChild).toBe(42)
+
+      // Exactly ONE run row exists for this start: no separate child run row.
+      const runs = yield* workflow.runs()
+      expect(runs.length).toBe(1)
+      expect(runs[0]!.id).toBe(started.id)
+
+      // The parent's logs include the child's prefixed log entry.
+      const messages = done.logs.map((l) => l.message)
+      expect(messages).toContain("child: child-ran")
+    }),
+  )
+
+  // Task 11b (b): nesting is limited to depth 1. A child that itself calls
+  // ctx.workflow must be refused — the nested call throws a WorkflowInvalidError
+  // mentioning the depth limit, and the run fails with that error.
+  it.instance("ctx.workflow enforces a depth-1 limit: a nested ctx.workflow call fails the run", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_GRANDCHILD_FIXTURE, NEST_GRANDCHILD_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_DEEP_CHILD_FIXTURE, NEST_DEEP_CHILD_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_DEEP_PARENT_FIXTURE, NEST_DEEP_PARENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const started = yield* workflow.start({ name: NEST_DEEP_PARENT_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("deep-parent workflow did not finish")))
+
+      expect(done.status).toBe("failed")
+      expect(done.error ?? "").toMatch(/WorkflowInvalidError|nesting|depth/i)
+
+      // Still exactly ONE run row — the failed nesting never created a second run.
+      const runs = yield* workflow.runs()
+      expect(runs.length).toBe(1)
+    }),
+  )
+
+  // Task 11b (c): the child's agent dispatches count against the SAME run's
+  // agent-lifetime cap. With the cap lowered to 3, the parent's one agent plus the
+  // child's dispatches collectively exceed it, so the over-cap dispatch (inside
+  // the child) fails the WHOLE run with a tagged AgentLimitError — proving the cap
+  // is shared, not reset per nested workflow.
+  it.instance("ctx.workflow shares the run's agent-lifetime cap with the child", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_AGENT_CHILD_FIXTURE, NEST_AGENT_CHILD_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_AGENT_PARENT_FIXTURE, NEST_AGENT_PARENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      Workflow.__testHooks.agentLimit(3)
+
+      const started = yield* workflow.start({
+        name: NEST_AGENT_PARENT_FIXTURE,
+        args: {},
+        prompt: costPromptOps(db, 0),
+      })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("agent-parent workflow did not finish")))
+
+      expect(done.status).toBe("failed")
+      expect(done.error ?? "").toMatch(/WorkflowAgentLimitError|agent.*limit/i)
+      // The cap is shared across parent + child: exactly 3 agents (1 parent + 2
+      // child) reach `completed` before the 4th dispatch is refused.
+      expect(done.agents.filter((a) => a.status === "completed").length).toBe(3)
+      // One run row only — the child never created its own run.
+      const runs = yield* workflow.runs()
+      expect(runs.length).toBe(1)
+    }),
+  )
+
+  // Task 11a (real timeout): ctx.shell("sleep 5", { timeout: 100 }) must kill the
+  // hung command and resolve PROMPTLY with a non-zero exitCode — never hang for the
+  // full 5s and never throw. The fixture records elapsed wall-clock so we can prove
+  // the timeout actually fired (well under the command's 5s natural duration).
+  it.instance(
+    "ctx.shell enforces a real wall-clock timeout: a hung command resolves promptly with non-zero exit",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* Effect.promise(() => writeWorkflow(test.directory, SHELL_TIMEOUT_FIXTURE, SHELL_TIMEOUT_WORKFLOW))
+        const workflow = yield* Workflow.Service
+
+        const started = yield* workflow.start({ name: SHELL_TIMEOUT_FIXTURE, args: {} })
+        const waited = yield* workflow.wait({ id: started.id })
+        const done = waited.run ?? (yield* Effect.fail(new Error("shell-timeout workflow did not finish")))
+
+        expect(done.status).toBe("completed")
+        const result = done.result as { exitCode: number; elapsed: number }
+        // A timed-out command is killed -> non-zero exit (mapped, not thrown).
+        expect(result.exitCode).not.toBe(0)
+        // It resolved promptly: well before the command's natural 5s duration.
+        expect(result.elapsed).toBeLessThan(3000)
+      }),
+    // Item 23: kill-switch — see the budget shell test above.
+    { config: { workflows: { shell_permission: false } } },
+  )
+
+  // Finding 5: a ctx.shell with NO timeout must have its OS child reaped on
+  // cancel — closing the run scope interrupts the Effect fiber, and the fix wires
+  // that interrupt to the AbortController so Process.run SIGTERMs the child. The
+  // shell writes a "running" marker immediately (so we can synchronize on the
+  // child being live) then sleeps 3s then writes a "leaked" marker. We cancel once
+  // the running marker exists and assert: the run is cancelled AND the leaked
+  // marker is NEVER written within a window comfortably past the 3s sleep — i.e.
+  // the orphaned child did not survive the cancel and fire the second touch.
+  it.instance(
+    "ctx.shell with no timeout has its OS child killed on cancel (no process leak)",
+    () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SHELL_LEAK_FIXTURE, SHELL_LEAK_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const running = path.join(test.directory, "shell-running.marker")
+      const leaked = path.join(test.directory, "shell-leaked.marker")
+
+      const run = yield* workflow.start({ name: SHELL_LEAK_FIXTURE, args: { running, leaked } })
+
+      // Wait until the shell child is actually live (it just wrote `running`).
+      yield* pollWithTimeout(
+        Effect.promise(() =>
+          fs
+            .stat(running)
+            .then(() => true as const)
+            .catch(() => undefined),
+        ),
+        "shell child never started (running marker not written)",
+      )
+
+      // Cancel mid-sleep: the scope close interrupts the shell fiber, which (with
+      // the fix) aborts the controller and SIGTERMs the OS child.
+      yield* workflow.cancel(run.id)
+      const after = yield* workflow.get(run.id)
+      expect(after?.status).toBe("cancelled")
+
+      // Give the child MORE than its 3s sleep to (incorrectly) fire the second
+      // touch if it were leaked. With the child killed, the leaked marker never
+      // appears; if the process leaked, it would appear ~3s after the touch ran.
+      yield* Effect.sleep("4 seconds")
+      const leakedExists = yield* Effect.promise(() =>
+        fs
+          .stat(leaked)
+          .then(() => true)
+          .catch(() => false),
+      )
+      expect(leakedExists).toBe(false)
+    }),
+    // Item 23: kill-switch — see the budget shell test above.
+    { config: { workflows: { shell_permission: false } } },
+    // The body sleeps 4s by design (leak window) — the 5s default timeout
+    // leaves <1s for spawn + poll + cancel.
+    15000,
+  )
+
+  // Item 23 (Stufe 1, deny): a caller session carrying a bash DENY rule gates
+  // ctx.shell — the run fails with the denial (the error names the command) and
+  // the process is NEVER spawned (the target file survives).
+  it.instance("ctx.shell honors a caller bash deny rule: run fails, process never spawned", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SHELL_GATE_FIXTURE, SHELL_GATE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sessions = yield* Session.Service
+
+      // The file the denied `rm` would delete — must still exist afterwards.
+      const target = "shell-deny.marker"
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, target), "keep me"))
+
+      const caller = yield* sessions.create({
+        permission: [{ permission: "bash", action: "deny", pattern: "rm *" }],
+      })
+      const run = yield* workflow.start({
+        name: SHELL_GATE_FIXTURE,
+        args: { command: `rm ${target}` },
+        caller: { sessionID: caller.id },
+      })
+      const done =
+        (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("gate run did not settle")))
+      expect(done.status).toBe("failed")
+      // The error names the command, so the failure is self-explanatory.
+      expect(done.error ?? "").toContain("rm shell-deny.marker")
+      expect(done.error ?? "").toMatch(/denied|rule/i)
+      // The process never spawned: the target file is untouched.
+      const survived = yield* Effect.promise(() =>
+        fs
+          .stat(path.join(test.directory, target))
+          .then(() => true)
+          .catch(() => false),
+      )
+      expect(survived).toBe(true)
+    }),
+  )
+
+  // Item 23 (Stufe 1, allow): a caller ALLOW rule lets ctx.shell run with no
+  // interactive ask — the run completing at all is the proof (an open ask would
+  // park it), and no pending permission request is left behind.
+  it.instance("ctx.shell with a caller bash allow rule runs through without an interactive ask", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SHELL_GATE_FIXTURE, SHELL_GATE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const sessions = yield* Session.Service
+      const permission = yield* Permission.Service
+
+      const caller = yield* sessions.create({
+        permission: [{ permission: "bash", action: "allow", pattern: "*" }],
+      })
+      const run = yield* workflow.start({
+        name: SHELL_GATE_FIXTURE,
+        args: { command: "echo gated-ok" },
+        caller: { sessionID: caller.id },
+      })
+      const done =
+        (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("gate run did not settle")))
+      expect(done.status).toBe("completed")
+      expect((done.result as { out: string }).out).toBe("gated-ok")
+      // No interactive ask was raised (the allow rule short-circuited it).
+      expect(yield* permission.list()).toHaveLength(0)
+    }),
+  )
+
+  // Item 23 (Stufe 1, cancel during an open ask): a headless run (no caller
+  // ruleset) parks on the interactive bash ask. Cancelling the run interrupts
+  // the open ask cleanly — the run finishes `cancelled`, the pending request is
+  // cleaned up (no leak), and the command never ran.
+  it.instance("cancel during an open ctx.shell ask unwinds the run as cancelled without leaking the request", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SHELL_GATE_FIXTURE, SHELL_GATE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const permission = yield* Permission.Service
+
+      const leaked = "shell-ask-leak.marker"
+      const run = yield* workflow.start({
+        name: SHELL_GATE_FIXTURE,
+        args: { command: `touch ${leaked}` },
+      })
+      // Wait until the gate's interactive ask is pending.
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const pending = yield* permission.list()
+          return pending.length > 0 ? pending : undefined
+        }),
+        "ctx.shell ask never became pending",
+      )
+      const cancelled = yield* workflow.cancel(run.id)
+      expect(cancelled?.status).toBe("cancelled")
+      // The pending request was cleaned up (ask's ensuring removed it).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const pending = yield* permission.list()
+          return pending.length === 0 ? true : undefined
+        }),
+        "pending ask was never cleaned up",
+      )
+      // The gated command never executed.
+      const leakedExists = yield* Effect.promise(() =>
+        fs
+          .stat(path.join(test.directory, leaked))
+          .then(() => true)
+          .catch(() => false),
+      )
+      expect(leakedExists).toBe(false)
+    }),
+  )
+
+  // Task 11b (phase restore): a child's setPhase must not bleed into the parent.
+  // Parent sets "plan", the nested child sets "research" (recorded prefixed as
+  // "phase-child: research" on its own log), and the parent's log AFTER the nested
+  // call must carry the parent's "plan" phase again — not the child's leftover.
+  it.instance("ctx.workflow restores the parent's phase after a nested child changes it", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_PHASE_CHILD_FIXTURE, NEST_PHASE_CHILD_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, NEST_PHASE_PARENT_FIXTURE, NEST_PHASE_PARENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const started = yield* workflow.start({ name: NEST_PHASE_PARENT_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("phase-parent workflow did not finish")))
+
+      expect(done.status).toBe("completed")
+      // The child's own log was attributed to its (prefixed) phase...
+      const childLog = done.logs.find((l) => l.message === "phase-child: inside-child")
+      expect(childLog?.phase).toBe("phase-child: research")
+      // ...and the parent's log AFTER the nested call carries the parent's phase,
+      // NOT the child's leftover "phase-child: research".
+      const parentLog = done.logs.find((l) => l.message === "after-nested")
+      expect(parentLog?.phase).toBe("plan")
+      // The run's terminal phase is the parent's, not the child's leftover.
+      expect(done.current_phase).toBe("plan")
+    }),
+  )
+
+  // Task 14: a workflow run now emits OTel spans — `workflow.run` for the run
+  // body and `workflow.agent` for each ctx.agent dispatch. The test stack has NO
+  // span-collection seam (no in-memory tracer/exporter is wired into the engine's
+  // layer), so this is a SMOKE test: it proves the spans are transparent (a full
+  // 1-agent run still completes, the agent step succeeds, and the prompt was
+  // dispatched exactly once). The spans themselves are exercised by the engine's
+  // default no-op tracer; behavioral equivalence is the real gate.
+  it.instance("a 1-agent run still completes with run/agent spans wrapping it (transparent)", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SINGLE_AGENT_FIXTURE, SINGLE_AGENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: SINGLE_AGENT_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("single-agent workflow did not finish")))
+
+      // The wrapping spans changed nothing: the run completes and its single agent
+      // step ran to completion against exactly one dispatched prompt.
+      expect(done.status).toBe("completed")
+      expect(done.agents.length).toBe(1)
+      expect(done.agents[0]?.status).toBe("completed")
+      expect(inputs.length).toBe(1)
+    }),
+  )
+
+  // Task 15(b): a structured phase declares a default `model`. While that phase is
+  // active, a ctx.agent call with NO explicit model resolves to the phase default;
+  // an explicit per-call model still wins over the phase default.
+  it.instance("a phase default model is used when ctx.agent gives no model; explicit model wins", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PHASE_MODEL_FIXTURE, PHASE_MODEL_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: PHASE_MODEL_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("phase-model workflow did not finish")))
+      expect(done.status).toBe("completed")
+
+      // Two dispatches. The first (no explicit model) resolved to the "verify"
+      // phase's default `stub/mini`; the second's explicit model won over it.
+      expect(inputs.length).toBe(2)
+      expect(String(inputs[0]?.model?.providerID)).toBe("stub")
+      expect(String(inputs[0]?.model?.modelID)).toBe("mini")
+      expect(String(inputs[1]?.model?.providerID)).toBe("other")
+      expect(String(inputs[1]?.model?.modelID)).toBe("explicit")
+    }),
+  )
+
+  // Item 16 (a): a per-call `phase` pins the node to that phase even after
+  // setPhase has moved the run's current phase — closing the parallel/pipeline
+  // race window deterministically (the sequential setPhase("b") stands in for
+  // the concurrent phase move).
+  it.instance("a per-call phase pins the agent node to that phase", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PERCALL_PHASE_FIXTURE, PERCALL_PHASE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const started = yield* workflow.start({ name: PERCALL_PHASE_FIXTURE, args: {}, prompt: immediatePromptOps() })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("percall-phase workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect(done.agents.length).toBe(2)
+      // The pinned step carries its per-call phase, not the moved current phase…
+      expect(done.agents[0]?.phase).toBe("a")
+      // …while an unpinned step still snapshots current_phase as before.
+      expect(done.agents[1]?.phase).toBe("b")
+    }),
+  )
+
+  // Item 16 (b): a per-call phase resolves ITS declared default model (explicit
+  // model still wins), never the global current phase's model — and it has no
+  // setPhase side effect on the run.
+  it.instance("a per-call phase resolves the declared phase default model without moving the run phase", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(test.directory, PERCALL_PHASE_MODEL_FIXTURE, PERCALL_PHASE_MODEL_WORKFLOW),
+      )
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({ name: PERCALL_PHASE_MODEL_FIXTURE, args: {}, prompt: ops })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("percall-phase-model workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect(inputs.length).toBe(3)
+      // Call 1: phase "y" is declared with stub/mini → that model is the default.
+      expect(String(inputs[0]?.model?.providerID)).toBe("stub")
+      expect(String(inputs[0]?.model?.modelID)).toBe("mini")
+      // Call 2: an explicit model wins over the per-call phase default.
+      expect(String(inputs[1]?.model?.providerID)).toBe("other")
+      expect(String(inputs[1]?.model?.modelID)).toBe("explicit")
+      // Call 3: pinned to "x" (no declared model) while the GLOBAL phase is "y"
+      // (model stub/mini) — the per-call phase must NOT inherit the global
+      // phase's model.
+      expect(inputs[2]?.model).toBeUndefined()
+      // The first two calls never moved the run's phase (no setPhase side
+      // effect); only the explicit setPhase("y") did.
+      expect(done.current_phase).toBe("y")
+      expect(done.agents[0]?.phase).toBe("y")
+      expect(done.agents[2]?.phase).toBe("x")
+    }),
+  )
+
+  // Item 16 (c): `label` is persisted on the agent node and survives the
+  // DB→fromRow roundtrip.
+  it.instance("a per-call label is persisted on the agent node and round-trips through fromRow", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, LABEL_FIXTURE, LABEL_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const started = yield* workflow.start({ name: LABEL_FIXTURE, args: {}, prompt: immediatePromptOps() })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("label workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect(done.agents[0]?.label).toBe("Find the bug")
+
+      // DB roundtrip (seedCompletedRow-style): a seeded row's agent label comes
+      // back through DB→fromRow.
+      const persistedId = Workflow.RunID.make("job_label_roundtrip")
+      yield* seedCompletedRow(persistedId, test.directory)
+      const persisted = (yield* workflow.get(persistedId)) ?? (yield* Effect.fail(new Error("seeded run not readable")))
+      expect(persisted.agents[0]?.label).toBe("seeded label")
+      // Item 7: the isolated-worktree location survives the roundtrip too.
+      expect(persisted.agents[0]?.worktree).toBe("/tmp/oc-wf-seeded")
+    }),
+  )
+
+  // Item 16 (d): a nested ctx.workflow child's per-call phase is prefixed with
+  // the child's logPrefix, consistent with its setPhase.
+  it.instance("a nested child's per-call phase is prefixed with the child name", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PERCALL_CHILD_FIXTURE, PERCALL_CHILD_WORKFLOW))
+      yield* Effect.promise(() => writeWorkflow(test.directory, PERCALL_PARENT_FIXTURE, PERCALL_PARENT_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const started = yield* workflow.start({ name: PERCALL_PARENT_FIXTURE, args: {}, prompt: immediatePromptOps() })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("percall-parent workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect(done.agents.length).toBe(1)
+      expect(done.agents[0]?.phase).toBe(`${PERCALL_CHILD_FIXTURE}: p`)
+    }),
+  )
+
+  // Item 16 (e): a per-call phase is resume-stable — the journal keys on
+  // node.phase, which carries the per-call phase on both the seed and the live
+  // lookup side, so a resumed run replays the pinned step instead of re-prompting.
+  it.instance("a per-call phase step replays from the journal on resume", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, PERCALL_PHASE_FIXTURE, PERCALL_PHASE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+
+      const firstOps = recordingPromptOps(db, 0)
+      const first = yield* workflow.start({ name: PERCALL_PHASE_FIXTURE, args: {}, prompt: firstOps.ops })
+      const firstDone =
+        (yield* workflow.wait({ id: first.id })).run ?? (yield* Effect.fail(new Error("first run did not finish")))
+      expect(firstDone.status).toBe("completed")
+      expect(firstOps.prompted.length).toBe(2)
+
+      // completed → paused so it is a legitimate resume source (journal kept).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          yield* db
+            .update(WorkflowRunTable)
+            .set({ status: "paused" })
+            .where(eq(WorkflowRunTable.id, first.id))
+            .run()
+            .pipe(Effect.orDie)
+          const current = yield* workflow.get(first.id)
+          return current?.status === "paused" ? current : undefined
+        }),
+        "source run never became paused",
+      )
+
+      const { ops: resumeOps, prompted } = recordingPromptOps(db, 0)
+      const resumed = yield* workflow.start({
+        name: PERCALL_PHASE_FIXTURE,
+        args: {},
+        prompt: resumeOps,
+        resume_of: first.id,
+      })
+      const done =
+        (yield* workflow.wait({ id: resumed.id })).run ??
+        (yield* Effect.fail(new Error("percall-phase resume did not finish")))
+      expect(done.status).toBe("completed")
+      // Both steps — the pinned and the unpinned one — replayed from the journal.
+      expect(prompted).toHaveLength(0)
+      expect(done.agents.every((agent) => agent.cached === true)).toBe(true)
+    }),
+  )
+
+  // Item 12: a run started with caller_model resolves a DEFAULT-agent step (no
+  // explicit/phase model) to the caller session's model; an explicitly chosen
+  // agent keeps its own model resolution (no inheritance).
+  it.instance("caller_model resolves a default-agent step; an explicit agent does not inherit it", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, CALLER_MODEL_FIXTURE, CALLER_MODEL_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({
+        name: CALLER_MODEL_FIXTURE,
+        args: {},
+        prompt: ops,
+        caller_model: { providerID: "stub", modelID: "caller" },
+      })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("caller-model workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect(inputs.length).toBe(2)
+      // The default-agent step inherited the caller session's model…
+      expect(String(inputs[0]?.model?.providerID)).toBe("stub")
+      expect(String(inputs[0]?.model?.modelID)).toBe("caller")
+      // …while the explicitly-chosen agent kept its own model resolution (the
+      // "general" agent declares no model, so nothing is dispatched).
+      expect(inputs[1]?.model).toBeUndefined()
+    }),
+  )
+
+  // Item 12: precedence — a declared phase default model still wins over the
+  // caller model (the inheritance tier sits BELOW phase model).
+  it.instance("a phase default model wins over caller_model", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, CALLER_PHASE_FIXTURE, CALLER_PHASE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops, inputs } = capturingPromptOps()
+
+      const started = yield* workflow.start({
+        name: CALLER_PHASE_FIXTURE,
+        args: {},
+        prompt: ops,
+        caller_model: { providerID: "stub", modelID: "caller" },
+      })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("caller-phase workflow did not finish")))
+      expect(done.status).toBe("completed")
+      expect(inputs.length).toBe(1)
+      expect(String(inputs[0]?.model?.providerID)).toBe("stub")
+      expect(String(inputs[0]?.model?.modelID)).toBe("mini")
+    }),
+  )
+
+  // Item 15: skipping an IN-FLIGHT agent step resolves its ctx.agent call to
+  // null, marks the node `skipped` (no budget charge), and the run continues.
+  it.instance("skipAgent resolves the in-flight agent call to null and the run continues", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SKIP_FIXTURE, SKIP_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops } = resolveOnAbortPromptOps()
+
+      const run = yield* workflow.start({ name: SKIP_FIXTURE, args: {}, prompt: ops })
+      // Wait until the step is genuinely in flight (session registered).
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          const node = current?.agents[0]
+          return node?.status === "running" && node.session_id ? current : undefined
+        }),
+        "agent node never started",
+      )
+      const snap = yield* workflow.skipAgent({ id: run.id, agentId: "1" })
+      expect(snap?.id).toBe(run.id)
+
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("run did not finish")))
+      expect(done.status).toBe("completed")
+      // The body observed null for the skipped step…
+      expect(done.result).toEqual({ skipped: true })
+      // …and the node settled as `skipped` with no charge (the abort artifact
+      // carries no real spend; the ensuring skips the charge for aborted steps).
+      expect(done.agents[0]?.status).toBe("skipped")
+      expect(done.agents[0]?.cost ?? 0).toBe(0)
+    }),
+  )
+
+  // Item 15: a skip that lands BEFORE the step's prompt dispatches (its node
+  // exists, its dispatch still waits for a run-semaphore permit) resolves the
+  // step without ever prompting. Deterministic via semaphore saturation: cap+1
+  // parallel steps, the (cap+1)-th waits while the first cap hang in prompts.
+  it.instance(
+    "a skip that lands before the step dispatches resolves it without ever prompting",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        // The lifetime-cap tests above leak their tiny agentLimit override (the
+        // seam is module-global, captured per run at start). This test dispatches
+        // cap+1 agents, so restore the production default for OUR run first.
+        Workflow.__testHooks.agentLimit(1_000)
+        // The engine's run-wide concurrency cap (agentConcurrencyCap) — kept in
+        // sync by the poll below, which REQUIRES exactly `cap` dispatched
+        // sessions and one undisptached node before proceeding.
+        const cap = Math.min(16, Math.max(2, os.cpus().length - 2))
+        yield* Effect.promise(() => writeWorkflow(test.directory, SKIP_PARALLEL_FIXTURE, SKIP_PARALLEL_WORKFLOW))
+        const workflow = yield* Workflow.Service
+        const { ops, started } = resolveOnAbortPromptOps()
+
+        const run = yield* workflow.start({
+          name: SKIP_PARALLEL_FIXTURE,
+          args: { count: cap + 1 },
+          prompt: ops,
+        })
+        // All cap+1 nodes exist; exactly cap are dispatched (session registered);
+        // one still waits for a permit. Generous bound: under full-suite load,
+        // creating `cap` child sessions (up to 16) can take a while — the
+        // saturation itself is deterministic.
+        const saturated = yield* pollWithTimeout(
+          Effect.gen(function* () {
+            const current = yield* workflow.get(run.id)
+            if (!current || current.agents.length !== cap + 1) return undefined
+            const dispatched = current.agents.filter((a) => a.session_id).length
+            const pending = current.agents.find((a) => a.status === "running" && !a.session_id)
+            return dispatched === cap && pending ? { pendingId: pending.id } : undefined
+          }),
+          "saturated batch never materialized",
+          "45 seconds",
+        )
+        // Skip the not-yet-dispatched node FIRST (nothing to abort yet)…
+        yield* workflow.skipAgent({ id: run.id, agentId: saturated.pendingId })
+        // …then skip the in-flight steps so permits free up and the run settles.
+        const live = yield* workflow.get(run.id)
+        for (const node of live?.agents ?? []) {
+          if (node.id === saturated.pendingId) continue
+          yield* workflow.skipAgent({ id: run.id, agentId: node.id }).pipe(Effect.ignore)
+        }
+
+        const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("run did not finish")))
+        expect(done.status).toBe("completed")
+        expect(done.result).toEqual({ allNull: true })
+        const skippedEarly = done.agents.find((a) => a.id === saturated.pendingId)
+        expect(skippedEarly?.status).toBe("skipped")
+        // The pre-dispatch skip never prompted: only the cap in-flight steps did.
+        expect(started.size).toBe(cap)
+      }),
+    90_000,
+  )
+
+  // Item 15: skipAgent's rejection matrix — completed node, unknown agent id,
+  // unknown run id, and a persisted (non-live) run.
+  it.instance("skipAgent rejects completed nodes, unknown agents, and non-live runs", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, AGENT_THEN_HANG_FIXTURE, AGENT_THEN_HANG_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      // Live run whose single agent node already COMPLETED (body still hanging).
+      const run = yield* workflow.start({ name: AGENT_THEN_HANG_FIXTURE, args: {}, prompt: immediatePromptOps() })
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current?.agents[0]?.status === "completed" ? current : undefined
+        }),
+        "agent node never completed",
+      )
+      const exitCompleted = yield* Effect.exit(workflow.skipAgent({ id: run.id, agentId: "1" }))
+      expect(Exit.isFailure(exitCompleted)).toBe(true)
+      expect(Exit.isFailure(exitCompleted) ? Cause.pretty(exitCompleted.cause) : "").toContain("is not running")
+
+      const exitUnknownAgent = yield* Effect.exit(workflow.skipAgent({ id: run.id, agentId: "99" }))
+      expect(Exit.isFailure(exitUnknownAgent)).toBe(true)
+      expect(Exit.isFailure(exitUnknownAgent) ? Cause.pretty(exitUnknownAgent.cause) : "").toContain("not found")
+
+      // Unknown run id → undefined (HTTP 404).
+      const unknown = yield* workflow.skipAgent({
+        id: Workflow.RunID.make("job_skip_unknown"),
+        agentId: "1",
+      })
+      expect(unknown).toBeUndefined()
+
+      // A persisted run without a live registry entry has nothing to skip → 409.
+      const persistedId = Workflow.RunID.make("job_skip_notlive")
+      yield* seedCompletedRow(persistedId, test.directory)
+      const exitNotLive = yield* Effect.exit(workflow.skipAgent({ id: persistedId, agentId: "1" }))
+      expect(Exit.isFailure(exitNotLive)).toBe(true)
+      expect(Exit.isFailure(exitNotLive) ? Cause.pretty(exitNotLive.cause) : "").toContain("is not live")
+
+      // Cleanup: stop the hanging body.
+      yield* workflow.cancel(run.id)
+    }),
+  )
+
+  // Item 15 (onError:"null"): a failing step resolves null so the body can
+  // branch; its node still records the failure.
+  it.instance("onError:null resolves a failing agent to null while the node stays failed", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, ONERROR_NULL_FIXTURE, ONERROR_NULL_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const run = yield* workflow.start({ name: ONERROR_NULL_FIXTURE, args: {}, prompt: failingPromptOps() })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("run did not finish")))
+      expect(done.status).toBe("completed")
+      expect(done.result).toEqual({ isNull: true })
+      expect(done.agents[0]?.status).toBe("failed")
+      expect(done.agents[0]?.error ?? "").toContain("boom")
+    }),
+  )
+
+  // Item 15: budget exhaustion is NEVER swallowed by onError:"null" — otherwise
+  // a while-loop with onError:null would spin forever against an exhausted cap.
+  it.instance("onError:null does NOT swallow budget exhaustion", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, ONERROR_BUDGET_FIXTURE, ONERROR_BUDGET_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const run = yield* workflow.start({
+        name: ONERROR_BUDGET_FIXTURE,
+        args: {},
+        prompt: immediatePromptOps(),
+        budget: 0,
+      })
+      const done = (yield* workflow.wait({ id: run.id })).run ?? (yield* Effect.fail(new Error("run did not finish")))
+      expect(done.status).toBe("failed")
+      expect(done.error ?? "").toMatch(/budget exhausted/i)
+    }),
+  )
+
+  // Item 15: a `skipped` node survives the DB→fromRow roundtrip.
+  it.instance("a skipped agent node round-trips through fromRow", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const { db } = yield* Database.Service
+      const id = Workflow.RunID.make("job_skipped_roundtrip")
+      const now = Date.now()
+      yield* db
+        .insert(WorkflowRunTable)
+        .values({
+          id,
+          workflow: HELLO_FIXTURE,
+          status: "completed",
+          started_at: now,
+          completed_at: now,
+          directory: test.directory,
+          logs: [],
+          agents: [{ id: "1", status: "skipped", started_at: now, completed_at: now, prompt: "skipped step" }],
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const persisted = (yield* workflow.get(id)) ?? (yield* Effect.fail(new Error("seeded run not readable")))
+      expect(persisted.agents[0]?.status).toBe("skipped")
+    }),
+  )
+
+  // Task 15(c): setPhase on a phase NOT declared in meta.phases is allowed — the
+  // run completes — but a run log records a warning naming the undeclared phase.
+  it.instance("setPhase on an undeclared phase completes the run and logs a warning", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, UNDECLARED_PHASE_FIXTURE, UNDECLARED_PHASE_WORKFLOW))
+      const workflow = yield* Workflow.Service
+
+      const started = yield* workflow.start({ name: UNDECLARED_PHASE_FIXTURE, args: {} })
+      const waited = yield* workflow.wait({ id: started.id })
+      const done = waited.run ?? (yield* Effect.fail(new Error("undeclared-phase workflow did not finish")))
+
+      // No error: an undeclared phase is allowed.
+      expect(done.status).toBe("completed")
+      // A run log warns about the undeclared phase.
+      const warning = done.logs.find((l) => l.message.includes('phase "undeclared" is not declared'))
+      expect(warning).toBeTruthy()
+    }),
+  )
+})
+
+// Track T8 Feature A: the engine save() seam the HTTP /workflow/save route reuses.
+// Mirrors the create tool's write logic (MetaReader validation + sanitized name +
+// project/global dir resolution + no-overwrite conflict), minus the tool-context
+// permission ask.
+const SAVE_SOURCE = `export const meta = { name: "saved-flow", description: "a saved run" }
+export async function run(args, ctx) { return { ok: true } }
+`
+
+describe("Workflow.save", () => {
+  it.instance("writes a project workflow file that is then discoverable", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const saved = yield* workflow.save({ name: "saved-flow", source: SAVE_SOURCE })
+      const expected = path.join(test.directory, ".opencode", "workflows", "saved-flow.ts")
+      expect(saved.path).toBe(expected)
+      // The file really landed on disk with the exact source.
+      const onDisk = yield* Effect.promise(() => Bun.file(expected).text())
+      expect(onDisk).toBe(SAVE_SOURCE)
+      // And it is now discoverable via list() (static meta extraction).
+      const list = yield* workflow.list()
+      const info = list.find((item) => item.name === "saved-flow")
+      expect(info?.valid).toBe(true)
+      expect(info?.path).toBe(expected)
+    }),
+  )
+
+  it.instance("saving with scope:global writes under the global config workflows dir", () =>
+    Effect.gen(function* () {
+      const workflow = yield* Workflow.Service
+      // Use a name unlikely to collide with any real global file in the test home.
+      const name = `t8-global-${Date.now()}`
+      const saved = yield* workflow.save({ name, source: SAVE_SOURCE.replace("saved-flow", name), scope: "global" })
+      const expected = path.join(Global.Path.config, "workflows", `${name}.ts`)
+      expect(saved.path).toBe(expected)
+      const onDisk = yield* Effect.promise(() => Bun.file(expected).text())
+      expect(onDisk).toContain(`name: "${name}"`)
+      // Clean up the global file so it does not leak into other tests.
+      yield* Effect.promise(() => fs.rm(expected).catch(() => {}))
+    }),
+  )
+
+  it.instance("a duplicate save fails with SaveConflictError (never overwrites)", () =>
+    Effect.gen(function* () {
+      const workflow = yield* Workflow.Service
+      yield* workflow.save({ name: "dup-flow", source: SAVE_SOURCE })
+      // A second save with a VALID source (so it clears the meta gate) must still
+      // be refused as a conflict — save never overwrites.
+      const second = yield* Effect.exit(workflow.save({ name: "dup-flow", source: SAVE_SOURCE }))
+      expect(Exit.isFailure(second)).toBe(true)
+      const conflict = Exit.isFailure(second) ? (Cause.squash(second.cause) as { _tag?: string }) : undefined
+      expect(conflict?._tag).toBe("WorkflowSaveConflictError")
+    }),
+  )
+
+  it.instance("a bad name fails with InvalidError before any write", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const result = yield* Effect.exit(workflow.save({ name: "../escape", source: SAVE_SOURCE }))
+      expect(Exit.isFailure(result)).toBe(true)
+      const badName = Exit.isFailure(result) ? (Cause.squash(result.cause) as { _tag?: string }) : undefined
+      expect(badName?._tag).toBe("WorkflowInvalidError")
+      // No traversal file was created.
+      const escaped = yield* Effect.promise(() =>
+        Bun.file(path.join(test.directory, ".opencode", "workflows", "../escape.ts")).exists(),
+      )
+      expect(escaped).toBe(false)
+    }),
+  )
+
+  it.instance("statically-invalid meta fails with InvalidError and writes nothing", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      // Non-literal meta (a call expression) is rejected by the AST-only MetaReader.
+      const result = yield* Effect.exit(
+        workflow.save({ name: "bad-meta", source: "export const meta = makeMeta()\nexport async function run() {}" }),
+      )
+      expect(Exit.isFailure(result)).toBe(true)
+      const badMeta = Exit.isFailure(result) ? (Cause.squash(result.cause) as { _tag?: string }) : undefined
+      expect(badMeta?._tag).toBe("WorkflowInvalidError")
+      const wrote = yield* Effect.promise(() =>
+        Bun.file(path.join(test.directory, ".opencode", "workflows", "bad-meta.ts")).exists(),
+      )
+      expect(wrote).toBe(false)
+    }),
+  )
+
+  // Cross-version phases compatibility (@VasyaYovbak): a migration/version
+  // mismatch between branches leaves old `workflow_run` rows in the local DB
+  // whose `definition.meta.phases` is the OLD wire shape (bare strings, e.g.
+  // `["setup","run"]`) instead of the normalized object form. The three tests
+  // below pin the round-trip the fix must hold across schema versions.
+
+  // (B) Normalize on READ: an OLD row whose phases are bare strings must be
+  // read back through get()/runs() as the canonical OBJECT form, AND that
+  // in-memory run must re-encode cleanly through the public `Run` schema (the
+  // shape the HTTP layer serializes) with no `undefined` title and no error —
+  // the failure the reviewer saw was the `Run` encode choking on string phases.
+  it.instance("reads an old string-phases row back as normalized object phases that re-encode cleanly", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const id = Workflow.RunID.make("job_oldstringphases")
+      // The OLD on-disk shape produced by a branch whose `phases` was `string[]`.
+      yield* seedRowWithRawMeta(id, test.directory, { name: HELLO_FIXTURE, phases: ["setup", "run"] })
+
+      const viaGet = yield* workflow.get(id)
+      const run = viaGet ?? (yield* Effect.fail(new Error("run not read")))
+      // Canonical object form regardless of the stored (string) shape.
+      expect(run.definition?.meta.phases).toEqual([{ title: "setup" }, { title: "run" }])
+
+      // runs() (the list path) must normalize identically.
+      const listed = yield* workflow.runs()
+      const fromList = listed.find((r) => r.id === id) ?? (yield* Effect.fail(new Error("run not listed")))
+      expect(fromList.definition?.meta.phases).toEqual([{ title: "setup" }, { title: "run" }])
+
+      // The public `Run` encode (the HTTP response shape) succeeds — pre-fix this
+      // threw / produced an `undefined` title because the run still held strings.
+      const encoded = Schema.encodeUnknownExit(Workflow.Run)(run)
+      expect(Exit.isSuccess(encoded)).toBe(true)
+    }),
+  )
+
+  // (A) Persist back-compat ENCODED form: a freshly started run with plain
+  // string phases must be PERSISTED as bare strings (`["setup"]`), NOT the
+  // in-memory normalized objects — so an OLDER reader whose schema still expects
+  // `phases: string[]` can decode our row. A phase carrying detail/model has no
+  // back-compat string form, so it stays an object.
+  it.instance("persists plain phases as back-compat strings while keeping structured phases as objects", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() =>
+        writeWorkflow(
+          test.directory,
+          "phase-encode",
+          `export const meta = { name: "PhaseEncode", phases: ["setup", { title: "verify", model: "stub/mini" }] }
+export async function run(args, ctx) { ctx.setPhase("setup"); return { ok: true } }
+`,
+        ),
+      )
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "phase-encode", args: {} })
+      yield* workflow.wait({ id: run.id })
+
+      // Read the RAW DB row — the persisted bytes, not the engine projection.
+      const row = yield* fetchRunRow(run.id)
+      const phases = (row.definition?.meta.phases ?? []) as unknown[]
+      // A title-only phase is stored as the bare STRING (decodable by an old
+      // `string[]` reader); a phase with a model stays a structured object.
+      expect(phases[0]).toBe("setup")
+      expect(phases[1]).toEqual({ title: "verify", model: "stub/mini" })
+
+      // The in-memory snapshot is still the NORMALIZED object form (only the
+      // persisted bytes change) — the live run keeps its canonical shape.
+      const snap = yield* workflow.get(run.id)
+      expect(snap?.definition?.meta.phases).toEqual([{ title: "setup" }, { title: "verify", model: "stub/mini" }])
+    }),
+  )
+
+  // (A) Non-mutation invariant: `encodeDefinitionForRow` runs on EVERY persist
+  // (each setPhase/log forks a progress write), so it must NEVER mutate the LIVE
+  // in-memory run — only the persisted bytes change. Drive a still-RUNNING run
+  // (a hanging agent step) whose phases are plain strings; by the time the agent
+  // is live at least one persist has already encoded the definition. A mid-run
+  // get() returns snapshot(active), i.e. the LIVE definition: its phases must
+  // still be the canonical OBJECT form. A mutating encode would have rewritten
+  // active.run.definition.meta.phases to strings and this would observe them.
+  it.instance("persist does not mutate the live run's in-memory object phases", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => writeWorkflow(test.directory, SLOW_FIXTURE, SLOW_WORKFLOW))
+      const workflow = yield* Workflow.Service
+      const { ops } = hangingPromptOps()
+      const run = yield* workflow.start({ name: SLOW_FIXTURE, args: {}, prompt: ops })
+
+      // Poll until the agent step is live — guarantees a progress persist (which
+      // calls encodeDefinitionForRow) has already run at least once.
+      const live = yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const current = yield* workflow.get(run.id)
+          return current && current.agents.some((a) => a.status === "running") ? current : undefined
+        }),
+        "agent never started",
+      )
+      // SLOW_WORKFLOW declares `phases: ["agent","after"]` (authored as strings),
+      // normalized to objects in memory. The live snapshot must STILL be objects.
+      expect(live.definition?.meta.phases).toEqual([{ title: "agent" }, { title: "after" }])
+
+      yield* workflow.cancel(run.id)
+    }),
+  )
+
+  // (A) `definition.source` survival: the prior fix populates `source` for every
+  // run (named/builtin/inline), and `encodeDefinitionForRow` only rewrites
+  // `meta.phases` — it must leave `source` byte-identical through persist→read.
+  // A blank source here would re-break "save as command" / the source preview.
+  it.instance("definition.source survives the phase-encode persist round-trip intact", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const source = `export const meta = { name: "SourceThroughEncode", phases: ["setup", "run"] }
+export async function run(args, ctx) { ctx.setPhase("setup"); return { ok: true } }
+`
+      yield* Effect.promise(() => writeWorkflow(test.directory, "source-through-encode", source))
+      const workflow = yield* Workflow.Service
+      const run = yield* workflow.start({ name: "source-through-encode", args: {} })
+      yield* workflow.wait({ id: run.id })
+
+      // Read back through the DB->fromRow path (the run is evicted post-terminal):
+      // source must be intact AND phases must round-trip to the object form.
+      const persisted = yield* workflow.get(run.id)
+      expect(persisted?.definition?.source).toBe(source)
+      expect(persisted?.definition?.meta.phases).toEqual([{ title: "setup" }, { title: "run" }])
+    }),
+  )
+
+  // (C) Per-row resilience: a single un-decodable/foreign row (here, `phases` is
+  // a malformed shape the decode rejects) must NOT blow up the whole list. The
+  // OTHER valid row must still come back. The fix COERCES the poison row (keeps
+  // it, with safe phases) rather than dropping it, so a user's run never silently
+  // vanishes from history — degrade, don't disappear.
+  it.instance("a poison definition row does not fail the whole list; valid rows still return", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const workflow = yield* Workflow.Service
+      const goodId = Workflow.RunID.make("job_resilientgood")
+      const poisonId = Workflow.RunID.make("job_resilientpoison")
+      // A valid (old-string-phases) row and a poison row whose `phases` is a
+      // shape neither a string nor a `{title}` object — the decode must reject it.
+      yield* seedRowWithRawMeta(goodId, test.directory, { name: HELLO_FIXTURE, phases: ["setup"] })
+      yield* seedRowWithRawMeta(poisonId, test.directory, { name: HELLO_FIXTURE, phases: [{ nope: 123 }, 42] })
+
+      // The list must not throw and must still surface the valid run.
+      const listed = yield* workflow.runs()
+      const good = listed.find((r) => r.id === goodId) ?? (yield* Effect.fail(new Error("valid run dropped")))
+      expect(good.definition?.meta.phases).toEqual([{ title: "setup" }])
+      // The poison row is coerced (kept, but with safe/empty phases), so it is
+      // still present and the whole list survived.
+      const poison = listed.find((r) => r.id === poisonId)
+      expect(poison).toBeDefined()
+    }),
+  )
+})
+
+describe("Workflow.fmt", () => {
+  test("fmt renders whenToUse inside the available_workflows block", () => {
+    const out = Workflow.fmt([
+      {
+        name: "deploy",
+        path: "/p/.opencode/workflows/deploy.ts",
+        valid: true,
+        meta: { name: "Deploy", description: "Deploy the app.", whenToUse: "When shipping to prod." },
+      },
+    ])
+    expect(out).toContain("<when_to_use>When shipping to prod.</when_to_use>")
+  })
+})

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -13,7 +13,8 @@
     "./tool": "./src/tool.ts",
     "./tui": "./src/tui.ts",
     "./v2/effect": "./src/v2/effect/index.ts",
-    "./v2/promise": "./src/v2/promise/index.ts"
+    "./v2/promise": "./src/v2/promise/index.ts",
+    "./workflow": "./src/workflow.ts"
   },
   "files": [
     "dist"

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -14,8 +14,10 @@ import type { Provider as ProviderV2, Model as ModelV2, Auth } from "@opencode-a
 
 import type { BunShell } from "./shell.js"
 import { type ToolDefinition } from "./tool.js"
+import type { WorkflowDefinition } from "./workflow.js"
 
 export * from "./tool.js"
+export * from "./workflow.js"
 
 export type ProviderContext = {
   source: "env" | "config" | "custom" | "api"
@@ -225,6 +227,14 @@ export interface Hooks {
   config?: (input: Config) => Promise<void>
   tool?: {
     [key: string]: ToolDefinition
+  }
+  /**
+   * Register workflows discoverable by name. File-based project/global workflows
+   * shadow plugin workflows; plugin workflows shadow built-ins. If multiple
+   * plugins register the same name, the first loaded plugin wins.
+   */
+  workflow?: {
+    [key: string]: WorkflowDefinition | string
   }
   auth?: AuthHook
   provider?: ProviderHook

--- a/packages/plugin/src/workflow.ts
+++ b/packages/plugin/src/workflow.ts
@@ -1,0 +1,264 @@
+type WorkflowArgumentType = "string" | "number" | "boolean"
+
+type WorkflowArgument = {
+  type?: WorkflowArgumentType
+  default?: unknown
+  description?: string
+}
+
+type WorkflowArguments = Record<string, WorkflowArgument>
+
+type WorkflowArgumentValue<T extends WorkflowArgument> = T["type"] extends "number"
+  ? number
+  : T["type"] extends "boolean"
+    ? boolean
+    : string
+
+type WorkflowArgs<Args extends WorkflowArguments | undefined> = Args extends WorkflowArguments
+  ? { readonly [Key in keyof Args]?: WorkflowArgumentValue<Args[Key]> }
+  : Record<string, unknown>
+
+export type WorkflowAgentInput = {
+  prompt: string
+  agent?: string
+  model?: string
+  /** Per-step model reasoning variant (e.g. "max"), threaded into the underlying prompt run. */
+  variant?: string
+  /**
+   * Per-step tool scoping for this agent step. A map of tool/permission name to
+   * whether it is enabled, with glob-able keys (e.g. `{ webfetch: false }` or
+   * `{ "skill_*": true }`). Each entry becomes an allow/deny permission rule on
+   * the child session, so the subagent only sees the tools you scope it to.
+   */
+  tools?: Record<string, boolean>
+  /**
+   * Skills to make available to this agent step. opencode loads skills at
+   * runtime via the `skill` tool, so naming them here prepends a "Load these
+   * skills before starting: …" directive to the prompt and enables the `skill`
+   * tool for the step (merged with any `tools` scoping). The agent loads each
+   * named skill before doing its work.
+   */
+  skills?: string[]
+  /**
+   * Files to attach to this agent step. Each path is resolved relative to the
+   * run's workspace directory (absolute paths are used as-is) and must exist —
+   * a missing file fails the step. Each attachment is appended after the prompt
+   * as a file part, so the agent can read it directly.
+   */
+  files?: string[]
+  schema?: unknown
+  permissionSessionID?: string
+  /**
+   * Explicit progress group for THIS call. Pins the step to the named phase
+   * regardless of where `ctx.setPhase` currently points — closing the race
+   * window when setPhase and agent() run under parallel/pipeline concurrency.
+   * A phase declared in `meta.phases` with a `model` activates that model as
+   * this call's default (an explicit `model` still wins). The run's current
+   * phase is NOT changed (no setPhase side effect).
+   */
+  phase?: string
+  /** Display name for this step in run views (defaults to the agent name). */
+  label?: string
+  /**
+   * Run this step's subagent in a FRESH `git worktree` instead of the run's
+   * workspace, so parallel agents that mutate files do not conflict. The
+   * worktree is created when the step dispatches and auto-removed when the run
+   * finishes or is cancelled. Requires the workspace to be a git repository;
+   * otherwise the step fails with a clear error.
+   */
+  isolation?: "worktree"
+  /**
+   * What a FAILING step resolves to. Default `"fail"`: the error propagates
+   * (the run fails unless you catch it). `"null"`: the step resolves `null`
+   * (its node stays `failed` with the error recorded) so the workflow body can
+   * branch on the outcome. Budget/lifetime limits and aborts are NEVER
+   * swallowed — those always throw regardless of this option.
+   */
+  onError?: "fail" | "null"
+}
+
+export type WorkflowAgentResult = {
+  data: unknown
+  text: string
+}
+
+export type WorkflowToolOptions = {
+  timeout?: number
+  onError?: "fail" | "null"
+}
+
+export type WorkflowToolResult = {
+  output: string
+  metadata?: Record<string, unknown>
+}
+
+export interface WorkflowToolFn {
+  (name: string, args?: Record<string, unknown>, options?: WorkflowToolOptions & { onError: "null" }): Promise<WorkflowToolResult | null>
+  (name: string, args?: Record<string, unknown>, options?: WorkflowToolOptions): Promise<WorkflowToolResult>
+}
+export type WorkflowParallelOptions = { concurrencyLimit?: number }
+export type WorkflowPipelineOptions = { concurrencyLimit?: number }
+
+/** A pipeline stage: receives the previous stage's output for this item plus the
+ * original item, and returns the next value. The first stage's `prev` is the
+ * item itself. Stages may change the type (`I → S1 → S2 …`). `index` is the
+ * item's position in the original items array — the same value for every stage
+ * an item flows through (a two-parameter stage simply ignores it). */
+export type WorkflowPipelineStage<Prev, Item, Next> = (prev: Prev, item: Item, index: number) => Promise<Next>
+
+/** Per-item pipeline. Each item flows through every stage SEQUENTIALLY (stage N+1
+ * receives stage N's result for that item), while items run concurrently against
+ * each other (no barrier between stages). Result is the last stage's output in
+ * item order. A stage that throws does NOT fail the whole pipeline — it drops ONLY
+ * that item to `null` at its position (skipping that item's remaining stages, and
+ * logging the drop); other items keep running. Only a run abort stays fatal.
+ * Filter the result before use, e.g. `.filter((x) => x !== null)`. Overloaded for
+ * 1..4 stages so heterogeneous types flow through. */
+export interface WorkflowPipelineFn {
+  <I, A>(
+    items: readonly I[],
+    s1: WorkflowPipelineStage<I, I, A>,
+    options?: WorkflowPipelineOptions,
+  ): Promise<(A | null)[]>
+  <I, A, B>(
+    items: readonly I[],
+    s1: WorkflowPipelineStage<I, I, A>,
+    s2: WorkflowPipelineStage<A, I, B>,
+    options?: WorkflowPipelineOptions,
+  ): Promise<(B | null)[]>
+  <I, A, B, C>(
+    items: readonly I[],
+    s1: WorkflowPipelineStage<I, I, A>,
+    s2: WorkflowPipelineStage<A, I, B>,
+    s3: WorkflowPipelineStage<B, I, C>,
+    options?: WorkflowPipelineOptions,
+  ): Promise<(C | null)[]>
+  <I, A, B, C, D>(
+    items: readonly I[],
+    s1: WorkflowPipelineStage<I, I, A>,
+    s2: WorkflowPipelineStage<A, I, B>,
+    s3: WorkflowPipelineStage<B, I, C>,
+    s4: WorkflowPipelineStage<C, I, D>,
+    options?: WorkflowPipelineOptions,
+  ): Promise<(D | null)[]>
+}
+
+export type WorkflowContext = {
+  /**
+   * Remaining run budget in USD. Reflects the live cost cap the run was started
+   * with, decremented by each agent step's actual cost. `Infinity` when the run
+   * was started without a budget (unlimited — the default). Read it to make a
+   * workflow budget-aware; the engine additionally fails the next `agent()` call
+   * with a budget error once this reaches zero.
+   *
+   * @deprecated USD-only view; prefer `ctx.budget.remaining()` (and
+   * `tokensRemaining()` for the token cap).
+   */
+  readonly budgetRemaining: number
+  /**
+   * Budget in Claude-Code API shape. USD: `total` (null when unlimited),
+   * `spent()` so far, `remaining()` (Infinity when unlimited). Tokens:
+   * `tokensTotal`/`tokensSpent()`/`tokensRemaining()` — the same trio for the
+   * independent output-token cap (`budget: { tokens }` at start).
+   */
+  readonly budget: {
+    readonly total: number | null
+    spent(): number
+    remaining(): number
+    readonly tokensTotal: number | null
+    tokensSpent(): number
+    tokensRemaining(): number
+  }
+  /**
+   * Switch the run's current phase. When the named phase is declared in
+   * `meta.phases` as a structured object with a `model`, that model becomes the
+   * DEFAULT for subsequent `ctx.agent` calls that omit an explicit `model` (an
+   * explicit per-call model still wins). Setting an UNDECLARED phase is allowed —
+   * it clears any phase-default model and logs a warning, never an error.
+   */
+  setPhase(phase: string): void
+  log(message: string): void
+  /**
+   * Run `tasks` concurrently and resolve to their results in task order. A thunk
+   * that throws (or whose `agent()` errors) does NOT fail the whole batch — it
+   * resolves to `null` at its position (the drop is logged); only a run abort
+   * stays fatal. Filter the result before use, e.g. `.filter((x) => x !== null)`.
+   */
+  parallel<T>(tasks: readonly (() => Promise<T>)[], options?: WorkflowParallelOptions): Promise<(T | null)[]>
+  pipeline: WorkflowPipelineFn
+  /**
+   * Resolves `null` when a human skips the step, or with `onError: "null"` when
+   * the step fails. Guard the result before dereferencing (`if (!r) …`).
+   */
+  agent(input: WorkflowAgentInput): Promise<WorkflowAgentResult | null>
+  /**
+   * Call an available opencode tool directly from the workflow without dispatching
+   * an agent step. Uses the same permission path as normal tool calls. With
+   * `onError: "null"`, a failing tool call resolves `null` instead of failing the run.
+   */
+  tool: WorkflowToolFn
+  /**
+   * Deterministic non-LLM step: run a shell command in the run's workspace (or an
+   * explicit `cwd`) and resolve to `{ output, exitCode }`. Unlike `agent()`, this
+   * consumes NO LLM turn and does NOT touch the run's budget — `budget.spent()`
+   * is unaffected. A non-zero exit is returned as `exitCode`, never thrown, so
+   * inspect `exitCode` to branch on failure.
+   */
+  shell(command: string, opts?: { timeout?: number; cwd?: string }): Promise<{ output: string; exitCode: number }>
+  /**
+   * Run another DISCOVERED workflow inline under the SAME run (no separate run
+   * row), sharing this run's concurrency, budget, abort scope, and agent-lifetime
+   * cap. Returns the child's `run()` result. Nesting is limited to depth 1: a
+   * workflow invoked via `ctx.workflow` cannot itself call `ctx.workflow`.
+   */
+  workflow(name: string, args?: Record<string, unknown>): Promise<unknown>
+  /**
+   * Ask a human a question and wait for the answer (human-in-the-loop). Persists
+   * the question on the run and resolves to `{ answer }` once it is answered via
+   * the workflow `answer` API, racing a timeout (default 10 minutes). If the
+   * timeout elapses unanswered the run PARKS as `paused` with the question kept —
+   * a later answer resumes the run and the body receives the reply (replayed from
+   * the journal) without asking again. `options` is an optional list of suggested
+   * answers surfaced to the human; the resolved `answer` is a free-form string.
+   */
+  question(input: { question: string; options?: readonly string[]; timeout?: number }): Promise<{ answer: string }>
+}
+
+/**
+ * A workflow phase. Authors may list a phase as a plain string (the title) or as
+ * a structured object. `model` is a per-phase DEFAULT model: a `ctx.agent` call
+ * made while that phase is active and given no explicit `model` resolves to it
+ * (an explicit per-call model still wins). `detail` is optional human copy.
+ */
+export type WorkflowPhase = string | { title: string; detail?: string; model?: string }
+
+export type WorkflowDefinition<Args extends WorkflowArguments | undefined = WorkflowArguments | undefined> = {
+  meta: {
+    name: string
+    description?: string
+    whenToUse?: string
+    phases?: readonly WorkflowPhase[]
+    arguments?: Args
+  }
+  run(args: WorkflowArgs<Args>, ctx: WorkflowContext): Promise<unknown>
+}
+
+export function workflow<const Args extends WorkflowArguments | undefined = undefined>(input: {
+  name: string
+  description?: string
+  whenToUse?: string
+  phases?: readonly WorkflowPhase[]
+  arguments?: Args
+  run(args: WorkflowArgs<Args>, ctx: WorkflowContext): Promise<unknown>
+}): WorkflowDefinition<Args> {
+  return {
+    meta: {
+      name: input.name,
+      description: input.description,
+      whenToUse: input.whenToUse,
+      phases: input.phases,
+      arguments: input.arguments,
+    },
+    run: input.run,
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Relates to #29789 — part 1/6 of splitting that oversized workflow PR into reviewable pieces. Workflow feature: #29059, #30308.

### Type of change

- [x] New feature
- [x] Refactor / code improvement

### What does this PR do?

Brings in the workflow engine only — `packages/opencode/src/workflow/**` plus the few modules it needs to typecheck. The old single 4,810-line `workflow.ts` is split into `schema.ts` / `errors.ts` / `types.ts`, with `workflow.ts` kept as a thin barrel; the public `Workflow.*` API is unchanged. This is the base of a 6-PR stack; the later layers (server/SDK, TUI, app/desktop, ctx.tool + plugin, docs) build on top of it.

### How did you verify your code works?

`bun turbo typecheck` passes (23/23). The workflow test suites pass locally — one macOS-only `realpath` test artifact remains (passes on Linux CI).

### Screenshots / recordings

N/A — engine code, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
