### PR TITLE
fix(tui): restore win32 Ctrl+C guard dropped by #31193

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -79,7 +79,7 @@ import type { EventSource } from "./context/sdk"
 import { DialogVariant } from "./component/dialog-variant"
 import { createTuiAttention } from "./attention"
 import * as TuiAudio from "./audio"
-import { win32DisableProcessedInput, win32FlushInputBuffer } from "./terminal-win32"
+import { win32DisableProcessedInput, win32FlushInputBuffer, win32InstallCtrlCGuard } from "./terminal-win32"
 import { destroyRenderer } from "./util/renderer"
 import { cliErrorMessage, errorFormat } from "./util/error"
 
@@ -180,6 +180,18 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
   const exit = { epilogue: undefined as string | undefined, reason: undefined as unknown }
   const result = yield* Effect.scoped(
     Effect.gen(function* () {
+      // Keep ENABLE_PROCESSED_INPUT disabled for the renderer's lifetime.
+      // Without the guard, runtimes/ConPTY can re-apply the flag, which turns
+      // Ctrl+C into a CTRL_C_EVENT and causes Windows Terminal to reset the
+      // tab title. Install before the renderer is created so the console mode
+      // is correct from the first frame (matches pre-refactor ordering).
+      const unguard = yield* Effect.acquireRelease(
+        Effect.sync(() => win32InstallCtrlCGuard()),
+        (release) =>
+          Effect.sync(() => {
+            if (typeof release === "function") release()
+          }),
+      )
       const renderer = yield* Effect.acquireRelease(
         Effect.tryPromise(() =>
           createCliRenderer({

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -125,3 +125,63 @@ test("app.exit prints the session epilogue after scoped cleanup", async () => {
     mock.restore()
   }
 })
+
+test("installs win32 Ctrl+C guard for renderer lifetime and releases it on shutdown", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  const core = await import("@opentui/core")
+  mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+
+  const win32 = await import("../src/terminal-win32")
+  let installCalls = 0
+  let unhookCalls = 0
+  mock.module("../src/terminal-win32", () => ({
+    ...win32,
+    win32InstallCtrlCGuard: () => {
+      installCalls++
+      return () => {
+        unhookCalls++
+      }
+    },
+  }))
+
+  const listeners = new Set(process.listeners("SIGHUP"))
+  const events = createEventSource()
+  const calls = createFetch()
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch: calls.fetch,
+        events: events.source,
+        args: {},
+        pluginHost: {
+          async start() {
+            started()
+          },
+          async dispose() {},
+        },
+      }).pipe(Effect.provide(Global.defaultLayer)),
+    )
+    await ready
+    expect(installCalls).toBe(1)
+    expect(unhookCalls).toBe(0)
+
+    process.emit("SIGHUP")
+    await task
+
+    expect(setup.renderer.isDestroyed).toBe(true)
+    expect(unhookCalls).toBe(1)
+    expect(process.listeners("SIGHUP").every((listener) => listeners.has(listener))).toBe(true)
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32293

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem**

`packages/tui/src/app.tsx` no longer calls `win32InstallCtrlCGuard()` after PR #31193 (commit `106f8e94d`, "refactor(tui): extract standalone package") extracted the TUI into a standalone package. The function still exists in `packages/tui/src/terminal-win32.ts` but is now dead code — only `win32DisableProcessedInput` and `win32FlushInputBuffer` made it into the import list (`app.tsx:82`).

Before the refactor, `tui()` called `const unguard = win32InstallCtrlCGuard()` at `packages/opencode/src/cli/cmd/tui/app.tsx:200` (v1.16.2). The guard installs:

- a `setRawMode` hook that re-clears `ENABLE_PROCESSED_INPUT` after known raw-mode toggles
- a `setInterval(enforce, 100ms).unref()` backstop that re-clears the flag periodically

Without these, `win32DisableProcessedInput()` only clears the flag once. Bun/ConPTY can re-apply `ENABLE_PROCESSED_INPUT` later (the flag is console-global, not per-process), which turns Ctrl+C into a `CTRL_C_EVENT` instead of stdin bytes. ConPTY resets the terminal title when handling `CTRL_C_EVENT`, so on Windows Terminal the tab title falls back to its `startingTitle` ("Windows PowerShell").

**User-visible impact**

Reported in #32293: after selecting text in the chat area and pressing Ctrl+C to copy, the Windows Terminal tab title drops from `OC | <session>` to `Windows PowerShell` and does not recover until the session is renamed (Ctrl+R) or the route switches. Copy itself still works, but the regression triggers on every copy and was traced via version bisection to v1.16.2 → v1.17.3 — `106f8e94d` lands between those releases (2026-06-07).

**Fix**

Re-install the guard via `Effect.acquireRelease` inside the existing `Effect.scoped` block, placed **before** the renderer is created (matching the v1.16.2 ordering, so the console mode is correct from the first frame). The release step calls the returned `unhook` only when it is a function (the guard returns `void` on non-Windows platforms).

The pre-existing `win32DisableProcessedInput()` call is kept as an immediate enforcement; the guard's `setImmediate(enforce)` inside `later()` is what keeps the flag from drifting back over the renderer's lifetime.

### How did you verify your code works?

- `bun run typecheck` in `packages/tui` passes.
- New test `installs win32 Ctrl+C guard for renderer lifetime and releases it on shutdown` in `packages/tui/test/app-lifecycle.test.tsx`:
  - mocks `../src/terminal-win32` so the assertion is platform-agnostic,
  - asserts `win32InstallCtrlCGuard` is called exactly once during startup,
  - asserts the returned `unhook` is **not** called while the renderer is alive,
  - emits `SIGHUP` to trigger scoped cleanup, then asserts `unhook` is called exactly once.
  - local run: `bun test --timeout 30000 --test-name-pattern "guard for renderer" test/app-lifecycle.test.tsx` → 1 pass, 5 expects.
- Existing `packages/tui/test/util/*` (46 tests) still pass — no regression in the renderer/util surface.

Note: the two pre-existing tests in the same file (`SIGHUP clears title...` and `app.exit prints the session epilogue...`) segfault locally on Bun 1.3.6/Windows inside `opentui.dll`. Verified pre-existing by stashing this PR's diff and re-running — crash reproduces without my changes. CI on Linux does not reproduce.

### Screenshots / recordings

N/A — pure logic fix, no visual change. The visible effect (tab title no longer resets after Ctrl+C copy) requires a live Windows Terminal session.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
