### PR TITLE
fix(core): skip missing paths in FileSystem.list

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -78,7 +78,14 @@ const baseLayer = Layer.effect(
       const absolute = path.resolve(location.directory, input ?? ".")
       if (!FSUtil.contains(location.directory, absolute))
         return yield* Effect.die(new Error("Path escapes the location"))
-      const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
+      // realPath fails when the target no longer exists; a missing path cannot
+      // be a symlink escaping the location, so fall back to the lexical path
+      // (already constrained above) and let callers decide how to handle it
+      // instead of crashing here.
+      const real = yield* fs.realPath(absolute).pipe(
+        Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(absolute)),
+        Effect.orDie,
+      )
       if (!FSUtil.contains(root, real)) return yield* Effect.die(new Error("Path escapes the location"))
       return { absolute, real, directory: location.directory, root }
     })
@@ -97,7 +104,14 @@ const baseLayer = Layer.effect(
       }),
       list: Effect.fn("FileSystem.list")(function* (input = {}) {
         const target = yield* resolve(input.path)
-        const info = yield* fs.stat(target.real).pipe(Effect.orDie)
+        const info = yield* fs.stat(target.real).pipe(
+          Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)),
+          Effect.orDie,
+        )
+        // A path that no longer exists on disk — for example a subdirectory
+        // removed after the watcher indexed it — is skipped rather than
+        // crashing the whole listing, so treat it as empty.
+        if (!info) return []
         if (info.type !== "Directory") return yield* Effect.die(new Error("Path is not a directory"))
         return yield* fs.readDirectoryEntries(target.real).pipe(
           Effect.orDie,

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -60,6 +60,18 @@ describe("FileSystem", () => {
     ),
   )
 
+  it.live("skips a subdirectory removed after indexing", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const sub = path.join(directory, "transient")
+        yield* Effect.promise(() => fs.mkdir(sub))
+        yield* Effect.promise(() => fs.rm(sub, { recursive: true }))
+        const entries = yield* (yield* FileSystem.Service).list({ path: RelativePath.make("transient") })
+        expect(entries).toEqual([])
+      }).pipe(provide(directory)),
+    ),
+  )
+
   it.live("rejects lexical escapes", () =>
     withTmp((directory) =>
       Effect.gen(function* () {


### PR DESCRIPTION
Closes #32374

### Problem

When a subdirectory that was indexed by the file watcher is deleted on disk and the project is then browsed, `FileSystem.list` throws an `ENOENT` defect and the whole file listing fails ("file listing failed").

The crash happens in two places, both using `Effect.orDie`:

- `resolve()` runs `realPath(absolute)` on the requested path — a removed path has no real path, so this dies before `list` even runs.
- `list` then runs `stat(target.real)`, which would also die for a missing path.

### Fix

Recover the not-found case in both spots:

- `resolve` falls back to the lexical `absolute` path when `realPath` reports `NotFound`. That path already passed the `contains(location.directory, …)` lexical check, and a path that does not exist cannot be a symlink escaping the location, so the second `contains(root, real)` guard still holds. All other `realPath` errors keep dying.
- `list` returns an empty list when the target no longer exists, matching the expected "skip it and continue" behavior. The escape and not-a-directory guards are unchanged.

This mirrors the existing `FSUtil.isDir` pattern, which already treats a missing path as "not a directory" rather than crashing.

### Test

Added `skips a subdirectory removed after indexing` to `location-filesystem.test.ts`: it creates a subdirectory, deletes it, then lists it and expects `[]`.

```
bun test test/location-filesystem.test.ts   # 4 pass
tsgo --noEmit                                # clean
```