### PR TITLE
fix(opencode): exit process after a non-interactive run

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -784,26 +784,27 @@ export const RunCommand = effectCmd({
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
               process.exitCode = 1
-              return
-            }
-            await finish()
-            return
+            } else await finish()
+          } else {
+            const model = pick(args.model)
+            const result = await client.session.prompt({
+              sessionID,
+              agent,
+              model,
+              variant: args.variant,
+              parts: [...files, { type: "text", text: message }],
+            })
+            if (result.error) {
+              if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
+              process.exitCode = 1
+            } else await finish()
           }
-
-          const model = pick(args.model)
-          const result = await client.session.prompt({
-            sessionID,
-            agent,
-            model,
-            variant: args.variant,
-            parts: [...files, { type: "text", text: message }],
-          })
-          if (result.error) {
-            if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
-            process.exitCode = 1
-            return
-          }
-          await finish()
+          // The server keeps handles alive (db connections, sockets, timers),
+          // so a non-interactive run would otherwise hang with an idle event
+          // loop instead of terminating. Exit explicitly once it finishes,
+          // matching the error paths above. Attach mode drives a separate
+          // server, so leave it untouched.
+          if (!args.attach) process.exit(process.exitCode ?? 0)
           return
         }
 

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -58,6 +58,23 @@ describe("opencode run (non-interactive subprocess)", () => {
     60_000,
   )
 
+  // Regression for #32335: after a successful prompt the process used to stay
+  // alive with an idle event loop (server db connections, sockets and timers
+  // keep handles open), so scheduled `opencode run` jobs leaked and piled up.
+  // A successful run must terminate promptly on its own; a hang would expire
+  // the harness timeout and surface as a signal-killed failure instead.
+  cliIt.concurrent(
+    "exits promptly after a successful prompt instead of hanging (regression for #32335)",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("done")
+        const result = yield* opencode.run("say hi", { timeoutMs: 20_000 })
+        opencode.expectExit(result, 0)
+        expect(result.durationMs).toBeLessThan(20_000)
+      }),
+    30_000,
+  )
+
   // --format json puts one JSON object per line on stdout for each emitted
   // event. Consumers (CI scripts, tooling) parse this stream. Asserts the
   // shape so a future event-emit change has to update this expectation.


### PR DESCRIPTION
### Issue for this PR

Closes #32335

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A non-interactive `opencode run` (the form scheduled cron jobs use) finishes its prompt and returns from the command handler, but the in-process server keeps handles open — db connections, unix sockets, timers. With nothing draining the event loop, the process stays alive on an idle loop instead of exiting, so scheduled runs pile up (re-parented to pid 1) and leak hundreds of MB of RSS each.

This exits explicitly once the non-interactive run completes, preserving the resolved exit code. It matches the rest of the command: every error branch in `run.ts` already calls `process.exit(1)`, and the success path was the only one that just set `process.exitCode` and returned. The block now converges on a single `process.exit(process.exitCode ?? 0)` after the work finishes.

Output is not truncated — `finish()` awaits the event loop that prints the response before the exit runs. Attach mode (`--attach`) drives a separate, already-running server, so it is left untouched.

### How did you verify your code works?

Added a regression test `exits promptly after a successful prompt instead of hanging` to `run-process.test.ts`, mirroring the existing #27371 hang regression: it runs a successful prompt through the real CLI subprocess and asserts a clean exit 0 well under the harness timeout.

```
bun test test/cli/run/run-process.test.ts   # 5 pass
tsgo --noEmit                                # clean
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
