### PR TITLE
fix(acp): surface subagent sessions and route child permissions

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -3,6 +3,8 @@ import type {
   Event,
   EventMessagePartDelta,
   EventMessagePartUpdated,
+  EventSessionCreated,
+  EventSessionDeleted,
   OpencodeClient,
   Part,
   SessionMessageResponse,
@@ -11,6 +13,7 @@ import type {
 import { Effect } from "effect"
 import { ACPSession } from "./session"
 import { ACPPermission } from "./permission"
+import { SessionResolver } from "./session-resolve"
 import { partsToContentChunks, type ReplayPart } from "./content"
 import {
   duplicateRunningToolUpdate,
@@ -40,6 +43,7 @@ export class Subscription {
   private readonly abort = new AbortController()
   private readonly shellSnapshots = new Map<string, string>()
   private readonly toolStarts = new Set<string>()
+  private readonly resolver: SessionResolver
   private readonly permission: ACPPermission.Handler
   private started = false
 
@@ -50,7 +54,8 @@ export class Subscription {
       session: ACPSession.Interface
     },
   ) {
-    this.permission = new ACPPermission.Handler(input)
+    this.resolver = new SessionResolver(input.session, input.sdk)
+    this.permission = new ACPPermission.Handler({ ...input, resolver: this.resolver })
   }
 
   start() {
@@ -70,6 +75,10 @@ export class Subscription {
       case "permission.asked":
         this.permission.handle(event)
         return
+      case "session.created":
+        return this.handleSessionCreated(event)
+      case "session.deleted":
+        return this.handleSessionDeleted(event)
       case "message.part.updated":
         return this.handlePartUpdated(event)
       case "message.part.delta":
@@ -84,6 +93,7 @@ export class Subscription {
     for (const part of message.parts) {
       await this.recordFetchedPart(message.info.sessionID, message, part)
       if (part.type === "tool") {
+        await this.trackTaskChildSession(message.info.sessionID, part, cwd ?? process.cwd())
         await this.handleToolPart(message.info.sessionID, part, cwd ?? process.cwd())
         continue
       }
@@ -128,10 +138,37 @@ export class Subscription {
     }
   }
 
+  private async handleSessionCreated(event: EventSessionCreated) {
+    const info = event.properties.info
+    if (!info.parentID) return
+
+    const parent = await Effect.runPromise(this.input.session.tryGet(info.parentID))
+    if (parent) {
+      await this.resolver.registerChild({
+        sessionId: info.id,
+        parentSessionId: info.parentID,
+        cwd: info.directory,
+      })
+      return
+    }
+
+    await this.resolver.resolve(info.id, info.directory)
+  }
+
+  private async handleSessionDeleted(event: EventSessionDeleted) {
+    const sessionId = event.properties.sessionID
+    this.resolver.invalidate(sessionId)
+    await Effect.runPromise(this.input.session.remove(sessionId)).catch(() => undefined)
+  }
+
+  private async resolveSession(sessionId: string, directory?: string) {
+    return await this.resolver.resolve(sessionId, directory)
+  }
+
   private async handlePartUpdated(event: EventMessagePartUpdated) {
     const part = event.properties.part
     const sessionId = part.sessionID || event.properties.sessionID
-    const session = await Effect.runPromise(this.input.session.tryGet(sessionId))
+    const session = await this.resolveSession(sessionId)
     if (!session) return
 
     await Effect.runPromise(
@@ -147,13 +184,14 @@ export class Subscription {
       }),
     )
     if (part.type === "tool") {
+      await this.trackTaskChildSession(session.id, part, session.cwd)
       await this.handleToolPart(session.id, part, session.cwd)
     }
   }
 
   private async handlePartDelta(event: EventMessagePartDelta) {
     const props = event.properties
-    const session = await Effect.runPromise(this.input.session.tryGet(props.sessionID))
+    const session = await this.resolveSession(props.sessionID)
     if (!session) return
 
     const known = await Effect.runPromise(
@@ -278,6 +316,16 @@ export class Subscription {
     }
   }
 
+  private async trackTaskChildSession(sessionId: string, part: ToolPart, cwd: string) {
+    const child = taskChildSession(part)
+    if (!child?.sessionId) return
+    await this.resolver.registerChild({
+      sessionId: child.sessionId,
+      parentSessionId: child.parentSessionId ?? sessionId,
+      cwd,
+    })
+  }
+
   private async runningTool(sessionId: string, part: ToolPart, cwd: string) {
     if (part.state.status !== "running") return
 
@@ -337,6 +385,17 @@ export class Subscription {
     this.toolStarts.delete(toolCallId)
     this.shellSnapshots.delete(toolCallId)
   }
+}
+
+function taskChildSession(part: ToolPart) {
+  if (part.tool !== "task") return
+  const metadata = "metadata" in part.state ? part.state.metadata : undefined
+  if (!metadata || typeof metadata !== "object") return
+  const values = metadata as Record<string, unknown>
+  const sessionId = typeof values.sessionId === "string" ? values.sessionId : undefined
+  const parentSessionId = typeof values.parentSessionId === "string" ? values.parentSessionId : undefined
+  if (!sessionId) return
+  return { sessionId, parentSessionId }
 }
 
 export * as ACPEvent from "./event"

--- a/packages/opencode/src/acp/permission.ts
+++ b/packages/opencode/src/acp/permission.ts
@@ -3,6 +3,7 @@ import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2"
 import { applyPatch } from "diff"
 import { exists, readText } from "@/util/filesystem"
 import type { ACPSession } from "./session"
+import type { SessionResolver } from "./session-resolve"
 import { toLocations, toToolKind, type ToolInput } from "./tool"
 import { Effect } from "effect"
 
@@ -24,6 +25,7 @@ export class Handler {
       sdk: OpencodeClient
       connection: Connection
       session: ACPSession.Interface
+      resolver: SessionResolver
     },
   ) {}
 
@@ -43,8 +45,10 @@ export class Handler {
 
   private async process(event: PermissionEvent) {
     const permission = event.properties
-    const session = await Effect.runPromise(this.input.session.tryGet(permission.sessionID))
+    const session = await this.input.resolver.resolve(permission.sessionID)
     if (!session) return
+
+    const root = await Effect.runPromise(this.input.session.getRoot(permission.sessionID)).catch(() => session)
 
     if (!this.input.connection.requestPermission) {
       await this.reply(permission.id, "reject", session.cwd)
@@ -53,12 +57,18 @@ export class Handler {
 
     const result = await this.input.connection
       .requestPermission({
-        sessionId: permission.sessionID,
+        sessionId: root.id,
         toolCall: {
           toolCallId: permission.tool?.callID ?? permission.id,
           status: "pending",
           title: permission.permission,
-          rawInput: permission.metadata,
+          rawInput:
+            root.id === session.id
+              ? permission.metadata
+              : {
+                  ...(permission.metadata && typeof permission.metadata === "object" ? permission.metadata : {}),
+                  childSessionId: session.id,
+                },
           kind: toToolKind(permission.permission),
           locations: toLocations(permission.permission, permission.metadata),
         },

--- a/packages/opencode/src/acp/session-resolve.ts
+++ b/packages/opencode/src/acp/session-resolve.ts
@@ -1,0 +1,104 @@
+import type { OpencodeClient } from "@opencode-ai/sdk/v2"
+import { Effect } from "effect"
+import type { ACPSession, RegisterChildInput } from "./session"
+
+const maxAncestryDepth = 32
+
+type SdkSessionInfo = {
+  readonly id: string
+  readonly parentID?: string
+  readonly directory: string
+}
+
+export class SessionResolver {
+  private readonly parentBySession = new Map<string, string>()
+
+  constructor(
+    private readonly session: ACPSession.Interface,
+    private readonly sdk: OpencodeClient,
+  ) {}
+
+  invalidate(sessionId: string) {
+    this.parentBySession.delete(sessionId)
+    for (const [child, parent] of this.parentBySession.entries()) {
+      if (parent === sessionId) this.parentBySession.delete(child)
+    }
+  }
+
+  async resolve(sessionId: string, directory?: string) {
+    const direct = await Effect.runPromise(this.session.tryGet(sessionId))
+    if (direct) return direct
+
+    const chain: Array<{ id: string; parentID: string; cwd: string }> = []
+    const seen = new Set<string>()
+    let currentID = sessionId
+
+    for (let depth = 0; depth < maxAncestryDepth; depth++) {
+      if (seen.has(currentID)) return undefined
+      seen.add(currentID)
+
+      const info = await this.fetchSdkSession(currentID, directory)
+      const parentID = info?.parentID
+      if (!parentID) return undefined
+
+      if (info) this.parentBySession.set(currentID, parentID)
+
+      chain.push({ id: currentID, parentID, cwd: info?.directory ?? "" })
+
+      const parent = await Effect.runPromise(this.session.tryGet(parentID))
+      if (parent) {
+        await this.registerChain(chain, parent.cwd)
+        return await Effect.runPromise(this.session.tryGet(sessionId))
+      }
+
+      currentID = parentID
+    }
+
+    return undefined
+  }
+
+  async registerChild(input: RegisterChildInput) {
+    await Effect.runPromise(
+      this.session.registerChild(input).pipe(Effect.catchTag("ACPSessionNotFoundError", () => Effect.void)),
+    )
+  }
+
+  private async fetchSdkSession(sessionId: string, directory?: string): Promise<SdkSessionInfo | undefined> {
+    const cachedParent = this.parentBySession.get(sessionId)
+    const data = await this.sdk.session
+      .get({ sessionID: sessionId, directory: directory ?? "" }, { throwOnError: false })
+      .then((response) => response.data)
+      .catch(() => undefined)
+
+    if (!data?.parentID && !cachedParent) return undefined
+
+    return {
+      id: data?.id ?? sessionId,
+      parentID: data?.parentID ?? cachedParent,
+      directory: data?.directory ?? "",
+    }
+  }
+
+  private async registerChain(chain: Array<{ id: string; parentID: string; cwd: string }>, fallbackCwd: string) {
+    for (const link of [...chain].reverse()) {
+      await this.registerChild({
+        sessionId: link.id,
+        parentSessionId: link.parentID,
+        cwd: link.cwd || fallbackCwd,
+      })
+    }
+  }
+}
+
+export async function resolveAcpSession(input: {
+  readonly sessionId: string
+  readonly session: ACPSession.Interface
+  readonly sdk: OpencodeClient
+  readonly directory?: string
+  readonly resolver?: SessionResolver
+}) {
+  const resolver = input.resolver ?? new SessionResolver(input.session, input.sdk)
+  return await resolver.resolve(input.sessionId, input.directory)
+}
+
+export * as ACPSessionResolve from "./session-resolve"

--- a/packages/opencode/src/acp/session.ts
+++ b/packages/opencode/src/acp/session.ts
@@ -22,6 +22,7 @@ export type KnownMessagePartMetadata = {
 
 export type Info = {
   id: string
+  rootSessionId: string
   cwd: string
   mcpServers: readonly McpServer[]
   createdAt: Date
@@ -33,6 +34,7 @@ export type Info = {
 
 export type StoreInput = {
   id: string
+  rootSessionId?: string
   cwd: string
   mcpServers?: readonly McpServer[]
   createdAt?: Date
@@ -58,12 +60,20 @@ export type PartMetadataLookupInput = {
   partId: string
 }
 
+export type RegisterChildInput = {
+  sessionId: string
+  parentSessionId: string
+  cwd?: string
+}
+
 export type Interface = {
   readonly create: (input: StoreInput) => Effect.Effect<Info>
   readonly load: (input: StoreInput) => Effect.Effect<Info>
   readonly list: (cwd?: string) => Effect.Effect<readonly Info[]>
   readonly get: (sessionId: string) => Effect.Effect<Info, ACPError.SessionNotFoundError>
   readonly tryGet: (sessionId: string) => Effect.Effect<Info | undefined>
+  readonly getRoot: (sessionId: string) => Effect.Effect<Info, ACPError.SessionNotFoundError>
+  readonly registerChild: (input: RegisterChildInput) => Effect.Effect<Info, ACPError.SessionNotFoundError>
   readonly remove: (sessionId: string) => Effect.Effect<Info | undefined>
   readonly setModel: (
     sessionId: string,
@@ -116,6 +126,12 @@ export const layer = Layer.effect(
       return yield* new ACPError.SessionNotFoundError({ sessionId })
     })
 
+    const getRoot: Interface["getRoot"] = Effect.fn("ACP.Session.getRoot")(function* (sessionId) {
+      const session = yield* get(sessionId)
+      if (session.rootSessionId === session.id) return session
+      return yield* get(session.rootSessionId)
+    })
+
     const update = Effect.fn("ACP.Session.update")(function* (sessionId: string, fn: (session: Info) => Info) {
       const result = yield* Ref.modify(sessions, (state) => {
         const session = state.get(sessionId)
@@ -133,9 +149,42 @@ export const layer = Layer.effect(
         if (!session) return [undefined, state] as const
         const next = new Map(state)
         next.delete(sessionId)
+        if (session.id === session.rootSessionId) {
+          for (const [id, item] of next.entries()) {
+            if (item.rootSessionId === sessionId && id !== sessionId) {
+              next.delete(id)
+            }
+          }
+        }
         return [snapshot(session), next] as const
       })
     })
+
+    const registerChild: Interface["registerChild"] = Effect.fn("ACP.Session.registerChild")((input) =>
+      Effect.gen(function* () {
+        const parent = yield* get(input.parentSessionId)
+        const existing = yield* tryGet(input.sessionId)
+        if (existing) {
+          if (existing.rootSessionId === parent.rootSessionId) return existing
+          return yield* update(input.sessionId, (session) => ({
+            ...session,
+            rootSessionId: parent.rootSessionId,
+            cwd: input.cwd ?? session.cwd,
+          }))
+        }
+
+        return yield* store({
+          id: input.sessionId,
+          cwd: input.cwd ?? parent.cwd,
+          createdAt: new Date(),
+          model: parent.model,
+          variant: parent.variant,
+          modeId: parent.modeId,
+          mcpServers: parent.mcpServers,
+          rootSessionId: parent.rootSessionId,
+        })
+      }),
+    )
 
     const setModel: Interface["setModel"] = Effect.fn("ACP.Session.setModel")((sessionId, model) =>
       update(sessionId, (session) => ({ ...session, model })),
@@ -170,12 +219,15 @@ export const layer = Layer.effect(
       load: store,
       list: Effect.fn("ACP.Session.list")(function* (cwd?: string) {
         return [...(yield* Ref.get(sessions)).values()]
+          .filter((session) => session.id === session.rootSessionId)
           .filter((session) => !cwd || session.cwd === cwd)
           .map(snapshot)
           .toSorted((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
       }),
       get,
       tryGet,
+      getRoot,
+      registerChild,
       remove,
       setModel,
       getModel: Effect.fn("ACP.Session.getModel")(function* (sessionId) {
@@ -205,6 +257,7 @@ export const defaultLayer = layer
 function makeSession(input: StoreInput): Info {
   return {
     id: input.id,
+    rootSessionId: input.rootSessionId ?? input.id,
     cwd: input.cwd,
     mcpServers: [...(input.mcpServers ?? [])],
     createdAt: input.createdAt ? new Date(input.createdAt) : new Date(),

--- a/packages/opencode/src/acp/tool.ts
+++ b/packages/opencode/src/acp/tool.ts
@@ -21,6 +21,7 @@ export type RunningToolState = {
   readonly status: "running"
   readonly input: ToolInput
   readonly title?: string
+  readonly metadata?: unknown
 }
 
 export type ErrorToolState = {
@@ -163,6 +164,7 @@ export function runningToolUpdate(input: {
     title: toolTitle(input.toolName, input.state.input, input.state.title),
     locations: toLocations(input.toolName, input.state.input, input.cwd),
     rawInput: rawInput(input.toolName, input.state.input, input.cwd),
+    ...(input.state.metadata !== undefined ? { rawOutput: { metadata: input.state.metadata } } : {}),
     ...(content ? { content } : {}),
   }
 }
@@ -180,6 +182,7 @@ export function duplicateRunningToolUpdate(input: {
     title: toolTitle(input.toolName, input.state.input, input.state.title),
     locations: toLocations(input.toolName, input.state.input, input.cwd),
     rawInput: rawInput(input.toolName, input.state.input, input.cwd),
+    ...(input.state.metadata !== undefined ? { rawOutput: { metadata: input.state.metadata } } : {}),
   }
 }
 

--- a/packages/opencode/test/acp/event.test.ts
+++ b/packages/opencode/test/acp/event.test.ts
@@ -538,6 +538,118 @@ describe("acp event routing", () => {
     expect(harness.updates[1]?.update).toMatchObject({ status: "in_progress", toolCallId: "call_1" })
   })
 
+  it("registers child task sessions and forwards their stream updates", async () => {
+    const harness = createHarness({
+      msg_child: assistantMessage("ses_child", "msg_child", "part_child", "text"),
+    })
+    await Effect.runPromise(harness.session.create({ id: "ses_root", cwd: "/workspace" }))
+
+    await harness.subscription.handle(
+      toolUpdated({
+        id: "part_call_task",
+        sessionID: "ses_root",
+        messageID: "msg_call_task",
+        type: "tool",
+        callID: "call_task",
+        tool: "task",
+        state: {
+          status: "running",
+          input: { description: "Run ps command" },
+          title: "Run ps command",
+          metadata: {
+            sessionId: "ses_child",
+            parentSessionId: "ses_root",
+          },
+          time: { start: Date.now() },
+        },
+      } satisfies ToolPart),
+    )
+
+    await harness.subscription.handle(partUpdated("ses_child", "msg_child", "part_child", "text"))
+    await harness.subscription.handle(textDelta("ses_child", "msg_child", "part_child", "hello child"))
+
+    const childUpdates = harness.updates.filter((item) => item.sessionId === "ses_child")
+    expect(harness.updates[1]?.update).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      rawOutput: { metadata: { sessionId: "ses_child", parentSessionId: "ses_root" } },
+    })
+    expect(childUpdates.at(-1)?.update).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "hello child" },
+    })
+  })
+
+  it("registers child sessions from session.created events", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_root", cwd: "/workspace" }))
+
+    await harness.subscription.handle({
+      id: "evt_created",
+      type: "session.created",
+      properties: {
+        sessionID: "ses_child",
+        info: {
+          id: "ses_child",
+          slug: "child",
+          projectID: "proj",
+          directory: "/workspace",
+          parentID: "ses_root",
+          title: "Child session",
+          version: "1",
+          time: { created: Date.now(), updated: Date.now() },
+        },
+      },
+    })
+
+    expect(await Effect.runPromise(harness.session.tryGet("ses_child"))).toMatchObject({
+      id: "ses_child",
+      rootSessionId: "ses_root",
+      cwd: "/workspace",
+    })
+  })
+
+  it("replays running task metadata and keeps child stream updates visible", async () => {
+    const harness = createHarness({
+      msg_child: assistantMessage("ses_child", "msg_child", "part_child", "text"),
+    })
+    await Effect.runPromise(harness.session.create({ id: "ses_root", cwd: "/workspace" }))
+
+    await harness.subscription.replayMessage(
+      assistantToolMessage({
+        id: "part_call_task",
+        sessionID: "ses_root",
+        messageID: "msg_call_task",
+        type: "tool",
+        callID: "call_task",
+        tool: "task",
+        state: {
+          status: "running",
+          input: { description: "Run ps command" },
+          title: "Run ps command",
+          metadata: {
+            sessionId: "ses_child",
+            parentSessionId: "ses_root",
+          },
+          time: { start: Date.now() },
+        },
+      } satisfies ToolPart),
+    )
+
+    await harness.subscription.handle(partUpdated("ses_child", "msg_child", "part_child", "text"))
+    await harness.subscription.handle(textDelta("ses_child", "msg_child", "part_child", "replayed child"))
+
+    expect(harness.updates.some((item) => item.sessionId === "ses_child")).toBe(true)
+    expect(
+      harness.updates
+        .filter((item) => item.sessionId === "ses_child")
+        .at(-1)
+        ?.update,
+    ).toMatchObject({
+      sessionUpdate: "agent_message_chunk",
+      content: { type: "text", text: "replayed child" },
+    })
+  })
+
   it("includes available input in the synthetic pending tool call", async () => {
     const harness = createHarness()
     await Effect.runPromise(harness.session.create({ id: "ses_pending_input", cwd: "/workspace" }))

--- a/packages/opencode/test/acp/permission.test.ts
+++ b/packages/opencode/test/acp/permission.test.ts
@@ -8,7 +8,9 @@ import type {
 import type { Event, OpencodeClient } from "@opencode-ai/sdk/v2"
 import { Effect, ManagedRuntime } from "effect"
 import { ACPEvent } from "@/acp/event"
+import { ACPPermission } from "@/acp/permission"
 import { ACPSession } from "@/acp/session"
+import { SessionResolver } from "@/acp/session-resolve"
 
 type PermissionEvent = Extract<Event, { type: "permission.asked" }>
 type PermissionReplyParams = Parameters<OpencodeClient["permission"]["reply"]>[0]
@@ -36,6 +38,7 @@ function makeSessionService() {
 function createHarness(
   requestPermission: (params: RequestPermissionRequest) => Promise<RequestPermissionResponse> = () =>
     Promise.resolve({ outcome: { outcome: "selected", optionId: "once" } }),
+  sdkSessionGet?: OpencodeClient["session"]["get"],
 ) {
   const replies: PermissionReplyParams[] = []
   const requests: RequestPermissionRequest[] = []
@@ -50,6 +53,8 @@ function createHarness(
     },
     session: {
       message: () => Promise.resolve({ data: undefined }),
+      get: (sdkSessionGet ??
+        (() => Promise.resolve({ data: undefined }))) as OpencodeClient["session"]["get"],
     },
   } as unknown as OpencodeClient
   const connection = {
@@ -197,6 +202,172 @@ describe("acp permissions", () => {
           patterns: ["/tmp/outside/*"],
         },
         locations: [{ path: "/tmp/outside" }],
+      },
+    })
+  })
+
+  it("routes child-session permission prompts through the root ACP session", async () => {
+    const harness = createHarness()
+    await createSession(harness.session, "ses_root")
+    await Effect.runPromise(
+      harness.session.registerChild({
+        sessionId: "ses_child",
+        parentSessionId: "ses_root",
+      }),
+    )
+
+    harness.subscription.handle(
+      permissionAsked("ses_child", "perm_child", {
+        metadata: { command: "ps aux" },
+        tool: { messageID: "msg_1", callID: "call_child" },
+      }),
+    )
+
+    await pollUntil(() => harness.replies.length === 1, "child permission was never replied")
+
+    expect(harness.requests[0]).toMatchObject({
+      sessionId: "ses_root",
+      toolCall: {
+        toolCallId: "call_child",
+        rawInput: { command: "ps aux", childSessionId: "ses_child" },
+      },
+    })
+    expect(harness.replies[0]).toEqual({ requestID: "perm_child", reply: "once", directory: "/workspace" })
+  })
+
+  it("auto-resolves child permissions through the SDK parent chain", async () => {
+    const harness = createHarness(undefined, ((input) =>
+      Promise.resolve({
+        data:
+          input.sessionID === "ses_child"
+            ? {
+                id: "ses_child",
+                parentID: "ses_root",
+                directory: "/workspace",
+              }
+            : undefined,
+      })) as OpencodeClient["session"]["get"])
+    await createSession(harness.session, "ses_root")
+
+    harness.subscription.handle(
+      permissionAsked("ses_child", "perm_resolved", {
+        metadata: { command: "ps aux" },
+        tool: { messageID: "msg_1", callID: "call_resolved" },
+      }),
+    )
+
+    await pollUntil(() => harness.replies.length === 1, "resolved child permission was never replied")
+
+    expect(harness.requests[0]).toMatchObject({
+      sessionId: "ses_root",
+      toolCall: {
+        toolCallId: "call_resolved",
+        rawInput: { command: "ps aux", childSessionId: "ses_child" },
+      },
+    })
+  })
+
+  it("routes concurrent child permission prompts from sibling subagents to the root session", async () => {
+    const harness = createHarness()
+    await createSession(harness.session, "ses_root")
+    await Effect.runPromise(
+      harness.session.registerChild({
+        sessionId: "ses_child_a",
+        parentSessionId: "ses_root",
+      }),
+    )
+    await Effect.runPromise(
+      harness.session.registerChild({
+        sessionId: "ses_child_b",
+        parentSessionId: "ses_root",
+      }),
+    )
+
+    harness.subscription.handle(
+      permissionAsked("ses_child_a", "perm_a", {
+        metadata: { command: "ps aux" },
+        tool: { messageID: "msg_a", callID: "call_a" },
+      }),
+    )
+    harness.subscription.handle(
+      permissionAsked("ses_child_b", "perm_b", {
+        metadata: { command: "ls" },
+        tool: { messageID: "msg_b", callID: "call_b" },
+      }),
+    )
+
+    await pollUntil(() => harness.requests.length === 2, "sibling child permissions were not both requested")
+    await pollUntil(() => harness.replies.length === 2, "sibling child permissions were not both replied")
+
+    expect(harness.requests.map((request) => request.sessionId)).toEqual(["ses_root", "ses_root"])
+    expect(harness.requests.map((request) => request.toolCall.rawInput)).toEqual([
+      { command: "ps aux", childSessionId: "ses_child_a" },
+      { command: "ls", childSessionId: "ses_child_b" },
+    ])
+  })
+
+  it("routes grandchild permission prompts through the root ACP session", async () => {
+    const session = makeSessionService()
+    await createSession(session, "ses_root")
+    const resolver = new SessionResolver(
+      session,
+      {
+        session: {
+          get: (input: { sessionID: string }) =>
+            Promise.resolve({
+              data:
+                input.sessionID === "ses_grandchild"
+                  ? {
+                      id: "ses_grandchild",
+                      parentID: "ses_child",
+                      directory: "/workspace",
+                    }
+                  : input.sessionID === "ses_child"
+                    ? {
+                        id: "ses_child",
+                        parentID: "ses_root",
+                        directory: "/workspace",
+                      }
+                    : undefined,
+            }),
+        },
+      } as unknown as OpencodeClient,
+    )
+    const replies: PermissionReplyParams[] = []
+    const requests: RequestPermissionRequest[] = []
+    const handler = new ACPPermission.Handler({
+      sdk: {
+        permission: {
+          reply: (params: PermissionReplyParams) => {
+            replies.push(params)
+            return Promise.resolve({ data: true })
+          },
+        },
+      } as unknown as OpencodeClient,
+      connection: {
+        requestPermission: (params: RequestPermissionRequest) => {
+          requests.push(params)
+          return Promise.resolve({ outcome: { outcome: "selected", optionId: "once" } })
+        },
+      },
+      session,
+      resolver,
+    })
+
+    handler.handle(
+      permissionAsked("ses_grandchild", "perm_grandchild", {
+        metadata: { command: "printf nested" },
+        tool: { messageID: "msg_gc", callID: "call_gc" },
+      }),
+    )
+
+    await pollUntil(() => replies.length === 1, "grandchild permission was never replied")
+
+    expect(requests[0]).toMatchObject({
+      sessionId: "ses_root",
+      toolCall: {
+        toolCallId: "call_gc",
+        rawInput: { command: "printf nested", childSessionId: "ses_grandchild" },
       },
     })
   })

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -13,9 +13,10 @@ import type {
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
-import { Effect } from "effect"
+import { Effect, ManagedRuntime } from "effect"
 import * as ACPService from "@/acp/service"
 import * as ACPError from "@/acp/error"
+import * as ACPSession from "@/acp/session"
 import { UsageService } from "@/acp/usage"
 import type { Provider } from "@/provider/provider"
 
@@ -375,6 +376,34 @@ describe("ACP service sessions", () => {
 
     expect(listed.sessions[0]?.sessionId).toBe(created.sessionId)
     expect(listed.sessions[0]?.cwd).toBe("/workspace")
+  })
+
+  it("does not list registered task child aliases in session/list", async () => {
+    const session = ManagedRuntime.make(ACPSession.defaultLayer).runSync(
+      ACPSession.Service.use((service) => Effect.succeed(service)),
+    )
+    await Effect.runPromise(session.create({ id: "ses_root", cwd: "/workspace" }))
+    await Effect.runPromise(
+      session.registerChild({
+        sessionId: "ses_child",
+        parentSessionId: "ses_root",
+      }),
+    )
+
+    const { service } = makeService()
+    const listed = await Effect.runPromise(
+      ACPService.make({
+        sdk: {
+          session: {
+            list: () => Promise.resolve({ data: [] }),
+          },
+        } as unknown as OpencodeClient,
+        connection: { sessionUpdate: () => Promise.resolve() },
+        session,
+      }).listSessions({ cwd: "/workspace" }),
+    )
+
+    expect(listed.sessions.map((item) => item.sessionId)).toEqual(["ses_root"])
   })
 
   it("lists all sessions with next cursor when the first page is full", async () => {

--- a/packages/opencode/test/acp/session-resolve.test.ts
+++ b/packages/opencode/test/acp/session-resolve.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2"
+import { Effect, ManagedRuntime } from "effect"
+import { SessionResolver } from "@/acp/session-resolve"
+import { ACPSession } from "@/acp/session"
+
+function makeSessionService() {
+  return ManagedRuntime.make(ACPSession.defaultLayer).runSync(
+    ACPSession.Service.use((service) => Effect.succeed(service)),
+  )
+}
+
+function sdkWithSessions(sessions: Record<string, { parentID?: string; directory?: string }>) {
+  return {
+    session: {
+      get: (input: { sessionID: string }) =>
+        Promise.resolve({
+          data: sessions[input.sessionID]
+            ? {
+                id: input.sessionID,
+                parentID: sessions[input.sessionID]?.parentID,
+                directory: sessions[input.sessionID]?.directory ?? "/workspace",
+              }
+            : undefined,
+        }),
+    },
+  } as unknown as OpencodeClient
+}
+
+describe("acp session resolve", () => {
+  it("registers unknown child sessions by walking the SDK parent chain", async () => {
+    const session = makeSessionService()
+    await Effect.runPromise(session.create({ id: "ses_root", cwd: "/workspace" }))
+    const resolver = new SessionResolver(session, sdkWithSessions({ ses_child: { parentID: "ses_root" } }))
+
+    const resolved = await resolver.resolve("ses_child")
+
+    expect(resolved).toMatchObject({
+      id: "ses_child",
+      rootSessionId: "ses_root",
+      cwd: "/workspace",
+    })
+    expect(await Effect.runPromise(session.getRoot("ses_child"))).toMatchObject({ id: "ses_root" })
+  })
+
+  it("registers nested grandchild sessions through the full ancestry chain", async () => {
+    const session = makeSessionService()
+    await Effect.runPromise(session.create({ id: "ses_root", cwd: "/workspace" }))
+    const resolver = new SessionResolver(
+      session,
+      sdkWithSessions({
+        ses_grandchild: { parentID: "ses_child" },
+        ses_child: { parentID: "ses_root" },
+      }),
+    )
+
+    const resolved = await resolver.resolve("ses_grandchild")
+
+    expect(resolved).toMatchObject({ id: "ses_grandchild", rootSessionId: "ses_root" })
+    expect(await Effect.runPromise(session.tryGet("ses_child"))).toMatchObject({ rootSessionId: "ses_root" })
+    expect(await Effect.runPromise(session.getRoot("ses_grandchild"))).toMatchObject({ id: "ses_root" })
+  })
+
+  it("returns undefined when the SDK parent chain contains a cycle", async () => {
+    const session = makeSessionService()
+    await Effect.runPromise(session.create({ id: "ses_root", cwd: "/workspace" }))
+    const resolver = new SessionResolver(
+      session,
+      sdkWithSessions({
+        ses_a: { parentID: "ses_b" },
+        ses_b: { parentID: "ses_a" },
+      }),
+    )
+
+    expect(await resolver.resolve("ses_a")).toBeUndefined()
+    expect(await Effect.runPromise(session.tryGet("ses_a"))).toBeUndefined()
+  })
+
+  it("invalidates cached parent lookups after session deletion", async () => {
+    const session = makeSessionService()
+    await Effect.runPromise(session.create({ id: "ses_root", cwd: "/workspace" }))
+    const resolver = new SessionResolver(session, sdkWithSessions({ ses_child: { parentID: "ses_root" } }))
+
+    await resolver.resolve("ses_child")
+    resolver.invalidate("ses_child")
+
+    const resolved = await resolver.resolve("ses_child")
+    expect(resolved).toMatchObject({ id: "ses_child", rootSessionId: "ses_root" })
+  })
+})

--- a/packages/opencode/test/acp/session.test.ts
+++ b/packages/opencode/test/acp/session.test.ts
@@ -40,6 +40,7 @@ describe("acp session state", () => {
 
       expect(created).toMatchObject({
         id: "ses_1",
+        rootSessionId: "ses_1",
         cwd: "/workspace",
         mcpServers: [mcpServer],
         model: model("anthropic", "claude-sonnet"),
@@ -195,6 +196,59 @@ describe("acp session state", () => {
       expect(removed?.knownParts.size).toBe(1)
       expect(missing).toBeUndefined()
       expect(missingPart).toBeUndefined()
+    }),
+  )
+
+  sessionTest.effect("registers child sessions against the root ACP session", () =>
+    Effect.gen(function* () {
+      yield* ACPSession.Service.use((session) => session.create({ id: "ses_root", cwd: "/workspace" }))
+      const child = yield* ACPSession.Service.use((session) =>
+        session.registerChild({
+          sessionId: "ses_child",
+          parentSessionId: "ses_root",
+        }),
+      )
+      const root = yield* ACPSession.Service.use((session) => session.getRoot("ses_child"))
+
+      expect(child.rootSessionId).toBe("ses_root")
+      expect(child.cwd).toBe("/workspace")
+      expect(root.id).toBe("ses_root")
+    }),
+  )
+
+  sessionTest.effect("lists only root sessions and omits registered child aliases", () =>
+    Effect.gen(function* () {
+      yield* ACPSession.Service.use((session) => session.create({ id: "ses_root", cwd: "/workspace" }))
+      yield* ACPSession.Service.use((session) =>
+        session.registerChild({
+          sessionId: "ses_child",
+          parentSessionId: "ses_root",
+        }),
+      )
+
+      const listed = yield* ACPSession.Service.use((session) => session.list("/workspace"))
+
+      expect(listed.map((item) => item.id)).toEqual(["ses_root"])
+    }),
+  )
+
+  sessionTest.effect("removing a root session clears registered child aliases", () =>
+    Effect.gen(function* () {
+      yield* ACPSession.Service.use((session) => session.create({ id: "ses_root", cwd: "/workspace" }))
+      yield* ACPSession.Service.use((session) =>
+        session.registerChild({
+          sessionId: "ses_child",
+          parentSessionId: "ses_root",
+        }),
+      )
+
+      yield* ACPSession.Service.use((session) => session.remove("ses_root"))
+
+      const missingRoot = yield* ACPSession.Service.use((session) => session.tryGet("ses_root"))
+      const missingChild = yield* ACPSession.Service.use((session) => session.tryGet("ses_child"))
+
+      expect(missingRoot).toBeUndefined()
+      expect(missingChild).toBeUndefined()
     }),
   )
 })

--- a/packages/opencode/test/acp/tool.test.ts
+++ b/packages/opencode/test/acp/tool.test.ts
@@ -5,6 +5,7 @@ import {
   completedToolRawOutput,
   extractImageAttachments,
   imageContents,
+  runningToolUpdate,
   shellOutputSnapshot,
   toLocations,
   toToolKind,
@@ -213,5 +214,22 @@ describe("acp tool conversion", () => {
     expect(shellOutputSnapshot({ metadata: { output: "line 1\nline 2" } })).toBe("line 1\nline 2")
     expect(shellOutputSnapshot({ metadata: { output: 42 } })).toBeUndefined()
     expect(shellOutputSnapshot({ metadata: undefined })).toBeUndefined()
+  })
+
+  test("includes running tool metadata in rawOutput", () => {
+    expect(
+      runningToolUpdate({
+        toolCallId: "call_task",
+        toolName: "task",
+        state: {
+          status: "running",
+          input: { description: "Run ps command" },
+          title: "Run ps command",
+          metadata: { sessionId: "ses_child", parentSessionId: "ses_root" },
+        },
+      }),
+    ).toMatchObject({
+      rawOutput: { metadata: { sessionId: "ses_child", parentSessionId: "ses_root" } },
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Register task/subagent child sessions in the ACP session store via `session.created`, task metadata, and SDK `parentID` ancestry resolution.
- Forward child text streams and tool updates to ACP clients using the child `sessionId`, while exposing running task `rawOutput.metadata` for card-to-child mapping.
- Route child `permission.asked` events to the root ACP session (`requestPermission` on root + `childSessionId` in `rawInput`), keeping per-leaf permission queues.
- Keep `session/list` root-only so registered child aliases do not pollute `listSessions`.

Closes #32388

## Design notes

- Compared to #21801, this keeps child `sessionUpdate` on the child session id so clients can inspect subagent activity in real time.
- Permission routing aligns with the direction in #30639, but also covers child stream/tool visibility and running task metadata.

## Test plan

- [x] `bun test test/acp/` (135 tests)
- [x] `bun test test/cli/acp/` (15 tests)
- [x] `bun run typecheck`
- [ ] Manual: `opencode acp` + client, prompt `起一个Subagent执行 ps aux`, verify child stream visible and permission appears on root session


Made with [Cursor](https://cursor.com)