### PR TITLE
fix(session): stop retaining full file-diff patch text in summaries

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -122,17 +122,38 @@ export const layer = Layer.effect(
       const target = messages.find((m) => m.info.id === input.messageID)
       if (!target || target.info.role !== "user") return
       const msgDiffs = yield* computeDiff({ messages })
-      target.info.summary = { ...target.info.summary, diffs: msgDiffs }
+      // Store only lightweight diff metadata (file/status/line counts), NOT the
+      // full per-file `patch` text. The patch text is the heavy part - on a long
+      // session that repeatedly edits the same large file it accumulated one
+      // full-file-content copy per turn in the in-memory message list (and in
+      // the synced session_diff state), driving multi-GB heap growth. The full
+      // patch is reconstructable on demand from the git-backed snapshots, which
+      // `diff()` below now does. Aggregate counts are preserved for the summary.
+      const summarized = msgDiffs.map(({ patch: _patch, ...rest }) => rest)
+      target.info.summary = {
+        ...target.info.summary,
+        additions: summarized.reduce((acc, d) => acc + d.additions, 0),
+        deletions: summarized.reduce((acc, d) => acc + d.deletions, 0),
+        files: summarized.length,
+        diffs: summarized,
+      }
       yield* sessions.updateMessage(target.info)
     })
 
     const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {
       if (!input.messageID) return []
-      const message = (yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
-        (item) => item.info.id === input.messageID,
-      )
+      const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
+      const message = all.find((item) => item.info.id === input.messageID)
       if (!message || message.info.role !== "user") return []
-      const diffs = message.info.summary?.diffs ?? []
+      // Recompute full diffs (with patch text) on demand so the heavy content is
+      // only materialized when a client actually requests it, not retained for
+      // the session's lifetime. Falls back to any stored diffs if recomputation
+      // yields nothing (e.g. legacy/imported sessions whose snapshots are gone).
+      const messages = all.filter(
+        (m) => m.info.id === input.messageID || (m.info.role === "assistant" && m.info.parentID === input.messageID),
+      )
+      let diffs = yield* computeDiff({ messages })
+      if (diffs.length === 0) diffs = message.info.summary?.diffs ?? []
       return diffs.map((item) => {
         if (item.file === undefined) return item
         const file = unquoteGitPath(item.file)

--- a/packages/opencode/test/session/summary-memory.test.ts
+++ b/packages/opencode/test/session/summary-memory.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { Session } from "@/session/session"
+import { SessionSummary } from "../../src/session/summary"
+import { Snapshot } from "../../src/snapshot"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+
+const env = Layer.mergeAll(
+  Session.defaultLayer,
+  SessionSummary.defaultLayer,
+  Snapshot.defaultLayer,
+  CrossSpawnSpawner.defaultLayer,
+)
+
+const it = testEffect(env)
+
+const tokens = { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
+
+// A large, unique file body so any retained full-text patch is unmistakable.
+const BIG = Array.from({ length: 4000 }, (_, i) => `line ${i} ${"x".repeat(40)}`).join("\n")
+
+describe("session summary memory retention", () => {
+  it.live(
+    "does not retain full patch text in stored summary diffs, but diff() still returns it",
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const summary = yield* SessionSummary.Service
+          const snapshot = yield* Snapshot.Service
+
+          yield* Effect.promise(() => fs.writeFile(path.join(dir, "big.txt"), "seed\n"))
+
+          const info = yield* session.create({})
+          const sid = info.id as SessionID
+
+          const u = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "user" as const,
+            sessionID: sid,
+            agent: "default",
+            model: { providerID: ProviderV2.ID.make("openai"), modelID: ModelV2.ID.make("gpt-4") },
+            time: { created: Date.now() },
+          })
+
+          const a = yield* session.updateMessage({
+            id: MessageID.ascending(),
+            role: "assistant" as const,
+            sessionID: sid,
+            mode: "default",
+            agent: "default",
+            path: { cwd: dir, root: dir },
+            cost: 0,
+            tokens,
+            modelID: ModelV2.ID.make("gpt-4"),
+            providerID: ProviderV2.ID.make("openai"),
+            parentID: u.id,
+            time: { created: Date.now() },
+            finish: "end_turn",
+          })
+
+          const before = yield* snapshot.track()
+          if (!before) throw new Error("expected before snapshot")
+          yield* Effect.promise(() => fs.writeFile(path.join(dir, "big.txt"), BIG))
+          const after = yield* snapshot.track()
+          if (!after) throw new Error("expected after snapshot")
+
+          yield* session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "step-start" as const,
+            snapshot: before,
+          })
+          yield* session.updatePart({
+            id: PartID.ascending(),
+            messageID: a.id,
+            sessionID: sid,
+            type: "step-finish" as const,
+            reason: "stop",
+            snapshot: after,
+            cost: 0,
+            tokens,
+          })
+
+          yield* summary.summarize({ sessionID: sid, messageID: u.id })
+
+          // Re-read the persisted/hydrated message to inspect what is RETAINED.
+          const messages = yield* session.messages({ sessionID: sid })
+          const target = messages.find((m) => m.info.id === u.id)
+          if (!target || target.info.role !== "user") throw new Error("no user message")
+          const stored = target.info.summary?.diffs ?? []
+
+          // The fix: stored diffs carry metadata but NOT the heavy patch text.
+          expect(stored.length).toBeGreaterThan(0)
+          for (const d of stored) {
+            expect(d.patch).toBeUndefined()
+          }
+          // Aggregate counts still computed.
+          expect(target.info.summary?.files).toBe(stored.length)
+
+          // But diff() still reconstructs full patch text on demand.
+          const onDemand = yield* summary.diff({ sessionID: sid, messageID: u.id })
+          expect(onDemand.length).toBeGreaterThan(0)
+          const withText = onDemand.filter((d) => typeof d.patch === "string" && d.patch.length > 0)
+          expect(withText.length).toBeGreaterThan(0)
+        }),
+      { git: true },
+    ),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #17622

Related: #20695 (Memory Megathread), #29730 (OOM: message history accumulation), #24445

### Type of change

- [x] Bug fix

### What does this PR do?

`SessionSummary.summarize()` stored the full per-file diff produced by `Snapshot.diffFull()` — including the complete `patch` text — onto `target.info.summary.diffs`, which is persisted into `message.data` and kept in the hydrated in-memory message list. On a session that repeatedly edits the same large file, each turn appends another full-file-content copy, so memory (and `message.data`) grows roughly linearly with edits, and reopening rehydrates all of it (#17622, and the symptoms in #24445 / #20695).

This changes `summarize()` to store only lightweight diff metadata (`file`, `status`, `additions`, `deletions`) and strip the heavy `patch` text. The aggregate `additions`/`deletions`/`files` counts are still computed. `diff()` now recomputes the full diff (with patch text) on demand via the existing `computeDiff()` path, so the diff viewer still gets full content when a client actually requests it — it just isn't retained for the session's lifetime. The full patch is always reconstructable from the git-backed snapshots, so storing it was redundant.

There's a fallback in `diff()` to the stored diffs when recomputation yields nothing, so legacy/imported sessions whose snapshots are gone still return whatever metadata they have.

### How did you verify your code works?

- Added `test/session/summary-memory.test.ts`: edits a 4000-line file across a turn, then asserts the stored `summary.diffs` carries no `patch` text (with correct file count) while `diff()` still returns full patch text on demand. It passes with the change and fails without it.
- Existing `test/session/{revert-compact,session}.test.ts` and `test/snapshot/snapshot.test.ts` still pass (66 tests).
- Ran a real TUI session from source and captured a heap snapshot before/after: the baseline retained 8 copies of the same ~2.7 MB file diff; after the change, 0 file-diff text is retained (only normal static assets remain).

### Screenshots / recordings

_N/A (no UI change; diff viewer output is unchanged)._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
