### PR TITLE
fix(core): tolerate legacy workspace migrations

### DIFF
--- a/packages/core/src/database/migration/20260410174513_workspace-name.ts
+++ b/packages/core/src/database/migration/20260410174513_workspace-name.ts
@@ -5,6 +5,12 @@ export default {
   id: "20260410174513_workspace-name",
   up(tx) {
     return Effect.gen(function* () {
+      const columns = yield* tx.all<{ name: string }>(`PRAGMA table_info(\`workspace\`)`)
+      const names = new Set(columns.map((column) => column.name))
+      const selectName = names.has("name") ? "`name`" : "''"
+      const selectDirectory = names.has("directory") ? "`directory`" : "NULL"
+      const selectExtra = names.has("extra") ? "`extra`" : "NULL"
+
       yield* tx.run(`PRAGMA foreign_keys=OFF;`)
       yield* tx.run(`
         CREATE TABLE \`__new_workspace\` (
@@ -19,7 +25,7 @@ export default {
         );
       `)
       yield* tx.run(
-        `INSERT INTO \`__new_workspace\`(\`id\`, \`type\`, \`branch\`, \`name\`, \`directory\`, \`extra\`, \`project_id\`) SELECT \`id\`, \`type\`, \`branch\`, \`name\`, \`directory\`, \`extra\`, \`project_id\` FROM \`workspace\`;`,
+        `INSERT INTO \`__new_workspace\`(\`id\`, \`type\`, \`branch\`, \`name\`, \`directory\`, \`extra\`, \`project_id\`) SELECT \`id\`, \`type\`, \`branch\`, ${selectName}, ${selectDirectory}, ${selectExtra}, \`project_id\` FROM \`workspace\`;`,
       )
       yield* tx.run(`DROP TABLE \`workspace\`;`)
       yield* tx.run(`ALTER TABLE \`__new_workspace\` RENAME TO \`workspace\`;`)

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -9,6 +9,7 @@ import { eq, inArray, sql } from "drizzle-orm"
 import { DatabaseMigration } from "@opencode-ai/core/database/migration"
 import { migrations } from "@opencode-ai/core/database/migration.gen"
 import sessionUsageMigration from "@opencode-ai/core/database/migration/20260510033149_session_usage"
+import workspaceNameMigration from "@opencode-ai/core/database/migration/20260410174513_workspace-name"
 import normalizeStoragePathsMigration from "@opencode-ai/core/database/migration/20260601010001_normalize_storage_paths"
 import sessionMessageProjectionOrderMigration from "@opencode-ai/core/database/migration/20260603040000_session_message_projection_order"
 import eventSourcedSessionInputMigration from "@opencode-ai/core/database/migration/20260604172448_event_sourced_session_input"
@@ -222,6 +223,43 @@ describe("DatabaseMigration", () => {
           expect.objectContaining({ name: "session_input_session_promoted_seq_idx", unique: 1 }),
           expect.objectContaining({ name: "session_input_session_admitted_seq_idx", unique: 1 }),
         ])
+      }),
+    )
+  })
+
+  test("defaults missing workspace names during legacy workspace rebuild", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`
+          CREATE TABLE workspace (
+            id text PRIMARY KEY,
+            type text NOT NULL,
+            branch text,
+            directory text,
+            extra text,
+            project_id text NOT NULL
+          )
+        `)
+        yield* db.run(sql`
+          INSERT INTO workspace (id, type, branch, directory, extra, project_id)
+          VALUES ('wrk_legacy', 'remote', 'main', '/repo', '{}', 'proj_legacy')
+        `)
+
+        yield* DatabaseMigration.applyOnly(db, [workspaceNameMigration])
+
+        expect(yield* db.get(sql`SELECT id, type, branch, name, directory, extra, project_id FROM workspace`)).toEqual({
+          id: "wrk_legacy",
+          type: "remote",
+          branch: "main",
+          name: "",
+          directory: "/repo",
+          extra: "{}",
+          project_id: "proj_legacy",
+        })
+        expect(yield* db.get(sql`SELECT dflt_value FROM pragma_table_info('workspace') WHERE name = 'name'`)).toEqual(
+          { dflt_value: "''" },
+        )
       }),
     )
   })


### PR DESCRIPTION
### Issue for this PR

Closes #32430

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes `20260410174513_workspace-name` tolerate older `workspace` table shapes that do not have a `name` column yet. The migration now inspects the existing columns before rebuilding the table and copies `''` for missing names while preserving existing `directory` and `extra` values when present.

This fixes upgrades that currently stop with `no such column: name`.

Repro: https://github.com/neriousy/opencode-workspace-migration-repro

The repro includes copied opencode migration file versions under `opencode-migrations/` and executes the copied `20260410174513_workspace-name/migration.sql` for the failing case.

Suspected origin:

- `7f37acdaaa89b358fb795ccd006d37ed7fa6672e` (`feat(core): rework workspace integration and adaptor interface`, package version `1.2.16`) added `20260303231226_add_workspace_fields/migration.sql`, which normally adds nullable `workspace.name`.
- `bf50d1c028e973ccc0beffdf568fca417b62f020` (`feat(core): expose workspace adaptors to plugins`, package version `1.4.3`) added `20260410174513_workspace-name/migration.sql`, whose copy step assumes `workspace.name` already exists.
- `7f571d36ea56cc3dd7059cfe82c729fb52b121eb` (`refactor(core): move database schema ownership`, package version `1.15.13`) moved the migration into `packages/core/src/database/migration/20260410174513_workspace-name.ts` with the same `SELECT name` assumption. Builds containing this path can surface the older assumption during upgrade.
- Proposed fix is mirrored in the repro at `opencode-migrations/20260410174513_workspace-name/proposed-fix.ts`.

### How did you verify your code works?

- Ran `bun test test/database-migration.test.ts` from `packages/core`
- Ran `bun typecheck` from `packages/core`
- Push hook ran repo-wide `bun turbo typecheck` successfully
- Ran `bun run repro` from `opencode-workspace-migration-repro`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
