### PR TITLE
docs: correct plugin cache path to packages dir

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -45,7 +45,7 @@ Browse available plugins in the [ecosystem](/docs/ecosystem#plugins).
 
 ### How plugins are installed
 
-**npm plugins** are installed automatically using Bun at startup. Packages and their dependencies are cached in `~/.cache/opencode/node_modules/`.
+**npm plugins** are installed automatically using Bun at startup. Packages and their dependencies are cached in `~/.cache/opencode/packages/`.
 
 **Local plugins** are loaded directly from the plugin directory. To use external packages, you must create a `package.json` within your config directory (see [Dependencies](#dependencies)), or publish the plugin to npm and [add it to your config](/docs/config#plugins).
 


### PR DESCRIPTION
### Issue for this PR

Closes #32421

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The plugins doc says npm plugins are cached in `~/.cache/opencode/node_modules/`, but the installer actually writes them to `~/.cache/opencode/packages/` (`path.join(global.cache, "packages", sanitize(pkg))` in `packages/core/src/npm.ts`). The `node_modules/` directory doesn't exist on current installs, so people can't find where their plugins landed. This updates the documented path to match the code.

Only the English source (`plugins.mdx`) is changed; the locale copies are regenerated by the i18n sync, so editing translations by hand would be churn.

### How did you verify your code works?

Traced the install target in `packages/core/src/npm.ts` and confirmed plugins install under `~/.cache/opencode/packages/<pkg>`, and that no `node_modules/` dir is created there. Docs-only change, no runtime code touched.

### Screenshots / recordings

_N/A — docs only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
