### PR TITLE
fix(tui): simplify timeline selection to prevent accidental message revert

### DIFF
--- a/packages/tui/src/routes/session/dialog-timeline.tsx
+++ b/packages/tui/src/routes/session/dialog-timeline.tsx
@@ -3,7 +3,6 @@ import { useSync } from "../../context/sync"
 import { DialogSelect, type DialogSelectOption } from "../../ui/dialog-select"
 import type { TextPart } from "@opencode-ai/sdk/v2"
 import { Locale } from "../../util/locale"
-import { DialogMessage } from "./dialog-message"
 import { useDialog } from "../../ui/dialog"
 import type { PromptInfo } from "../../component/prompt/history"
 
@@ -33,9 +32,7 @@ export function DialogTimeline(props: {
         value: message.id,
         footer: Locale.time(message.time.created),
         onSelect: (dialog) => {
-          dialog.replace(() => (
-            <DialogMessage messageID={message.id} sessionID={props.sessionID} setPrompt={props.setPrompt} />
-          ))
+          dialog.clear()
         },
       })
     }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When selecting a message in the Timeline dialog, the previous behavior would immediately open a sub-dialog with Revert/Copy/Fork actions, which was easy to trigger accidentally (heppened to me several times).

This change modifies the onSelect callback to call dialog.clear() instead of dialog.replace(), so selecting a message simply closes the Timeline dialog. The message still scrolls into view via the onMove callback, but no sub-dialog appears.

Also removes the unused DialogMessage import.


**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
tested on my own machine(see the screen record).

### Screenshots / recordings

https://github.com/user-attachments/assets/7df83dbb-27ce-445c-9c10-982d5d3cf062

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
