### PR TITLE
fix(cli): avoid spinner escape spam on plugin install in non-TTY

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -1,3 +1,5 @@
+import { EOL } from "os"
+
 import { intro, log, outro, spinner } from "@clack/prompts"
 import { Effect } from "effect"
 
@@ -44,8 +46,21 @@ export type PlugCtx = {
   directory: string
 }
 
+// The clack spinner relies on carriage returns and ANSI escape sequences to
+// animate in place. In a non-TTY (CI, subprocess, PowerShell pipe) those are
+// not interpreted, so every frame lands on its own line. Fall back to plain
+// static text when stdout is not a terminal.
+function staticSpinner(): Spin {
+  return {
+    start: (msg) => process.stdout.write(msg + EOL),
+    stop: (msg) => {
+      if (msg) process.stdout.write(msg + EOL)
+    },
+  }
+}
+
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => (process.stdout.isTTY ? spinner() : staticSpinner()),
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),


### PR DESCRIPTION
### Issue for this PR

Closes #27908

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode plugin install` uses the clack spinner, which animates by emitting carriage returns and ANSI escape sequences. In a non-TTY environment (CI, a subprocess, a piped PowerShell session) those control characters are not interpreted, so every animation frame is printed on its own line with `Installing plugin package...` repeated.

This guards the default spinner factory with a `process.stdout.isTTY` check (the same approach already used in `cli/ui.ts`). When stdout is not a terminal it falls back to a static spinner that writes the start/stop message once as plain text, with no escape sequences. TTY behavior is unchanged.

### How did you verify your code works?

- `bun typecheck` passes.
- `bun test test/plugin/install.test.ts` -> 21 pass.
- The change is confined to `defaultPlugDeps`; the existing tests inject their own spinner via `PlugDeps`, so production behavior is the only thing affected and the test surface is unchanged.

### Screenshots / recordings

_N/A - CLI output change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
