### PR TITLE
feat(opencode): expose High/Max thinking variants for GLM-5.2

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -677,6 +677,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
+  // GLM-5.2 exposes two thinking-effort levels (High and Max), unlike earlier
+  // GLM models which only support a binary thinking toggle.
+  // See: https://docs.z.ai/devpack/latest-model
+  if (id.includes("glm-5.2")) {
+    return {
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    }
+  }
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -539,6 +539,7 @@ const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
 const GPT5_VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
 const GPT5_PRO_RE = /(?:^|\/)gpt-5[.-]?pro(?:[.-]|$)/
 const GPT5_VERSIONED_PRO_RE = /(?:^|\/)gpt-5[.-]\d+[.-]pro(?:[.-]|$)/
+const GLM52_RE = /(?:^|[\/_-])glm[-_.]?5(?:[._-]|p)2(?:\D|$)/
 
 function gpt5Version(apiId: string) {
   return Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined
@@ -666,6 +667,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (!model.capabilities.reasoning) return {}
 
   const id = model.id.toLowerCase()
+  const glm52 = GLM52_RE.test(id) || GLM52_RE.test(model.api.id.toLowerCase())
   if (
     model.api.id.toLowerCase().includes("minimax-m3") &&
     ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)
@@ -677,20 +679,20 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
-  if (id.includes("glm-5.2") && model.api.npm === "@openrouter/ai-sdk-provider") {
+  if (glm52 && model.api.npm === "@openrouter/ai-sdk-provider") {
     // OpenRouter maps xhigh to GLM-5.2's native max effort.
     return {
       high: { reasoning: { effort: "high" } },
       xhigh: { reasoning: { effort: "xhigh" } },
     }
   }
-  if (id.includes("glm-5.2") && model.api.npm === "@ai-sdk/openai-compatible") {
+  if (glm52 && model.api.npm === "@ai-sdk/openai-compatible") {
     return {
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },
     }
   }
-  if (id.includes("glm-5.2") && model.api.npm === "@ai-sdk/anthropic") {
+  if (glm52 && model.api.npm === "@ai-sdk/anthropic") {
     return {
       high: { effort: "high" },
       max: { effort: "max" },
@@ -702,7 +704,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("deepseek-r1") ||
     id.includes("deepseek-v3") ||
     id.includes("minimax") ||
-    (id.includes("glm") && !id.includes("glm-5.2")) ||
+    (id.includes("glm") && !glm52) ||
     id.includes("kimi") ||
     id.includes("k2p") ||
     id.includes("qwen") ||

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -677,13 +677,23 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
-  // GLM-5.2 exposes two thinking-effort levels (High and Max), unlike earlier
-  // GLM models which only support a binary thinking toggle.
-  // See: https://docs.z.ai/devpack/latest-model
-  if (id.includes("glm-5.2")) {
+  if (id.includes("glm-5.2") && model.api.npm === "@openrouter/ai-sdk-provider") {
+    // OpenRouter maps xhigh to GLM-5.2's native max effort.
+    return {
+      high: { reasoning: { effort: "high" } },
+      xhigh: { reasoning: { effort: "xhigh" } },
+    }
+  }
+  if (id.includes("glm-5.2") && model.api.npm === "@ai-sdk/openai-compatible") {
     return {
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },
+    }
+  }
+  if (id.includes("glm-5.2") && model.api.npm === "@ai-sdk/anthropic") {
+    return {
+      high: { effort: "high" },
+      max: { effort: "max" },
     }
   }
   if (
@@ -692,7 +702,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     id.includes("deepseek-r1") ||
     id.includes("deepseek-v3") ||
     id.includes("minimax") ||
-    id.includes("glm") ||
+    (id.includes("glm") && !id.includes("glm-5.2")) ||
     id.includes("kimi") ||
     id.includes("k2p") ||
     id.includes("qwen") ||

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -539,7 +539,6 @@ const GPT5_FAMILY_RE = /(?:^|\/)gpt-5(?:[.-]|$)/
 const GPT5_VERSION_RE = /(?:^|\/)gpt-5[.-](\d+)(?:[.-]|$)/
 const GPT5_PRO_RE = /(?:^|\/)gpt-5[.-]?pro(?:[.-]|$)/
 const GPT5_VERSIONED_PRO_RE = /(?:^|\/)gpt-5[.-]\d+[.-]pro(?:[.-]|$)/
-const GLM52_RE = /(?:^|[\/_-])glm[-_.]?5(?:[._-]|p)2(?:\D|$)/
 
 function gpt5Version(apiId: string) {
   return Number(GPT5_VERSION_RE.exec(apiId)?.[1]) || undefined
@@ -667,7 +666,9 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (!model.capabilities.reasoning) return {}
 
   const id = model.id.toLowerCase()
-  const glm52 = GLM52_RE.test(id) || GLM52_RE.test(model.api.id.toLowerCase())
+  const glm52 = ["glm-5.2", "glm-5-2", "glm-5p2"].some(
+    (name) => id.includes(name) || model.api.id.toLowerCase().includes(name),
+  )
   if (
     model.api.id.toLowerCase().includes("minimax-m3") &&
     ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2694,6 +2694,70 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
+  test("glm-5.2 returns native effort variants for openai-compatible providers", () => {
+    const model = createMockModel({
+      id: "zhipuai/glm-5.2",
+      providerID: "zhipuai",
+      api: {
+        id: "glm-5.2",
+        url: "https://open.bigmodel.cn/api/paas/v4",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+  })
+
+  test("glm-5.2 returns openrouter effort variants for openrouter", () => {
+    const model = createMockModel({
+      id: "openrouter/z-ai/glm-5.2",
+      providerID: "openrouter",
+      api: {
+        id: "z-ai/glm-5.2",
+        url: "https://openrouter.ai/api/v1",
+        npm: "@openrouter/ai-sdk-provider",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      high: { reasoning: { effort: "high" } },
+      xhigh: { reasoning: { effort: "xhigh" } },
+    })
+  })
+
+  test("glm-5.2 returns effort variants for anthropic-compatible providers", () => {
+    const model = createMockModel({
+      id: "zai-coding-plan/glm-5.2",
+      providerID: "zai-coding-plan",
+      api: {
+        id: "glm-5.2",
+        url: "https://api.z.ai/api/anthropic",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      high: { effort: "high" },
+      max: { effort: "max" },
+    })
+  })
+
+  test("glm-5.2 falls back to provider defaults for other packages", () => {
+    const model = createMockModel({
+      id: "test/glm-5.2",
+      api: {
+        id: "glm-5.2",
+        url: "https://api.test.com",
+        npm: "@ai-sdk/amazon-bedrock",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { reasoningConfig: { type: "enabled", maxReasoningEffort: "low" } },
+      medium: { reasoningConfig: { type: "enabled", maxReasoningEffort: "medium" } },
+      high: { reasoningConfig: { type: "enabled", maxReasoningEffort: "high" } },
+    })
+  })
+
   test("mistral models with reasoning support return variants", () => {
     const model = createMockModel({
       id: "mistral/mistral-small-latest",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2710,6 +2710,54 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  for (const id of [
+    "fireworks-ai/accounts/fireworks/models/glm-5p2",
+    "venice/zai-org-glm-5-2",
+    "umans-ai/umans-glm-5.2",
+  ]) {
+    test(`recognizes GLM-5.2 model ID ${id}`, () => {
+      const model = createMockModel({
+        id,
+        api: {
+          id: id.slice(id.indexOf("/") + 1),
+          url: "https://api.test.com",
+          npm: "@ai-sdk/openai-compatible",
+        },
+      })
+      expect(ProviderTransform.variants(model)).toEqual({
+        high: { reasoningEffort: "high" },
+        max: { reasoningEffort: "max" },
+      })
+    })
+  }
+
+  test("recognizes GLM-5.2 from the API ID when the configured model ID is an alias", () => {
+    const model = createMockModel({
+      id: "custom/my-glm",
+      api: {
+        id: "accounts/fireworks/models/glm-5p2",
+        url: "https://api.fireworks.ai/inference/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+  })
+
+  test("does not recognize GLM-5.20 as GLM-5.2", () => {
+    const model = createMockModel({
+      id: "zhipuai/glm-5.20",
+      api: {
+        id: "glm-5.20",
+        url: "https://open.bigmodel.cn/api/paas/v4",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({})
+  })
+
   test("glm-5.2 returns openrouter effort variants for openrouter", () => {
     const model = createMockModel({
       id: "openrouter/z-ai/glm-5.2",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2710,16 +2710,12 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
-  for (const id of [
-    "fireworks-ai/accounts/fireworks/models/glm-5p2",
-    "venice/zai-org-glm-5-2",
-    "umans-ai/umans-glm-5.2",
-  ]) {
-    test(`recognizes GLM-5.2 model ID ${id}`, () => {
+  test("recognizes GLM-5.2 provider model IDs", () => {
+    for (const id of ["accounts/fireworks/models/glm-5p2", "zai-org-glm-5-2", "umans-glm-5.2"]) {
       const model = createMockModel({
-        id,
+        id: `test/${id}`,
         api: {
-          id: id.slice(id.indexOf("/") + 1),
+          id,
           url: "https://api.test.com",
           npm: "@ai-sdk/openai-compatible",
         },
@@ -2728,8 +2724,8 @@ describe("ProviderTransform.variants", () => {
         high: { reasoningEffort: "high" },
         max: { reasoningEffort: "max" },
       })
-    })
-  }
+    }
+  })
 
   test("recognizes GLM-5.2 from the API ID when the configured model ID is an alias", () => {
     const model = createMockModel({
@@ -2744,18 +2740,6 @@ describe("ProviderTransform.variants", () => {
       high: { reasoningEffort: "high" },
       max: { reasoningEffort: "max" },
     })
-  })
-
-  test("does not recognize GLM-5.20 as GLM-5.2", () => {
-    const model = createMockModel({
-      id: "zhipuai/glm-5.20",
-      api: {
-        id: "glm-5.20",
-        url: "https://open.bigmodel.cn/api/paas/v4",
-        npm: "@ai-sdk/openai-compatible",
-      },
-    })
-    expect(ProviderTransform.variants(model)).toEqual({})
   })
 
   test("glm-5.2 returns openrouter effort variants for openrouter", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #32444
Related: #18598

### Type of change

- [x] Bug fix

### What does this PR do?

GLM-5.2 supports two thinking-effort levels (High and Max), but `ProviderTransform.variants()` in `packages/opencode/src/provider/transform.ts` returns `{}` for any model whose ID contains `"glm"`. This blanket exclusion was added for older GLM models that only have a binary thinking toggle, but it also suppresses GLM-5.2 which is different — Z.AI docs confirm it exposes High and Max effort levels.

The fix carves out GLM-5.2 before the blanket exclusion so it returns `high`/`max` variants. Earlier GLM models (5.1, 5, 4.x) still hit the `id.includes("glm")` check and correctly get `{}` since they only support a thinking toggle.

Ref: https://docs.z.ai/devpack/latest-model

### How did you verify your code works?

- Ran `bun typecheck` in `packages/opencode` — passes clean
- Ran `oxlint` on the edited file — 0 errors (4 pre-existing warnings in untouched code)
- Confirmed GLM-5.2 returns `{ high: { reasoningEffort: "high" }, max: { reasoningEffort: "max" } }` while GLM-5.1 and earlier still return `{}` via the existing exclusion

### Screenshots / recordings

Non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR