### PR TITLE
fix(console): preserve tool names in anthropic to oa-compat conversion

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -200,9 +200,9 @@ export function toOaCompatibleRequest(body: CommonRequest) {
     ? body.tools.map((tool: any) => ({
         type: "function",
         function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
+          name: tool.function?.name,
+          description: tool.function?.description,
+          parameters: tool.function?.parameters ?? tool.function?.input_schema,
         },
       }))
     : undefined

--- a/packages/console/app/test/providerConversion.test.ts
+++ b/packages/console/app/test/providerConversion.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { fromAnthropicRequest } from "../src/routes/zen/util/provider/anthropic"
+import { toOaCompatibleRequest } from "../src/routes/zen/util/provider/openai-compatible"
+
+describe("anthropic to oa-compat tool conversion", () => {
+  test("preserves tool names from Claude Code style anthropic requests", () => {
+    const anthropicBody = {
+      model: "deepseek-v4-flash-free",
+      max_tokens: 1024,
+      tools: [
+        {
+          name: "Bash",
+          description: "Run a bash command",
+          input_schema: {
+            type: "object",
+            properties: {
+              command: { type: "string" },
+            },
+            required: ["command"],
+          },
+        },
+      ],
+      messages: [{ role: "user", content: "run echo hello" }],
+    }
+
+    const common = fromAnthropicRequest(anthropicBody)
+    const oaCompat = toOaCompatibleRequest(common)
+
+    expect(oaCompat.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "Bash",
+          description: "Run a bash command",
+          parameters: anthropicBody.tools[0].input_schema,
+        },
+      },
+    ])
+  })
+
+  test("passes through already-normalized common request tools", () => {
+    const common = {
+      model: "north-mini-code-free",
+      messages: [{ role: "user" as const, content: "hi" }],
+      tools: [
+        {
+          type: "function" as const,
+          function: {
+            name: "Read",
+            description: "Read a file",
+            parameters: { type: "object", properties: { path: { type: "string" } } },
+          },
+        },
+      ],
+    }
+
+    const oaCompat = toOaCompatibleRequest(common)
+
+    expect(oaCompat.tools?.[0]?.function?.name).toBe("Read")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #27047 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When Zen routes Anthropic-format `/v1/messages` requests to oa-compat models (e.g. `deepseek-v4-flash-free`, `north-mini-code-free`), tools go through `fromAnthropicRequest` → `toOaCompatibleRequest`. The first step already nests tool metadata under function, but `toOaCompatibleRequest` was still reading `tool.name`, `tool.description`, and `tool.parameters`. Those fields are undefined on the common request shape, so upstream providers received tools with a missing `function.name` and returned 400s like `tools[0].function: missing field 'name'`.

This change reads from `tool.function.*` instead, which matches what `fromAnthropicRequest` actually produces.

### How did you verify your code works?
```cd packages/console/app && bun test test/providerConversion.test.ts```
Also ran `bun typecheck` locally.

### Screenshots / recordings
N/A — server-side request conversion only.

### Checklist

- [x]  I have tested my changes locally
- [x]  I have not included unrelated changes in this PR