### PR TITLE
fix(tui): show message when --continue finds no previous session

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -273,16 +273,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                             <ArgsProvider {...input.args}>
                               <KVProvider>
                                 <ToastProvider>
-                                  <RouteProvider
-                                    initialRoute={
-                                      input.args.continue
-                                        ? {
-                                            type: "session",
-                                            sessionID: "dummy",
-                                          }
-                                        : undefined
-                                    }
-                                  >
+                                  <RouteProvider initialRoute={undefined}>
                                     <TuiConfigProvider config={input.config}>
                                       <PluginRuntimeProvider value={pluginRuntime}>
                                         <SDKProvider
@@ -504,6 +495,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       } else {
         route.navigate({ type: "session", sessionID: match })
       }
+    } else {
+      toast.show({ message: "No previous session found", variant: "info" })
+      continued = true
     }
   })
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -281,6 +281,7 @@ export function Session() {
     void (async () => {
       const previousWorkspace = untrack(() => project.workspace.current())
       const result = await sdk.client.session.get({ sessionID }, { throwOnError: true })
+      if (route.sessionID !== sessionID) return
       if (!result.data) {
         toast.show({
           message: `Session not found: ${sessionID}`,


### PR DESCRIPTION
### Issue for this PR

Currently, when we run `opencode -c` but have no previous session, it will print error at the home

<img width="1512" height="943" alt="image" src="https://github.com/user-attachments/assets/916df69b-c7c6-43ac-894a-08889b0a3ab4" />


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Replace "dummy" sessionId at RouteProvider with `undefined`, the `--continue` navigation will be handled by the `createEffect` not the initial route.
- Add toast "No previous session found" in the `else` branch where `--continue` has no match
- Add race condition guard,  so a stale session.get() call for a replaced sessionID doesn't fire a false "Session not found" error.

### How did you verify your code works?

- Run `bun dev --continue` when there is no previous session, now it directing to home without printing error
- Run `bun dev --continue` when previous session exists, running normally

### Screenshots / recordings

<img width="442" height="868" alt="image" src="https://github.com/user-attachments/assets/ccea995a-93c4-45e5-bcac-1ed70ed36e1d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
