### PR TITLE
fix(filesystem): return empty list when listing a missing path

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -78,7 +78,9 @@ const baseLayer = Layer.effect(
       const absolute = path.resolve(location.directory, input ?? ".")
       if (!FSUtil.contains(location.directory, absolute))
         return yield* Effect.die(new Error("Path escapes the location"))
-      const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
+      const real = yield* fs
+        .realPath(absolute)
+        .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(absolute)), Effect.orDie)
       if (!FSUtil.contains(root, real)) return yield* Effect.die(new Error("Path escapes the location"))
       return { absolute, real, directory: location.directory, root }
     })
@@ -97,7 +99,10 @@ const baseLayer = Layer.effect(
       }),
       list: Effect.fn("FileSystem.list")(function* (input = {}) {
         const target = yield* resolve(input.path)
-        const info = yield* fs.stat(target.real).pipe(Effect.orDie)
+        const info = yield* fs
+          .stat(target.real)
+          .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)), Effect.orDie)
+        if (info === undefined) return []
         if (info.type !== "Directory") return yield* Effect.die(new Error("Path is not a directory"))
         return yield* fs.readDirectoryEntries(target.real).pipe(
           Effect.orDie,

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -60,6 +60,15 @@ describe("FileSystem", () => {
     ),
   )
 
+  it.live("returns empty list for a missing path", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const entries = yield* (yield* FileSystem.Service).list({ path: RelativePath.make("missing") })
+        expect(entries).toEqual([])
+      }).pipe(provide(directory)),
+    ),
+  )
+
   it.live("rejects lexical escapes", () =>
     withTmp((directory) =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #32374

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`FileSystem.Service.list()` crashed with an uncaught `NotFound`/ENOENT defect when the requested path did not exist on disk, because `resolve()` called `fs.realPath(absolute)` and `list()` called `fs.stat(target.real)`, both piped through `Effect.orDie` with no handling for the `NotFound` reason.

This PR catches the `PlatformError`/`NotFound` reason in both places, following the existing pattern used by `readFileStringSafe` in `fs-util.ts`:

- `resolve()` now falls back to `real = absolute` when `realPath` reports `NotFound`, instead of dying.
- `list()` now treats a `NotFound` from `fs.stat()` as "nothing here" and returns `[]`, instead of dying.

### How did you verify your code works?

Added a regression test in `packages/core/test/location-filesystem.test.ts` (`"returns empty list for a missing path"`) that calls `list({ path: RelativePath.make("missing") })` against a path that doesn't exist and asserts it returns `[]`.

Ran `bun test packages/core/test/location-filesystem.test.ts` — 4 pass, 0 fail. Ran `bun run typecheck` for `packages/core` — clean.

### Screenshots / recordings

_N/A — backend/library change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR