### PR TITLE
fix(mcp): retry transient bootstrap failures

### DIFF
--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -16,6 +16,7 @@ import { type ServerHealth } from "@/utils/server-health"
 import { useGlobal } from "@/context/global"
 import { useSettings } from "@/context/settings"
 import { useMcpToggle } from "@/context/mcp"
+import { mcpStatusDetail } from "./status-popover-policy"
 
 const pluginEmptyMessage = (value: string, file: string): JSXElement => {
   const parts = value.split(file)
@@ -400,6 +401,9 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                 <For each={mcpNames()}>
                   {(name) => {
                     const status = () => mcpStatus(name)
+                    const detail = () => {
+                      return mcpStatusDetail(sync().data.mcp?.[name], language.t("mcp.auth.clickToAuthenticate"))
+                    }
                     const enabled = () => status() === "connected"
                     return (
                       <button
@@ -425,10 +429,8 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
                           <span class="flex items-center gap-2 min-w-0">
                             <span class="text-14-regular text-text-base truncate">{name}</span>
                           </span>
-                          <Show when={status() === "needs_auth"}>
-                            <span class="text-11-regular text-text-weaker truncate">
-                              {language.t("mcp.auth.clickToAuthenticate")}
-                            </span>
+                          <Show when={detail()}>
+                            <span class="text-11-regular text-text-weaker truncate">{detail()}</span>
                           </Show>
                         </span>
                         <div onClick={(event) => event.stopPropagation()}>

--- a/packages/app/src/components/status-popover-policy.test.ts
+++ b/packages/app/src/components/status-popover-policy.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import type { McpStatus } from "@opencode-ai/sdk/v2/client"
+import { mcpStatusDetail, mcpStatusIssue } from "./status-popover-policy"
+
+describe("status popover MCP policy", () => {
+  test("treats failed MCP status as critical degradation", () => {
+    expect(
+      mcpStatusIssue({
+        context7: { status: "failed", error: "net::ERR_NETWORK_CHANGED" },
+      }),
+    ).toBe("critical")
+    expect(
+      mcpStatusIssue({
+        context7: { status: "needs_client_registration", error: "client id required" },
+        grep_app: { status: "needs_auth" },
+      }),
+    ).toBe("critical")
+  })
+
+  test("treats auth-only MCP status as warning", () => {
+    expect(
+      mcpStatusIssue({
+        context7: { status: "connected" },
+        grep_app: { status: "needs_auth" },
+      }),
+    ).toBe("warning")
+  })
+
+  test("leaves connected or disabled MCP status neutral", () => {
+    expect(
+      mcpStatusIssue({
+        context7: { status: "connected" },
+        grep_app: { status: "disabled" },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("shows actionable detail for degraded MCP rows", () => {
+    expect(mcpStatusDetail({ status: "needs_auth" }, "Authenticate")).toBe("Authenticate")
+    expect(mcpStatusDetail({ status: "failed", error: "tools/list failed" }, "Authenticate")).toBe(
+      "tools/list failed",
+    )
+    expect(
+      mcpStatusDetail({ status: "needs_client_registration", error: "client id required" }, "Authenticate"),
+    ).toBe("client id required")
+    expect(mcpStatusDetail({ status: "connected" } as McpStatus, "Authenticate")).toBeUndefined()
+  })
+})

--- a/packages/app/src/components/status-popover-policy.ts
+++ b/packages/app/src/components/status-popover-policy.ts
@@ -1,0 +1,14 @@
+import type { McpStatus } from "@opencode-ai/sdk/v2/client"
+
+export function mcpStatusIssue(mcp: Record<string, McpStatus> | undefined) {
+  const status = Object.values(mcp ?? {})
+  if (status.some((item) => item.status === "failed" || item.status === "needs_client_registration")) {
+    return "critical" as const
+  }
+  if (status.some((item) => item.status === "needs_auth")) return "warning" as const
+}
+
+export function mcpStatusDetail(status: McpStatus | undefined, needsAuth: string) {
+  if (status?.status === "needs_auth") return needsAuth
+  if (status?.status === "failed" || status?.status === "needs_client_registration") return status.error
+}

--- a/packages/app/src/components/status-popover.tsx
+++ b/packages/app/src/components/status-popover.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from "@/context/language"
 import { useServer } from "@/context/server"
 import { useSync } from "@/context/sync"
 import { useGlobal } from "@/context/global"
+import { mcpStatusIssue } from "./status-popover-policy"
 
 const Body = lazy(() => import("./status-popover-body").then((x) => ({ default: x.StatusPopoverBody })))
 const ServerBody = lazy(() => import("./status-popover-body").then((x) => ({ default: x.StatusPopoverServerBody })))
@@ -19,15 +20,10 @@ export function StatusPopover() {
   const sync = useSync()
   const [shown, setShown] = createSignal(false)
   const ready = createMemo(() => global.servers.health[server.key]?.healthy === false || sync().data.mcp_ready)
-  const mcpIssue = createMemo(() => {
-    const mcp = Object.values(sync().data.mcp ?? {})
-    const failed = mcp.some((item) => item.status === "failed" || item.status === "needs_client_registration")
-    const warn = mcp.some((item) => item.status === "needs_auth")
-    if (failed) return "critical" as const
-    if (warn) return "warning" as const
-  })
-  const serverHealthy = () => global.servers.health[server.key]?.healthy === true
-  const healthy = createMemo(() => global.servers.health[server.key]?.healthy === true && !mcpIssue())
+  const mcpIssue = createMemo(() => mcpStatusIssue(sync().data.mcp))
+  const serverHealth = () => global.servers.health[server.key]?.healthy
+  const serverHealthy = () => serverHealth() === true
+  const healthy = createMemo(() => serverHealthy() && !mcpIssue())
 
   return (
     <Popover
@@ -50,8 +46,9 @@ export function StatusPopover() {
               "absolute -top-px -right-px size-1.5 rounded-full": true,
               "bg-icon-success-base": ready() && healthy(),
               "bg-icon-warning-base": ready() && serverHealthy() && mcpIssue() === "warning",
-              "bg-icon-critical-base": serverHealthy() || (ready() && serverHealthy() && mcpIssue() === "critical"),
-              "bg-border-weak-base": serverHealthy() || !ready(),
+              "bg-icon-critical-base":
+                serverHealth() === false || (ready() && serverHealthy() && mcpIssue() === "critical"),
+              "bg-border-weak-base": serverHealth() === undefined || !ready(),
             }}
           />
         </div>
@@ -87,13 +84,7 @@ function DirectoryStatusPopover() {
   const [shown, setShown] = createSignal(false)
   const serverHealth = () => global.servers.health[server.key]?.healthy
   const ready = createMemo(() => serverHealth() === false || sync().data.mcp_ready)
-  const mcpIssue = createMemo(() => {
-    const mcp = Object.values(sync().data.mcp ?? {})
-    const failed = mcp.some((item) => item.status === "failed" || item.status === "needs_client_registration")
-    const warn = mcp.some((item) => item.status === "needs_auth")
-    if (failed) return "critical" as const
-    if (warn) return "warning" as const
-  })
+  const mcpIssue = createMemo(() => mcpStatusIssue(sync().data.mcp))
   const healthy = createMemo(() => serverHealth() === true && !mcpIssue())
   const state = createMemo<StatusPopoverState>(() => ({
     shown: shown(),

--- a/packages/app/src/context/server-sync.test.ts
+++ b/packages/app/src/context/server-sync.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test"
+import { QueryClient } from "@tanstack/solid-query"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { canDisposeDirectory, pickDirectoriesToEvict } from "./global-sync/eviction"
 import { estimateRootSessionTotal, loadRootSessionsWithFallback } from "./global-sync/session-load"
+import { ServerScope } from "@/utils/server-scope"
+import { loadMcpQuery } from "./server-sync"
 
 describe("pickDirectoriesToEvict", () => {
   test("keeps pinned stores and evicts idle stores", () => {
@@ -60,6 +64,47 @@ describe("loadRootSessionsWithFallback", () => {
       { directory: "dir", roots: true, limit: 25 },
       { directory: "dir", roots: true },
     ])
+  })
+})
+
+describe("loadMcpQuery", () => {
+  test("retries transient fetch failures", async () => {
+    let calls = 0
+    const result = await new QueryClient().fetchQuery(
+      loadMcpQuery(ServerScope.local, "/repo", {
+        mcp: {
+          status: async () => {
+            calls++
+            if (calls === 1) throw new TypeError("Failed to fetch")
+            return { data: { context7: { status: "connected" } } }
+          },
+        },
+      } as unknown as OpencodeClient),
+    )
+
+    expect(result).toEqual({ context7: { status: "connected" } })
+    expect(calls).toBe(2)
+  })
+
+  test("does not multiply retries through the query client", async () => {
+    let calls = 0
+
+    await expect(
+      new QueryClient({
+        defaultOptions: { queries: { retryDelay: 1 } },
+      }).fetchQuery(
+        loadMcpQuery(ServerScope.local, "/repo", {
+          mcp: {
+            status: async () => {
+              calls++
+              throw new TypeError("Failed to fetch")
+            },
+          },
+        } as unknown as OpencodeClient),
+      ),
+    ).rejects.toThrow("Failed to fetch")
+
+    expect(calls).toBe(3)
   })
 })
 

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -55,7 +55,8 @@ type GlobalStore = {
 export const loadMcpQuery = (scope: ServerScope, directory: string, sdk: OpencodeClient) =>
   queryOptions({
     queryKey: [scope, directory, "mcp"] as const,
-    queryFn: () => sdk.mcp.status().then((r) => r.data ?? {}),
+    retry: false,
+    queryFn: () => retry(() => sdk.mcp.status().then((r) => r.data ?? {})),
   })
 
 export const loadLspQuery = (scope: ServerScope, directory: string, sdk: OpencodeClient) =>

--- a/packages/core/src/util/retry.ts
+++ b/packages/core/src/util/retry.ts
@@ -6,26 +6,28 @@ export interface RetryOptions {
   retryIf?: (error: unknown) => boolean
 }
 
-const TRANSIENT_MESSAGES = [
+const TRANSIENT_NETWORK_MESSAGES = [
   "load failed",
   "network connection was lost",
   "network request failed",
   "failed to fetch",
+  "net::err_network_changed",
+  "net::err_network_io_suspended",
   "econnreset",
   "econnrefused",
   "etimedout",
   "socket hang up",
 ]
 
-function isTransientError(error: unknown): boolean {
+export function isTransientNetworkError(error: unknown): boolean {
   if (!error) return false
   // oxlint-disable-next-line no-base-to-string -- error is unknown, intentional coercion for message matching
   const message = String(error instanceof Error ? error.message : error).toLowerCase()
-  return TRANSIENT_MESSAGES.some((m) => message.includes(m))
+  return TRANSIENT_NETWORK_MESSAGES.some((m) => message.includes(m))
 }
 
 export async function retry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
-  const { attempts = 3, delay = 500, factor = 2, maxDelay = 10000, retryIf = isTransientError } = options
+  const { attempts = 3, delay = 500, factor = 2, maxDelay = 10000, retryIf = isTransientNetworkError } = options
 
   let lastError: unknown
   for (let attempt = 0; attempt < attempts; attempt++) {

--- a/packages/core/test/util/retry.test.ts
+++ b/packages/core/test/util/retry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { isTransientNetworkError, retry } from "@opencode-ai/core/util/retry"
+
+describe("util.retry", () => {
+  test("recognizes transient Electron network errors", () => {
+    expect(isTransientNetworkError(new Error("net::ERR_NETWORK_CHANGED"))).toBe(true)
+    expect(isTransientNetworkError(new Error("net::ERR_NETWORK_IO_SUSPENDED"))).toBe(true)
+  })
+
+  test("rejects non-transient errors", () => {
+    expect(isTransientNetworkError(new Error("Unauthorized"))).toBe(false)
+  })
+
+  test("stops after attempts are exhausted", async () => {
+    let calls = 0
+
+    await expect(
+      retry(
+        async () => {
+          calls++
+          throw new TypeError("Failed to fetch")
+        },
+        { attempts: 2, delay: 1 },
+      ),
+    ).rejects.toThrow("Failed to fetch")
+
+    expect(calls).toBe(2)
+  })
+})

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -35,6 +35,10 @@ export async function paginate<T, R extends { nextCursor?: string }>(
   throw new Error(`MCP list exceeded ${MAX_LIST_PAGES} pages`)
 }
 
+export function listToolDefs(client: Client, timeout?: number) {
+  return listTools(client, timeout ?? DEFAULT_TIMEOUT)
+}
+
 export function defs(client: Client, timeout?: number) {
   return listTools(client, timeout ?? DEFAULT_TIMEOUT).pipe(Effect.catch(() => Effect.void))
 }

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -22,6 +22,7 @@ import { NamedError } from "@opencode-ai/core/util/error"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { withTimeout } from "@/util/timeout"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { isTransientNetworkError } from "@opencode-ai/core/util/retry"
 import { McpOAuthProvider, OAUTH_CALLBACK_PATH } from "./oauth-provider"
 import { McpOAuthCallback } from "./oauth-callback"
 import { McpAuth } from "./auth"
@@ -29,7 +30,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { EventV2 } from "@opencode-ai/core/event"
 import { TuiEvent } from "@/server/tui-event"
 import open from "open"
-import { Cause, Effect, Exit, Layer, Option, Context, Schema, Stream } from "effect"
+import { Cause, Effect, Exit, Layer, Option, Context, Schema, Schedule, Stream } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
@@ -37,6 +38,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { McpCatalog } from "./catalog"
 
 const DEFAULT_TIMEOUT = 30_000
+const STARTUP_RETRY_SCHEDULE = Schedule.exponential(500).pipe(Schedule.jittered, Schedule.both(Schedule.recurs(3)))
 const CLIENT_OPTIONS = {
   capabilities: {
     // https://github.com/anomalyco/opencode/issues/11948
@@ -133,6 +135,10 @@ function isMcpConfigured(entry: McpEntry): entry is ConfigMCPV1.Info {
 
 function remoteURL(value: string) {
   if (URL.canParse(value)) return new URL(value)
+}
+
+function retryableStatus(status: Status): status is Extract<Status, { status: "failed" }> {
+  return status.status === "failed" && isTransientNetworkError(status.error)
 }
 
 interface CreateResult {
@@ -368,6 +374,7 @@ export const layer = Layer.effect(
             : yield* connectLocal(key, mcp as ConfigMCPV1.Info & { type: "local" })
 
         if (!mcpClient) {
+          if (retryableStatus(status)) return yield* Effect.fail(new Error(status.error))
           if (status.status !== "connected" && status.status !== "disabled") {
             yield* Effect.logWarning("server unavailable", { key, type: mcp.type, status: status.status })
           }
@@ -375,10 +382,9 @@ export const layer = Layer.effect(
         }
 
         return yield* Effect.gen(function* () {
-          const listed = mcpClient.getServerCapabilities()?.tools ? yield* McpCatalog.defs(mcpClient, mcp.timeout) : []
-          if (!listed) {
-            return yield* Effect.fail(new Error("Failed to get tools"))
-          }
+          const listed = mcpClient.getServerCapabilities()?.tools
+            ? yield* McpCatalog.listToolDefs(mcpClient, mcp.timeout)
+            : []
           return { mcpClient, status, defs: listed } satisfies CreateResult
         }).pipe(
           Effect.catchCause((cause) =>
@@ -386,6 +392,10 @@ export const layer = Layer.effect(
           ),
         )
       },
+      Effect.retry({
+        while: isTransientNetworkError,
+        schedule: STARTUP_RETRY_SCHEDULE,
+      }),
       Effect.map((result): CreateResult => result),
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) return Effect.interrupt

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -49,6 +49,9 @@ let lastCreatedClientName: string | undefined
 let connectShouldFail = false
 let connectShouldHang = false
 let connectError = "Mock transport cannot connect"
+let connectFailuresRemaining = 0
+let listToolsFailuresRemaining = 0
+let transportStartCount = 0
 // Tracks how many Client instances were created (detects leaks)
 let clientCreateCount = 0
 // Tracks how many times transport.close() is called across all mock transports
@@ -94,7 +97,12 @@ class MockStdioTransport {
     if (lastCreatedClientName) stdioOptsByName.set(lastCreatedClientName, opts)
   }
   async start() {
+    transportStartCount++
     if (connectShouldHang) return new Promise<void>(() => {}) // never resolves
+    if (connectFailuresRemaining > 0) {
+      connectFailuresRemaining--
+      throw new Error(connectError)
+    }
     if (connectShouldFail) throw new Error(connectError)
   }
   async close() {
@@ -106,7 +114,12 @@ class MockStreamableHTTP {
   // oxlint-disable-next-line no-useless-constructor
   constructor(_url: URL, _opts?: any) {}
   async start() {
+    transportStartCount++
     if (connectShouldHang) return new Promise<void>(() => {}) // never resolves
+    if (connectFailuresRemaining > 0) {
+      connectFailuresRemaining--
+      throw new Error(connectError)
+    }
     if (connectShouldFail) throw new Error(connectError)
   }
   async close() {
@@ -119,7 +132,12 @@ class MockSSE {
   // oxlint-disable-next-line no-useless-constructor
   constructor(_url: URL, _opts?: any) {}
   async start() {
+    transportStartCount++
     if (connectShouldHang) return new Promise<void>(() => {}) // never resolves
+    if (connectFailuresRemaining > 0) {
+      connectFailuresRemaining--
+      throw new Error(connectError)
+    }
     if (connectShouldFail) throw new Error(connectError)
   }
   async close() {
@@ -181,6 +199,10 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
 
     async listTools(params?: { cursor?: string }) {
       if (this._state) this._state.listToolsCalls++
+      if (listToolsFailuresRemaining > 0) {
+        listToolsFailuresRemaining--
+        throw new Error(this._state?.listToolsError ?? "listTools failed")
+      }
       if (this._state?.listToolsShouldFail) {
         throw new Error(this._state.listToolsError)
       }
@@ -246,6 +268,9 @@ beforeEach(() => {
   connectShouldFail = false
   connectShouldHang = false
   connectError = "Mock transport cannot connect"
+  connectFailuresRemaining = 0
+  listToolsFailuresRemaining = 0
+  transportStartCount = 0
   clientCreateCount = 0
   transportCloseCount = 0
 })
@@ -1016,7 +1041,145 @@ it.instance(
 // ========================================================================
 
 it.instance(
-  "server that fails to connect is marked as failed",
+  "retries transient network failures while connecting configured servers",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "flaky-server"
+        const serverState = getOrCreateClientState("flaky-server")
+        connectError = "net::ERR_NETWORK_CHANGED"
+        connectFailuresRemaining = 1
+        serverState.tools = [
+          {
+            name: "available_tool",
+            description: "works after reconnect",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ]
+
+        const status = yield* mcp.status()
+        expect(status["flaky-server"]?.status).toBe("connected")
+
+        expect(transportStartCount).toBe(2)
+        expect(Object.keys(yield* mcp.tools())).toEqual(["flaky-server_available_tool"])
+      }),
+    ),
+  {
+    config: {
+      mcp: {
+        "flaky-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "stops retrying transient connect failures after the startup retry budget",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "exhausted-server"
+        getOrCreateClientState("exhausted-server")
+        connectError = "net::ERR_NETWORK_CHANGED"
+        connectFailuresRemaining = 4
+
+        const status = yield* mcp.status()
+        expect(status["exhausted-server"]?.status).toBe("failed")
+        if (status["exhausted-server"]?.status === "failed") {
+          expect(status["exhausted-server"].error).toContain("net::ERR_NETWORK_CHANGED")
+        }
+
+        expect(transportStartCount).toBe(4)
+        expect(Object.keys(yield* mcp.tools()).length).toBe(0)
+      }),
+    ),
+  {
+    config: {
+      mcp: {
+        "exhausted-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "retries transient network failures while listing configured server tools",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "flaky-list-server"
+        const serverState = getOrCreateClientState("flaky-list-server")
+        serverState.listToolsError = "net::ERR_NETWORK_IO_SUSPENDED"
+        listToolsFailuresRemaining = 1
+        serverState.tools = [
+          {
+            name: "available_tool",
+            description: "works after list retry",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ]
+
+        const status = yield* mcp.status()
+        expect(status["flaky-list-server"]?.status).toBe("connected")
+
+        expect(serverState.listToolsCalls).toBe(2)
+        expect(Object.keys(yield* mcp.tools())).toEqual(["flaky-list-server_available_tool"])
+      }),
+    ),
+  {
+    config: {
+      mcp: {
+        "flaky-list-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "stops retrying transient tool listing failures after the startup retry budget",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "exhausted-list-server"
+        const serverState = getOrCreateClientState("exhausted-list-server")
+        serverState.listToolsError = "net::ERR_NETWORK_IO_SUSPENDED"
+        listToolsFailuresRemaining = 4
+
+        const status = yield* mcp.status()
+        expect(status["exhausted-list-server"]?.status).toBe("failed")
+        if (status["exhausted-list-server"]?.status === "failed") {
+          expect(status["exhausted-list-server"].error).toContain("net::ERR_NETWORK_IO_SUSPENDED")
+        }
+
+        expect(serverState.listToolsCalls).toBe(4)
+        expect(transportStartCount).toBe(4)
+        expect(serverState.closed).toBe(true)
+        expect(Object.keys(yield* mcp.tools()).length).toBe(0)
+      }),
+    ),
+  {
+    config: {
+      mcp: {
+        "exhausted-list-server": {
+          type: "local",
+          command: ["echo", "test"],
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "does not retry non-transient connect failures",
   () =>
     MCP.Service.use((mcp: MCPNS.Interface) =>
       Effect.gen(function* () {
@@ -1025,18 +1188,13 @@ it.instance(
         connectShouldFail = true
         connectError = "Connection refused"
 
-        yield* mcp.add("fail-connect", {
-          type: "local",
-          command: ["echo", "test"],
-        })
-
         const status = yield* mcp.status()
         expect(status["fail-connect"]?.status).toBe("failed")
         if (status["fail-connect"]?.status === "failed") {
           expect(status["fail-connect"].error).toContain("Connection refused")
         }
+        expect(transportStartCount).toBe(1)
 
-        // No tools should be available
         const tools = yield* mcp.tools()
         expect(Object.keys(tools).length).toBe(0)
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #32379

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Desktop can see transient fetch and MCP startup failures after sleep/wake or network changes, such as `Failed to fetch`, `net::ERR_NETWORK_CHANGED`, and `net::ERR_NETWORK_IO_SUSPENDED`. When that happened during MCP bootstrap, affected MCP tools could stay unavailable until restart.

This adds bounded retries for transient MCP bootstrap failures. The app-side MCP status query uses the shared retry helper and disables TanStack Query's outer retry so the retry budget is not multiplied. The backend MCP startup path retries transient connect and `tools/list` failures with a bounded Effect schedule, then degrades to the existing failed MCP status if the retry budget is exhausted.

Failed MCP status now flows through the existing status popover path. The popover uses the same MCP severity policy in both status indicator variants and shows the failed server detail in the MCP row.

### How did you verify your code works?

From `packages/app`:

- `bun test --preload ./happydom.ts src/components/status-popover-policy.test.ts src/context/server-sync.test.ts`
- `bun typecheck`

From `packages/core`:

- `bun test test/util/retry.test.ts`
- `bun typecheck`

From `packages/opencode`:

- `bun test --timeout 30000 test/mcp/lifecycle.test.ts`
- `bun typecheck`

Also ran:

- `git diff --check`
- pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

N/A. This uses the existing MCP status popover surface.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR