### PR TITLE
feat: experimental.chat.system.transform: add agent name as input argument

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -378,7 +378,7 @@ export const layer = Layer.effect(
           : undefined
 
         const system = [PROMPT_GENERATE]
-        yield* plugin.trigger("experimental.chat.system.transform", { model: resolved }, { system })
+        yield* plugin.trigger("experimental.chat.system.transform", { model: resolved, agent: 'user' }, { system })
         const existing = yield* InstanceState.useEffect(state, (s) => s.list())
 
         // TODO: clean this up so provider specific logic doesnt bleed over

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -68,7 +68,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
   const header = system[0]
   yield* input.plugin.trigger(
     "experimental.chat.system.transform",
-    { sessionID: input.sessionID, model: input.model },
+    { sessionID: input.sessionID, model: input.model, agent: input.agent.name },
     { system },
   )
   if (system.length > 2 && system[0] === header) {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  Agent,
   Event,
   createOpencodeClient,
   Project,
@@ -289,7 +290,7 @@ export interface Hooks {
     },
   ) => Promise<void>
   "experimental.chat.system.transform"?: (
-    input: { sessionID?: string; model: Model },
+    input: { sessionID?: string; model: Model; agent?: Agent.name },
     output: {
       system: string[]
     },


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This change transforms this:

```ts
"experimental.chat.system.transform": async (input, output) => {
  console.log("session, system", input.sessionID, output.system);
},
```

into supporting this:

```ts
"experimental.chat.system.transform": async (input, output) => {
  if (input.agent === 'title') return output;
  console.log("session, agent, system", input.sessionID, input.agent, output.system);
},
```

### How did you verify your code works?

Built on Arch Linux and modified [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) like this:

```diff
diff --git a/.opencode/plugins/ponytail.mjs b/.opencode/plugins/ponytail.mjs
index 2fd3625..f8a0f1f 100644
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -46,7 +46,13 @@ export default async ({ client } = {}) => {
     // Append the ruleset to the system prompt every turn.
     'experimental.chat.system.transform': async (_input, output) => {
       const mode = readMode();
-      if (mode === 'off') return;
+      // Avoid injecting ourselves into OpenCode title generation
+      if (mode === 'off' || _input.agent === 'title') return output;
       output.system.push(getPonytailInstructions(mode));
     },
```

OpenCode uses a `title` agent with a system message `You are a title generator. You output ONLY a thread title. Nothing else. ...`. However, when a very small agent is used (like `smollm2-135M-it`) the additional system prompt injected by the ponytail plugin proves too much for the model to handle.

This change allows the plugin to filter out `title` agent requests and not inject system message for that puprpose — it is likely not intended to be used that way anyway.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
