### PR TITLE
fix(mcp): enable progress timeout resets

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -61,6 +61,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
           resetTimeoutOnProgress: true,
           signal: options.abortSignal,
           timeout,
+          // The MCP SDK only sends a progress token when this hook is present, enabling timeout resets.
           onprogress: () => {},
         },
       )

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -61,6 +61,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
           resetTimeoutOnProgress: true,
           signal: options.abortSignal,
           timeout,
+          onprogress: () => {},
         },
       )
       if (result.isError) throw new Error(formatToolErrorContent(result.content))

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -19,6 +19,12 @@ interface MockClientState {
   listResourcesCalls: number
   getPromptTimeout?: number
   readResourceTimeout?: number
+  callToolOptions?: {
+    resetTimeoutOnProgress?: boolean
+    signal?: AbortSignal
+    timeout?: number
+    onprogress?: (progress: unknown) => void
+  }
   requestCalls: number
   listToolsShouldFail: boolean
   listToolsError: string
@@ -232,6 +238,11 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     async readResource(params: { uri: string }, options?: { timeout?: number }) {
       if (this._state) this._state.readResourceTimeout = options?.timeout
       return { contents: [{ uri: params.uri, text: "test" }] }
+    }
+
+    async callTool(_params: unknown, _schema: unknown, options?: MockClientState["callToolOptions"]) {
+      if (this._state) this._state.callToolOptions = options
+      return { content: [{ type: "text", text: "ok" }] }
     }
 
     async close() {
@@ -918,6 +929,39 @@ it.instance(
         expect(yield* mcp.resources()).toEqual({})
         expect(serverState.listPromptsCalls).toBe(0)
         expect(serverState.listResourcesCalls).toBe(0)
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "MCP tool calls include a progress handler so progress can reset timeouts",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "progress-server"
+        const serverState = getOrCreateClientState("progress-server")
+        serverState.capabilities = { tools: {} }
+
+        yield* mcp.add("progress-server", {
+          type: "local",
+          command: ["echo", "test"],
+          timeout: 2500,
+        })
+
+        const tools = yield* mcp.tools()
+        const tool = tools["progress-server_test_tool"]
+        expect(tool).toBeDefined()
+
+        const abort = new AbortController()
+        yield* Effect.promise(() =>
+          tool.execute?.({}, { toolCallId: "call_1", messages: [], abortSignal: abort.signal } as never),
+        )
+
+        expect(serverState.callToolOptions?.resetTimeoutOnProgress).toBe(true)
+        expect(serverState.callToolOptions?.signal).toBe(abort.signal)
+        expect(serverState.callToolOptions?.timeout).toBe(2500)
+        expect(typeof serverState.callToolOptions?.onprogress).toBe("function")
       }),
     ),
   { config: { mcp: {} } },

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -19,12 +19,6 @@ interface MockClientState {
   listResourcesCalls: number
   getPromptTimeout?: number
   readResourceTimeout?: number
-  callToolOptions?: {
-    resetTimeoutOnProgress?: boolean
-    signal?: AbortSignal
-    timeout?: number
-    onprogress?: (progress: unknown) => void
-  }
   requestCalls: number
   listToolsShouldFail: boolean
   listToolsError: string
@@ -238,11 +232,6 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     async readResource(params: { uri: string }, options?: { timeout?: number }) {
       if (this._state) this._state.readResourceTimeout = options?.timeout
       return { contents: [{ uri: params.uri, text: "test" }] }
-    }
-
-    async callTool(_params: unknown, _schema: unknown, options?: MockClientState["callToolOptions"]) {
-      if (this._state) this._state.callToolOptions = options
-      return { content: [{ type: "text", text: "ok" }] }
     }
 
     async close() {
@@ -929,39 +918,6 @@ it.instance(
         expect(yield* mcp.resources()).toEqual({})
         expect(serverState.listPromptsCalls).toBe(0)
         expect(serverState.listResourcesCalls).toBe(0)
-      }),
-    ),
-  { config: { mcp: {} } },
-)
-
-it.instance(
-  "MCP tool calls include a progress handler so progress can reset timeouts",
-  () =>
-    MCP.Service.use((mcp: MCPNS.Interface) =>
-      Effect.gen(function* () {
-        lastCreatedClientName = "progress-server"
-        const serverState = getOrCreateClientState("progress-server")
-        serverState.capabilities = { tools: {} }
-
-        yield* mcp.add("progress-server", {
-          type: "local",
-          command: ["echo", "test"],
-          timeout: 2500,
-        })
-
-        const tools = yield* mcp.tools()
-        const tool = tools["progress-server_test_tool"]
-        expect(tool).toBeDefined()
-
-        const abort = new AbortController()
-        yield* Effect.promise(() =>
-          tool.execute?.({}, { toolCallId: "call_1", messages: [], abortSignal: abort.signal } as never),
-        )
-
-        expect(serverState.callToolOptions?.resetTimeoutOnProgress).toBe(true)
-        expect(serverState.callToolOptions?.signal).toBe(abort.signal)
-        expect(serverState.callToolOptions?.timeout).toBe(2500)
-        expect(typeof serverState.callToolOptions?.onprogress).toBe("function")
       }),
     ),
   { config: { mcp: {} } },


### PR DESCRIPTION
### Issue for this PR

Fixes #28186
Refs #28567, #24965, #21701, #14499, #24964, #28246

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

opencode already passes `resetTimeoutOnProgress: true` when calling MCP tools, but the MCP TS SDK only adds `_meta.progressToken` when an `onprogress` callback is present.

Without that callback, long-running MCP tools can still hit the client timeout even if the server supports progress notifications. This adds a no-op progress handler so the SDK sends the progress token and can reset the request timeout when progress arrives.

I kept this intentionally small. Surfacing progress in the UI/logs should be a separate follow-up since that starts touching product shape.

### How did you verify your code works?

Verified against the installed `@modelcontextprotocol/sdk@1.29.0` implementation: request metadata only receives a progress token when `onprogress` is present, and progress notifications reset the timeout only after resolving that token to a registered handler.

Ran:

```bash
bun test --timeout 30000 test/mcp/lifecycle.test.ts --only-failures
bun typecheck
```

### Notes

This is the same small compatibility shape as the earlier progress PRs, but rebased onto current `dev`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR