### PR TITLE
feat(mcp): publish resource list change events

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -13,6 +13,7 @@ import {
   ListRootsRequestSchema,
   type LoggingMessageNotification,
   LoggingMessageNotificationSchema,
+  ResourceListChangedNotificationSchema,
   type Tool as MCPToolDef,
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js"
@@ -60,7 +61,7 @@ export const Resource = Schema.Struct({
 export type Resource = Schema.Schema.Type<typeof Resource>
 
 export const ToolsChanged = McpEvent.ToolsChanged
-
+export const ResourcesChanged = McpEvent.ResourcesChanged
 export const BrowserOpenFailed = McpEvent.BrowserOpenFailed
 
 export const Failed = NamedError.create("MCPFailed", {
@@ -450,17 +451,25 @@ export const layer = Layer.effect(
         bridge.promise(serverLog(name, notification.params)),
       )
 
-      if (!client.getServerCapabilities()?.tools) return
-      client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
-        if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
+      const capabilities = client.getServerCapabilities()
+      if (capabilities?.resources) {
+        client.setNotificationHandler(ResourceListChangedNotificationSchema, async () => {
+          if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
+          await bridge.promise(events.publish(ResourcesChanged, { server: name }).pipe(Effect.ignore))
+        })
+      }
+      if (capabilities?.tools) {
+        client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
+          if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
-        const listed = await bridge.promise(McpCatalog.defs(client, timeout))
-        if (!listed) return
-        if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
+          const listed = await bridge.promise(McpCatalog.defs(client, timeout))
+          if (!listed) return
+          if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
-        s.defs[name] = listed
-        await bridge.promise(events.publish(ToolsChanged, { server: name }).pipe(Effect.ignore))
-      })
+          s.defs[name] = listed
+          await bridge.promise(events.publish(ToolsChanged, { server: name }).pipe(Effect.ignore))
+        })
+      }
     }
 
     function serverLog(name: string, params: LoggingMessageNotification["params"]) {

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,10 +1,15 @@
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { expect, mock, beforeEach } from "bun:test"
-import { ListRootsRequestSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
-import { Cause, Effect, Exit } from "effect"
+import {
+  ListRootsRequestSchema,
+  ResourceListChangedNotificationSchema,
+  ToolListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import { Cause, Deferred, Effect, Exit } from "effect"
+import { GlobalBus } from "@/bus/global"
 import type { MCP as MCPNS } from "../../src/mcp/index"
-import { testEffect } from "../lib/effect"
+import { awaitWithTimeout, testEffect } from "../lib/effect"
 import { TestInstance } from "../fixture/fixture"
 
 // --- Mock infrastructure ---
@@ -543,6 +548,41 @@ it.instance(
         expect(serverState.listToolsCalls).toBe(2)
       }),
     ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "resource list change notifications publish a resource change event",
+  () =>
+    Effect.gen(function* () {
+      const mcp = yield* MCP.Service
+      const seen = yield* Deferred.make<string>()
+      const listener = (event: { payload: { type?: string; properties?: { server?: string } } }) => {
+        if (event.payload.type === "mcp.resources.changed" && event.payload.properties?.server)
+          Deferred.doneUnsafe(seen, Effect.succeed(event.payload.properties.server))
+      }
+      yield* Effect.acquireRelease(
+        Effect.sync(() => GlobalBus.on("event", listener)),
+        () => Effect.sync(() => GlobalBus.off("event", listener)),
+      )
+
+      lastCreatedClientName = "resource-notify-server"
+      const serverState = getOrCreateClientState("resource-notify-server")
+      serverState.capabilities = { resources: {} }
+
+      yield* mcp.add("resource-notify-server", {
+        type: "local",
+        command: ["echo", "test"],
+      })
+
+      const handler = serverState.notificationHandlers.get(ResourceListChangedNotificationSchema)
+      expect(handler).toBeDefined()
+      yield* Effect.promise(() => handler?.())
+
+      expect(
+        yield* awaitWithTimeout(Deferred.await(seen), "mcp.resources.changed event was not published"),
+      ).toBe("resource-notify-server")
+    }),
   { config: { mcp: {} } },
 )
 

--- a/packages/schema/src/mcp-event.ts
+++ b/packages/schema/src/mcp-event.ts
@@ -10,6 +10,13 @@ export const ToolsChanged = Event.define({
   },
 })
 
+export const ResourcesChanged = Event.define({
+  type: "mcp.resources.changed",
+  schema: {
+    server: Schema.String,
+  },
+})
+
 export const BrowserOpenFailed = Event.define({
   type: "mcp.browser.open.failed",
   schema: {
@@ -18,4 +25,4 @@ export const BrowserOpenFailed = Event.define({
   },
 })
 
-export const Definitions = Event.inventory(ToolsChanged, BrowserOpenFailed)
+export const Definitions = Event.inventory(ToolsChanged, ResourcesChanged, BrowserOpenFailed)


### PR DESCRIPTION
### Issue for this PR

Refs #28567

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the first small slice of MCP resource notification support.

When an MCP server advertises `resources`, opencode now registers a handler for `notifications/resources/list_changed` and publishes a typed `mcp.resources.changed` event with the server name.

This gives clients/UI/plugin code a clean signal to refresh resource lists without polling or treating MCP-originated updates as user messages.

I intentionally kept this to list-change notifications only. `notifications/resources/updated` should come in a follow-up with explicit subscribe/unsubscribe behaviour, otherwise opencode would be handling resource updates it never chose to watch.

### How did you verify your code works?

Added an MCP lifecycle test for a resource-only MCP server. The test triggers the mocked `ResourceListChangedNotificationSchema` handler and verifies a `mcp.resources.changed` event is emitted.

Ran:

```bash
bun test --timeout 30000 test/mcp/lifecycle.test.ts --only-failures
bun run typecheck
bun test --timeout 30000 test/mcp --only-failures
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR