### PR TITLE
feat(mcp): surface tool progress

### DIFF
--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -294,6 +294,14 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
           }
         })
       },
+      "session.next.tool.progress.report": (event) => {
+        return updateOwnedAssistant(event.data.assistantMessageID, (draft) => {
+          const match = latestTool(draft, event.data.callID)
+          if (match && match.state.status === "running") {
+            match.state.structured = event.data.structured
+          }
+        })
+      },
       "session.next.tool.success": (event) => {
         return updateOwnedAssistant(event.data.assistantMessageID, (draft) => {
           const match = latestTool(draft, event.data.callID)

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -387,6 +387,7 @@ export const layer = Layer.effectDiscard(
     yield* events.project(SessionEvent.Tool.Input.Ended, (event) => run(db, event))
     yield* events.project(SessionEvent.Tool.Called, (event) => run(db, event))
     yield* events.project(SessionEvent.Tool.Progress, (event) => run(db, event))
+    yield* events.project(SessionEvent.Tool.ProgressReport, (event) => run(db, event))
     yield* events.project(SessionEvent.Tool.Success, (event) => run(db, event))
     yield* events.project(SessionEvent.Tool.Failed, (event) => run(db, event))
     yield* events.project(SessionEvent.Reasoning.Started, (event) => run(db, event))

--- a/packages/core/test/session-tool-progress.test.ts
+++ b/packages/core/test/session-tool-progress.test.ts
@@ -101,6 +101,22 @@ describe("Tool.Progress", () => {
         state: { status: "running", structured: { phase: "checkpoint" }, content: content("saved") },
       })
 
+      yield* service.publish(SessionEvent.Tool.ProgressReport, {
+        sessionID,
+        timestamp,
+        assistantMessageID,
+        callID: "call-success",
+        report: { progress: 2, total: 4, message: "halfway", source: "mcp" },
+        structured: { source: "mcp", progress: 2, total: 4, message: "halfway" },
+      })
+      expect((yield* readAssistant).content[0]).toMatchObject({
+        state: {
+          status: "running",
+          structured: { source: "mcp", progress: 2, total: 4, message: "halfway" },
+          content: content("saved"),
+        },
+      })
+
       const success = yield* service.publish(SessionEvent.Tool.Success, {
         sessionID,
         timestamp,
@@ -150,6 +166,7 @@ describe("Tool.Progress", () => {
         .all()
         .pipe(Effect.orDie)
       expect(rows.map((row) => row.type)).toContain(EventV2.versionedType(SessionEvent.Tool.Progress.type, 1))
+      expect(rows.map((row) => row.type)).toContain(EventV2.versionedType(SessionEvent.Tool.ProgressReport.type, 1))
       expect(rows.map((row) => row.type)).toContain(EventV2.versionedType(SessionEvent.Tool.Success.type, 1))
       expect(rows.map((row) => row.type)).toContain(EventV2.versionedType(SessionEvent.Tool.Failed.type, 1))
     }),

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import {
   CallToolResultSchema,
   ListToolsResultSchema,
+  type Progress,
   ToolSchema,
   type Tool as MCPToolDef,
 } from "@modelcontextprotocol/sdk/types.js"
@@ -10,6 +11,9 @@ import { Effect } from "effect"
 
 const DEFAULT_TIMEOUT = 30_000
 const MAX_LIST_PAGES = 1_000
+
+export type ProgressCallback = (progress: Progress) => void
+type ToolExecutionOptionsWithProgress = { onprogress?: ProgressCallback }
 
 const TolerantListToolsResultSchema = ListToolsResultSchema.extend({
   tools: ToolSchema.omit({ outputSchema: true }).array(),
@@ -62,7 +66,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
           signal: options.abortSignal,
           timeout,
           // The MCP SDK only sends a progress token when this hook is present, enabling timeout resets.
-          onprogress: () => {},
+          onprogress: (progress) => (options as ToolExecutionOptionsWithProgress).onprogress?.(progress),
         },
       )
       if (result.isError)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1079,8 +1079,7 @@ export const layer = Layer.effect(
     })
 
     const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts, never, EventV2Bridge.Service> =
-      Effect.fn("SessionPrompt.run")(
-      function* (sessionID: SessionID) {
+      Effect.fn("SessionPrompt.run")(function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
@@ -1337,8 +1336,7 @@ export const layer = Layer.effect(
 
         yield* compaction.prune({ sessionID }).pipe(Effect.ignore, Effect.forkIn(scope))
         return yield* lastAssistant(sessionID)
-      },
-    )
+      })
 
     const loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.loop")(function* (
       input: LoopInput,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1078,7 +1078,8 @@ export const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
-    const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.run")(
+    const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts, never, EventV2Bridge.Service> =
+      Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
         let structured: unknown
@@ -1342,7 +1343,11 @@ export const layer = Layer.effect(
     const loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.loop")(function* (
       input: LoopInput,
     ) {
-      return yield* state.ensureRunning(input.sessionID, lastAssistant(input.sessionID), runLoop(input.sessionID))
+      return yield* state.ensureRunning(
+        input.sessionID,
+        lastAssistant(input.sessionID),
+        runLoop(input.sessionID).pipe(Effect.provideService(EventV2Bridge.Service, events)),
+      )
     })
 
     const shell: (input: ShellInput) => Effect.Effect<SessionV1.WithParts, Session.BusyError> = Effect.fn(

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -40,7 +40,7 @@ const SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES = new Set([
   "image/webp",
 ])
 
-export function mcpProgressToToolProgress(progress: Parameters<ProgressCallback>[0]) {
+export function mcpProgressToToolProgressReport(progress: Parameters<ProgressCallback>[0]) {
   const structured: Record<string, unknown> = {
     source: "mcp",
     progress: progress.progress,
@@ -48,8 +48,13 @@ export function mcpProgressToToolProgress(progress: Parameters<ProgressCallback>
     ...(progress.message !== undefined ? { message: progress.message } : {}),
   }
   return {
+    report: {
+      progress: progress.progress,
+      ...(progress.total !== undefined ? { total: progress.total } : {}),
+      ...(progress.message !== undefined ? { message: progress.message } : {}),
+      source: "mcp" as const,
+    },
     structured,
-    content: progress.message ? [{ type: "text" as const, text: progress.message }] : [],
   }
 }
 
@@ -418,10 +423,10 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
             yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
             const onprogress: ProgressCallback = (progress) => {
-              const state = mcpProgressToToolProgress(progress)
+              const state = mcpProgressToToolProgressReport(progress)
               void run.promise(
                 events
-                  .publish(SessionEvent.Tool.Progress, {
+                  .publish(SessionEvent.Tool.ProgressReport, {
                     sessionID: ctx.sessionID,
                     assistantMessageID: SessionMessage.ID.make(input.processor.message.id),
                     callID: opts.toolCallId,

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -3,6 +3,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import { MCP } from "@/mcp"
+import type { ProgressCallback } from "@/mcp/catalog"
 import { Permission } from "@/permission"
 import { Tool } from "@/tool/tool"
 import { ToolJsonSchema } from "@/tool/json-schema"
@@ -12,7 +13,7 @@ import { Truncate } from "@/tool/truncate"
 import { Plugin } from "@/plugin"
 import type { TaskPromptOps } from "@/tool/task"
 import { type Tool as AITool, tool, jsonSchema, type ToolExecutionOptions, asSchema } from "ai"
-import { Effect } from "effect"
+import { DateTime, Effect } from "effect"
 import { MessageV2 } from "./message-v2"
 import { Session } from "./session"
 import { SessionProcessor } from "./processor"
@@ -21,6 +22,9 @@ import { EffectBridge } from "@/effect/bridge"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { isRecord } from "@/util/record"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionEvent } from "@opencode-ai/core/session/event"
+import { SessionMessage } from "@opencode-ai/core/session/message"
 
 const MCP_RESOURCE_TOOLS = {
   list: "list_mcp_resources",
@@ -35,6 +39,19 @@ const SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES = new Set([
   "image/png",
   "image/webp",
 ])
+
+export function mcpProgressToToolProgress(progress: Parameters<ProgressCallback>[0]) {
+  const structured: Record<string, unknown> = {
+    source: "mcp",
+    progress: progress.progress,
+    ...(progress.total !== undefined ? { total: progress.total } : {}),
+    ...(progress.message !== undefined ? { message: progress.message } : {}),
+  }
+  return {
+    structured,
+    content: progress.message ? [{ type: "text" as const, text: progress.message }] : [],
+  }
+}
 
 export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   agent: Agent.Info
@@ -52,6 +69,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   const registry = yield* ToolRegistry.Service
   const mcp = yield* MCP.Service
   const truncate = yield* Truncate.Service
+  const events = yield* EventV2Bridge.Service
 
   const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => ({
     sessionID: input.session.id,
@@ -399,7 +417,21 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           )
           const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
             yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
-            return yield* Effect.promise(() => execute(args, opts))
+            const onprogress: ProgressCallback = (progress) => {
+              const state = mcpProgressToToolProgress(progress)
+              void run.promise(
+                events
+                  .publish(SessionEvent.Tool.Progress, {
+                    sessionID: ctx.sessionID,
+                    assistantMessageID: SessionMessage.ID.make(input.processor.message.id),
+                    callID: opts.toolCallId,
+                    timestamp: DateTime.makeUnsafe(Date.now()),
+                    ...state,
+                  })
+                  .pipe(Effect.ignore),
+              )
+            }
+            return yield* Effect.promise(() => execute(args, { ...opts, onprogress } as never))
           }).pipe(
             Effect.withSpan("Tool.execute", {
               attributes: {

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -21,6 +21,12 @@ interface MockClientState {
   listResourceTemplatesCalls: number
   getPromptTimeout?: number
   readResourceTimeout?: number
+  callToolOptions?: {
+    resetTimeoutOnProgress?: boolean
+    signal?: AbortSignal
+    timeout?: number
+    onprogress?: (progress: { progress: number; total?: number; message?: string }) => void
+  }
   requestCalls: number
   listToolsShouldFail: boolean
   listToolsError: string
@@ -253,6 +259,12 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
     async readResource(params: { uri: string }, options?: { timeout?: number }) {
       if (this._state) this._state.readResourceTimeout = options?.timeout
       return { contents: [{ uri: params.uri, text: "test" }] }
+    }
+
+    async callTool(_params: unknown, _schema: unknown, options?: MockClientState["callToolOptions"]) {
+      if (this._state) this._state.callToolOptions = options
+      options?.onprogress?.({ progress: 2, total: 4, message: "halfway" })
+      return { content: [{ type: "text", text: "ok" }] }
     }
 
     async close() {
@@ -1008,6 +1020,51 @@ it.instance(
         expect(yield* mcp.resources()).toEqual({})
         expect(serverState.listPromptsCalls).toBe(0)
         expect(serverState.listResourcesCalls).toBe(0)
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "MCP tool calls include a progress handler so progress can reset timeouts",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "progress-server"
+        const serverState = getOrCreateClientState("progress-server")
+        serverState.capabilities = { tools: {} }
+
+        yield* mcp.add("progress-server", {
+          type: "local",
+          command: ["echo", "test"],
+          timeout: 2500,
+        })
+
+        const tools = yield* mcp.tools()
+        const tool = tools["progress-server_test_tool"]
+        expect(tool).toBeDefined()
+
+        const abort = new AbortController()
+        let progress: unknown
+        yield* Effect.promise(() =>
+          tool.execute?.(
+            {},
+            {
+              toolCallId: "call_1",
+              messages: [],
+              abortSignal: abort.signal,
+              onprogress: (value: unknown) => {
+                progress = value
+              },
+            } as never,
+          ),
+        )
+
+        expect(serverState.callToolOptions?.resetTimeoutOnProgress).toBe(true)
+        expect(serverState.callToolOptions?.signal).toBe(abort.signal)
+        expect(serverState.callToolOptions?.timeout).toBe(2500)
+        expect(typeof serverState.callToolOptions?.onprogress).toBe("function")
+        expect(progress).toEqual({ progress: 2, total: 4, message: "halfway" })
       }),
     ),
   { config: { mcp: {} } },

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1047,17 +1047,14 @@ it.instance(
         const abort = new AbortController()
         let progress: unknown
         yield* Effect.promise(() =>
-          tool.execute?.(
-            {},
-            {
-              toolCallId: "call_1",
-              messages: [],
-              abortSignal: abort.signal,
-              onprogress: (value: unknown) => {
-                progress = value
-              },
-            } as never,
-          ),
+          tool.execute?.({}, {
+            toolCallId: "call_1",
+            messages: [],
+            abortSignal: abort.signal,
+            onprogress: (value: unknown) => {
+              progress = value
+            },
+          } as never),
         )
 
         expect(serverState.callToolOptions?.resetTimeoutOnProgress).toBe(true)

--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -1,26 +1,21 @@
 import { describe, expect, it } from "bun:test"
-import { mcpProgressToToolProgress } from "../../src/session/tools"
+import { mcpProgressToToolProgressReport } from "../../src/session/tools"
 
 describe("SessionTools MCP progress", () => {
-  it("maps MCP progress into standard running tool progress", () => {
-    expect(mcpProgressToToolProgress({ progress: 2, total: 4, message: "halfway" })).toEqual({
+  it("maps MCP progress into a status report, not partial tool output", () => {
+    expect(mcpProgressToToolProgressReport({ progress: 2, total: 4, message: "halfway" })).toEqual({
+      report: {
+        progress: 2,
+        total: 4,
+        message: "halfway",
+        source: "mcp",
+      },
       structured: {
         source: "mcp",
         progress: 2,
         total: 4,
         message: "halfway",
       },
-      content: [{ type: "text", text: "halfway" }],
-    })
-  })
-
-  it("keeps progress display bounded when no message is provided", () => {
-    expect(mcpProgressToToolProgress({ progress: 2 })).toEqual({
-      structured: {
-        source: "mcp",
-        progress: 2,
-      },
-      content: [],
     })
   })
 })

--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { mcpProgressToToolProgress } from "../../src/session/tools"
+
+describe("SessionTools MCP progress", () => {
+  it("maps MCP progress into standard running tool progress", () => {
+    expect(mcpProgressToToolProgress({ progress: 2, total: 4, message: "halfway" })).toEqual({
+      structured: {
+        source: "mcp",
+        progress: 2,
+        total: 4,
+        message: "halfway",
+      },
+      content: [{ type: "text", text: "halfway" }],
+    })
+  })
+
+  it("keeps progress display bounded when no message is provided", () => {
+    expect(mcpProgressToToolProgress({ progress: 2 })).toEqual({
+      structured: {
+        source: "mcp",
+        progress: 2,
+      },
+      content: [],
+    })
+  })
+})

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -339,6 +339,22 @@ export namespace Tool {
   })
   export type Progress = typeof Progress.Type
 
+  export const ProgressReport = Event.define({
+    type: "session.next.tool.progress.report",
+    ...options,
+    schema: {
+      ...ToolBase,
+      report: Schema.Struct({
+        progress: Schema.Finite,
+        total: Schema.Finite.pipe(Schema.optional),
+        message: Schema.String.pipe(Schema.optional),
+        source: Schema.Literal("mcp"),
+      }),
+      structured: Schema.Record(Schema.String, Schema.Any),
+    },
+  })
+  export type ProgressReport = typeof ProgressReport.Type
+
   export const Success = Event.define({
     type: "session.next.tool.success",
     ...options,
@@ -464,6 +480,7 @@ export const DurableDefinitions = Event.inventory(
   Tool.Input.Ended,
   Tool.Called,
   Tool.Progress,
+  Tool.ProgressReport,
   Tool.Success,
   Tool.Failed,
   Reasoning.Started,
@@ -500,6 +517,7 @@ export const Definitions = Event.inventory(
   Tool.Input.Ended,
   Tool.Called,
   Tool.Progress,
+  Tool.ProgressReport,
   Tool.Success,
   Tool.Failed,
   Retried,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -39,6 +39,7 @@ export type Event =
   | EventSessionNextToolInputEnded
   | EventSessionNextToolCalled
   | EventSessionNextToolProgress
+  | EventSessionNextToolProgressReport
   | EventSessionNextToolSuccess
   | EventSessionNextToolFailed
   | EventSessionNextRetried
@@ -1088,6 +1089,25 @@ export type GlobalEvent = {
       }
     | {
         id: string
+        type: "session.next.tool.progress.report"
+        properties: {
+          timestamp: number
+          sessionID: string
+          assistantMessageID: string
+          callID: string
+          report: {
+            progress: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+            total?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+            message?: string
+            source?: string
+          }
+          structured: {
+            [key: string]: unknown
+          }
+        }
+      }
+    | {
+        id: string
         type: "session.next.tool.success"
         properties: {
           timestamp: number
@@ -1628,6 +1648,7 @@ export type GlobalEvent = {
     | SyncEventSessionNextToolInputEnded
     | SyncEventSessionNextToolCalled
     | SyncEventSessionNextToolProgress
+    | SyncEventSessionNextToolProgressReport
     | SyncEventSessionNextToolSuccess
     | SyncEventSessionNextToolFailed
     | SyncEventSessionNextRetried
@@ -2774,6 +2795,7 @@ export type V2Event =
   | V2EventSessionNextToolInputEnded
   | V2EventSessionNextToolCalled
   | V2EventSessionNextToolProgress
+  | V2EventSessionNextToolProgressReport
   | V2EventSessionNextToolSuccess
   | V2EventSessionNextToolFailed
   | V2EventSessionNextRetried
@@ -3554,6 +3576,32 @@ export type SyncEventSessionNextToolProgress = {
         [key: string]: unknown
       }
       content: Array<LlmToolContent>
+    }
+  }
+}
+
+export type SyncEventSessionNextToolProgressReport = {
+  type: "sync"
+  id: string
+  syncEvent: {
+    type: "session.next.tool.progress.report.1"
+    id: string
+    seq: number
+    aggregateID: string
+    data: {
+      timestamp: number
+      sessionID: string
+      assistantMessageID: string
+      callID: string
+      report: {
+        progress: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+        total?: number | "NaN" | "Infinity" | "-Infinity" | "Infinity" | "-Infinity" | "NaN"
+        message?: string
+        source?: string
+      }
+      structured: {
+        [key: string]: unknown
+      }
     }
   }
 }
@@ -5589,6 +5637,35 @@ export type V2EventSessionNextToolProgress = {
   }
 }
 
+export type V2EventSessionNextToolProgressReport = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  type: "session.next.tool.progress.report"
+  data: {
+    timestamp: number
+    sessionID: string
+    assistantMessageID: string
+    callID: string
+    report: {
+      progress: number | "NaN" | "Infinity" | "-Infinity"
+      total?: number | "NaN" | "Infinity" | "-Infinity"
+      message?: string
+      source: "mcp"
+    }
+    structured: {
+      [key: string]: unknown
+    }
+  }
+}
+
 export type V2EventSessionNextToolSuccess = {
   id: string
   metadata?: {
@@ -7074,6 +7151,26 @@ export type EventSessionNextToolProgress = {
       [key: string]: unknown
     }
     content: Array<LlmToolContent>
+  }
+}
+
+export type EventSessionNextToolProgressReport = {
+  id: string
+  type: "session.next.tool.progress.report"
+  properties: {
+    timestamp: number
+    sessionID: string
+    assistantMessageID: string
+    callID: string
+    report: {
+      progress: number | "NaN" | "Infinity" | "-Infinity"
+      total?: number | "NaN" | "Infinity" | "-Infinity"
+      message?: string
+      source?: string
+    }
+    structured: {
+      [key: string]: unknown
+    }
   }
 }
 

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -15359,6 +15359,9 @@
             "$ref": "#/components/schemas/EventSessionNextToolProgress"
           },
           {
+            "$ref": "#/components/schemas/EventSessionNextToolProgressReport"
+          },
+          {
             "$ref": "#/components/schemas/EventSessionNextToolSuccess"
           },
           {
@@ -18652,6 +18655,104 @@
                   },
                   "type": {
                     "type": "string",
+                    "enum": ["session.next.tool.progress.report"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {
+                      "timestamp": {
+                        "type": "number"
+                      },
+                      "sessionID": {
+                        "type": "string",
+                        "pattern": "^ses"
+                      },
+                      "assistantMessageID": {
+                        "type": "string",
+                        "pattern": "^msg_"
+                      },
+                      "callID": {
+                        "type": "string"
+                      },
+                      "report": {
+                        "type": "object",
+                        "properties": {
+                          "progress": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["NaN"]
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["Infinity"]
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["-Infinity"]
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["Infinity", "-Infinity", "NaN"]
+                              }
+                            ]
+                          },
+                          "total": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["NaN"]
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["Infinity"]
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["-Infinity"]
+                              },
+                              {
+                                "type": "string",
+                                "enum": ["Infinity", "-Infinity", "NaN"]
+                              }
+                            ]
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "source": {
+                            "type": "string"
+                          }
+                        },
+                        "required": ["progress"],
+                        "additionalProperties": false
+                      },
+                      "structured": {
+                        "type": "object"
+                      }
+                    },
+                    "required": ["timestamp", "sessionID", "assistantMessageID", "callID", "report", "structured"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^evt_"
+                  },
+                  "type": {
+                    "type": "string",
                     "enum": ["session.next.tool.success"]
                   },
                   "properties": {
@@ -20495,6 +20596,9 @@
               },
               {
                 "$ref": "#/components/schemas/SyncEventSessionNextToolProgress"
+              },
+              {
+                "$ref": "#/components/schemas/SyncEventSessionNextToolProgressReport"
               },
               {
                 "$ref": "#/components/schemas/SyncEventSessionNextToolSuccess"
@@ -23751,6 +23855,9 @@
             "$ref": "#/components/schemas/V2EventSessionNextToolProgress"
           },
           {
+            "$ref": "#/components/schemas/V2EventSessionNextToolProgressReport"
+          },
+          {
             "$ref": "#/components/schemas/V2EventSessionNextToolSuccess"
           },
           {
@@ -26139,6 +26246,125 @@
                   }
                 },
                 "required": ["timestamp", "sessionID", "assistantMessageID", "callID", "structured", "content"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "id", "seq", "aggregateID", "data"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["type", "id", "syncEvent"],
+        "additionalProperties": false
+      },
+      "SyncEventSessionNextToolProgressReport": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["sync"]
+          },
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "syncEvent": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["session.next.tool.progress.report.1"]
+              },
+              "id": {
+                "type": "string",
+                "pattern": "^evt_"
+              },
+              "seq": {
+                "type": "number"
+              },
+              "aggregateID": {
+                "type": "string"
+              },
+              "data": {
+                "type": "object",
+                "properties": {
+                  "timestamp": {
+                    "type": "number"
+                  },
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses"
+                  },
+                  "assistantMessageID": {
+                    "type": "string",
+                    "pattern": "^msg_"
+                  },
+                  "callID": {
+                    "type": "string"
+                  },
+                  "report": {
+                    "type": "object",
+                    "properties": {
+                      "progress": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["NaN"]
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["Infinity"]
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["-Infinity"]
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["Infinity", "-Infinity", "NaN"]
+                          }
+                        ]
+                      },
+                      "total": {
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["NaN"]
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["Infinity"]
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["-Infinity"]
+                          },
+                          {
+                            "type": "string",
+                            "enum": ["Infinity", "-Infinity", "NaN"]
+                          }
+                        ]
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["progress"],
+                    "additionalProperties": false
+                  },
+                  "structured": {
+                    "type": "object"
+                  }
+                },
+                "required": ["timestamp", "sessionID", "assistantMessageID", "callID", "report", "structured"],
                 "additionalProperties": false
               }
             },
@@ -33180,6 +33406,103 @@
         "required": ["id", "type", "data"],
         "additionalProperties": false
       },
+      "V2EventSessionNextToolProgressReport": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "durable": {
+            "type": "object",
+            "properties": {
+              "aggregateID": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "integer"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["aggregateID", "seq", "version"],
+            "additionalProperties": false
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationRef"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["session.next.tool.progress.report"]
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "assistantMessageID": {
+                "type": "string",
+                "pattern": "^msg_"
+              },
+              "callID": {
+                "type": "string"
+              },
+              "report": {
+                "type": "object",
+                "properties": {
+                  "progress": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN", "Infinity", "-Infinity"]
+                      }
+                    ]
+                  },
+                  "total": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN", "Infinity", "-Infinity"]
+                      }
+                    ]
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string",
+                    "enum": ["mcp"]
+                  }
+                },
+                "required": ["progress", "source"],
+                "additionalProperties": false
+              },
+              "structured": {
+                "type": "object"
+              }
+            },
+            "required": ["timestamp", "sessionID", "assistantMessageID", "callID", "report", "structured"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "data"],
+        "additionalProperties": false
+      },
       "V2EventSessionNextToolSuccess": {
         "type": "object",
         "properties": {
@@ -37480,6 +37803,96 @@
               }
             },
             "required": ["timestamp", "sessionID", "assistantMessageID", "callID", "structured", "content"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventSessionNextToolProgressReport": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["session.next.tool.progress.report"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "assistantMessageID": {
+                "type": "string",
+                "pattern": "^msg_"
+              },
+              "callID": {
+                "type": "string"
+              },
+              "report": {
+                "type": "object",
+                "properties": {
+                  "progress": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
+                  "total": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["NaN"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity"]
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["-Infinity"]
+                      }
+                    ]
+                  },
+                  "message": {
+                    "type": "string"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": ["progress"],
+                "additionalProperties": false
+              },
+              "structured": {
+                "type": "object"
+              }
+            },
+            "required": ["timestamp", "sessionID", "assistantMessageID", "callID", "report", "structured"],
             "additionalProperties": false
           }
         },

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -303,6 +303,16 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             match.state.content = [...event.data.content]
           })
           break
+        case "session.next.tool.progress.report":
+          message.update(event.data.sessionID, (draft) => {
+            const match = message.latestTool(
+              message.assistant(draft, event.data.assistantMessageID),
+              event.data.callID,
+            )
+            if (match?.state.status !== "running") return
+            match.state.structured = event.data.structured
+          })
+          break
         case "session.next.tool.success":
           message.update(event.data.sessionID, (draft) => {
             const match = message.latestTool(message.assistant(draft, event.data.assistantMessageID), event.data.callID)


### PR DESCRIPTION
### Issue for this PR

Refs #28567
Depends on #32477

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Builds on #32477 by turning MCP progress notifications into opencode's existing running-tool progress surface.

The MCP catalog now forwards SDK progress notifications to a caller-provided progress callback. The session MCP tool wrapper uses that callback to publish `session.next.tool.progress`, which is already consumed by the session state/TUI path.

I kept this intentionally small:

- no new UI component
- no tool cancellation changes
- no generic MCP notification framework yet
- no `resources/updated` handling

This is just the first progress/status surface slice: MCP progress now has a real tool/session event path instead of only acting as a timeout keepalive.

### How did you verify your code works?

Added tests for:

- forwarding MCP SDK progress through the converted MCP tool
- mapping MCP progress into standard running-tool progress state

Ran:

```bash
bun test --timeout 30000 test/mcp/lifecycle.test.ts --only-failures
bun test --timeout 30000 test/session/tools.test.ts --only-failures
bun test --timeout 30000 test/mcp --only-failures
bun test --timeout 30000 test/session --only-failures
bun run typecheck
```

### Notes

This PR is stacked on #32477. Until #32477 merges, GitHub may show the progress keepalive commit in this diff as well.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
