### PR TITLE
fix(tui): attach auth token when editor port comes from env

### DIFF
--- a/packages/opencode/test/cli/tui/editor-context.test.tsx
+++ b/packages/opencode/test/cli/tui/editor-context.test.tsx
@@ -7,7 +7,7 @@ import { EditorContextProvider, useEditorContext, type EditorIntegration } from 
 import { tmpdir } from "../../fixture/fixture"
 import { FakeWebSocket } from "../../lib/websocket"
 import { TestTuiContexts } from "../../fixture/tui-environment"
-import { discoverEditorConnection } from "@opencode-ai/tui/editor"
+import { discoverEditorConnection, discoverEditorConnectionByPort } from "@opencode-ai/tui/editor"
 
 const originalClaudePort = process.env.CLAUDE_CODE_SSE_PORT
 const originalOpencodePort = process.env.OPENCODE_EDITOR_SSE_PORT
@@ -51,6 +51,7 @@ function mountEditorContext(WebSocketImpl?: typeof WebSocket) {
 
 const editorService: EditorIntegration = {
   connection: discoverEditorConnection,
+  connectionByPort: discoverEditorConnectionByPort,
 }
 
 function createWebSocketImpl(...sockets: FakeWebSocket[]) {
@@ -159,6 +160,14 @@ test("useEditorContext favors configured port over lock files", async () => {
   await mkdir(ideDirectory, { recursive: true })
   await writeFile(
     path.join(ideDirectory, "3001.lock"),
+    JSON.stringify({
+      transport: "ws",
+      workspaceFolders: [startupDirectory],
+    }),
+  )
+
+  await writeFile(
+    path.join(ideDirectory, "4010.lock"),
     JSON.stringify({
       transport: "ws",
       workspaceFolders: [startupDirectory],
@@ -287,6 +296,68 @@ test("useEditorContext connects with OPENCODE_EDITOR_SSE_PORT", async () => {
   process.env.OPENCODE_EDITOR_SSE_PORT = "4020"
   spyOn(process, "cwd").mockImplementation(() => tmp.path)
   const socket = new FakeWebSocket("ws://127.0.0.1:4020")
+
+  const mounted = mountEditorContext(createWebSocketImpl(socket))
+  await nextTick()
+
+  expect(socket.closed).toBeFalse()
+
+  mounted.dispose()
+})
+
+test("useEditorContext authorizes a configured SSE port using the lock file token", async () => {
+  await using tmp = await tmpdir()
+  const startupDirectory = path.join(tmp.path, "startup")
+  const ideDirectory = path.join(tmp.path, ".claude", "ide")
+  await mkdir(startupDirectory, { recursive: true })
+  await mkdir(ideDirectory, { recursive: true })
+  await writeFile(
+    path.join(ideDirectory, "4030.lock"),
+    JSON.stringify({
+      transport: "ws",
+      workspaceFolders: [startupDirectory],
+      authToken: "secret-token",
+    }),
+  )
+
+  process.env.CLAUDE_CODE_SSE_PORT = "4030"
+  process.env.OPENCODE_EDITOR_SSE_PORT = undefined
+  spyOn(process, "cwd").mockImplementation(() => startupDirectory)
+  spyOn(os, "homedir").mockImplementation(() => tmp.path)
+  const socket = new FakeWebSocket("ws://127.0.0.1:4030", {
+    headers: { "x-claude-code-ide-authorization": "secret-token" },
+  })
+
+  const mounted = mountEditorContext(createWebSocketImpl(socket))
+  await nextTick()
+
+  expect(socket.closed).toBeFalse()
+
+  mounted.dispose()
+})
+
+test("useEditorContext falls back to lock discovery when the configured port is stale", async () => {
+  await using tmp = await tmpdir()
+  const startupDirectory = path.join(tmp.path, "startup")
+  const ideDirectory = path.join(tmp.path, ".claude", "ide")
+  await mkdir(startupDirectory, { recursive: true })
+  await mkdir(ideDirectory, { recursive: true })
+  await writeFile(
+    path.join(ideDirectory, "4041.lock"),
+    JSON.stringify({
+      transport: "ws",
+      workspaceFolders: [startupDirectory],
+      authToken: "disc-token",
+    }),
+  )
+
+  process.env.CLAUDE_CODE_SSE_PORT = "4040"
+  process.env.OPENCODE_EDITOR_SSE_PORT = undefined
+  spyOn(process, "cwd").mockImplementation(() => startupDirectory)
+  spyOn(os, "homedir").mockImplementation(() => tmp.path)
+  const socket = new FakeWebSocket("ws://127.0.0.1:4041", {
+    headers: { "x-claude-code-ide-authorization": "disc-token" },
+  })
 
   const mounted = mountEditorContext(createWebSocketImpl(socket))
   await nextTick()

--- a/packages/tui/src/context/editor.ts
+++ b/packages/tui/src/context/editor.ts
@@ -106,6 +106,7 @@ type EditorConnection = {
 
 export type EditorIntegration = Readonly<{
   connection?(directory: string): EditorConnection | undefined
+  connectionByPort?(port: number): EditorConnection | undefined
   selection?(directory: string): Promise<unknown>
 }>
 
@@ -173,7 +174,7 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
     const connect = () => {
       if (closed) return
 
-      const connection = resolveEditorConnection(directory, port, editor.connection)
+      const connection = resolveEditorConnection(directory, port, editor.connection, editor.connectionByPort)
       if (!connection) {
         if (!zedTerminal) {
           setStore("status", "disabled")
@@ -320,7 +321,10 @@ export const { use: useEditorContext, provider: EditorContextProvider } = create
 
     return {
       enabled() {
-        return Boolean(resolveEditorConnection(directory, port, editor.connection) || (zedTerminal && editor.selection))
+        return Boolean(
+          resolveEditorConnection(directory, port, editor.connection, editor.connectionByPort) ||
+            (zedTerminal && editor.selection),
+        )
       },
       connected() {
         return store.status === "connected"
@@ -362,12 +366,14 @@ function resolveEditorConnection(
   directory: string,
   port: number | undefined,
   discover: ((directory: string) => EditorConnection | undefined) | undefined,
+  connectionByPort: ((port: number) => EditorConnection | undefined) | undefined,
 ): EditorConnection | undefined {
   if (port) {
-    return {
-      url: `ws://127.0.0.1:${port}`,
-      source: `env:${port}`,
-    }
+    const connection = connectionByPort?.(port)
+    if (connection) return connection
+    const discovered = discover?.(directory)
+    if (discovered) return discovered
+    return { url: `ws://127.0.0.1:${port}`, source: `env:${port}` }
   }
 
   return discover?.(directory)

--- a/packages/tui/src/editor.ts
+++ b/packages/tui/src/editor.ts
@@ -53,6 +53,24 @@ export async function openEditor(input: { value: string; renderer: CliRenderer; 
   }
 }
 
+function readEditorLock(file: string) {
+  const port = Number.parseInt(path.basename(file, ".lock"), 10)
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return undefined
+  try {
+    const value = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>
+    if (value.transport !== undefined && value.transport !== "ws") return undefined
+    return {
+      port,
+      authToken: typeof value.authToken === "string" ? value.authToken : undefined,
+      workspaceFolders: Array.isArray(value.workspaceFolders)
+        ? value.workspaceFolders.filter((item): item is string => typeof item === "string")
+        : [],
+    }
+  } catch {
+    return undefined
+  }
+}
+
 export function discoverEditorConnection(directory: string) {
   const root = path.join(os.homedir(), ".claude", "ide")
   const contains = (parent: string) => {
@@ -65,28 +83,19 @@ export function discoverEditorConnection(directory: string) {
       .filter((entry) => entry.endsWith(".lock"))
       .flatMap((entry) => {
         const file = path.join(root, entry)
-        const port = Number.parseInt(path.basename(file, ".lock"), 10)
-        if (!Number.isInteger(port) || port <= 0 || port > 65535) return []
-        try {
-          const value = JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>
-          if (value.transport !== undefined && value.transport !== "ws") return []
-          const folders = Array.isArray(value.workspaceFolders)
-            ? value.workspaceFolders.filter((item): item is string => typeof item === "string")
-            : []
-          const score = Math.max(0, ...folders.map(contains))
-          if (!score) return []
-          return [
-            {
-              url: `ws://127.0.0.1:${port}`,
-              authToken: typeof value.authToken === "string" ? value.authToken : undefined,
-              source: `lock:${port}`,
-              score,
-              mtime: statSync(file).mtimeMs,
-            },
-          ]
-        } catch {
-          return []
-        }
+        const lock = readEditorLock(file)
+        if (!lock) return []
+        const score = Math.max(0, ...lock.workspaceFolders.map(contains))
+        if (!score) return []
+        return [
+          {
+            url: `ws://127.0.0.1:${lock.port}`,
+            authToken: lock.authToken,
+            source: `lock:${lock.port}`,
+            score,
+            mtime: statSync(file).mtimeMs,
+          },
+        ]
       })
       .sort((left, right) => right.score - left.score || right.mtime - left.mtime)
       .map(({ url, authToken, source }) => ({ url, authToken, source }))[0]
@@ -95,7 +104,18 @@ export function discoverEditorConnection(directory: string) {
   }
 }
 
+export function discoverEditorConnectionByPort(port: number) {
+  const lock = readEditorLock(path.join(os.homedir(), ".claude", "ide", `${port}.lock`))
+  if (!lock) return undefined
+  return {
+    url: `ws://127.0.0.1:${lock.port}`,
+    authToken: lock.authToken,
+    source: `env:${lock.port}`,
+  }
+}
+
 export const editorIntegration = {
   connection: discoverEditorConnection,
+  connectionByPort: discoverEditorConnectionByPort,
   selection: (directory: string) => resolveZedSelection(resolveZedDbPath() ?? "", directory),
 }


### PR DESCRIPTION
### Issue for this PR

Closes #29570
Closes #26852

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the editor file/selection context not syncing when opencode runs in a VSCode / Cursor integrated terminal.

The Claude Code extension injects `CLAUDE_CODE_SSE_PORT` into integrated terminals and writes a matching `~/.claude/ide/<port>.lock` whose `authToken` its WebSocket server requires. External terminals don't get the env var, so they already worked via lock-file discovery. Two bugs on the configured-port path:

1. **Missing auth token (#29570):** the connection was opened without the token, so the server closed it with `1008 Unauthorized` and no `selection_changed` events ever arrived.
2. **Stale port (#26852):** when the env var pointed at a dead port (e.g. left over from a previous VSCode session, its lock already gone), opencode kept retrying it and never fell back to lock discovery.

Now, for a configured port we read its `~/.claude/ide/<port>.lock` and attach the token; if that lock is missing we fall back to scanning `~/.claude/ide` for the live server matching the working directory. This runs on every (re)connect, so if the server dies mid-session it recovers on its own. A lockless `OPENCODE_EDITOR_SSE_PORT` override still connects directly. Also extracted a small `readEditorLock` helper so the by-directory and by-port lookups don't duplicate the parse/validate logic.

### How did you verify your code works?

- Reproduced against the running Claude Code server: tokenless connect → `1008 Unauthorized`; with the lock token → handshake OK + `selection_changed`. A dead `CLAUDE_CODE_SSE_PORT` falls back to the live server.
- Added regression tests: a configured port attaches the lock token, and a stale configured port (no lock) falls back to discovery.
- `bun test test/cli/tui/editor-context.test.tsx` passes (7); `tsgo --noEmit` passes for `packages/tui` and `packages/opencode`.

### Screenshots / recordings

N/A — not a visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR