### PR TITLE
fix(opencode): allow clearing session archive time

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -72,7 +72,7 @@ function sessionRow(info: SessionV1.SessionInfo): typeof SessionTable.$inferInse
     time_created: info.time.created,
     time_updated: info.time.updated,
     time_compacting: info.time.compacting,
-    time_archived: info.time.archived,
+    time_archived: info.time.archived ?? null,
   }
 }
 

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -182,6 +182,33 @@ describe("SessionV2.create", () => {
     }),
   )
 
+  it.effect("clears archived projection when a legacy update omits archived time", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionV2.Service
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+      const input = { id, location }
+      const created = yield* session.create(input)
+      yield* db.update(SessionTable).set({ time_archived: 123 }).where(eq(SessionTable.id, id)).run().pipe(Effect.orDie)
+
+      yield* events.publish(SessionV1.Event.Updated, {
+        sessionID: id,
+        info: SessionV1.SessionInfo.make({
+          id,
+          slug: "updated",
+          version: "test",
+          projectID: created.projectID,
+          directory: created.location.directory,
+          title: "updated",
+          time: { created: 0, updated: 1 },
+        }),
+      })
+
+      const row = yield* db.select().from(SessionTable).where(eq(SessionTable.id, id)).get().pipe(Effect.orDie)
+      expect(row?.time_archived).toBeNull()
+    }),
+  )
+
   it.effect("persists creation through the existing legacy created event", () =>
     Effect.gen(function* () {
       const session = yield* SessionV2.Service

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -52,7 +52,7 @@ export const UpdatePayload = Schema.Struct({
   permission: Schema.optional(PermissionV1.Ruleset),
   time: Schema.optional(
     Schema.Struct({
-      archived: Schema.optional(Session.ArchivedTimestamp),
+      archived: Schema.optional(Schema.NullOr(Session.ArchivedTimestamp)),
     }),
   ),
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -195,8 +195,8 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
           permission: Permission.merge(current.permission ?? [], ctx.payload.permission),
         })
       }
-      if (ctx.payload.time?.archived !== undefined) {
-        yield* session.setArchived({ sessionID: ctx.params.sessionID, time: ctx.payload.time.archived })
+      if (ctx.payload.time && Object.hasOwn(ctx.payload.time, "archived")) {
+        yield* session.setArchived({ sessionID: ctx.params.sessionID, time: ctx.payload.time.archived ?? undefined })
       }
       return yield* requireSession(ctx.params.sessionID)
     })

--- a/packages/opencode/src/server/routes/instance/httpapi/public.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/public.ts
@@ -137,6 +137,11 @@ function matchLegacyOpenApi(input: Record<string, unknown>) {
             : operation.requestBody.content?.["application/json"]?.schema?.properties
           if (properties?.id) properties.id = { anyOf: [properties.id, { type: "null" }] }
         }
+        if (path === "/session/{sessionID}" && method === "patch") {
+          const timeProperties = body?.schema?.properties?.time?.properties
+          const archived = timeProperties?.archived
+          if (archived) timeProperties.archived = nullable(archived)
+        }
       }
       for (const response of Object.values(operation.responses ?? {})) {
         for (const content of Object.values(response.content ?? {})) {

--- a/packages/opencode/test/server/httpapi-public-openapi.test.ts
+++ b/packages/opencode/test/server/httpapi-public-openapi.test.ts
@@ -23,7 +23,10 @@ type OpenApiOperation = {
     readonly schema?: { readonly type?: string }
   }>
   readonly responses?: Record<string, OpenApiResponse>
-  readonly requestBody?: { readonly required?: boolean }
+  readonly requestBody?: {
+    readonly required?: boolean
+    readonly content?: Record<string, { readonly schema?: OpenApiSchema }>
+  }
   readonly security?: unknown
 }
 type OpenApiPathItem = Partial<Record<Method, OpenApiOperation>>
@@ -53,6 +56,15 @@ function responseRef(response: OpenApiResponse | undefined) {
 
 function componentName(ref: string) {
   return ref.replace("#/components/schemas/", "")
+}
+
+function schemaRef(spec: OpenApiSpec, schema: OpenApiSchema | undefined) {
+  if (!schema?.$ref) return schema
+  return spec.components.schemas[componentName(schema.$ref)]
+}
+
+function jsonRequestSchema(spec: OpenApiSpec, path: string, method: Method) {
+  return schemaRef(spec, spec.paths[path]?.[method]?.requestBody?.content?.["application/json"]?.schema)
 }
 
 function componentNames(response: OpenApiResponse | undefined) {
@@ -113,6 +125,15 @@ describe("PublicApi OpenAPI v2 errors", () => {
     ]) {
       expect(spec.paths[path]?.post?.requestBody?.required, path).toBe(true)
     }
+  })
+
+  test("documents nullable archived session update payload", () => {
+    const spec = OpenApi.fromApi(PublicApi) as OpenApiSpec
+    const body = jsonRequestSchema(spec, "/session/{sessionID}", "patch")
+    const time = schemaRef(spec, body?.properties?.time)
+    const archived = schemaRef(spec, time?.properties?.archived)
+
+    expect(archived?.anyOf?.some((item) => item.type === "null")).toBe(true)
   })
 
   test("documents integration discovery and connection routes", () => {

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -838,6 +838,39 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "clears archived timestamp with null update payload",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory, "content-type": "application/json" }
+        const session = yield* createSession({ title: "archived" })
+        yield* requestJson<Session.Info>(pathFor(SessionPaths.update, { sessionID: session.id }), {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ time: { archived: 123 } }),
+        })
+        const unchanged = yield* requestJson<Session.Info>(pathFor(SessionPaths.update, { sessionID: session.id }), {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ time: {} }),
+        })
+        expect(unchanged.time.archived).toBe(123)
+
+        const response = yield* request(pathFor(SessionPaths.update, { sessionID: session.id }), {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify({ time: { archived: null } }),
+        })
+
+        expect(response.status).toBe(200)
+        const updated = yield* json<Session.Info>(response)
+        expect(updated.time.archived).toBeUndefined()
+        expect(Object.hasOwn(updated.time as Record<string, unknown>, "archived")).toBe(false)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "uses project-scoped path and directory precedence",
     () =>
       Effect.gen(function* () {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -3505,7 +3505,7 @@ export class Session2 extends HeyApiClient {
       }
       permission?: PermissionRuleset
       time?: {
-        archived?: number
+        archived?: number | null
       }
     },
     options?: Options<never, ThrowOnError>,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -7655,7 +7655,7 @@ export type SessionUpdateData = {
     }
     permission?: PermissionRuleset
     time?: {
-      archived?: number
+      archived?: number | null
     }
   }
   path: {


### PR DESCRIPTION
### Issue for this PR

Closes #24153 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

We only have the way to archive a session, but we can't cancel the operation. It bothered me when doing extended development.

Fixes session archive updates so `PATCH /session/:sessionID` can clear `time.archived` with:

```json
{ "time": { "archived": null } }
```

Previously this payload was accepted but treated like the field was omitted, so the session stayed archived.

The fix makes the update payload schema accept `null`, checks whether the `archived` field is actually present instead of checking only for `undefined`, and maps `null` to the existing clear-archive path. `time: {}` still remains a no-op. The projected session row also writes `NULL` when archived time is absent, so replayed legacy session updates do not keep stale archive timestamps.

The generated SDK/OpenAPI output now reflects `archived?: number | null`.

### How did you verify your code works?

Ran:

```sh
cd packages/core && bun test --timeout 30000 test/session-create.test.ts
cd packages/core && bun typecheck
cd packages/opencode && bun test --timeout 30000 test/server/httpapi-session.test.ts test/server/httpapi-public-openapi.test.ts
cd packages/opencode && bun typecheck
```

### Screenshots / recordings

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
