### PR TITLE
fix: handle Copilot Claude assistant prefill and tool text leaks

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -51,6 +51,19 @@ export namespace ProviderTransform {
     model: Provider.Model,
     options: Record<string, unknown>,
   ): ModelMessage[] {
+    // GitHub Copilot Claude (Opus 4.8 etc) rejects requests that end with an assistant
+    // message: "This model does not support assistant message prefill. The conversation
+    // must end with a user message." This happens after interrupted/partial turns and
+    // when isLastStep injects a trailing assistant MAX_STEPS instruction. Append a
+    // synthetic user message instead of dropping the assistant so MAX_STEPS and any
+    // partial content are preserved in context.
+    if (model.api.npm === "@ai-sdk/github-copilot" && `${model.id} ${model.api.id}`.toLowerCase().includes("claude")) {
+      const last = msgs.at(-1)
+      if (last?.role === "assistant") {
+        msgs = [...msgs, { role: "user", content: [{ type: "text", text: "Continue." }] }]
+      }
+    }
+
     // Anthropic rejects messages with empty content - filter out empty string messages
     // and remove empty text/reasoning parts from array content
     if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/amazon-bedrock") {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -21,6 +21,15 @@ export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
   const log = Log.create({ service: "session.processor" })
 
+  // GitHub Copilot Claude can leak literal tool-call text into assistant prose.
+  function scrub(text: string) {
+    let out = text.replace(/(?:call\s+)?<invoke\b[\s\S]*?(?:<\/invoke>|$)/gi, "")
+    const leak =
+      /^\s*call\s+(read|write|edit|grep|bash|glob|list|task|skill|question|batch|multiedit|apply_patch|webfetch|websearch|codesearch|todowrite)\b[^\n]{0,40}$/gim
+    if ((out.match(leak)?.length ?? 0) >= 3) out = out.replace(leak, "")
+    return out.replace(/\n{3,}/g, "\n\n").trimEnd()
+  }
+
   export type Info = Awaited<ReturnType<typeof create>>
   export type Result = Awaited<ReturnType<Info["process"]>>
 
@@ -35,6 +44,9 @@ export namespace SessionProcessor {
     let blocked = false
     let attempt = 0
     let needsCompaction = false
+    const claude =
+      input.model.api.npm === "@ai-sdk/github-copilot" &&
+      `${input.model.id} ${input.model.api.id}`.toLowerCase().includes("claude")
 
     const result = {
       get message() {
@@ -48,8 +60,30 @@ export namespace SessionProcessor {
         needsCompaction = false
         const shouldBreak = (await Config.get()).experimental?.continue_loop_on_deny !== true
         while (true) {
+          let currentText: MessageV2.TextPart | undefined
+          const clean = async () => {
+            if (!claude || !currentText) return
+            const text = scrub(currentText.text.trimEnd())
+            if (!text) {
+              await Session.removePart({
+                sessionID: currentText.sessionID,
+                messageID: currentText.messageID,
+                partID: currentText.id,
+              })
+              currentText = undefined
+              return
+            }
+            if (text !== currentText.text) {
+              currentText.text = text
+              currentText.time = {
+                start: currentText.time?.start ?? Date.now(),
+                end: Date.now(),
+              }
+              await Session.updatePart(currentText)
+            }
+            currentText = undefined
+          }
           try {
-            let currentText: MessageV2.TextPart | undefined
             let reasoningMap: Record<string, MessageV2.ReasoningPart> = {}
             const stream = await LLM.stream(streamInput)
 
@@ -320,6 +354,18 @@ export namespace SessionProcessor {
                 case "text-end":
                   if (currentText) {
                     currentText.text = currentText.text.trimEnd()
+                    if (claude) {
+                      currentText.text = scrub(currentText.text)
+                      if (!currentText.text) {
+                        await Session.removePart({
+                          sessionID: currentText.sessionID,
+                          messageID: currentText.messageID,
+                          partID: currentText.id,
+                        })
+                        currentText = undefined
+                        break
+                      }
+                    }
                     const textOutput = await Plugin.trigger(
                       "experimental.text.complete",
                       {
@@ -384,6 +430,8 @@ export namespace SessionProcessor {
               })
               await SessionStatus.set(input.sessionID, { type: "idle" })
             }
+          } finally {
+            await clean().catch((e) => log.error("clean", { error: e }))
           }
           if (snapshot) {
             const patch = await Snapshot.patch(snapshot)

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1162,6 +1162,77 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
     expect(result[0].content[1]).toEqual({ type: "text", text: "Result" })
   })
 
+  test("appends synthetic user after trailing assistant for GitHub Copilot Claude", () => {
+    const model = {
+      ...anthropicModel,
+      id: "github-copilot/claude-opus-4.8",
+      providerID: "github-copilot",
+      api: {
+        id: "claude-opus-4.8",
+        url: "https://api.githubcopilot.com/v1/messages",
+        npm: "@ai-sdk/github-copilot",
+      },
+    }
+
+    const result = ProviderTransform.message(
+      [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: [{ type: "text", text: "partial" }] },
+      ] as any[],
+      model,
+      {},
+    )
+
+    expect(result).toHaveLength(3)
+    expect(result[1]?.role).toBe("assistant")
+    expect(Array.isArray(result[1]?.content) && result[1].content[0]?.type === "text" && result[1].content[0].text).toBe(
+      "partial",
+    )
+    expect(result[2]?.role).toBe("user")
+    expect(
+      Array.isArray(result[2]?.content) && result[2].content[0]?.type === "text" && result[2].content[0].text,
+    ).toBe("Continue.")
+  })
+
+  test("does not append synthetic user when Copilot Claude already ends with user", () => {
+    const model = {
+      ...anthropicModel,
+      id: "github-copilot/claude-opus-4.8",
+      providerID: "github-copilot",
+      api: {
+        id: "claude-opus-4.8",
+        url: "https://api.githubcopilot.com/v1/messages",
+        npm: "@ai-sdk/github-copilot",
+      },
+    }
+
+    const result = ProviderTransform.message(
+      [
+        { role: "assistant", content: [{ type: "text", text: "done" }] },
+        { role: "user", content: [{ type: "text", text: "Next" }] },
+      ] as any[],
+      model,
+      {},
+    )
+
+    expect(result).toHaveLength(2)
+    expect(result.at(-1)?.role).toBe("user")
+  })
+
+  test("keeps trailing assistant for non-Copilot Claude", () => {
+    const result = ProviderTransform.message(
+      [
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: [{ type: "text", text: "partial" }] },
+      ] as any[],
+      anthropicModel,
+      {},
+    )
+
+    expect(result).toHaveLength(2)
+    expect(result.at(-1)?.role).toBe("assistant")
+  })
+
   test("filters empty content for bedrock provider", () => {
     const bedrockModel = {
       ...anthropicModel,


### PR DESCRIPTION
### Issue for this PR

Withdrawn workaround.
Related to #31247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GitHub Copilot Claude can reject requests that end with an assistant message. This can happen after interrupted/partial turns and when the max-steps path appends a final assistant instruction.

This PR appends a small synthetic user turn for Copilot Claude requests that would otherwise end with assistant, so the provider sees a valid final user turn while the trailing assistant context is still preserved.

It also scrubs Copilot Claude pseudo tool-call text before assistant text parts are finalized, including raw or partial `<invoke>` blocks and repeated short `call <tool>` lines that can otherwise be persisted as normal assistant text.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts test/provider/copilot/convert-to-copilot-messages.test.ts test/provider/copilot/copilot-chat-model.test.ts` - 151 passed / 0 failed
- `bun typecheck` from `packages/opencode` - passed
- pre-push hook `bun turbo typecheck` from repo root - passed across 13 tasks
- `git diff --check` - passed

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR