### PR TITLE
fix(core): update customize-opencode skill — add tui.json docs, tools field, mcp permission docs

### DIFF
--- a/packages/core/src/plugin/skill.ts
+++ b/packages/core/src/plugin/skill.ts
@@ -23,7 +23,7 @@ export const Plugin = PluginV2.define({
           skill: new SkillV2.Info({
             name: "customize-opencode",
             description:
-              "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself.",
+              "Use ONLY when the user is editing or creating opencode's own configuration: opencode.json, opencode.jsonc, tui.json, tui.jsonc, files under .opencode/, or files under ~/.config/opencode/. Also use when creating or fixing opencode agents, subagents, skills, plugins, MCP servers, or permission rules. Do not use for the user's own application code, or for any project that is not configuring opencode itself.",
             location: AbsolutePath.make("/builtin/customize-opencode.md"),
             content: CustomizeOpencodeContent,
           }),

--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -41,6 +41,8 @@ already-loaded config until then.
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | Project config                | `./opencode.json`, `./opencode.jsonc`, or `.opencode/opencode.json` (opencode walks up from the cwd to the worktree root) |
 | Global config                 | `~/.config/opencode/opencode.json` (NOT `~/.opencode/`)                                                                   |
+| Project TUI config            | `./tui.json`, `./tui.jsonc`, or `.opencode/tui.json`                                                                     |
+| Global TUI config             | `~/.config/opencode/tui.json`                                                                                            |
 | Project agents                | `.opencode/agent/<name>.md` or `.opencode/agents/<name>.md`                                                               |
 | Global agents                 | `~/.config/opencode/agent(s)/<name>.md`                                                                                   |
 | Project skills                | `.opencode/skill(s)/<name>/SKILL.md`                                                                                      |
@@ -49,6 +51,45 @@ already-loaded config until then.
 
 Configs from each scope are deep-merged. Project overrides global. Unknown
 top-level keys in `opencode.json` are rejected with `ConfigInvalidError`.
+
+## TUI config (tui.json)
+
+The TUI (terminal UI) has its own parallel config system with a separate file,
+`tui.json` (or `tui.jsonc`). It is loaded by the TUI plugin system
+(`plugin/tui/runtime.ts`), independently from the server plugin system that
+reads `opencode.json`.
+
+**Where it's loaded from** (merged in order, project overrides global):
+`~/.config/opencode/tui.json` → `./tui.json` → `.opencode/tui.json`. It can
+also be overridden with `OPENCODE_TUI_CONFIG`.
+
+**Valid top-level fields:**
+
+- `$schema` - JSON Schema URL
+- `theme` - Theme name
+- `keybinds` - Keybinding overrides
+- `plugin` - Array of plugin specs (same shape as `opencode.json`'s `plugin`)
+- `plugin_enabled` - Object mapping plugin name to boolean
+- `leader_timeout` - Leader key timeout in ms (default: 2000)
+- `attention` - Attention notification and sound settings
+- `prompt` - Prompt textarea size settings
+- `scroll_speed` - TUI scroll speed
+- `scroll_acceleration` - Scroll acceleration settings
+- `diff_style` - `"auto"` (adapts to terminal width) or `"stacked"` (always single column)
+- `mouse` - Enable/disable mouse capture (default: `true`)
+
+**Why this matters for plugins:**
+
+A plugin can be declared in either or both configs. Plugins with only a server
+export (`dist/index.js`) are typically declared in `opencode.json`. Plugins with
+a TUI export (`src/tui/`) must be declared in `tui.json`. Some plugins (like
+`@cortexkit/opencode-magic-context`) provide **both** exports and can be listed
+in either file — if you remove it from `opencode.json` but it's still in
+`tui.json`, it will continue loading via the TUI side.
+
+The `/plugins` TUI panel lists **TUI plugins only** — server plugins from
+`opencode.json` do not appear there. To see all plugins, check both config
+files.
 
 ## opencode.json
 
@@ -263,8 +304,8 @@ frontmatter.
 `mode` is one of `"primary"`, `"subagent"`, `"all"`.
 
 Allowed top-level frontmatter fields: `name, model, variant, description, mode,
-hidden, color, steps, options, permission, disable, temperature, top_p`. Any
-unknown field is silently routed into `options`.
+hidden, color, steps, tools (deprecated), options, permission, disable,
+temperature, top_p`. Any unrecognized field is silently routed into `options`.
 
 To disable a built-in agent: `agent: { build: { disable: true } }`, or in a
 file, `disable: true` in frontmatter.
@@ -381,11 +422,23 @@ rules last.
 `permission: "allow"` (a string at the top level) is shorthand for "allow
 everything" and is rarely what the user wants.
 
-Known permission keys: `read, edit, glob, grep, list, bash, task,
-external_directory, todowrite, question, webfetch, websearch, lsp, doom_loop,
-skill`. Some of these (`todowrite,
+Known permission keys: `read, edit, glob, grep, list, bash, task, skill, lsp,
+question, webfetch, websearch, external_directory, todowrite, doom_loop`. Some
+of these (`todowrite,
 question, webfetch, websearch, doom_loop`) only accept a flat
 action, not a per-pattern object.
+
+> **MCP tools cannot be controlled via a `mcp` permission key** — `mcp` is not
+> a recognized permission key. To restrict MCP tools on an agent, use the
+> `"*"` catch-all pattern:
+>
+> ```json
+> { "permission": { "*": "deny", "read": "allow" } }
+> ```
+>
+> The `"*"` key at the top level of the permission object matches **any tool**,
+> including MCP tools. Insertion order still applies (last matching rule wins),
+> so put broad `"*"` rules first and specific tool rules after.
 
 `external_directory` patterns are filesystem paths (use `~/`, absolute paths,
 or globs like `~/projects/**`).


### PR DESCRIPTION
Closes #31982

## Changes

### 1. Documented `tui.json` parallel plugin system (new section)

The skill only documented `opencode.json` and never mentioned that the TUI has its own `tui.json` config file with a separate `plugin` array — loaded by an independent plugin system (`plugin/tui/runtime.ts`). If a user removes a plugin from `opencode.json` but it's also declared in `tui.json$/, it keeps loading via the TUI side.

Adds:
- `tui.json` rows to the "Where files live" table
- New "TUI config (tui.json)" section with valid fields and the distinction between server plugins vs TUI plugins
- Note that `/plugins` panel lists TUI plugins only, not server plugins
- Updated skill description to mention `tui.json$/, `tui.jsonc`

### 2. Added `tools` (deprecated) to frontmatter field list

The `tools` field exists in the JSON Schema (as deprecated) but was missing from the allowed frontmatter fields list. Changed "unknown field" to "unrecognized field" for accuracy.

### 3. Documented MCP permission handling + `"*"` catch-all pattern

- Added a note that `mcp` is NOT a recognized permission key (MCP tools cannot be controlled via `permission.mcp`)
- Documented the `"*"` catch-all pattern as the correct way to restrict MCP tools on an agent
- Added the missing `skill` key to the known permission keys list