### PR TITLE
fix(mcp): stabilize tool ordering

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -670,7 +670,9 @@ const layer = Layer.effect(
       const config = cfg.mcp ?? {}
       const defaultTimeout = cfg.experimental?.mcp_timeout
 
-      for (const [clientName, client] of Object.entries(s.clients)) {
+      for (const [clientName, client] of Object.entries(s.clients).sort(
+        ([a], [b]) => McpCatalog.sanitize(a).localeCompare(McpCatalog.sanitize(b)) || a.localeCompare(b),
+      )) {
         if (s.status[clientName]?.status !== "connected") continue
         const mcpConfig = config[clientName]
         const listed = s.defs[clientName]
@@ -679,7 +681,10 @@ const layer = Layer.effect(
           continue
         }
         const timeout = requestTimeout(s, clientName, mcpConfig, defaultTimeout)
-        for (const def of listed) {
+        for (const def of [...listed].sort(
+          (a, b) =>
+            McpCatalog.sanitize(a.name).localeCompare(McpCatalog.sanitize(b.name)) || a.name.localeCompare(b.name),
+        )) {
           result[McpCatalog.toolName(clientName, def.name)] = { def, client, timeout }
         }
       }

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -408,6 +408,36 @@ it.instance(
 )
 
 it.instance(
+  "tools() returns MCP tools in stable sanitized key order",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "z-server"
+        getOrCreateClientState("z-server").tools = [
+          { name: "z.tool", description: "Z tool", inputSchema: { type: "object", properties: {} } },
+          { name: "a-tool", description: "A tool", inputSchema: { type: "object", properties: {} } },
+        ]
+        yield* mcp.add("z-server", { type: "local", command: ["echo", "test"] })
+
+        lastCreatedClientName = "a.server"
+        getOrCreateClientState("a.server").tools = [
+          { name: "z-tool", description: "Z tool", inputSchema: { type: "object", properties: {} } },
+          { name: "a.tool", description: "A tool", inputSchema: { type: "object", properties: {} } },
+        ]
+        yield* mcp.add("a.server", { type: "local", command: ["echo", "test"] })
+
+        expect(Object.keys(yield* mcp.tools())).toEqual([
+          "a_server_a_tool",
+          "a_server_z-tool",
+          "z-server_a-tool",
+          "z-server_z_tool",
+        ])
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
   "follows cursors when listing tools, prompts, and resources",
   () =>
     MCP.Service.use((mcp: MCPNS.Interface) =>


### PR DESCRIPTION
### Issue for this PR

Fixes #23571

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Sorts MCP servers and tools by their final sanitized prompt tool keys before building the tool map, so equivalent MCP configs produce deterministic tool order across reconnects and restarts.

### How did you verify your code works?

- `bun test test/mcp/lifecycle.test.ts`
- `bun typecheck`
- `bunx oxlint packages/opencode/src/mcp/index.ts packages/opencode/test/mcp/lifecycle.test.ts` (0 errors; existing warnings)
- `git diff --check`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
