### PR TITLE
fix(core): strip perplexity agent response fields

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -9,6 +9,8 @@ import { ProviderV2 } from "./provider"
 
 type SDK = any
 
+const PERPLEXITY_AGENT_UNSUPPORTED_RESPONSE_FIELDS = ["store", "temperature", "include", "tool_choice"] as const
+
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
   if (!res.body) return res
@@ -69,7 +71,7 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
   const chunkTimeout = options.chunkTimeout
   delete options.chunkTimeout
   options.fetch = async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
-    const opts = { ...(init ?? {}) }
+    const opts = { ...init }
     const signals = [
       opts.signal,
       typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined,
@@ -87,10 +89,23 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
       opts.body &&
       opts.method === "POST"
     ) {
-      const body = JSON.parse(opts.body as string)
-      if (body.store !== true && Array.isArray(body.input)) {
-        for (const item of body.input) {
-          if ("id" in item) delete item.id
+      if (typeof opts.body === "string") {
+        const body = JSON.parse(opts.body)
+        if (body.store !== true && Array.isArray(body.input)) {
+          for (const item of body.input) {
+            if ("id" in item) delete item.id
+          }
+          opts.body = JSON.stringify(body)
+        }
+      }
+    }
+
+    if (model.providerID === "perplexity-agent" && typeof opts.body === "string" && opts.method === "POST") {
+      const url = typeof input === "string" || input instanceof URL ? input.toString() : input.url
+      if (url.endsWith("/responses")) {
+        const body = JSON.parse(opts.body)
+        for (const field of PERPLEXITY_AGENT_UNSUPPORTED_RESPONSE_FIELDS) {
+          delete body[field]
         }
         opts.body = JSON.stringify(body)
       }

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { AISDK } from "@opencode-ai/core/aisdk"
+import { EventV2 } from "@opencode-ai/core/event"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { testEffect } from "./lib/effect"
+import { model } from "./plugin/provider-helper"
+
+const itWithAISDK = testEffect(
+  AISDK.layer.pipe(Layer.provideMerge(PluginV2.locationLayer.pipe(Layer.provide(EventV2.defaultLayer)))),
+)
+
+function languageSdk() {
+  return {
+    languageModel: (modelID: string) => ({
+      modelId: modelID,
+      provider: "test",
+      specificationVersion: "v3",
+    }),
+  }
+}
+
+describe("AISDK", () => {
+  itWithAISDK.effect("strips Perplexity Agent response fields rejected by its OpenAI-compatible endpoint", () =>
+    Effect.gen(function* () {
+      const bodies: Array<Record<string, unknown>> = []
+      const plugin = yield* PluginV2.Service
+      const aisdk = yield* AISDK.Service
+
+      yield* plugin.add({
+        id: PluginV2.ID.make("capture-perplexity-agent-fetch"),
+        effect: Effect.succeed({
+          "aisdk.sdk": (evt) =>
+            Effect.promise(async () => {
+              await evt.options.fetch("https://api.perplexity.ai/v1/responses", {
+                method: "POST",
+                body: JSON.stringify({
+                  model: "openai/gpt-5.5",
+                  input: [],
+                  stream: true,
+                  store: false,
+                  temperature: 1,
+                  include: ["reasoning.encrypted_content"],
+                  tool_choice: "auto",
+                  max_output_tokens: 16,
+                }),
+              })
+              evt.sdk = languageSdk()
+            }),
+        }),
+      })
+
+      yield* aisdk.language(
+        model("perplexity-agent", "gpt-5.5", {
+          api: {
+            id: ModelV2.ID.make("openai/gpt-5.5"),
+            type: "aisdk",
+            package: "@ai-sdk/openai",
+            url: "https://api.perplexity.ai/v1",
+          },
+          request: {
+            headers: {},
+            body: {
+              fetch: async (_input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+                if (typeof init?.body !== "string") throw new Error("expected string body")
+                bodies.push(JSON.parse(init.body))
+                return new Response("ok")
+              },
+            },
+          },
+        }),
+      )
+
+      expect(bodies).toEqual([
+        {
+          model: "openai/gpt-5.5",
+          input: [],
+          stream: true,
+          max_output_tokens: 16,
+        },
+      ])
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #32108

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Strips the OpenAI Responses fields that Perplexity Agent currently rejects from `perplexity-agent` `/responses` requests while leaving other OpenAI-compatible providers unchanged.

### How did you verify your code works?

- `bun test test/aisdk.test.ts`
- `bun typecheck`
- `bunx oxlint packages/core/src/aisdk.ts packages/core/test/aisdk.test.ts`
- `git diff --check`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
