### PR TITLE
fix(config): warn when opencode.json and opencode.jsonc coexist

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -200,6 +200,26 @@ export const layer = Layer.effect(
     // Apply general settings first and more specific settings last:
     // global config, project files, then `.opencode` files.
     const configs = [...(supplementary[0] ?? []), ...direct, ...supplementary.slice(1).flat()]
+    // When both opencode.json and opencode.jsonc live in the same directory they
+    // are loaded and merged silently, so a stale or partial file can override
+    // keys from the other with no indication. Warn so the conflict is visible.
+    const byDirectory = new Map<string, Set<string>>()
+    for (const config of configs) {
+      if (config.type !== "document" || !config.path) continue
+      const base = path.basename(config.path)
+      if (base !== "opencode.json" && base !== "opencode.jsonc") continue
+      const directory = path.dirname(config.path)
+      const seen = byDirectory.get(directory) ?? new Set<string>()
+      seen.add(base)
+      byDirectory.set(directory, seen)
+    }
+    for (const [directory, seen] of byDirectory) {
+      if (seen.has("opencode.json") && seen.has("opencode.jsonc")) {
+        yield* Effect.logWarning(
+          `both opencode.json and opencode.jsonc found in ${directory}; they are merged, so one file can silently override keys from the other`,
+        )
+      }
+    }
     // Rules use the opposite order so a user-global rule can override a
     // repository rule. Statement order inside each file stays unchanged.
     yield* policy.load(

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import fs from "fs/promises"
 import { describe, expect } from "bun:test"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Layer, Logger, Schema } from "effect"
 import { FastCheck } from "effect/testing"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigProvider } from "@opencode-ai/core/config/provider"
@@ -768,6 +768,40 @@ describe("Config", () => {
           )
         })
       }),
+    ),
+  )
+
+  it.live("warns when opencode.json and opencode.jsonc coexist in one directory", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all([
+              fs.writeFile(path.join(tmp.path, "opencode.json"), JSON.stringify({ model: "provider/a" })),
+              fs.writeFile(path.join(tmp.path, "opencode.jsonc"), JSON.stringify({ model: "provider/b" })),
+            ]),
+          )
+
+          const entries: Array<ReturnType<typeof Logger.formatStructured.log>> = []
+          const logger = Logger.formatStructured.pipe(
+            Logger.map((entry): void => {
+              entries.push(entry)
+            }),
+          )
+
+          yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            yield* config.entries()
+          }).pipe(Effect.provide(testLayer(tmp.path)), Effect.provide(Logger.layer([logger])))
+
+          const warning = entries.find((entry) => String(entry.message).includes("opencode.jsonc"))
+          expect(warning).toBeDefined()
+          expect(String(warning?.message)).toContain(tmp.path)
+        }),
+      ),
     ),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #32447

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When both `opencode.json` and `opencode.jsonc` exist in the same config directory, the loader (`packages/core/src/config.ts`) reads and merges both with no indication to the user. A stale or partial `.jsonc` can override specific keys from the `.json` silently. In the reported case a leftover `.jsonc` pointed an MCP server's command at a path that no longer existed, which surfaced only as a confusing `ENOENT ... posix_spawn` error with no hint that a second config file was the cause.

This groups the loaded documents by directory and emits a warning when both `opencode.json` and `opencode.jsonc` are present in the same one, naming the directory so the merge is visible. Behavior is otherwise unchanged - both files are still loaded and merged as before.

### How did you verify your code works?

- Added a test in `packages/core/test/config/config.test.ts` that writes both files into one directory, captures logs via a structured logger, and asserts the warning fires and names the directory.
- `bun test test/config/config.test.ts` -> 15 pass.
- `bun typecheck` passes.

### Screenshots / recordings

_N/A - log output change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
