### PR TITLE
fix(agent): apply configured tool_choice to model requests

### DIFF
--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -17,6 +17,9 @@ const AgentSchema = Schema.StructWithRest(
     }),
     temperature: Schema.optional(Schema.Finite),
     top_p: Schema.optional(Schema.Finite),
+    tool_choice: Schema.optional(Schema.Literals(["auto", "required", "none"])).annotate({
+      description: "How the model should select tools: auto, required, or none",
+    }),
     prompt: Schema.optional(Schema.String),
     tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
       description: "@deprecated Use 'permission' field instead",
@@ -48,6 +51,7 @@ const KNOWN_KEYS = new Set([
   "description",
   "temperature",
   "top_p",
+  "tool_choice",
   "mode",
   "hidden",
   "color",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -40,6 +40,7 @@ export const Info = Schema.Struct({
   hidden: Schema.optional(Schema.Boolean),
   topP: Schema.optional(Schema.Finite),
   temperature: Schema.optional(Schema.Finite),
+  toolChoice: Schema.optional(Schema.Literals(["auto", "required", "none"])),
   color: Schema.optional(Schema.String),
   permission: PermissionV1.Ruleset,
   model: Schema.optional(
@@ -282,6 +283,7 @@ export const layer = Layer.effect(
           item.description = value.description ?? item.description
           item.temperature = value.temperature ?? item.temperature
           item.topP = value.top_p ?? item.topP
+          item.toolChoice = value.tool_choice ?? item.toolChoice
           item.mode = value.mode ?? item.mode
           item.color = value.color ?? item.color
           item.hidden = value.hidden ?? item.hidden

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1343,7 +1343,7 @@ export const layer = Layer.effect(
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
               tools,
               model,
-              toolChoice: format.type === "json_schema" ? "required" : undefined,
+              toolChoice: format.type === "json_schema" ? "required" : agent.toolChoice,
             })
 
             if (structured !== undefined) {

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -74,6 +74,25 @@ it.instance("build agent has correct default properties", () =>
   }),
 )
 
+it.instance(
+  "agent tool_choice config is applied to the agent",
+  () =>
+    Effect.gen(function* () {
+      const build = yield* load((svc) => svc.get("build"))
+      expect(build).toBeDefined()
+      expect(build?.toolChoice).toBe("required")
+    }),
+  {
+    config: {
+      agent: {
+        build: {
+          tool_choice: "required",
+        },
+      },
+    },
+  },
+)
+
 it.instance("plan agent denies edits except .opencode/plans/*", () =>
   Effect.gen(function* () {
     const plan = yield* load((svc) => svc.get("plan"))

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -288,6 +288,28 @@ If no temperature is specified, OpenCode uses model-specific defaults; typically
 
 ---
 
+### Tool choice
+
+Control how the model decides whether to call a tool with the `tool_choice` config.
+
+```json title="opencode.json"
+{
+  "agent": {
+    "build": {
+      "tool_choice": "required"
+    }
+  }
+}
+```
+
+- **`auto`**: The model decides whether to call a tool. This is the default.
+- **`required`**: The model must call a tool. Useful for models that don't reliably emit tool calls on their own.
+- **`none`**: The model is not allowed to call tools.
+
+If not set, OpenCode lets the provider use its default behavior (`auto`).
+
+---
+
 ### Max steps
 
 Control the maximum number of agentic iterations an agent can perform before being forced to respond with text only. This allows users who wish to control costs to set a limit on agentic actions.


### PR DESCRIPTION
### Issue for this PR

Closes #32465

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Setting `tool_choice` on an agent in `opencode.json` had no effect - the key was accepted without error and silently dropped, so the request always sent the provider default (effectively `tool_choice: auto`). For models that don't reliably emit tool calls under `auto`, this made agentic sessions impossible: the model was never asked to commit to a tool call.

Root cause: the v1 agent schema (`packages/core/src/v1/config/agent.ts`) uses `StructWithRest`, and its `normalize()` moves any key not listed in `KNOWN_KEYS` into `options`. `tool_choice` was neither a declared field nor in `KNOWN_KEYS`, so it ended up buried in `options` and never reached the agent builder.

Changes:
- Declare `tool_choice` (`auto` | `required` | `none`) on the v1 agent schema and add it to `KNOWN_KEYS` so it survives `normalize`.
- Carry it onto the runtime agent as `toolChoice` in the agent builder (same pattern as `temperature`/`top_p`).
- Pass it into the chat request in `session/prompt.ts`. Structured output (`json_schema`) still forces `required` as before; otherwise the agent's configured value is used.
- Document the option in `agents.mdx`.

The request plumbing for `toolChoice` already existed (`session/llm.ts`, `native-request.ts`); this just connects the config to it.

### How did you verify your code works?

- Added a test in `packages/opencode/test/agent/agent.test.ts` asserting `agent.build.tool_choice: "required"` in config resolves to `toolChoice === "required"` on the built agent.
- `bun test test/agent/agent.test.ts test/config/config.test.ts` -> 138 pass.
- `bun typecheck` passes for both `core` and `opencode`.

### Screenshots / recordings

_N/A._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
