### PR TITLE
fix(core): skip fff home/root scan when cwd is home

### DIFF
--- a/packages/core/src/filesystem/search-scan.ts
+++ b/packages/core/src/filesystem/search-scan.ts
@@ -1,0 +1,19 @@
+import path from "path"
+
+/**
+ * fff's home/root scanning walks UP from `basePath` toward `$HOME` and the
+ * filesystem root to pull surrounding files into the index. That is useful
+ * from inside a project, but when the working directory already is `$HOME`
+ * (or an ancestor of it, or the filesystem root) the walk degenerates into a
+ * full-tree content index of the entire home directory and pegs the CPU
+ * (see #32511). Skip the upward scan for those degenerate roots.
+ */
+export function shouldScanUpward(directory: string, home: string): boolean {
+  const dir = path.resolve(directory)
+  const resolvedHome = path.resolve(home)
+  if (dir === path.parse(dir).root) return false
+  if (dir === resolvedHome) return false
+  const withSep = dir.endsWith(path.sep) ? dir : dir + path.sep
+  if (resolvedHome.startsWith(withSep)) return false
+  return true
+}

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -1,5 +1,6 @@
 export * as FileSystemSearch from "./search"
 
+import os from "os"
 import path from "path"
 import { Context, Effect, Layer, Scope } from "effect"
 import { Fff } from "#fff"
@@ -10,6 +11,7 @@ import { Location } from "../location"
 import { Ripgrep } from "../ripgrep"
 import { RelativePath } from "../schema"
 import { Flag } from "../flag/flag"
+import { shouldScanUpward } from "./search-scan"
 
 export interface Interface {
   readonly find: (input: FileSystem.FindInput) => Effect.Effect<FileSystem.Entry[]>
@@ -127,13 +129,14 @@ export const fffLayer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const location = yield* Location.Service
+    const scanUpward = shouldScanUpward(location.directory, os.homedir())
     const result = yield* Effect.try({
       try: () =>
         Fff.create({
           basePath: location.directory,
           aiMode: true,
-          enableFsRootScanning: true,
-          enableHomeDirScanning: true,
+          enableFsRootScanning: scanUpward,
+          enableHomeDirScanning: scanUpward,
         }),
       catch: (cause) => cause,
     }).pipe(Effect.orDie)

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
+import { shouldScanUpward } from "@opencode-ai/core/filesystem/search-scan"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "../fixture/tmpdir"
@@ -40,4 +41,25 @@ describe("Ripgrep", () => {
       }),
     ),
   )
+})
+
+describe("shouldScanUpward", () => {
+  const home = path.resolve("/home/alice")
+
+  test("scans upward from a project directory inside home", () => {
+    expect(shouldScanUpward(path.join(home, "projects", "app"), home)).toBe(true)
+  })
+
+  test("does not scan when the directory is home itself", () => {
+    expect(shouldScanUpward(home, home)).toBe(false)
+  })
+
+  test("does not scan from the filesystem root", () => {
+    const root = path.parse(home).root
+    expect(shouldScanUpward(root, home)).toBe(false)
+  })
+
+  test("does not scan from an ancestor of home", () => {
+    expect(shouldScanUpward(path.dirname(home), home)).toBe(false)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #32511

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`fffLayer` in `packages/core/src/filesystem/search.ts` created the fff index with `enableFsRootScanning: true` and `enableHomeDirScanning: true` hard-coded. Those flags make fff walk **up** from `basePath` toward `$HOME` and the filesystem root to gather surrounding context, which is useful from inside a project.

The problem is when the working directory already is `$HOME` (the reported case is `opencode serve` launched with `WorkingDirectory = $HOME`). The upward walk then degenerates into a full-tree directory walk plus per-file content (bigram) indexing of the **entire home directory** — the reporter's CPU sample pins 100% of the load to fff's scan/index threads (`add_file_content`, `walk_filesystem`), CPU sits at ~1000% (≈10 cores) and RSS climbs past 3 GB without converging. `OPENCODE_DISABLE_FFF=1` was the only workaround.

This gates both flags behind a small pure helper `shouldScanUpward(directory, home)` (new `search-scan.ts`, kept dependency-free so it stays unit-testable without the filesystem layer graph). It returns `false` — i.e. no upward scan — when the directory is the home directory, an ancestor of home, or the filesystem root, the cases where "scan toward home/root" means "scan everything". In a normal project directory the behavior is unchanged.

### How did you verify your code works?

Added a `shouldScanUpward` unit suite to `search.test.ts` covering: a project dir inside home (scans), home itself (does not), the filesystem root (does not), and an ancestor of home (does not).

```
bun test test/filesystem/search.test.ts   # 6 pass
bun run typecheck                          # clean
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
