### PR TITLE
fix(opencode): honor agent tool_choice config

### DIFF
--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -17,6 +17,9 @@ const AgentSchema = Schema.StructWithRest(
     }),
     temperature: Schema.optional(Schema.Finite),
     top_p: Schema.optional(Schema.Finite),
+    tool_choice: Schema.optional(Schema.Literals(["auto", "required", "none"])).annotate({
+      description: "How the model selects tools for this agent (default: auto).",
+    }),
     prompt: Schema.optional(Schema.String),
     tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)).annotate({
       description: "@deprecated Use 'permission' field instead",
@@ -48,6 +51,7 @@ const KNOWN_KEYS = new Set([
   "description",
   "temperature",
   "top_p",
+  "tool_choice",
   "mode",
   "hidden",
   "color",

--- a/packages/core/test/config/agent-v1.test.ts
+++ b/packages/core/test/config/agent-v1.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
+import { ConfigAgentV1 } from "@opencode-ai/core/v1/config/agent"
+
+const decode = Schema.decodeUnknownSync(ConfigAgentV1.Info)
+
+describe("ConfigAgentV1 tool_choice", () => {
+  test("keeps tool_choice as a known top-level field", () => {
+    const agent = decode({ tool_choice: "required" })
+    expect(agent.tool_choice).toBe("required")
+    expect(agent.options?.["tool_choice"]).toBeUndefined()
+  })
+
+  test("rejects an unknown tool_choice value", () => {
+    expect(() => decode({ tool_choice: "sometimes" })).toThrow()
+  })
+})

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -40,6 +40,7 @@ export const Info = Schema.Struct({
   hidden: Schema.optional(Schema.Boolean),
   topP: Schema.optional(Schema.Finite),
   temperature: Schema.optional(Schema.Finite),
+  toolChoice: Schema.optional(Schema.Literals(["auto", "required", "none"])),
   color: Schema.optional(Schema.String),
   permission: PermissionV1.Ruleset,
   model: Schema.optional(
@@ -282,6 +283,7 @@ export const layer = Layer.effect(
           item.description = value.description ?? item.description
           item.temperature = value.temperature ?? item.temperature
           item.topP = value.top_p ?? item.topP
+          item.toolChoice = value.tool_choice ?? item.toolChoice
           item.mode = value.mode ?? item.mode
           item.color = value.color ?? item.color
           item.hidden = value.hidden ?? item.hidden

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1343,7 +1343,7 @@ export const layer = Layer.effect(
               messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
               tools,
               model,
-              toolChoice: format.type === "json_schema" ? "required" : undefined,
+              toolChoice: format.type === "json_schema" ? "required" : agent.toolChoice,
             })
 
             if (structured !== undefined) {


### PR DESCRIPTION
### Issue for this PR

Closes #32465

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Setting `tool_choice` on an agent in `opencode.json` had no effect — the key was accepted without error and silently dropped, so the provider always received `tool_choice: "auto"`. For models that don't reliably emit tool calls under `auto`, that makes agentic runs impossible (the model never gets asked to commit to a tool call).

The `llm` layer already plumbs `toolChoice` end to end (`session/llm.ts` → native request/runtime → per-provider lowering); the only missing link was config → request. The prompt builder hard-coded `toolChoice` to `undefined` for normal turns (it was only ever set to `"required"` for `json_schema` output).

This wires the existing capability up:

- adds `tool_choice` (`"auto" | "required" | "none"`) to the agent config schema and registers it as a known key so it stays a top-level field instead of being swept into `options`,
- adds the matching `toolChoice` field to the loaded agent info and maps `tool_choice` → `toolChoice` during agent loading (next to `temperature` / `top_p`),
- uses the agent's configured `toolChoice` when building the request.

`json_schema` output still forces `"required"`. When `tool_choice` is unset, `toolChoice` stays `undefined` and behavior is unchanged.

### How did you verify your code works?

Added a schema test asserting `tool_choice` is preserved as a top-level field (not moved into `options`) and that an unknown value is rejected. Existing agent-loading suite still passes.

```
bun test packages/core/test/config/agent-v1.test.ts   # 2 pass
bun test packages/opencode/test/agent/agent.test.ts    # 43 pass
bun run typecheck                                      # clean (core + opencode)
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
