### PR TITLE
fix(session): let message delete recover busy sessions

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -16,7 +16,7 @@ import { SessionSummary } from "@/session/summary"
 import { Todo } from "@/session/todo"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
-import { Cause, Effect, Option, Schema, Scope } from "effect"
+import { Cause, Effect, Exit, Option, Schema, Scope } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
@@ -379,7 +379,14 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID; messageID: MessageID }
     }) {
       yield* requireSession(ctx.params.sessionID)
-      yield* SessionError.mapBusy(runState.assertNotBusy(ctx.params.sessionID))
+      const busy = yield* runState.assertNotBusy(ctx.params.sessionID).pipe(Effect.exit)
+      if (Exit.isFailure(busy)) {
+        if (Cause.squash(busy.cause) instanceof Session.BusyError) {
+          yield* runState.cancel(ctx.params.sessionID)
+        } else {
+          yield* SessionError.mapBusy(Effect.failCause(busy.cause))
+        }
+      }
       yield* session.removeMessage(ctx.params)
       return true
     })

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -379,6 +379,9 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID; messageID: MessageID }
     }) {
       yield* requireSession(ctx.params.sessionID)
+      yield* SessionError.mapStorageNotFound(
+        MessageV2.get({ sessionID: ctx.params.sessionID, messageID: ctx.params.messageID }),
+      )
       const busy = yield* runState.assertNotBusy(ctx.params.sessionID).pipe(Effect.exit)
       if (Exit.isFailure(busy)) {
         if (Cause.squash(busy.cause) instanceof Session.BusyError) {

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -4,7 +4,7 @@ import { NodeHttpServer, NodeServices } from "@effect/platform-node"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
-import { Cause, Config, Effect, Exit, Layer } from "effect"
+import { Cause, Config, Effect, Exit, Fiber, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse, HttpRouter, HttpServer } from "effect/unstable/http"
 import { layerWebSocketConstructorGlobal } from "effect/unstable/socket/Socket"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -23,7 +23,6 @@ import * as HttpSessionError from "../../src/server/routes/instance/httpapi/hand
 import { SessionPaths } from "../../src/server/routes/instance/httpapi/groups/session"
 import { Session } from "@/session/session"
 import { MessageID, PartID, SessionID, type SessionID as SessionIDType } from "../../src/session/schema"
-import { MessageV2 } from "../../src/session/message-v2"
 import { Database } from "@opencode-ai/core/database/database"
 import { SessionInputTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionMessage } from "@opencode-ai/core/session/message"
@@ -434,6 +433,41 @@ describe("session HttpApi", () => {
         root: sessionDirectory,
       })
     }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
+  )
+
+  it.live("deleteMessage cancels a busy session before deleting the message", () =>
+    Effect.gen(function* () {
+      const llm = yield* TestLLMServer
+      yield* llm.hang
+
+      const config = testProviderConfig(llm.url)
+      const directory = yield* tmpdirScoped({ git: true, config })
+      const headers = { "x-opencode-directory": directory, "content-type": "application/json" }
+      const session = yield* createSession({ title: "delete busy" }).pipe(provideInstanceEffect(directory))
+      const message = yield* createTextMessage(session.id, "stuck").pipe(provideInstanceEffect(directory))
+
+      const prompt = yield* request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          agent: "build",
+          model: { providerID: "test", modelID: "test-model" },
+          parts: [{ type: "text", text: "hang" }],
+        }),
+      }).pipe(Effect.forkScoped)
+      yield* llm.wait(1)
+
+      expect(
+        yield* requestJson<boolean>(
+          pathFor(SessionPaths.deleteMessage, { sessionID: session.id, messageID: message.info.id }),
+          { method: "DELETE", headers },
+        ),
+      ).toBe(true)
+
+      const exit = yield* Fiber.await(prompt).pipe(Effect.timeout("5 seconds"))
+      expect(Exit.isSuccess(exit)).toBe(true)
+    }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
+    10_000,
   )
 
   it.instance(

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -435,38 +435,88 @@ describe("session HttpApi", () => {
     }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
   )
 
-  it.live("deleteMessage cancels a busy session before deleting the message", () =>
-    Effect.gen(function* () {
-      const llm = yield* TestLLMServer
-      yield* llm.hang
+  it.live(
+    "deleteMessage cancels a busy session before deleting the message",
+    () =>
+      Effect.gen(function* () {
+        const llm = yield* TestLLMServer
+        yield* llm.hang
 
-      const config = testProviderConfig(llm.url)
-      const directory = yield* tmpdirScoped({ git: true, config })
-      const headers = { "x-opencode-directory": directory, "content-type": "application/json" }
-      const session = yield* createSession({ title: "delete busy" }).pipe(provideInstanceEffect(directory))
-      const message = yield* createTextMessage(session.id, "stuck").pipe(provideInstanceEffect(directory))
+        const config = testProviderConfig(llm.url)
+        const directory = yield* tmpdirScoped({ git: true, config })
+        const headers = { "x-opencode-directory": directory, "content-type": "application/json" }
+        const session = yield* createSession({ title: "delete busy" }).pipe(provideInstanceEffect(directory))
+        const message = yield* createTextMessage(session.id, "stuck").pipe(provideInstanceEffect(directory))
 
-      const prompt = yield* request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
-        method: "POST",
-        headers,
-        body: JSON.stringify({
-          agent: "build",
-          model: { providerID: "test", modelID: "test-model" },
-          parts: [{ type: "text", text: "hang" }],
-        }),
-      }).pipe(Effect.forkScoped)
-      yield* llm.wait(1)
+        const prompt = yield* request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            agent: "build",
+            model: { providerID: "test", modelID: "test-model" },
+            parts: [{ type: "text", text: "hang" }],
+          }),
+        }).pipe(Effect.forkScoped)
+        yield* llm.wait(1)
 
-      expect(
-        yield* requestJson<boolean>(
-          pathFor(SessionPaths.deleteMessage, { sessionID: session.id, messageID: message.info.id }),
+        expect(
+          yield* requestJson<boolean>(
+            pathFor(SessionPaths.deleteMessage, { sessionID: session.id, messageID: message.info.id }),
+            { method: "DELETE", headers },
+          ),
+        ).toBe(true)
+
+        const exit = yield* Fiber.await(prompt).pipe(Effect.timeout("5 seconds"))
+        expect(Exit.isSuccess(exit)).toBe(true)
+      }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
+    10_000,
+  )
+
+  it.live(
+    "deleteMessage does not cancel a busy session when the message is missing",
+    () =>
+      Effect.gen(function* () {
+        const llm = yield* TestLLMServer
+        yield* llm.hang
+
+        const config = testProviderConfig(llm.url)
+        const directory = yield* tmpdirScoped({ git: true, config })
+        const headers = { "x-opencode-directory": directory, "content-type": "application/json" }
+        const session = yield* createSession({ title: "missing busy delete" }).pipe(provideInstanceEffect(directory))
+        const missingMessageID = MessageID.ascending("msg_missing_busy_delete")
+
+        const prompt = yield* request(pathFor(SessionPaths.prompt, { sessionID: session.id }), {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            agent: "build",
+            model: { providerID: "test", modelID: "test-model" },
+            parts: [{ type: "text", text: "hang" }],
+          }),
+        }).pipe(Effect.forkScoped)
+        yield* llm.wait(1)
+
+        const response = yield* request(
+          pathFor(SessionPaths.deleteMessage, { sessionID: session.id, messageID: missingMessageID }),
           { method: "DELETE", headers },
-        ),
-      ).toBe(true)
+        )
+        expect(response.status).toBe(404)
 
-      const exit = yield* Fiber.await(prompt).pipe(Effect.timeout("5 seconds"))
-      expect(Exit.isSuccess(exit)).toBe(true)
-    }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
+        const completedBeforeAbort = yield* Fiber.await(prompt).pipe(
+          Effect.as(true),
+          Effect.timeoutOrElse({ duration: "250 millis", orElse: () => Effect.succeed(false) }),
+        )
+        expect(completedBeforeAbort).toBe(false)
+
+        expect(
+          yield* requestJson<boolean>(pathFor(SessionPaths.abort, { sessionID: session.id }), {
+            method: "POST",
+            headers,
+          }),
+        ).toBe(true)
+        const exit = yield* Fiber.await(prompt).pipe(Effect.timeout("5 seconds"))
+        expect(Exit.isSuccess(exit)).toBe(true)
+      }).pipe(Effect.provide(TestLLMServer.layer), Effect.provide(CrossSpawnSpawner.defaultLayer)),
     10_000,
   )
 
@@ -968,6 +1018,15 @@ describe("session HttpApi", () => {
             { method: "DELETE", headers },
           ),
         ).toBe(true)
+
+        const missingDelete = yield* request(
+          pathFor(SessionPaths.deleteMessage, {
+            sessionID: session.id,
+            messageID: MessageID.ascending("msg_missing_delete"),
+          }),
+          { method: "DELETE", headers },
+        )
+        expect(missingDelete.status).toBe(404)
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #27907

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`DELETE /session/:sessionID/message/:messageID` used to fail with `Session is busy` when the session was stuck behind a never-finishing tool call. That left users unable to delete the bad message through the HTTP API.

This changes the delete-message handler to treat an explicit delete as a recovery action: if the session runner is busy, it first uses the existing `SessionRunState.cancel()` path, then removes the requested message. Non-busy errors still go through the existing error mapping.

### How did you verify your code works?

- `bun test test/server/httpapi-session.test.ts -t "deleteMessage cancels a busy session before deleting the message"`
- `bun typecheck`
- `bunx oxlint packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts packages/opencode/test/server/httpapi-session.test.ts` (0 errors; existing warnings only)
- `git diff --check`
- pre-push `bun turbo typecheck` passed across 23 packages

### Screenshots / recordings

N/A, HTTP API behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR