### PR TITLE
fix(tui): skip initial theme probe in tmux

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -8,7 +8,7 @@ import { ClipboardProvider, useClipboard } from "./context/clipboard"
 import { ExitProvider, useExit } from "./context/exit"
 import { EpilogueProvider } from "./context/epilogue"
 import * as Selection from "./util/selection"
-import { createCliRenderer, MouseButton, type CliRenderer } from "@opentui/core"
+import { createCliRenderer, MouseButton } from "@opentui/core"
 import { RouteProvider, useRoute } from "./context/route"
 import {
   Switch,
@@ -82,6 +82,7 @@ import * as TuiAudio from "./audio"
 import { win32DisableProcessedInput, win32FlushInputBuffer } from "./terminal-win32"
 import { destroyRenderer } from "./util/renderer"
 import { cliErrorMessage, errorFormat } from "./util/error"
+import { resolveInitialThemeMode } from "./util/theme-mode"
 
 const appGlobalBindingCommands = [
   "session.list",
@@ -229,7 +230,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
       yield* Effect.tryPromise(async () => {
         // Prewarm palette before ThemeProvider mounts so `system` theme avoids a first-paint fallback flash.
         void renderer.getPalette({ size: 16 }).catch(() => undefined)
-        const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
+        const mode = await resolveInitialThemeMode(renderer)
         if (renderer.isDestroyed) return
 
         await render(() => {

--- a/packages/tui/src/util/theme-mode.ts
+++ b/packages/tui/src/util/theme-mode.ts
@@ -1,0 +1,27 @@
+import type { CliRenderer } from "@opentui/core"
+
+type ThemeModeProbeEnvironment = Readonly<{
+  STY?: string
+  TERM?: string
+  TMUX?: string
+}>
+
+type ThemeModeRenderer = Pick<CliRenderer, "waitForThemeMode">
+
+function currentThemeModeProbeEnvironment(): ThemeModeProbeEnvironment {
+  return {
+    STY: process.env.STY,
+    TERM: process.env.TERM,
+    TMUX: process.env.TMUX,
+  }
+}
+
+export function shouldSkipInitialThemeModeProbe(env: ThemeModeProbeEnvironment = currentThemeModeProbeEnvironment()) {
+  const term = env.TERM ?? ""
+  return Boolean(env.TMUX || env.STY || term.startsWith("tmux") || term.startsWith("screen"))
+}
+
+export async function resolveInitialThemeMode(renderer: ThemeModeRenderer, env?: ThemeModeProbeEnvironment) {
+  if (shouldSkipInitialThemeModeProbe(env)) return "dark"
+  return (await renderer.waitForThemeMode(1000)) ?? "dark"
+}

--- a/packages/tui/test/util/theme-mode.test.ts
+++ b/packages/tui/test/util/theme-mode.test.ts
@@ -17,7 +17,10 @@ test("skips the blocking initial theme probe inside multiplexers", async () => {
 
   expect(shouldSkipInitialThemeModeProbe({ TMUX: "/tmp/tmux-501/default,123,0", TERM: "xterm-256color" })).toBe(true)
   expect(shouldSkipInitialThemeModeProbe({ STY: "123.screen", TERM: "screen-256color" })).toBe(true)
+  expect(shouldSkipInitialThemeModeProbe({ TERM: "tmux" })).toBe(true)
   expect(shouldSkipInitialThemeModeProbe({ TERM: "tmux-256color" })).toBe(true)
+  expect(shouldSkipInitialThemeModeProbe({ TERM: "screen" })).toBe(true)
+  expect(shouldSkipInitialThemeModeProbe({ TERM: "screen-256color" })).toBe(true)
   expect(await resolveInitialThemeMode(setup.renderer, { TMUX: "/tmp/tmux-501/default,123,0" })).toBe("dark")
   expect(setup.timeouts).toEqual([])
 })
@@ -26,6 +29,8 @@ test("waits for the initial theme mode on direct terminal sessions", async () =>
   const setup = createRenderer("light")
 
   expect(shouldSkipInitialThemeModeProbe({ TERM: "xterm-256color" })).toBe(false)
+  expect(shouldSkipInitialThemeModeProbe({ TMUX: "", STY: "", TERM: "xterm-256color" })).toBe(false)
+  expect(shouldSkipInitialThemeModeProbe({})).toBe(false)
   expect(await resolveInitialThemeMode(setup.renderer, { TERM: "xterm-256color" })).toBe("light")
   expect(setup.timeouts).toEqual([1000])
 })

--- a/packages/tui/test/util/theme-mode.test.ts
+++ b/packages/tui/test/util/theme-mode.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test"
+import { resolveInitialThemeMode, shouldSkipInitialThemeModeProbe } from "../../src/util/theme-mode"
+
+function createRenderer(mode: "dark" | "light" | null) {
+  const timeouts: number[] = []
+  const renderer = {
+    waitForThemeMode(timeout: number) {
+      timeouts.push(timeout)
+      return Promise.resolve(mode)
+    },
+  }
+  return { renderer, timeouts }
+}
+
+test("skips the blocking initial theme probe inside multiplexers", async () => {
+  const setup = createRenderer("light")
+
+  expect(shouldSkipInitialThemeModeProbe({ TMUX: "/tmp/tmux-501/default,123,0", TERM: "xterm-256color" })).toBe(true)
+  expect(shouldSkipInitialThemeModeProbe({ STY: "123.screen", TERM: "screen-256color" })).toBe(true)
+  expect(shouldSkipInitialThemeModeProbe({ TERM: "tmux-256color" })).toBe(true)
+  expect(await resolveInitialThemeMode(setup.renderer, { TMUX: "/tmp/tmux-501/default,123,0" })).toBe("dark")
+  expect(setup.timeouts).toEqual([])
+})
+
+test("waits for the initial theme mode on direct terminal sessions", async () => {
+  const setup = createRenderer("light")
+
+  expect(shouldSkipInitialThemeModeProbe({ TERM: "xterm-256color" })).toBe(false)
+  expect(await resolveInitialThemeMode(setup.renderer, { TERM: "xterm-256color" })).toBe("light")
+  expect(setup.timeouts).toEqual([1000])
+})
+
+test("falls back to dark when the direct terminal probe times out", async () => {
+  const setup = createRenderer(null)
+
+  expect(await resolveInitialThemeMode(setup.renderer, { TERM: "xterm-256color" })).toBe("dark")
+  expect(setup.timeouts).toEqual([1000])
+})


### PR DESCRIPTION
### Issue for this PR

Closes #24475

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Avoids the blocking initial `waitForThemeMode(1000)` call when OpenCode starts inside tmux or screen-style multiplexers. Those environments can lose or delay OSC theme replies, which leaves startup waiting for the full timeout before the first draw.

The direct-terminal path still waits for the renderer theme mode once and falls back to dark if no response arrives. The multiplexer path uses dark immediately so the TUI can render without waiting on OSC replies.

### How did you verify your code works?

- `bun test test/util/theme-mode.test.ts` from `packages/tui`
- `bun typecheck` from `packages/tui`
- `bunx oxlint packages/tui/src/app.tsx packages/tui/src/util/theme-mode.ts packages/tui/test/util/theme-mode.test.ts` from repo root (existing warnings only in `app.tsx`)
- `git diff --check`
- pre-push `bun turbo typecheck`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR