### PR TITLE
fix(provider): preserve MiniMax cache by default

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1114,11 +1114,6 @@ export function options(input: {
 
   const modelId = input.model.api.id.toLowerCase()
 
-  // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
-  if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
-    result["thinking"] = { type: "adaptive" }
-  }
-
   // Enable thinking by default for kimi models using anthropic SDK
   if (
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -189,13 +189,13 @@ describe("ProviderTransform.options - minimax m3 thinking", () => {
       limit: { output: 64_000 },
     }) as any
 
-  test("explicitly enables adaptive thinking with the anthropic SDK", () => {
+  test("uses the native default with the anthropic SDK", () => {
     expect(
       ProviderTransform.options({
         model: createModel("@ai-sdk/anthropic"),
         sessionID: "test-session-123",
       }).thinking,
-    ).toEqual({ type: "adaptive" })
+    ).toBeUndefined()
   })
 
   test("uses the native default with the openai-compatible SDK", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #31755

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops forcing `thinking: { type: "adaptive" }` onto MiniMax M3 requests that use the Anthropic SDK path by default.

MiniMax users reported that cache reads work when the variant is explicitly `none`, but the current default path still injects adaptive thinking before any variant is selected. This makes `default` behave like `thinking`, which can burn through MiniMax token-plan quota and disable effective caching.

The explicit MiniMax M3 variants remain unchanged:

- `none` still sends `thinking: { type: "disabled" }`
- `thinking` still sends `thinking: { type: "adaptive" }`
- default now sends no thinking override

### How did you verify your code works?

- `bun test test/provider/transform.test.ts --test-name-pattern "minimax m3 thinking|minimax m3 using"` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bunx oxlint packages/opencode/src/provider/transform.ts packages/opencode/test/provider/transform.test.ts` from repo root (existing warnings only)
- `git diff --check`
- pre-push `bun turbo typecheck`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR