### PR TITLE
fix(tui): surface clipboard write failures

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -71,6 +71,7 @@ export async function read() {
   const { default: clipboardy } = await import("clipboardy")
   const text = await clipboardy.read().catch(() => undefined)
   if (text) return { data: text, mime: "text/plain" }
+  return undefined
 }
 
 export function copyCommand(
@@ -91,6 +92,38 @@ export function copyCommand(
       "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; Set-Clipboard -Value ([Console]::In.ReadToEnd())",
     ]
   }
+  return undefined
+}
+
+type ClipboardyModule = {
+  default: {
+    write(text: string): Promise<void>
+  }
+}
+
+export function createCopyMethod(input: {
+  os: NodeJS.Platform
+  wayland: boolean
+  has: (name: string) => boolean
+  run: (command: string, args?: string[], input?: string) => Promise<Buffer>
+  loadClipboardy: () => Promise<ClipboardyModule>
+}) {
+  const native = copyCommand(input.os, input.wayland, input.has)
+  if (native?.[0] === "osascript") {
+    return async (text: string) => {
+      const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+      await input.run("osascript", ["-e", `set the clipboard to "${escaped}"`])
+    }
+  }
+  if (native) {
+    return async (text: string) => {
+      await input.run(native[0], native.slice(1), text)
+    }
+  }
+  return async (text: string) => {
+    const { default: clipboardy } = await input.loadClipboardy()
+    await clipboardy.write(text)
+  }
 }
 
 let copyMethod: Promise<(text: string) => Promise<void>> | undefined
@@ -98,22 +131,13 @@ let copyMethod: Promise<(text: string) => Promise<void>> | undefined
 function getCopyMethod() {
   return (copyMethod ??= (async () => {
     const { which } = await import("@opencode-ai/core/util/which")
-    const native = copyCommand(platform(), Boolean(process.env.WAYLAND_DISPLAY), (name) => Boolean(which(name)))
-    if (native?.[0] === "osascript") {
-      return async (text: string) => {
-        const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-        await command("osascript", ["-e", `set the clipboard to "${escaped}"`]).catch(() => undefined)
-      }
-    }
-    if (native) {
-      return async (text: string) => {
-        await command(native[0], native.slice(1), text).catch(() => undefined)
-      }
-    }
-    return async (text: string) => {
-      const { default: clipboardy } = await import("clipboardy")
-      await clipboardy.write(text).catch(() => undefined)
-    }
+    return createCopyMethod({
+      os: platform(),
+      wayland: Boolean(process.env.WAYLAND_DISPLAY),
+      has: (name) => Boolean(which(name)),
+      run: command,
+      loadClipboardy: () => import("clipboardy"),
+    })
   })())
 }
 

--- a/packages/tui/test/clipboard.test.ts
+++ b/packages/tui/test/clipboard.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { copyCommand } from "../src/clipboard"
+import { copyCommand, createCopyMethod } from "../src/clipboard"
 
 test("prefers Wayland clipboard when available", () => {
   expect(copyCommand("linux", true, (name) => name === "wl-copy")).toEqual(["wl-copy"])
@@ -16,4 +16,50 @@ test("falls back through X11 clipboard commands", () => {
 
 test("returns undefined when native clipboard is unavailable", () => {
   expect(copyCommand("linux", false, () => false)).toBeUndefined()
+})
+
+test("propagates native clipboard write failures", async () => {
+  const write = createCopyMethod({
+    os: "linux",
+    wayland: false,
+    has: (name) => name === "xclip",
+    run: async () => {
+      throw new Error("xclip failed")
+    },
+    loadClipboardy: async () => ({
+      default: {
+        write: async () => {},
+      },
+    }),
+  })
+
+  await write("hello").then(
+    () => {
+      throw new Error("expected write to fail")
+    },
+    (err) => expect(err).toEqual(new Error("xclip failed")),
+  )
+})
+
+test("propagates clipboardy write failures", async () => {
+  const write = createCopyMethod({
+    os: "linux",
+    wayland: false,
+    has: () => false,
+    run: async () => Buffer.alloc(0),
+    loadClipboardy: async () => ({
+      default: {
+        write: async () => {
+          throw new Error("clipboard unavailable")
+        },
+      },
+    }),
+  })
+
+  await write("hello").then(
+    () => {
+      throw new Error("expected write to fail")
+    },
+    (err) => expect(err).toEqual(new Error("clipboard unavailable")),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #24713
Related #7048
Related #4754

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Stops swallowing failures from native clipboard commands and `clipboardy.write`.
- Preserves the existing clipboard backend selection in one helper, but lets write failures reject so TUI callers show their existing failure/error toast instead of a false "Copied" success.
- Adds regression tests for native clipboard and clipboardy write failures.

### How did you verify your code works?

- `bun test test/clipboard.test.ts` from `packages/tui`
- `bun typecheck` from `packages/tui`
- `bunx oxlint packages/tui/src/clipboard.ts packages/tui/test/clipboard.test.ts`
- `git diff --check`
- pre-push `bun turbo typecheck`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR