### PR TITLE
feat(opencode): support models.dev reasoning options

### DIFF
--- a/packages/core/src/model-request.ts
+++ b/packages/core/src/model-request.ts
@@ -84,7 +84,16 @@ const profiles = new Map<string, Profile>([
       ]),
     },
   ],
-  ["@ai-sdk/anthropic", { namespace: "anthropic", semantics: new Map([["thinking", "thinking"]]) }],
+  [
+    "@ai-sdk/anthropic",
+    {
+      namespace: "anthropic",
+      semantics: new Map([
+        ["thinking", "thinking"],
+        ["effort", "effort"],
+      ]),
+    },
+  ],
 ])
 
 export const namespace = (packageName: string) => profiles.get(packageName)?.namespace

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -43,6 +43,22 @@ const Cost = Schema.Struct({
   ),
 })
 
+export const ReasoningOption = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("effort"),
+    values: Schema.Array(Schema.NullOr(Schema.String)),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("toggle"),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("budget_tokens"),
+    min: Schema.optional(Schema.Finite),
+    max: Schema.optional(Schema.Finite),
+  }),
+])
+export type ReasoningOption = Schema.Schema.Type<typeof ReasoningOption>
+
 export const Model = Schema.Struct({
   id: Schema.String,
   name: Schema.String,
@@ -60,6 +76,7 @@ export const Model = Schema.Struct({
       }),
     ]),
   ),
+  reasoning_options: Schema.optional(Schema.Array(ReasoningOption)),
   cost: Schema.optional(Cost),
   limit: Schema.Struct({
     context: Schema.Finite,

--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -7,6 +7,7 @@ import { ModelRequest } from "../model-request"
 import { ModelsDev } from "../models-dev"
 import { PluginV2 } from "../plugin"
 import { ProviderV2 } from "../provider"
+import { ReasoningVariants } from "../reasoning-variants"
 
 function released(date: string) {
   const time = Date.parse(date)
@@ -40,8 +41,8 @@ function cost(input: ModelsDev.Model["cost"]) {
   ]
 }
 
-function variants(model: ModelsDev.Model, packageName?: string) {
-  return Object.entries(model.experimental?.modes ?? {}).map(([id, item]) => {
+export function variants(model: ModelsDev.Model, providerID: string, packageName?: string) {
+  const modes = Object.entries(model.experimental?.modes ?? {}).map(([id, item]) => {
     const request = ModelRequest.normalizeAiSdkOptions(packageName, item.provider?.body ?? {})
     return {
       id: ModelV2.VariantID.make(id),
@@ -49,6 +50,18 @@ function variants(model: ModelsDev.Model, packageName?: string) {
       ...request,
     }
   })
+  const efforts = ReasoningVariants.fromOptions(
+    { npm: packageName, apiID: model.id, modelID: model.id, providerID },
+    model.reasoning_options,
+  )
+  const fromEfforts = Object.entries(efforts ?? {})
+    .filter(([id]) => !modes.some((mode) => mode.id === id))
+    .map(([id, body]) => ({
+      id: ModelV2.VariantID.make(id),
+      headers: {},
+      ...ModelRequest.normalizeAiSdkOptions(packageName, body),
+    }))
+  return [...modes, ...fromEfforts]
 }
 
 export const ModelsDevPlugin = PluginV2.define({
@@ -119,7 +132,7 @@ export const ModelsDevPlugin = PluginV2.define({
                 input: [...(model.modalities?.input ?? [])],
                 output: [...(model.modalities?.output ?? [])],
               }
-              draft.variants = variants(model, model.provider?.npm ?? item.npm)
+              draft.variants = variants(model, item.id, model.provider?.npm ?? item.npm)
               draft.time.released = released(model.release_date)
               draft.cost = cost(model.cost)
               draft.status = model.status ?? "active"

--- a/packages/core/src/reasoning-variants.ts
+++ b/packages/core/src/reasoning-variants.ts
@@ -1,0 +1,166 @@
+export * as ReasoningVariants from "./reasoning-variants"
+
+// Generates reasoning variants from models.dev `reasoning_options` data. The
+// data only says which efforts a model supports; this module owns the wire
+// encoding so catalog and provider paths stay in sync.
+
+export const INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"] as const
+
+export interface Target {
+  readonly npm?: string
+  readonly apiID: string
+  readonly modelID: string
+  readonly providerID: string
+}
+
+export function fromOptions(
+  target: Target,
+  options: ReadonlyArray<{ readonly type: string; readonly values?: ReadonlyArray<string | null> }> | undefined,
+): Record<string, Record<string, unknown>> | undefined {
+  const efforts = [
+    ...new Set(
+      (options ?? [])
+        .flatMap((option) => (option.type === "effort" ? (option.values ?? []) : []))
+        .filter((value): value is string => typeof value === "string"),
+    ),
+  ]
+  if (efforts.length === 0) return undefined
+  return effortVariants(target, efforts)
+}
+
+export function anthropicOpus47OrLater(apiID: string) {
+  const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)/i.exec(apiID)
+  if (!version) return false
+  const major = Number(version[1] ?? version[3])
+  const minor = Number(version[2] ?? version[4])
+  return major > 4 || (major === 4 && minor >= 7)
+}
+
+export function anthropicAdaptiveEfforts(apiID: string): string[] | null {
+  if (anthropicOpus47OrLater(apiID) || apiID.includes("fable-5")) {
+    return ["low", "medium", "high", "xhigh", "max"]
+  }
+  if (
+    ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6", "4-6-sonnet", "4.6-sonnet"].some((v) =>
+      apiID.includes(v),
+    )
+  ) {
+    return ["low", "medium", "high", "max"]
+  }
+  return null
+}
+
+export function anthropicOmitsThinking(apiID: string) {
+  return anthropicOpus47OrLater(apiID) || apiID.includes("fable-5")
+}
+
+export function wrapInSapModelParams(
+  variants: Record<string, Record<string, unknown>>,
+): Record<string, Record<string, unknown>> {
+  return Object.fromEntries(Object.entries(variants).map(([id, value]) => [id, { modelParams: value }]))
+}
+
+function copilotAnthropicEfforts(apiID: string, efforts: string[]) {
+  if (apiID.includes("opus-4.7")) return ["medium"]
+  return efforts.filter((value) => value !== "max" && value !== "xhigh")
+}
+
+function anthropicEffortVariants(target: Target, efforts: string[]): Record<string, Record<string, unknown>> {
+  const filtered = target.providerID === "github-copilot" ? copilotAnthropicEfforts(target.apiID, efforts) : efforts
+  const adaptive = anthropicAdaptiveEfforts(target.apiID) !== null
+  return Object.fromEntries(
+    filtered.map((effort) => [
+      effort,
+      adaptive
+        ? {
+            thinking: {
+              type: "adaptive",
+              ...(anthropicOmitsThinking(target.apiID) ? { display: "summarized" } : {}),
+            },
+            effort,
+          }
+        : { effort },
+    ]),
+  )
+}
+
+function effortVariants(target: Target, efforts: string[]): Record<string, Record<string, unknown>> {
+  const fromEffort = (encode: (effort: string) => Record<string, unknown>) =>
+    Object.fromEntries(efforts.map((effort) => [effort, encode(effort)]))
+
+  switch (target.npm) {
+    case "@openrouter/ai-sdk-provider":
+      return fromEffort((effort) => ({ reasoning: { effort } }))
+
+    case "@ai-sdk/gateway":
+      if (target.modelID.includes("anthropic")) return anthropicEffortVariants(target, efforts)
+      if (target.modelID.includes("google"))
+        return fromEffort((effort) => ({ includeThoughts: true, thinkingLevel: effort }))
+      return fromEffort((effort) => ({ reasoningEffort: effort }))
+
+    case "@ai-sdk/github-copilot":
+      if (target.modelID.includes("gemini")) return {}
+      if (target.modelID.includes("claude")) return fromEffort((effort) => ({ reasoningEffort: effort }))
+      return fromEffort((effort) => ({
+        reasoningEffort: effort,
+        reasoningSummary: "auto",
+        include: INCLUDE_ENCRYPTED_REASONING,
+      }))
+
+    case "@ai-sdk/azure":
+    case "@ai-sdk/amazon-bedrock/mantle":
+    case "@ai-sdk/openai":
+      return fromEffort((effort) => ({
+        reasoningEffort: effort,
+        reasoningSummary: "auto",
+        include: INCLUDE_ENCRYPTED_REASONING,
+      }))
+
+    case "@ai-sdk/anthropic":
+    case "@ai-sdk/google-vertex/anthropic":
+      return anthropicEffortVariants(target, efforts)
+
+    case "@ai-sdk/amazon-bedrock":
+      if (anthropicAdaptiveEfforts(target.apiID)) {
+        return fromEffort((effort) => ({
+          reasoningConfig: {
+            type: "adaptive",
+            maxReasoningEffort: effort,
+            ...(anthropicOmitsThinking(target.apiID) ? { display: "summarized" } : {}),
+          },
+        }))
+      }
+      return fromEffort((effort) => ({
+        reasoningConfig: {
+          type: "enabled",
+          maxReasoningEffort: effort,
+        },
+      }))
+
+    case "@ai-sdk/google-vertex":
+    case "@ai-sdk/google":
+      return fromEffort((effort) => ({ thinkingConfig: { includeThoughts: true, thinkingLevel: effort } }))
+
+    case "@jerome-benoit/sap-ai-provider-v2": {
+      if (target.modelID.toLowerCase().includes("anthropic")) {
+        const adaptive = anthropicAdaptiveEfforts(target.apiID) !== null
+        return wrapInSapModelParams(
+          fromEffort((effort) =>
+            adaptive
+              ? {
+                  thinking: {
+                    type: "adaptive",
+                    ...(anthropicOmitsThinking(target.apiID) ? { display: "summarized" } : {}),
+                  },
+                  output_config: { effort },
+                }
+              : { output_config: { effort } },
+          ),
+        )
+      }
+      return wrapInSapModelParams(fromEffort((effort) => ({ reasoning_effort: effort })))
+    }
+  }
+
+  return fromEffort((effort) => ({ reasoningEffort: effort }))
+}

--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -12,6 +12,26 @@ export const Model = Schema.Struct({
   release_date: Schema.optional(Schema.String),
   attachment: Schema.optional(Schema.Boolean),
   reasoning: Schema.optional(Schema.Boolean),
+  reasoning_options: Schema.optional(
+    Schema.mutable(
+      Schema.Array(
+        Schema.Union([
+          Schema.Struct({
+            type: Schema.Literal("toggle"),
+          }),
+          Schema.Struct({
+            type: Schema.Literal("effort"),
+            values: Schema.mutable(Schema.Array(Schema.NullOr(Schema.String))),
+          }),
+          Schema.Struct({
+            type: Schema.Literal("budget_tokens"),
+            min: Schema.optional(Schema.Finite),
+            max: Schema.optional(Schema.Finite),
+          }),
+        ]),
+      ),
+    ),
+  ).annotate({ description: "Reasoning controls this model supports; effort values drive reasoning variants" }),
   temperature: Schema.optional(Schema.Boolean),
   tool_call: Schema.optional(Schema.Boolean),
   interleaved: Schema.optional(

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -610,7 +610,8 @@ describe("Config", () => {
                 model: {
                   request: {
                     body: {
-                      output_config: { effort: "high", task_budget: 4096 },
+                      effort: "high",
+                      output_config: { task_budget: 4096 },
                       metadata: { user_id: "user-1" },
                     },
                   },

--- a/packages/core/test/models-dev-plugin.test.ts
+++ b/packages/core/test/models-dev-plugin.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ModelsDev } from "@opencode-ai/core/models-dev"
+import { variants } from "@opencode-ai/core/plugin/models-dev"
+
+const model = (input: Partial<ModelsDev.Model> & { id: string }): ModelsDev.Model => ({
+  name: input.id,
+  release_date: "2026-01-01",
+  attachment: false,
+  reasoning: true,
+  temperature: true,
+  tool_call: true,
+  limit: { context: 200_000, output: 64_000 },
+  ...input,
+})
+
+describe("ModelsDevPlugin reasoning_options", () => {
+  test("generates anthropic effort variants as semantic thinking + effort options", () => {
+    const result = variants(
+      model({
+        id: "claude-sonnet-4-6",
+        reasoning_options: [
+          { type: "effort", values: ["low", "medium", "high", "max"] },
+          { type: "budget_tokens", min: 1024 },
+        ],
+      }),
+      "anthropic",
+      "@ai-sdk/anthropic",
+    )
+
+    expect(result.map((variant) => variant.id)).toEqual(
+      ["low", "medium", "high", "max"].map((id) => ModelV2.VariantID.make(id)),
+    )
+    expect(result[2]).toMatchObject({
+      id: "high",
+      headers: {},
+      body: {},
+      options: { thinking: { type: "adaptive" }, effort: "high" },
+    })
+  })
+
+  test("merges effort variants after curated experimental modes, skipping null values and collisions", () => {
+    const result = variants(
+      model({
+        id: "deepseek-v4",
+        reasoning_options: [{ type: "toggle" }, { type: "effort", values: [null, "high", "max"] }],
+        experimental: {
+          modes: {
+            high: { provider: { body: { reasoning_effort: "high", custom: true } } },
+          },
+        },
+      }),
+      "compat",
+      "@ai-sdk/openai-compatible",
+    )
+
+    expect(result.map((variant) => variant.id)).toEqual(["high", "max"].map((id) => ModelV2.VariantID.make(id)))
+    expect(result[0]).toMatchObject({
+      id: "high",
+      body: { custom: true },
+      options: { reasoningEffort: "high" },
+    })
+    expect(result[1]).toMatchObject({
+      id: "max",
+      body: {},
+      options: { reasoningEffort: "max" },
+    })
+  })
+})

--- a/packages/llm/src/protocols/anthropic-messages.ts
+++ b/packages/llm/src/protocols/anthropic-messages.ts
@@ -146,10 +146,16 @@ const AnthropicToolChoice = Schema.Union([
   Schema.Struct({ type: Schema.tag("tool"), name: Schema.String }),
 ])
 
-const AnthropicThinking = Schema.Struct({
-  type: Schema.tag("enabled"),
-  budget_tokens: Schema.Number,
-})
+const AnthropicThinking = Schema.Union([
+  Schema.Struct({
+    type: Schema.tag("enabled"),
+    budget_tokens: Schema.Number,
+  }),
+  Schema.Struct({
+    type: Schema.tag("adaptive"),
+    display: Schema.optional(Schema.String),
+  }),
+])
 
 const AnthropicBodyFields = {
   model: Schema.String,
@@ -164,6 +170,7 @@ const AnthropicBodyFields = {
   top_k: Schema.optional(Schema.Number),
   stop_sequences: optionalArray(Schema.String),
   thinking: Schema.optional(AnthropicThinking),
+  output_config: Schema.optional(Schema.Struct({ effort: Schema.String })),
 }
 const AnthropicMessagesBody = Schema.Struct(AnthropicBodyFields)
 export type AnthropicMessagesBody = Schema.Schema.Type<typeof AnthropicMessagesBody>
@@ -490,7 +497,14 @@ const anthropicOptions = (request: LLMRequest) => request.providerOptions?.anthr
 
 const lowerThinking = Effect.fn("AnthropicMessages.lowerThinking")(function* (request: LLMRequest) {
   const thinking = anthropicOptions(request)?.thinking
-  if (!ProviderShared.isRecord(thinking) || thinking.type !== "enabled") return undefined
+  if (!ProviderShared.isRecord(thinking)) return undefined
+  if (thinking.type === "adaptive") {
+    return {
+      type: "adaptive" as const,
+      ...(typeof thinking.display === "string" ? { display: thinking.display } : {}),
+    }
+  }
+  if (thinking.type !== "enabled") return undefined
   const budget =
     typeof thinking.budgetTokens === "number"
       ? thinking.budgetTokens
@@ -500,6 +514,12 @@ const lowerThinking = Effect.fn("AnthropicMessages.lowerThinking")(function* (re
   if (budget === undefined) return yield* invalid("Anthropic thinking provider option requires budgetTokens")
   return { type: "enabled" as const, budget_tokens: budget }
 })
+
+const lowerOutputConfig = (request: LLMRequest) => {
+  const effort = anthropicOptions(request)?.effort
+  if (typeof effort !== "string") return undefined
+  return { effort }
+}
 
 const fromRequest = Effect.fn("AnthropicMessages.fromRequest")(function* (request: LLMRequest) {
   const toolChoice = request.toolChoice ? yield* lowerToolChoice(request.toolChoice) : undefined
@@ -539,6 +559,7 @@ const fromRequest = Effect.fn("AnthropicMessages.fromRequest")(function* (reques
     top_k: generation?.topK,
     stop_sequences: generation?.stop,
     thinking: yield* lowerThinking(request),
+    output_config: lowerOutputConfig(request),
   }
 })
 
@@ -839,7 +860,10 @@ export const route = Route.make({
   endpoint: Endpoint.path(PATH, { baseURL: DEFAULT_BASE_URL }),
   auth: Auth.none,
   framing: Framing.sse,
-  headers: () => ({ "anthropic-version": "2023-06-01" }),
+  headers: ({ request }) => ({
+    "anthropic-version": "2023-06-01",
+    ...(typeof anthropicOptions(request)?.effort === "string" ? { "anthropic-beta": "effort-2025-11-24" } : {}),
+  }),
 })
 
 export * as AnthropicMessages from "./anthropic-messages"

--- a/packages/llm/test/provider/anthropic-messages.test.ts
+++ b/packages/llm/test/provider/anthropic-messages.test.ts
@@ -57,6 +57,59 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
+  it.effect("lowers enabled thinking to a budget", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<AnthropicMessages.AnthropicMessagesBody>(
+        LLM.updateRequest(request, {
+          providerOptions: { anthropic: { thinking: { type: "enabled", budgetTokens: 16_000 } } },
+        }),
+      )
+      expect(prepared.body.thinking).toEqual({ type: "enabled", budget_tokens: 16_000 })
+      expect(prepared.body.output_config).toBeUndefined()
+    }),
+  )
+
+  it.effect("lowers adaptive thinking and effort to output_config", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<AnthropicMessages.AnthropicMessagesBody>(
+        LLM.updateRequest(request, {
+          providerOptions: {
+            anthropic: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+          },
+        }),
+      )
+      expect(prepared.body.thinking).toEqual({ type: "adaptive", display: "summarized" })
+      expect(prepared.body.output_config).toEqual({ effort: "high" })
+    }),
+  )
+
+  it.effect("adds the effort beta header only when effort is set", () =>
+    Effect.gen(function* () {
+      const seen: Record<string, string>[] = []
+      const body = () =>
+        sseEvents(
+          { type: "message_start", message: { usage: { input_tokens: 1 } } },
+          { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } },
+          { type: "message_stop" },
+        )
+      const layer = dynamicResponse((input) =>
+        Effect.sync(() => {
+          seen.push({ ...input.request.headers })
+          return input.respond(body(), { headers: { "content-type": "text/event-stream" } })
+        }),
+      )
+
+      yield* LLMClient.generate(
+        LLM.updateRequest(request, { providerOptions: { anthropic: { effort: "high" } } }),
+      ).pipe(Effect.provide(layer))
+      yield* LLMClient.generate(request).pipe(Effect.provide(layer))
+
+      expect(seen[0]["anthropic-version"]).toBe("2023-06-01")
+      expect(seen[0]["anthropic-beta"]).toBe("effort-2025-11-24")
+      expect(seen[1]["anthropic-beta"]).toBeUndefined()
+    }),
+  )
+
   it.effect("lowers chronological system updates natively for Claude Opus 4.8 with cache hints", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<AnthropicMessages.AnthropicMessagesBody>(

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -970,9 +970,25 @@ const ProviderInterleaved = Schema.Union([
   }),
 ])
 
+const ProviderReasoningOption = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("toggle"),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("effort"),
+    values: Schema.Array(Schema.String),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("budget_tokens"),
+    min: optionalOmitUndefined(Schema.Finite),
+    max: optionalOmitUndefined(Schema.Finite),
+  }),
+])
+
 const ProviderCapabilities = Schema.Struct({
   temperature: Schema.Boolean,
   reasoning: Schema.Boolean,
+  reasoningOptions: optionalOmitUndefined(Schema.Array(ProviderReasoningOption)),
   attachment: Schema.Boolean,
   toolcall: Schema.Boolean,
   input: ProviderModalities,
@@ -1168,6 +1184,16 @@ function cost(c: ModelsDev.Model["cost"]): Model["cost"] {
   return result
 }
 
+function reasoningOptions(options: ModelsDev.Model["reasoning_options"]): Model["capabilities"]["reasoningOptions"] {
+  return options
+    ?.filter((option) => option.type === "toggle" || option.type === "effort" || option.type === "budget_tokens")
+    .map((option) =>
+      option.type === "effort"
+        ? { ...option, values: option.values.filter((value): value is string => typeof value === "string") }
+        : { ...option },
+    )
+}
+
 function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model): Model {
   const base: Model = {
     id: ModelV2.ID.make(model.id),
@@ -1191,6 +1217,7 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
     capabilities: {
       temperature: model.temperature ?? false,
       reasoning: model.reasoning ?? false,
+      reasoningOptions: reasoningOptions(model.reasoning_options),
       attachment: model.attachment ?? false,
       toolcall: model.tool_call ?? true,
       input: {
@@ -1212,7 +1239,6 @@ function fromModelsDevModel(provider: ModelsDev.Provider, model: ModelsDev.Model
     release_date: model.release_date ?? "",
     variants: {},
   }
-
   return {
     ...base,
     variants: mapValues(ProviderTransform.variants(base), (v) => v),
@@ -1413,6 +1439,8 @@ export const layer = Layer.effect(
               capabilities: {
                 temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
                 reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
+                reasoningOptions:
+                  reasoningOptions(model.reasoning_options) ?? existingModel?.capabilities.reasoningOptions,
                 attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
                 toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,
                 input: {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -3,6 +3,7 @@ import { mergeDeep, unique } from "remeda"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@opencode-ai/core/models-dev"
+import { ReasoningVariants } from "@opencode-ai/core/reasoning-variants"
 import { iife } from "@/util/iife"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
@@ -16,11 +17,6 @@ function mimeToModality(mime: string): Modality | undefined {
 }
 
 export const OUTPUT_TOKEN_MAX = 32_000
-
-// OpenAI Responses `include` value that returns the encrypted reasoning state
-// needed for stateless multi-turn reasoning (store: false). Hoisted so every
-// branch that requests it stays in lockstep.
-const INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"] as const
 
 export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
@@ -595,34 +591,6 @@ function openaiCompatibleReasoningEfforts(id: string) {
   return gpt5CodexReasoningEfforts(apiId) ?? versionedGpt5ReasoningEfforts(apiId) ?? OPENAI_EFFORTS
 }
 
-function anthropicOpus47OrLater(apiId: string) {
-  // Matches "opus-4.7" (Anthropic/Bedrock/Vertex) and "claude-4.7-opus" (SAP AI Core inverted).
-  // Greedy \d+ correctly extends to multi-digit majors (e.g. "claude-10.0-opus") for forward compatibility.
-  const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)/i.exec(apiId)
-  if (!version) return false
-  const major = Number(version[1] ?? version[3])
-  const minor = Number(version[2] ?? version[4])
-  return major > 4 || (major === 4 && minor >= 7)
-}
-
-function anthropicAdaptiveEfforts(apiId: string): string[] | null {
-  if (anthropicOpus47OrLater(apiId) || apiId.includes("fable-5")) {
-    return ["low", "medium", "high", "xhigh", "max"]
-  }
-  if (
-    ["opus-4-6", "opus-4.6", "4-6-opus", "4.6-opus", "sonnet-4-6", "sonnet-4.6", "4-6-sonnet", "4.6-sonnet"].some((v) =>
-      apiId.includes(v),
-    )
-  ) {
-    return ["low", "medium", "high", "max"]
-  }
-  return null
-}
-
-function anthropicOmitsThinking(apiId: string) {
-  return anthropicOpus47OrLater(apiId) || apiId.includes("fable-5")
-}
-
 function googleThinkingLevelEfforts(apiId: string) {
   const id = apiId.toLowerCase()
   if (!id.includes("gemini-3")) return ["low", "high"]
@@ -636,12 +604,6 @@ function googleThinkingBudgetMax(apiId: string) {
   const id = apiId.toLowerCase()
   if (id.includes("2.5") && id.includes("pro") && !id.includes("flash")) return 32_768
   return 24_576
-}
-
-// SAP's Zod schema drops unknown top-level keys; reasoning controls survive
-// only via `modelParams` (catchall), forwarded verbatim by the SAP SDKs.
-function wrapInSapModelParams(variants: Record<string, Record<string, any>>): Record<string, Record<string, any>> {
-  return Object.fromEntries(Object.entries(variants).map(([k, v]) => [k, { modelParams: v }]))
 }
 
 function googleThinkingVariants(model: Provider.Model): Record<string, Record<string, any>> {
@@ -665,6 +627,12 @@ function googleThinkingVariants(model: Provider.Model): Record<string, Record<st
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
 
+  const fromData = ReasoningVariants.fromOptions(
+    { npm: model.api.npm, apiID: model.api.id, modelID: model.id, providerID: model.providerID },
+    model.capabilities.reasoningOptions,
+  )
+  if (fromData) return fromData
+
   const id = model.id.toLowerCase()
   if (
     model.api.id.toLowerCase().includes("minimax-m3") &&
@@ -675,8 +643,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       thinking: { thinking: { type: "adaptive" } },
     }
   }
-  const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
-  const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
+  const adaptiveThinkingOmitted = ReasoningVariants.anthropicOmitsThinking(model.api.id)
+  const adaptiveEfforts = ReasoningVariants.anthropicAdaptiveEfforts(model.api.id)
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||
@@ -815,7 +783,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: INCLUDE_ENCRYPTED_REASONING,
+            include: ReasoningVariants.INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
       )
@@ -849,7 +817,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: INCLUDE_ENCRYPTED_REASONING,
+            include: ReasoningVariants.INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
       )
@@ -863,7 +831,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           {
             reasoningEffort: effort,
             reasoningSummary: "auto",
-            include: INCLUDE_ENCRYPTED_REASONING,
+            include: ReasoningVariants.INCLUDE_ENCRYPTED_REASONING,
           },
         ]),
       )
@@ -1010,7 +978,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         if (adaptiveEfforts) {
           // Bedrock adaptive splits `effort` out into `output_config` (vs Anthropic
           // native which inlines it). Opus 4.7+ flipped `display` default to "omitted".
-          return wrapInSapModelParams(
+          return ReasoningVariants.wrapInSapModelParams(
             Object.fromEntries(
               adaptiveEfforts.map((effort) => [
                 effort,
@@ -1022,19 +990,21 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
             ),
           )
         }
-        return wrapInSapModelParams({
+        return ReasoningVariants.wrapInSapModelParams({
           high: { thinking: { type: "enabled", budget_tokens: 16000 } },
           max: { thinking: { type: "enabled", budget_tokens: 31999 } },
         })
       }
       if (id.includes("gemini") && id.includes("2.5")) {
-        return wrapInSapModelParams(googleThinkingVariants(model))
+        return ReasoningVariants.wrapInSapModelParams(googleThinkingVariants(model))
       }
       if (id.includes("gpt") || /\bo[1-9]/.test(id)) {
         const efforts = openaiReasoningEfforts(id, model.release_date)
-        return wrapInSapModelParams(Object.fromEntries(efforts.map((effort) => [effort, { reasoning_effort: effort }])))
+        return ReasoningVariants.wrapInSapModelParams(
+          Object.fromEntries(efforts.map((effort) => [effort, { reasoning_effort: effort }])),
+        )
       }
-      return wrapInSapModelParams(
+      return ReasoningVariants.wrapInSapModelParams(
         Object.fromEntries(["low", "medium", "high"].map((effort) => [effort, { reasoning_effort: effort }])),
       )
     }
@@ -1161,7 +1131,7 @@ export function options(input: {
         result["reasoningSummary"] = "auto"
       }
       if (input.model.api.npm === "@ai-sdk/openai" || input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle") {
-        result["include"] = INCLUDE_ENCRYPTED_REASONING
+        result["include"] = ReasoningVariants.INCLUDE_ENCRYPTED_REASONING
       }
     }
 
@@ -1178,7 +1148,7 @@ export function options(input: {
 
     if (input.model.providerID.startsWith("opencode")) {
       result["promptCacheKey"] = input.sessionID
-      result["include"] = INCLUDE_ENCRYPTED_REASONING
+      result["include"] = ReasoningVariants.INCLUDE_ENCRYPTED_REASONING
       result["reasoningSummary"] = "auto"
     }
   }

--- a/packages/opencode/test/provider/model-status.test.ts
+++ b/packages/opencode/test/provider/model-status.test.ts
@@ -14,18 +14,19 @@ describe("provider model status schemas", () => {
 
   test("accepts active status across public provider schemas", () => {
     expect(Schema.decodeUnknownSync(ConfigProviderV1.Model)({ status: "active" }).status).toBe("active")
-    expect(
-      Schema.decodeUnknownSync(ModelsDev.Model)({
-        id: "test-model",
-        name: "Test Model",
-        release_date: "2026-01-01",
-        attachment: false,
-        reasoning: false,
-        temperature: true,
-        tool_call: true,
-        limit: { context: 128000, output: 8192 },
-      }).status,
-    ).toBeUndefined()
+    const decoded = Schema.decodeUnknownSync(ModelsDev.Model)({
+      id: "test-model",
+      name: "Test Model",
+      release_date: "2026-01-01",
+      attachment: false,
+      reasoning: false,
+      reasoning_options: [{ type: "effort", values: ["high", "max"] }],
+      temperature: true,
+      tool_call: true,
+      limit: { context: 128000, output: 8192 },
+    })
+    expect(decoded.reasoning_options).toEqual([{ type: "effort", values: ["high", "max"] }])
+    expect(decoded.status).toBeUndefined()
     expect(
       Schema.decodeUnknownSync(Provider.Model)({
         id: "test-model",

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1285,6 +1285,40 @@ test("mode cost preserves over-200k pricing from base model", () => {
   })
 })
 
+test("models.dev reasoning_options generate exact reasoning effort variants", () => {
+  const provider = {
+    id: "zhipuai-coding-plan",
+    name: "Zhipu AI Coding Plan",
+    env: [],
+    api: "https://open.bigmodel.cn/api/coding/paas/v4",
+    npm: "@ai-sdk/openai-compatible",
+    models: {
+      "glm-5.2": {
+        id: "glm-5.2",
+        name: "GLM-5.2",
+        family: "glm",
+        release_date: "2026-06-13",
+        attachment: false,
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["high", "max"] }],
+        temperature: true,
+        tool_call: true,
+        interleaved: { field: "reasoning_content" },
+        limit: {
+          context: 1_000_000,
+          output: 131_072,
+        },
+      },
+    },
+  } as unknown as ModelsDev.Provider
+
+  const model = Provider.fromModelsDevProvider(provider).models["glm-5.2"]
+  expect(model.variants).toEqual({
+    high: { reasoningEffort: "high" },
+    max: { reasoningEffort: "max" },
+  })
+})
+
 test("models.dev normalization fills required response fields", () => {
   const provider = {
     id: "gateway",

--- a/packages/opencode/test/provider/reasoning-options.test.ts
+++ b/packages/opencode/test/provider/reasoning-options.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, test } from "bun:test"
+import { Schema } from "effect"
+import { ConfigProviderV1 } from "@opencode-ai/core/v1/config/provider"
+import { ModelsDev } from "@opencode-ai/core/models-dev"
+import { Provider } from "@/provider/provider"
+import { ProviderTransform } from "@/provider/transform"
+
+const options = [
+  { type: "toggle" },
+  { type: "effort", values: [null, "low", "medium", "high", "xhigh", "max", "ultrathink"] },
+  { type: "budget_tokens", min: 1024 },
+  { type: "budget_tokens", min: 0, max: 24_576 },
+]
+
+describe("reasoning_options schemas", () => {
+  test("models.dev model schema decodes all known option shapes", () => {
+    const model = Schema.decodeUnknownSync(ModelsDev.Model)({
+      id: "test-model",
+      name: "Test Model",
+      release_date: "2026-01-01",
+      attachment: false,
+      reasoning: true,
+      reasoning_options: options,
+      temperature: true,
+      tool_call: true,
+      limit: { context: 128000, output: 8192 },
+    })
+    expect(model.reasoning_options).toEqual(options as typeof model.reasoning_options)
+  })
+
+  test("config model schema decodes reasoning_options", () => {
+    const model = Schema.decodeUnknownSync(ConfigProviderV1.Model)({ reasoning_options: options })
+    expect(model.reasoning_options).toEqual(options as typeof model.reasoning_options)
+  })
+
+  test("provider capabilities decode sanitized reasoningOptions", () => {
+    const resolved = [
+      { type: "toggle" },
+      { type: "effort", values: ["low", "medium", "high", "xhigh", "max", "ultrathink"] },
+      { type: "budget_tokens", min: 1024 },
+      { type: "budget_tokens", min: 0, max: 24_576 },
+    ]
+    const capabilities = Schema.decodeUnknownSync(Provider.Model.fields.capabilities)({
+      temperature: true,
+      reasoning: true,
+      reasoningOptions: resolved,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    })
+    expect(capabilities.reasoningOptions).toEqual(resolved as typeof capabilities.reasoningOptions)
+    expect(() =>
+      Schema.decodeUnknownSync(Provider.Model.fields.capabilities)({
+        temperature: true,
+        reasoning: true,
+        reasoningOptions: [{ type: "effort", values: [null, "low"] }],
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      }),
+    ).toThrow()
+  })
+})
+
+describe("ProviderTransform.variants - models.dev reasoning_options", () => {
+  const createModel = (overrides: Partial<any> = {}): Provider.Model =>
+    ({
+      id: "test/test-model",
+      providerID: "test",
+      api: {
+        id: "test-model",
+        url: "https://api.test.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      name: "Test Model",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 200_000, output: 64_000 },
+      status: "active",
+      options: {},
+      headers: {},
+      release_date: "2024-01-01",
+      ...overrides,
+    }) as Provider.Model
+
+  const withOptions = (model: Provider.Model, reasoningOptions: any[]) => {
+    model.capabilities.reasoningOptions = reasoningOptions
+    return model
+  }
+
+  test("effort values drive GLM variants for openai-compatible packages", () => {
+    const model = withOptions(
+      createModel({
+        id: "zhipuai-coding-plan/glm-5.2",
+        providerID: "zhipuai-coding-plan",
+        api: { id: "glm-5.2", url: "", npm: "@ai-sdk/openai-compatible" },
+      }),
+      [{ type: "toggle" }, { type: "effort", values: ["high", "max"] }],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+  })
+
+  test("openai packages include summaries and encrypted reasoning", () => {
+    const model = withOptions(createModel({ api: { id: "gpt-x", url: "", npm: "@ai-sdk/openai" } }), [
+      { type: "effort", values: ["low", "high"] },
+    ])
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { reasoningEffort: "low", reasoningSummary: "auto", include: ["reasoning.encrypted_content"] },
+      high: { reasoningEffort: "high", reasoningSummary: "auto", include: ["reasoning.encrypted_content"] },
+    })
+  })
+
+  test("null efforts, duplicates, and unknown option types are ignored", () => {
+    const model = withOptions(createModel(), [
+      { type: "future-thing", anything: true },
+      { type: "effort", values: [null, "low"] },
+      { type: "effort", values: ["low", "high"] },
+    ])
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+    })
+  })
+
+  test("toggle-only data falls back to hardcoded variants", () => {
+    const model = withOptions(
+      createModel({
+        id: "minimax/minimax-m3",
+        providerID: "minimax",
+        api: { id: "MiniMax-M3", url: "", npm: "@ai-sdk/anthropic" },
+      }),
+      [{ type: "toggle" }],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    })
+  })
+
+  test("anthropic adaptive models wrap effort in adaptive thinking", () => {
+    const model = withOptions(
+      createModel({
+        id: "anthropic/claude-sonnet-4-6",
+        providerID: "anthropic",
+        api: { id: "claude-sonnet-4-6", url: "", npm: "@ai-sdk/anthropic" },
+      }),
+      [
+        { type: "effort", values: ["low", "medium", "high", "max"] },
+        { type: "budget_tokens", min: 1024 },
+      ],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { thinking: { type: "adaptive" }, effort: "low" },
+      medium: { thinking: { type: "adaptive" }, effort: "medium" },
+      high: { thinking: { type: "adaptive" }, effort: "high" },
+      max: { thinking: { type: "adaptive" }, effort: "max" },
+    })
+  })
+
+  test("anthropic non-adaptive models encode efforts as plain effort", () => {
+    const model = withOptions(
+      createModel({
+        id: "anthropic/claude-opus-4-5",
+        providerID: "anthropic",
+        api: { id: "claude-opus-4-5", url: "", npm: "@ai-sdk/anthropic" },
+      }),
+      [{ type: "effort", values: ["low", "medium", "high"] }],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { effort: "low" },
+      medium: { effort: "medium" },
+      high: { effort: "high" },
+    })
+  })
+
+  test("github-copilot anthropic models filter unsupported efforts", () => {
+    const model = withOptions(
+      createModel({
+        id: "github-copilot/claude-sonnet-4-6",
+        providerID: "github-copilot",
+        api: { id: "claude-sonnet-4-6", url: "", npm: "@ai-sdk/anthropic" },
+      }),
+      [{ type: "effort", values: ["low", "medium", "high", "max"] }],
+    )
+    expect(Object.keys(ProviderTransform.variants(model))).toEqual(["low", "medium", "high"])
+  })
+
+  test("openrouter encodes efforts as reasoning.effort", () => {
+    const model = withOptions(
+      createModel({
+        id: "openrouter/x-ai/grok-4.3",
+        providerID: "openrouter",
+        api: { id: "x-ai/grok-4.3", url: "", npm: "@openrouter/ai-sdk-provider" },
+      }),
+      [{ type: "effort", values: ["low", "high"] }],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { reasoning: { effort: "low" } },
+      high: { reasoning: { effort: "high" } },
+    })
+  })
+
+  test("google encodes efforts as thinkingConfig levels", () => {
+    const model = withOptions(
+      createModel({
+        id: "google/gemini-3-pro-preview",
+        providerID: "google",
+        api: { id: "gemini-3-pro-preview", url: "", npm: "@ai-sdk/google" },
+      }),
+      [{ type: "effort", values: ["low", "high"] }],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { thinkingConfig: { includeThoughts: true, thinkingLevel: "low" } },
+      high: { thinkingConfig: { includeThoughts: true, thinkingLevel: "high" } },
+    })
+  })
+
+  test("bedrock non-adaptive models encode efforts as maxReasoningEffort", () => {
+    const model = withOptions(
+      createModel({
+        id: "amazon-bedrock/anthropic.claude-opus-4-5-20251101-v1:0",
+        providerID: "amazon-bedrock",
+        api: { id: "anthropic.claude-opus-4-5-20251101-v1:0", url: "", npm: "@ai-sdk/amazon-bedrock" },
+      }),
+      [{ type: "effort", values: ["low", "medium", "high"] }],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { reasoningConfig: { type: "enabled", maxReasoningEffort: "low" } },
+      medium: { reasoningConfig: { type: "enabled", maxReasoningEffort: "medium" } },
+      high: { reasoningConfig: { type: "enabled", maxReasoningEffort: "high" } },
+    })
+  })
+
+  test("sap anthropic adaptive models wrap efforts in modelParams", () => {
+    const model = withOptions(
+      createModel({
+        id: "sap-ai-core/anthropic--claude-4.6-sonnet",
+        providerID: "sap-ai-core",
+        api: { id: "anthropic--claude-4.6-sonnet", url: "", npm: "@jerome-benoit/sap-ai-provider-v2" },
+      }),
+      [{ type: "effort", values: ["low", "max"] }],
+    )
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { modelParams: { thinking: { type: "adaptive" }, output_config: { effort: "low" } } },
+      max: { modelParams: { thinking: { type: "adaptive" }, output_config: { effort: "max" } } },
+    })
+  })
+
+  test("unknown packages default to openai-compatible reasoningEffort", () => {
+    const model = withOptions(createModel({ api: { id: "some-model", url: "", npm: "@ai-sdk/some-future-sdk" } }), [
+      { type: "effort", values: ["low", "ultrathink"] },
+    ])
+    expect(ProviderTransform.variants(model)).toEqual({
+      low: { reasoningEffort: "low" },
+      ultrathink: { reasoningEffort: "ultrathink" },
+    })
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1788,6 +1788,20 @@ export type ProviderConfig = {
       release_date?: string
       attachment?: boolean
       reasoning?: boolean
+      reasoning_options?: Array<
+        | {
+            type: "toggle"
+          }
+        | {
+            type: "effort"
+            values: Array<string>
+          }
+        | {
+            type: "budget_tokens"
+            min?: number
+            max?: number
+          }
+      >
       temperature?: boolean
       tool_call?: boolean
       interleaved?:
@@ -2060,6 +2074,20 @@ export type Model = {
   capabilities: {
     temperature: boolean
     reasoning: boolean
+    reasoningOptions?: Array<
+      | {
+          type: "toggle"
+        }
+      | {
+          type: "effort"
+          values: Array<string>
+        }
+      | {
+          type: "budget_tokens"
+          min?: number
+          max?: number
+        }
+    >
     attachment: boolean
     toolcall: boolean
     input: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -20001,6 +20001,58 @@
                 "reasoning": {
                   "type": "boolean"
                 },
+                "reasoning_options": {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["toggle"]
+                          }
+                        },
+                        "required": ["type"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["effort"]
+                          },
+                          "values": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": ["type", "values"],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": ["budget_tokens"]
+                          },
+                          "min": {
+                            "type": "number"
+                          },
+                          "max": {
+                            "type": "number"
+                          }
+                        },
+                        "required": ["type"],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
                 "temperature": {
                   "type": "boolean"
                 },
@@ -20767,6 +20819,58 @@
               },
               "reasoning": {
                 "type": "boolean"
+              },
+              "reasoningOptions": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": ["toggle"]
+                        }
+                      },
+                      "required": ["type"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": ["effort"]
+                        },
+                        "values": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": ["type", "values"],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": ["budget_tokens"]
+                        },
+                        "min": {
+                          "type": "number"
+                        },
+                        "max": {
+                          "type": "number"
+                        }
+                      },
+                      "required": ["type"],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
               },
               "attachment": {
                 "type": "boolean"


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR uses models.dev `reasoning_options` effort data to drive model variants instead of relying only on hardcoded provider/model guesses.

It adds shared reasoning variant encoding in core, wires it into the models.dev catalog plugin and opencode provider normalization, keeps sanitized `reasoningOptions` on provider capabilities, and updates SDK/OpenAPI output. It also teaches the native Anthropic Messages route to lower adaptive thinking plus effort into the expected wire shape.

This makes models like `zhipuai-coding-plan/glm-5.2`, which advertises only `high` and `max`, show exactly those effort variants without adding GLM-specific hardcoding.

### How did you verify your code works?

- `TMPDIR=/private/tmp bun test test/provider/provider.test.ts test/provider/model-status.test.ts test/provider/reasoning-options.test.ts --timeout 30000` from `packages/opencode`
- `TMPDIR=/private/tmp bun test test/models-dev-plugin.test.ts test/config/config.test.ts --timeout 30000` from `packages/core`
- `TMPDIR=/private/tmp bun test test/provider/anthropic-messages.test.ts --timeout 30000` from `packages/llm`
- `TMPDIR=/private/tmp bun run typecheck` from `packages/core`
- `TMPDIR=/private/tmp bun run typecheck` from `packages/llm`
- `TMPDIR=/private/tmp bun run typecheck` from `packages/opencode`
- `TMPDIR=/private/tmp bun run typecheck` from `packages/sdk/js`
- `TMPDIR=/private/tmp bun run --cwd packages/sdk/js build`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
