### PR TITLE
fix: include file content preview in oldString not found error

### DIFF
--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -163,9 +163,9 @@ export const layer = Layer.effectDiscard(
                 const newString = convertToLineEnding(input.newString, ending)
                 const replacements = countOccurrences(source.text, oldString)
                 if (replacements === 0) {
+                  const preview = source.text.length > 500 ? source.text.slice(0, 500) + "\n..." : source.text
                   return yield* new ToolFailure({
-                    message:
-                      "Could not find oldString in the file. It must match exactly, including whitespace and indentation.",
+                    message: `Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\n${preview}`,
                   })
                 }
                 if (replacements > 1 && input.replaceAll !== true) {

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -301,7 +301,7 @@ describe("EditTool", () => {
                 ).toEqual({
                   type: "error",
                   value:
-                    "Could not find oldString in the file. It must match exactly, including whitespace and indentation.",
+                    "Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\nsame same",
                 })
                 expect(
                   yield* executeTool(registry, call({ path: "matches.txt", oldString: "same", newString: "after" })),
@@ -309,6 +309,37 @@ describe("EditTool", () => {
                   type: "error",
                   value:
                     "Found multiple exact matches for oldString. Provide more surrounding context or set replaceAll to true.",
+                })
+                expect(writes).toEqual([])
+              }),
+            ),
+          ),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
+  it.live("truncates the file content preview in the oldString not found error to 500 characters", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const target = path.join(tmp.path, "long.txt")
+        const content = "a".repeat(600)
+        return Effect.promise(() =>
+          fs.writeFile(target, content),
+        ).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              Effect.gen(function* () {
+                const result = yield* executeTool(
+                  registry,
+                  call({ path: "long.txt", oldString: "not present", newString: "after" }),
+                )
+                expect(result).toEqual({
+                  type: "error",
+                  value: `Could not find oldString in the file. It must match exactly, including whitespace and indentation.\n\nFile content preview:\n${"a".repeat(500)}\n...`,
                 })
                 expect(writes).toEqual([])
               }),


### PR DESCRIPTION
### Issue for this PR

Closes #30863

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the edit tool cannot find oldString in a file, the error message only returns a generic string with no file context. The AI must then guess what the correct oldString should be, which wastes multiple turns and can cascade into hitting MAX_STEPS.

This fix appends up to 500 characters of the already-loaded file content as a preview in the error message. source.text is already read before the match check, so this is a pure slice() with no extra I/O or side effects.

### How did you verify your code works?

- Updated existing test for the missing-string case to assert the new preview-containing message
- Added a new test with a 600-character file to verify truncation at 500 characters
- Ran bun test test/tool-edit.test.ts locally: 10 pass, 1 fail. The single failure (keeps the locked edit schema, semantics docstring, and deferred TODOs visible) is pre-existing on dev and unrelated to this change
- Ran bun run typecheck in packages/core: clean

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
