### PR TITLE
fix(core): tolerate drifted workspace name migration

### DIFF
--- a/packages/core/src/database/migration/20260410174513_workspace-name.ts
+++ b/packages/core/src/database/migration/20260410174513_workspace-name.ts
@@ -5,6 +5,19 @@ export default {
   id: "20260410174513_workspace-name",
   up(tx) {
     return Effect.gen(function* () {
+      const columns = new Set(
+        (yield* tx.all<{ name: string }>(`PRAGMA table_info(\`workspace\`)`)).map((column) => column.name),
+      )
+      const select = [
+        "`id`",
+        columns.has("type") ? "`type`" : "'branch' AS `type`",
+        columns.has("branch") ? "`branch`" : "NULL AS `branch`",
+        columns.has("name") ? "`name`" : "'' AS `name`",
+        columns.has("directory") ? "`directory`" : "NULL AS `directory`",
+        columns.has("extra") ? "`extra`" : "NULL AS `extra`",
+        "`project_id`",
+      ].join(", ")
+
       yield* tx.run(`PRAGMA foreign_keys=OFF;`)
       yield* tx.run(`
         CREATE TABLE \`__new_workspace\` (
@@ -18,9 +31,7 @@ export default {
           CONSTRAINT \`fk_workspace_project_id_project_id_fk\` FOREIGN KEY (\`project_id\`) REFERENCES \`project\`(\`id\`) ON DELETE CASCADE
         );
       `)
-      yield* tx.run(
-        `INSERT INTO \`__new_workspace\`(\`id\`, \`type\`, \`branch\`, \`name\`, \`directory\`, \`extra\`, \`project_id\`) SELECT \`id\`, \`type\`, \`branch\`, \`name\`, \`directory\`, \`extra\`, \`project_id\` FROM \`workspace\`;`,
-      )
+      yield* tx.run(`INSERT INTO \`__new_workspace\`(\`id\`, \`type\`, \`branch\`, \`name\`, \`directory\`, \`extra\`, \`project_id\`) SELECT ${select} FROM \`workspace\`;`)
       yield* tx.run(`DROP TABLE \`workspace\`;`)
       yield* tx.run(`ALTER TABLE \`__new_workspace\` RENAME TO \`workspace\`;`)
       yield* tx.run(`PRAGMA foreign_keys=ON;`)

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -20,6 +20,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionSchema } from "@opencode-ai/core/session/schema"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import sessionMetadataMigration from "@opencode-ai/core/database/migration/20260511173437_session-metadata"
+import workspaceNameMigration from "@opencode-ai/core/database/migration/20260410174513_workspace-name"
 import type { SqlClient as SqlClientService } from "effect/unstable/sql/SqlClient"
 import { Database } from "@opencode-ai/core/database/database"
 import { tmpdir } from "./fixture/tmpdir"
@@ -120,6 +121,34 @@ describe("DatabaseMigration", () => {
 
         expect(yield* db.get(sql`SELECT agent FROM session_context_epoch WHERE session_id = 'ses_existing'`)).toEqual({
           agent: "build",
+        })
+      }),
+    )
+  })
+
+  test("repairs legacy workspace rows when name column is missing", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`CREATE TABLE project (id text PRIMARY KEY)`)
+        yield* db.run(
+          sql`CREATE TABLE workspace (id text PRIMARY KEY, branch text, project_id text NOT NULL, type text NOT NULL, directory text, extra text)`,
+        )
+        yield* db.run(sql`INSERT INTO project (id) VALUES ('project_1')`)
+        yield* db.run(
+          sql`INSERT INTO workspace (id, branch, project_id, type, directory, extra) VALUES ('wrk_1', 'main', 'project_1', 'branch', '/repo', '{"foo":true}')`,
+        )
+
+        yield* DatabaseMigration.applyOnly(db, [workspaceNameMigration])
+
+        expect(yield* db.get(sql`SELECT id, type, branch, name, directory, extra, project_id FROM workspace WHERE id = 'wrk_1'`)).toEqual({
+          id: 'wrk_1',
+          type: 'branch',
+          branch: 'main',
+          name: '',
+          directory: '/repo',
+          extra: '{"foo":true}',
+          project_id: 'project_1',
         })
       }),
     )


### PR DESCRIPTION
## Summary
- make the `workspace-name` migration rebuild rows from whichever legacy `workspace` columns actually exist instead of assuming `name` is present
- add a regression test covering drifted local databases where `workspace.type` exists but `workspace.name` does not
- prevent `opencode auth login` and other startup paths from crashing on stale local SQLite schema drift

## Testing
- bun test test/database-migration.test.ts