### PR TITLE
fix(app): prevent overlapping new session submits

### DIFF
--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -367,4 +367,34 @@ describe("prompt submit worktree selection", () => {
     expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
     expect(optimisticSeeded).toEqual([true])
   })
+
+  test("ignores overlapping new session submits", async () => {
+    const submit = createPromptSubmit({
+      prompt,
+      info: () => undefined,
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      newSessionWorktree: () => selected,
+      onNewSessionWorktreeReset: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    const event = { preventDefault: () => undefined } as unknown as Event
+
+    await Promise.all([submit.handleSubmit(event), submit.handleSubmit(event)])
+
+    expect(createdSessions).toEqual(["/repo/worktree-a"])
+    expect(optimistic).toHaveLength(1)
+    expect(storedSessions["/repo/worktree-a"]).toEqual([{ id: "session-1", title: "New session 1" }])
+  })
 })

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -97,6 +97,26 @@ beforeAll(async () => {
     base64Encode: (value: string) => value,
   }))
 
+  mock.module("@tanstack/solid-query", () => ({
+    useMutation: (factory: () => { mutationFn: (input?: unknown) => unknown }) => {
+      const options = factory()
+      const mutation = {
+        isPending: false,
+        variables: undefined as unknown,
+        async mutateAsync(input?: unknown) {
+          mutation.isPending = true
+          mutation.variables = input
+          try {
+            return await options.mutationFn(input)
+          } finally {
+            mutation.isPending = false
+          }
+        },
+      }
+      return mutation
+    },
+  }))
+
   mock.module("@/context/local", () => ({
     useLocal: () => ({
       model: {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -295,9 +295,20 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     })
   }
 
+  let submitting = false
   const handleSubmit = async (event: Event) => {
     event.preventDefault()
 
+    if (submitting) return
+    submitting = true
+    try {
+      return await submit()
+    } finally {
+      submitting = false
+    }
+  }
+
+  const submit = async () => {
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
     const images = input.imageAttachments().slice()

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -1,4 +1,5 @@
 import type { Message, Session } from "@opencode-ai/sdk/v2/client"
+import { useMutation } from "@tanstack/solid-query"
 import { showToast } from "@/utils/toast"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { Binary } from "@opencode-ai/core/util/binary"
@@ -295,19 +296,6 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     })
   }
 
-  let submitting = false
-  const handleSubmit = async (event: Event) => {
-    event.preventDefault()
-
-    if (submitting) return
-    submitting = true
-    try {
-      return await submit()
-    } finally {
-      submitting = false
-    }
-  }
-
   const submit = async () => {
     const currentPrompt = prompt.current()
     const text = currentPrompt.map((part) => ("content" in part ? part.content : "")).join("")
@@ -601,6 +589,17 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       restoreCommentItems(commentItems)
       restoreInput()
     })
+  }
+
+  const submitMutation = useMutation(() => ({
+    mutationFn: submit,
+  }))
+
+  const handleSubmit = (event: Event) => {
+    event.preventDefault()
+
+    if (submitMutation.isPending) return
+    return submitMutation.mutateAsync()
   }
 
   return {


### PR DESCRIPTION
### Issue for this PR

Closes #32541

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents overlapping Web UI prompt submissions from creating duplicate root sessions during the new-session flow.

I found this after starting a new Web UI conversation and immediately aborting: the session list showed two sessions with the same generated title. Inspecting the local opencode database showed two independent root sessions created milliseconds apart with the same first user message; one continued and one recorded `MessageAbortedError`.

The Web submit path creates a session before navigation updates the route. During that window, another submit can still see no `params.id` and create a second session for the same prompt. This adds a local in-flight guard around the Web submit handler, matching the same kind of protection already used in the TUI path.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/components/prompt-input/submit.test.ts`
- `bun typecheck`
- `git diff --check`
- Tested on a local instance

### Screenshots / recordings

Issue:
<img width="351" height="447" alt="image" src="https://github.com/user-attachments/assets/f42c5491-f7db-4a33-8f20-d92adcbebc39" />


Video of it working properly:

https://github.com/user-attachments/assets/91010ca5-c1d9-43be-b7a9-a240814116de



### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
