### PR TITLE
feat(plugin): add tool.execute.error hook for failed tool calls

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -319,7 +319,7 @@ Hook surface (mutate `output` in place; return `void`):
 - `event(input)`: every bus event
 - `config(cfg)`: once on init with the merged config
 - `chat.message`, `chat.params`, `chat.headers`
-- `tool.execute.before`, `tool.execute.after`
+- `tool.execute.before`, `tool.execute.after`, `tool.execute.error`
 - `tool.definition`
 - `command.execute.before`
 - `shell.env`

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -4,7 +4,8 @@ import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import { MCP } from "@/mcp"
 import { Permission } from "@/permission"
-import { Tool } from "@/tool/tool"
+import { Question } from "@/question"
+import { Tool, InvalidArgumentsError } from "@/tool/tool"
 import { ToolJsonSchema } from "@/tool/json-schema"
 import { ToolRegistry } from "@/tool/registry"
 import { Truncate } from "@/tool/truncate"
@@ -12,7 +13,9 @@ import { Truncate } from "@/tool/truncate"
 import { Plugin } from "@/plugin"
 import type { TaskPromptOps } from "@/tool/task"
 import { type Tool as AITool, tool, jsonSchema, type ToolExecutionOptions, asSchema } from "ai"
-import { Effect } from "effect"
+import { Cause, Effect } from "effect"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { errorMessage } from "@/util/error"
 import { MessageV2 } from "./message-v2"
 import { Session } from "./session"
 import { SessionProcessor } from "./processor"
@@ -20,6 +23,33 @@ import { PartID } from "./schema"
 import { EffectBridge } from "@/effect/bridge"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+
+export type ToolErrorAuthority = "tool" | "runtime" | "plugin"
+
+export interface ToolErrorInfo {
+  error: string
+  retryable: boolean
+  authority: ToolErrorAuthority
+}
+
+/**
+ * Classify a failed tool call for the `tool.execute.error` plugin hook. Pass
+ * `authority: "plugin"` when the failure originates in a plugin `before`/`after`
+ * hook; otherwise the authority and retryability are derived from the raised error.
+ */
+export function classifyToolError(error: unknown, authority?: "plugin"): ToolErrorInfo {
+  const message = errorMessage(error)
+  // A plugin hook vetoed or crashed the call; the model may recover by adjusting and retrying.
+  if (authority === "plugin") return { error: message, retryable: true, authority }
+  // Permission/question rejections are raised by the runtime and are deterministic —
+  // re-issuing the identical call will be rejected again.
+  if (error instanceof PermissionV1.RejectedError || error instanceof Question.RejectedError)
+    return { error: message, retryable: false, authority: "runtime" }
+  // Invalid arguments are a deterministic tool-side failure; the model must rewrite the call.
+  if (error instanceof InvalidArgumentsError) return { error: message, retryable: false, authority: "tool" }
+  // Default: a tool-raised failure that a retry or fallback may recover from.
+  return { error: message, retryable: true, authority: "tool" }
+}
 
 export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   agent: Agent.Info
@@ -37,6 +67,25 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   const registry = yield* ToolRegistry.Service
   const mcp = yield* MCP.Service
   const truncate = yield* Truncate.Service
+
+  // Fire `tool.execute.error` if `self` fails, then re-propagate the original failure.
+  // User-initiated interruptions are handled by the abort path and are not tool failures.
+  const onToolError = <A, E, R>(
+    self: Effect.Effect<A, E, R>,
+    meta: { tool: string; ctx: Tool.Context; args: any },
+    authority?: "plugin",
+  ) =>
+    self.pipe(
+      Effect.tapCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.void
+          : plugin.trigger(
+              "tool.execute.error",
+              { tool: meta.tool, sessionID: meta.ctx.sessionID, callID: meta.ctx.callID, args: meta.args },
+              classifyToolError(Cause.squash(cause), authority),
+            ),
+      ),
+    )
 
   const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => ({
     sessionID: input.session.id,
@@ -84,12 +133,17 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
         return run.promise(
           Effect.gen(function* () {
             const ctx = context(args, options)
-            yield* plugin.trigger(
-              "tool.execute.before",
-              { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
-              { args },
+            const meta = { tool: item.id, ctx, args }
+            yield* onToolError(
+              plugin.trigger(
+                "tool.execute.before",
+                { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
+                { args },
+              ),
+              meta,
+              "plugin",
             )
-            const result = yield* item.execute(args, ctx)
+            const result = yield* onToolError(item.execute(args, ctx), meta)
             const output = {
               ...result,
               attachments: result.attachments?.map((attachment) => ({
@@ -99,10 +153,14 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
                 messageID: input.processor.message.id,
               })),
             }
-            yield* plugin.trigger(
-              "tool.execute.after",
-              { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
-              output,
+            yield* onToolError(
+              plugin.trigger(
+                "tool.execute.after",
+                { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
+                output,
+              ),
+              meta,
+              "plugin",
             )
             if (options.abortSignal?.aborted) {
               yield* input.processor.completeToolCall(options.toolCallId, output)
@@ -125,28 +183,40 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
       run.promise(
         Effect.gen(function* () {
           const ctx = context(args, opts)
-          yield* plugin.trigger(
-            "tool.execute.before",
-            { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
-            { args },
+          const meta = { tool: key, ctx, args }
+          yield* onToolError(
+            plugin.trigger(
+              "tool.execute.before",
+              { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
+              { args },
+            ),
+            meta,
+            "plugin",
           )
-          const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
-            yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
-            return yield* Effect.promise(() => execute(args, opts))
-          }).pipe(
-            Effect.withSpan("Tool.execute", {
-              attributes: {
-                "tool.name": key,
-                "tool.call_id": opts.toolCallId,
-                "session.id": ctx.sessionID,
-                "message.id": input.processor.message.id,
-              },
-            }),
+          const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* onToolError(
+            Effect.gen(function* () {
+              yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
+              return yield* Effect.promise(() => execute(args, opts))
+            }).pipe(
+              Effect.withSpan("Tool.execute", {
+                attributes: {
+                  "tool.name": key,
+                  "tool.call_id": opts.toolCallId,
+                  "session.id": ctx.sessionID,
+                  "message.id": input.processor.message.id,
+                },
+              }),
+            ),
+            meta,
           )
-          yield* plugin.trigger(
-            "tool.execute.after",
-            { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
-            result,
+          yield* onToolError(
+            plugin.trigger(
+              "tool.execute.after",
+              { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
+              result,
+            ),
+            meta,
+            "plugin",
           )
 
           const textParts: string[] = []

--- a/packages/opencode/test/session/tool-execute-error.test.ts
+++ b/packages/opencode/test/session/tool-execute-error.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { jsonSchema, type Tool as AITool } from "ai"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+
+import { SessionTools, classifyToolError } from "@/session/tools"
+import { Tool, InvalidArgumentsError } from "@/tool/tool"
+import { Plugin } from "@/plugin"
+import { Permission } from "@/permission"
+import { ToolRegistry } from "@/tool/registry"
+import { MCP } from "@/mcp"
+import { Truncate } from "@/tool/truncate"
+import { Question } from "@/question"
+import { SessionID, MessageID } from "@/session/schema"
+import { testEffect } from "../lib/effect"
+
+// A plugin whose `trigger` records every hook invocation so tests can assert
+// which of before/after/error fired (and with what payload). It can optionally
+// throw inside `tool.execute.before` to simulate a plugin veto.
+function recordingPlugin(options?: { vetoTool?: string; failAfterTool?: string }) {
+  const calls: { name: string; input: any; output: any }[] = []
+  const layer = Layer.succeed(
+    Plugin.Service,
+    Plugin.Service.of({
+      init: () => Effect.void,
+      list: () => Effect.succeed([]),
+      trigger: ((name: string, input: any, output: any) => {
+        calls.push({ name, input, output })
+        // The real Plugin.trigger runs each hook via `Effect.promise(async () => fn(...))`,
+        // so a hook that throws surfaces as a failing Effect (defect) — not a sync throw.
+        if (name === "tool.execute.before" && options?.vetoTool && input?.tool === options.vetoTool) {
+          return Effect.die(new Error("vetoed by plugin"))
+        }
+        if (name === "tool.execute.after" && options?.failAfterTool && input?.tool === options.failAfterTool) {
+          return Effect.die(new Error("after hook crashed"))
+        }
+        return Effect.succeed(output)
+      }) as Plugin.Interface["trigger"],
+    }),
+  )
+  return { calls, layer, names: () => calls.map((c) => c.name) }
+}
+
+const permissionLayer = Layer.succeed(
+  Permission.Service,
+  {
+    ask: () => Effect.void,
+    reply: () => Effect.void,
+    list: () => Effect.succeed([]),
+  } as unknown as Permission.Interface,
+)
+
+const truncateLayer = Layer.succeed(
+  Truncate.Service,
+  {
+    output: (text: string) => Effect.succeed({ content: text, truncated: false as const }),
+    write: (text: string) => Effect.succeed(text),
+    cleanup: () => Effect.void,
+    limits: () => Effect.succeed({ maxLines: 1000, maxBytes: 1000 }),
+  } as unknown as Truncate.Interface,
+)
+
+function registryLayer(defs: Tool.Def[]) {
+  return Layer.succeed(
+    ToolRegistry.Service,
+    {
+      ids: () => Effect.succeed(defs.map((d) => d.id)),
+      all: () => Effect.succeed(defs),
+      named: () => Effect.die("not used"),
+      tools: () => Effect.succeed(defs),
+    } as unknown as ToolRegistry.Interface,
+  )
+}
+
+function mcpLayer(tools: Record<string, AITool> = {}) {
+  return Layer.succeed(MCP.Service, { tools: () => Effect.succeed(tools) } as unknown as MCP.Interface)
+}
+
+const emptyObjectSchema = { type: "object", properties: {}, additionalProperties: false } as const
+
+// Minimal Provider.Model — only providerID and api.id are read on this path.
+const model = { providerID: ProviderV2.ID.make("test"), api: { id: "test-model" } } as any
+
+const resolveInput = () => ({
+  agent: { name: "build", permission: [] } as any,
+  model,
+  session: { id: SessionID.make("ses_test"), permission: [] } as any,
+  processor: {
+    message: { id: MessageID.make("msg_test") },
+    updateToolCall: () => Effect.void,
+    completeToolCall: () => Effect.void,
+  } as any,
+  bypassAgentCheck: true,
+  messages: [],
+  promptOps: {} as any,
+})
+
+const baseLayers = (registry: Layer.Layer<ToolRegistry.Service>, plugin: Layer.Layer<Plugin.Service>, mcp = {}) =>
+  Layer.mergeAll(plugin, permissionLayer, truncateLayer, registry, mcpLayer(mcp))
+
+const it = testEffect(Layer.empty)
+
+function builtinTool(id: string, execute: Tool.Def["execute"]): Tool.Def {
+  return {
+    id,
+    description: id,
+    parameters: {} as any,
+    jsonSchema: emptyObjectSchema as any,
+    execute,
+  }
+}
+
+const callOptions = (callID: string) => ({
+  toolCallId: callID,
+  abortSignal: new AbortController().signal,
+  messages: [],
+})
+
+describe("classifyToolError", () => {
+  it.effect("marks generic tool errors retryable with tool authority", () =>
+    Effect.sync(() => {
+      const info = classifyToolError(new Error("boom"))
+      expect(info).toEqual({ error: "boom", retryable: true, authority: "tool" })
+    }),
+  )
+
+  it.effect("marks permission rejections non-retryable with runtime authority", () =>
+    Effect.sync(() => {
+      const info = classifyToolError(new PermissionV1.RejectedError({ permission: "edit", callID: "c" } as any))
+      expect(info.retryable).toBe(false)
+      expect(info.authority).toBe("runtime")
+    }),
+  )
+
+  it.effect("marks question rejections non-retryable with runtime authority", () =>
+    Effect.sync(() => {
+      const info = classifyToolError(new Question.RejectedError({} as any))
+      expect(info.retryable).toBe(false)
+      expect(info.authority).toBe("runtime")
+    }),
+  )
+
+  it.effect("marks invalid arguments non-retryable with tool authority", () =>
+    Effect.sync(() => {
+      const info = classifyToolError(new InvalidArgumentsError({ tool: "read", detail: "bad" }))
+      expect(info.retryable).toBe(false)
+      expect(info.authority).toBe("tool")
+    }),
+  )
+
+  it.effect("forces plugin authority when requested", () =>
+    Effect.sync(() => {
+      const info = classifyToolError(new Error("vetoed"), "plugin")
+      expect(info.authority).toBe("plugin")
+    }),
+  )
+})
+
+describe("tool.execute.error (builtin path)", () => {
+  it.effect("fires before+after, not error, on success", () => {
+    const plugin = recordingPlugin()
+    const registry = registryLayer([
+      builtinTool("ok", () => Effect.succeed({ title: "ok", metadata: {}, output: "done" })),
+    ])
+    return Effect.gen(function* () {
+      const tools = yield* SessionTools.resolve(resolveInput())
+      yield* Effect.promise(() => (tools["ok"].execute as any)({}, callOptions("call_ok")))
+      expect(plugin.names()).toEqual(["tool.execute.before", "tool.execute.after"])
+      expect(plugin.names()).not.toContain("tool.execute.error")
+    }).pipe(Effect.provide(baseLayers(registry, plugin.layer)))
+  })
+
+  it.effect("fires before+error, not after, on failure, with matching callID", () => {
+    const plugin = recordingPlugin()
+    const registry = registryLayer([builtinTool("fail", () => Effect.die(new Error("boom")))])
+    return Effect.gen(function* () {
+      const tools = yield* SessionTools.resolve(resolveInput())
+      const exit = yield* Effect.promise(() =>
+        (tools["fail"].execute as any)({}, callOptions("call_fail")).then(
+          () => "resolved",
+          (e: unknown) => e,
+        ),
+      )
+      expect(exit).not.toBe("resolved")
+      expect(plugin.names()).toEqual(["tool.execute.before", "tool.execute.error"])
+      const error = plugin.calls.find((c) => c.name === "tool.execute.error")!
+      expect(error.input.callID).toBe("call_fail")
+      expect(error.input.tool).toBe("fail")
+      expect(error.output).toEqual({ error: "boom", retryable: true, authority: "tool" })
+    }).pipe(Effect.provide(baseLayers(registry, plugin.layer)))
+  })
+
+  it.effect("fires error with plugin authority when a before-hook vetoes", () => {
+    const plugin = recordingPlugin({ vetoTool: "veto" })
+    let executed = false
+    const registry = registryLayer([
+      builtinTool("veto", () =>
+        Effect.sync(() => {
+          executed = true
+          return { title: "veto", metadata: {}, output: "done" }
+        }),
+      ),
+    ])
+    return Effect.gen(function* () {
+      const tools = yield* SessionTools.resolve(resolveInput())
+      yield* Effect.promise(() => (tools["veto"].execute as any)({}, callOptions("call_veto")).catch(() => {}))
+      expect(executed).toBe(false)
+      const error = plugin.calls.find((c) => c.name === "tool.execute.error")
+      expect(error).toBeDefined()
+      expect(error!.output.authority).toBe("plugin")
+      expect(plugin.names()).not.toContain("tool.execute.after")
+    }).pipe(Effect.provide(baseLayers(registry, plugin.layer)))
+  })
+
+  it.effect("fires error with plugin authority when an after-hook crashes", () => {
+    const plugin = recordingPlugin({ failAfterTool: "ok" })
+    const registry = registryLayer([
+      builtinTool("ok", () => Effect.succeed({ title: "ok", metadata: {}, output: "done" })),
+    ])
+    return Effect.gen(function* () {
+      const tools = yield* SessionTools.resolve(resolveInput())
+      yield* Effect.promise(() => (tools["ok"].execute as any)({}, callOptions("call_after")).catch(() => {}))
+      expect(plugin.names()).toEqual(["tool.execute.before", "tool.execute.after", "tool.execute.error"])
+      const error = plugin.calls.find((c) => c.name === "tool.execute.error")!
+      expect(error.output.authority).toBe("plugin")
+    }).pipe(Effect.provide(baseLayers(registry, plugin.layer)))
+  })
+})
+
+describe("tool.execute.error (MCP path)", () => {
+  function mcpTool(execute: (args: any, opts: any) => Promise<any>): AITool {
+    return { inputSchema: jsonSchema(emptyObjectSchema as any), execute } as unknown as AITool
+  }
+
+  it.effect("fires before+after, not error, on success", () => {
+    const plugin = recordingPlugin()
+    const registry = registryLayer([])
+    const mcp = {
+      mcp_ok: mcpTool(async () => ({ content: [{ type: "text", text: "ok" }], metadata: {} })),
+    }
+    return Effect.gen(function* () {
+      const tools = yield* SessionTools.resolve(resolveInput())
+      yield* Effect.promise(() => (tools["mcp_ok"].execute as any)({}, callOptions("call_mcp_ok")))
+      expect(plugin.names()).toEqual(["tool.execute.before", "tool.execute.after"])
+    }).pipe(Effect.provide(baseLayers(registry, plugin.layer, mcp)))
+  })
+
+  it.effect("fires before+error, not after, on failure", () => {
+    const plugin = recordingPlugin()
+    const registry = registryLayer([])
+    const mcp = {
+      mcp_fail: mcpTool(async () => {
+        throw new Error("mcp boom")
+      }),
+    }
+    return Effect.gen(function* () {
+      const tools = yield* SessionTools.resolve(resolveInput())
+      yield* Effect.promise(() => (tools["mcp_fail"].execute as any)({}, callOptions("call_mcp_fail")).catch(() => {}))
+      expect(plugin.names()).toEqual(["tool.execute.before", "tool.execute.error"])
+      const error = plugin.calls.find((c) => c.name === "tool.execute.error")!
+      expect(error.input.tool).toBe("mcp_fail")
+      expect(error.output.error).toBe("mcp boom")
+    }).pipe(Effect.provide(baseLayers(registry, plugin.layer, mcp)))
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -279,6 +279,29 @@ export interface Hooks {
       metadata: any
     },
   ) => Promise<void>
+  /**
+   * Fires when a tool call fails. Complements `tool.execute.after`, which only fires
+   * on success — a failed call routes its error to the message stream without a
+   * plugin-visible `after`-side signal. The `callID` correlates deterministically
+   * with the matching `tool.execute.before`, so frameworks doing admission control
+   * (reflexion/retry, fallback routing, circuit-breaking, policy gates) can react to
+   * failures without reconciling callIDs against the assistant message stream.
+   *
+   * - `error` — the human-readable failure message.
+   * - `retryable` — whether re-issuing the call could plausibly succeed (false for
+   *   deterministic failures like rejected permissions or invalid arguments).
+   * - `authority` — what raised the failure: `tool` (the tool's own logic),
+   *   `runtime` (opencode, e.g. a rejected permission), or `plugin` (a `before`/`after`
+   *   hook threw).
+   */
+  "tool.execute.error"?: (
+    input: { tool: string; sessionID: string; callID: string; args: any },
+    output: {
+      error: string
+      retryable: boolean
+      authority: "tool" | "runtime" | "plugin"
+    },
+  ) => Promise<void>
   "experimental.chat.messages.transform"?: (
     input: {},
     output: {

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -200,6 +200,7 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 - `tool.execute.after`
 - `tool.execute.before`
+- `tool.execute.error`
 
 #### TUI Events
 
@@ -250,6 +251,27 @@ export const EnvProtection = async ({ project, client, $, directory, worktree })
     "tool.execute.before": async (input, output) => {
       if (input.tool === "read" && output.args.filePath.includes(".env")) {
         throw new Error("Do not read .env files")
+      }
+    },
+  }
+}
+```
+
+---
+
+### React to tool failures
+
+`tool.execute.after` only fires when a tool call succeeds. To observe failures —
+for retry, fallback routing, or policy decisions — use `tool.execute.error`. Its
+`callID` matches the `tool.execute.before` for the same call.
+
+```javascript title=".opencode/plugins/retry-logger.js"
+export const RetryLogger = async () => {
+  return {
+    "tool.execute.error": async (input, output) => {
+      // output: { error: string, retryable: boolean, authority: "tool" | "runtime" | "plugin" }
+      if (output.retryable) {
+        console.log(`Tool ${input.tool} (${input.callID}) failed but may be retried: ${output.error}`)
       }
     },
   }


### PR DESCRIPTION
### Issue for this PR

Closes #27900

### Type of change

- [x] New feature

### What does this PR do?

`tool.execute.after` only fires on success. When a tool's execute fails, `Tool.execute` converts the error to a defect via `Effect.orDie`, so the `after` trigger site is never reached and the error just goes to the message stream. Plugins that need to react to failures (retry, fallback, circuit-breaking) have no hook to listen on.

This adds `tool.execute.error`, fired on failure in both the built-in and MCP tool paths in `session/tools.ts`, before the error propagates. Because failures are defects, I catch at the cause level with `Effect.tapCause` (not `tapError`) and skip interruptions with `Cause.hasInterruptsOnly`, since user aborts are handled by the abort path. The `callID` matches the `tool.execute.before` for the same call, so plugins don't have to reconcile callIDs against the message stream.

Payload is `{ error, retryable, authority }`. Authority is `runtime` for permission/question rejections, `tool` for invalid-args and other tool errors, and `plugin` when a before/after hook throws. I used a separate event rather than adding a `status` field to `after` so existing `after ⇒ success` assumptions don't silently break.

Happy to drop `retryable`/`authority` to just `{ error }` if you'd prefer a smaller surface — that's the part I'm least sure about.

### How did you verify your code works?

`bun run typecheck` passes. Added `test/session/tool-execute-error.test.ts`, which drives the real `SessionTools.resolve` with a recording plugin and asserts: success fires before+after (not error); failure fires before+error (not after) with the matching callID; a before-veto and an after-crash both report `authority: plugin`; both the built-in and MCP paths; plus a unit matrix for the classifier. The existing `plugin/trigger` test still passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR