### PR TITLE
fix(opencode): gate step-cap assistant message behind maxStepsMessage config

### DIFF
--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -35,6 +35,10 @@ const AgentSchema = Schema.StructWithRest(
       description: "Maximum number of agentic iterations before forcing text-only response",
     }),
     maxSteps: Schema.optional(PositiveInt).annotate({ description: "@deprecated Use 'steps' field instead." }),
+    maxStepsMessage: Schema.optional(Schema.Boolean).annotate({
+      description:
+        "Append the 'maximum steps reached' assistant message on the final step (default: true). Set to false for models that reject a trailing assistant message, such as Claude 4.6+.",
+    }),
     permission: Schema.optional(ConfigPermissionV1.Info),
   }),
   [Schema.Record(Schema.String, Schema.Any)],
@@ -53,6 +57,7 @@ const KNOWN_KEYS = new Set([
   "color",
   "steps",
   "maxSteps",
+  "maxStepsMessage",
   "options",
   "permission",
   "disable",

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -52,6 +52,7 @@ export const Info = Schema.Struct({
   prompt: Schema.optional(Schema.String),
   options: Schema.Record(Schema.String, Schema.Unknown),
   steps: Schema.optional(Schema.Finite),
+  maxStepsMessage: Schema.optional(Schema.Boolean),
 }).annotate({ identifier: "Agent" })
 export type Info = DeepMutable<Schema.Schema.Type<typeof Info>>
 
@@ -275,6 +276,7 @@ export const layer = Layer.effect(
               permission: Permission.merge(defaults, user),
               options: {},
               native: false,
+              maxStepsMessage: true,
             }
           if (value.model) item.model = Provider.parseModel(value.model)
           item.variant = value.variant ?? item.variant
@@ -287,10 +289,12 @@ export const layer = Layer.effect(
           item.hidden = value.hidden ?? item.hidden
           item.name = value.name ?? item.name
           item.steps = value.steps ?? item.steps
+          item.maxStepsMessage = value.maxStepsMessage ?? item.maxStepsMessage
           item.options = mergeDeep(item.options, value.options ?? {})
           item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
         }
 
+        for (const a of Object.values(agents)) a.maxStepsMessage ??= true
         // Ensure Truncate.GLOB is allowed unless explicitly configured
         for (const name in agents) {
           const agent = agents[name]

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1340,7 +1340,7 @@ export const layer = Layer.effect(
               sessionID,
               parentSessionID: session.parentID,
               system,
-              messages: [...modelMsgs, ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
+              messages: [...modelMsgs, ...(isLastStep && agent.maxStepsMessage !== false ? [{ role: "assistant" as const, content: MAX_STEPS }] : [])],
               tools,
               model,
               toolChoice: format.type === "json_schema" ? "required" : undefined,

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -323,6 +323,24 @@ it.instance(
 )
 
 it.instance(
+  "agent maxStepsMessage config sets maxStepsMessage property",
+  () =>
+    Effect.gen(function* () {
+      const build = yield* load((svc) => svc.get("build"))
+      const plan = yield* load((svc) => svc.get("plan"))
+      expect(build?.maxStepsMessage).toBe(false)
+      expect(plan?.maxStepsMessage).toBe(true)
+    }),
+  {
+    config: {
+      agent: {
+        build: { maxStepsMessage: false },
+      },
+    },
+  },
+)
+
+it.instance(
   "agent mode can be overridden",
   () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -791,6 +791,56 @@ it.instance("loop continues when finish is stop but assistant has tool parts", (
   }),
 )
 
+it.instance("appends MAXIMUM STEPS REACHED message on the final step by default", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      agent: { build: { steps: 1 } },
+    }))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "Pinned",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.text("done")
+    yield* prompt.loop({ sessionID: session.id })
+    const inputs = yield* llm.inputs
+    expect(JSON.stringify(inputs)).toContain("MAXIMUM STEPS REACHED")
+  }),
+)
+
+it.instance("omits MAXIMUM STEPS REACHED message when maxStepsMessage is false", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      agent: { build: { steps: 1, maxStepsMessage: false } },
+    }))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "Pinned",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.text("done")
+    yield* prompt.loop({ sessionID: session.id })
+    const inputs = yield* llm.inputs
+    expect(JSON.stringify(inputs)).not.toContain("MAXIMUM STEPS REACHED")
+  }),
+)
+
 it.instance("failed subtask preserves metadata on error tool state", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig((url) => ({


### PR DESCRIPTION
### Issue for this PR

Fixes #32548

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an agent hits its step cap, the prompt loop appends an assistant-role message with the "MAXIMUM STEPS REACHED" text. This ends the request on an assistant turn, which counts as a response prefill. Claude models with thinking enabled reject prefills with HTTP 400.

From Anthropic's [extended thinking docs](https://docs.claude.com/en/docs/build-with-claude/extended-thinking), Feature compatibility: "You can't pre-fill responses when thinking is enabled."

I ran into this with bounded subagents in [opencode-fusion](https://github.com/kevinfaveri/opencode-fusion). Any agent hitting the step cap on a thinking-enabled Claude model gets the same 400.

The fix adds a `maxStepsMessage` boolean to agent config. Defaults to `true`, so existing behavior is unchanged. When set to `false`, the trailing assistant message is not appended.

Three files:
- `packages/core/src/v1/config/agent.ts` (schema + KNOWN_KEYS)
- `packages/opencode/src/agent/agent.ts` (runtime field + mapping, defaults `true`)
- `packages/opencode/src/session/prompt.ts` (gate: `isLastStep && agent.maxStepsMessage !== false`)

**Important:** this relates to many open issues like https://github.com/anomalyco/opencode/issues/13768 and https://github.com/anomalyco/opencode/issues/27920. However, those issues are more broad and don't involve a specific plugin usage (which can happen in scenarios with other plugins or local harness setup using structured outputs or max tools being very limited). 

I choose to simply add a possibility that agents can be configured in any way the user want WHEN max steps are reached, avoiding taking any opinion on how it should be handled globally or not (e.g. don't affect the primary model at all). However, if you force your primary model to always call an agent, you could use this new feature to enforce removal of trailling message to fix the above issues OR alternatively you can set all built in agents opencode has to false on this new property so that it don't do message trailling that is what is problematic.

**Note**: Since plugins can access and set the config for specific agents they can create / dispatch, the idea is that I will use this so that opencode-fusion detects if its a claude 4.6+ model and then disable trailling message on the panel and/or judge.

**Note 2**, to reinforce: this PR is focused specifically on the edge case of when it reaches max steps, it appends a trailling message that is problematic with thinking on models.

### How did you verify your code works?

Config test in `test/agent/agent.test.ts`: default resolves to `true`, explicit `false` resolves to `false`. Prompt loop tests in `test/session/prompt.test.ts`: default appends the message, `maxStepsMessage: false` omits it. Full suites pass locally. `turbo typecheck` passes all 23 packages. Build compiles on bun 1.3.14.

Checked with my own https://github.com/kevinfaveri/opencode-fusion plugin by setting editing its code to, when setting the unbounded agent that I use for panels and judge to set this maxStepsMessage to false. After this is merged, I will follow up with an updated version of opencode-fusion and edit the Readme.MD there to account for the new setting.

It is very easy to validate locally, by the way, if you want to double check: just set all your agents (built in like build/plan to steps: 1 and set the max steps message to false, which will make it work. Omit (current behavior) or set to true and it will fail loudly). Attached issue has example export et al.

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
