### PR TITLE
fix(web): persist docs language selection

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -299,6 +299,7 @@ export default defineConfig({
         Head: "./src/components/Head.astro",
         Header: "./src/components/Header.astro",
         Footer: "./src/components/Footer.astro",
+        LanguageSelect: "./src/components/LanguageSelect.astro",
         SiteTitle: "./src/components/SiteTitle.astro",
       },
       plugins: [

--- a/packages/web/src/components/Footer.astro
+++ b/packages/web/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import config from "virtual:starlight/user-config"
-import LanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro"
+import LanguageSelect from "./LanguageSelect.astro"
 import { Icon } from "@astrojs/starlight/components"
 
 const { lang, editUrl, lastUpdated, entry } = Astro.locals.starlightRoute

--- a/packages/web/src/components/LanguageSelect.astro
+++ b/packages/web/src/components/LanguageSelect.astro
@@ -1,0 +1,29 @@
+---
+import config from "virtual:starlight/user-config"
+import StarlightLanguageSelect from "@astrojs/starlight/components/LanguageSelect.astro"
+
+const locales = Object.keys(config.locales ?? {})
+---
+
+<opencode-language-select data-locales={JSON.stringify(locales)}>
+  <StarlightLanguageSelect />
+</opencode-language-select>
+
+<script>
+  document.addEventListener("change", (event) => {
+    if (!(event.target instanceof HTMLSelectElement)) return
+    const wrapper = event.target.closest("opencode-language-select")
+    if (!(wrapper instanceof HTMLElement)) return
+
+    const locales = JSON.parse(wrapper.dataset.locales ?? "[]") as string[]
+    const locale = locales[event.target.selectedIndex]
+    if (!locale) return
+    document.cookie = `oc_locale=${encodeURIComponent(locale === "root" ? "en" : locale)}; Path=/; Max-Age=31536000; SameSite=Lax`
+  })
+</script>
+
+<style>
+  opencode-language-select {
+    display: contents;
+  }
+</style>


### PR DESCRIPTION
## Summary
- persist explicit docs language selections in the `oc_locale` cookie
- map Starlight's root locale to the existing `en` cookie value
- use the same selector behavior in the header, mobile menu, and custom footer

## Testing
- `bun run build` from `packages/web`
- `git diff --check`

`bun run astro check` still reports pre-existing `MessageV2` and `opencode/session` type errors in the share UI; the new component has no diagnostics.

Closes #14409
Closes #15194
Closes #15904
Closes #15984
Closes #16278
Closes #17665
Closes #18541
Closes #20362
Closes #20655
Closes #22219
Closes #22415
Closes #29326