### PR TITLE
fix: publish beta once per sync

### DIFF
--- a/.github/actions/nix-hashes/action.yml
+++ b/.github/actions/nix-hashes/action.yml
@@ -1,0 +1,87 @@
+name: "Nix Hashes"
+description: "Compute or collect native node_modules hashes"
+inputs:
+  operation:
+    description: "Operation to perform: compute or update"
+    required: true
+  system:
+    description: "Nix system to compute a hash for"
+    required: false
+  artifact-prefix:
+    description: "Prefix used for hash artifacts"
+    required: false
+    default: "hash"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Nix
+      if: inputs.operation == 'compute'
+      uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+
+    - name: Compute node_modules hash
+      if: inputs.operation == 'compute'
+      shell: bash
+      env:
+        SYSTEM: ${{ inputs.system }}
+      run: |
+        set -euo pipefail
+
+        BUILD_LOG=$(mktemp)
+        trap 'rm -f "$BUILD_LOG"' EXIT
+
+        HASH=""
+        MAX_ATTEMPTS=3
+        for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++)); do
+          nix build ".#packages.${SYSTEM}.node_modules_updater" --no-link 2>&1 | tee "$BUILD_LOG" || true
+          HASH="$(nix run --inputs-from . nixpkgs#gnugrep -- -oP 'got:\s*\Ksha256-[A-Za-z0-9+/=]+' "$BUILD_LOG" | tail -n1 || true)"
+          [ -n "$HASH" ] && break
+
+          if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
+            echo "::warning::Attempt ${ATTEMPT}/${MAX_ATTEMPTS} produced no hash for ${SYSTEM}; retrying in $((ATTEMPT * 10))s"
+            sleep $((ATTEMPT * 10))
+          fi
+        done
+
+        if [ -z "$HASH" ]; then
+          echo "::error::Failed to compute hash for ${SYSTEM} after ${MAX_ATTEMPTS} attempts"
+          cat "$BUILD_LOG"
+          exit 1
+        fi
+
+        echo "$HASH" > hash.txt
+        echo "Computed hash for ${SYSTEM}: $HASH"
+
+    - name: Upload hash
+      if: inputs.operation == 'compute'
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: ${{ inputs.artifact-prefix }}-${{ inputs.system }}
+        path: hash.txt
+        retention-days: 1
+
+    - name: Download hashes
+      if: inputs.operation == 'update'
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        path: hashes
+        pattern: ${{ inputs.artifact-prefix }}-*
+
+    - name: Update hashes.json
+      if: inputs.operation == 'update'
+      shell: bash
+      env:
+        ARTIFACT_PREFIX: ${{ inputs.artifact-prefix }}
+      run: |
+        set -euo pipefail
+
+        HASH_FILE="nix/hashes.json"
+        [ -f "$HASH_FILE" ] || echo '{"nodeModules":{}}' > "$HASH_FILE"
+
+        for SYSTEM in x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin; do
+          HASH="$(tr -d '[:space:]' < "hashes/${ARTIFACT_PREFIX}-${SYSTEM}/hash.txt")"
+          echo "${SYSTEM}: ${HASH}"
+          jq --arg sys "$SYSTEM" --arg h "$HASH" '.nodeModules[$sys] = $h' "$HASH_FILE" > tmp.json
+          mv tmp.json "$HASH_FILE"
+        done
+
+        cat "$HASH_FILE"

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+concurrency:
+  group: beta
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -31,7 +35,40 @@ jobs:
         run: bun i -g opencode-ai
 
       - name: Sync beta branch
+        id: sync
         env:
+          BETA_PUSH: "false"
           GH_TOKEN: ${{ steps.setup-git-committer.outputs.token }}
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         run: bun script/beta.ts
+
+      - name: Bundle beta branch
+        if: steps.sync.outputs.changed == 'true'
+        run: git bundle create beta.bundle beta ^origin/dev
+
+      - name: Upload beta branch
+        if: steps.sync.outputs.changed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: beta-branch
+          path: beta.bundle
+          retention-days: 1
+
+    outputs:
+      changed: ${{ steps.sync.outputs.changed }}
+
+  update-hashes:
+    needs: sync
+    if: needs.sync.outputs.changed == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/nix-hashes-reusable.yml
+    with:
+      branch: beta
+      bundle-artifact: beta-branch
+      bundle-base: dev
+      artifact-prefix: beta-hash
+      force: true
+      opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+    secrets:
+      opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}

--- a/.github/workflows/nix-hashes-reusable.yml
+++ b/.github/workflows/nix-hashes-reusable.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Download branch bundle
         if: inputs.bundle-artifact != ''

--- a/.github/workflows/nix-hashes-reusable.yml
+++ b/.github/workflows/nix-hashes-reusable.yml
@@ -1,0 +1,150 @@
+name: reusable-nix-hashes
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to update"
+        required: true
+        type: string
+      bundle-artifact:
+        description: "Optional artifact containing an unpushed branch bundle"
+        required: false
+        type: string
+        default: ""
+      bundle-base:
+        description: "Base branch required by the branch bundle"
+        required: false
+        type: string
+        default: ""
+      artifact-prefix:
+        description: "Unique prefix for matrix artifacts"
+        required: false
+        type: string
+        default: "hash"
+      force:
+        description: "Force push the updated branch"
+        required: false
+        type: boolean
+        default: false
+      opencode-app-id:
+        description: "OpenCode GitHub App ID"
+        required: true
+        type: string
+    secrets:
+      opencode-app-secret:
+        description: "OpenCode GitHub App private key"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  compute:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - system: aarch64-linux
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+          - system: x86_64-darwin
+            runner: macos-15-intel
+          - system: aarch64-darwin
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download branch bundle
+        if: inputs.bundle-artifact != ''
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.bundle-artifact }}
+
+      - name: Checkout bundled branch
+        if: inputs.bundle-artifact != ''
+        env:
+          BASE: ${{ inputs.bundle-base }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [ -n "$BASE" ]; then
+            git fetch origin "$BASE"
+          fi
+          git fetch "${BRANCH}.bundle" "${BRANCH}:refs/heads/${BRANCH}"
+          git checkout "$BRANCH"
+
+      - name: Compute Nix hash
+        uses: ./.github/actions/nix-hashes
+        with:
+          operation: compute
+          system: ${{ matrix.system }}
+          artifact-prefix: ${{ inputs.artifact-prefix }}
+
+  update:
+    needs: compute
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Git Committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ inputs.opencode-app-id }}
+          opencode-app-secret: ${{ secrets.opencode-app-secret }}
+
+      - name: Download branch bundle
+        if: inputs.bundle-artifact != ''
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.bundle-artifact }}
+
+      - name: Checkout branch
+        env:
+          BASE: ${{ inputs.bundle-base }}
+          BRANCH: ${{ inputs.branch }}
+          BUNDLE_ARTIFACT: ${{ inputs.bundle-artifact }}
+        run: |
+          if [ -n "$BUNDLE_ARTIFACT" ]; then
+            if [ -n "$BASE" ]; then
+              git fetch origin "$BASE"
+            fi
+            git fetch "${BRANCH}.bundle" "${BRANCH}:refs/heads/${BRANCH}"
+            git checkout "$BRANCH"
+            exit 0
+          fi
+
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+
+      - name: Update Nix hashes
+        uses: ./.github/actions/nix-hashes
+        with:
+          operation: update
+          artifact-prefix: ${{ inputs.artifact-prefix }}
+
+      - name: Commit and push hashes
+        env:
+          BRANCH: ${{ inputs.branch }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+
+          HASH_FILE="nix/hashes.json"
+          if [ -n "$(git status --short -- "$HASH_FILE")" ]; then
+            git add "$HASH_FILE"
+            git commit -m "chore: update nix node_modules hashes"
+          fi
+
+          if [ "$FORCE" = "true" ]; then
+            git push origin "$BRANCH" --force --no-verify
+            exit 0
+          fi
+
+          git pull --rebase --autostash origin "$BRANCH"
+          git push origin "HEAD:$BRANCH"

--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -1,12 +1,9 @@
 name: nix-hashes
 
-permissions:
-  contents: write
-
 on:
   workflow_dispatch:
   push:
-    branches: [dev, beta]
+    branches: [dev]
     paths:
       - "bun.lock"
       - "package.json"
@@ -15,148 +12,21 @@ on:
       - "nix/node_modules.nix"
       - "nix/scripts/**"
       - "patches/**"
+      - ".github/actions/nix-hashes/**"
       - ".github/workflows/nix-hashes.yml"
+      - ".github/workflows/nix-hashes-reusable.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Native runners required: bun install cross-compilation flags (--os/--cpu)
-  # do not produce byte-identical node_modules as native installs.
-  compute-hash:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - system: x86_64-linux
-            runner: blacksmith-4vcpu-ubuntu-2404
-          - system: aarch64-linux
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
-          - system: x86_64-darwin
-            runner: macos-15-intel
-          - system: aarch64-darwin
-            runner: macos-latest
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Nix
-        uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
-
-      - name: Compute node_modules hash
-        id: hash
-        env:
-          SYSTEM: ${{ matrix.system }}
-        run: |
-          set -euo pipefail
-
-          BUILD_LOG=$(mktemp)
-          trap 'rm -f "$BUILD_LOG"' EXIT
-
-          HASH=""
-          MAX_ATTEMPTS=3
-          for ((ATTEMPT = 1; ATTEMPT <= MAX_ATTEMPTS; ATTEMPT++)); do
-            # Build with fakeHash to trigger hash mismatch and reveal correct hash
-            nix build ".#packages.${SYSTEM}.node_modules_updater" --no-link 2>&1 | tee "$BUILD_LOG" || true
-
-            HASH="$(nix run --inputs-from . nixpkgs#gnugrep -- -oP 'got:\s*\Ksha256-[A-Za-z0-9+/=]+' "$BUILD_LOG" | tail -n1 || true)"
-
-            [ -n "$HASH" ] && break
-
-            if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
-              echo "::warning::Attempt ${ATTEMPT}/${MAX_ATTEMPTS} produced no hash for ${SYSTEM}; retrying in $((ATTEMPT * 10))s"
-              sleep $((ATTEMPT * 10))
-            fi
-          done
-
-          if [ -z "$HASH" ]; then
-            echo "::error::Failed to compute hash for ${SYSTEM} after ${MAX_ATTEMPTS} attempts"
-            cat "$BUILD_LOG"
-            exit 1
-          fi
-
-          echo "$HASH" > hash.txt
-          echo "Computed hash for ${SYSTEM}: $HASH"
-
-      - name: Upload hash
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: hash-${{ matrix.system }}
-          path: hash.txt
-          retention-days: 1
-
-  update-hashes:
-    needs: compute-hash
-    if: github.event_name != 'pull_request'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-          ref: ${{ github.ref_name }}
-
-      - name: Setup git committer
-        uses: ./.github/actions/setup-git-committer
-        with:
-          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
-          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
-
-      - name: Pull latest changes
-        run: |
-          git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-
-      - name: Download hash artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          path: hashes
-          pattern: hash-*
-
-      - name: Update hashes.json
-        run: |
-          set -euo pipefail
-
-          HASH_FILE="nix/hashes.json"
-
-          [ -f "$HASH_FILE" ] || echo '{"nodeModules":{}}' > "$HASH_FILE"
-
-          for SYSTEM in x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin; do
-            FILE="hashes/hash-${SYSTEM}/hash.txt"
-            if [ -f "$FILE" ]; then
-              HASH="$(tr -d '[:space:]' < "$FILE")"
-              echo "${SYSTEM}: ${HASH}"
-              jq --arg sys "$SYSTEM" --arg h "$HASH" '.nodeModules[$sys] = $h' "$HASH_FILE" > tmp.json
-              mv tmp.json "$HASH_FILE"
-            else
-              echo "::warning::Missing hash for ${SYSTEM}"
-            fi
-          done
-
-          cat "$HASH_FILE"
-
-      - name: Commit changes
-        run: |
-          set -euo pipefail
-
-          HASH_FILE="nix/hashes.json"
-
-          if [ -z "$(git status --short -- "$HASH_FILE")" ]; then
-            echo "No changes to commit"
-            echo "### Nix hashes" >> "$GITHUB_STEP_SUMMARY"
-            echo "Status: no changes" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          git add "$HASH_FILE"
-          git commit -m "chore: update nix node_modules hashes"
-
-          git pull --rebase --autostash origin "$GITHUB_REF_NAME"
-          git push origin HEAD:"$GITHUB_REF_NAME"
-
-          echo "### Nix hashes" >> "$GITHUB_STEP_SUMMARY"
-          echo "Status: committed $(git rev-parse --short HEAD)" >> "$GITHUB_STEP_SUMMARY"
+  update:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/nix-hashes-reusable.yml
+    with:
+      branch: ${{ github.ref_name }}
+      opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+    secrets:
+      opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}

--- a/script/beta.ts
+++ b/script/beta.ts
@@ -18,6 +18,11 @@ interface FailedPR {
   reason: string
 }
 
+async function setChanged(value: boolean) {
+  if (!process.env.GITHUB_OUTPUT) return
+  await fs.appendFile(process.env.GITHUB_OUTPUT, `changed=${value}\n`)
+}
+
 async function commentOnPR(prNumber: number, reason: string) {
   const body = `⚠️ **Blocking Beta Release**
 
@@ -217,6 +222,7 @@ async function smoke(prs: PR[], applied: number[]) {
 }
 
 async function main() {
+  await setChanged(false)
   console.log("Fetching open PRs with beta label...")
 
   const stdout =
@@ -345,6 +351,13 @@ async function main() {
     } else {
       console.log("Validated beta branch now matches remote contents, no push needed")
     }
+    return
+  }
+
+  await setChanged(true)
+
+  if (process.env.BETA_PUSH === "false") {
+    console.log("Validated beta branch is ready to push")
     return
   }
 


### PR DESCRIPTION
The hourly beta sync can currently trigger two publications when dependency changes require refreshed Nix hashes. The initial beta push starts a release, then the hash update adds another commit and starts a second release for the same hourly batch.

That breaks the expectation that users see at most one downloadable beta per sync interval and can briefly publish artifacts from a commit that is immediately superseded. Beta should only become visible after all release-required metadata is ready, while the existing dev hash updates should keep the same behavior.