### PR TITLE
fix(provider): warn on unknown disabled_providers/enabled_providers keys

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1072,6 +1072,22 @@ export function defaultModelIDs<T extends { models: Record<string, { id: string 
   return mapValues(providers, (item) => sort(Object.values(item.models))[0].id)
 }
 
+export function unknownProviderFilters(input: {
+  known: Iterable<string>
+  disabled?: readonly string[]
+  enabled?: readonly string[]
+}): string[] {
+  const known = new Set(input.known)
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const key of [...(input.disabled ?? []), ...(input.enabled ?? [])]) {
+    if (known.has(key) || seen.has(key)) continue
+    seen.add(key)
+    result.push(key)
+  }
+  return result
+}
+
 export class ModelNotFoundError extends Schema.TaggedErrorClass<ModelNotFoundError>()("ProviderModelNotFoundError", {
   providerID: ProviderV2.ID,
   modelID: ModelV2.ID,
@@ -1467,6 +1483,20 @@ export const layer = Layer.effect(
           }
           database[providerID] = parsed
         }
+
+        // warn about disabled_providers/enabled_providers keys that match no
+        // known provider — these are silently ignored otherwise, the root cause
+        // of users disabling a provider and seeing no effect (typo'd key, or a
+        // model served through a gateway whose providerID isn't the brand name).
+        const unknownFilters = unknownProviderFilters({
+          known: Object.keys(database),
+          disabled: cfg.disabled_providers,
+          enabled: cfg.enabled_providers,
+        })
+        if (unknownFilters.length > 0)
+          yield* Effect.logWarning("ignoring unknown provider keys in disabled_providers/enabled_providers", {
+            keys: unknownFilters,
+          })
 
         // load env
         const envs = yield* env.all()

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -145,6 +145,39 @@ it.instance(
   { config: { enabled_providers: ["anthropic"] } },
 )
 
+test("unknownProviderFilters reports a disabled_providers key with no matching provider", () => {
+  const unknown = Provider.unknownProviderFilters({
+    known: ["anthropic", "openai"],
+    disabled: ["deepseek"],
+  })
+  expect(unknown).toEqual(["deepseek"])
+})
+
+test("unknownProviderFilters ignores keys that match a known provider", () => {
+  const unknown = Provider.unknownProviderFilters({
+    known: ["anthropic", "openai"],
+    disabled: ["anthropic"],
+  })
+  expect(unknown).toEqual([])
+})
+
+test("unknownProviderFilters reports an enabled_providers key with no matching provider", () => {
+  const unknown = Provider.unknownProviderFilters({
+    known: ["anthropic", "github-copilot"],
+    enabled: ["anthropic", "copilot"],
+  })
+  expect(unknown).toEqual(["copilot"])
+})
+
+test("unknownProviderFilters returns only unknown keys, deduped across both lists", () => {
+  const unknown = Provider.unknownProviderFilters({
+    known: ["anthropic", "openai"],
+    disabled: ["openai", "zen"],
+    enabled: ["anthropic", "zen", "deepseek"],
+  })
+  expect(unknown).toEqual(["zen", "deepseek"])
+})
+
 it.instance(
   "model whitelist filters models for provider",
   Effect.gen(function* () {


### PR DESCRIPTION
## Problem

Closes #32528 (and the older duplicate #24832).

`disabled_providers` / `enabled_providers` filtering works correctly — but only when the key matches a real provider ID. When a user lists a key that matches **no known provider**, it is **silently ignored**. This is the actual root cause behind "disabling a provider does nothing":

- typo'd / guessed keys (`"copilot"`, `"zen"`, `"github-copilot"` vs the real ID), and
- a brand name like `"deepseek"` for a model that is actually served through the **opencode gateway** (its `providerID` is `opencode`, not `deepseek`), so disabling `"deepseek"` can't hide it.

In every case the user gets no feedback that their config had no effect.

## Change

- Add a small pure helper `Provider.unknownProviderFilters({ known, disabled?, enabled? })` that returns the configured filter keys matching no known provider ID (deduped, order-preserving).
- In the provider state layer, after the provider database is fully built (so all valid provider IDs are known, including config-defined providers), emit a single `Effect.logWarning` listing any unknown keys.

No behavior change for valid keys; this only surfaces silently-ignored ones.

## Tests

- 4 new unit tests in `test/provider/provider.test.ts` covering: unknown `disabled_providers` key, valid key ignored, unknown `enabled_providers` key, and mixed valid/unknown deduped across both lists.
- Full provider test file: 92 pass / 0 fail. `tsgo --noEmit`: clean.

Note: the detection logic is unit-tested; the one-line `logWarning` glue is not asserted on, as there is no existing precedent in the suite for capturing log output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)