### PR TITLE
fix(mcp): pass tool name and args to permission ask

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -131,7 +131,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             { args },
           )
           const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
-            yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
+            yield* ctx.ask({ permission: key, metadata: args, patterns: [key], always: [key] })
             return yield* Effect.promise(() => execute(args, opts))
           }).pipe(
             Effect.withSpan("Tool.execute", {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -10,6 +10,8 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
 import { fileURLToPath, pathToFileURL } from "url"
 import { NamedError } from "@opencode-ai/core/util/error"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { dynamicTool, jsonSchema } from "ai"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { BackgroundJob } from "@/background/job"
 import { Command } from "../../src/command"
@@ -163,7 +165,7 @@ const blockingProcessor = Layer.succeed(
   }),
 )
 
-function makePrompt(input?: { processor?: "blocking" }) {
+function makePrompt(input?: { processor?: "blocking"; mcp?: Layer.Layer<MCP.Service> }) {
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
@@ -176,7 +178,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
     lsp,
-    mcp,
+    input?.mcp ?? mcp,
     FSUtil.defaultLayer,
     BackgroundJob.defaultLayer,
     status,
@@ -2323,4 +2325,93 @@ noLLMServer.instance(
       }
     }),
   30_000,
+)
+
+// MCP wrapper permission payload — see packages/opencode/src/session/tools.ts.
+// The wrapper must forward the tool name as the permission key/pattern and the
+// raw tool arguments as metadata so SDK consumers can reason about the call.
+const mcpWithEchoTool = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    tools: () =>
+      Effect.succeed({
+        echo_say: dynamicTool({
+          description: "echo back the greeting",
+          inputSchema: jsonSchema({
+            type: "object",
+            properties: { greeting: { type: "string" } },
+            required: ["greeting"],
+            additionalProperties: false,
+          }),
+          execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+        }),
+      }),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in prompt-effect tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const mcpIt = testEffect(Layer.mergeAll(TestLLMServer.layer, makePrompt({ mcp: mcpWithEchoTool })))
+
+mcpIt.instance("mcp tool ask publishes tool name and args (regression: #19549)", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const events = yield* EventV2Bridge.Service
+    const seen = yield* Deferred.make<PermissionV1.Request>()
+    const unsub = yield* events.listen((event) => {
+      if (event.type === Permission.Event.Asked.type)
+        Deferred.doneUnsafe(seen, Effect.succeed(event.data as PermissionV1.Request))
+      return Effect.void
+    })
+    yield* Effect.addFinalizer(() => unsub)
+
+    const prompt = yield* SessionPrompt.Service
+    const permission = yield* Permission.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "MCP wrapper ask",
+      permission: [{ permission: "*", pattern: "*", action: "ask" }],
+    })
+
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "say hi" }],
+    })
+    yield* llm.tool("echo_say", { greeting: "hi" })
+    yield* llm.text("done")
+
+    const fiber = yield* prompt.loop({ sessionID: session.id }).pipe(Effect.forkChild)
+
+    const request = yield* Deferred.await(seen).pipe(
+      Effect.timeoutOrElse({
+        duration: Duration.seconds(5),
+        orElse: () => Effect.fail(new Error("timed out waiting for permission.asked")),
+      }),
+    )
+    expect(request.permission).toBe("echo_say")
+    expect(request.patterns).toEqual(["echo_say"])
+    expect(request.always).toEqual(["echo_say"])
+    expect(request.metadata).toEqual({ greeting: "hi" })
+
+    yield* permission.reply({ requestID: request.id, reply: "once" })
+
+    const exit = yield* Fiber.await(fiber)
+    expect(Exit.isSuccess(exit)).toBe(true)
+  }),
 )


### PR DESCRIPTION
### Issue for this PR

Fixes #19549

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The MCP tool wrapper in `packages/opencode/src/session/tools.ts` was calling `ctx.ask` with hardcoded wildcards:

```ts
ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
```

That caused three observable problems:

1. The permission dock rendered `*` instead of the actual MCP tool name (the original report on #19549).
2. Picking "Always allow" on any MCP tool saved a rule against `pattern: "*"` instead of the tool name, so approving one MCP tool silently approved every MCP tool in the session.
3. SDK / `serve` consumers received an empty `metadata` on the `permission.asked` event, so a host UI couldn't display the tool input or reason about it.

The fix aligns the MCP wrapper with the convention used by every other tool (`bash`, `webfetch`, `task`, `read`, `edit`, …): forward the action key as both `permission` and `patterns`/`always`, and pass the tool's input as `metadata`.

```ts
ctx.ask({ permission: key, metadata: args, patterns: [key], always: [key] })
```

The `metadata` field is already typed `Schema.Record(Schema.String, Schema.Unknown)`, so MCP tool args (also `Record<string, unknown>`) fit the schema without any wire-format change.

### How did you verify your code works?

- Added `mcp tool ask publishes tool name and args (regression: #19549)` in `packages/opencode/test/session/prompt.test.ts`. It registers a fake one-tool MCP layer, subscribes to `Permission.Event.Asked` via `EventV2Bridge`, drives the prompt loop to invoke the tool with `{ greeting: "hi" }`, and asserts:
  - `request.permission === "echo_say"`
  - `request.patterns === ["echo_say"]`
  - `request.always === ["echo_say"]`
  - `request.metadata === { greeting: "hi" }`
  - The loop completes cleanly after a `once` reply.
- `bun test test/session/prompt.test.ts` from `packages/opencode/` — 55 pre-existing tests pass + the new one, 0 failures.
- `bun typecheck` clean.
- Manually re-ran the wrapper through a local MCP server: dock now shows the actual tool name, "Always allow" scopes to that one tool, and the `permission.asked` event payload carries the tool arguments.

### Screenshots / recordings

No UI changes — only the data the existing dock already renders.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR