### PR TITLE
fix(mcp): default tool schema properties

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -119,7 +119,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     if (!execute) continue
 
     const schema = yield* Effect.promise(() => Promise.resolve(asSchema(item.inputSchema).jsonSchema))
-    const transformed = ProviderTransform.schema(input.model, schema)
+    const transformed = ProviderTransform.schema(input.model, { ...schema, properties: schema.properties ?? {} })
     item.inputSchema = jsonSchema(transformed)
     item.execute = (args, opts) =>
       run.promise(


### PR DESCRIPTION
## Summary
- default missing or null MCP tool schema `properties` to an empty object
- apply the MCP boundary normalization for every provider

This matches the MCP schema preparation used by Codex and ensures object-shaped MCP tools always expose a root `properties` object before provider transforms run.

## Testing
- `bun typecheck` (packages/opencode)
- `git diff --check -- packages/opencode/src/session/tools.ts`