### PR TITLE
fix: Speculative fix for incorrect time.start reset in tool call logging

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -56,7 +56,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             metadata: val.metadata,
             status: "running",
             input: args,
-            time: { start: Date.now() },
+            time: match.state.status === "running" ? match.state.time : { start: Date.now() },
           },
         }
       }),


### PR DESCRIPTION
Codex + gpt-5.5 came up with this.  I have not tested this yet.

### Issue for this PR

Closes #32574

### Type of change

- [x] Bug fix

### What does this PR do?

Speculative fix for #32574.  See the commit message.

### How did you verify your code works?

I have not (yet).  I have never worked with bun/JS/TS before.  But I can.

### Screenshots / recordings

See #32574

### Checklist

- [ ] I have tested my changes locally ... I will do that shortly
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
