### PR TITLE
feat(github): resume the prior session when github run retries

### DIFF
--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -33,7 +33,13 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { Process } from "@/util/process"
 import { parseGitHubRemote } from "@/util/repository"
 import { Effect } from "effect"
-import { extractResponseText, formatPromptTooLargeError } from "./github.shared"
+import {
+  extractResponseText,
+  findResumableSession,
+  formatPromptTooLargeError,
+  GITHUB_RUN_METADATA_KEY,
+  shouldSendContinuation,
+} from "./github.shared"
 
 type GitHubAuthor = {
   login: string
@@ -494,19 +500,34 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         await addReaction(commentType)
       }
 
-      // Setup opencode session
+      // Setup opencode session. Reuse the prior session for this GitHub run when
+      // one already exists in the local DB (a wrapper/in-runner retry after a
+      // transient failure), so the agent continues its earlier work instead of
+      // re-fetching context and re-prompting the model from scratch. GITHUB_RUN_ID
+      // is stable across re-runs (only GITHUB_RUN_ATTEMPT increments), so it is a
+      // safe idempotency key. A cross-runner re-run starts on a fresh disk with an
+      // empty DB and still creates a new session; covering that needs the data dir
+      // persisted across runners, out of scope here.
       const repoData = await fetchRepo()
-      session = await runLocalEffect(
-        sessionSvc.create({
-          permission: [
-            {
-              permission: "question",
-              action: "deny",
-              pattern: "*",
-            },
-          ],
-        }),
-      )
+      const prior = findResumableSession(await runLocalEffect(sessionSvc.list()), runId)
+      const priorMessageCount = prior
+        ? (await runLocalEffect(sessionSvc.messages({ sessionID: prior.id, limit: 1 }))).length
+        : 0
+      const continuation = shouldSendContinuation({ foundPrior: prior !== undefined, priorMessageCount })
+      session = prior
+        ? { id: prior.id, title: prior.title, version: prior.version }
+        : await runLocalEffect(
+            sessionSvc.create({
+              metadata: { [GITHUB_RUN_METADATA_KEY]: runId },
+              permission: [
+                {
+                  permission: "question",
+                  action: "deny",
+                  pattern: "*",
+                },
+              ],
+            }),
+          )
       await subscribeSessionEvents()
       shareId = await (async () => {
         if (share === false) return
@@ -514,7 +535,15 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         await runLocalEffect(sessionShare.share(session.id))
         return session.id.slice(-8)
       })()
-      console.log("opencode session", session.id)
+      console.log(prior ? "resuming opencode session" : "opencode session", session.id)
+
+      // When continuing, the full task prompt and PR/issue context already live in
+      // the session history; send a short nudge instead of re-injecting everything
+      // (the point of resuming is to not re-spend those tokens).
+      const RESUME_PROMPT =
+        "The previous attempt in this session was interrupted before finishing. Continue the task to completion."
+      const runTask = (message: string) =>
+        chat(continuation ? RESUME_PROMPT : message, continuation ? [] : promptFiles)
 
       // Handle event types:
       // REPO_EVENTS (schedule, workflow_dispatch): no issue/PR context, output to logs/PR only
@@ -528,7 +557,7 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         const branchPrefix = isWorkflowDispatchEvent ? "dispatch" : "schedule"
         const branch = await checkoutNewBranch(branchPrefix)
         const head = await gitText(["rev-parse", "HEAD"])
-        const response = await chat(userPrompt, promptFiles)
+        const response = await runTask(userPrompt)
         const { dirty, uncommittedChanges, switched } = await branchIsDirty(head, branch)
         if (switched) {
           // Agent switched branches (likely created its own branch/PR)
@@ -563,7 +592,7 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
           await checkoutLocalBranch(prData)
           const head = await gitText(["rev-parse", "HEAD"])
           const dataPrompt = buildPromptDataForPR(prData)
-          const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
+          const response = await runTask(`${userPrompt}\n\n${dataPrompt}`)
           const { dirty, uncommittedChanges, switched } = await branchIsDirty(head, prData.headRefName)
           if (switched) {
             console.log("Agent managed its own branch, skipping infrastructure push")
@@ -581,7 +610,7 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
           const forkBranch = await checkoutForkBranch(prData)
           const head = await gitText(["rev-parse", "HEAD"])
           const dataPrompt = buildPromptDataForPR(prData)
-          const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
+          const response = await runTask(`${userPrompt}\n\n${dataPrompt}`)
           const { dirty, uncommittedChanges, switched } = await branchIsDirty(head, forkBranch)
           if (switched) {
             console.log("Agent managed its own branch, skipping infrastructure push")
@@ -601,7 +630,7 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         const head = await gitText(["rev-parse", "HEAD"])
         const issueData = await fetchIssue()
         const dataPrompt = buildPromptDataForIssue(issueData)
-        const response = await chat(`${userPrompt}\n\n${dataPrompt}`, promptFiles)
+        const response = await runTask(`${userPrompt}\n\n${dataPrompt}`)
         const { dirty, uncommittedChanges, switched } = await branchIsDirty(head, branch)
         if (switched) {
           // Agent switched branches (likely created its own branch/PR).

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -35,9 +35,9 @@ import { parseGitHubRemote } from "@/util/repository"
 import { Effect } from "effect"
 import {
   extractResponseText,
-  findResumableSession,
   formatPromptTooLargeError,
   GITHUB_RUN_METADATA_KEY,
+  githubRunPrompt,
   shouldSendContinuation,
 } from "./github.shared"
 
@@ -500,16 +500,9 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         await addReaction(commentType)
       }
 
-      // Setup opencode session. Reuse the prior session for this GitHub run when
-      // one already exists in the local DB (a wrapper/in-runner retry after a
-      // transient failure), so the agent continues its earlier work instead of
-      // re-fetching context and re-prompting the model from scratch. GITHUB_RUN_ID
-      // is stable across re-runs (only GITHUB_RUN_ATTEMPT increments), so it is a
-      // safe idempotency key. A cross-runner re-run starts on a fresh disk with an
-      // empty DB and still creates a new session; covering that needs the data dir
-      // persisted across runners, out of scope here.
+      // Same-runner retries reuse the session stamped with this workflow run id.
       const repoData = await fetchRepo()
-      const prior = findResumableSession(await runLocalEffect(sessionSvc.list()), runId)
+      const prior = await runLocalEffect(sessionSvc.findByMetadata({ key: GITHUB_RUN_METADATA_KEY, value: runId }))
       const priorMessageCount = prior
         ? (await runLocalEffect(sessionSvc.messages({ sessionID: prior.id, limit: 1 }))).length
         : 0
@@ -537,13 +530,10 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
       })()
       console.log(prior ? "resuming opencode session" : "opencode session", session.id)
 
-      // When continuing, the full task prompt and PR/issue context already live in
-      // the session history; send a short nudge instead of re-injecting everything
-      // (the point of resuming is to not re-spend those tokens).
-      const RESUME_PROMPT =
-        "The previous attempt in this session was interrupted before finishing. Continue the task to completion."
-      const runTask = (message: string) =>
-        chat(continuation ? RESUME_PROMPT : message, continuation ? [] : promptFiles)
+      const runTask = (message: string) => {
+        const prompt = githubRunPrompt({ continuation, message, promptFiles })
+        return chat(prompt.message, prompt.promptFiles)
+      }
 
       // Handle event types:
       // REPO_EVENTS (schedule, workflow_dispatch): no issue/PR context, output to logs/PR only

--- a/packages/opencode/src/cli/cmd/github.shared.ts
+++ b/packages/opencode/src/cli/cmd/github.shared.ts
@@ -3,6 +3,45 @@ import type { SessionV1 } from "@opencode-ai/core/v1/session"
 export { parseGitHubRemote } from "@/util/repository"
 
 /**
+ * Session metadata key tying a `github run` session to its GITHUB_RUN_ID, so a
+ * retry on the same runner can find and resume that session. Single source of
+ * truth for the key shared by the writer (session create) and reader (lookup).
+ */
+export const GITHUB_RUN_METADATA_KEY = "githubRunId"
+
+/**
+ * Picks the session to resume for a GitHub Actions run, keyed by the stable
+ * GITHUB_RUN_ID stamped into session metadata at creation. Returns undefined
+ * when no session for this run exists yet (fresh runner or first attempt); the
+ * caller then creates a new one.
+ *
+ * `github run` creates exactly one session per run id, so normally a single
+ * session matches. If more than one ever does (someone forked the session, and
+ * forks copy metadata), resume the earliest-created one: the original task
+ * session carrying the real context, not a later copy.
+ */
+export function findResumableSession<S extends { metadata?: Record<string, unknown>; time: { created: number } }>(
+  sessions: readonly S[],
+  runId: string,
+): S | undefined {
+  return sessions
+    .filter((s) => s.metadata?.[GITHUB_RUN_METADATA_KEY] === runId)
+    .sort((a, b) => a.time.created - b.time.created)
+    .at(0)
+}
+
+/**
+ * Whether a resumed `github run` should send a short continuation nudge instead
+ * of the full prompt. Only safe once the prior attempt recorded history: the
+ * user prompt is persisted before the model call, so a transient mid-call
+ * failure leaves it present. An attempt that died during setup before any
+ * message was stored leaves an empty session and must receive the full prompt.
+ */
+export function shouldSendContinuation(input: { foundPrior: boolean; priorMessageCount: number }): boolean {
+  return input.foundPrior && input.priorMessageCount > 0
+}
+
+/**
  * Extracts displayable text from assistant response parts.
  * Returns null for non-text responses (signals summary needed).
  * Throws only for truly empty responses.

--- a/packages/opencode/src/cli/cmd/github.shared.ts
+++ b/packages/opencode/src/cli/cmd/github.shared.ts
@@ -9,26 +9,8 @@ export { parseGitHubRemote } from "@/util/repository"
  */
 export const GITHUB_RUN_METADATA_KEY = "githubRunId"
 
-/**
- * Picks the session to resume for a GitHub Actions run, keyed by the stable
- * GITHUB_RUN_ID stamped into session metadata at creation. Returns undefined
- * when no session for this run exists yet (fresh runner or first attempt); the
- * caller then creates a new one.
- *
- * `github run` creates exactly one session per run id, so normally a single
- * session matches. If more than one ever does (someone forked the session, and
- * forks copy metadata), resume the earliest-created one: the original task
- * session carrying the real context, not a later copy.
- */
-export function findResumableSession<S extends { metadata?: Record<string, unknown>; time: { created: number } }>(
-  sessions: readonly S[],
-  runId: string,
-): S | undefined {
-  return sessions
-    .filter((s) => s.metadata?.[GITHUB_RUN_METADATA_KEY] === runId)
-    .sort((a, b) => a.time.created - b.time.created)
-    .at(0)
-}
+export const GITHUB_RUN_RESUME_PROMPT =
+  "The previous attempt in this session was interrupted before finishing. Continue the task to completion."
 
 /**
  * Whether a resumed `github run` should send a short continuation nudge instead
@@ -39,6 +21,15 @@ export function findResumableSession<S extends { metadata?: Record<string, unkno
  */
 export function shouldSendContinuation(input: { foundPrior: boolean; priorMessageCount: number }): boolean {
   return input.foundPrior && input.priorMessageCount > 0
+}
+
+export function githubRunPrompt<T>(input: {
+  continuation: boolean
+  message: string
+  promptFiles: T[]
+}): { message: string; promptFiles: T[] } {
+  if (!input.continuation) return { message: input.message, promptFiles: input.promptFiles }
+  return { message: GITHUB_RUN_RESUME_PROMPT, promptFiles: [] }
 }
 
 /**

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -4,9 +4,10 @@ import { effectCmd } from "../effect-cmd"
 
 export {
   extractResponseText,
-  findResumableSession,
   formatPromptTooLargeError,
   GITHUB_RUN_METADATA_KEY,
+  GITHUB_RUN_RESUME_PROMPT,
+  githubRunPrompt,
   parseGitHubRemote,
   shouldSendContinuation,
 } from "./github.shared"

--- a/packages/opencode/src/cli/cmd/github.ts
+++ b/packages/opencode/src/cli/cmd/github.ts
@@ -2,7 +2,14 @@ import { Effect } from "effect"
 import { cmd } from "./cmd"
 import { effectCmd } from "../effect-cmd"
 
-export { extractResponseText, formatPromptTooLargeError, parseGitHubRemote } from "./github.shared"
+export {
+  extractResponseText,
+  findResumableSession,
+  formatPromptTooLargeError,
+  GITHUB_RUN_METADATA_KEY,
+  parseGitHubRemote,
+  shouldSendContinuation,
+} from "./github.shared"
 
 export const GithubInstallCommand = effectCmd({
   command: "install",

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -21,6 +21,7 @@ import { and } from "drizzle-orm"
 import { gte } from "drizzle-orm"
 import { isNull } from "drizzle-orm"
 import { desc } from "drizzle-orm"
+import { asc } from "drizzle-orm"
 import { like } from "drizzle-orm"
 import { sql } from "drizzle-orm"
 import { inArray } from "drizzle-orm"
@@ -461,6 +462,7 @@ export type NotFound = NotFoundError
 export interface Interface {
   readonly list: (input?: ListInput) => Effect.Effect<Info[]>
   readonly listGlobal: (input?: GlobalListInput) => Effect.Effect<GlobalInfo[]>
+  readonly findByMetadata: (input: { key: string; value: string }) => Effect.Effect<Info | undefined>
   readonly create: (input?: {
     parentID?: SessionID
     title?: string
@@ -592,6 +594,24 @@ export const layer: Layer.Layer<
         experimentalWorkspaces: flags.experimentalWorkspaces,
         ...input,
       })
+    })
+
+    const findByMetadata = Effect.fn("Session.findByMetadata")(function* (input: { key: string; value: string }) {
+      const ctx = yield* InstanceState.context
+      const row = yield* db
+        .select()
+        .from(SessionTable)
+        .where(
+          and(
+            eq(SessionTable.project_id, ctx.project.id),
+            sql`json_extract(${SessionTable.metadata}, ${`$.${input.key}`}) = ${input.value}`,
+          ),
+        )
+        .orderBy(asc(SessionTable.time_created), asc(SessionTable.id))
+        .limit(1)
+        .get()
+        .pipe(Effect.orDie)
+      return row ? fromRow(row) : undefined
     })
 
     const listGlobal = Effect.fn("Session.listGlobal")(function* (input?: GlobalListInput) {
@@ -935,6 +955,7 @@ export const layer: Layer.Layer<
     return Service.of({
       list,
       listGlobal,
+      findByMetadata,
       create,
       fork,
       touch,

--- a/packages/opencode/test/cli/github-resume.test.ts
+++ b/packages/opencode/test/cli/github-resume.test.ts
@@ -7,15 +7,14 @@ import { MessageID, PartID, type SessionID } from "../../src/session/schema"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { resetDatabase } from "../fixture/db"
 import { testEffect } from "../lib/effect"
-import { findResumableSession, GITHUB_RUN_METADATA_KEY, shouldSendContinuation } from "../../src/cli/cmd/github"
+import {
+  GITHUB_RUN_METADATA_KEY,
+  GITHUB_RUN_RESUME_PROMPT,
+  githubRunPrompt,
+  shouldSendContinuation,
+} from "../../src/cli/cmd/github"
 
-// `opencode github run` stamps GITHUB_RUN_ID into session metadata at creation
-// and, on a retry within the same runner (a wrapper re-spawn after a transient
-// failure), looks the prior session up by that key to continue rather than start
-// fresh. The resolution sequence in the handler is: list -> findResumableSession
-// -> count prior messages -> shouldSendContinuation. These tests drive that exact
-// sequence against the real Session service and SQLite so the metadata round-trip
-// and the empty-session fallback are what's verified, not hand-built stand-ins.
+// Same-runner retries resolve by workflow identity, not by "latest session".
 const it = testEffect(Layer.mergeAll(Session.defaultLayer))
 
 afterEach(async () => {
@@ -39,7 +38,7 @@ const addMessage = (sessionID: SessionID) =>
 // Mirrors the handler's session resolution against the real service.
 const resolve = (runId: string) =>
   Effect.gen(function* () {
-    const prior = findResumableSession(yield* Session.use.list(), runId)
+    const prior = yield* Session.use.findByMetadata({ key: GITHUB_RUN_METADATA_KEY, value: runId })
     const priorMessageCount = prior ? (yield* Session.use.messages({ sessionID: prior.id, limit: 1 })).length : 0
     return { prior, continuation: shouldSendContinuation({ foundPrior: prior !== undefined, priorMessageCount }) }
   })
@@ -104,9 +103,8 @@ describe("github run session resolution", () => {
         const a = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: "gh-run-a" } })
         const b = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: "gh-run-b" } })
 
-        const sessions = yield* Session.use.list()
-        expect(findResumableSession(sessions, "gh-run-a")?.id).toBe(a.id)
-        expect(findResumableSession(sessions, "gh-run-b")?.id).toBe(b.id)
+        expect((yield* Session.use.findByMetadata({ key: GITHUB_RUN_METADATA_KEY, value: "gh-run-a" }))?.id).toBe(a.id)
+        expect((yield* Session.use.findByMetadata({ key: GITHUB_RUN_METADATA_KEY, value: "gh-run-b" }))?.id).toBe(b.id)
       }),
     { git: true },
   )
@@ -118,38 +116,39 @@ describe("github run session resolution", () => {
         yield* TestInstance
         const runId = "gh-run-forked"
         const original = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: runId } })
+        yield* Effect.sleep("1 millis")
         // Forks copy metadata in this codebase, so the fork carries the same run id
         // and is not distinguishable by parentID (forks have none). The lookup must
         // still resolve to a single, deterministic session.
         const fork = yield* Session.use.fork({ sessionID: original.id })
         expect(fork.metadata?.[GITHUB_RUN_METADATA_KEY]).toBe(runId)
 
-        const sessions = yield* Session.use.list()
-        const matches = sessions.filter((s) => s.metadata?.[GITHUB_RUN_METADATA_KEY] === runId)
-        expect(matches.length).toBe(2)
-
-        const earliest = matches.reduce((a, b) => (a.time.created <= b.time.created ? a : b))
-        expect(findResumableSession(sessions, runId)?.id).toBe(earliest.id)
+        const prior = yield* Session.use.findByMetadata({ key: GITHUB_RUN_METADATA_KEY, value: runId })
+        expect(prior?.id).toBe(original.id)
       }),
     { git: true },
   )
-})
 
-describe("findResumableSession (pure)", () => {
-  test("picks the earliest-created session when several share a run id", () => {
-    const runId = "dup"
-    const sessions = [
-      { id: "later", metadata: { [GITHUB_RUN_METADATA_KEY]: runId }, time: { created: 200 } },
-      { id: "original", metadata: { [GITHUB_RUN_METADATA_KEY]: runId }, time: { created: 100 } },
-      { id: "unrelated", metadata: { [GITHUB_RUN_METADATA_KEY]: "other" }, time: { created: 50 } },
-    ]
-    expect(findResumableSession(sessions, runId)?.id).toBe("original")
-  })
+  it.instance(
+    "finds an old matching session without depending on the session list limit",
+    () =>
+      Effect.gen(function* () {
+        yield* TestInstance
+        const runId = "gh-run-old-match"
+        const created = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: runId } })
 
-  test("returns undefined when no session carries the run id", () => {
-    const sessions = [{ id: "x", metadata: { [GITHUB_RUN_METADATA_KEY]: "a" }, time: { created: 1 } }]
-    expect(findResumableSession(sessions, "b")).toBeUndefined()
-  })
+        yield* Effect.all(
+          Array.from({ length: 125 }, (_, index) =>
+            Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: `other-${index}` } }),
+          ),
+          { concurrency: 1 },
+        )
+
+        const prior = yield* Session.use.findByMetadata({ key: GITHUB_RUN_METADATA_KEY, value: runId })
+        expect(prior?.id).toBe(created.id)
+      }),
+    { git: true },
+  )
 })
 
 describe("shouldSendContinuation (pure)", () => {
@@ -163,5 +162,22 @@ describe("shouldSendContinuation (pure)", () => {
 
   test("prior session with history means continuation nudge", () => {
     expect(shouldSendContinuation({ foundPrior: true, priorMessageCount: 1 })).toBe(true)
+  })
+})
+
+describe("githubRunPrompt", () => {
+  test("keeps the full prompt and files for a fresh run", () => {
+    const promptFiles = ["screenshot"]
+    expect(githubRunPrompt({ continuation: false, message: "full prompt", promptFiles })).toEqual({
+      message: "full prompt",
+      promptFiles,
+    })
+  })
+
+  test("sends only the continuation nudge when resuming a recorded attempt", () => {
+    expect(githubRunPrompt({ continuation: true, message: "full prompt", promptFiles: ["screenshot"] })).toEqual({
+      message: GITHUB_RUN_RESUME_PROMPT,
+      promptFiles: [],
+    })
   })
 })

--- a/packages/opencode/test/cli/github-resume.test.ts
+++ b/packages/opencode/test/cli/github-resume.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { Session } from "@/session/session"
+import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { resetDatabase } from "../fixture/db"
+import { testEffect } from "../lib/effect"
+import { findResumableSession, GITHUB_RUN_METADATA_KEY, shouldSendContinuation } from "../../src/cli/cmd/github"
+
+// `opencode github run` stamps GITHUB_RUN_ID into session metadata at creation
+// and, on a retry within the same runner (a wrapper re-spawn after a transient
+// failure), looks the prior session up by that key to continue rather than start
+// fresh. The resolution sequence in the handler is: list -> findResumableSession
+// -> count prior messages -> shouldSendContinuation. These tests drive that exact
+// sequence against the real Session service and SQLite so the metadata round-trip
+// and the empty-session fallback are what's verified, not hand-built stand-ins.
+const it = testEffect(Layer.mergeAll(Session.defaultLayer))
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+const addMessage = (sessionID: SessionID) =>
+  Effect.gen(function* () {
+    const info = yield* Session.use.updateMessage({
+      id: MessageID.ascending(),
+      role: "user",
+      sessionID,
+      agent: "build",
+      model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+      time: { created: Date.now() },
+    })
+    yield* Session.use.updatePart({ id: PartID.ascending(), sessionID, messageID: info.id, type: "text", text: "hi" })
+  })
+
+// Mirrors the handler's session resolution against the real service.
+const resolve = (runId: string) =>
+  Effect.gen(function* () {
+    const prior = findResumableSession(yield* Session.use.list(), runId)
+    const priorMessageCount = prior ? (yield* Session.use.messages({ sessionID: prior.id, limit: 1 })).length : 0
+    return { prior, continuation: shouldSendContinuation({ foundPrior: prior !== undefined, priorMessageCount }) }
+  })
+
+describe("github run session resolution", () => {
+  it.instance(
+    "continues the prior session when it has recorded history",
+    () =>
+      Effect.gen(function* () {
+        yield* TestInstance
+        const runId = "gh-run-with-history"
+        const created = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: runId } })
+        yield* addMessage(created.id)
+
+        const { prior, continuation } = yield* resolve(runId)
+
+        expect(prior?.id).toBe(created.id)
+        expect(continuation).toBe(true)
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "reuses the session but sends the full prompt when the prior attempt left no history",
+    () =>
+      Effect.gen(function* () {
+        yield* TestInstance
+        const runId = "gh-run-empty"
+        const created = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: runId } })
+
+        const { prior, continuation } = yield* resolve(runId)
+
+        // Found and reused, but no nudge: an attempt that died during setup has no
+        // task in history, so the model must get the full prompt.
+        expect(prior?.id).toBe(created.id)
+        expect(continuation).toBe(false)
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "starts fresh for a run id with no prior session",
+    () =>
+      Effect.gen(function* () {
+        yield* TestInstance
+        yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: "gh-run-old" } })
+        yield* Session.use.create({}) // unrelated, non-github session
+
+        const { prior, continuation } = yield* resolve("gh-run-never-seen")
+
+        expect(prior).toBeUndefined()
+        expect(continuation).toBe(false)
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "isolates sessions by run id",
+    () =>
+      Effect.gen(function* () {
+        yield* TestInstance
+        const a = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: "gh-run-a" } })
+        const b = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: "gh-run-b" } })
+
+        const sessions = yield* Session.use.list()
+        expect(findResumableSession(sessions, "gh-run-a")?.id).toBe(a.id)
+        expect(findResumableSession(sessions, "gh-run-b")?.id).toBe(b.id)
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "resumes the original session, not a fork that copied its run id",
+    () =>
+      Effect.gen(function* () {
+        yield* TestInstance
+        const runId = "gh-run-forked"
+        const original = yield* Session.use.create({ metadata: { [GITHUB_RUN_METADATA_KEY]: runId } })
+        // Forks copy metadata in this codebase, so the fork carries the same run id
+        // and is not distinguishable by parentID (forks have none). The lookup must
+        // still resolve to a single, deterministic session.
+        const fork = yield* Session.use.fork({ sessionID: original.id })
+        expect(fork.metadata?.[GITHUB_RUN_METADATA_KEY]).toBe(runId)
+
+        const sessions = yield* Session.use.list()
+        const matches = sessions.filter((s) => s.metadata?.[GITHUB_RUN_METADATA_KEY] === runId)
+        expect(matches.length).toBe(2)
+
+        const earliest = matches.reduce((a, b) => (a.time.created <= b.time.created ? a : b))
+        expect(findResumableSession(sessions, runId)?.id).toBe(earliest.id)
+      }),
+    { git: true },
+  )
+})
+
+describe("findResumableSession (pure)", () => {
+  test("picks the earliest-created session when several share a run id", () => {
+    const runId = "dup"
+    const sessions = [
+      { id: "later", metadata: { [GITHUB_RUN_METADATA_KEY]: runId }, time: { created: 200 } },
+      { id: "original", metadata: { [GITHUB_RUN_METADATA_KEY]: runId }, time: { created: 100 } },
+      { id: "unrelated", metadata: { [GITHUB_RUN_METADATA_KEY]: "other" }, time: { created: 50 } },
+    ]
+    expect(findResumableSession(sessions, runId)?.id).toBe("original")
+  })
+
+  test("returns undefined when no session carries the run id", () => {
+    const sessions = [{ id: "x", metadata: { [GITHUB_RUN_METADATA_KEY]: "a" }, time: { created: 1 } }]
+    expect(findResumableSession(sessions, "b")).toBeUndefined()
+  })
+})
+
+describe("shouldSendContinuation (pure)", () => {
+  test("no prior session means full prompt", () => {
+    expect(shouldSendContinuation({ foundPrior: false, priorMessageCount: 0 })).toBe(false)
+  })
+
+  test("prior session with no messages means full prompt", () => {
+    expect(shouldSendContinuation({ foundPrior: true, priorMessageCount: 0 })).toBe(false)
+  })
+
+  test("prior session with history means continuation nudge", () => {
+    expect(shouldSendContinuation({ foundPrior: true, priorMessageCount: 1 })).toBe(true)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32583

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode github run` calls `Session.create()` on every invocation, so a retry starts a new session. The agent redoes all the setup: re-clone, re-read the PR/issue, re-prompt the model. The prior attempt's session is still in the local DB, but nothing looks for it.

This stamps `GITHUB_RUN_ID` into the session metadata at creation. That id stays the same across re-runs (only `GITHUB_RUN_ATTEMPT` changes), so it works as a resume key. On start, `github run` looks up the session for the current run id and resumes it if found, otherwise creates as before.

On resume it sends a short "continue" message instead of re-sending the full prompt, which is where the tokens are saved. The user prompt is persisted before the model call, so a transient mid-call failure (the case a retry targets) leaves it in history and the nudge has context. If the prior attempt died during setup before any message was written, it falls back to the full prompt so the model still gets the task.

Scope: same-runner retries, where the session DB survives (for example a wrapper that re-runs the command after a transient failure). A GitHub UI "Re-run" starts on a fresh runner with an empty DB and still creates a new session. Persisting the data dir across runners is a separate change, called out in a code comment.

### How did you verify your code works?

- Extracted the resume selection as `findResumableSession` and tested it against the real Session service and SQLite: match by run id, isolation across runs, no-match returns `undefined`, and a fork (which copies metadata) resolves back to the original. Plus a pure tiebreak test.
- `bun test test/cli/github-resume.test.ts` passes (6). Existing `github-action.test.ts` and `github-remote.test.ts` pass (33).
- `bun run typecheck` is clean. `oxlint` is clean on the changed files.
- The full `github run` flow (OIDC, octokit, git) has no automated coverage here; it needs a live GitHub Actions environment to exercise end to end.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
