### PR TITLE
fix(app): close review panel on middle-click

### DIFF
--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -262,7 +262,7 @@ export function SessionSidePanel(props: {
                         }}
                       >
                         <Show when={reviewTab() && props.canReview()}>
-                          <Tabs.Trigger value="review">
+                          <Tabs.Trigger value="review" onMiddleClick={() => view().reviewPanel.close()}>
                             <div class="flex items-center gap-1.5">
                               <div>{language.t("session.tab.review")}</div>
                               <Show when={props.hasReview()}>


### PR DESCRIPTION
### Issue for this PR

Closes #32587

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a middle-click handler to the desktop Review tab that closes the review panel.

File and context tabs already support middle-click close. This makes the synthetic Review tab behave consistently when there are no other tabs to close.

### How did you verify your code works?

- Manually started the desktop dev app with `bun run dev:desktop`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
