### PR TITLE
fix(opencode): send system context as structured messages on OpenAI OAuth path

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -54,7 +54,6 @@ const mergeOptions = (target: Record<string, any>, source: Record<string, any> |
   mergeDeep(target, source ?? {}) as Record<string, any>
 
 export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: PrepareInput) {
-  const isOpenaiOauth = input.provider.id === "openai" && input.auth?.type === "oauth"
   const system = [
     [
       ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),
@@ -96,20 +95,17 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
     delete options.reasoningSummary
     delete options.include
   }
-  if (isOpenaiOauth) options.instructions = system.join("\n")
-
-  const messages =
-    isOpenaiOauth || input.isWorkflow
-      ? input.messages
-      : [
-          ...system.map(
-            (x): ModelMessage => ({
-              role: "system",
-              content: x,
-            }),
-          ),
-          ...input.messages,
-        ]
+  const messages = input.isWorkflow
+    ? input.messages
+    : [
+        ...system.map(
+          (x): ModelMessage => ({
+            role: "system",
+            content: x,
+          }),
+        ),
+        ...input.messages,
+      ]
 
   const params = yield* input.plugin.trigger(
     "chat.params",

--- a/packages/opencode/test/session/llm-request-prep.test.ts
+++ b/packages/opencode/test/session/llm-request-prep.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import type { ModelMessage } from "ai"
+import { LLMRequestPrep } from "../../src/session/llm/request"
+import type { Plugin } from "@/plugin"
+import type { Provider } from "@/provider/provider"
+import type { Agent } from "../../src/agent/agent"
+import type { RuntimeFlags } from "@/effect/runtime-flags"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { SessionID, MessageID } from "../../src/session/schema"
+
+// Passthrough plugin stub: trigger returns the output unchanged
+const stubPlugin: Plugin.Interface = {
+  trigger: (_name: any, _input: any, output: any) => Effect.succeed(output),
+  list: () => Effect.succeed([]),
+  init: () => Effect.succeed(undefined),
+}
+
+const stubModel: Provider.Model = {
+  id: ModelV2.ID.make("gpt-5.2"),
+  providerID: ProviderV2.ID.make("openai"),
+  api: { id: "gpt-5.2", url: "https://api.openai.com/v1", npm: "@ai-sdk/openai" },
+  name: "GPT 5.2",
+  capabilities: {
+    temperature: true,
+    reasoning: true,
+    attachment: false,
+    toolcall: true,
+    input: { text: true, audio: false, image: false, video: false, pdf: false },
+    output: { text: true, audio: false, image: false, video: false, pdf: false },
+    interleaved: false,
+  },
+  cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+  limit: { context: 200_000, output: 100_000 },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2026-01-01",
+}
+
+const stubFlags: RuntimeFlags.Info = {
+  autoShare: false,
+  pure: false,
+  disableDefaultPlugins: false,
+  disableEmbeddedWebUi: false,
+  disableExternalSkills: false,
+  disableLspDownload: false,
+  disableClaudeCodePrompt: false,
+  disableClaudeCodeSkills: false,
+  enableExa: false,
+  enableParallel: false,
+  enableExperimentalModels: false,
+  enableQuestionTool: false,
+  experimentalReferences: false,
+  experimentalBackgroundSubagents: false,
+  experimentalLspTy: false,
+  experimentalLspTool: false,
+  experimentalOxfmt: false,
+  experimentalPlanMode: false,
+  experimentalEventSystem: false,
+  experimentalWorkspaces: false,
+  experimentalIconDiscovery: false,
+  outputTokenMax: undefined,
+  bashDefaultTimeoutMs: undefined,
+  experimentalNativeLlm: false,
+  experimentalWebSockets: false,
+  client: "cli",
+}
+
+const stubAgent: Agent.Info = {
+  name: "test",
+  mode: "primary",
+  prompt: "You are a test assistant.",
+  options: {},
+  permission: [],
+}
+
+const sessionID = SessionID.make("session-prep-test")
+
+const stubUser: SessionV1.User = {
+  id: MessageID.make("msg_prep-test"),
+  sessionID,
+  role: "user",
+  time: { created: Date.now() },
+  agent: "test",
+  model: { providerID: ProviderV2.ID.make("openai"), modelID: ModelV2.ID.make("gpt-5.2") },
+}
+
+const stubProvider: Provider.Info = {
+  id: ProviderV2.ID.make("openai"),
+  name: "OpenAI",
+  source: "env",
+  env: ["OPENAI_API_KEY"],
+  options: {},
+  models: {},
+}
+
+const baseInput = {
+  user: stubUser,
+  sessionID,
+  model: stubModel,
+  agent: stubAgent,
+  system: ["System instruction A"],
+  messages: [{ role: "user", content: "Hello" }] as ModelMessage[],
+  tools: {},
+  provider: stubProvider,
+  auth: undefined,
+  plugin: stubPlugin,
+  flags: stubFlags,
+  isWorkflow: false,
+}
+
+describe("LLMRequestPrep.prepare", () => {
+  test("OAuth path sends system entries as structured messages, not instructions", async () => {
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        ...baseInput,
+        provider: { ...stubProvider, id: ProviderV2.ID.make("openai") },
+        auth: { type: "oauth", refresh: "r", access: "a", expires: 9999999999 },
+        system: ["System instruction A", "System instruction B"],
+      }),
+    )
+
+    // instructions must not be set on the OAuth path after the fix
+    expect(result.params.options.instructions).toBeUndefined()
+
+    // system entries appear as structured {role: "system"} messages at the head
+    const systemMessages = result.messages.filter((m) => m.role === "system")
+    expect(systemMessages.length).toBeGreaterThan(0)
+    expect(result.messages[0]).toMatchObject({ role: "system" })
+
+    // total messages = system entries + input messages
+    const inputMessages = [{ role: "user", content: "Hello" }] as ModelMessage[]
+    expect(result.messages.length).toBe(result.system.length + inputMessages.length)
+  })
+
+  test("non-OAuth path prepends system entries as structured messages", async () => {
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        ...baseInput,
+        provider: { ...stubProvider, id: ProviderV2.ID.make("openai") },
+        auth: undefined,
+        system: ["System instruction A"],
+      }),
+    )
+
+    expect(result.params.options.instructions).toBeUndefined()
+    expect(result.messages[0]).toMatchObject({ role: "system" })
+
+    const inputMessages = [{ role: "user", content: "Hello" }] as ModelMessage[]
+    expect(result.messages.length).toBe(result.system.length + inputMessages.length)
+  })
+
+  test("workflow path passes input messages through without system prepend", async () => {
+    const inputMessages = [{ role: "user", content: "Hello" }] as ModelMessage[]
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        ...baseInput,
+        isWorkflow: true,
+        system: ["System instruction A", "System instruction B"],
+        messages: inputMessages,
+      }),
+    )
+
+    // workflow messages are passed through unchanged
+    expect(result.messages).toEqual(inputMessages)
+
+    // system entries must not be duplicated into messages
+    expect(result.messages.every((m) => m.role !== "system")).toBe(true)
+  })
+
+  test("empty system array produces only the original input messages", async () => {
+    const inputMessages = [{ role: "user", content: "Hello" }] as ModelMessage[]
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        ...baseInput,
+        system: [],
+        messages: inputMessages,
+      }),
+    )
+
+    // With an empty system array the agent prompt still generates one system entry,
+    // so we check that no extra duplication happened beyond that.
+    const userMessages = result.messages.filter((m) => m.role === "user")
+    expect(userMessages).toMatchObject(inputMessages)
+  })
+
+  test("multi-entry system produces one structured message per entry in order", async () => {
+    const systemEntries = ["First system entry", "Second system entry", "Third system entry"]
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        ...baseInput,
+        system: systemEntries,
+        // Use agent.prompt so we know the first system entry comes from it
+        agent: { ...stubAgent, prompt: "Agent prompt" },
+      }),
+    )
+
+    // The prepare function joins all system parts into a compacted array, then
+    // maps each element to {role: "system", content: ...}. The leading messages
+    // must all be system role and appear before the user message.
+    const systemMessages = result.messages.filter((m) => m.role === "system")
+    expect(systemMessages.length).toBe(result.system.length)
+    expect(systemMessages.length).toBeGreaterThan(0)
+
+    // Each system message corresponds to an entry in result.system in order
+    for (let i = 0; i < systemMessages.length; i++) {
+      expect(systemMessages[i]).toMatchObject({
+        role: "system",
+        content: result.system[i],
+      })
+    }
+
+    // User message follows after all system messages
+    expect(result.messages[systemMessages.length]).toMatchObject({ role: "user" })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32505

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The OpenAI OAuth / Codex request path currently flattens the entire assembled system context (environment, skills, loaded instruction files, memory guidance) into `options.instructions` as a single joined string, while the non-OAuth path sends that same content as structured system messages prepended to the message array. This patch removes the `instructions` flattening and routes the OAuth path through the same structured-message construction that already works for non-OAuth OpenAI requests, so the Codex-family API receives system context in the same shape regardless of auth method. The `isWorkflow` passthrough is intentionally left unchanged.

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/llm-request-prep.test.ts` — 5 pass, 14 expect() calls; covers OAuth, non-OAuth, workflow, empty/multi-entry system array cases
- `cd packages/opencode && bun test test/session/llm.test.ts` — 26 pass, 74 expect() calls; existing LLM stream tests pass with no regression
- `cd packages/opencode && bun typecheck` — clean

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
