### PR TITLE
fix(provider): expose GLM-5.2 thinking-effort variants (high, max)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -677,6 +677,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
   const adaptiveEfforts = anthropicAdaptiveEfforts(model.api.id)
+  // GLM-5.2 exposes two meaningful thinking-effort levels (high and max).
+  // Older GLM models only had a binary toggle, so they fall through to the
+  // blanket exclusion below. See: https://docs.z.ai/devpack/latest-model
+  if (id.includes("glm-5.2")) {
+    return {
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    }
+  }
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2694,6 +2694,24 @@ describe("ProviderTransform.variants", () => {
     expect(result).toEqual({})
   })
 
+  test("glm-5.2 returns high and max effort variants", () => {
+    const model = createMockModel({
+      id: "zhipuai/glm-5.2",
+      providerID: "zhipuai",
+      api: {
+        id: "glm-5.2",
+        url: "https://api.z.ai/api/coding/paas/v4",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: { reasoning: true },
+    })
+    const result = ProviderTransform.variants(model)
+    expect(result).toEqual({
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+  })
+
   test("mistral models with reasoning support return variants", () => {
     const model = createMockModel({
       id: "mistral/mistral-small-latest",


### PR DESCRIPTION
### Issue for this PR

Closes #32444

### Type of change

- [x] Bug fix

### What does this PR do?

The `variants()` function in `transform.ts` had a blanket early-return `id.includes("glm")` that returned `{}` for all GLM models. This was correct for GLM-4/5/5.1 (binary reasoning toggle only), but GLM-5.2 exposes two distinct thinking-effort levels via `reasoningEffort`: `high` and `max` (see [Z.AI docs](https://docs.z.ai/devpack/latest-model)).

Added a `glm-5.2` special case before the blanket exclusion that returns `{ high: { reasoningEffort: "high" }, max: { reasoningEffort: "max" } }`. This matches the existing pattern used for other per-model effort special cases in the same function (minimax-m3, grok, deepseek-v4).

The `glm-5.2` check is scoped narrowly enough that it matches `zhipuai/glm-5.2` and `glm-5.2[1m]` but does not match older models (glm-4, glm-5, glm-5.1).

### How did you verify your code works?

- Read the full `variants()` function to confirm the blanket `glm` exclusion and understand the existing per-model special-case pattern.
- Verified the Z.AI API contract: GLM-5.2 supports `reasoningEffort` with `high` and `max` values (`low`/`medium` are silently mapped to `high`).
- Verified `model.capabilities.reasoning` is `true` for `zhipuai/glm-5.2` on models.dev, so the function reaches the new branch instead of short-circuiting at the top.
- Wrote a test following the exact pattern of the adjacent `"glm returns empty object"` test, using `createMockModel` with `capabilities: { reasoning: true }`.
- Verified the matching logic standalone: `"zhipuai/glm-5.2".includes("glm-5.2")` = true, `"glm/glm-4".includes("glm-5.2")` = false, `"glm/glm-5.1".includes("glm-5.2")` = false.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR