### PR TITLE
fix(core): Fix for incorrect time.start reset in tool call logging (#32574)

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -56,7 +56,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             metadata: val.metadata,
             status: "running",
             input: args,
-            time: { start: Date.now() },
+            time: match.state.status === "running" ? match.state.time : { start: Date.now() },
           },
         }
       }),

--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -1,0 +1,163 @@
+import { expect } from "bun:test"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Agent } from "@/agent/agent"
+import { MCP } from "@/mcp"
+import { Permission } from "@/permission"
+import { Provider } from "@/provider/provider"
+import { Session } from "@/session/session"
+import { MessageID, PartID, SessionID } from "@/session/schema"
+import { SessionProcessor } from "@/session/processor"
+import { SessionTools } from "@/session/tools"
+import { Tool } from "@/tool/tool"
+import { ToolRegistry } from "@/tool/registry"
+import { Truncate } from "@/tool/truncate"
+import { Plugin } from "@/plugin"
+import { Effect, Layer, Schema } from "effect"
+import { testEffect } from "../lib/effect"
+
+const callID = "call-test"
+const sessionID = SessionID.make("ses_test")
+const messageID = MessageID.ascending()
+const partID = PartID.ascending()
+
+const agent: Agent.Info = {
+  name: "build",
+  mode: "primary",
+  options: {},
+  permission: [{ permission: "*", pattern: "*", action: "allow" }],
+}
+
+const model = {
+  providerID: ProviderV2.ID.make("test"),
+  api: { id: "test-model" },
+} as Provider.Model
+
+function fakeMcp() {
+  return MCP.Service.of({
+    tools: () => Effect.succeed({}),
+  } as Partial<MCP.Interface> as MCP.Interface)
+}
+
+const fakePlugin = Plugin.Service.of({
+  init: () => Effect.void,
+  list: () => Effect.succeed([]),
+  trigger: (_name, _input, output) => Effect.succeed(output),
+} satisfies Plugin.Interface)
+
+const fakePermission = Permission.Service.of({
+  ask: () => Effect.void,
+  reply: () => Effect.void,
+  list: () => Effect.succeed([]),
+} satisfies Permission.Interface)
+
+const fakeTruncate = Truncate.Service.of({
+  cleanup: () => Effect.void,
+  write: () => Effect.succeed("output.txt"),
+  output: (text: string) => Effect.succeed({ content: text, truncated: false }),
+  limits: () => Effect.succeed({ maxLines: 2000, maxBytes: 50 * 1024 }),
+} satisfies Truncate.Interface)
+
+const layer = Layer.mergeAll(
+  Layer.succeed(Plugin.Service, fakePlugin),
+  Layer.succeed(Permission.Service, fakePermission),
+  Layer.succeed(MCP.Service, fakeMcp()),
+  Layer.succeed(Truncate.Service, fakeTruncate),
+  Layer.succeed(
+    ToolRegistry.Service,
+    ToolRegistry.Service.of({
+      ids: () => Effect.succeed(["timing"]),
+      all: () => Effect.succeed([]),
+      named: () => Effect.die("unused"),
+      tools: () =>
+        Effect.succeed([
+          {
+            id: "timing",
+            description: "updates metadata more than once",
+            parameters: Schema.Struct({}),
+            jsonSchema: { type: "object", properties: {} },
+            execute: (_args, ctx) =>
+              Effect.gen(function* () {
+                yield* ctx.metadata({ metadata: { output: "first" } })
+                yield* ctx.metadata({ metadata: { output: "second" } })
+                return { title: "timing", metadata: {}, output: "done" }
+              }),
+          } satisfies Tool.Def,
+        ]),
+    }),
+  ),
+)
+
+const it = testEffect(layer)
+
+it.effect("preserves running tool start time across metadata updates", () =>
+  Effect.gen(function* () {
+    const state: SessionV1.ToolPart = {
+      id: partID,
+      sessionID,
+      messageID,
+      type: "tool",
+      tool: "timing",
+      callID,
+      state: {
+        status: "running",
+        input: {},
+        time: { start: 100 },
+      },
+    }
+    const updates: number[] = []
+    const processor = {
+      message: {
+        id: messageID,
+        sessionID,
+        role: "assistant",
+        parentID: MessageID.ascending(),
+        agent: "build",
+        mode: "build",
+        path: { cwd: "/tmp", root: "/tmp" },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        modelID: ModelV2.ID.make("test-model"),
+        providerID: ProviderV2.ID.make("test"),
+        time: { created: 1 },
+      } satisfies SessionV1.Assistant,
+      updateToolCall: (_toolCallID, update) =>
+        Effect.sync(() => {
+          const next = update(state)
+          state.state = next.state
+          if (state.state.status === "running") updates.push(state.state.time.start)
+          return state
+        }),
+      completeToolCall: () => Effect.void,
+    } satisfies Pick<SessionProcessor.Handle, "message" | "updateToolCall" | "completeToolCall">
+
+    const tools = yield* SessionTools.resolve({
+      agent,
+      model,
+      session: { id: sessionID, permission: [] } as Session.Info,
+      processor,
+      bypassAgentCheck: false,
+      messages: [],
+      promptOps: {} as never,
+    })
+    const execute = tools.timing.execute
+    if (!execute) throw new Error("timing tool is missing execute")
+
+    yield* Effect.promise(() =>
+      execute(
+        {},
+        {
+          toolCallId: callID,
+          abortSignal: new AbortController().signal,
+        },
+      ),
+    )
+
+    expect(updates).toEqual([100, 100])
+    expect(state.state.status).toBe("running")
+    if (state.state.status === "running") {
+      expect(state.state.time.start).toBe(100)
+    }
+  }),
+)


### PR DESCRIPTION
## Description

New test fails if you don't have this fix.

### Issue for this PR

Closes #32574

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the "start" time in the "time" block for json tool calling output so it produces the right start time and time difference.

Before this fix, running:

```bash
time opencode run --format=json "Run the comamnd 'time sleep 10s' and report what it shows" | jq
```

produced a JSON dict like:

```json
{
  "type": "text",
  "timestamp": 1781623587086,
  "sessionID": "ses_12ef5b29dffeNWj9H9elnMCmbv",
  "part": {
    "id": "prt_ed10a7fc1001cnEl1E5FBGo5IC",
    "messageID": "msg_ed10a7ef7001MqJ2vUha3IZkzN",
    "sessionID": "ses_12ef5b29dffeNWj9H9elnMCmbv",
    "type": "text",
    "text": "The command produced the following output:\n\n```\nreal\t0m10.001s\nuser\t0m0.000s\nsys\t0m0.001s\n```",
    "time": {
      "start": 1781623586753,
      "end": 1781623587085
    }
  }
}
```

where 1781623587085 - 1781623586753 = 332 ms, or 0.332 sec and is clearly not anywhere close to 10 seconds.

After the fix in this PR, the local build of of `opencode` produces something like:

```json
{
  "type": "text",
  "timestamp": 1781635217752,
  "sessionID": "ses_12e44bf64ffer14wSI0QfvgZtj",
  "part": {
    "id": "prt_ed1bbd3c9001Iv3RErkj2zz4dz",
    "messageID": "msg_ed1bbc128001JABc8U374fps3W",
    "sessionID": "ses_12e44bf64ffer14wSI0QfvgZtj",
    "type": "text",
    "text": "The command took approximately 10 seconds to complete:\n\n```\nreal\t0m10.001s\nuser\t0m0.000s\nsys\t0m0.001s\n```\n\n- **real**: Total elapsed time (10.001s)\n- **user**: CPU time in user mode (negligible)\n- **sys**: CPU time in kernel mode (negligible)",
    "time": {
      "start": 1781635208137,
      "end": 1781635217750
    }
  }
}
```

where 1781635217750 - 1781635208137 = 9613 ms = 9.613 sec is close enough to 10.0 sec.

### How did you verify your code works?

I added a new unit test in this PR that fails without the patch and passed with the patch.

I also built and run the binary locally with:

```bash
time /mounted_from_host/PROJECTS/opencode/packages/opencode/dist/opencode-linux-x64/bin/opencode \
  run --format=json --model opencode/nemotron-3-ultra-free \
  "Run the comamnd 'time sleep 10s' and report what it shows" | jq
```

and verified that it gave a reasonable timing for a command that should take 10 sec.  The above produced:

```json
{
  "type": "text",
  "timestamp": 1781635217752,
  "sessionID": "ses_12e44bf64ffer14wSI0QfvgZtj",
  "part": {
    "id": "prt_ed1bbd3c9001Iv3RErkj2zz4dz",
    "messageID": "msg_ed1bbc128001JABc8U374fps3W",
    "sessionID": "ses_12e44bf64ffer14wSI0QfvgZtj",
    "type": "text",
    "text": "The command took approximately 10 seconds to complete:\n\n```\nreal\t0m10.001s\nuser\t0m0.000s\nsys\t0m0.001s\n```\n\n- **real**: Total elapsed time (10.001s)\n- **user**: CPU time in user mode (negligible)\n- **sys**: CPU time in kernel mode (negligible)",
    "time": {
      "start": 1781635208137,
      "end": 1781635217750
    }
  }
}
```

where 1781635217750 - 1781635208137 = 9613 ms = 9.613 sec is close enough to 10.0 sec.

### Screenshots / recordings

I don't have any screenshots.  They are not needed.  The above is enough to fully expose the defect and demonstrate the fix.

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
