### PR TITLE
fix(session): preserve reasoning part type on model switch

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -372,11 +372,13 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         }
         if (part.type === "reasoning") {
           if (differentModel) {
-            if (part.text.trim().length > 0)
-              assistantMessage.parts.push({
-                type: "text",
-                text: part.text,
-              })
+            // Strip providerMetadata on model switch to avoid provider-specific
+            // leakage (e.g., Bedrock thinking signatures), but preserve the
+            // reasoning part type for prefix cache compatibility
+            assistantMessage.parts.push({
+              type: "reasoning",
+              text: part.text,
+            })
             continue
           }
           assistantMessage.parts.push({


### PR DESCRIPTION
### Issue for this PR

Closes #32603

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Switching between models triggers mass prefix cache invalidation, causing long delays as the model re-processes the entire conversation history.

PR #25303 fixed Bedrock signature validation by converting reasoning parts to text when switching models. This broke prefix caching because the `reasoning_content` field gets lost. Plan and Build modes use different model IDs to support different sampling parameters per the model card, so switching modes triggers this conversion even though it's the same underlying model.

This change preserves reasoning parts as they were for the prior model, while stripping provider-specific metadata. This maintains the message structure prefix caches on while preventing Bedrock signature leakage between models.

### How did you verify your code works?

Network capture analysis comparing requests before and after model switches:

**Before fix:**
- Build mode: Assistant messages include `reasoning_content` field
- Plan mode (or switch to another model): `reasoning_content` field missing from most assistant messages

**After fix:**
- Build mode: Assistant messages include `reasoning_content` field
- Plan mode (or switch to another model): Assistant messages include `reasoning_content` field

Both modes now maintain the `reasoning_content` field, enabling prefix cache hits on model switches.

### Screenshots / recordings

N/A -- terminal behavior

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
