### PR TITLE
fix(shell): apply external_directory check to redirect targets

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -124,6 +124,51 @@ function commands(node: Node) {
   return node.descendantsOfType("command").filter((child): child is Node => Boolean(child))
 }
 
+// Pseudo-devices and fd targets that are never a real out-of-project file. Used to
+// avoid spurious external_directory prompts for redirects such as `2>/dev/null`.
+const REDIRECT_DEVICES = new Set(["/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty", "/dev/zero"])
+
+// Collect the file destinations of a command's redirects (e.g. the `out.txt` in
+// `cmd > out.txt`, the `~/.bashrc` in `cmd >> ~/.bashrc`, the `f` in `cmd 2> f`).
+// tree-sitter-bash models these as `file_redirect` siblings of the command inside a
+// `redirected_statement`, so the command-name scan in parts() never inspects them
+// (it skips `redirection` nodes). Without this, a write whose only out-of-project
+// path is the redirect target (e.g. `echo data > /var/www/html/x`, where `echo` is
+// not in FILES and the target is a redirection node skipped by parts()) bypasses the
+// external_directory permission. fd duplications (`>&2`, dest is a `number`),
+// here-docs/here-strings (not file_redirect), and the std-stream pseudo-devices are
+// not real files and are skipped. PowerShell redirects use a different grammar and
+// are left to argPath's existing handling; this scan is bash/posix only.
+function redirectFiles(node: Node, ps: boolean) {
+  if (ps) return [] as string[]
+  const parent = node.parent
+  if (!parent || parent.type !== "redirected_statement") return [] as string[]
+  const out: string[] = []
+  for (let i = 0; i < parent.childCount; i++) {
+    const redirect = parent.child(i)
+    if (!redirect || redirect.type !== "file_redirect") continue
+    let dest: Node | undefined
+    for (let j = 0; j < redirect.childCount; j++) {
+      const child = redirect.child(j)
+      if (!child) continue
+      if (
+        child.type === "word" ||
+        child.type === "string" ||
+        child.type === "raw_string" ||
+        child.type === "concatenation"
+      ) {
+        dest = child
+        break
+      }
+    }
+    if (!dest) continue
+    const text = dest.text
+    if (REDIRECT_DEVICES.has(text) || text.startsWith("/dev/fd/")) continue
+    out.push(text)
+  }
+  return out
+}
+
 function unquote(text: string) {
   if (text.length < 2) return text
   const first = text[0]
@@ -408,6 +453,18 @@ export const ShellTool = Tool.define(
             const dir = (yield* fs.isDir(resolved)) ? resolved : path.dirname(resolved)
             scan.dirs.add(dir)
           }
+        }
+
+        // Redirect destinations resolve through the same argPath/containsPath path as
+        // positional args of FILES commands. argPath bails on dynamic values ($VAR,
+        // $(...), backticks) via dynamic(), so those redirect targets are fail-open in
+        // the same way every other arg in this scan already is.
+        for (const arg of redirectFiles(node, ps)) {
+          const resolved = yield* argPath(arg, cwd, ps, shell)
+          yield* Effect.logInfo("resolved redirect path", { arg, resolved })
+          if (!resolved || containsPath(resolved, instance)) continue
+          const dir = (yield* fs.isDir(resolved)) ? resolved : path.dirname(resolved)
+          scan.dirs.add(dir)
         }
 
         if (tokens.length && (!cmd || !CWD.has(cmd))) {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1236,3 +1236,158 @@ describe("tool.shell truncation", () => {
     ),
   )
 })
+
+describe("tool.shell redirect external_directory", () => {
+  each("asks for external_directory permission for output redirect target", () =>
+    Effect.gen(function* () {
+      const outerTmp = yield* tmpdirScoped()
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          const target = path.join(outerTmp, "dump.txt")
+          expect(
+            yield* fail(
+              {
+                command: `env > ${target}`,
+                description: "Redirect env outside project",
+              },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          const expected = glob(path.join(outerTmp, "*"))
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain(expected)
+          expect(extDirReq!.metadata).toMatchObject({ directories: [outerTmp] })
+        }),
+      )
+    }),
+  )
+
+  each("asks for external_directory permission for append redirect target", () =>
+    Effect.gen(function* () {
+      const outerTmp = yield* tmpdirScoped()
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          const target = path.join(outerTmp, "authorized_keys")
+          expect(
+            yield* fail(
+              {
+                command: `echo secret >> ${target}`,
+                description: "Append outside project",
+              },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain(glob(path.join(outerTmp, "*")))
+        }),
+      )
+    }),
+  )
+
+  each("asks for external_directory permission for stderr redirect target", () =>
+    Effect.gen(function* () {
+      const outerTmp = yield* tmpdirScoped()
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          const target = path.join(outerTmp, "err.log")
+          expect(
+            yield* fail(
+              {
+                command: `ls 2> ${target}`,
+                description: "Redirect stderr outside project",
+              },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain(glob(path.join(outerTmp, "*")))
+        }),
+      )
+    }),
+  )
+
+  each("asks for external_directory permission for input redirect source", () =>
+    Effect.gen(function* () {
+      const outerTmp = yield* tmpdirScoped()
+      yield* Effect.promise(() => Bun.write(path.join(outerTmp, "in.txt"), "x"))
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const err = new Error("stop after permission")
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          const source = path.join(outerTmp, "in.txt")
+          expect(
+            yield* fail(
+              {
+                command: `wc -l < ${source}`,
+                description: "Read input redirect outside project",
+              },
+              capture(requests, err),
+            ),
+          ).toMatchObject({ message: err.message })
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeDefined()
+          expect(extDirReq!.patterns).toContain(glob(path.join(outerTmp, "*")))
+        }),
+      )
+    }),
+  )
+
+  each("does not ask for external_directory permission for /dev/null and fd-dup redirects", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          yield* run(
+            {
+              command: "ls /etc > /dev/null 2>&1",
+              description: "Discard output",
+            },
+            capture(requests),
+          )
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeUndefined()
+        }),
+      )
+    }),
+  )
+
+  each("does not ask for external_directory permission for in-project redirect target", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const requests: Array<Omit<PermissionV1.Request, "id" | "sessionID" | "tool">> = []
+          yield* run(
+            {
+              command: `env > ${path.join(tmp, "local.txt")}`,
+              description: "Redirect inside project",
+            },
+            capture(requests),
+          )
+          const extDirReq = requests.find((r) => r.permission === "external_directory")
+          expect(extDirReq).toBeUndefined()
+        }),
+      )
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32628

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The shell tool scans a command's path arguments and gates out-of-project ones through `external_directory`, but it `continue`s past `redirection` nodes and never looks at the redirect target. So `cp foo /tmp/x` asks for `external_directory` while `cat foo > /tmp/x`, `env > /tmp/x`, or `echo k >> ~/.ssh/authorized_keys` write outside the project without ever hitting that permission — only `bash` fires. That makes the shell redirect the one write path that ignores a boundary every other tool (`write`/`edit`/`cp`) respects.

The fix pulls each `file_redirect` destination and runs it through the same `argPath → containsPath → scan.dirs` path the command's normal args already use, so an external redirect target asks for `external_directory` exactly like `cp` to the same place. fd-dups (`>&`, `2>&1`), here-docs, and std-stream pseudo-devices (`/dev/null`, `/dev/stdout`, `/dev/fd/*`) are skipped; in-project targets are unaffected. It reuses the existing scan pipeline rather than adding a parallel path, which is why it stays consistent with how `cp` is already handled.

Out of scope (unchanged): interpreter forms that build the path at runtime (`sh -c '… > /out'`, `$(…)`) — same limitation as the existing argument scan.

### How did you verify your code works?

`bun test test/tool/shell.test.ts` → 29 pass / 0 fail (23 existing + 6 new). As a control I ran the 6 new tests against the unpatched `shell.ts`: exactly the 4 "should ask" redirect cases fail (gate silent) and the 2 no-false-positive cases pass — so the tests detect the real defect, not just confirm the new code. I also reproduced it by hand on `dev`: with `external_directory: ask`, `cp src /external/x` prompts but `env > /external/x` does not before the change, and both prompt after.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
