### PR TITLE
fix(tui): prevent whitespace-only prompt from being submitted

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -951,7 +951,7 @@ export function Prompt(props: PromptProps) {
     if (props.disabled) return false
     if (workspace.creating() || move.creating()) return false
     if (auto()?.visible) return false
-    if (!store.prompt.input) return false
+    if (!store.prompt.input.trim()) return false
     const agent = local.agent.current()
     if (!agent) return false
     const trimmed = store.prompt.input.trim()


### PR DESCRIPTION
### Issue for this PR

Closes #32631

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Issue:** Pressing Enter on a whitespace-only prompt (spaces, tabs, etc.) submits a blank user message to the session.

**Root cause:** The submit guard checked `!store.prompt.input`, but a whitespace-only string is truthy, so it passed and triggered submission.

**Fix:** Add `.trim()` to the guard:

\`\`\`diff
- if (!store.prompt.input) return false
+ if (!store.prompt.input.trim()) return false
\`\`\`

The trimmed value is already computed two lines below for slash-command detection (`const trimmed = store.prompt.input.trim()`), so this is a minimal, safe change with no side effects.

### How did you verify your code works?

Typed one or more spaces into the TUI prompt and pressed Enter — no message was submitted. Normal (non-whitespace) input continues to submit as expected.

### Screenshots / recordings

_N/A — no visual change; blank submission simply no longer occurs._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR