### PR TITLE
fix(acp): include resource URI as source prefix in text parts

### DIFF
--- a/packages/opencode/src/acp/content.ts
+++ b/packages/opencode/src/acp/content.ts
@@ -76,7 +76,19 @@ export function contentBlockToParts(block: ContentBlock): PromptPart[] {
 
     case "resource":
       if ("text" in block.resource) {
-        return [{ type: "text", text: block.resource.text }]
+        const { uri, text } = block.resource
+        let source = uri
+        try {
+          if (uri.startsWith("zed://")) {
+            source = new URL(uri).searchParams.get("path") ?? uri
+          } else if (uri.startsWith("file://")) {
+            const u = new URL(uri)
+            source = u.pathname + u.hash
+          }
+        } catch {
+          // keep uri as-is
+        }
+        return [{ type: "text", text: `${source}\n${text}` }]
       }
       if (block.resource.mimeType) {
         return [

--- a/packages/opencode/test/acp/content.test.ts
+++ b/packages/opencode/test/acp/content.test.ts
@@ -99,7 +99,7 @@ describe("acp content conversion", () => {
     ])
   })
 
-  test("resource with text becomes a text part", () => {
+  test("resource with text includes file path prefix so LLM knows the source", () => {
     expect(
       contentBlockToParts({
         type: "resource",
@@ -109,7 +109,31 @@ describe("acp content conversion", () => {
           text: "context",
         },
       }),
-    ).toEqual([{ type: "text", text: "context" }])
+    ).toEqual([{ type: "text", text: "/tmp/context.txt\ncontext" }])
+  })
+
+  test("resource with zed:// uri decodes path for the prefix", () => {
+    expect(
+      contentBlockToParts({
+        type: "resource",
+        resource: {
+          uri: "zed://workspace?path=/home/user/project/src/main.ts",
+          text: "export function main() {}",
+        },
+      }),
+    ).toEqual([{ type: "text", text: "/home/user/project/src/main.ts\nexport function main() {}" }])
+  })
+
+  test("resource with file:// uri preserves line-range fragment in prefix", () => {
+    expect(
+      contentBlockToParts({
+        type: "resource",
+        resource: {
+          uri: "file:///src/app.ts#L10-L20",
+          text: "const x = 1",
+        },
+      }),
+    ).toEqual([{ type: "text", text: "/src/app.ts#L10-L20\nconst x = 1" }])
   })
 
   test("resource with blob and mimeType becomes a data URL file part", () => {

--- a/packages/ui/src/components/file.tsx
+++ b/packages/ui/src/components/file.tsx
@@ -52,7 +52,6 @@ const VIRTUALIZE_BYTES = 500_000
 const codeMetrics = {
   ...DEFAULT_VIRTUAL_FILE_METRICS,
   lineHeight: 24,
-  spacing: 0,
 } satisfies Partial<VirtualFileMetrics>
 
 type SharedProps<T> = {

--- a/packages/ui/src/pierre/virtualizer.ts
+++ b/packages/ui/src/pierre/virtualizer.ts
@@ -16,7 +16,6 @@ const cache = new WeakMap<Document | HTMLElement, Entry>()
 export const virtualMetrics: Partial<VirtualFileMetrics> = {
   lineHeight: 24,
   hunkSeparatorHeight: 24,
-  spacing: 0,
 }
 
 function scrollable(value: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #32558

### Type of change

- [x] Bug fix

### What does this PR do?

When an editor (e.g. Zed) sends a code selection via ACP, it uses a `type: "resource"` ContentBlock where `resource.uri` carries the file path (+ optional line range) and `resource.text` carries the selected text. `contentBlockToParts()` was silently dropping `resource.uri`, so the LLM received the selected text with no indication of which file it came from.

The fix decodes `resource.uri` to a human-readable source path (handling `file://` and `zed://` schemes, preserving `#L10-L20` fragment anchors) and prepends it as a one-line header before `resource.text`. This mirrors how `resource_link` already exposes the URI to the model.

Also removes two stale `spacing: 0` references that no longer exist in `VirtualFileMetrics` after a `@pierre/diffs` update — they caused a typecheck failure in the enterprise package.

### How did you verify your code works?

Updated the existing `resource with text` test to assert the path prefix and added two new test cases: one for `zed://` URIs and one for `file://` URIs with line-range fragments. All 15 tests in `test/acp/content.test.ts` pass. Full monorepo typecheck passes.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR