### PR TITLE
fix(session): anchor system prompt date to session-start time

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1326,7 +1326,7 @@ export const layer = Layer.effect(
 
             const [skills, env, instructions, modelMsgs] = yield* Effect.all([
               sys.skills(agent),
-              sys.environment(model),
+              sys.environment(model, session.time.created),
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -39,7 +39,7 @@ export function provider(model: Provider.Model) {
 }
 
 export interface Interface {
-  readonly environment: (model: Provider.Model) => Effect.Effect<string[]>
+  readonly environment: (model: Provider.Model, sessionCreated?: number) => Effect.Effect<string[]>
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
 }
 
@@ -52,7 +52,7 @@ export const layer = Layer.effect(
     const locations = yield* LocationServiceMap
 
     return Service.of({
-      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model) {
+      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model, sessionCreated?: number) {
         const ctx = yield* InstanceState.context
         const references = yield* Effect.gen(function* () {
           yield* (yield* PluginBoot.Service).wait()
@@ -67,7 +67,7 @@ export const layer = Layer.effect(
             `  Workspace root folder: ${ctx.worktree}`,
             `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
-            `  Today's date: ${new Date().toDateString()}`,
+            `  Today's date: ${new Date(sessionCreated ?? Date.now()).toDateString()}`,
             `</env>`,
           ].join("\n"),
           references.length === 0


### PR DESCRIPTION
## Problem

`SystemPrompt.environment()` emits `Today's date: ${new Date().toDateString()}` on every LLM request. `applyCaching()` in `provider/transform.ts` marks the first two system messages with `cacheControl`, so the date lands inside the cached prefix.

`toDateString()` rolls over at local midnight. A session active across midnight sends a different system prefix on the next request — full cache miss, and the entire system block is re-billed as a write instead of a read. It is the only daily-changing token in that block; all other fields (model id, cwd, platform, git status) are session-stable. Caching is therefore defeated exactly for the long-running sessions that benefit most.

## Fix

Pass the session's creation timestamp (`session.time.created`) into `SystemPrompt.environment()` and use `new Date(sessionCreated ?? Date.now()).toDateString()` in place of `new Date().toDateString()`.

The date shown to the model is now pinned to the moment the session was opened. It never changes between requests in the same session, so the cached system prefix remains stable across midnight.

For short sessions (the common case) the behaviour is identical to before. For sessions that span midnight the model sees the session-start date rather than the current date — a minor semantic trade-off that eliminates a needless cache miss.

## Changes

- `packages/opencode/src/session/system.ts`: extend `Interface.environment` with optional `sessionCreated?: number`; replace `new Date()` with `new Date(sessionCreated ?? Date.now())`
- `packages/opencode/src/session/prompt.ts`: pass `session.time.created` at the call site

Fixes #32622