### PR TITLE
feat(tui): add session history sidebar

### DIFF
--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -12,6 +12,7 @@ import { useEditorContext } from "../context/editor"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useTuiConfig } from "../config"
 import { HomeSessionDestinationProvider } from "./home/session-destination"
+import { Sidebar } from "./session/sidebar"
 
 let once = false
 const placeholder = {
@@ -69,23 +70,26 @@ export function Home() {
 
   return (
     <HomeSessionDestinationProvider>
-      <box flexGrow={1} alignItems="center" paddingLeft={2} paddingRight={2}>
-        <box flexGrow={1} minHeight={0} />
-        <box height={4} minHeight={0} flexShrink={1} />
-        <box flexShrink={0}>
-          <pluginRuntime.Slot name="home_logo" mode="replace">
-            <Logo />
-          </pluginRuntime.Slot>
+      <box flexDirection="row" flexGrow={1} minHeight={0}>
+        <Sidebar />
+        <box flexGrow={1} alignItems="center" paddingLeft={2} paddingRight={2}>
+          <box flexGrow={1} minHeight={0} />
+          <box height={4} minHeight={0} flexShrink={1} />
+          <box flexShrink={0}>
+            <pluginRuntime.Slot name="home_logo" mode="replace">
+              <Logo />
+            </pluginRuntime.Slot>
+          </box>
+          <box height={1} minHeight={0} flexShrink={1} />
+          <box width="100%" maxWidth={promptMaxWidth()} zIndex={1000} paddingTop={1} flexShrink={0}>
+            <pluginRuntime.Slot name="home_prompt" mode="replace" ref={bind}>
+              <Prompt ref={bind} right={<pluginRuntime.Slot name="home_prompt_right" />} placeholders={placeholder} />
+            </pluginRuntime.Slot>
+          </box>
+          <pluginRuntime.Slot name="home_bottom" />
+          <box flexGrow={1} minHeight={0} />
+          <Toast />
         </box>
-        <box height={1} minHeight={0} flexShrink={1} />
-        <box width="100%" maxWidth={promptMaxWidth()} zIndex={1000} paddingTop={1} flexShrink={0}>
-          <pluginRuntime.Slot name="home_prompt" mode="replace" ref={bind}>
-            <Prompt ref={bind} right={<pluginRuntime.Slot name="home_prompt_right" />} placeholders={placeholder} />
-          </pluginRuntime.Slot>
-        </box>
-        <pluginRuntime.Slot name="home_bottom" />
-        <box flexGrow={1} minHeight={0} />
-        <Toast />
       </box>
       <box width="100%" flexShrink={0}>
         <pluginRuntime.Slot name="home_footer" mode="single_winner" />

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -260,15 +260,15 @@ export function Session() {
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
 
-  const wide = createMemo(() => dimensions().width > 120)
+  const wide = createMemo(() => dimensions().width > 80)
   const sidebarVisible = createMemo(() => {
     if (session()?.parentID) return false
     if (sidebarOpen()) return true
-    if (sidebar() === "auto" && wide()) return true
+    if (sidebar() === "auto") return true
     return false
   })
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() && wide() ? 42 : 0) - 4)
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -1,55 +1,66 @@
 import { useProject } from "../../context/project"
 import { useSync } from "../../context/sync"
-import { createMemo, Show } from "solid-js"
+import { createMemo, For, Show, createSignal } from "solid-js"
 import { useTheme } from "../../context/theme"
 import { useTuiConfig } from "../../config"
 import { InstallationChannel, InstallationVersion } from "@opencode-ai/core/installation/version"
 import { usePluginRuntime } from "../../plugin/runtime"
+import { useRoute } from "../../context/route"
 
 import { getScrollAcceleration } from "../../util/scroll"
 import { WorkspaceLabel } from "../../component/workspace-label"
 
-export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+export function Sidebar(props: { sessionID?: string; overlay?: boolean }) {
   const pluginRuntime = usePluginRuntime()
   const project = useProject()
   const sync = useSync()
   const { theme } = useTheme()
   const tuiConfig = useTuiConfig()
-  const session = createMemo(() => sync.session.get(props.sessionID))
+  const { navigate } = useRoute()
+  const session = createMemo(() => (props.sessionID ? sync.session.get(props.sessionID) : undefined))
   const workspace = () => {
     const workspaceID = session()?.workspaceID
     if (!workspaceID) return
     return project.workspace.get(workspaceID)
   }
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
+  const hasSession = () => !!session()
+
+  const allSessions = createMemo(() => {
+    const currentWorkspace = project.workspace.current()
+    return sync.data.session
+      .filter((s) => s.workspaceID === currentWorkspace && !s.parentID)
+      .toSorted((a, b) => b.time.created - a.time.created)
+      .slice(0, 50)
+  })
 
   return (
-    <Show when={session()}>
-      <box
-        backgroundColor={theme.backgroundPanel}
-        width={42}
-        height="100%"
-        paddingTop={1}
-        paddingBottom={1}
-        paddingLeft={2}
-        paddingRight={2}
-        position={props.overlay ? "absolute" : "relative"}
+    <box
+      backgroundColor={theme.backgroundPanel}
+      width={42}
+      height="100%"
+      paddingTop={1}
+      paddingBottom={1}
+      paddingLeft={2}
+      paddingRight={2}
+      position={props.overlay ? "absolute" : "relative"}
+    >
+      <scrollbox
+        flexGrow={1}
+        scrollAcceleration={scrollAcceleration()}
+        verticalScrollbarOptions={{
+          trackOptions: {
+            backgroundColor: theme.background,
+            foregroundColor: theme.borderActive,
+          },
+        }}
       >
-        <scrollbox
-          flexGrow={1}
-          scrollAcceleration={scrollAcceleration()}
-          verticalScrollbarOptions={{
-            trackOptions: {
-              backgroundColor: theme.background,
-              foregroundColor: theme.borderActive,
-            },
-          }}
-        >
-          <box flexShrink={0} gap={1} paddingRight={1}>
+        <box flexDirection="column" flexShrink={0} gap={1} paddingRight={1}>
+          <Show when={hasSession()}>
             <pluginRuntime.Slot
               name="sidebar_title"
               mode="single_winner"
-              session_id={props.sessionID}
+              session_id={props.sessionID ?? ""}
               title={session()!.title}
               share_url={session()!.share?.url}
             >
@@ -82,22 +93,49 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                 </Show>
               </box>
             </pluginRuntime.Slot>
-            <pluginRuntime.Slot name="sidebar_content" session_id={props.sessionID} />
-          </box>
-        </scrollbox>
+            <pluginRuntime.Slot name="sidebar_content" session_id={props.sessionID ?? ""} />
+          </Show>
 
-        <box flexShrink={0} gap={1} paddingTop={1}>
-          <pluginRuntime.Slot name="sidebar_footer" mode="single_winner" session_id={props.sessionID}>
+          <Show when={allSessions().length > 0}>
+            <box height={1} />
             <text fg={theme.textMuted}>
-              <span style={{ fg: theme.success }}>•</span> <b>Open</b>
-              <span style={{ fg: theme.text }}>
-                <b>Code</b>
-              </span>{" "}
-              <span>{InstallationVersion}</span>
+              <b>Session History</b>
             </text>
-          </pluginRuntime.Slot>
+            <box height={1} />
+            <For each={allSessions()}>
+              {(s) => {
+                const [hover, setHover] = createSignal(false)
+                const isActive = s.id === props.sessionID
+                return (
+                  <box
+                    onMouseOver={() => setHover(true)}
+                    onMouseOut={() => setHover(false)}
+                    onMouseUp={() => navigate({ type: "session", sessionID: s.id })}
+                    paddingLeft={1}
+                    backgroundColor={hover() || isActive ? theme.backgroundElement : undefined}
+                  >
+                    <text fg={isActive ? theme.accent : theme.text}>
+                      {s.title || "Untitled"}
+                    </text>
+                  </box>
+                )
+              }}
+            </For>
+          </Show>
         </box>
+      </scrollbox>
+
+      <box flexShrink={0} gap={1} paddingTop={1}>
+        <pluginRuntime.Slot name="sidebar_footer" mode="single_winner" session_id={props.sessionID ?? ""}>
+          <text fg={theme.textMuted}>
+            <span style={{ fg: theme.success }}>•</span> <b>Open</b>
+            <span style={{ fg: theme.text }}>
+              <b>Code</b>
+            </span>{" "}
+            <span>{InstallationVersion}</span>
+          </text>
+        </pluginRuntime.Slot>
       </box>
-    </Show>
+    </box>
   )
 }


### PR DESCRIPTION
Add a session history list to the right sidebar, allowing users to quickly navigate between sessions.

## Changes
- \sidebar.tsx\: Added session history list below current session info, sorted by creation time (newest first), click to navigate
- \home.tsx\: Sidebar now visible on the home screen (not just in sessions)
- \session/index.tsx\: Removed 120-column width threshold for sidebar display; uses overlay mode on narrow terminals to preserve content space

## Testing
Run the built binary or \un run --conditions=browser ./src/index.ts\ from \packages/opencode\.