### PR TITLE
fix(session): anchor system prompt date to session-start time

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1326,7 +1326,7 @@ export const layer = Layer.effect(
 
             const [skills, env, instructions, modelMsgs] = yield* Effect.all([
               sys.skills(agent),
-              sys.environment(model),
+              sys.environment(model, session.time.created),
               instruction.system().pipe(Effect.orDie),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -39,7 +39,7 @@ export function provider(model: Provider.Model) {
 }
 
 export interface Interface {
-  readonly environment: (model: Provider.Model) => Effect.Effect<string[]>
+  readonly environment: (model: Provider.Model, sessionCreated?: number) => Effect.Effect<string[]>
   readonly skills: (agent: Agent.Info) => Effect.Effect<string | undefined>
 }
 
@@ -52,7 +52,7 @@ export const layer = Layer.effect(
     const locations = yield* LocationServiceMap
 
     return Service.of({
-      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model) {
+      environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model, sessionCreated?: number) {
         const ctx = yield* InstanceState.context
         const references = yield* Effect.gen(function* () {
           yield* (yield* PluginBoot.Service).wait()
@@ -67,7 +67,7 @@ export const layer = Layer.effect(
             `  Workspace root folder: ${ctx.worktree}`,
             `  Is directory a git repo: ${ctx.project.vcs === "git" ? "yes" : "no"}`,
             `  Platform: ${process.platform}`,
-            `  Today's date: ${new Date().toDateString()}`,
+            `  Today's date: ${new Date(sessionCreated ?? Date.now()).toDateString()}`,
             `</env>`,
           ].join("\n"),
           references.length === 0


### PR DESCRIPTION
### Issue for this PR

Closes #32622

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SystemPrompt.environment()` called `new Date().toDateString()` on every LLM request. The environment block ends up in `system[0]`, which `applyCaching()` marks with `cacheControl: { type: "ephemeral" }` — so any date change busts the entire cached system prefix.

At midnight, the date string changes. Any long-running session that crosses midnight would lose its system prompt cache hit and re-bill all those tokens as writes.

Fix: pass `session.time.created` (a Unix ms timestamp already available in scope) into `environment()` and use it as the date source. The date is now anchored to when the session opened, so the cached system block stays stable for the session lifetime.

Two-file change: update the interface and implementation signature in `system.ts`, update the call site in `prompt.ts`.

Trade-off: a session that spans midnight shows the session-start date rather than the current date. Minor inaccuracy for a rare edge case, avoids the cache bust.

### How did you verify your code works?

Traced through `applyCaching()` in `transform.ts` and `prepare()` in `session/llm/request.ts` to confirm the environment block lands in the cached `system[0]`. Ran `bun run typecheck` across all packages — passes clean.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR