### PR TITLE
feat(plugin): let tool.execute.before short-circuit with a result

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -84,12 +84,18 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
         return run.promise(
           Effect.gen(function* () {
             const ctx = context(args, options)
+            const before: { args: any; result?: string } = { args }
             yield* plugin.trigger(
               "tool.execute.before",
               { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
-              { args },
+              before,
             )
-            const result = yield* item.execute(args, ctx)
+            // A plugin may short-circuit the call by setting `result`: skip
+            // execution and return the supplied output instead.
+            const result =
+              before.result !== undefined
+                ? { title: "", output: before.result, metadata: {} }
+                : yield* item.execute(before.args, ctx)
             const output = {
               ...result,
               attachments: result.attachments?.map((attachment) => ({
@@ -125,24 +131,31 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
       run.promise(
         Effect.gen(function* () {
           const ctx = context(args, opts)
+          const before: { args: any; result?: string } = { args }
           yield* plugin.trigger(
             "tool.execute.before",
             { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
-            { args },
+            before,
           )
-          const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
-            yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
-            return yield* Effect.promise(() => execute(args, opts))
-          }).pipe(
-            Effect.withSpan("Tool.execute", {
-              attributes: {
-                "tool.name": key,
-                "tool.call_id": opts.toolCallId,
-                "session.id": ctx.sessionID,
-                "message.id": input.processor.message.id,
-              },
-            }),
-          )
+          // A plugin may short-circuit the call by setting `result`: skip
+          // execution (and the permission prompt) and return the supplied
+          // output as a single text content item instead.
+          const result: Awaited<ReturnType<NonNullable<typeof execute>>> =
+            before.result !== undefined
+              ? { content: [{ type: "text", text: before.result }] }
+              : yield* Effect.gen(function* () {
+                  yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
+                  return yield* Effect.promise(() => execute(before.args, opts))
+                }).pipe(
+                  Effect.withSpan("Tool.execute", {
+                    attributes: {
+                      "tool.name": key,
+                      "tool.call_id": opts.toolCallId,
+                      "session.id": ctx.sessionID,
+                      "message.id": input.processor.message.id,
+                    },
+                  }),
+                )
           yield* plugin.trigger(
             "tool.execute.after",
             { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -265,7 +265,16 @@ export interface Hooks {
   ) => Promise<void>
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },
-    output: { args: any },
+    output: {
+      args: any
+      /**
+       * If set, the tool is NOT executed and this string is returned as its
+       * output instead. Lets a plugin answer a tool call itself (e.g. a cache
+       * or memory plugin that already holds the result). The "tool.execute.after"
+       * hook still runs on the substituted result.
+       */
+      result?: string
+    },
   ) => Promise<void>
   "shell.env"?: (
     input: { cwd: string; sessionID?: string; callID?: string },


### PR DESCRIPTION
### Issue for this PR

Refs #5148

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

It lets a plugin short-circuit a tool call from `tool.execute.before` by supplying the result itself.

`tool.execute.before` currently only exposes `{ args }`, so a plugin can rewrite arguments but cannot prevent the tool from running. In `SessionTools.resolve` the runtime always calls the tool after the hook (the native path around L92 and the MCP path around L135). `tool.execute.after` can rewrite the output, but only after the work already happened, and `permission.ask` can deny a call but returns an error rather than a usable result.

This adds an optional `result?: string` to the before-hook output. If a plugin sets it, the tool is not executed and that string is returned as the tool output instead; `tool.execute.after` still runs on the substituted result. It is wired through both the native and MCP tool paths. Hooks that do not set `result` behave exactly as before, so it is backwards compatible.

The motivating case is a cache/memory plugin that already holds the answer for a `read`/`grep` and wants to return it instead of doing the read. This is the minimal "early termination" slice of the broader middleware pipeline discussed in #5148 (a prior attempt, #18689, implemented a larger version but was auto-closed before review). The `Hooks` interface is hand-written in `packages/plugin`, so no SDK regeneration applies.

### How did you verify your code works?

`bun run typecheck` passes for both the `opencode` and `plugin` packages (no errors in the changed files), `prettier --check` is clean, and `oxlint` reports no errors on the two files. I did not add an automated test: the `SessionTools.resolve` plugin-hook path has no existing unit-test harness and a full session/plugin integration test would be disproportionate to the change, so I verified by typechecking and tracing both branches. Happy to add coverage if you can point me at the right harness.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
