### PR TITLE
fix(opencode): refresh models before provider listing

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -16,6 +16,7 @@ import { Env } from "../env"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { iife } from "@/util/iife"
 import { Global } from "@opencode-ai/core/global"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import path from "path"
 import { pathToFileURL } from "url"
 import { Effect, Layer, Context, Schema, Types } from "effect"
@@ -1297,6 +1298,9 @@ export const layer = Layer.effect(
       Effect.gen(function* () {
         const bridge = yield* EffectBridge.make()
         const cfg = yield* config.get()
+        if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !Flag.OPENCODE_MODELS_PATH) {
+          yield* modelsDevSvc.refresh()
+        }
         const modelsDev = yield* modelsDevSvc.get()
         const catalog = mapValues(modelsDev, fromModelsDevProvider)
         const database = mapValues(catalog, toPublicInfo)


### PR DESCRIPTION
### Issue for this PR

Closes #32698

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Provider listing builds its in-memory model list from the local models.dev cache. If that cache is stale when opencode starts, `/models` can show old provider models even though a refresh would fetch the new catalog.

This refreshes models.dev before the provider service snapshots the provider/model list. It skips that behavior when models fetching is disabled or `OPENCODE_MODELS_PATH` is set, so fixture/custom catalog flows keep their existing behavior.

This fixes newly added Nebius Token Factory models not appearing in `/models` when the local models cache is stale.

### How did you verify your code works?

- Ran `bun run --cwd packages/opencode typecheck`
- Tested a clean cache with `NEBIUS_API_KEY=test ... opencode models nebius` and confirmed the active Nebius Token Factory models are listed

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR