### PR TITLE
feat(tui): expose a prompt facade to TUI plugins (text, extmarks, cursor geometry)

### DIFF
--- a/packages/opencode/src/plugin/tui/runtime.ts
+++ b/packages/opencode/src/plugin/tui/runtime.ts
@@ -609,6 +609,12 @@ function pluginApi(runtime: RuntimeState, plugin: PluginEntry, scope: PluginScop
     },
   }
 
+  const prompt: TuiPluginApi["prompt"] = {
+    ref: () => api.prompt.ref(),
+    onChange: (callback) => scope.track(api.prompt.onChange(callback)),
+    onCursorChange: (callback) => scope.track(api.prompt.onCursorChange(callback)),
+  }
+
   return {
     app: api.app,
     attention: createScopedAttention(api.attention, scope, load.plugin_root),
@@ -617,6 +623,7 @@ function pluginApi(runtime: RuntimeState, plugin: PluginEntry, scope: PluginScop
     keys: api.keys,
     keymap,
     mode: createScopedMode(api.mode, scope),
+    prompt,
     route,
     ui: api.ui,
     tuiConfig: api.tuiConfig,

--- a/packages/opencode/test/cli/tui/plugin-loader.test.ts
+++ b/packages/opencode/test/cli/tui/plugin-loader.test.ts
@@ -1330,3 +1330,107 @@ test("updates installed theme when plugin metadata changes", async () => {
     delete process.env.OPENCODE_PLUGIN_META_FILE
   }
 })
+
+test("auto-disposes plugin prompt onChange subscriptions", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const file = path.join(dir, "prompt-change-plugin.ts")
+      const spec = pathToFileURL(file).href
+      await Bun.write(
+        file,
+        `export default {
+  id: "demo.prompt.change",
+  tui: async (api) => {
+    api.prompt.onChange(() => {})
+  },
+}
+`,
+      )
+      return { spec }
+    },
+  })
+
+  let change_add = 0
+  let change_drop = 0
+  const prompt = {
+    ref: () => undefined,
+    onChange: () => {
+      change_add += 1
+      return () => {
+        change_drop += 1
+      }
+    },
+    onCursorChange: () => () => {},
+  } as NonNullable<Parameters<typeof createTuiPluginApi>[0]>["prompt"]
+  const wait = spyOn(TuiConfig, "waitForDependencies").mockResolvedValue()
+  const cwd = spyOn(process, "cwd").mockImplementation(() => tmp.path)
+
+  try {
+    await TuiPluginRuntime.init({
+      api: createTuiPluginApi({ prompt }),
+      config: createTuiResolvedConfig({
+        plugin: [tmp.extra.spec],
+        plugin_origins: [{ spec: tmp.extra.spec, scope: "local", source: path.join(tmp.path, "tui.json") }],
+      }),
+    })
+    expect(change_add).toBe(1)
+    expect(change_drop).toBe(0)
+  } finally {
+    await TuiPluginRuntime.dispose()
+    expect(change_drop).toBe(1)
+    cwd.mockRestore()
+    wait.mockRestore()
+  }
+})
+
+test("auto-disposes plugin prompt onCursorChange subscriptions", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      const file = path.join(dir, "prompt-cursor-plugin.ts")
+      const spec = pathToFileURL(file).href
+      await Bun.write(
+        file,
+        `export default {
+  id: "demo.prompt.cursor",
+  tui: async (api) => {
+    api.prompt.onCursorChange(() => {})
+  },
+}
+`,
+      )
+      return { spec }
+    },
+  })
+
+  let cursor_add = 0
+  let cursor_drop = 0
+  const prompt = {
+    ref: () => undefined,
+    onChange: () => () => {},
+    onCursorChange: () => {
+      cursor_add += 1
+      return () => {
+        cursor_drop += 1
+      }
+    },
+  } as NonNullable<Parameters<typeof createTuiPluginApi>[0]>["prompt"]
+  const wait = spyOn(TuiConfig, "waitForDependencies").mockResolvedValue()
+  const cwd = spyOn(process, "cwd").mockImplementation(() => tmp.path)
+
+  try {
+    await TuiPluginRuntime.init({
+      api: createTuiPluginApi({ prompt }),
+      config: createTuiResolvedConfig({
+        plugin: [tmp.extra.spec],
+        plugin_origins: [{ spec: tmp.extra.spec, scope: "local", source: path.join(tmp.path, "tui.json") }],
+      }),
+    })
+    expect(cursor_add).toBe(1)
+    expect(cursor_drop).toBe(0)
+  } finally {
+    await TuiPluginRuntime.dispose()
+    expect(cursor_drop).toBe(1)
+    cwd.mockRestore()
+    wait.mockRestore()
+  }
+})

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -92,6 +92,7 @@ type Opts = {
   mode?: HostPluginApi["mode"]
   count?: Count
   keymap?: HostPluginApi["keymap"]
+  prompt?: HostPluginApi["prompt"]
   tuiConfig?: Partial<HostPluginApi["tuiConfig"]>
   app?: Partial<HostPluginApi["app"]>
   state?: {
@@ -113,6 +114,7 @@ type Opts = {
     mode?: HostPluginApi["theme"]["mode"]
     ready?: boolean
     current?: HostPluginApi["theme"]["current"]
+    syntax?: HostPluginApi["theme"]["syntax"]
   }
 }
 
@@ -220,6 +222,11 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
     renderer,
     slots: {
       register: () => "fixture-slot",
+    },
+    prompt: opts.prompt ?? {
+      ref: () => undefined,
+      onChange: () => () => {},
+      onCursorChange: () => () => {},
     },
     plugins: {
       list: () => [],
@@ -350,6 +357,10 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       get ready() {
         return opts.theme?.ready ?? true
       },
+      syntax: opts.theme?.syntax ?? (() => ({
+        registerStyle: () => 0,
+        getStyleId: () => null,
+      })),
     },
   }
 }

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -16,7 +16,7 @@ import type {
   TextPart,
   Config as SdkConfig,
 } from "@opencode-ai/sdk/v2"
-import type { CliRenderer, KeyEvent, RGBA, Renderable, SlotMode } from "@opentui/core"
+import type { CliRenderer, KeyEvent, RGBA, Renderable, SlotMode, TextareaRenderable } from "@opentui/core"
 import type { Binding, Keymap } from "@opentui/keymap"
 import {
   createBindingLookup as createKeymapBindingLookup,
@@ -206,6 +206,26 @@ export type TuiPromptRef = {
   blur(): void
   focus(): void
   submit(): void
+  readonly text: string
+  getTextRange(startOffset: number, endOffset: number): string
+  replaceRange(startOffset: number, endOffset: number, replacement: string): void
+  readonly extmarks: TextareaRenderable["extmarks"]
+  readonly cursorOffset: number
+}
+
+export type TuiPromptApi = {
+  /** The live prompt ref, or undefined before the prompt has mounted. Read
+   *  on demand (e.g. inside onChange) — the ref is replaced on route
+   *  changes. */
+  ref(): TuiPromptRef | undefined
+  /** Subscribe to prompt content changes (per keystroke / programmatic
+   *  edit). Survives prompt remounts. Returns a disposer. */
+  onChange(callback: () => void): () => void
+  /** Subscribe to prompt cursor moves (arrows, click positioning, drag,
+   *  word-moves, paste, delete, undo/redo). Deduplicated per offset — one
+   *  callback per logical move. Survives prompt remounts. Returns a
+   *  disposer. */
+  onCursorChange(callback: () => void): () => void
 }
 
 export type TuiPromptProps = {
@@ -356,6 +376,25 @@ export type TuiThemeCurrent = {
   readonly thinkingOpacity: number
 }
 
+export type TuiStyleDefinition = {
+  fg?: string
+  bg?: string
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  dim?: boolean
+}
+
+export type TuiSyntaxStyle = {
+  /** Register a named style. Re-registering the same name is idempotent
+   *  (returns the existing id and overwrites the previous definition) —
+   *  safe to call on plugin reload. Returns the style id (use with
+   *  extmark create({ styleId })). */
+  registerStyle(name: string, definition: TuiStyleDefinition): number
+  /** Look up a style id by name, or null if not registered. */
+  getStyleId(name: string): number | null
+}
+
 export type TuiTheme = {
   readonly current: TuiThemeCurrent
   readonly selected: string
@@ -364,6 +403,10 @@ export type TuiTheme = {
   install: (jsonPath: string) => Promise<void>
   mode: () => "dark" | "light"
   readonly ready: boolean
+  /** Register a named style and get back a style id. Use the id when
+   *  creating extmarks to render styled underlines/cursors on the
+   *  prompt. Re-registering the same name is idempotent. */
+  syntax(): TuiSyntaxStyle
 }
 
 export type TuiKV = {
@@ -591,6 +634,7 @@ export type TuiPluginApi = {
   keys: TuiKeys
   keymap: TuiKeymap
   mode: TuiModeApi
+  prompt: TuiPromptApi
   route: {
     register: (routes: TuiRouteDefinition[]) => () => void
     navigate: (name: string, params?: Record<string, unknown>) => void

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -208,6 +208,10 @@ export type TuiPromptRef = {
   submit(): void
   readonly text: string
   getTextRange(startOffset: number, endOffset: number): string
+  /** Replace [startOffset, endOffset) (display-width offsets) with `replacement`.
+   *  If startOffset > endOffset the range is treated as a pure INSERTION at
+   *  min(startOffset, endOffset) — it never deletes. Cursor lands at the end of
+   *  the replacement. Preserves undo history and the extmark controller. */
   replaceRange(startOffset: number, endOffset: number, replacement: string): void
   readonly extmarks: Pick<NonNullable<TextareaRenderable["extmarks"]>,
     | "create" | "delete" | "get" | "getAll" | "getVirtual" | "getAtOffset"
@@ -404,10 +408,8 @@ export type TuiStyleDefinition = {
 }
 
 export type TuiSyntaxStyle = {
-  /** Register a named style. Re-registering the same name is idempotent
-   *  (returns the existing id and overwrites the previous definition) —
-   *  safe to call on plugin reload. Returns the style id (use with
-   *  extmark create({ styleId })). */
+  /** Register (or update) a named syntax style. Returns the same id for a given
+   *  name across calls and updates the style definition on repeat registration. */
   registerStyle(name: string, definition: TuiStyleDefinition): number
   /** Look up a style id by name, or null if not registered. */
   getStyleId(name: string): number | null

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -211,6 +211,13 @@ export type TuiPromptRef = {
   replaceRange(startOffset: number, endOffset: number, replacement: string): void
   readonly extmarks: TextareaRenderable["extmarks"]
   readonly cursorOffset: number
+  /** Move the cursor to a display-width offset (same model as cursorOffset). */
+  setCursorOffset(offset: number): void
+  /** Convert a display-width offset (same model as cursorOffset) to
+   *  absolute screen coordinates. Returns null when the prompt is
+   *  unmounted, the offset is out of range, or the textarea has not
+   *  been laid out yet. */
+  offsetToScreen(offset: number): { x: number; y: number } | null
 }
 
 export type TuiPromptApi = {

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -226,12 +226,20 @@ export type TuiPromptApi = {
    *  changes. */
   ref(): TuiPromptRef | undefined
   /** Subscribe to prompt content changes (per keystroke / programmatic
-   *  edit). Survives prompt remounts. Returns a disposer. */
+   *  edit). Survives prompt remounts. Returns a disposer. Note:
+   *  per-channel reentrancy is guarded (a nested same-channel emit is
+   *  dropped), but a subscriber that mutates the OTHER channel which in
+   *  turn mutates this one can form a synchronous A→B→A loop. Plugins
+   *  MUST NOT create circular cross-channel mutations. */
   onChange(callback: () => void): () => void
   /** Subscribe to prompt cursor moves (arrows, click positioning, drag,
    *  word-moves, paste, delete, undo/redo). Deduplicated per offset — one
    *  callback per logical move. Survives prompt remounts. Returns a
-   *  disposer. */
+   *  disposer. Note: per-channel reentrancy is guarded (a nested
+   *  same-channel emit is dropped), but a subscriber that mutates the
+   *  OTHER channel which in turn mutates this one can form a synchronous
+   *  A→B→A loop. Plugins MUST NOT create circular cross-channel
+   *  mutations. */
   onCursorChange(callback: () => void): () => void
 }
 

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -209,7 +209,10 @@ export type TuiPromptRef = {
   readonly text: string
   getTextRange(startOffset: number, endOffset: number): string
   replaceRange(startOffset: number, endOffset: number, replacement: string): void
-  readonly extmarks: TextareaRenderable["extmarks"]
+  readonly extmarks: Pick<NonNullable<TextareaRenderable["extmarks"]>,
+    | "create" | "delete" | "get" | "getAll" | "getVirtual" | "getAtOffset"
+    | "getAllForTypeId" | "registerType" | "getTypeId" | "getTypeName" | "getMetadataFor"
+  >
   readonly cursorOffset: number
   /** Move the cursor to a display-width offset (same model as cursorOffset). */
   setCursorOffset(offset: number): void

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -392,6 +392,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       dialog,
       keymap,
       kv,
+      promptRef,
       route,
       routes: pluginRuntime.routes,
       event,

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -28,7 +28,7 @@ import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
 import { useExit } from "../../context/exit"
-import { planRangeReplace, promptOffsetWidth, viewportScreenCoords } from "../../prompt/display"
+import { planRangeReplace, promptOffsetWidth, viewportScreenCoords, type SafeExtmarks } from "../../prompt/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "../../prompt/history"
 import { computePromptTraits } from "../../prompt/traits"
@@ -108,7 +108,7 @@ export type PromptRef = {
   /** The textarea's extmark controller — range decorations for plugins.
    *  Offsets are display-width. Use registerType to namespace; never touch
    *  the "prompt-part" type. */
-  readonly extmarks: TextareaRenderable["extmarks"]
+  readonly extmarks: SafeExtmarks
   /** Current cursor offset in display-width cells (0-based, same model as
    *  getTextRange/replaceRange). 0 when the prompt has not mounted. */
   readonly cursorOffset: number

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -28,7 +28,7 @@ import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
 import { useExit } from "../../context/exit"
-import { planRangeReplace, promptOffsetWidth, viewportScreenCoords, type SafeExtmarks } from "../../prompt/display"
+import { makeGuardedAccessors, planRangeReplace, promptOffsetWidth, viewportScreenCoords, type SafeExtmarks } from "../../prompt/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "../../prompt/history"
 import { computePromptTraits } from "../../prompt/traits"
@@ -614,6 +614,8 @@ export function Prompt(props: PromptProps) {
     ]),
   }))
 
+  const guarded = makeGuardedAccessors(() => input)
+
   const ref: PromptRef = {
     get focused() {
       return input.focused
@@ -622,22 +624,16 @@ export function Prompt(props: PromptProps) {
       return store.prompt
     },
     get text() {
-      return input.plainText
+      return guarded.text()
     },
     getTextRange(startOffset, endOffset) {
-      return input.getTextRange(startOffset, endOffset)
+      return guarded.getTextRange(startOffset, endOffset)
     },
     replaceRange(startOffset, endOffset, replacement) {
-      const plan = planRangeReplace(input.plainText, startOffset, endOffset, replacement)
-      for (const action of plan.actions) {
-        if (action.type === "setCursor") input.cursorOffset = action.offset
-        else if (action.type === "setSelection") input.setSelection(action.start, action.end)
-        else if (action.type === "insertText") input.insertText(action.value)
-        else if (action.type === "clearSelection") input.clearSelection()
-      }
+      guarded.replaceRange(startOffset, endOffset, replacement)
     },
     get extmarks() {
-      return input.extmarks
+      return guarded.extmarks
     },
     get cursorOffset() {
       return input?.cursorOffset ?? 0
@@ -664,12 +660,8 @@ export function Prompt(props: PromptProps) {
       input.gotoBufferEnd()
     },
     reset() {
-      input.clear()
-      input.extmarks.clear()
-      setStore("prompt", {
-        input: "",
-        parts: [],
-      })
+      guarded.reset() // guarded handles input.clear() + input.extmarks.clear() (no-op if destroyed)
+      setStore("prompt", { input: "", parts: [] })
       setStore("extmarkToPartIndex", new Map())
     },
     submit() {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -28,7 +28,7 @@ import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
 import { useExit } from "../../context/exit"
-import { planRangeReplace, promptOffsetWidth } from "../../prompt/display"
+import { planRangeReplace, promptOffsetWidth, viewportScreenCoords } from "../../prompt/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "../../prompt/history"
 import { computePromptTraits } from "../../prompt/traits"
@@ -123,10 +123,10 @@ export type PromptRef = {
    *
    *  Implementation: maps offset → logical {row, col} via
    *  editBuffer.offsetToPosition, then adjusts for the viewport's
-   *  scrollY and adds the textarea's screenX/screenY. Prompts rarely
-   *  wrap (wrapMode="none" is the default), so logical col ≈ visual col
-   *  for v1. If wrap is ever enabled, visual col may differ from logical
-   *  col for long lines. */
+   *  scrollX/scrollY and adds the textarea's screenX/screenY. Prompts
+   *  rarely wrap (wrapMode="none" is the default), so logical col ≈
+   *  visual col for v1. If wrap is ever enabled, visual col may differ
+   *  from logical col for long lines. */
   offsetToScreen(offset: number): { x: number; y: number } | null
 }
 
@@ -647,23 +647,9 @@ export function Prompt(props: PromptProps) {
     },
     offsetToScreen(offset: number): { x: number; y: number } | null {
       if (!input || input.isDestroyed) return null
-      // offsetToPosition returns logical {row, col} in the edit buffer.
-      // For a non-wrapping textarea (the default), logical col equals
-      // visual col. If wrap mode is ever enabled, visual col may differ
-      // from logical col for long lines — a future improvement would use
-      // editorView.getVisualCursor() after a temporary cursor move, but
-      // that mutates state. For v1, logical ≈ visual is acceptable.
       const pos = input.editBuffer.offsetToPosition(offset)
       if (!pos) return null
-      const viewport = input.editorView.getViewport()
-      const visualRow = pos.row - viewport.offsetY
-      const visualCol = pos.col
-      // Guard: if the row is scrolled out of view, don't render the overlay.
-      if (visualRow < 0 || visualRow >= viewport.height) return null
-      return {
-        x: input.screenX + visualCol,
-        y: input.screenY + visualRow,
-      }
+      return viewportScreenCoords(pos, input.editorView.getViewport(), input.screenX, input.screenY)
     },
     focus() {
       input.focus()

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -28,7 +28,7 @@ import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
 import { useExit } from "../../context/exit"
-import { promptOffsetWidth } from "../../prompt/display"
+import { planRangeReplace, promptOffsetWidth } from "../../prompt/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "../../prompt/history"
 import { computePromptTraits } from "../../prompt/traits"
@@ -51,6 +51,7 @@ import { createFadeIn } from "../../util/signal"
 import { DialogSkill } from "../dialog-skill"
 import { DialogWorkspaceUnavailable } from "../dialog-workspace-unavailable"
 import { useArgs } from "../../context/args"
+import { usePromptRef } from "../../context/prompt"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useLeaderActive, useOpencodeKeymap } from "../../keymap"
 import { useTuiConfig } from "../../config"
 import { usePromptWorkspace } from "./workspace"
@@ -94,6 +95,23 @@ export type PromptRef = {
   blur(): void
   focus(): void
   submit(): void
+  /** Live buffer text (includes paste/file placeholder tokens). */
+  readonly text: string
+  /** Substring by display-width offsets (the extmark/cursor offset model). */
+  getTextRange(startOffset: number, endOffset: number): string
+  /** Replace [startOffset, endOffset) (display-width offsets) with
+   *  `replacement`, preserving undo history AND the textarea's extmark
+   *  controller (uses setSelection+insertText+clearSelection for non-empty
+   *  ranges and cursor-set+insertText for empty ranges). Cursor lands at
+   *  the end of the replacement. */
+  replaceRange(startOffset: number, endOffset: number, replacement: string): void
+  /** The textarea's extmark controller — range decorations for plugins.
+   *  Offsets are display-width. Use registerType to namespace; never touch
+   *  the "prompt-part" type. */
+  readonly extmarks: TextareaRenderable["extmarks"]
+  /** Current cursor offset in display-width cells (0-based, same model as
+   *  getTextRange/replaceRange). 0 when the prompt has not mounted. */
+  readonly cursorOffset: number
 }
 
 const money = new Intl.NumberFormat("en-US", {
@@ -143,6 +161,7 @@ let stashed: { prompt: PromptInfo; cursor: number } | undefined
 export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
   let anchor: BoxRenderable
+  let lastEmittedCursorOffset: number | undefined
   const [inputTarget, setInputTarget] = createSignal<TextareaRenderable | undefined>()
 
   const leader = useLeaderActive()
@@ -171,6 +190,7 @@ export function Prompt(props: PromptProps) {
   const dimensions = useTerminalDimensions()
   const { theme, syntax } = useTheme()
   const kv = useKV()
+  const promptRefContext = usePromptRef()
   const animationsEnabled = createMemo(() => kv.get("animations_enabled", true))
   const list = createMemo(() => props.placeholders?.normal ?? [])
   const shell = createMemo(() => props.placeholders?.shell ?? [])
@@ -584,6 +604,27 @@ export function Prompt(props: PromptProps) {
     },
     get current() {
       return store.prompt
+    },
+    get text() {
+      return input.plainText
+    },
+    getTextRange(startOffset, endOffset) {
+      return input.getTextRange(startOffset, endOffset)
+    },
+    replaceRange(startOffset, endOffset, replacement) {
+      const plan = planRangeReplace(input.plainText, startOffset, endOffset, replacement)
+      for (const action of plan.actions) {
+        if (action.type === "setCursor") input.cursorOffset = action.offset
+        else if (action.type === "setSelection") input.setSelection(action.start, action.end)
+        else if (action.type === "insertText") input.insertText(action.value)
+        else if (action.type === "clearSelection") input.clearSelection()
+      }
+    },
+    get extmarks() {
+      return input.extmarks
+    },
+    get cursorOffset() {
+      return input?.cursorOffset ?? 0
     },
     focus() {
       input.focus()
@@ -1379,8 +1420,16 @@ export function Prompt(props: PromptProps) {
                 auto()?.onInput(value)
                 syncExtmarksWithPromptParts()
                 setCursorVersion((value) => value + 1)
+                promptRefContext.emitChange()
               }}
-              onCursorChange={() => setCursorVersion((value) => value + 1)}
+              onCursorChange={() => {
+                const offset = input?.cursorOffset ?? 0
+                setCursorVersion((value) => value + 1)
+                if (offset !== lastEmittedCursorOffset) {
+                  lastEmittedCursorOffset = offset
+                  promptRefContext.emitCursorChange()
+                }
+              }}
               onKeyDown={(e: { preventDefault(): void }) => {
                 if (props.disabled) {
                   e.preventDefault()

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -99,11 +99,10 @@ export type PromptRef = {
   readonly text: string
   /** Substring by display-width offsets (the extmark/cursor offset model). */
   getTextRange(startOffset: number, endOffset: number): string
-  /** Replace [startOffset, endOffset) (display-width offsets) with
-   *  `replacement`, preserving undo history AND the textarea's extmark
-   *  controller (uses setSelection+insertText+clearSelection for non-empty
-   *  ranges and cursor-set+insertText for empty ranges). Cursor lands at
-   *  the end of the replacement. */
+  /** Replace [startOffset, endOffset) (display-width offsets) with `replacement`.
+   *  If startOffset > endOffset the range is treated as a pure INSERTION at
+   *  min(startOffset, endOffset) — it never deletes. Cursor lands at the end of
+   *  the replacement. Preserves undo history and the extmark controller. */
   replaceRange(startOffset: number, endOffset: number, replacement: string): void
   /** The textarea's extmark controller — range decorations for plugins.
    *  Offsets are display-width. Use registerType to namespace; never touch

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -112,6 +112,22 @@ export type PromptRef = {
   /** Current cursor offset in display-width cells (0-based, same model as
    *  getTextRange/replaceRange). 0 when the prompt has not mounted. */
   readonly cursorOffset: number
+  /** Move the cursor to a display-width offset (same model as cursorOffset).
+   *  Clamped to >= 0; the textarea handles the upper bound. No-op when the
+   *  prompt is not mounted. */
+  setCursorOffset(offset: number): void
+  /** Convert a display-width offset (same model as cursorOffset /
+   *  getTextRange) to absolute screen coordinates {x, y}. Returns null
+   *  when the prompt is unmounted, the offset is out of range, or the
+   *  textarea has not been laid out yet.
+   *
+   *  Implementation: maps offset → logical {row, col} via
+   *  editBuffer.offsetToPosition, then adjusts for the viewport's
+   *  scrollY and adds the textarea's screenX/screenY. Prompts rarely
+   *  wrap (wrapMode="none" is the default), so logical col ≈ visual col
+   *  for v1. If wrap is ever enabled, visual col may differ from logical
+   *  col for long lines. */
+  offsetToScreen(offset: number): { x: number; y: number } | null
 }
 
 const money = new Intl.NumberFormat("en-US", {
@@ -625,6 +641,29 @@ export function Prompt(props: PromptProps) {
     },
     get cursorOffset() {
       return input?.cursorOffset ?? 0
+    },
+    setCursorOffset(offset: number): void {
+      if (input) input.cursorOffset = Math.max(0, offset)
+    },
+    offsetToScreen(offset: number): { x: number; y: number } | null {
+      if (!input || input.isDestroyed) return null
+      // offsetToPosition returns logical {row, col} in the edit buffer.
+      // For a non-wrapping textarea (the default), logical col equals
+      // visual col. If wrap mode is ever enabled, visual col may differ
+      // from logical col for long lines — a future improvement would use
+      // editorView.getVisualCursor() after a temporary cursor move, but
+      // that mutates state. For v1, logical ≈ visual is acceptable.
+      const pos = input.editBuffer.offsetToPosition(offset)
+      if (!pos) return null
+      const viewport = input.editorView.getViewport()
+      const visualRow = pos.row - viewport.offsetY
+      const visualCol = pos.col
+      // Guard: if the row is scrolled out of view, don't render the overlay.
+      if (visualRow < 0 || visualRow >= viewport.height) return null
+      return {
+        x: input.screenX + visualCol,
+        y: input.screenY + visualRow,
+      }
     },
     focus() {
       input.focus()
@@ -1482,7 +1521,16 @@ export function Prompt(props: PromptProps) {
                   input.cursorColor = theme.text
                 }, 0)
               }}
-              onMouseDown={(r: MouseEvent) => r.target?.focus()}
+              onMouseDown={(r: MouseEvent) => {
+                r.target?.focus()
+                queueMicrotask(() => {
+                  const offset = input?.cursorOffset ?? 0
+                  if (offset !== lastEmittedCursorOffset) {
+                    lastEmittedCursorOffset = offset
+                    promptRefContext.emitCursorChange()
+                  }
+                })
+              }}
               focusedBackgroundColor={theme.backgroundElement}
               cursorColor={props.disabled ? theme.backgroundElement : theme.text}
               syntaxStyle={syntax()}

--- a/packages/tui/src/context/prompt.tsx
+++ b/packages/tui/src/context/prompt.tsx
@@ -1,18 +1,67 @@
 import { createSimpleContext } from "./helper"
 import type { PromptRef } from "../component/prompt"
 
+export function createPromptRefContextValue() {
+  let current: PromptRef | undefined
+  const changeSubscribers = new Set<() => void>()
+  const cursorSubscribers = new Set<() => void>()
+
+  const emit = (subs: Set<() => void>) => {
+    if (emitting) return
+    emitting = true
+    try {
+      for (const callback of subs) {
+        try {
+          callback()
+        } catch {
+          // a bad subscriber must not break the prompt or other subscribers
+        }
+      }
+    } finally {
+      emitting = false
+    }
+  }
+  let emitting = false
+
+  return {
+    get current() {
+      return current
+    },
+    set(ref: PromptRef | undefined) {
+      current = ref
+    },
+    /** Subscribe to prompt content changes (fires per keystroke / programmatic
+     *  edit). Survives prompt remounts (route changes) — the subscription
+     *  lives on the context, not the component. Returns a disposer. */
+    onChange(callback: () => void) {
+      changeSubscribers.add(callback)
+      return () => {
+        changeSubscribers.delete(callback)
+      }
+    },
+    /** Called by the prompt component's onContentChange. Reentrancy: nested
+     *  emit calls from within a subscriber are dropped to prevent loops. */
+    emitChange() {
+      emit(changeSubscribers)
+    },
+    /** Subscribe to prompt cursor moves (arrows, click, drag, word-moves,
+     *  paste, delete, undo/redo). Survives prompt remounts. Returns a
+     *  disposer. */
+    onCursorChange(callback: () => void) {
+      cursorSubscribers.add(callback)
+      return () => {
+        cursorSubscribers.delete(callback)
+      }
+    },
+    /** Called by the prompt component's onCursorChange. Reentrancy: nested
+     *  emit calls from within a subscriber are dropped to prevent loops. */
+    emitCursorChange() {
+      emit(cursorSubscribers)
+    },
+  }
+}
+
 export const { use: usePromptRef, provider: PromptRefProvider } = createSimpleContext({
   name: "PromptRef",
-  init: () => {
-    let current: PromptRef | undefined
-
-    return {
-      get current() {
-        return current
-      },
-      set(ref: PromptRef | undefined) {
-        current = ref
-      },
-    }
-  },
+  init: createPromptRefContextValue,
 })

--- a/packages/tui/src/context/prompt.tsx
+++ b/packages/tui/src/context/prompt.tsx
@@ -6,22 +6,18 @@ export function createPromptRefContextValue() {
   const changeSubscribers = new Set<() => void>()
   const cursorSubscribers = new Set<() => void>()
 
-  const emit = (subs: Set<() => void>) => {
-    if (emitting) return
-    emitting = true
-    try {
-      for (const callback of subs) {
-        try {
-          callback()
-        } catch {
-          // a bad subscriber must not break the prompt or other subscribers
-        }
+  let emittingChange = false
+  let emittingCursor = false
+
+  const fire = (subs: Set<() => void>) => {
+    for (const callback of subs) {
+      try {
+        callback()
+      } catch {
+        // a bad subscriber must not break the prompt or other subscribers
       }
-    } finally {
-      emitting = false
     }
   }
-  let emitting = false
 
   return {
     get current() {
@@ -32,31 +28,52 @@ export function createPromptRefContextValue() {
     },
     /** Subscribe to prompt content changes (fires per keystroke / programmatic
      *  edit). Survives prompt remounts (route changes) — the subscription
-     *  lives on the context, not the component. Returns a disposer. */
+     *  lives on the context, not the component. Returns a disposer. Note:
+     *  per-channel reentrancy is guarded (a nested same-channel emit is
+     *  dropped), but a subscriber that mutates the OTHER channel which in
+     *  turn mutates this one can form a synchronous A→B→A loop. Plugins
+     *  MUST NOT create circular cross-channel mutations. */
     onChange(callback: () => void) {
       changeSubscribers.add(callback)
       return () => {
         changeSubscribers.delete(callback)
       }
     },
-    /** Called by the prompt component's onContentChange. Reentrancy: nested
-     *  emit calls from within a subscriber are dropped to prevent loops. */
+    /** Called by the prompt component's onContentChange. Per-channel reentrancy:
+     *  a nested emitChange from within a change subscriber is dropped; a cursor
+     *  emit from within a change subscriber still fires (independent channel). */
     emitChange() {
-      emit(changeSubscribers)
+      if (emittingChange) return
+      emittingChange = true
+      try {
+        fire(changeSubscribers)
+      } finally {
+        emittingChange = false
+      }
     },
     /** Subscribe to prompt cursor moves (arrows, click, drag, word-moves,
      *  paste, delete, undo/redo). Survives prompt remounts. Returns a
-     *  disposer. */
+     *  disposer. Note: per-channel reentrancy is guarded (a nested
+     *  same-channel emit is dropped), but a subscriber that mutates the
+     *  OTHER channel which in turn mutates this one can form a synchronous
+     *  A→B→A loop. Plugins MUST NOT create circular cross-channel
+     *  mutations. */
     onCursorChange(callback: () => void) {
       cursorSubscribers.add(callback)
       return () => {
         cursorSubscribers.delete(callback)
       }
     },
-    /** Called by the prompt component's onCursorChange. Reentrancy: nested
-     *  emit calls from within a subscriber are dropped to prevent loops. */
+    /** Called by the prompt component's onCursorChange. Per-channel reentrancy:
+     *  a nested emitCursorChange from within a cursor subscriber is dropped. */
     emitCursorChange() {
-      emit(cursorSubscribers)
+      if (emittingCursor) return
+      emittingCursor = true
+      try {
+        fire(cursorSubscribers)
+      } finally {
+        emittingCursor = false
+      }
     },
   }
 }

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -13,6 +13,7 @@ import { DialogConfirm } from "../ui/dialog-confirm"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { DialogSelect, type DialogSelectOption as SelectOption } from "../ui/dialog-select"
 import { Prompt } from "../component/prompt"
+import type { usePromptRef } from "../context/prompt"
 import type { useToast } from "../ui/toast"
 import * as Keymap from "../keymap"
 import { createCommandShim } from "./command-shim"
@@ -26,6 +27,7 @@ type Input = {
   dialog: ReturnType<typeof useDialog>
   keymap: ReturnType<typeof useOpencodeKeymap>
   kv: ReturnType<typeof useKV>
+  promptRef: ReturnType<typeof usePromptRef>
   route: ReturnType<typeof useRoute>
   routes: PluginRoutes
   event: ReturnType<typeof useEvent>
@@ -193,6 +195,11 @@ export function createTuiApiAdapters(input: Input): Omit<TuiPluginApi, "lifecycl
         return Keymap.getOpencodeModeStack(input.keymap).push(mode)
       },
     },
+    prompt: {
+      ref: () => input.promptRef.current,
+      onChange: (callback) => input.promptRef.onChange(callback),
+      onCursorChange: (callback) => input.promptRef.onCursorChange(callback),
+    },
     route: {
       register(list) {
         return input.routes.register(list)
@@ -349,6 +356,17 @@ export function createTuiApiAdapters(input: Input): Omit<TuiPluginApi, "lifecycl
       },
       get ready() {
         return input.theme.ready
+      },
+      syntax() {
+        const style = input.theme.syntax()
+        return {
+          registerStyle(name, definition) {
+            return style.registerStyle(name, definition)
+          },
+          getStyleId(name) {
+            return style.getStyleId(name)
+          },
+        }
       },
     },
   }

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -133,3 +133,19 @@ export function planRangeReplace(
     ],
   }
 }
+
+/** Map a logical edit-buffer position to absolute screen coords, accounting
+ *  for both axes of viewport scroll. Returns null when the position is
+ *  scrolled outside the viewport on either axis. Pure — no native deps. */
+export function viewportScreenCoords(
+  pos: { row: number; col: number },
+  viewport: { offsetX: number; offsetY: number; width: number; height: number },
+  screenX: number,
+  screenY: number,
+): { x: number; y: number } | null {
+  const visualRow = pos.row - viewport.offsetY
+  const visualCol = pos.col - viewport.offsetX
+  if (visualRow < 0 || visualRow >= viewport.height) return null
+  if (visualCol < 0 || visualCol >= viewport.width) return null
+  return { x: screenX + visualCol, y: screenY + visualRow }
+}

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -1,3 +1,5 @@
+import type { TextareaRenderable } from "@opentui/core"
+
 const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" })
 
 export function promptOffsetWidth(value: string) {
@@ -149,3 +151,56 @@ export function viewportScreenCoords(
   if (visualCol < 0 || visualCol >= viewport.width) return null
   return { x: screenX + visualCol, y: screenY + visualRow }
 }
+
+// Use TextareaRenderable directly as the input type — it's importable from
+// @opentui/core (re-exported via renderables/index.d.ts:23 → Textarea.js) and
+// already used in index.tsx. Council R2 Should (rev-1): prefer this over a
+// hand-written `GuardInput` intermediate so the helpers' input type can't
+// drift from the real textarea. `makeGuardedAccessors` (Task 4) takes the same
+// `() => TextareaRenderable | undefined`.
+// (If a future opentui bump makes the direct import heavy, fall back to a
+//  minimal structural type covering: isDestroyed, extmarks, plainText,
+//  getTextRange, cursorOffset, setSelection, insertText, clearSelection, clear.)
+type GuardInput = TextareaRenderable
+
+/** Plugin-safe extmarks facade. ALWAYS returns a facade (never undefined) so
+ *  it can be built ONCE — the component creates the factory before the
+ *  textarea mounts (`input` is assigned later at index.tsx:1504), so a
+ *  build-time controller capture would be permanently undefined. Each method
+ *  re-reads the input via `live()` and no-ops when absent/destroyed (a plugin
+ *  that captured the facade before unmount can't deref a destroyed
+ *  controller — finding 6). Delegates as `input.extmarks.method(...)` so
+ *  `this` is the controller (finding 5 — no .bind needed). Omits
+ *  clear()/destroy() (wipe internal prompt-part marks / tear down).
+ *
+ *  Unmounted/destroyed sentinel (council R2 Should, rev-1+rev-3): when the
+ *  prompt is unmounted these no-op to `create`/`registerType` → -1,
+ *  `delete` → false, `get*` → null/[]. A plugin CANNOT distinguish "no
+ *  extmarks" from "prompt gone"; treat any -1 type/mark id as a no-op and do
+ *  not persist it. Document this on the plugin-facing JSDoc too. */
+export function safeExtmarks(getInput: () => GuardInput | undefined): SafeExtmarks {
+  const live = () => {
+    const input = getInput()
+    return !input || input.isDestroyed ? undefined : input.extmarks
+  }
+  return {
+    create: (opts) => live()?.create(opts) ?? -1,
+    delete: (id) => live()?.delete(id) ?? false,
+    get: (id) => live()?.get(id) ?? null,
+    getAll: () => live()?.getAll() ?? [],
+    getVirtual: () => live()?.getVirtual() ?? [],
+    getAtOffset: (offset) => live()?.getAtOffset(offset) ?? [],
+    getAllForTypeId: (typeId) => live()?.getAllForTypeId(typeId) ?? [],
+    registerType: (name) => live()?.registerType(name) ?? -1,
+    getTypeId: (name) => live()?.getTypeId(name) ?? null,
+    getTypeName: (typeId) => live()?.getTypeName(typeId) ?? null,
+    getMetadataFor: (id) => live()?.getMetadataFor(id) ?? null,
+  }
+}
+
+type RawExtmarks = NonNullable<TextareaRenderable["extmarks"]>
+export type SafeExtmarks = Pick<
+  RawExtmarks,
+  | "create" | "delete" | "get" | "getAll" | "getVirtual" | "getAtOffset"
+  | "getAllForTypeId" | "registerType" | "getTypeId" | "getTypeName" | "getMetadataFor"
+>

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -9,7 +9,7 @@ export function promptOffsetWidth(value: string) {
   return width
 }
 
-function displayOffsetIndex(value: string, offset: number) {
+export function displayOffsetIndex(value: string, offset: number) {
   if (offset <= 0) return 0
 
   let width = 0
@@ -44,5 +44,92 @@ export function mentionTriggerIndex(value: string, offset = promptOffsetWidth(va
   const query = text.slice(index)
   if ((before === undefined || /\s/.test(before)) && !/\s/.test(query)) {
     return promptOffsetWidth(text.slice(0, index))
+  }
+}
+
+/** Snap a display-width offset to the nearest grapheme boundary. Direction
+ *  "down" returns the largest offset <= the input that is a grapheme start;
+ *  "up" returns the smallest offset >= the input that is a grapheme end
+ *  (i.e. the offset just after the current grapheme). */
+export function snapOffsetToGraphemeBoundary(
+  value: string,
+  offset: number,
+  direction: "down" | "up",
+): number {
+  const total = promptOffsetWidth(value)
+  if (offset <= 0) return 0
+  if (offset >= total) return total
+
+  let width = 0
+  for (const part of graphemes.segment(value)) {
+    const segWidth = promptOffsetWidth(part.segment)
+    const next = width + segWidth
+    if (direction === "down") {
+      if (next > offset) return width
+      if (next === offset) return offset
+    } else {
+      if (width >= offset) return width
+      if (next >= offset) return next
+    }
+    width = next
+  }
+  return total
+}
+
+export type RangeReplaceAction =
+  | { type: "setCursor"; offset: number }
+  | { type: "setSelection"; start: number; end: number }
+  | { type: "insertText"; value: string }
+  | { type: "clearSelection" }
+
+export interface RangeReplacePlan {
+  /** Final text after the plan is applied. */
+  readonly text: string
+  /** Display-width cursor offset after the plan is applied. */
+  readonly cursor: number
+  /** Actions to perform on the textarea in order. */
+  readonly actions: readonly RangeReplaceAction[]
+}
+
+/** Plan a display-width-offset range replace/insert that preserves the
+ *  textarea's extmark controller (uses setSelection+insertText+clearSelection
+ *  for non-empty ranges, and cursor-set+insertText for pure insertions). */
+export function planRangeReplace(
+  text: string,
+  startOffset: number,
+  endOffset: number,
+  replacement: string,
+): RangeReplacePlan {
+  const total = promptOffsetWidth(text)
+  const rawStart = Math.max(0, Math.min(startOffset, total))
+  const rawEnd = Math.max(0, Math.min(endOffset, total))
+  // Treat start>end as an insertion at the (smaller) start — never a delete.
+  const isInsertion = rawStart === rawEnd || rawStart > rawEnd
+  const insAt = Math.min(rawStart, rawEnd)
+
+  if (isInsertion) {
+    const snapped = snapOffsetToGraphemeBoundary(text, insAt, "down")
+    const insertWidth = promptOffsetWidth(replacement)
+    const newText = displaySlice(text, 0, snapped) + replacement + displaySlice(text, snapped)
+    return {
+      text: newText,
+      cursor: snapped + insertWidth,
+      actions: [{ type: "setCursor", offset: snapped }, { type: "insertText", value: replacement }],
+    }
+  }
+
+  const sStart = Math.min(snapOffsetToGraphemeBoundary(text, rawStart, "down"), rawEnd)
+  const sEnd = Math.max(snapOffsetToGraphemeBoundary(text, rawEnd, "up"), sStart)
+  const before = displaySlice(text, 0, sStart)
+  const after = displaySlice(text, sEnd)
+  const insertWidth = promptOffsetWidth(replacement)
+  return {
+    text: before + replacement + after,
+    cursor: sStart + insertWidth,
+    actions: [
+      { type: "setSelection", start: sStart, end: sEnd },
+      { type: "insertText", value: replacement },
+      { type: "clearSelection" },
+    ],
   }
 }

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -204,3 +204,47 @@ export type SafeExtmarks = Pick<
   | "create" | "delete" | "get" | "getAll" | "getVirtual" | "getAtOffset"
   | "getAllForTypeId" | "registerType" | "getTypeId" | "getTypeName" | "getMetadataFor"
 >
+
+/** Guarded PromptRef accessors. Each derefs the live input via getInput and
+ *  no-ops when the input is absent or destroyed — so a plugin holding a
+ *  retained ref after the prompt unmounts can't crash the TUI. Pure factory
+ *  (only a type dep on TextareaRenderable) → unit-testable without a native
+ *  textarea. */
+export function makeGuardedAccessors(getInput: () => TextareaRenderable | undefined) {
+  return {
+    text(): string {
+      const input = getInput()
+      if (!input || input.isDestroyed) return ""
+      return input.plainText
+    },
+    getTextRange(startOffset: number, endOffset: number): string {
+      const input = getInput()
+      if (!input || input.isDestroyed) return ""
+      return input.getTextRange(startOffset, endOffset)
+    },
+    replaceRange(startOffset: number, endOffset: number, replacement: string): void {
+      const input = getInput()
+      if (!input || input.isDestroyed) return
+      const plan = planRangeReplace(input.plainText, startOffset, endOffset, replacement)
+      for (const action of plan.actions) {
+        if (action.type === "setCursor") input.cursorOffset = action.offset
+        else if (action.type === "setSelection") input.setSelection(action.start, action.end)
+        else if (action.type === "insertText") input.insertText(action.value)
+        else if (action.type === "clearSelection") input.clearSelection()
+      }
+    },
+    /** Guarded INPUT side of reset (the crash-prone part): clears the textarea
+     *  and its extmark controller. The component's reset() calls this, then
+     *  does its own SolidJS setStore(...) (which can't live here). Council
+     *  consensus finding #1: reset must be in the factory so ALL guarded input
+     *  ops share one source of truth. */
+    reset(): void {
+      const input = getInput()
+      if (!input || input.isDestroyed) return
+      input.clear()
+      input.extmarks.clear()
+    },
+    // The plugin-safe extmarks facade (Task 3), built once and self-guarding.
+    extmarks: safeExtmarks(getInput),
+  }
+}

--- a/packages/tui/test/context/prompt.test.ts
+++ b/packages/tui/test/context/prompt.test.ts
@@ -93,3 +93,26 @@ describe("prompt ref context", () => {
     dispose()
   })
 })
+
+test("onChange handler that emits a cursor change is NOT dropped (cross-channel)", () => {
+  const ctx = createPromptRefContextValue()
+  let cursorFired = 0
+  ctx.onCursorChange(() => cursorFired++)
+  ctx.onChange(() => {
+    // a plugin reacting to content by moving the cursor → triggers emitCursorChange
+    ctx.emitCursorChange()
+  })
+  ctx.emitChange()
+  expect(cursorFired).toBe(1) // was 0 with the shared `emitting` flag
+})
+
+test("same-channel reentrancy is still guarded (no infinite loop)", () => {
+  const ctx = createPromptRefContextValue()
+  let n = 0
+  ctx.onChange(() => {
+    n++
+    if (n < 5) ctx.emitChange() // re-entrant same-channel emit must be dropped
+  })
+  ctx.emitChange()
+  expect(n).toBe(1)
+})

--- a/packages/tui/test/context/prompt.test.ts
+++ b/packages/tui/test/context/prompt.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test"
+import { createPromptRefContextValue } from "../../src/context/prompt"
+
+describe("prompt ref context", () => {
+  test("set/current round-trips", () => {
+    const ctx = createPromptRefContextValue()
+    expect(ctx.current).toBeUndefined()
+    const fake = { marker: "fake-ref" } as never
+    ctx.set(fake)
+    expect(ctx.current).toBe(fake)
+    ctx.set(undefined)
+    expect(ctx.current).toBeUndefined()
+  })
+
+  test("onChange subscribers fire on emitChange and dispose cleanly", () => {
+    const ctx = createPromptRefContextValue()
+    let calls = 0
+    const dispose = ctx.onChange(() => {
+      calls += 1
+    })
+    ctx.emitChange()
+    ctx.emitChange()
+    expect(calls).toBe(2)
+    dispose()
+    ctx.emitChange()
+    expect(calls).toBe(2)
+  })
+
+  test("onCursorChange subscribers fire on emitCursorChange and dispose cleanly", () => {
+    const ctx = createPromptRefContextValue()
+    let calls = 0
+    const dispose = ctx.onCursorChange(() => {
+      calls += 1
+    })
+    ctx.emitCursorChange()
+    ctx.emitCursorChange()
+    expect(calls).toBe(2)
+    dispose()
+    ctx.emitCursorChange()
+    expect(calls).toBe(2)
+  })
+
+  test("change and cursor subscriptions are independent", () => {
+    const ctx = createPromptRefContextValue()
+    let contentCalls = 0
+    let cursorCalls = 0
+    ctx.onChange(() => {
+      contentCalls += 1
+    })
+    ctx.onCursorChange(() => {
+      cursorCalls += 1
+    })
+    ctx.emitChange()
+    expect(contentCalls).toBe(1)
+    expect(cursorCalls).toBe(0)
+    ctx.emitCursorChange()
+    expect(contentCalls).toBe(1)
+    expect(cursorCalls).toBe(1)
+  })
+
+  test("a throwing subscriber does not break the others", () => {
+    const ctx = createPromptRefContextValue()
+    let contentCalled = false
+    let cursorCalled = false
+    ctx.onChange(() => {
+      throw new Error("bad content subscriber")
+    })
+    ctx.onChange(() => {
+      contentCalled = true
+    })
+    ctx.onCursorChange(() => {
+      throw new Error("bad cursor subscriber")
+    })
+    ctx.onCursorChange(() => {
+      cursorCalled = true
+    })
+    expect(() => ctx.emitChange()).not.toThrow()
+    expect(contentCalled).toBe(true)
+    expect(() => ctx.emitCursorChange()).not.toThrow()
+    expect(cursorCalled).toBe(true)
+  })
+
+  test("nested emit calls from within a subscriber are dropped (reentrancy guard)", () => {
+    const ctx = createPromptRefContextValue()
+    let innerCalls = 0
+    const dispose = ctx.onChange(() => {
+      innerCalls += 1
+      ctx.emitChange()
+      ctx.emitCursorChange()
+    })
+    ctx.emitChange()
+    expect(innerCalls).toBe(1)
+    dispose()
+  })
+})

--- a/packages/tui/test/prompt/display-range.test.ts
+++ b/packages/tui/test/prompt/display-range.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "bun:test"
+import {
+  displayOffsetIndex,
+  displaySlice,
+  planRangeReplace,
+  promptOffsetWidth,
+  snapOffsetToGraphemeBoundary,
+  type RangeReplaceAction,
+} from "../../src/prompt/display"
+
+function apply(initialText: string, actions: readonly RangeReplaceAction[]) {
+  const calls: string[] = []
+  let cursor = 0
+  let text = initialText
+  let selStart = 0
+  let selEnd = 0
+  for (const action of actions) {
+    if (action.type === "setCursor") {
+      cursor = action.offset
+      selStart = displayOffsetIndex(text, action.offset)
+      selEnd = selStart
+      calls.push(`setCursor(${action.offset})`)
+      continue
+    }
+    if (action.type === "setSelection") {
+      selStart = displayOffsetIndex(text, action.start)
+      selEnd = displayOffsetIndex(text, action.end)
+      cursor = action.end
+      calls.push(`setSelection(${action.start},${action.end})`)
+      continue
+    }
+    if (action.type === "insertText") {
+      text = text.slice(0, selStart) + action.value + text.slice(selEnd)
+      cursor = selStart + promptOffsetWidth(action.value)
+      selStart = cursor
+      selEnd = cursor
+      calls.push(`insertText(${JSON.stringify(action.value)})`)
+      continue
+    }
+    if (action.type === "clearSelection") {
+      selStart = cursor
+      selEnd = cursor
+      calls.push("clearSelection()")
+      continue
+    }
+  }
+  return { calls, text, cursor }
+}
+
+describe("snapOffsetToGraphemeBoundary", () => {
+  test("clamp 0 to 0", () => {
+    expect(snapOffsetToGraphemeBoundary("abc", 0, "down")).toBe(0)
+    expect(snapOffsetToGraphemeBoundary("abc", 0, "up")).toBe(0)
+  })
+
+  test("clamp past end to total width", () => {
+    expect(snapOffsetToGraphemeBoundary("abc", 99, "down")).toBe(3)
+    expect(snapOffsetToGraphemeBoundary("abc", 99, "up")).toBe(3)
+  })
+
+  test("ascii boundary alignment is identity", () => {
+    expect(snapOffsetToGraphemeBoundary("abcdef", 3, "down")).toBe(3)
+    expect(snapOffsetToGraphemeBoundary("abcdef", 3, "up")).toBe(3)
+  })
+
+  test("CJK 你a: snap down mid-grapheme", () => {
+    expect(snapOffsetToGraphemeBoundary("你a", 1, "down")).toBe(0)
+    expect(snapOffsetToGraphemeBoundary("你a", 2, "down")).toBe(2)
+  })
+
+  test("CJK 你a: snap up mid-grapheme", () => {
+    expect(snapOffsetToGraphemeBoundary("你a", 1, "up")).toBe(2)
+    expect(snapOffsetToGraphemeBoundary("你a", 2, "up")).toBe(2)
+  })
+
+  test("emoji 😀a: snap down mid-surrogate", () => {
+    expect(snapOffsetToGraphemeBoundary("😀a", 1, "down")).toBe(0)
+  })
+
+  test("ZWJ family 👨‍👩‍👧 is one grapheme (width 2)", () => {
+    const family = "👨‍👩‍👧"
+    expect(promptOffsetWidth(family)).toBe(2)
+    expect(snapOffsetToGraphemeBoundary(family + "x", 1, "down")).toBe(0)
+    expect(snapOffsetToGraphemeBoundary(family + "x", 1, "up")).toBe(2)
+    expect(snapOffsetToGraphemeBoundary(family + "x", 2, "down")).toBe(2)
+    expect(snapOffsetToGraphemeBoundary(family + "x", 2, "up")).toBe(2)
+  })
+})
+
+describe("planRangeReplace — extmark-safe primitive", () => {
+  test("replacement never calls replaceText (only setSelection+insertText+clearSelection)", () => {
+    const plan = planRangeReplace("hello world", 0, 5, "J")
+    const result = apply("hello world", plan.actions)
+    expect(result.calls).toEqual(["setSelection(0,5)", 'insertText("J")', "clearSelection()"])
+    expect(result.text).toBe("J world")
+  })
+
+  test("pure insertion uses setCursor (NOT setSelection) — empty range is not a delete", () => {
+    const plan = planRangeReplace("abc", 1, 1, "X")
+    const result = apply("abc", plan.actions)
+    expect(result.calls).toEqual(["setCursor(1)", 'insertText("X")'])
+    expect(result.text).toBe("aXbc")
+  })
+
+  test("empty-range mid-grapheme insertion: snaps DOWN only (no spurious delete)", () => {
+    const plan = planRangeReplace("你a", 1, 1, "X")
+    const result = apply("你a", plan.actions)
+    expect(plan.actions.map((a) => a.type)).toEqual(["setCursor", "insertText"])
+    expect(result.calls).toEqual(["setCursor(0)", 'insertText("X")'])
+    expect(result.text).toBe("X你a")
+  })
+
+  test("CJK mid-grapheme replace [1,2) on '你a': snaps [0,2) — 你 fully selected", () => {
+    const plan = planRangeReplace("你a", 1, 2, "Z")
+    const result = apply("你a", plan.actions)
+    expect(result.calls).toEqual(["setSelection(0,2)", 'insertText("Z")', "clearSelection()"])
+    expect(result.text).toBe("Za")
+  })
+
+  test("CJK 你a, replace [0,2) with 'X': 你 dropped, a remains", () => {
+    const plan = planRangeReplace("你a", 0, 2, "X")
+    const result = apply("你a", plan.actions)
+    expect(result.text).toBe("Xa")
+  })
+
+  test("emoji 😀x, replace [0,2) with X: 😀 dropped, x remains", () => {
+    const plan = planRangeReplace("😀x", 0, 2, "X")
+    const result = apply("😀x", plan.actions)
+    expect(result.text).toBe("Xx")
+  })
+
+  test("emoji ZWJ 👨‍👩‍👧, replace [0,2) with X: family dropped, x remains", () => {
+    const plan = planRangeReplace("👨‍👩‍👧x", 0, 2, "X")
+    const result = apply("👨‍👩‍👧x", plan.actions)
+    expect(result.text).toBe("Xx")
+  })
+
+  test("boundary insertion at end: cursor snaps to total width", () => {
+    const plan = planRangeReplace("abc", 3, 3, "X")
+    expect(plan.cursor).toBe(4)
+    const result = apply("abc", plan.actions)
+    expect(result.text).toBe("abcX")
+  })
+
+  test("boundary insertion at start: cursor is replacement width", () => {
+    const plan = planRangeReplace("abc", 0, 0, "X")
+    const result = apply("abc", plan.actions)
+    expect(result.text).toBe("Xabc")
+    expect(plan.cursor).toBe(1)
+  })
+
+  test("out-of-range start clamps to 0", () => {
+    const plan = planRangeReplace("abc", -5, 2, "X")
+    const result = apply("abc", plan.actions)
+    expect(result.text).toBe("Xc")
+  })
+
+  test("out-of-range end clamps to total width", () => {
+    const plan = planRangeReplace("abc", 0, 99, "X")
+    const result = apply("abc", plan.actions)
+    expect(result.text).toBe("X")
+  })
+
+  test("inverted range (start > end) is normalized to insertion at the smaller offset", () => {
+    const plan = planRangeReplace("abc", 3, 0, "X")
+    const result = apply("abc", plan.actions)
+    expect(result.calls).toEqual(["setCursor(0)", 'insertText("X")'])
+    expect(result.text).toBe("Xabc")
+  })
+
+  test("replacement containing newlines: cursor counts \\n as 1", () => {
+    const plan = planRangeReplace("abc", 1, 1, "X\nY")
+    expect(plan.cursor).toBe(4)
+  })
+
+  test("replacement containing CJK: cursor counts width 2", () => {
+    const plan = planRangeReplace("abc", 0, 0, "你")
+    expect(plan.cursor).toBe(2)
+  })
+
+  test("replacement containing ZWJ family: cursor counts width 2", () => {
+    const plan = planRangeReplace("abc", 0, 0, "👨‍👩‍👧")
+    expect(plan.cursor).toBe(2)
+  })
+
+  test("plan does not contain any replaceText action (preserves extmark controller)", () => {
+    const plan = planRangeReplace("the qick brown fox", 4, 8, "quick")
+    expect(plan.actions.some((a) => (a as { type: string }).type === "replaceText")).toBe(false)
+  })
+
+  test("CJK 你a: empty range at offset 2 (after 你) is a true insertion, not a delete", () => {
+    const plan = planRangeReplace("你a", 2, 2, "X")
+    const result = apply("你a", plan.actions)
+    expect(result.calls).toEqual(["setCursor(2)", 'insertText("X")'])
+    expect(result.text).toBe("你Xa")
+  })
+
+  test("emoji 😀: empty range at offset 2 (after emoji) is a true insertion", () => {
+    const plan = planRangeReplace("😀a", 2, 2, "X")
+    const result = apply("😀a", plan.actions)
+    expect(result.calls).toEqual(["setCursor(2)", 'insertText("X")'])
+    expect(result.text).toBe("😀Xa")
+  })
+
+  test("replace across newlines (\\n = 1) offsets", () => {
+    const plan = planRangeReplace("ab\ncd", 3, 5, "X")
+    const result = apply("ab\ncd", plan.actions)
+    expect(result.text).toBe("ab\nX")
+    expect(plan.cursor).toBe(4)
+  })
+
+  test("displaySlice: extract prompt-part extmark text by offset range", () => {
+    const family = "👨‍👩‍👧"
+    const text = family + "ab"
+    expect(displaySlice(text, 0, 2)).toBe(family)
+    expect(displaySlice(text, 2, 3)).toBe("a")
+  })
+
+  test("replace range wholly inside a grapheme (CJK 你) snaps to full grapheme selection", () => {
+    const plan = planRangeReplace("你ab", 1, 1, "X")
+    const result = apply("你ab", plan.actions)
+    expect(result.calls).toEqual(["setCursor(0)", 'insertText("X")'])
+    expect(result.text).toBe("X你ab")
+  })
+})

--- a/packages/tui/test/prompt/display-range.test.ts
+++ b/packages/tui/test/prompt/display-range.test.ts
@@ -223,3 +223,30 @@ describe("planRangeReplace — extmark-safe primitive", () => {
     expect(result.text).toBe("X你ab")
   })
 })
+
+import { viewportScreenCoords } from "../../src/prompt/display"
+
+describe("viewportScreenCoords", () => {
+  const vp = { offsetX: 0, offsetY: 0, width: 80, height: 10 }
+  test("no scroll: adds screen origin to logical position", () => {
+    expect(viewportScreenCoords({ row: 2, col: 5 }, vp, 3, 1)).toEqual({ x: 8, y: 3 })
+  })
+  test("horizontal scroll: subtracts viewport.offsetX from col", () => {
+    expect(viewportScreenCoords({ row: 0, col: 40 }, { ...vp, offsetX: 30 }, 3, 1)).toEqual({ x: 13, y: 1 })
+  })
+  test("vertical scroll: subtracts viewport.offsetY from row", () => {
+    expect(viewportScreenCoords({ row: 12, col: 0 }, { ...vp, offsetY: 5 }, 0, 0)).toEqual({ x: 0, y: 7 })
+  })
+  test("col scrolled left of viewport → null", () => {
+    expect(viewportScreenCoords({ row: 0, col: 10 }, { ...vp, offsetX: 30 }, 0, 0)).toBeNull()
+  })
+  test("col past right edge → null", () => {
+    expect(viewportScreenCoords({ row: 0, col: 85 }, vp, 0, 0)).toBeNull()
+  })
+  test("row above viewport → null", () => {
+    expect(viewportScreenCoords({ row: 1, col: 0 }, { ...vp, offsetY: 5 }, 0, 0)).toBeNull()
+  })
+  test("row below viewport → null", () => {
+    expect(viewportScreenCoords({ row: 10, col: 0 }, vp, 0, 0)).toBeNull()
+  })
+})

--- a/packages/tui/test/prompt/extmark-facade.test.ts
+++ b/packages/tui/test/prompt/extmark-facade.test.ts
@@ -9,7 +9,7 @@ function makeController() {
     create(this: any) { this._marks.push(1); return this._marks.length },
     delete(this: any, id: number) { calls.push("delete"); return id > 0 },
     get() { return null },
-    getAll(this: any) { return this._marks.slice() },
+    getAll(this: any) { return this._marks.slice().map((id: number) => ({ id, start: 0, end: 0, virtual: false, typeId: 1 })) },
     getVirtual() { return [] },
     getAtOffset() { return [] },
     getAllForTypeId() { return [] },
@@ -26,22 +26,22 @@ function makeController() {
 describe("safeExtmarks facade", () => {
   test("omits clear and destroy", () => {
     const { controller } = makeController()
-    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller as any }))
+    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller } as any))
     expect((safe as any).clear).toBeUndefined()
     expect((safe as any).destroy).toBeUndefined()
   })
 
   test("delegates with correct `this` binding", () => {
     const { controller } = makeController()
-    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller as any }))
+    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller } as any))
     expect(safe.create({} as any)).toBe(1) // touched controller._marks via `this`
-    expect(safe.getAll()).toEqual([1])
+    expect(safe.getAll()).toEqual([{ id: 1, start: 0, end: 0, virtual: false, typeId: 1 }])
     expect(safe.registerType("x")).toBe(2)
   })
 
   test("never calls clear/destroy on the raw controller", () => {
     const { controller, calls } = makeController()
-    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller as any }))
+    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller } as any))
     safe.create({} as any)
     expect(calls).toEqual([]) // no clear/destroy reachable
   })
@@ -49,7 +49,7 @@ describe("safeExtmarks facade", () => {
   test("destroyed input: facade methods no-op safely (finding 6)", () => {
     const { controller, calls } = makeController()
     let destroyed = false
-    const safe = safeExtmarks(() => ({ get isDestroyed() { return destroyed }, extmarks: controller as any }))
+    const safe = safeExtmarks(() => ({ get isDestroyed() { return destroyed }, extmarks: controller } as any))
     destroyed = true // plugin captured `safe` before unmount, calls after
     expect(() => safe.create({} as any)).not.toThrow()
     expect(safe.getAll()).toEqual([])

--- a/packages/tui/test/prompt/extmark-facade.test.ts
+++ b/packages/tui/test/prompt/extmark-facade.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test"
+import { safeExtmarks } from "../../src/prompt/display"
+
+function makeController() {
+  const calls: string[] = []
+  // function expressions + `this` use → verifies the facade binds correctly.
+  const controller = {
+    _marks: [] as number[],
+    create(this: any) { this._marks.push(1); return this._marks.length },
+    delete(this: any, id: number) { calls.push("delete"); return id > 0 },
+    get() { return null },
+    getAll(this: any) { return this._marks.slice() },
+    getVirtual() { return [] },
+    getAtOffset() { return [] },
+    getAllForTypeId() { return [] },
+    registerType() { return 2 },
+    getTypeId() { return null },
+    getTypeName() { return null },
+    getMetadataFor() { return null },
+    clear() { calls.push("clear") },
+    destroy() { calls.push("destroy") },
+  }
+  return { controller, calls }
+}
+
+describe("safeExtmarks facade", () => {
+  test("omits clear and destroy", () => {
+    const { controller } = makeController()
+    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller as any }))
+    expect((safe as any).clear).toBeUndefined()
+    expect((safe as any).destroy).toBeUndefined()
+  })
+
+  test("delegates with correct `this` binding", () => {
+    const { controller } = makeController()
+    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller as any }))
+    expect(safe.create({} as any)).toBe(1) // touched controller._marks via `this`
+    expect(safe.getAll()).toEqual([1])
+    expect(safe.registerType("x")).toBe(2)
+  })
+
+  test("never calls clear/destroy on the raw controller", () => {
+    const { controller, calls } = makeController()
+    const safe = safeExtmarks(() => ({ isDestroyed: false, extmarks: controller as any }))
+    safe.create({} as any)
+    expect(calls).toEqual([]) // no clear/destroy reachable
+  })
+
+  test("destroyed input: facade methods no-op safely (finding 6)", () => {
+    const { controller, calls } = makeController()
+    let destroyed = false
+    const safe = safeExtmarks(() => ({ get isDestroyed() { return destroyed }, extmarks: controller as any }))
+    destroyed = true // plugin captured `safe` before unmount, calls after
+    expect(() => safe.create({} as any)).not.toThrow()
+    expect(safe.getAll()).toEqual([])
+    expect(safe.get(1)).toBeNull()
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/tui/test/prompt/extmark-replace.test.ts
+++ b/packages/tui/test/prompt/extmark-replace.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import { TextareaRenderable } from "@opentui/core"
+import { planRangeReplace } from "../../src/prompt/display"
+
+function applyActions(input: TextareaRenderable, text: string, actions: ReturnType<typeof planRangeReplace>["actions"]) {
+  for (const action of actions) {
+    if (action.type === "setCursor") input.cursorOffset = action.offset
+    else if (action.type === "setSelection") input.setSelection(action.start, action.end)
+    else if (action.type === "insertText") input.insertText(action.value)
+    else if (action.type === "clearSelection") input.clearSelection()
+  }
+  return input.plainText
+}
+
+describe("PromptRef.replaceRange — real TextareaRenderable extmark preservation", () => {
+  test("extmark covers the suffix; after replaceRange the suffix shifts but survives", async () => {
+    const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+    try {
+      const input = new TextareaRenderable(setup.renderer, { initialValue: "hello world" })
+      const typeId = input.extmarks.registerType("facade-test")
+      const id = input.extmarks.create({ start: 6, end: 11, typeId, virtual: true })
+      expect(input.plainText).toBe("hello world")
+      expect(input.extmarks.getAllForTypeId(typeId)).toHaveLength(1)
+
+      const plan = planRangeReplace("hello world", 0, 5, "J")
+      const result = applyActions(input, "hello world", plan.actions)
+      expect(result).toBe("J world")
+
+      const remaining = input.extmarks.getAllForTypeId(typeId)
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.id).toBe(id)
+      expect(remaining[0]?.start).toBe(2)
+      expect(remaining[0]?.end).toBe(7)
+    } finally {
+      if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    }
+  })
+
+  test("pure insertion mid-text shifts downstream extmark offsets and preserves it", async () => {
+    const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+    try {
+      const input = new TextareaRenderable(setup.renderer, { initialValue: "the  brown fox" })
+      const typeId = input.extmarks.registerType("facade-test")
+      const id = input.extmarks.create({ start: 4, end: 15, typeId, virtual: true })
+
+      const plan = planRangeReplace("the  brown fox", 4, 4, "quick ")
+      const result = applyActions(input, "the  brown fox", plan.actions)
+      expect(result).toBe("the quick  brown fox")
+
+      const remaining = input.extmarks.getAllForTypeId(typeId)
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.id).toBe(id)
+      expect(remaining[0]?.start).toBe(10)
+      expect(remaining[0]?.end).toBe(21)
+    } finally {
+      if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    }
+  })
+
+  test("replaceRange across a plugin extmark deletes the extmark (range contains it)", async () => {
+    const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+    try {
+      const input = new TextareaRenderable(setup.renderer, { initialValue: "hello world" })
+      const typeId = input.extmarks.registerType("facade-test")
+      input.extmarks.create({ start: 6, end: 11, typeId, virtual: true })
+
+      const plan = planRangeReplace("hello world", 4, 11, "X")
+      const result = applyActions(input, "hello world", plan.actions)
+      expect(result).toBe("hellX")
+
+      expect(input.extmarks.getAllForTypeId(typeId)).toHaveLength(0)
+    } finally {
+      if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    }
+  })
+})

--- a/packages/tui/test/prompt/ref-lifecycle.test.ts
+++ b/packages/tui/test/prompt/ref-lifecycle.test.ts
@@ -1,0 +1,51 @@
+import { describe, test, expect } from "bun:test"
+import { makeGuardedAccessors } from "../../src/prompt/display"
+
+describe("makeGuardedAccessors (retained-ref lifecycle guards)", () => {
+  const live = () => {
+    const calls: string[] = []
+    const input: any = {
+      isDestroyed: false,
+      plainText: "hello world",
+      getTextRange: (a: number, b: number) => `range:${a}-${b}`,
+      extmarks: { create: () => 1, clear: () => calls.push("ex.clear") },
+      cursorOffset: 0,
+      setSelection: () => calls.push("setSelection"),
+      insertText: () => calls.push("insertText"),
+      clearSelection: () => calls.push("clearSelection"),
+      clear: () => calls.push("clear"),
+    }
+    return { input, calls }
+  }
+
+  test("live input: methods delegate", () => {
+    const { input, calls } = live()
+    const acc = makeGuardedAccessors(() => input)
+    expect(acc.text()).toBe("hello world")
+    expect(acc.getTextRange(1, 4)).toBe("range:1-4")
+    expect(acc.extmarks.create({} as any)).toBe(1) // extmarks is the SafeExtmarks facade (a property)
+    acc.reset()
+    expect(calls).toContain("clear")     // input.clear()
+    expect(calls).toContain("ex.clear")  // input.extmarks.clear()
+  })
+
+  test("destroyed input: read methods no-op safely, no throw", () => {
+    const { input, calls } = live()
+    input.isDestroyed = true
+    const acc = makeGuardedAccessors(() => input)
+    expect(acc.text()).toBe("")
+    expect(acc.getTextRange(1, 4)).toBe("")
+    expect(() => acc.replaceRange(0, 1, "x")).not.toThrow()
+    expect(() => acc.reset()).not.toThrow()
+    expect(acc.extmarks.create({} as any)).toBe(-1) // facade method no-ops to its fallback
+    expect(calls).toEqual([]) // nothing touched the destroyed input
+  })
+
+  test("undefined input (never mounted): no-op safely", () => {
+    const acc = makeGuardedAccessors(() => undefined)
+    expect(acc.text()).toBe("")
+    expect(() => acc.replaceRange(0, 1, "x")).not.toThrow()
+    expect(() => acc.reset()).not.toThrow()
+    expect(acc.extmarks.getAll()).toEqual([]) // facade defined even when never mounted
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #19226

This PR adds the plugin-API primitives that enable inline ghost-text / Copilot-style completion (#19226) — `onChange`/`onCursorChange` to react to edits, `extmarks` for inline styled spans, and `offsetToScreen` to anchor an overlay. It doesn't ship a ghost-text feature itself; it gives plugins the surface to build one (and autocomplete, syntax highlighting, etc.). It also enables / relates to several other TUI-plugin and prompt requests:

- Related to #17425 — plugin-triggered input injection (`replaceRange` / `setCursorOffset` deliver the TUI half)
- Related to #27813 — projected-session prompt hooks (`onChange` / `replaceRange` are building blocks)
- Related to #27899 — headless prompt-mutation hook (this delivers the TUI-side equivalent)

### Type of change

- [x] New feature

### What does this PR do?

Gives TUI plugins controlled access to the prompt input, so a plugin can build things like autocomplete, inline syntax highlighting, or AI ghost-text overlays — none of which are possible today because the prompt internals aren't reachable from a plugin. It adds a `prompt` facade (`api.prompt`) plus a `theme.syntax()` style registry to the TUI plugin API.

The new surface (all on `packages/plugin/src/tui.ts`, the public type):

- `api.prompt.ref()` — the live prompt ref, or `undefined` before mount (read on demand; it's replaced on route changes).
- `api.prompt.onChange(cb)` / `api.prompt.onCursorChange(cb)` — subscribe to content edits and cursor moves; survive prompt remounts; return disposers.
- On the ref: `text`, `getTextRange(start, end)`, `replaceRange(start, end, replacement)`, `cursorOffset` / `setCursorOffset(offset)`, `offsetToScreen(offset)` (offset → absolute screen x/y, for anchoring an overlay), and a narrowed `extmarks` controller (create/delete/query inline styled spans on the prompt text).
- `theme.syntax()` — `registerStyle(name, def) → id` / `getStyleId(name)`, so a plugin gets a stable style id to use when creating extmarks.

A few semantics worth calling out (they're documented inline on the types):

- All offsets are **display-width** offsets, consistent with `cursorOffset` (not raw string indices), so wide/zero-width characters behave correctly.
- `replaceRange` with `start > end` is treated as a pure **insertion** at the lower bound (it never deletes), and it preserves the prompt's undo history and extmark controller rather than rebuilding the buffer.
- `offsetToScreen` accounts for horizontal scroll and returns `null` when the prompt is unmounted, the offset is out of range, or the textarea hasn't been laid out yet — so a plugin polling it during teardown won't get stale coordinates.
- Retained refs are guarded: if a plugin holds a ref across a remount, calling into a destroyed input is a no-op/empty rather than a crash.
- The change/cursor channels guard against same-channel reentrancy (a nested emit on the same channel is dropped); the one thing a plugin must not do is create a circular **cross-channel** mutation (onChange → mutate cursor → onCursorChange → mutate text → …), which is documented as a constraint.

Most of the commits after the first two are hardening of exactly these edge cases (scroll-aware `offsetToScreen`, per-channel emit guards, destroyed-ref guards, the insertion/inverted-range semantics) — they came out of an internal review pass.

### How did you verify your code works?

- `bun typecheck` clean on both `packages/tui` and `packages/plugin`.
- New tests for the facade, all green locally: display-offset ↔ screen conversion with horizontal scroll, the extmark facade + extmark-preserving `replaceRange`, ref lifecycle across remount (retained-ref guards), the change/cursor subscription channels, and the opencode-side plugin-loader wiring (`test/cli/tui/plugin-loader.test.ts`). ~70 assertions across the prompt/context/loader suites.
- The API was reviewed against the edge cases above before finalizing (offset model, inverted-range insertion, teardown/remount safety, reentrancy).

### Screenshots / recordings

No user-facing visual change on its own — this is a plugin-facing API; the visuals come from whatever plugin consumes it. Happy to attach a short recording of a sample overlay plugin if useful.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR