### PR TITLE
fix(core): strip server credentials from PTY child environments

### DIFF
--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -203,6 +203,12 @@ export const layer = Layer.effect(
         TERM: "xterm-256color",
         OPENCODE_TERMINAL: "1",
       } as Record<string, string>
+      // Strip server credentials so embedded terminals don't inherit them.
+      // The desktop sidecar sets these in its own process.env; without stripping
+      // them, any `opencode serve` run from an embedded terminal would silently
+      // require the sidecar's auto-generated password.
+      delete env.OPENCODE_SERVER_PASSWORD
+      delete env.OPENCODE_SERVER_USERNAME
       if (process.platform === "win32") {
         env.LC_ALL = "C.UTF-8"
         env.LC_CTYPE = "C.UTF-8"


### PR DESCRIPTION
## Problem

The desktop sidecar sets `OPENCODE_SERVER_PASSWORD` directly in `process.env` so the embedded server requires authentication. PTY terminals are spawned with `...process.env`, so every embedded shell session inherits that variable.

When a user runs `opencode serve` (or `opencode web`) from the embedded terminal, the new server silently picks up the sidecar's auto-generated password and requires authentication — even though the user never configured one themselves. The `OPENCODE_SERVER_PASSWORD is not set; server is unsecured` warning is also suppressed because the variable *is* set (via inheritance).

## Fix

Delete `OPENCODE_SERVER_PASSWORD` and `OPENCODE_SERVER_USERNAME` from the assembled PTY environment after the spread so the sidecar's credentials stay internal to the server process and never reach user-facing terminals.

## Testing

Existing test `keeps PTY websocket tickets optional when server auth is disabled` (httpapi-listen.test.ts) still passes. All 11 listen tests pass.