### PR TITLE
fix(acp): route permission replies to origin directory

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -24,6 +24,7 @@ import {
 type Connection = Pick<AgentSideConnection, "sessionUpdate"> &
   Partial<Pick<AgentSideConnection, "requestPermission" | "writeTextFile">>
 type GlobalEventEnvelope = {
+  directory?: string
   payload?: Event
 }
 type GlobalEventStream = {
@@ -65,10 +66,10 @@ export class Subscription {
     this.abort.abort()
   }
 
-  async handle(event: Event) {
+  async handle(event: Event, directory?: string) {
     switch (event.type) {
       case "permission.asked":
-        this.permission.handle(event)
+        this.permission.handle(event, directory)
         return
       case "message.part.updated":
         return this.handlePartUpdated(event)
@@ -122,7 +123,7 @@ export class Subscription {
       for await (const event of events.stream) {
         if (this.abort.signal.aborted) return
         if (!event.payload) continue
-        await this.handle(event.payload).catch(() => {})
+        await this.handle(event.payload, event.directory).catch(() => {})
       }
       if (!this.abort.signal.aborted) await new Promise((resolve) => setTimeout(resolve, 1000))
     }

--- a/packages/opencode/src/acp/permission.ts
+++ b/packages/opencode/src/acp/permission.ts
@@ -27,11 +27,11 @@ export class Handler {
     },
   ) {}
 
-  handle(event: PermissionEvent) {
+  handle(event: PermissionEvent, directory?: string) {
     const permission = event.properties
     const previous = this.queues.get(permission.sessionID) ?? Promise.resolve()
     const next = previous
-      .then(() => this.process(event))
+      .then(() => this.process(event, directory))
       .catch(() => {})
       .finally(() => {
         if (this.queues.get(permission.sessionID) === next) {
@@ -41,13 +41,14 @@ export class Handler {
     this.queues.set(permission.sessionID, next)
   }
 
-  private async process(event: PermissionEvent) {
+  private async process(event: PermissionEvent, directory?: string) {
     const permission = event.properties
     const session = await Effect.runPromise(this.input.session.tryGet(permission.sessionID))
     if (!session) return
+    const replyDirectory = directory ?? session.cwd
 
     if (!this.input.connection.requestPermission) {
-      await this.reply(permission.id, "reject", session.cwd)
+      await this.reply(permission.id, "reject", replyDirectory)
       return
     }
 
@@ -65,7 +66,7 @@ export class Handler {
         options: permissionOptions,
       })
       .catch(async () => {
-        await this.reply(permission.id, "reject", session.cwd)
+        await this.reply(permission.id, "reject", replyDirectory)
         return undefined
       })
 
@@ -73,7 +74,7 @@ export class Handler {
 
     const reply = selectedReply(result)
     if (reply !== "once" && reply !== "always") {
-      await this.reply(permission.id, "reject", session.cwd)
+      await this.reply(permission.id, "reject", replyDirectory)
       return
     }
 
@@ -81,7 +82,7 @@ export class Handler {
       await this.writeProposedEdit(session.id, permission.metadata).catch(() => {})
     }
 
-    await this.reply(permission.id, reply, session.cwd)
+    await this.reply(permission.id, reply, replyDirectory)
   }
 
   private async reply(requestID: string, reply: Reply, directory: string) {

--- a/packages/opencode/test/acp/permission.test.ts
+++ b/packages/opencode/test/acp/permission.test.ts
@@ -165,6 +165,20 @@ describe("acp permissions", () => {
     expect(harness.replies).toEqual([{ requestID: "perm_1", reply: "once", directory: "/workspace" }])
   })
 
+  it("replies to permissions using the event origin directory", async () => {
+    const harness = createHarness()
+    await createSession(harness.session, "ses_a", "/loaded")
+
+    await harness.subscription.handle(
+      permissionAsked("ses_a", "perm_origin", { tool: { messageID: "msg_1", callID: "call_1" } }),
+      "/created",
+    )
+
+    await pollUntil(() => harness.replies.length === 1, "permission was never replied")
+
+    expect(harness.replies).toEqual([{ requestID: "perm_origin", reply: "once", directory: "/created" }])
+  })
+
   it("forwards external_directory metadata and locations to requestPermission", async () => {
     const harness = createHarness()
     await createSession(harness.session, "ses_a")


### PR DESCRIPTION
Fixes #31964.

## What changed
- Carry the global event envelope directory into ACP permission handling.
- Reply to permission requests using the event origin directory, falling back to the ACP session cwd for older/direct events.
- Add a regression test for a loaded ACP session whose current cwd differs from the directory where the permission was asked.

## Validation
- `bun test test/acp/permission.test.ts`
- `bun typecheck` from `packages/opencode`
- `bunx oxlint packages/opencode/src/acp/event.ts packages/opencode/src/acp/permission.ts packages/opencode/test/acp/permission.test.ts` -> 0 errors, existing warnings only
- `bunx prettier --check packages/opencode/src/acp/event.ts packages/opencode/src/acp/permission.ts packages/opencode/test/acp/permission.test.ts`
- `git diff --check`
- pre-push `bun turbo typecheck` -> 23 tasks passed