### PR TITLE
fix(tui): preserve text when editing slash command with argument

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -638,7 +638,7 @@ export function Autocomplete(props: {
 
   function hide() {
     const text = props.input().plainText
-    if (store.visible === "/" && !text.endsWith(" ") && text.startsWith("/")) {
+    if (store.visible === "/" && /^\/\S*$/.test(text)) {
       const cursor = props.input().logicalCursor
       props.input().deleteRange(0, 0, cursor.row, cursor.col)
       // Sync the prompt store immediately since onContentChange is async


### PR DESCRIPTION
### Issue for this PR

Closes #31567

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the slash command input deleting everything before the cursor when the command has an argument. So if we type `/foo-command x` and move its cursor back to fix a typo in the command name for instance, it wipes from the start of the line up to the cursor instead of just removing the one char.

The autocomplete clears the typed command on close, which it needs to do so executed commands like `/new` don't leave `/new` sitting in the prompt however it was also matching commands that have an argument, so editing inside the name triggered the wipe.

Changed the check so it only clears when the whole input is just the command and nothing else (space, argument).  Bare commands still get cleared like before, anything with an argument is left alone now.

### How did you verify your code works?

- `/foo-command x`, went back into the name and typed/backspaced, only that char changes now
- `/new` from the menu still runs and clears the text, no regression there
- typecheck passes for the tui package

### Screenshots / recordings

https://github.com/user-attachments/assets/d2fcaa17-5b01-4c8f-879f-ad9e5c7f934e

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
