### PR TITLE
fix(tui): request root sessions in switcher dialog

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -18,6 +18,18 @@ import { errorMessage } from "../util/error"
 import { DialogSessionDeleteFailed } from "./dialog-session-delete-failed"
 import { useCommandShortcut } from "../keymap"
 
+type SessionListFilter = { scope?: "project"; path?: string }
+
+export function createDialogSessionListQuery(input: { search?: string; filter: SessionListFilter }) {
+  const search = input.search?.trim()
+  return {
+    roots: true,
+    limit: search ? 30 : 100,
+    ...(search ? { search } : {}),
+    ...input.filter,
+  }
+}
+
 export function DialogSessionList() {
   const dialog = useDialog()
   const route = useRoute()
@@ -33,17 +45,26 @@ export function DialogSessionList() {
   const quickSwitch1 = useCommandShortcut("session.quick_switch.1")
   const quickSwitch9 = useCommandShortcut("session.quick_switch.9")
 
+  const [browseResults, { refetch: refetchBrowse }] = createResource(
+    () => sync.session.query(),
+    async (filter) => {
+      const result = await sdk.client.session.list(createDialogSessionListQuery({ filter }))
+      return result.data ?? []
+    },
+  )
   const [searchResults, { refetch }] = createResource(
     () => ({ query: search(), filter: sync.session.query() }),
     async (input) => {
       if (!input.query) return undefined
-      const result = await sdk.client.session.list({ search: input.query, limit: 30, ...input.filter })
+      const result = await sdk.client.session.list(
+        createDialogSessionListQuery({ search: input.query, filter: input.filter }),
+      )
       return result.data ?? []
     },
   )
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
-  const sessions = createMemo(() => searchResults() ?? sync.data.session)
+  const sessions = createMemo(() => searchResults() ?? browseResults() ?? [])
 
   function recover(session: NonNullable<ReturnType<typeof sessions>[number]>) {
     const workspace = project.workspace.get(session.workspaceID!)
@@ -107,7 +128,7 @@ export function DialogSessionList() {
             return false
           }
           await project.workspace.sync()
-          await sync.session.refresh()
+          await refetchBrowse()
           if (search()) await refetch()
           if (info?.workspaceID === session.workspaceID) {
             route.navigate({ type: "home" })
@@ -138,7 +159,7 @@ export function DialogSessionList() {
       .map((x) => x.id)
   }
 
-  const [browseOrder] = createSignal<string[]>(orderByRecency(sync.data.session))
+  const browseOrder = createMemo(() => orderByRecency(browseResults() ?? []))
 
   const quickSwitchHint = createMemo(() => {
     const first = quickSwitch1()
@@ -276,9 +297,7 @@ export function DialogSessionList() {
                 setToDelete(undefined)
                 return
               }
-              if (status && status !== "connected") {
-                await sync.session.refresh()
-              }
+              await refetchBrowse()
               if (search()) await refetch()
               setToDelete(undefined)
               return

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -155,7 +155,7 @@ export const {
 
     function listSessions() {
       return sdk.client.session
-        .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
+        .list({ roots: true, start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -155,7 +155,7 @@ export const {
 
     function listSessions() {
       return sdk.client.session
-        .list({ roots: true, start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
+        .list({ start: Date.now() - 30 * 24 * 60 * 60 * 1000, ...sessionListQuery() })
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 

--- a/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
@@ -6,6 +6,7 @@ import { KVProvider, useKV } from "../../../../src/context/kv"
 import { ProjectProvider, useProject } from "../../../../src/context/project"
 import { SDKProvider } from "../../../../src/context/sdk"
 import { SyncProvider, useSync } from "../../../../src/context/sync"
+import { ExitProvider } from "../../../../src/context/exit"
 import { createEventSource, createFetch, type FetchHandler, directory } from "../../../fixture/tui-sdk"
 import { TestTuiContexts } from "../../../fixture/tui-environment"
 export { createEventSource, createFetch, directory, eventSource, json, worktree } from "../../../fixture/tui-sdk"
@@ -48,9 +49,11 @@ export async function mount(override?: FetchHandler, state?: string) {
         <KVProvider>
           <SDKProvider url="http://test" directory={directory} fetch={calls.fetch} events={events.source}>
             <ProjectProvider>
-              <SyncProvider>
-                <Probe />
-              </SyncProvider>
+              <ExitProvider exit={() => {}}>
+                <SyncProvider>
+                  <Probe />
+                </SyncProvider>
+              </ExitProvider>
             </ProjectProvider>
           </SDKProvider>
         </KVProvider>

--- a/packages/tui/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync.test.tsx
@@ -25,7 +25,7 @@ describe("tui sync", () => {
 
     try {
       expect(kv.get("session_directory_filter_enabled", true)).toBe(true)
-      expect(session.at(-1)?.searchParams.get("roots")).toBe("true")
+      expect(session.at(-1)?.searchParams.get("roots")).toBeNull()
       expect(session.at(-1)?.searchParams.get("scope")).toBeNull()
       expect(session.at(-1)?.searchParams.get("path")).toBe("packages/tui")
 
@@ -34,7 +34,7 @@ describe("tui sync", () => {
 
       expect(session.at(-1)?.searchParams.get("scope")).toBe("project")
       expect(session.at(-1)?.searchParams.get("path")).toBeNull()
-      expect(session.at(-1)?.searchParams.get("roots")).toBe("true")
+      expect(session.at(-1)?.searchParams.get("roots")).toBeNull()
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync.test.tsx
@@ -25,6 +25,7 @@ describe("tui sync", () => {
 
     try {
       expect(kv.get("session_directory_filter_enabled", true)).toBe(true)
+      expect(session.at(-1)?.searchParams.get("roots")).toBe("true")
       expect(session.at(-1)?.searchParams.get("scope")).toBeNull()
       expect(session.at(-1)?.searchParams.get("path")).toBe("packages/tui")
 
@@ -33,6 +34,7 @@ describe("tui sync", () => {
 
       expect(session.at(-1)?.searchParams.get("scope")).toBe("project")
       expect(session.at(-1)?.searchParams.get("path")).toBeNull()
+      expect(session.at(-1)?.searchParams.get("roots")).toBe("true")
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/component/dialog-session-list.test.ts
+++ b/packages/tui/test/component/dialog-session-list.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test"
+import { createDialogSessionListQuery } from "../../src/component/dialog-session-list"
+
+describe("dialog session list", () => {
+  test("requests root sessions for the default browse list", () => {
+    expect(createDialogSessionListQuery({ filter: { path: "packages/tui" } })).toEqual({
+      roots: true,
+      limit: 100,
+      path: "packages/tui",
+    })
+  })
+
+  test("requests root sessions for search results", () => {
+    expect(createDialogSessionListQuery({ search: "deploy", filter: { scope: "project" } })).toEqual({
+      roots: true,
+      limit: 30,
+      search: "deploy",
+      scope: "project",
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #16270
Closes #32725

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI session switch dialog now requests root sessions from dialog-local browse and search queries. This keeps the existing directory/project filters and passes `roots: true`, so recently updated subagent child sessions cannot consume the server-side session list limit before the dialog renders top-level sessions.

The shared TUI sync cache remains a mixed root+child session list for parent/child navigation, subagent footer metadata, and child permission/question aggregation.

The tests cover both sides of that split: the dialog query helper requests root sessions, while the shared sync refresh does not add `roots=true`.

### How did you verify your code works?

- Checked the local OpenCode database for a project with many child sessions: recent session rows were dominated by child sessions while top-level sessions still existed.
- Ran `bun test test/component/dialog-session-list.test.ts test/cli/cmd/tui/sync.test.tsx` from `packages/tui`.
- Ran `bun run typecheck` from `packages/tui`.
- Ran `git diff --check`.
- Pre-push hook ran `bun turbo typecheck` successfully.

### Screenshots / recordings

Not included. This fixes session switcher data loading rather than visual layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR