### PR TITLE
fix(app): auto-detect text direction (RTL) for messages and composer

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1561,6 +1561,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                 <div class="relative max-h-[180px] overflow-y-auto no-scrollbar" ref={(el) => (scrollRef = el)}>
                   <div
                     data-component="prompt-input"
+                    dir="auto"
                     ref={(el) => {
                       editorRef = el
                       props.ref?.(el)
@@ -1740,6 +1741,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               >
                 <div
                   data-component="prompt-input"
+                  dir="auto"
                   ref={(el) => {
                     editorRef = el
                     props.ref?.(el)

--- a/packages/ui/src/components/markdown.css
+++ b/packages/ui/src/components/markdown.css
@@ -3,6 +3,9 @@
   min-width: 0;
   max-width: 100%;
   overflow-wrap: break-word;
+  /* Auto-detect direction per paragraph (RTL for Hebrew/Arabic). Pairs with the
+     dir="auto" attribute on the container, which sets box direction for markers. */
+  unicode-bidi: plaintext;
   color: var(--text-strong);
   font-family: var(--font-family-sans);
   font-size: var(--font-size-base); /* 14px */
@@ -66,8 +69,8 @@
   ol {
     margin-top: 8px;
     margin-bottom: 12px;
-    margin-left: 0;
-    padding-left: 32px;
+    margin-inline-start: 0;
+    padding-inline-start: 32px;
     list-style-position: outside;
   }
 
@@ -77,7 +80,7 @@
 
   ol {
     list-style-type: decimal;
-    padding-left: 2.25rem;
+    padding-inline-start: 2.25rem;
   }
 
   li {
@@ -103,18 +106,18 @@
   li > ol {
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
-    padding-left: 1rem; /* Minimal indent for nesting only */
+    padding-inline-start: 1rem; /* Minimal indent for nesting only */
   }
 
   li > ol {
-    padding-left: 1.75rem;
+    padding-inline-start: 1.75rem;
   }
 
   /* Blockquotes */
   blockquote {
-    border-left: 2px solid var(--border-weak-base);
+    border-inline-start: 2px solid var(--border-weak-base);
     margin: 1.5rem 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
     color: var(--text-weak);
     font-style: normal;
   }
@@ -213,6 +216,11 @@
     margin-bottom: 32px;
     overflow: auto;
 
+    /* Code is always LTR, even inside an RTL message */
+    unicode-bidi: normal;
+    direction: ltr;
+    text-align: left;
+
     scrollbar-width: none;
     &::-webkit-scrollbar {
       display: none;
@@ -248,7 +256,7 @@
     /* Minimal borders for structure, matching TUI "lines" roughly but keeping it web-clean */
     border-bottom: 1px solid var(--border-weaker-base);
     padding: 12px;
-    text-align: left;
+    text-align: start;
     vertical-align: top;
   }
 

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -467,6 +467,7 @@ export function Markdown(
   return (
     <div
       data-component="markdown"
+      dir="auto"
       classList={{
         ...local.classList,
         [local.class ?? ""]: !!local.class,

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -1166,7 +1166,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
       <Show when={text()}>
         <>
           <div data-slot="user-message-body">
-            <div data-slot="user-message-text">
+            <div data-slot="user-message-text" dir="auto">
               <HighlightedText text={text()} references={inlineFiles()} agents={agents()} />
             </div>
           </div>


### PR DESCRIPTION
### Issue for this PR

Closes #32726
Related (open): #14257, #16875

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hebrew and Arabic text in messages and the composer currently renders left-to-right and left-aligned, so it reads incorrectly: punctuation and list markers end up on the wrong side. This is a content-level rendering bug, not a UI-language setting, so it affects anyone typing or receiving RTL text even while the UI is in English.

The fix is small and content-driven:

- `dir="auto"` on the markdown, user-message, and composer containers, so each message picks its direction from its own text content.
- In `markdown.css`, list and blockquote spacing moves from physical `padding-left` / `margin-left` / `border-left` to logical `*-inline-start`, so indentation and quote borders land on the correct side in RTL. This is a no-op for LTR content.
- `unicode-bidi: plaintext` on the markdown container for per-paragraph direction (the codebase already uses this utility for file paths).
- Code blocks are pinned to LTR so code is unaffected inside an RTL message.

This is intentionally narrower than #32247, which mirrors the whole UI when the app language is set to Arabic. This PR is language-agnostic and content-based: it fixes reading and writing RTL text without switching the UI language, and covers Hebrew as well as Arabic. The two can coexist; this one targets the text-rendering bug specifically.

### How did you verify your code works?

Verified the rendering with English, Hebrew, and mixed messages, including nested lists, blockquotes, inline code, and code blocks:

- Before: Hebrew/Arabic content renders left-to-right and left-aligned, with list markers and blockquote borders on the wrong side.
- After: it renders right-to-left with correct alignment, list markers, indentation, and quote borders. English rendering is unchanged, and code blocks stay LTR.

### Screenshots / recordings

This is a small, deterministic CSS + `dir="auto"` change, so the before/after is described above rather than shown. Happy to add a screen recording if a maintainer wants one.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
