### PR TITLE
fix(provider): support OpenRouter model variants 🚀

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1757,6 +1757,17 @@ export const layer = Layer.effect(
       InstanceState.use(state, (s) => s.providers[providerID]),
     )
 
+    const OPENROUTER_VARIANTS = new Set(["free", "extended", "exacto", "thinking", "online", "nitro"])
+
+    const openRouterVariant = (modelID: ModelV2.ID): { base: ModelV2.ID; variant: string } | undefined => {
+      const id = String(modelID)
+      const separator = id.lastIndexOf(":")
+      if (separator === -1) return undefined
+      const variant = id.slice(separator + 1)
+      if (!OPENROUTER_VARIANTS.has(variant)) return undefined
+      return { base: ModelV2.ID.make(id.slice(0, separator)), variant }
+    }
+
     const getModel = Effect.fn("Provider.getModel")(function* (providerID: ProviderV2.ID, modelID: ModelV2.ID) {
       const s = yield* InstanceState.get(state)
       const provider = s.providers[providerID]
@@ -1771,14 +1782,27 @@ export const layer = Layer.effect(
       }
 
       const info = provider.models[modelID]
-      if (!info) {
-        const current = modelSuggestions(provider, modelID, runtimeFlags.enableExperimentalModels)
-        const suggestions = current.length
-          ? current
-          : modelSuggestions(s.catalog[providerID], modelID, runtimeFlags.enableExperimentalModels)
-        return yield* new ModelNotFoundError({ providerID, modelID, suggestions })
+      if (info) return info
+
+      if (providerID === ProviderV2.ID.openrouter) {
+        const variant = openRouterVariant(modelID)
+        if (variant) {
+          const base = provider.models[variant.base]
+          if (base) {
+            return {
+              ...base,
+              id: modelID,
+              api: { ...base.api, id: `${base.api.id}:${variant.variant}` },
+            }
+          }
+        }
       }
-      return info
+
+      const current = modelSuggestions(provider, modelID, runtimeFlags.enableExperimentalModels)
+      const suggestions = current.length
+        ? current
+        : modelSuggestions(s.catalog[providerID], modelID, runtimeFlags.enableExperimentalModels)
+      return yield* new ModelNotFoundError({ providerID, modelID, suggestions })
     })
 
     const getLanguage = Effect.fn("Provider.getLanguage")(function* (model: Model) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -322,6 +322,70 @@ it.instance("getModel throws ModelNotFoundError for invalid provider", () =>
   }),
 )
 
+it.instance(
+  "getModel resolves OpenRouter variant suffixes to the base model",
+  () =>
+    Effect.gen(function* () {
+      yield* set("OPENROUTER_API_KEY", "test-api-key")
+      const provider = yield* Provider.Service
+      const base = yield* provider.getModel(
+        ProviderV2.ID.openrouter,
+        ModelV2.ID.make("deepseek/deepseek-r1-0528"),
+      )
+      expect(String(base.id)).toBe("deepseek/deepseek-r1-0528")
+      expect(base.api.id).toBe("deepseek/deepseek-r1-0528")
+
+      const free = yield* provider.getModel(
+        ProviderV2.ID.openrouter,
+        ModelV2.ID.make("deepseek/deepseek-r1-0528:free"),
+      )
+      expect(String(free.id)).toBe("deepseek/deepseek-r1-0528:free")
+      expect(free.api.id).toBe("deepseek/deepseek-r1-0528:free")
+
+      const extended = yield* provider.getModel(
+        ProviderV2.ID.openrouter,
+        ModelV2.ID.make("deepseek/deepseek-r1-0528:extended"),
+      )
+      expect(String(extended.id)).toBe("deepseek/deepseek-r1-0528:extended")
+      expect(extended.api.id).toBe("deepseek/deepseek-r1-0528:extended")
+    }),
+  {
+    config: {
+      provider: {
+        openrouter: {
+          models: {
+            "deepseek/deepseek-r1-0528": { name: "DeepSeek R1" },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "getModel rejects unknown OpenRouter variant suffixes",
+  () =>
+    Effect.gen(function* () {
+      yield* set("OPENROUTER_API_KEY", "test-api-key")
+      const provider = yield* Provider.Service
+      const exit = yield* provider
+        .getModel(ProviderV2.ID.openrouter, ModelV2.ID.make("deepseek/deepseek-r1-0528:unknown"))
+        .pipe(Effect.exit)
+      expect(exit._tag).toBe("Failure")
+    }),
+  {
+    config: {
+      provider: {
+        openrouter: {
+          models: {
+            "deepseek/deepseek-r1-0528": { name: "DeepSeek R1" },
+          },
+        },
+      },
+    },
+  },
+)
+
 // Pure synchronous unit tests — no Effect runtime needed.
 
 test("parseModel correctly parses provider/model string", () => {
@@ -334,6 +398,12 @@ test("parseModel handles model IDs with slashes", () => {
   const result = Provider.parseModel("openrouter/anthropic/claude-3-opus")
   expect(String(result.providerID)).toBe("openrouter")
   expect(String(result.modelID)).toBe("anthropic/claude-3-opus")
+})
+
+test("parseModel preserves OpenRouter variant suffixes", () => {
+  const result = Provider.parseModel("openrouter/openai/gpt-4o-mini:free")
+  expect(String(result.providerID)).toBe("openrouter")
+  expect(String(result.modelID)).toBe("openai/gpt-4o-mini:free")
 })
 
 it.instance("defaultModel returns first available model when no config set", () =>


### PR DESCRIPTION
## Summary
OpenRouter model variants (`:free`, `:extended`, `:exacto`, `:thinking`, `:online`, `:nitro`) were rejected because the model catalog only contains the base model ID. This change resolves a variant-suffixed model ID to its base catalog entry and passes the full suffixed ID to the OpenRouter SDK.

## Changes
- `packages/opencode/src/provider/provider.ts`
  - Recognize OpenRouter variant suffixes during model lookup.
  - Return the base model with `id` and `api.id` updated to include the variant suffix.
- `packages/opencode/test/provider/provider.test.ts`
  - Add tests for parsing and resolving `:free`/`:extended` variants.
  - Ensure unknown suffixes still fail with `ModelNotFoundError`.

## Testing
- `bun test test/provider/provider.test.ts` — 91 pass, 0 fail ✅
- `bun test test/acp/config-option.test.ts` — 16 pass, 0 fail ✅
- `bun typecheck` ✅

## Related docs
- https://openrouter.ai/docs/guides/routing/model-variants/free
- https://openrouter.ai/docs/guides/routing/model-variants/extended
- https://openrouter.ai/docs/guides/routing/model-variants/exacto
- https://openrouter.ai/docs/guides/routing/model-variants/thinking
- https://openrouter.ai/docs/guides/routing/model-variants/online
- https://openrouter.ai/docs/guides/routing/model-variants/nitro
