### PR TITLE
fix(session): skip working-tree restore when reverting a no-change turn

### DIFF
--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -68,8 +68,13 @@ export const layer = Layer.effect(
       if (!rev) return session
 
       rev.snapshot = session.revert?.snapshot ?? (yield* snap.track())
-      if (session.revert?.snapshot) yield* snap.restore(session.revert.snapshot)
-      yield* snap.revert(patches)
+      // A reverted turn that produced no file changes must not touch the working
+      // tree: the forced read-tree/checkout-index would clobber unstaged changes.
+      // Only run the file-restore path when there are patches to revert.
+      if (patches.length > 0) {
+        if (session.revert?.snapshot) yield* snap.restore(session.revert.snapshot)
+        yield* snap.revert(patches)
+      }
       if (rev.snapshot) rev.diff = yield* snap.diff(rev.snapshot)
       const range = all.filter((msg) => msg.info.id >= rev.messageID)
       const diffs = yield* summary.computeDiff({ messages: range })

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -636,4 +636,41 @@ describe("revert + compact workflow", () => {
       { git: true },
     ),
   )
+
+  it.live(
+    "reverting a turn with no file changes leaves the working tree untouched",
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+
+          yield* write(path.join(dir, "a.txt"), "a0")
+
+          const info = yield* session.create({})
+          const sid = info.id
+
+          // A turn that only chats (no `patch` parts) — nothing changed on disk.
+          const u = yield* user(sid)
+          yield* text(sid, u.id, "what is the capital of France?")
+          const a = yield* assistant(sid, u.id, dir)
+          yield* text(sid, a.id, "Paris.")
+
+          // The user edits a file after the turn; this is unstaged work that an
+          // undo of a no-op turn must not clobber.
+          yield* write(path.join(dir, "a.txt"), "unstaged-edit")
+
+          yield* revert.revert({
+            sessionID: sid,
+            messageID: u.id,
+          })
+
+          // Revert state is still recorded even though no files were touched.
+          expect((yield* session.get(sid)).revert?.messageID).toBe(u.id)
+          // The working tree is left exactly as the user left it.
+          expect(yield* read(path.join(dir, "a.txt"))).toBe("unstaged-edit")
+        }),
+      { git: true },
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #32529

### Type of change

- [x] Bug fix

### What does this PR do?

Reverting a turn that changed no files still ran the forced snapshot restore (git read-tree + git checkout-index -a -f), which overwrites the working tree and wipes the user's unstaged edits. I guarded the restore/revert path on `patches.length > 0` so undoing a no-op turn leaves the working tree alone. The revert bookkeeping (diff, storage write, events, setRevert) still runs regardless, so revert state is recorded as before.

### How did you verify your code works?

Added a test in test/session/revert-compact.test.ts: write an unstaged edit, revert a chat-only (no-patch) turn, and assert the file is untouched while revert state is still recorded. Ran the revert-compact suite locally with bun — the new test and the existing ones pass.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR