### PR TITLE
fix(session): don't let auto-title overwrite a title set mid-turn

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -247,6 +247,12 @@ const layer = Layer.effect(
         .find((line) => line.length > 0)
       if (!cleaned) return
       const t = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
+      // Re-read the session from storage: a plugin or user may have renamed it
+      // (e.g. via session.rename/setTitle) mid-turn while the title was being
+      // generated. The captured `input.session` is stale, so honour the latest
+      // title and skip the auto-title if it is no longer the default.
+      const current = yield* sessions.get(input.session.id).pipe(Effect.orDie)
+      if (!Session.isDefaultTitle(current.title)) return
       yield* sessions
         .setTitle({ sessionID: input.session.id, title: t })
         .pipe(Effect.catchCause((cause) => Effect.logError("failed to generate title", { error: Cause.squash(cause) })))

--- a/packages/opencode/test/lib/llm-server.ts
+++ b/packages/opencode/test/lib/llm-server.ts
@@ -624,6 +624,7 @@ namespace TestLLMServer {
     readonly error: (status: number, body: unknown) => Effect.Effect<void>
     readonly hang: Effect.Effect<void>
     readonly hold: (value: string, wait: PromiseLike<unknown>) => Effect.Effect<void>
+    readonly holdTitle: (wait: PromiseLike<unknown>) => Effect.Effect<void>
     readonly reset: Effect.Effect<void>
     readonly hits: Effect.Effect<Hit[]>
     readonly calls: Effect.Effect<number>
@@ -645,6 +646,10 @@ export class TestLLMServer extends Context.Service<TestLLMServer, TestLLMServer.
       let list: Queue[] = []
       let waits: Wait[] = []
       let misses: Hit[] = []
+      // Optional gate for the auto-title request: when set, the title response is
+      // held until this promise resolves. Lets tests open a window to mutate the
+      // session (e.g. a plugin rename) while title generation is in flight.
+      let titleHold: PromiseLike<unknown> | undefined
 
       const queue = (...input: (Item | Reply)[]) => {
         list = [...list, ...input.map((value) => ({ item: item(value) }))]
@@ -676,7 +681,12 @@ export class TestLLMServer extends Context.Service<TestLLMServer, TestLLMServer.
         if (isTitleRequest(body)) {
           hits = [...hits, current]
           yield* notify()
-          const auto: Sse = { type: "sse", head: [role()], tail: [textLine("E2E Title"), finishLine("stop")] }
+          const auto: Sse = {
+            type: "sse",
+            head: [role()],
+            tail: [textLine("E2E Title"), finishLine("stop")],
+            wait: titleHold,
+          }
           if (mode === "responses") return send(responses(auto, modelFrom(body)))
           return send(auto)
         }
@@ -756,11 +766,15 @@ export class TestLLMServer extends Context.Service<TestLLMServer, TestLLMServer.
         hold: Effect.fn("TestLLMServer.hold")(function* (value: string, wait: PromiseLike<unknown>) {
           queue(reply().wait(wait).text(value).stop().item())
         }),
+        holdTitle: Effect.fn("TestLLMServer.holdTitle")(function* (wait: PromiseLike<unknown>) {
+          titleHold = wait
+        }),
         reset: Effect.sync(() => {
           hits = []
           list = []
           waits = []
           misses = []
+          titleHold = undefined
         }),
         hits: Effect.sync(() => [...hits]),
         calls: Effect.sync(() => hits.length),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -588,6 +588,57 @@ it.instance("legacy prompt emits message events without session.next events", ()
   }),
 )
 
+it.instance(
+  "auto-title does not clobber a title set mid-turn",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+
+      // No explicit title => session keeps its default title, so the first-turn
+      // auto-title generation path runs (the guard sees a default title).
+      const chat = yield* sessions.create({})
+      expect(Session.isDefaultTitle((yield* sessions.get(chat.id)).title)).toBe(true)
+
+      // Hold the auto-title LLM response open so we get a deterministic window
+      // to rename the session while title generation is in flight.
+      const gate = yield* Deferred.make<void>()
+      yield* llm.holdTitle(deferredAsPromise(gate))
+      yield* llm.text("world")
+
+      yield* user(chat.id, "hello")
+      const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+
+      // Wait for both the assistant turn and the (held) auto-title request to
+      // arrive. Once the title request is recorded the title fork is past its
+      // start-of-turn guard and blocked on the gate.
+      yield* llm.wait(2)
+
+      // Simulate a plugin / user renaming the session mid-turn.
+      yield* sessions.setTitle({ sessionID: chat.id, title: "Custom plugin title" })
+
+      // Release the auto-title response; the fork now re-reads the session, sees
+      // the non-default title, and must skip its setTitle.
+      yield* Deferred.succeed(gate, void 0)
+
+      const exit = yield* Fiber.await(fiber)
+      expect(Exit.isSuccess(exit)).toBe(true)
+
+      // The custom title must survive: auto-title generation ("E2E Title") must
+      // not overwrite the mid-turn rename.
+      yield* pollWithTimeout(
+        Effect.gen(function* () {
+          const title = (yield* sessions.get(chat.id)).title
+          expect(title).not.toBe("E2E Title")
+          return title === "Custom plugin title" ? (true as const) : undefined
+        }),
+        "session title was not preserved after mid-turn rename",
+      )
+    }),
+  30_000,
+)
+
 it.instance("loop surfaces content-filter finishes as session errors", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #32710

### Type of change

- [x] Bug fix

### What does this PR do?

First-turn auto-title generation checked the session title captured once at the start of the turn, so if a plugin (or the user) renamed the session while the turn was still running, the auto-generated title clobbered the custom one. I re-read the session from storage right before setTitle and skip when the title is no longer the default.

### How did you verify your code works?

Added a test in test/session/prompt.test.ts that holds the title-generation response open (via a new holdTitle gate in the LLM test harness), renames the session mid-flight, then releases it and asserts the custom title survives. Ran it locally with bun — passes.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR