### PR TITLE
fix(provider): don't send store to the perplexity-agent provider

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1098,11 +1098,14 @@ export function options(input: {
   }
 
   // openai and providers using openai package should set store to false by default.
+  // perplexity-agent reuses the @ai-sdk/openai package but its /v1/responses endpoint
+  // rejects OpenAI-Responses-only fields like `store`, so exclude it here.
   if (
-    input.model.providerID === "openai" ||
-    input.model.api.npm === "@ai-sdk/openai" ||
-    input.model.api.npm === "@ai-sdk/github-copilot" ||
-    input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
+    input.model.providerID !== "perplexity-agent" &&
+    (input.model.providerID === "openai" ||
+      input.model.api.npm === "@ai-sdk/openai" ||
+      input.model.api.npm === "@ai-sdk/github-copilot" ||
+      input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle")
   ) {
     result["store"] = false
   }
@@ -1255,9 +1258,8 @@ export function options(input: {
 export function smallOptions(model: Provider.Model) {
   const small = Object.values(model.variants ?? {})[0] ?? {}
   if (
-    model.providerID === "openai" ||
-    model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/github-copilot"
+    model.providerID !== "perplexity-agent" &&
+    (model.providerID === "openai" || model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/github-copilot")
   ) {
     const base = { store: false }
     return mergeDeep(base, small)

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -172,6 +172,24 @@ describe("ProviderTransform.options - setCacheKey", () => {
     })
     expect(result.store).toBe(false)
   })
+
+  test("should NOT set store for perplexity-agent provider (perplexity rejects unknown field 'store')", () => {
+    const perplexityModel = {
+      ...mockModel,
+      providerID: "perplexity-agent",
+      api: {
+        id: "perplexity/sonar",
+        url: "https://api.perplexity.ai/v1",
+        npm: "@ai-sdk/openai",
+      },
+    }
+    const result = ProviderTransform.options({
+      model: perplexityModel,
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.store).toBeUndefined()
+  })
 })
 
 describe("ProviderTransform.options - zai/zhipuai thinking", () => {
@@ -4688,6 +4706,38 @@ describe("ProviderTransform.smallOptions - gpt-5 chat/search", () => {
       expect(ProviderTransform.smallOptions(createModel(testCase.id))).toEqual(testCase.options)
     })
   }
+})
+
+describe("ProviderTransform.smallOptions - perplexity-agent store exclusion", () => {
+  test("does not set store for perplexity-agent (perplexity rejects unknown field 'store')", () => {
+    const result = ProviderTransform.smallOptions({
+      id: "perplexity-agent/perplexity/sonar",
+      providerID: "perplexity-agent",
+      api: {
+        id: "perplexity/sonar",
+        url: "https://api.perplexity.ai/v1",
+        npm: "@ai-sdk/openai",
+      },
+      capabilities: { reasoning: false },
+      limit: { output: 8192 },
+    } as any)
+    expect(result.store).toBeUndefined()
+  })
+
+  test("still sets store=false for a normal @ai-sdk/openai provider", () => {
+    const result = ProviderTransform.smallOptions({
+      id: "openai/gpt-4",
+      providerID: "openai",
+      api: {
+        id: "gpt-4",
+        url: "https://api.openai.com",
+        npm: "@ai-sdk/openai",
+      },
+      capabilities: { reasoning: false },
+      limit: { output: 8192 },
+    } as any)
+    expect(result.store).toBe(false)
+  })
 })
 
 test("ProviderTransform.smallOptions preserves the weakest OpenRouter reasoning effort", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #32108

### Type of change

- [x] Bug fix

### What does this PR do?

The built-in perplexity-agent provider uses the @ai-sdk/openai adapter, so it matched the OpenAI-Responses `store: false` injection — but Perplexity's /v1/responses endpoint rejects it with `unknown field "store"`, so every request failed. I excluded perplexity-agent from the store injection in both options() and smallOptions(); all other @ai-sdk/openai providers still get store: false.

### How did you verify your code works?

Added tests in test/provider/transform.test.ts asserting perplexity-agent gets no store field while a normal openai provider still does, for both options() and smallOptions(). Ran them locally with bun — 4 pass.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR