### PR TITLE
fix(lsp): let custom servers configure languageId

### DIFF
--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -14,6 +14,10 @@ export const Entry = Schema.Union([
     disabled: Schema.optional(Schema.Boolean),
     env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
     initialization: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+    languageId: Schema.optional(Schema.String).annotate({
+      description:
+        'The LSP languageId sent to the server for opened documents (e.g. "r", "toml"). When set, this takes precedence over the languageId inferred from the file extension. Required by some custom servers (e.g. R\'s languageserver) to provide hover, completions, and diagnostics.',
+    }),
   }),
 ]).pipe((schema) => schema)
 

--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -557,7 +557,11 @@ export async function create(input: {
         )
         const text = await Filesystem.readText(request.path)
         const extension = path.extname(request.path)
-        const languageId = LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
+        // A languageId configured for the server takes precedence over the
+        // extension table, which falls back to "plaintext". Some custom servers
+        // (e.g. R's languageserver) only respond when sent their expected
+        // languageId rather than the default "plaintext".
+        const languageId = input.server.languageId ?? LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
 
         const document = files[request.path]
         if (document !== undefined) {

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -178,6 +178,7 @@ export const layer = Layer.effect(
                     env: { ...process.env, ...item.env },
                   }),
                   initialization: item.initialization,
+                  languageId: item.languageId,
                 }),
               }
             }

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -25,6 +25,10 @@ const output = (cmd: string[], opts: Process.RunOptions = {}) => Process.text(cm
 export interface Handle {
   process: ChildProcessWithoutNullStreams
   initialization?: Record<string, any>
+  // Overrides the languageId inferred from the file extension when opening
+  // documents. Set by custom servers (via config `languageId`) that require a
+  // specific languageId to provide hover/completions/diagnostics.
+  languageId?: string
 }
 
 type RootFunction = (file: string, ctx: InstanceContext) => Promise<string | undefined>

--- a/packages/opencode/test/config/lsp.test.ts
+++ b/packages/opencode/test/config/lsp.test.ts
@@ -29,6 +29,13 @@ describe("ConfigLSPV1.Info refinement", () => {
       expect(decodeEffect(input)).toEqual(input)
     })
 
+    test("custom server with languageId passes", () => {
+      const input = {
+        languageserver: { command: ["R", "--slave", "-e", "languageserver::run()"], extensions: [".r", ".R"], languageId: "r" },
+      }
+      expect(decodeEffect(input)).toEqual(input)
+    })
+
     test("disabled custom server passes (no extensions needed)", () => {
       const input = { "my-lsp": { disabled: true as const } }
       expect(decodeEffect(input)).toEqual(input)

--- a/packages/opencode/test/fixture/lsp/fake-lsp-server.js
+++ b/packages/opencode/test/fixture/lsp/fake-lsp-server.js
@@ -3,6 +3,7 @@
 let nextId = 1
 let readBuffer = Buffer.alloc(0)
 let lastChange = null
+let lastDidOpen = null
 let initializeParams = null
 let diagnosticRequestCount = 0
 let registeredCapability = false
@@ -139,6 +140,7 @@ function handle(raw) {
   }
 
   if (data.method === "textDocument/didOpen") {
+    lastDidOpen = data.params
     maybeRegister("didOpen")
     return
   }
@@ -203,6 +205,11 @@ function handle(raw) {
 
   if (data.method === "test/get-last-change") {
     sendResponse(data.id, lastChange)
+    return
+  }
+
+  if (data.method === "test/get-last-did-open") {
+    sendResponse(data.id, lastDidOpen)
     return
   }
 

--- a/packages/opencode/test/lsp/client.test.ts
+++ b/packages/opencode/test/lsp/client.test.ts
@@ -187,6 +187,71 @@ describe("LSPClient interop", () => {
     })
   })
 
+  test("didOpen uses the server's configured languageId", async () => {
+    const handle = spawnFakeServer() as any
+    await using tmp = await tmpdir()
+    // The extension table would infer "typescript" for ".ts"; the configured
+    // languageId must take precedence, proving precedence rather than a
+    // coincidental match.
+    const file = path.join(tmp.path, "client.ts")
+    await Bun.write(file, "print(1)\n")
+
+    await withTestInstance({
+      directory: tmp.path,
+      fn: async (ctx) => {
+        const client = await LSPClient.create({
+          serverID: "fake",
+          server: {
+            ...(handle as unknown as LSPServer.Handle),
+            languageId: "r",
+          },
+          root: tmp.path,
+          directory: tmp.path,
+          instance: ctx,
+        })
+
+        await client.notify.open({ path: file })
+
+        const didOpen = await client.connection.sendRequest<{
+          textDocument: { languageId: string; uri: string }
+        }>("test/get-last-did-open", {})
+        expect(didOpen.textDocument.languageId).toBe("r")
+        expect(didOpen.textDocument.uri).toBe(pathToFileURL(file).href)
+
+        await client.shutdown()
+      },
+    })
+  })
+
+  test("didOpen falls back to the extension table when no languageId is configured", async () => {
+    const handle = spawnFakeServer() as any
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "client.ts")
+    await Bun.write(file, "const x = 1\n")
+
+    await withTestInstance({
+      directory: tmp.path,
+      fn: async (ctx) => {
+        const client = await LSPClient.create({
+          serverID: "fake",
+          server: handle as unknown as LSPServer.Handle,
+          root: tmp.path,
+          directory: tmp.path,
+          instance: ctx,
+        })
+
+        await client.notify.open({ path: file })
+
+        const didOpen = await client.connection.sendRequest<{
+          textDocument: { languageId: string }
+        }>("test/get-last-did-open", {})
+        expect(didOpen.textDocument.languageId).toBe("typescript")
+
+        await client.shutdown()
+      },
+    })
+  })
+
   test("document mode falls back to push diagnostics", async () => {
     const handle = spawnFakeServer() as any
     await using tmp = await tmpdir()


### PR DESCRIPTION
### Issue for this PR

Closes #32023

### Type of change

- [x] Bug fix

### What does this PR do?

Custom LSP servers configured in opencode.json were always sent languageId: "plaintext", so servers like R's languageserver returned no hover/completions/diagnostics. I added an optional `languageId` field to the LSP config entry and thread it to the didOpen notification, taking precedence over the extension-inferred id (then the builtin table, then plaintext).

### How did you verify your code works?

Added tests: test/lsp/client.test.ts asserts didOpen uses the configured languageId and falls back to the extension table otherwise (passes locally with bun); test/config/lsp.test.ts asserts the schema accepts the new field.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR