### PR TITLE
docs: add opencode-loop to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,7 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
-
+| [opencode-loop](https://github.com/ByBrawe/opencode-loop)                                          | Auto-continue with `/loop` commands and `opencode-loopd` for idle-safe recurring OpenCode workflows  |
 ---
 
 ## Projects


### PR DESCRIPTION
Adds [[opencode-loop](https://github.com/ByBrawe/opencode-loop)](https://github.com/ByBrawe/opencode-loop) to the OpenCode Ecosystem plugins list.

opencode-loop provides Claude Code-style auto-continue for OpenCode with `/loop` commands and the `opencode-loopd` daemon for idle-safe recurring workflows.