### PR TITLE
fix(web): add clipboard fallback for non-HTTPS contexts

### DIFF
--- a/packages/web/src/components/share/copy-button.tsx
+++ b/packages/web/src/components/share/copy-button.tsx
@@ -11,12 +11,27 @@ export function CopyButton(props: CopyButtonProps) {
   const [copied, setCopied] = createSignal(false)
   const messages = useShareMessages()
 
-  function handleCopyClick() {
-    if (props.text) {
-      navigator.clipboard.writeText(props.text).catch((err) => console.error("Copy failed", err))
+  async function handleCopyClick() {
+    if (!props.text) return
 
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(props.text)
+      } else {
+        // Fallback for non-HTTPS contexts (e.g., localhost)
+        const textarea = document.createElement("textarea")
+        textarea.value = props.text
+        textarea.style.position = "fixed"
+        textarea.style.left = "-9999px"
+        document.body.appendChild(textarea)
+        textarea.select()
+        document.execCommand("copy")
+        document.body.removeChild(textarea)
+      }
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error("Copy failed", err)
     }
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #32664

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The copy-to-clipboard button for code blocks doesn't work in `opencode web` when opened on localhost without HTTPS. This is because `navigator.clipboard` requires HTTPS in most browsers.

This PR adds a fallback using `document.execCommand('copy')` when `navigator.clipboard` is not available. The fix is in `packages/web/src/components/share/copy-button.tsx`.

The change is minimal and preserves existing behavior when HTTPS is available. The fallback only activates when the clipboard API is unavailable.

### How did you verify your code works?

- Tested on localhost without HTTPS — copy button now works
- Tested on HTTPS — existing behavior unchanged
- Tested on desktop app — no regression

### Screenshots / recordings

N/A — UI behavior unchanged, only the copy mechanism changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR