### PR TITLE
fix(opencode): re-read plugin.trigger output to support array replacement

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -356,8 +356,8 @@ export const layer = Layer.effect(
         { context: [], prompt: undefined },
       )
       const nextPrompt = compacting.prompt ?? buildPrompt({ previousSummary, context: compacting.context })
-      const msgs = structuredClone(selected.head)
-      yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+      let msgs = structuredClone(selected.head)
+      msgs = (yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })).messages
       const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, {
         stripMedia: true,
         toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -975,11 +975,11 @@ export const layer = Layer.effect(
         return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
       })
 
-      const resolvedParts = yield* Effect.forEach(input.parts, resolvePart, { concurrency: "unbounded" }).pipe(
+      let resolvedParts = yield* Effect.forEach(input.parts, resolvePart, { concurrency: "unbounded" }).pipe(
         Effect.map((x) => x.flat().map(assign)),
       )
 
-      yield* plugin.trigger(
+      const chatResult = yield* plugin.trigger(
         "chat.message",
         {
           sessionID: input.sessionID,
@@ -990,6 +990,7 @@ export const layer = Layer.effect(
         },
         { message: info, parts: resolvedParts },
       )
+      resolvedParts = chatResult.parts
 
       const parts = yield* Effect.forEach(resolvedParts, (part) =>
         part.type === "file" && part.mime.startsWith("image/")
@@ -1322,7 +1323,7 @@ export const layer = Layer.effect(
               }
             }
 
-            yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+            msgs = (yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })).messages
 
             const [skills, env, instructions, modelMsgs] = yield* Effect.all([
               sys.skills(agent),


### PR DESCRIPTION
## Problem

Plugins that reassign `output.messages = newArray` in `experimental.chat.messages.transform` or `chat.message` hooks had their changes silently dropped.

The root cause: `plugin.trigger()` returns the modified `output` object (line 292 of plugin/index.ts), but all 3 call sites discard the return value via `yield* trigger(...)` without assignment.

Only in-place array mutation (e.g. `msgs.splice()`) worked; closure replacement via `output.messages = newArray` was a silent no-op.

## Fix

Captured the returned `output` object from `plugin.trigger()` at all 3 call sites and re-assigned the variables passed downstream.

### prompt.ts — messages.transform
```diff
- yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+ msgs = (yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })).messages
```

### compaction.ts — messages.transform
```diff
- const msgs = structuredClone(selected.head)
- yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+ let msgs = structuredClone(selected.head)
+ msgs = (yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })).messages
```

### prompt.ts — chat.message
```diff
- yield* plugin.trigger("chat.message", {...}, { message: info, parts: resolvedParts })
+ const chatResult = yield* plugin.trigger("chat.message", {...}, { message: info, parts: resolvedParts })
+ resolvedParts = chatResult.parts
```

Fixes #25754
