### PR TITLE
fix(skill): prevent recursive sub-skill discovery using single-level glob

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -20,9 +20,9 @@ import { isRecord } from "@/util/record"
 
 const CLAUDE_EXTERNAL_DIR = ".claude"
 const AGENTS_EXTERNAL_DIR = ".agents"
-const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
-const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"
-const SKILL_PATTERN = "**/SKILL.md"
+const EXTERNAL_SKILL_PATTERN = "skills/*/SKILL.md"
+const OPENCODE_SKILL_PATTERN = "{skill,skills}/*/SKILL.md"
+const SKILL_PATTERN = "*/SKILL.md"
 
 // Built-in skill that ships with opencode. The model's intuition for what an
 // opencode.json should look like is often wrong, and opencode hard-fails on


### PR DESCRIPTION
### Issue for this PR
Closes #28485

### Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Changes skill discovery glob from recursive to single-level.
This prevents sub-skills in nested directories from being loaded
as independent top-level skills, avoiding context bloat.

### How did you verify your code works?
- Verified only direct child SKILL.md files are discovered
- Confirmed nested sub-directory SKILL.md files are not registered
- No impact on existing flat skill layouts

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR