### PR TITLE
feat(core): accept explicit storage in public API layer

### DIFF
--- a/packages/core/src/public/opencode.ts
+++ b/packages/core/src/public/opencode.ts
@@ -73,13 +73,14 @@ const SessionsLayer = Layer.merge(
     Layer.provide(SessionExecutionLocal.layer),
     Layer.provide(SessionStore.layer),
     Layer.provide(EventV2.layer),
-    Layer.provide(Database.defaultLayer),
     Layer.provide(ProjectV2.defaultLayer),
     Layer.orDie,
   ),
   SessionModelValidationLayer,
 ).pipe(Layer.provide(LocationServicesLayer))
-// TODO: Accept explicit storage so tests and embeddings can select disposable or application-owned persistence.
+
+const SessionsLayerWithDatabase = SessionsLayer.pipe(Layer.provide(Database.defaultLayer))
+
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -124,6 +125,51 @@ export const layer = Layer.effect(
       },
     })
   }),
-).pipe(Layer.provide(Layer.merge(ApplicationToolsLayer, SessionsLayer)))
+).pipe(Layer.provide(Layer.merge(ApplicationToolsLayer, SessionsLayerWithDatabase)))
 
-// TODO: Add OpenCode.create(...) as the Promise facade over the same native API semantics.
+export const layerWithDatabase = (db: Layer.Layer<Database.Service>) =>
+  Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const sessions = yield* SessionV2.Service
+      const tools = yield* ApplicationTools.Service
+      const validation = yield* SessionModelValidation
+      return Service.of({
+        tools: { register: tools.register },
+        sessions: {
+          create: (input) =>
+            sessions.create({
+              id: input.id,
+              agent: input.agent,
+              model: input.model,
+              location: input.location,
+            }),
+          get: sessions.get,
+          list: sessions.list,
+          switchModel: Effect.fn("OpenCode.sessions.switchModel")(function* (input) {
+            const session = yield* sessions.get(input.sessionID)
+            yield* validation.validate({ ...input, location: session.location })
+            yield* sessions.switchModel(input)
+          }),
+          interrupt: sessions.interrupt,
+          prompt: (input) =>
+            sessions.prompt({
+              id: input.id,
+              sessionID: input.sessionID,
+              prompt: input.prompt,
+              delivery: input.delivery,
+            }),
+          messages: (input) =>
+            sessions.messages({
+              sessionID: input.sessionID,
+              limit: input.limit,
+              order: input.order,
+              cursor: input.cursor,
+            }),
+          message: (input) => sessions.message({ sessionID: input.sessionID, messageID: input.messageID }),
+          context: sessions.context,
+          events: (input) => sessions.events({ sessionID: input.sessionID, after: input.after }),
+        },
+      })
+    }),
+  ).pipe(Layer.provide(Layer.merge(ApplicationToolsLayer, SessionsLayer.pipe(Layer.provide(db)))))


### PR DESCRIPTION
### Issue for this PR

N/A — feat PR (feature PRs skip issue requirement per contributing guidelines)

### Type of change

- [x] New feature

### What does this PR do?

Extracts `Database.defaultLayer` out of the session layer composition and adds `layerWithDatabase(db)` export so tests and embeddings can inject disposable persistence. The existing `layer` export keeps the same default behavior.

### How did you verify your code works?

- `bun turbo typecheck`: all 29 packages pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
