### PR TITLE
fix(tui): restore ESC interrupt for delegated subagent sessions

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -198,6 +198,8 @@ export function Session() {
     const current = session()
     return current ? { directory: current.directory, workspaceID: current.workspaceID } : undefined
   })
+  const sessionStatus = createMemo(() => sync.data.session_status[route.sessionID]?.type ?? "idle")
+  const sessionBusy = createMemo(() => sessionStatus() !== "idle")
 
   createEffect(() => {
     const title = Locale.truncate(session()?.title ?? "", 50)
@@ -275,6 +277,41 @@ export function Session() {
   const toast = useToast()
   const sdk = useSDK()
   const editor = useEditorContext()
+
+  const [interruptCount, setInterruptCount] = createSignal(0)
+  let interruptTimer: ReturnType<typeof setTimeout> | undefined
+  const resetInterrupt = () => {
+    setInterruptCount(0)
+    if (interruptTimer) {
+      clearTimeout(interruptTimer)
+      interruptTimer = undefined
+    }
+  }
+
+  createEffect(
+    on(
+      () => sessionStatus() === "idle",
+      (isIdle) => {
+        if (isIdle) resetInterrupt()
+      },
+      { defer: true },
+    ),
+  )
+
+  createEffect(
+    on(
+      () => route.sessionID,
+      () => resetInterrupt(),
+      { defer: true },
+    ),
+  )
+
+  onCleanup(() => {
+    if (interruptTimer) {
+      clearTimeout(interruptTimer)
+      interruptTimer = undefined
+    }
+  })
 
   createEffect(() => {
     const sessionID = route.sessionID
@@ -1111,6 +1148,48 @@ export function Session() {
 
   useBindings(() => ({
     mode: OPENCODE_BASE_MODE,
+    bindings: tuiConfig.keybinds.get("session.interrupt").map((binding) => ({
+      ...binding,
+      cmd: "session.child.interrupt",
+    })),
+    commands: [
+      {
+        name: "session.child.interrupt",
+        title: "Interrupt subagent session",
+        category: "Session",
+        hidden: true,
+        enabled: !!session()?.parentID && sessionStatus() !== "idle",
+        run: () => {
+          dialog.clear()
+          const next = interruptCount() + 1
+          if (next >= 2) {
+            resetInterrupt()
+            void sdk.client.session
+              .abort({ sessionID: route.sessionID })
+              .then(() => {
+                // Server cancels the runner but does not emit session-wide
+                // permission/question cleanup events; clear stale local state
+                sync.set("permission", route.sessionID, [])
+                sync.set("question", route.sessionID, [])
+              })
+              .catch((error: unknown) => {
+                toast.show({
+                  message: errorMessage(error),
+                  variant: "error",
+                })
+              })
+          } else {
+            setInterruptCount(next)
+            if (interruptTimer) clearTimeout(interruptTimer)
+            interruptTimer = setTimeout(resetInterrupt, 5000)
+          }
+        },
+      },
+    ],
+  }))
+
+  useBindings(() => ({
+    mode: OPENCODE_BASE_MODE,
     enabled: foregroundTasks().length > 0,
     priority: 1,
     bindings: tuiConfig.keybinds.get("session.background"),
@@ -1293,7 +1372,10 @@ export function Session() {
                   />
                 </Show>
                 <Show when={session()?.parentID}>
-                  <SubagentFooter />
+                  <SubagentFooter
+                    interruptCount={interruptCount}
+                    sessionBusy={sessionBusy}
+                  />
                 </Show>
                 <Show when={visible()}>
                   <pluginRuntime.Slot

--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createSignal, Show } from "solid-js"
+import type { Accessor } from "solid-js"
 import { useRouteData } from "../../context/route"
 import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
@@ -8,7 +9,10 @@ import { Locale } from "../../util/locale"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 
-export function SubagentFooter() {
+export function SubagentFooter(props: {
+  interruptCount: Accessor<number>
+  sessionBusy: Accessor<boolean>
+}) {
   const route = useRouteData("session")
   const sync = useSync()
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
@@ -59,6 +63,8 @@ export function SubagentFooter() {
   const parentShortcut = useCommandShortcut("session.parent")
   const previousShortcut = useCommandShortcut("session.child.previous")
   const nextShortcut = useCommandShortcut("session.child.next")
+  const interruptShortcut = useCommandShortcut("session.child.interrupt")
+  const armed = createMemo(() => props.interruptCount() > 0)
   const [hover, setHover] = createSignal<"parent" | "prev" | "next" | null>(null)
   useTerminalDimensions()
 
@@ -94,6 +100,25 @@ export function SubagentFooter() {
             </Show>
           </box>
           <box flexDirection="row" gap={2}>
+            <Show when={props.sessionBusy()}>
+              <text fg={armed() ? theme.primary : theme.text}>
+                {armed() ? (
+                  <>
+                    <span style={{ fg: armed() ? theme.primary : theme.textMuted }}>
+                      {interruptShortcut()}
+                    </span>{" "}
+                    again to interrupt
+                  </>
+                ) : (
+                  <>
+                    Interrupt{" "}
+                    <span style={{ fg: armed() ? theme.primary : theme.textMuted }}>
+                      {interruptShortcut()}
+                    </span>
+                  </>
+                )}
+              </text>
+            </Show>
             <box
               onMouseOver={() => setHover("parent")}
               onMouseOut={() => setHover(null)}


### PR DESCRIPTION
### Issue for this PR

Closes #3699 and #4073 and #23534

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes a regression. The functionality was there before and has gone some releases ago.

`ESC` could not stop delegated subtasks because the session.interrupt binding was only registered inside the prompt composer, which is hidden for child sessions. Subagent sessions had no `ESC` handler at all (but they had in the past).

Add a dedicated useBindings layer in the session route that remaps the configured `session.interrupt key` (default: `Escape`) to a new command session.child.interrupt, scoped to child sessions that are not idle.

Well-known double-press logic (first press arms a 5 s timer, second press fires session.abort) mirrors the parent prompt behavior. On abort the pending permission and question entries for the subagent are cleared immediately so the parent thread does not deadlock.

The `SubagentFooter` shows dynamic `esc interrupt` / `esc again to interrupt` feedback with the actual bound key.

### How did you verify your code works?

Compiled & battle tested.

### Screenshots / recordings
<img width="500" height="31" alt="opencode-escape" src="https://github.com/user-attachments/assets/08a13402-7662-4716-b58f-b73901387236" />

**UPDATE**: Upon requestion, I'm using `escape` now (OpenTUI default). Also, I'm writing `Interrupt escape` (keybind on the right side). So it matches the existing keybinds.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR