### PR TITLE
fix(opencode): preserve execution metadata on tool completion

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -217,7 +217,12 @@ export const layer = Layer.effect(
             status: "completed",
             input: match.part.state.input,
             output: output.output,
-            metadata: output.metadata,
+            // Preserve metadata accumulated during execution (via ctx.metadata,
+            // e.g. the subagent `sessionId` set by the task tool) so it is not
+            // dropped when the final result — or a plugin's tool.execute.after
+            // hook — returns metadata without those keys. Result metadata wins
+            // on conflict.
+            metadata: { ...match.part.state.metadata, ...output.metadata },
             title: output.title,
             time: { start: match.part.state.time.start, end: Date.now() },
             attachments: output.attachments,

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -768,6 +768,90 @@ it.live("session.processor effect tests complete AI SDK tool calls when native f
   ),
 )
 
+it.live("session.processor effect tests preserve execution metadata when result omits it", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const database = yield* Database.Service
+        const { processors, session, provider } = yield* boot()
+
+        yield* llm.toolHang("lookup", { query: "weather" })
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "tool")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const run = yield* handle
+          .process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+            } satisfies SessionV1.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "tool" }],
+            tools: {},
+          })
+          .pipe(Effect.forkChild)
+
+        yield* llm.wait(1)
+        const running = yield* waitFor(
+          MessageV2.parts(msg.id).pipe(
+            Effect.map((parts) => parts.find((part): part is SessionV1.ToolPart => part.type === "tool")),
+            Effect.provideService(Database.Service, database),
+          ),
+          "timed out waiting for tool part",
+        )
+
+        // Simulate metadata accumulated during execution via ctx.metadata
+        // (e.g. the subagent `sessionId` the task tool records while running).
+        yield* handle.updateToolCall(running.callID, (part) => ({
+          ...part,
+          state: {
+            status: "running",
+            input: part.state.status === "pending" ? {} : part.state.input,
+            metadata: { sessionId: "ses_child" },
+            time: { start: Date.now() },
+          },
+        }))
+
+        // Complete with a result whose metadata DROPS sessionId, mirroring a
+        // plugin tool.execute.after hook (or final result) that returns {}.
+        yield* handle.completeToolCall(running.callID, {
+          title: "Lookup",
+          output: "result",
+          metadata: {},
+        })
+
+        // Interrupt the hanging stream before asserting so a failed assertion
+        // surfaces cleanly instead of timing out the still-running fiber.
+        yield* Fiber.interrupt(run)
+
+        const parts = yield* MessageV2.parts(msg.id)
+        const call = parts.find((part): part is SessionV1.ToolPart => part.type === "tool")
+
+        expect(call?.state.status).toBe("completed")
+        if (call?.state.status !== "completed") return
+        // sessionId set during execution must survive completion so the TUI can
+        // still navigate into the subagent session.
+        expect(call.state.metadata.sessionId).toBe("ses_child")
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
 it.live("session.processor effect tests mark pending tools as aborted on cleanup", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>


### PR DESCRIPTION
Closes #32773

### What

`completeToolCall` overwrote the tool part's `state.metadata` with the final result metadata. The `task` tool sets the child `sessionId` via `ctx.metadata` while running, so when the final result metadata doesn't carry it forward (e.g. a plugin's `tool.execute.after` hook returns `metadata: {}`), `sessionId` is lost from the completed part.

The TUI `Task` component navigates and hydrates the subagent session from `state.metadata.sessionId`, so those subagent entries became unclickable and showed `0ms` / no toolcalls. Keyboard nav (`ctrl+x` + down) still worked because it resolves children from the session tree, not the part metadata.

This merges the execution-time metadata with the result metadata on completion; result metadata still wins on conflict.

### How verified

- Added `processor-effect` test: a tool that records `sessionId` during execution and then completes with empty result metadata must keep `sessionId` on the completed part. Fails before the change (`Received: undefined`), passes after.
- `bun test test/session/processor-effect.test.ts` (16/16), plus `test/tool/task.test.ts`, `test/session/structured-output.test.ts`, `test/tool/edit.test.ts` green.
- `tsgo --noEmit` clean.
