### PR TITLE
fix(console): evenly space landing page footer links

### DIFF
--- a/packages/console/app/src/routes/index.css
+++ b/packages/console/app/src/routes/index.css
@@ -1163,20 +1163,17 @@ body {
     border-top: 1px solid var(--color-border-weak);
     display: flex;
     flex-direction: row;
-
-    @media (max-width: 65rem) {
-      border-bottom: 1px solid var(--color-border-weak);
-    }
+    flex-wrap: nowrap;
+    justify-content: center;
 
     [data-slot="cell"] {
-      flex: 1;
-      text-align: center;
+      flex: none;
 
       a {
         text-decoration: none;
-        padding: 2rem 0;
-        width: 100%;
-        display: block;
+        padding: 2rem 1.5rem;
+        display: inline-block;
+        white-space: nowrap;
 
         span {
           color: var(--color-text-weak);
@@ -1188,7 +1185,6 @@ body {
       }
 
       a:hover {
-        background: var(--color-background-weak);
         text-decoration: underline;
         text-underline-offset: var(--space-1);
         text-decoration-thickness: 1px;
@@ -1196,25 +1192,8 @@ body {
     }
 
     [data-slot="cell"] + [data-slot="cell"] {
-      border-left: 1px solid var(--color-border-weak);
-
-      @media (max-width: 40rem) {
-        border-left: none;
-      }
-    }
-
-    /* Mobile: third column on its own row */
-    @media (max-width: 25rem) {
-      flex-wrap: wrap;
-
-      [data-slot="cell"] {
-        flex: 1 0 100%;
-        border-left: none;
-        border-top: 1px solid var(--color-border-weak);
-      }
-
-      [data-slot="cell"]:nth-child(1) {
-        border-top: none;
+      a {
+        border-left: 1px solid var(--color-border-weak);
       }
     }
   }

--- a/packages/console/app/src/routes/index.css
+++ b/packages/console/app/src/routes/index.css
@@ -1196,6 +1196,35 @@ body {
         border-left: 1px solid var(--color-border-weak);
       }
     }
+
+    @media (min-width: 26.5625rem) and (max-width: 40rem) {
+      gap: clamp(0rem, 3vw, 2.5rem);
+
+      [data-slot="cell"] {
+        flex: 0 0 auto;
+
+        a {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 2rem clamp(0.5rem, 2vw, 1.5rem);
+          min-width: clamp(2.75rem, 11vw, 7.5rem);
+          min-height: 5.5rem;
+          text-align: center;
+        }
+      }
+
+      [data-slot="cell"] + [data-slot="cell"] {
+        a {
+          border-left: none;
+        }
+      }
+
+      [data-slot="cell"] a:hover {
+        background: var(--color-background-weak);
+      }
+    }
+
   }
 
   [data-component="legal"] {


### PR DESCRIPTION
### Issue for this PR

Closes #32782

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The footer links (GitHub, Docs, Changelog, Discord, X) below the subscribe section looked uneven at the Mobile L width because equal-width footer cells made short labels like "X" feel isolated.

Adds a Mobile L-only footer adjustment for `425px` through `640px`:

- keeps all footer links on one line
- centers the row with content-sized cells
- gives each link a consistent hover/tap area
- removes the divider borders in that Mobile L range so spacing reads evenly

Mobile S and Mobile M keep the existing footer rules and are not affected by this scoped media query.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/console/app`
- Tested the CSS live via DevTools at the Mobile L `425px` preset
- Confirmed the final CSS is scoped to `@media (min-width: 26.5625rem) and (max-width: 40rem)`

### Screenshots / recordings

Before: equal-width columns created uneven gaps around short labels.
After: Mobile L keeps the links in one centered row with balanced spacing.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
