### PR TITLE
fix(opencode): escape {env:} substitutions to keep config JSON valid

### DIFF
--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -34,7 +34,11 @@ function dir(input: ParseSource) {
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
   let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-    return (input.env?.[varName] ?? process.env[varName]) || ""
+    const value = (input.env?.[varName] ?? process.env[varName]) || ""
+    // Escape for the JSON string context the token sits in, mirroring the
+    // {file:} branch below; otherwise a value with backslashes (e.g. a native
+    // Windows path) or quotes produces invalid JSON.
+    return JSON.stringify(value).slice(1, -1)
   })
 
   const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -515,6 +515,22 @@ it.instance("handles environment variable substitution", () =>
   ),
 )
 
+it.instance("escapes env values with backslashes so JSON stays valid", () =>
+  withProcessEnv(
+    "TEST_WIN_PATH",
+    "C:\\Users\\me\\AppData\\Roaming",
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* writeConfigEffect(test.directory, {
+        $schema: "https://opencode.ai/config.json",
+        username: "{env:TEST_WIN_PATH}",
+      })
+      const config = yield* Config.use.get()
+      expect(config.username).toBe("C:\\Users\\me\\AppData\\Roaming")
+    }),
+  ),
+)
+
 it.instance("preserves env variables when adding $schema to config", () =>
   withProcessEnv(
     "PRESERVE_VAR",


### PR DESCRIPTION
### Issue for this PR

Closes #32695

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`{env:VAR}` substitution in config text inserted the raw environment value directly into the JSON source before parsing. When the value contains characters that are significant inside a JSON string — most commonly backslashes in a native Windows path (`C:\Users\me\...`), but also quotes or newlines — the result was invalid JSON and the config failed to load on startup.

The sibling `{file:...}` substitution in the same function already guards against this by emitting `JSON.stringify(content).slice(1, -1)`. This change applies the same escaping to the `{env:VAR}` value so the substituted string is always valid inside its surrounding JSON string. Plain values (tokens, usernames, URLs) are unaffected since escaping a string with no special characters returns it unchanged.

### How did you verify your code works?

Added a unit test in `packages/opencode/test/config/config.test.ts` that sets an env var to a Windows-style path containing backslashes, references it via `{env:VAR}`, and asserts the config loads with the value intact. The test fails on the previous code (config parse error) and passes with the fix. `bun test test/config/config.test.ts`, `tsgo --noEmit` for the package, and Prettier all pass.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
