### PR TITLE
fix(opencode): handle missing binary file attachments gracefully

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -929,6 +929,25 @@ export const layer = Layer.effect(
                 ]
               }
 
+              const exit = yield* fsys.readFile(filepath).pipe(Effect.exit)
+              if (Exit.isFailure(exit)) {
+                const error = Cause.squash(exit.cause)
+                yield* Effect.logError("failed to read file", { error, filepath })
+                const message = error instanceof Error ? error.message : String(error)
+                yield* events.publish(Session.Event.Error, {
+                  sessionID: input.sessionID,
+                  error: new NamedError.Unknown({ message }).toObject(),
+                })
+                return [
+                  {
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: `Read tool failed to read ${filepath} with the following error: ${message}`,
+                  },
+                ]
+              }
               return [
                 {
                   messageID: info.id,
@@ -942,9 +961,7 @@ export const layer = Layer.effect(
                   messageID: info.id,
                   sessionID: input.sessionID,
                   type: "file",
-                  url:
-                    `data:${mime};base64,` +
-                    Buffer.from(yield* fsys.readFile(filepath).pipe(Effect.catch(Effect.die))).toString("base64"),
+                  url: `data:${mime};base64,` + Buffer.from(exit.value).toString("base64"),
                   mime,
                   filename: part.filename!,
                   source: part.source,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -628,6 +628,43 @@ noLLMServer.instance.skip(
   { config: cfg },
 )
 
+noLLMServer.instance(
+  "missing binary file attachment resolves to an error instead of crashing the session",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Attach" })
+
+      const missing = path.join(process.cwd(), "opencode-missing-attachment-fixture.html")
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          {
+            type: "file",
+            mime: "text/html",
+            filename: "opencode-missing-attachment-fixture.html",
+            url: pathToFileURL(missing).href,
+          },
+        ],
+      })
+
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const parts = messages.flatMap((message) => message.parts)
+      expect(
+        parts.some(
+          (part) =>
+            part.type === "text" &&
+            part.text.includes("failed to read") &&
+            part.text.includes("opencode-missing-attachment-fixture.html"),
+        ),
+      ).toBe(true)
+    }),
+  { config: cfg },
+)
+
 it.instance("static loop returns assistant text through local provider", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #32777

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Attaching a binary file (image, PDF, HTML, etc.) whose path does not exist crashed the TUI with an unhandled `PlatformError`, leaving the session unresponsive.

In `resolveUserPart` (`packages/opencode/src/session/prompt.ts`), text-file and directory attachments read with `Effect.exit` and, on failure, log the error, publish a `Session.Event.Error`, and return a synthetic text part describing the failure. The binary-file branch instead read with `Effect.catch(Effect.die)`, which converts any read error (including `NotFound`) into an unrecoverable defect that crashes the session.

This change makes the binary branch use the same `Effect.exit` + `Exit.isFailure` recovery as the text and directory branches, so a missing binary attachment surfaces an error message instead of crashing. The success path is unchanged (the file bytes are read from `exit.value`).

### How did you verify your code works?

Added a regression test in `packages/opencode/test/session/prompt.test.ts` that attaches a non-existent `file://` binary attachment and asserts the prompt resolves to a synthetic "failed to read" message rather than crashing. The test fails on the previous code (unhandled defect) and passes with the fix. `bun test test/session/prompt.test.ts`, `tsgo --noEmit` for the package, and Prettier all pass.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
