### PR TITLE
fix(config): json-escape env/file substitutions into config text

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -219,8 +219,8 @@ export const layer = Layer.effect(
       const expanded = yield* Effect.promise(() =>
         ConfigVariable.substitute(
           "path" in options
-            ? { text, type: "path", path: options.path, env }
-            : { text, type: "virtual", ...options, env },
+            ? { text, type: "path", path: options.path, env, jsonEscape: true }
+            : { text, type: "virtual", ...options, env, jsonEscape: true },
         ),
       )
       const parsed = ConfigParse.jsonc(expanded, source)

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -97,7 +97,7 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
   const load = (text: string, configFilepath: string): Effect.Effect<Info> =>
     Effect.gen(function* () {
       const expanded = yield* Effect.promise(() =>
-        ConfigVariable.substitute({ text, type: "path", path: configFilepath, missing: "empty" }),
+        ConfigVariable.substitute({ text, type: "path", path: configFilepath, missing: "empty", jsonEscape: true }),
       )
       const data = ConfigParse.jsonc(expanded, configFilepath)
       if (!isRecord(data)) return {} as Info

--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -20,6 +20,14 @@ type SubstituteInput = ParseSource & {
   text: string
   missing?: "error" | "empty"
   env?: Record<string, string>
+  /**
+   * Escape substituted values so they remain valid inside a JSON string when
+   * the result is fed to a JSON parser. Without this, a value containing
+   * backslashes (e.g. a native Windows path `C:\Users\me`) or quotes breaks
+   * the surrounding document. Leave off when substituting into an already
+   * parsed string (e.g. a remote-config url or header value).
+   */
+  jsonEscape?: boolean
 }
 
 function source(input: ParseSource) {
@@ -33,8 +41,9 @@ function dir(input: ParseSource) {
 /** Apply {env:VAR} and {file:path} substitutions to config text. */
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
+  const escape = input.jsonEscape ? (value: string) => JSON.stringify(value).slice(1, -1) : (value: string) => value
   let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-    return (input.env?.[varName] ?? process.env[varName]) || ""
+    return escape((input.env?.[varName] ?? process.env[varName]) || "")
   })
 
   const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))
@@ -82,7 +91,7 @@ export async function substitute(input: SubstituteInput) {
       })
     ).trim()
 
-    out += JSON.stringify(fileContent).slice(1, -1)
+    out += escape(fileContent)
     cursor = index + token.length
   }
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -515,6 +515,22 @@ it.instance("handles environment variable substitution", () =>
   ),
 )
 
+it.instance("escapes backslashes in env substitution so Windows paths stay valid JSON", () =>
+  withProcessEnv(
+    "WIN_PATH_VAR",
+    "C:\\Users\\me\\AppData\\Roaming\\MyApp",
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* writeConfigEffect(test.directory, {
+        $schema: "https://opencode.ai/config.json",
+        username: "{env:WIN_PATH_VAR}",
+      })
+      const config = yield* Config.use.get()
+      expect(config.username).toBe("C:\\Users\\me\\AppData\\Roaming\\MyApp")
+    }),
+  ),
+)
+
 it.instance("preserves env variables when adding $schema to config", () =>
   withProcessEnv(
     "PRESERVE_VAR",


### PR DESCRIPTION
### Issue for this PR

Closes #32695

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`{env:VAR}` is substituted into the raw config document *before* it is parsed as JSON (`ConfigVariable.substitute()` runs, then `ConfigParse.jsonc()`). When the variable holds a native Windows path like `C:\Users\me\AppData\Roaming\MyApp`, the backslashes land in the document as invalid JSON escape sequences, so startup fails with `InvalidEscapeCharacter`.

The `{file:}` branch already guarded against this by escaping its content with `JSON.stringify(...).slice(1, -1)`; the `{env:}` branch did not.

Fix: add a `jsonEscape` option to `substitute()` and set it from the two callers whose output is fed to a JSON parser — `config.ts` (`loadConfig`) and `tui.ts` (`loadState`). When set, both `{env:}` and `{file:}` values are escaped so they stay valid inside a JSON string. The remote-config `url`/`header` callers leave it off, because they substitute into values that are already parsed strings, not JSON text — escaping there would corrupt a URL or header. As a side effect this also makes `{file:}` correct for those callers (it was previously always escaped, which was wrong for a plain-string context).

Why it works: inside a JSON string the only thing that matters is that backslashes, quotes and control characters are escaped. `JSON.stringify(value).slice(1, -1)` produces exactly the escaped inner content, so `C:\Users\me` becomes `C:\\Users\\me` in the document and parses back to the original path.

### How did you verify your code works?

- Added a test in `packages/opencode/test/config/config.test.ts` that sets an env var to a backslash Windows path, references it via `{env:...}` in config, and asserts it round-trips to the original path. Fails before the change (JSON parse error), passes after.
- `bun test test/config/config.test.ts` -> 95 pass. `bun test test/config/tui.test.ts` -> 33 pass.
- Existing env-in-url and env-in-header tests still pass, confirming the non-JSON callers are unaffected.
- `bun typecheck` passes across all 23 packages.

### Screenshots / recordings

_N/A — not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR