### PR TITLE
fix(patch): match canonically equivalent unicode

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -480,7 +480,17 @@ function seekSequence(lines: string[], pattern: string[], startIndex: number, eo
     (a, b) => normalizeUnicode(a.trim()) === normalizeUnicode(b.trim()),
     eof,
   )
-  return normalized
+  if (normalized !== -1) return normalized
+
+  // Pass 5: canonical Unicode equivalence.
+  const nfc = tryMatch(
+    lines,
+    pattern,
+    startIndex,
+    (a, b) => a.trim().normalize("NFC") === b.trim().normalize("NFC"),
+    eof,
+  )
+  return nfc
 }
 
 function generateUnifiedDiff(oldContent: string, newContent: string): string {

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -530,4 +530,28 @@ EOF`
       expect(yield* readText(target)).toBe(`He said "hi"\nsome${emDash}dash\nend\n`)
     }),
   )
+
+  it.instance("matches with canonically equivalent Unicode text", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx } = makeCtx()
+      const target = path.join(test.directory, "canonical.txt")
+      const nfdLine = "Район: Астана".normalize("NFD")
+      const nfcLine = "Район: Астана".normalize("NFC")
+
+      expect(nfdLine).not.toBe(nfcLine)
+      expect(nfdLine.normalize("NFC")).toBe(nfcLine)
+      yield* writeText(target, `# Сводка\n${nfdLine}\n`)
+
+      const patchText = `*** Begin Patch
+*** Update File: canonical.txt
+@@
+-${nfcLine}
++Район: Алматы
+*** End Patch`
+
+      yield* execute({ patchText }, ctx)
+      expect(yield* readText(target)).toBe("# Сводка\nРайон: Алматы\n")
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31651

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`apply_patch` could fail to match a file line when the file stores the text in NFD form and the patch old line uses NFC form. The text is canonically equivalent, but the existing match passes only handled exact text, whitespace differences, and punctuation normalization.

This adds a final `seekSequence` pass that compares trimmed lines after NFC normalization. Existing match priority stays the same; the new pass only handles Unicode canonical equivalence after the stricter passes fail.

### How did you verify your code works?

- `bun test test/tool/apply_patch.test.ts -t "matches with canonically equivalent Unicode text"`
- `bun test test/tool/apply_patch.test.ts`
- `bun test test/patch/patch.test.ts`
- `prettier --check packages/opencode/src/patch/index.ts packages/opencode/test/tool/apply_patch.test.ts`
- `git diff --check HEAD~1..HEAD`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR