### PR TITLE
fix(session): inherit parent directory, workspaceID, and projectID in subagent + fork sessions

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -717,16 +717,39 @@ export const layer: Layer.Layer<
     }) {
       const ctx = yield* InstanceState.context
       const workspace = yield* InstanceState.workspaceID
+
+      // When this is a subagent session (parentID set), inherit the parent's
+      // workspace context — directory and workspaceID. Without this, child
+      // sessions fall back to ctx.directory (daemon process.cwd()), which is
+      // unrelated to the parent's actual project. That mismatch caused every
+      // subagent tool call to read against the wrong worktree, triggering
+      // external_directory permission asks for paths the parent's worktree
+      // fully owns. Effect.catchCause ensures a missing/race-deleted parent
+      // degrades gracefully back to ctx.directory.
+      let directory = ctx.directory
+      let resolvedWorkspaceID = input?.workspaceID ?? workspace
+      if (input?.parentID) {
+        const parent = yield* get(input.parentID).pipe(
+          Effect.catchCause(() => Effect.succeed(undefined)),
+        )
+        if (parent) {
+          directory = parent.directory
+          if (input?.workspaceID === undefined) {
+            resolvedWorkspaceID = parent.workspaceID ?? resolvedWorkspaceID
+          }
+        }
+      }
+
       return yield* createNext({
         parentID: input?.parentID,
-        directory: ctx.directory,
-        path: sessionPath(ctx.worktree, ctx.directory),
+        directory,
+        path: sessionPath(ctx.worktree, directory),
         title: input?.title,
         agent: input?.agent,
         model: input?.model,
         metadata: input?.metadata,
         permission: input?.permission,
-        workspaceID: input?.workspaceID ?? workspace,
+        workspaceID: resolvedWorkspaceID,
       })
     })
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -549,13 +549,14 @@ export const layer: Layer.Layer<
       path?: string
       metadata?: typeof Metadata.Type
       permission?: PermissionV1.Ruleset
+      projectID?: ProjectV2.ID
     }) {
       const ctx = yield* InstanceState.context
       const result: Info = {
         id: SessionID.descending(input.id),
         slug: Slug.create(),
         version: InstallationVersion,
-        projectID: ctx.project.id,
+        projectID: input.projectID ?? ctx.project.id,
         directory: input.directory,
         path: input.path,
         workspaceID: input.workspaceID,
@@ -728,6 +729,7 @@ export const layer: Layer.Layer<
       // degrades gracefully back to ctx.directory.
       let directory = ctx.directory
       let resolvedWorkspaceID = input?.workspaceID ?? workspace
+      let parentProjectID: ProjectV2.ID | undefined = undefined
       if (input?.parentID) {
         const parent = yield* get(input.parentID).pipe(
           Effect.catchCause(() => Effect.succeed(undefined)),
@@ -737,6 +739,7 @@ export const layer: Layer.Layer<
           if (input?.workspaceID === undefined) {
             resolvedWorkspaceID = parent.workspaceID ?? resolvedWorkspaceID
           }
+          parentProjectID = parent.projectID
         }
       }
 
@@ -750,6 +753,8 @@ export const layer: Layer.Layer<
         metadata: input?.metadata,
         permission: input?.permission,
         workspaceID: resolvedWorkspaceID,
+        // projectID must travel with directory to keep session identity consistent
+        projectID: parentProjectID,
       })
     })
 
@@ -763,6 +768,7 @@ export const layer: Layer.Layer<
         workspaceID: original.workspaceID,
         title,
         metadata: structuredClone(original.metadata),
+        projectID: original.projectID,
       })
       const msgs = yield* messages({ sessionID: input.sessionID })
       const idMap = new Map<string, MessageID>()

--- a/packages/opencode/test/session/project-inheritance.test.ts
+++ b/packages/opencode/test/session/project-inheritance.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect } from "bun:test"
+import { Database } from "@opencode-ai/core/database/database"
+import { Effect, Layer } from "effect"
+import { Agent } from "@/agent/agent"
+import { BackgroundJob } from "@/background/job"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Config } from "@/config/config"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { Session } from "@/session/session"
+import { SessionRunState } from "@/session/run-state"
+import { SessionStatus } from "@/session/status"
+import { Truncate } from "@/tool/truncate"
+import { ToolRegistry } from "@/tool/registry"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { InstanceState } from "@/effect/instance-state"
+import { disposeAllInstances } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const layer = Layer.mergeAll(
+  Agent.defaultLayer,
+  BackgroundJob.defaultLayer,
+  EventV2Bridge.defaultLayer,
+  Config.defaultLayer,
+  CrossSpawnSpawner.defaultLayer,
+  Session.defaultLayer,
+  SessionRunState.defaultLayer,
+  SessionStatus.defaultLayer,
+  Truncate.defaultLayer,
+  ToolRegistry.defaultLayer,
+  Database.defaultLayer,
+  RuntimeFlags.layer({}),
+).pipe(Layer.provide(Ripgrep.defaultLayer))
+
+const it = testEffect(layer)
+
+describe("session project inheritance", () => {
+  it.instance("subagent inherits parent projectID and directory", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const parent = yield* sessions.create({ title: "Parent" })
+      const child = yield* sessions.create({ parentID: parent.id, title: "Child" })
+
+      expect(child.projectID).toBe(parent.projectID)
+      expect(child.directory).toBe(parent.directory)
+    }),
+  )
+
+  it.instance("fork inherits original projectID and directory", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const original = yield* sessions.create({ title: "Original" })
+      const forked = yield* sessions.fork({ sessionID: original.id })
+
+      expect(forked.projectID).toBe(original.projectID)
+      expect(forked.directory).toBe(original.directory)
+    }),
+  )
+
+  it.instance("session without parentID falls back to the instance project", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "Standalone" })
+      const ctx = yield* InstanceState.context
+
+      expect(session.projectID).toBe(ctx.project.id)
+      expect(session.directory).toBe(ctx.directory)
+    }),
+  )
+})


### PR DESCRIPTION
Closes #30355


### Description

When opencode is run in HTTP server mode, the directory is always set to ctx.directory, which is the daemon's process.cwd(), NOT the parent session's context. For subagent sessions (parentID set), this is wrong:
they should inherit the parent's directory to maintain workspace coherence.

### Plugins

_No response_

### OpenCode version

_No response_

### Steps to reproduce

**Evidence (Session IDs from live observation, port 4096):**
- Parent session: `ses_17cdba9cfffeC5A6FQLkMAFYtM`
  - Created in headless client project root
  - Correct: `directory=/path/to/headless/client/project/directory`
  - `workspaceID=wsv2_6uN7E5rF1I0rJy2qL`

- Child Planner session: `ses_17cb08557ffe8G2ucNG1fi1F0c`
  - Created by Brain task tool for subagent execution
  - Incorrect: `directory=/path/to/opencode/daemon/home` (daemon's $HOME)
  - Should have been: `directory=/path/to/headless/client/project/directory` (inherited from parent)

**Call trace:** 
- `headless client` makes HTTP POST to daemon's task endpoint with parent session context
- Daemon's `task.ts` creates child session via `Session.create({ parentID })`
- `session.ts` `Session.create()` previously did NOT inherit parent's directory
- Result: child receives `ctx.directory` = daemon `process.cwd()` = `/path/to/opencode/daemon/home`


### Screenshot and/or share link

_No response_

### Operating System

Linux Debian/testing

### Terminal

xterm

## Resolution

See #32807 (supersedes #30650). The new PR is a fresh PR from the feature branch with improved scope: it adds structural projectID inheritance (so project_id can't drift from directory) on top of the original directory/workspaceID inheritance, includes a dedicated regression test, and excludes the unrelated bin/opencode ESM-shim change. Result is a conflict-free branch upstream can merge directly.

Note: cross-project fork directory divergence is a separate deferred concern.

Supersedes #30650 (superseded by a smaller, cleaner branch — see note below).

## Changes

### Fix 1: Subagent sessions (parentID set) inherit the parent's `directory` and `workspaceID`

Without this, child sessions fell back to the daemon's cwd, causing external_directory permission asks for paths the parent's worktree owns.

### Fix 2: NEW - subagent and forked sessions inherit the parent/original `projectID` structurally

So a session's `project_id` can never drift from its `directory`. Pure passthrough from already-resolved session objects; no `Project.fromDirectory` calls (no DB side effects).

## Excluded by design

The unrelated `bin/opencode` ESM-shim change that was bundled in the original PR is intentionally NOT part of this branch.

## Verification

- `bun typecheck` clean
- New regression test `packages/opencode/test/session/project-inheritance.test.ts` (3 cases: subagent inheritance, fork inheritance, no-parent fallback) passes
- Combined with existing `test/tool/task.test.ts` = 21 pass / 0 fail

## Note

This PR is a fresh PR from the feature branch. The feature branch contains 4 commits over dev (including a fix for agent/model population that was not part of the original feature branch). This PR is cleaner and more focused than the original PR #30650.
