### PR TITLE
fix(web): add clipboard fallback for non-HTTPS contexts

### DIFF
--- a/packages/web/src/components/share/copy-button.tsx
+++ b/packages/web/src/components/share/copy-button.tsx
@@ -11,12 +11,27 @@ export function CopyButton(props: CopyButtonProps) {
   const [copied, setCopied] = createSignal(false)
   const messages = useShareMessages()
 
-  function handleCopyClick() {
-    if (props.text) {
-      navigator.clipboard.writeText(props.text).catch((err) => console.error("Copy failed", err))
+  async function handleCopyClick() {
+    if (!props.text) return
 
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(props.text)
+      } else {
+        // Fallback for non-HTTPS contexts (e.g., localhost)
+        const textarea = document.createElement("textarea")
+        textarea.value = props.text
+        textarea.style.position = "fixed"
+        textarea.style.left = "-9999px"
+        document.body.appendChild(textarea)
+        textarea.select()
+        document.execCommand("copy")
+        document.body.removeChild(textarea)
+      }
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error("Copy failed", err)
     }
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #32664

### Type of change

- [x] Bug fix

### What does this PR do?

The copy-to-clipboard button for code blocks doesn't work in `opencode web` when opened on localhost without HTTPS. `navigator.clipboard` requires a secure context in most browsers, so the button silently fails.

Added a fallback using `document.execCommand('copy')` when `navigator.clipboard` isn't available. The logic tries the modern API first, and falls back to creating a temporary textarea + execCommand if that's not possible.

### How did you verify your code works?

- Tested on localhost without HTTPS — copy button works now
- Tested on HTTPS — existing behavior unchanged
- Desktop app — no regression

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR