### PR TITLE
fix(opencode): normalize MCP structured arguments

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -6,10 +6,11 @@ import {
   type Tool as MCPToolDef,
 } from "@modelcontextprotocol/sdk/types.js"
 import { dynamicTool, jsonSchema, type JSONSchema7, type Tool } from "ai"
-import { Effect } from "effect"
+import { Effect, Option, Schema } from "effect"
 
 const DEFAULT_TIMEOUT = 30_000
 const MAX_LIST_PAGES = 1_000
+const decodeJsonString = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
 
 const TolerantListToolsResultSchema = ListToolsResultSchema.extend({
   tools: ToolSchema.omit({ outputSchema: true }).array(),
@@ -54,7 +55,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
       const result = await client.callTool(
         {
           name: mcpTool.name,
-          arguments: (args || {}) as Record<string, unknown>,
+          arguments: normalizeArguments(args, inputSchema),
         },
         CallToolResultSchema,
         {
@@ -79,6 +80,53 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
       }
     },
   })
+}
+
+function normalizeArguments(args: unknown, schema: JSONSchema7): Record<string, unknown> {
+  const value = normalizeValue(args || {}, schema)
+  if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>
+  return {}
+}
+
+function normalizeValue(value: unknown, schema: JSONSchema7 | undefined): unknown {
+  const decoded = typeof value === "string" && expectsStructuredValue(schema) ? decodeString(value, schema) : value
+  if (Array.isArray(decoded)) return decoded.map((item) => normalizeValue(item, itemSchema(schema)))
+  if (!decoded || typeof decoded !== "object" || !schema?.properties) return decoded
+  return Object.fromEntries(
+    Object.entries(decoded).map(([key, item]) => [key, normalizeValue(item, propertySchema(schema, key))]),
+  )
+}
+
+function decodeString(value: string, schema: JSONSchema7 | undefined) {
+  if (value === "" && expectsObject(schema)) return {}
+  if (value === "" && expectsArray(schema)) return []
+  return Option.getOrUndefined(decodeJsonString(value)) ?? value
+}
+
+function propertySchema(schema: JSONSchema7, key: string) {
+  const value = schema.properties?.[key]
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JSONSchema7) : undefined
+}
+
+function itemSchema(schema: JSONSchema7 | undefined) {
+  const value = schema?.items
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JSONSchema7) : undefined
+}
+
+function expectsStructuredValue(schema: JSONSchema7 | undefined) {
+  return expectsObject(schema) || expectsArray(schema)
+}
+
+function expectsObject(schema: JSONSchema7 | undefined) {
+  if (!schema || typeof schema !== "object") return false
+  if (schema.type === "object") return true
+  return Array.isArray(schema.type) ? schema.type.includes("object") : "properties" in schema
+}
+
+function expectsArray(schema: JSONSchema7 | undefined) {
+  if (!schema || typeof schema !== "object") return false
+  if (schema.type === "array") return true
+  return Array.isArray(schema.type) ? schema.type.includes("array") : "items" in schema
 }
 
 export function fetch<T extends { name: string }>(

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test"
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
+
+import { McpCatalog } from "../../src/mcp/catalog"
+
+function toolClient(calls: Record<string, unknown>[]) {
+  return {
+    callTool: async (request: { arguments?: Record<string, unknown> }) => {
+      calls.push(request.arguments ?? {})
+      return { content: [{ type: "text" as const, text: "ok" }] }
+    },
+  } as unknown as Client
+}
+
+describe("McpCatalog.convertTool", () => {
+  test("parses JSON strings for object-shaped arguments", async () => {
+    const calls: Record<string, unknown>[] = []
+    const tool = McpCatalog.convertTool(
+      {
+        name: "send-mail",
+        inputSchema: {
+          type: "object",
+          properties: {
+            body: {
+              type: "object",
+              properties: {
+                subject: { type: "string" },
+              },
+            },
+          },
+        },
+      },
+      toolClient(calls),
+    )
+
+    await tool.execute?.({ body: '{"subject":"hello"}' }, { toolCallId: "call", messages: [], abortSignal: undefined })
+
+    expect(calls).toEqual([{ body: { subject: "hello" } }])
+  })
+
+  test("converts empty strings to empty objects for object-shaped arguments", async () => {
+    const calls: Record<string, unknown>[] = []
+    const tool = McpCatalog.convertTool(
+      {
+        name: "nextjs_call",
+        inputSchema: {
+          type: "object",
+          properties: {
+            args: { type: "object", properties: {} },
+          },
+        },
+      },
+      toolClient(calls),
+    )
+
+    await tool.execute?.({ args: "" }, { toolCallId: "call", messages: [], abortSignal: undefined })
+
+    expect(calls).toEqual([{ args: {} }])
+  })
+
+  test("leaves invalid JSON strings unchanged", async () => {
+    const calls: Record<string, unknown>[] = []
+    const tool = McpCatalog.convertTool(
+      {
+        name: "nextjs_call",
+        inputSchema: {
+          type: "object",
+          properties: {
+            args: { type: "object", properties: {} },
+          },
+        },
+      },
+      toolClient(calls),
+    )
+
+    await tool.execute?.({ args: "not json" }, { toolCallId: "call", messages: [], abortSignal: undefined })
+
+    expect(calls).toEqual([{ args: "not json" }])
+  })
+})

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -77,4 +77,44 @@ describe("McpCatalog.convertTool", () => {
 
     expect(calls).toEqual([{ args: "not json" }])
   })
+
+  test("parses JSON strings for array-shaped arguments", async () => {
+    const calls: Record<string, unknown>[] = []
+    const tool = McpCatalog.convertTool(
+      {
+        name: "nextjs_call",
+        inputSchema: {
+          type: "object",
+          properties: {
+            args: { type: "array", items: { type: "string" } },
+          },
+        },
+      },
+      toolClient(calls),
+    )
+
+    await tool.execute?.({ args: '["pages","app"]' }, { toolCallId: "call", messages: [], abortSignal: undefined })
+
+    expect(calls).toEqual([{ args: ["pages", "app"] }])
+  })
+
+  test("converts empty strings to empty arrays for array-shaped arguments", async () => {
+    const calls: Record<string, unknown>[] = []
+    const tool = McpCatalog.convertTool(
+      {
+        name: "nextjs_call",
+        inputSchema: {
+          type: "object",
+          properties: {
+            args: { type: "array", items: { type: "string" } },
+          },
+        },
+      },
+      toolClient(calls),
+    )
+
+    await tool.execute?.({ args: "" }, { toolCallId: "call", messages: [], abortSignal: undefined })
+
+    expect(calls).toEqual([{ args: [] }])
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Related to #28472

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some setups hand MCP servers an object or array argument as a JSON string, which the server then rejects with `expected object, received string`. When the advertised schema says a field is an object or array, this PR parses that JSON string back into a structured value before calling `client.callTool`. Empty strings become `{}`/`[]`; invalid JSON is left untouched so the server still returns its own error. It is a no-op when the argument is already structured.

### How did you verify your code works?

- `bun test test/mcp/catalog.test.ts` and `bun run typecheck` from `packages/opencode`; `bun run lint` from the repo root (0 errors).
- Instrumented the forwarding boundary and ran real tool calls through OpenCode against a real MCP server, across 5 models / 3 providers (OpenAI gpt-5.4, gpt-5.4-mini; Copilot gpt-4.1, gpt-5.4; Gemini 2.5 Flash) and 3 object-schema shapes (shallow object, free-form object, deeply nested object like ms-365 `send-mail` `body`). With current models the argument always arrives as a proper object and the unfixed path already accepts it. When a JSON string is forced, the unfixed path returns the exact `-32602 ... expected object, received string` and this change accepts it.

### Scope and limitations

This is a tolerance shim. It only does anything when an upstream component (an older model, a proxy, or a re-serializing SDK) emits a JSON string for an object/array field; otherwise it is a no-op. I could not reproduce the original failure with current models in clean OpenCode, so this is defensive rather than a guaranteed fix for a specific server. Note that next-devtools' `nextjs_call` advertises `args` as `type: "string"`, so this change does not affect it. Schema detection is intentionally minimal: `anyOf`/`oneOf`/`$ref` and `string | object` unions are not handled. Happy to extend, or to drop this if you'd rather not carry it.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
