### PR TITLE
fix(opencode): pass configured headers to Copilot models

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -70,6 +70,7 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
         return CopilotModels.get(
           base(auth.enterpriseUrl),
           {
+            ...(provider.options?.headers as Record<string, string> | undefined),
             Authorization: `Bearer ${auth.refresh}`,
             "User-Agent": `opencode/${InstallationVersion}`,
             "X-GitHub-Api-Version": API_VERSION,


### PR DESCRIPTION
## Summary
- pass configured GitHub Copilot provider headers to the models discovery request
- preserve plugin-owned authorization, user agent, and API version headers

Fixes #23816

## Verification
- `bun typecheck` from `packages/opencode`