### PR TITLE
feat: add --update-plugins flag to bypass plugin cache

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -122,7 +122,8 @@ export const layer = Layer.effect(
         }
       })()
 
-      if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
+      const forceUpdate = process.env.OPENCODE_UPDATE_PLUGINS === "1"
+      if (!forceUpdate && (yield* afs.existsSafe(path.join(dir, "node_modules", name)))) {
         return resolveEntryPoint(name, path.join(dir, "node_modules", name))
       }
 

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -62,6 +62,40 @@ describe("Npm.add", () => {
 
     expect(Option.isSome(entry.entrypoint)).toBe(true)
   })
+
+  test("bypasses cache when OPENCODE_UPDATE_PLUGINS=1", async () => {
+    await using tmp = await tmpdir()
+    const spec = "this-package-does-not-exist-in-npm-12345@1.0.0"
+    const cacheDir = path.join(tmp.path, "cache")
+    const dir = path.join(cacheDir, "packages", Npm.sanitize(spec))
+    
+    // Manually create the cache folder to simulate a cached package
+    await fs.mkdir(path.join(dir, "node_modules", "this-package-does-not-exist-in-npm-12345"), { recursive: true })
+    await Bun.write(path.join(dir, "node_modules", "this-package-does-not-exist-in-npm-12345", "index.js"), "")
+
+    // 1. Without env variable, it uses the cache and succeeds
+    const entry1 = await Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      return yield* npm.add(spec)
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(cacheDir)), Effect.runPromise)
+    
+    expect(Option.isSome(entry1.entrypoint)).toBe(true)
+    expect(entry1.directory).toContain("this-package-does-not-exist-in-npm-12345")
+
+    // 2. With env variable, it bypasses cache, calls reify, and fails (because package doesn't exist)
+    process.env.OPENCODE_UPDATE_PLUGINS = "1"
+    try {
+      await Effect.gen(function* () {
+        const npm = yield* Npm.Service
+        return yield* npm.add(spec)
+      }).pipe(Effect.scoped, Effect.provide(npmLayer(cacheDir)), Effect.runPromise)
+      expect().fail("Should have thrown")
+    } catch (e: any) {
+      expect(e._tag).toBe("NpmInstallFailedError")
+    } finally {
+      delete process.env.OPENCODE_UPDATE_PLUGINS
+    }
+  })
 })
 
 describe("Npm.install", () => {

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -63,11 +63,18 @@ const cli = yargs(args)
     describe: "run without external plugins",
     type: "boolean",
   })
+  .option("update-plugins", {
+    describe: "force update external plugins",
+    type: "boolean",
+  })
   .middleware(async (opts) => {
     if (opts.printLogs) process.env.OPENCODE_PRINT_LOGS = "1"
     if (opts.logLevel) process.env.OPENCODE_LOG_LEVEL = opts.logLevel
     if (opts.pure) {
       process.env.OPENCODE_PURE = "1"
+    }
+    if (opts.updatePlugins || opts["update-plugins"]) {
+      process.env.OPENCODE_UPDATE_PLUGINS = "1"
     }
 
     Heap.start()


### PR DESCRIPTION
### Issue for this PR

Closes #30526
Closes #18544

### Type of change

- [x] New feature

### What does this PR do?

This PR introduces a global `--update-plugins` CLI flag that forces the internal arborist instance to bypass the local cache check. When this flag is passed, `Npm.add` ignores the existing `node_modules` cache directory and successfully executes `arborist.reify` to fetch the true `@latest` tags directly from the npm registry.

### How did you verify your code works?

I wrote a test in `packages/core/test/npm.test.ts` that mocks a local cache directory and asserts that when `OPENCODE_UPDATE_PLUGINS=1` is set, `Npm.add` successfully bypasses it and attempts the network reify.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
