### PR TITLE
fix(config): support additive config directories

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -169,7 +169,9 @@ export const layer = Layer.effect(
       ]
     })
 
-    const globalDirectory = AbsolutePath.make(global.config)
+    const globalDirectories = Array.from(new Set([global.config, ...global.extraConfigDirs])).map((directory) =>
+      AbsolutePath.make(directory),
+    )
     const locationIsGlobal = path.resolve(location.directory) === path.resolve(global.config)
     // Read configuration once when this location opens. Later calls reuse these
     // values until the location is reopened.
@@ -182,13 +184,10 @@ export const layer = Layer.effect(
             stop: location.project.directory,
           })
           .pipe(Effect.orDie)
-    const directories = [
-      globalDirectory,
-      ...discovered
-        .filter((item) => path.basename(item) === ".opencode")
-        .toReversed()
-        .map((directory) => AbsolutePath.make(directory)),
-    ]
+    const projectDirectories = discovered
+      .filter((item) => path.basename(item) === ".opencode")
+      .toReversed()
+      .map((directory) => AbsolutePath.make(directory))
     // A config closer to the opened directory should win over one higher up.
     // Search starts nearby, so reverse the results before applying them.
     const directPaths = discovered.filter((item) => path.basename(item) !== ".opencode").toReversed()
@@ -196,10 +195,11 @@ export const layer = Layer.effect(
       Effect.orDie,
       Effect.map((configs) => configs.filter((config): config is Document => config !== undefined)),
     )
-    const supplementary = yield* Effect.forEach(directories, loadDirectory).pipe(Effect.orDie)
+    const globalSupplementary = yield* Effect.forEach(globalDirectories, loadDirectory).pipe(Effect.orDie)
+    const projectSupplementary = yield* Effect.forEach(projectDirectories, loadDirectory).pipe(Effect.orDie)
     // Apply general settings first and more specific settings last:
-    // global config, project files, then `.opencode` files.
-    const configs = [...(supplementary[0] ?? []), ...direct, ...supplementary.slice(1).flat()]
+    // global config, extra config dirs, project files, then `.opencode` files.
+    const configs = [...globalSupplementary.flat(), ...direct, ...projectSupplementary.flat()]
     // Rules use the opposite order so a user-global rule can override a
     // repository rule. Statement order inside each file stays unchanged.
     yield* policy.load(

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -169,10 +169,17 @@ export const layer = Layer.effect(
       ]
     })
 
-    const globalDirectories = Array.from(new Set([global.config, ...global.extraConfigDirs])).map((directory) =>
-      AbsolutePath.make(directory),
+    const extraConfigDirs = Array.from(
+      new Map(
+        global.extraConfigDirs
+          .filter((directory) => path.resolve(directory) !== path.resolve(global.config))
+          .map((directory) => [path.resolve(directory), directory]),
+      ).values(),
     )
-    const locationIsGlobal = path.resolve(location.directory) === path.resolve(global.config)
+    const extraConfigDirSet = new Set(extraConfigDirs.map((directory) => path.resolve(directory)))
+    const locationIsGlobal = [global.config, ...extraConfigDirs].some(
+      (directory) => path.resolve(location.directory) === path.resolve(directory),
+    )
     // Read configuration once when this location opens. Later calls reuse these
     // values until the location is reopened.
     const discovered = locationIsGlobal
@@ -186,6 +193,7 @@ export const layer = Layer.effect(
           .pipe(Effect.orDie)
     const projectDirectories = discovered
       .filter((item) => path.basename(item) === ".opencode")
+      .filter((item) => !extraConfigDirSet.has(path.resolve(item)))
       .toReversed()
       .map((directory) => AbsolutePath.make(directory))
     // A config closer to the opened directory should win over one higher up.
@@ -195,11 +203,15 @@ export const layer = Layer.effect(
       Effect.orDie,
       Effect.map((configs) => configs.filter((config): config is Document => config !== undefined)),
     )
-    const globalSupplementary = yield* Effect.forEach(globalDirectories, loadDirectory).pipe(Effect.orDie)
+    const globalSupplementary = yield* loadDirectory(AbsolutePath.make(global.config)).pipe(Effect.orDie)
     const projectSupplementary = yield* Effect.forEach(projectDirectories, loadDirectory).pipe(Effect.orDie)
+    const extraSupplementary = yield* Effect.forEach(
+      extraConfigDirs.map((directory) => AbsolutePath.make(directory)),
+      loadDirectory,
+    ).pipe(Effect.orDie)
     // Apply general settings first and more specific settings last:
-    // global config, extra config dirs, project files, then `.opencode` files.
-    const configs = [...globalSupplementary.flat(), ...direct, ...projectSupplementary.flat()]
+    // global config, project files, `.opencode` files, then env-provided config directories.
+    const configs = [...globalSupplementary, ...direct, ...projectSupplementary.flat(), ...extraSupplementary.flat()]
     // Rules use the opposite order so a user-global rule can override a
     // repository rule. Statement order inside each file stays unchanged.
     yield* policy.load(

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -1,3 +1,4 @@
+import path from "path"
 import { Config } from "effect"
 
 export function truthy(key: string) {
@@ -10,6 +11,10 @@ const fff = process.env["OPENCODE_DISABLE_FFF"]
 
 function enabledByExperimental(key: string) {
   return process.env[key] === undefined ? truthy("OPENCODE_EXPERIMENTAL") : truthy(key)
+}
+
+function splitPathList(value: string | undefined) {
+  return value?.split(path.delimiter).filter(Boolean) ?? []
 }
 
 export const Flag = {
@@ -62,6 +67,9 @@ export const Flag = {
   },
   get OPENCODE_CONFIG_DIR() {
     return process.env["OPENCODE_CONFIG_DIR"]
+  },
+  get OPENCODE_CONFIG_DIRS() {
+    return splitPathList(process.env["OPENCODE_CONFIG_DIRS"])
   },
   get OPENCODE_PURE() {
     return truthy("OPENCODE_PURE")

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -14,7 +14,17 @@ function enabledByExperimental(key: string) {
 }
 
 function splitPathList(value: string | undefined) {
-  return value?.split(path.delimiter).filter(Boolean) ?? []
+  return (
+    value
+      ?.split(path.delimiter)
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0) ?? []
+  )
+}
+
+export function configDirectories() {
+  const directory = process.env["OPENCODE_CONFIG_DIR"]?.trim()
+  return [...splitPathList(process.env["OPENCODE_CONFIG_DIRS"]), ...(directory ? [directory] : [])]
 }
 
 export const Flag = {
@@ -66,7 +76,8 @@ export const Flag = {
     return process.env["OPENCODE_TUI_CONFIG"]
   },
   get OPENCODE_CONFIG_DIR() {
-    return process.env["OPENCODE_CONFIG_DIR"]
+    const directory = process.env["OPENCODE_CONFIG_DIR"]?.trim()
+    return directory || undefined
   },
   get OPENCODE_CONFIG_DIRS() {
     return splitPathList(process.env["OPENCODE_CONFIG_DIRS"])

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -4,7 +4,7 @@ import { xdgData, xdgCache, xdgConfig, xdgState } from "xdg-basedir"
 import os from "os"
 import { Context, Effect, Layer } from "effect"
 import { Flock } from "./util/flock"
-import { Flag } from "./flag/flag"
+import { configDirectories } from "./flag/flag"
 import { LayerNode } from "./effect/layer-node"
 
 const app = "opencode"
@@ -64,7 +64,7 @@ export function make(input: Partial<Interface> = {}): Interface {
     data: Path.data,
     cache: Path.cache,
     config: Path.config,
-    extraConfigDirs: [...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []), ...Flag.OPENCODE_CONFIG_DIRS],
+    extraConfigDirs: configDirectories(),
     state: Path.state,
     tmp: Path.tmp,
     bin: Path.bin,

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -49,6 +49,8 @@ export interface Interface {
   readonly data: string
   readonly cache: string
   readonly config: string
+  /** Additional config directory layers loaded after the XDG config directory. */
+  readonly extraConfigDirs: readonly string[]
   readonly state: string
   readonly tmp: string
   readonly bin: string
@@ -61,7 +63,8 @@ export function make(input: Partial<Interface> = {}): Interface {
     home: Path.home,
     data: Path.data,
     cache: Path.cache,
-    config: Flag.OPENCODE_CONFIG_DIR ?? Path.config,
+    config: Path.config,
+    extraConfigDirs: [...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []), ...Flag.OPENCODE_CONFIG_DIRS],
     state: Path.state,
     tmp: Path.tmp,
     bin: Path.bin,

--- a/packages/core/src/instruction-context.ts
+++ b/packages/core/src/instruction-context.ts
@@ -52,7 +52,19 @@ export const layer = Layer.effectDiscard(
             })
         ).map(FSUtil.resolve),
       )
-      const paths = Array.dedupe([FSUtil.resolve(join(global.config, "AGENTS.md")), ...discovered])
+      const globalInstructionPaths = yield* Effect.forEach(
+        [global.config, ...global.extraConfigDirs].toReversed(),
+        (directory) =>
+          Effect.gen(function* () {
+            const filepath = FSUtil.resolve(join(directory, "AGENTS.md"))
+            return (yield* fs.existsSafe(filepath)) ? filepath : undefined
+          }),
+        { concurrency: "unbounded" },
+      )
+      const paths = Array.dedupe([
+        ...globalInstructionPaths.filter((path): path is string => path !== undefined).slice(0, 1),
+        ...discovered,
+      ])
       const files = yield* Effect.forEach(
         paths,
         (path) =>

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -772,7 +772,7 @@ describe("Config", () => {
     ),
   )
 
-  it.live("loads extra config directories after global config and before project config", () =>
+  it.live("loads custom config directories after project config with singular last", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
@@ -781,12 +781,14 @@ describe("Config", () => {
         const global = path.join(tmp.path, "global")
         const firstExtra = path.join(tmp.path, "extra-a")
         const secondExtra = path.join(tmp.path, "extra-b")
+        const singularExtra = path.join(tmp.path, "extra-singular")
         const root = path.join(tmp.path, "repo")
         return Effect.gen(function* () {
           yield* Effect.promise(async () => {
             await fs.mkdir(global, { recursive: true })
             await fs.mkdir(firstExtra, { recursive: true })
             await fs.mkdir(secondExtra, { recursive: true })
+            await fs.mkdir(singularExtra, { recursive: true })
             await fs.mkdir(path.join(root, ".opencode"), { recursive: true })
             await Promise.all([
               fs.writeFile(
@@ -800,6 +802,10 @@ describe("Config", () => {
               fs.writeFile(
                 path.join(secondExtra, "opencode.json"),
                 JSON.stringify({ $schema: "extra-b", model: "extra-b/model" }),
+              ),
+              fs.writeFile(
+                path.join(singularExtra, "opencode.json"),
+                JSON.stringify({ $schema: "extra-singular", model: "extra-singular/model" }),
               ),
               fs.writeFile(
                 path.join(root, "opencode.json"),
@@ -819,19 +825,21 @@ describe("Config", () => {
 
             expect(entries.filter((entry) => entry.type === "directory").map((entry) => entry.path)).toEqual([
               AbsolutePath.make(global),
+              AbsolutePath.make(path.join(root, ".opencode")),
               AbsolutePath.make(firstExtra),
               AbsolutePath.make(secondExtra),
-              AbsolutePath.make(path.join(root, ".opencode")),
+              AbsolutePath.make(singularExtra),
             ])
             expect(documents.map((document) => document.info.$schema)).toEqual([
               "global",
-              "extra-a",
-              "extra-b",
               "project",
               "project-dot",
+              "extra-a",
+              "extra-b",
+              "extra-singular",
             ])
-            expect(Config.latest(entries, "model")).toBe("project-dot/model")
-          }).pipe(Effect.provide(testLayer(root, global, root, undefined, [firstExtra, secondExtra])))
+            expect(Config.latest(entries, "model")).toBe("extra-singular/model")
+          }).pipe(Effect.provide(testLayer(root, global, root, undefined, [firstExtra, secondExtra, singularExtra])))
         })
       }),
     ),

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -24,10 +24,11 @@ function testLayer(
   globalDirectory = path.join(directory, "global"),
   projectDirectory = directory,
   vcs?: Project.Vcs,
+  extraConfigDirs: readonly string[] = [],
 ) {
   return Config.locationLayer.pipe(
     Layer.provide(FSUtil.defaultLayer),
-    Layer.provide(Global.layerWith({ config: globalDirectory })),
+    Layer.provide(Global.layerWith({ config: globalDirectory, extraConfigDirs })),
     Layer.provide(
       Layer.succeed(
         Location.Service,
@@ -766,6 +767,71 @@ describe("Config", () => {
               }),
             ),
           )
+        })
+      }),
+    ),
+  )
+
+  it.live("loads extra config directories after global config and before project config", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) => {
+        const global = path.join(tmp.path, "global")
+        const firstExtra = path.join(tmp.path, "extra-a")
+        const secondExtra = path.join(tmp.path, "extra-b")
+        const root = path.join(tmp.path, "repo")
+        return Effect.gen(function* () {
+          yield* Effect.promise(async () => {
+            await fs.mkdir(global, { recursive: true })
+            await fs.mkdir(firstExtra, { recursive: true })
+            await fs.mkdir(secondExtra, { recursive: true })
+            await fs.mkdir(path.join(root, ".opencode"), { recursive: true })
+            await Promise.all([
+              fs.writeFile(
+                path.join(global, "opencode.json"),
+                JSON.stringify({ $schema: "global", model: "global/model" }),
+              ),
+              fs.writeFile(
+                path.join(firstExtra, "opencode.json"),
+                JSON.stringify({ $schema: "extra-a", model: "extra-a/model" }),
+              ),
+              fs.writeFile(
+                path.join(secondExtra, "opencode.json"),
+                JSON.stringify({ $schema: "extra-b", model: "extra-b/model" }),
+              ),
+              fs.writeFile(
+                path.join(root, "opencode.json"),
+                JSON.stringify({ $schema: "project", model: "project/model" }),
+              ),
+              fs.writeFile(
+                path.join(root, ".opencode", "opencode.json"),
+                JSON.stringify({ $schema: "project-dot", model: "project-dot/model" }),
+              ),
+            ])
+          })
+
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const entries = yield* config.entries()
+            const documents = entries.filter((entry) => entry.type === "document")
+
+            expect(entries.filter((entry) => entry.type === "directory").map((entry) => entry.path)).toEqual([
+              AbsolutePath.make(global),
+              AbsolutePath.make(firstExtra),
+              AbsolutePath.make(secondExtra),
+              AbsolutePath.make(path.join(root, ".opencode")),
+            ])
+            expect(documents.map((document) => document.info.$schema)).toEqual([
+              "global",
+              "extra-a",
+              "extra-b",
+              "project",
+              "project-dot",
+            ])
+            expect(Config.latest(entries, "model")).toBe("project-dot/model")
+          }).pipe(Effect.provide(testLayer(root, global, root, undefined, [firstExtra, secondExtra])))
         })
       }),
     ),

--- a/packages/core/test/global.test.ts
+++ b/packages/core/test/global.test.ts
@@ -13,4 +13,26 @@ describe("global paths", () => {
   test("tmp path is created on module load", async () => {
     expect((await fs.stat(Global.Path.tmp)).isDirectory()).toBe(true)
   })
+
+  test("config directory env vars add extra config directories", () => {
+    const previousDir = process.env.OPENCODE_CONFIG_DIR
+    const previousDirs = process.env.OPENCODE_CONFIG_DIRS
+    process.env.OPENCODE_CONFIG_DIR = "/tmp/opencode-extra-config"
+    process.env.OPENCODE_CONFIG_DIRS = ["/tmp/opencode-extra-a", "/tmp/opencode-extra-b"].join(path.delimiter)
+    try {
+      const global = Global.make()
+
+      expect(global.config).toBe(Global.Path.config)
+      expect(global.extraConfigDirs).toEqual([
+        "/tmp/opencode-extra-config",
+        "/tmp/opencode-extra-a",
+        "/tmp/opencode-extra-b",
+      ])
+    } finally {
+      if (previousDir === undefined) delete process.env.OPENCODE_CONFIG_DIR
+      else process.env.OPENCODE_CONFIG_DIR = previousDir
+      if (previousDirs === undefined) delete process.env.OPENCODE_CONFIG_DIRS
+      else process.env.OPENCODE_CONFIG_DIRS = previousDirs
+    }
+  })
 })

--- a/packages/core/test/global.test.ts
+++ b/packages/core/test/global.test.ts
@@ -17,16 +17,16 @@ describe("global paths", () => {
   test("config directory env vars add extra config directories", () => {
     const previousDir = process.env.OPENCODE_CONFIG_DIR
     const previousDirs = process.env.OPENCODE_CONFIG_DIRS
-    process.env.OPENCODE_CONFIG_DIR = "/tmp/opencode-extra-config"
-    process.env.OPENCODE_CONFIG_DIRS = ["/tmp/opencode-extra-a", "/tmp/opencode-extra-b"].join(path.delimiter)
+    process.env.OPENCODE_CONFIG_DIR = " /tmp/opencode-extra-config "
+    process.env.OPENCODE_CONFIG_DIRS = [" /tmp/opencode-extra-a ", "", "/tmp/opencode-extra-b"].join(path.delimiter)
     try {
       const global = Global.make()
 
       expect(global.config).toBe(Global.Path.config)
       expect(global.extraConfigDirs).toEqual([
-        "/tmp/opencode-extra-config",
         "/tmp/opencode-extra-a",
         "/tmp/opencode-extra-b",
+        "/tmp/opencode-extra-config",
       ])
     } finally {
       if (previousDir === undefined) delete process.env.OPENCODE_CONFIG_DIR

--- a/packages/core/test/instruction-context.test.ts
+++ b/packages/core/test/instruction-context.test.ts
@@ -96,6 +96,46 @@ describe("InstructionContext", () => {
     ),
   )
 
+  it.live("uses highest-priority extra config directory AGENTS.md", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const global = path.join(tmp.path, "global")
+          const base = path.join(tmp.path, "base")
+          const team = path.join(tmp.path, "team")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(global, { recursive: true })
+            await fs.mkdir(base, { recursive: true })
+            await fs.mkdir(team, { recursive: true })
+            await fs.writeFile(path.join(global, "AGENTS.md"), "global")
+            await fs.writeFile(path.join(base, "AGENTS.md"), "base")
+            await fs.writeFile(path.join(team, "AGENTS.md"), "team")
+          })
+
+          const context = yield* SystemContextRegistry.Service.pipe(
+            Effect.flatMap((service) => service.load()),
+            Effect.provide(InstructionContext.layer.pipe(Layer.provideMerge(SystemContextRegistry.layer))),
+            Effect.provide(FSUtil.defaultLayer),
+            Effect.provide(Global.layerWith({ config: global, extraConfigDirs: [base, team] })),
+            Effect.provide(
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(tmp.path) })),
+              ),
+            ),
+          )
+
+          expect((yield* SystemContext.initialize(context)).baseline).toBe(
+            `Instructions from: ${path.join(team, "AGENTS.md")}\nteam`,
+          )
+        }),
+      ),
+    ),
+  )
+
   it.live("keeps an empty AGENTS.md as available context", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -247,7 +247,12 @@ export const layer = Layer.effect(
       let result: Info = {}
       // Seed the default global config with the schema for editor completion, but avoid writing when the user
       // explicitly routes config through env-provided paths or content.
-      if (!Flag.OPENCODE_CONFIG && !Flag.OPENCODE_CONFIG_DIR && !Flag.OPENCODE_CONFIG_CONTENT) {
+      if (
+        !Flag.OPENCODE_CONFIG &&
+        !Flag.OPENCODE_CONFIG_DIR &&
+        !Flag.OPENCODE_CONFIG_DIRS.length &&
+        !Flag.OPENCODE_CONFIG_CONTENT
+      ) {
         const file = globalConfigFile()
         if (!existsSync(file)) {
           yield* fs
@@ -414,14 +419,19 @@ export const layer = Layer.effect(
 
         const directories = yield* ConfigPaths.directories(ctx.directory, ctx.worktree)
 
-        if (Flag.OPENCODE_CONFIG_DIR) {
-          yield* Effect.logDebug("loading config from OPENCODE_CONFIG_DIR", { path: Flag.OPENCODE_CONFIG_DIR })
+        const extraConfigDirs = new Set([
+          ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
+          ...Flag.OPENCODE_CONFIG_DIRS,
+        ])
+
+        if (extraConfigDirs.size) {
+          yield* Effect.logDebug("loading config from extra config dirs", { paths: [...extraConfigDirs] })
         }
 
         const deps: Fiber.Fiber<void>[] = []
 
         for (const dir of directories) {
-          if (dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR) {
+          if (dir.endsWith(".opencode") || extraConfigDirs.has(dir)) {
             for (const file of ["opencode.json", "opencode.jsonc"]) {
               const source = path.join(dir, file)
               yield* Effect.logDebug(`loading config from ${source}`)

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -419,19 +419,17 @@ export const layer = Layer.effect(
 
         const directories = yield* ConfigPaths.directories(ctx.directory, ctx.worktree)
 
-        const extraConfigDirs = new Set([
-          ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
-          ...Flag.OPENCODE_CONFIG_DIRS,
-        ])
+        const extraConfigDirs = ConfigPaths.customDirectories()
+        const extraConfigDirSet = new Set(extraConfigDirs)
 
-        if (extraConfigDirs.size) {
-          yield* Effect.logDebug("loading config from extra config dirs", { paths: [...extraConfigDirs] })
+        if (extraConfigDirs.length) {
+          yield* Effect.logDebug("loading config from extra config dirs", { paths: extraConfigDirs })
         }
 
         const deps: Fiber.Fiber<void>[] = []
 
         for (const dir of directories) {
-          if (dir.endsWith(".opencode") || extraConfigDirs.has(dir)) {
+          if (dir.endsWith(".opencode") || extraConfigDirSet.has(dir)) {
             for (const file of ["opencode.json", "opencode.jsonc"]) {
               const source = path.join(dir, file)
               yield* Effect.logDebug(`loading config from ${source}`)

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -22,6 +22,10 @@ export const files = Effect.fn("ConfigPaths.projectFiles")(function* (
 
 export const directories = Effect.fn("ConfigPaths.directories")(function* (directory: string, worktree?: string) {
   const afs = yield* FSUtil.Service
+  const extraConfigDirs = [
+    ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
+    ...Flag.OPENCODE_CONFIG_DIRS,
+  ]
   return unique([
     Global.Path.config,
     ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
@@ -36,7 +40,7 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
       start: Global.Path.home,
       stop: Global.Path.home,
     })),
-    ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
+    ...extraConfigDirs,
   ])
 })
 

--- a/packages/opencode/src/config/paths.ts
+++ b/packages/opencode/src/config/paths.ts
@@ -1,7 +1,7 @@
 export * as ConfigPaths from "./paths"
 
 import path from "path"
-import { Flag } from "@opencode-ai/core/flag/flag"
+import { Flag, configDirectories } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
 import { unique } from "remeda"
 import * as Effect from "effect/Effect"
@@ -22,11 +22,9 @@ export const files = Effect.fn("ConfigPaths.projectFiles")(function* (
 
 export const directories = Effect.fn("ConfigPaths.directories")(function* (directory: string, worktree?: string) {
   const afs = yield* FSUtil.Service
-  const extraConfigDirs = [
-    ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
-    ...Flag.OPENCODE_CONFIG_DIRS,
-  ]
-  return unique([
+  const custom = customDirectories()
+  const customSet = new Set(custom.map((dir) => path.resolve(dir)))
+  const base = [
     Global.Path.config,
     ...(!Flag.OPENCODE_DISABLE_PROJECT_CONFIG
       ? yield* afs.up({
@@ -40,10 +38,18 @@ export const directories = Effect.fn("ConfigPaths.directories")(function* (direc
       start: Global.Path.home,
       stop: Global.Path.home,
     })),
-    ...extraConfigDirs,
-  ])
+  ].filter((dir) => !customSet.has(path.resolve(dir)))
+  return unique([...base, ...custom])
 })
 
 export function fileInDirectory(dir: string, name: string) {
   return [path.join(dir, `${name}.json`), path.join(dir, `${name}.jsonc`)]
+}
+
+export function customDirectories() {
+  return unique(configDirectories())
+}
+
+export function isConfigDirectory(dir: string) {
+  return dir.endsWith(".opencode") || customDirectories().some((custom) => path.resolve(custom) === path.resolve(dir))
 }

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -167,7 +167,7 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     })
 
   // Every config dir we may read from: global config dir, any `.opencode`
-  // folders between cwd and home, and OPENCODE_CONFIG_DIR.
+  // folders between cwd and home, and extra config dirs from env.
   const directories = yield* ConfigPaths.directories(ctx.directory)
   yield* Effect.promise(() => migrateTuiConfig({ directories, cwd: ctx.directory }))
 
@@ -195,13 +195,16 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     yield* mergeFile(acc, file)
   }
 
-  // 4. `.opencode` directories (and OPENCODE_CONFIG_DIR) discovered while
+  // 4. `.opencode` directories (and extra config dirs) discovered while
   // walking up the tree. Also returned below so callers can install plugin
   // dependencies from each location.
-  const dirs = unique(directories).filter((dir) => dir.endsWith(".opencode") || dir === Flag.OPENCODE_CONFIG_DIR)
+  const extraConfigDirs = new Set([
+    ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
+    ...Flag.OPENCODE_CONFIG_DIRS,
+  ])
+  const dirs = unique(directories).filter((dir) => dir.endsWith(".opencode") || extraConfigDirs.has(dir))
 
   for (const dir of dirs) {
-    if (!dir.endsWith(".opencode") && dir !== Flag.OPENCODE_CONFIG_DIR) continue
     for (const file of ConfigPaths.fileInDirectory(dir, "tui")) {
       yield* mergeFile(acc, file)
     }

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -198,11 +198,7 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
   // 4. `.opencode` directories (and extra config dirs) discovered while
   // walking up the tree. Also returned below so callers can install plugin
   // dependencies from each location.
-  const extraConfigDirs = new Set([
-    ...(Flag.OPENCODE_CONFIG_DIR ? [Flag.OPENCODE_CONFIG_DIR] : []),
-    ...Flag.OPENCODE_CONFIG_DIRS,
-  ])
-  const dirs = unique(directories).filter((dir) => dir.endsWith(".opencode") || extraConfigDirs.has(dir))
+  const dirs = unique(directories).filter(ConfigPaths.isConfigDirectory)
 
   for (const dir of dirs) {
     for (const file of ConfigPaths.fileInDirectory(dir, "tui")) {

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -57,8 +57,9 @@ export const layer: Layer.Layer<
     const global = yield* Global.Service
     const flags = yield* RuntimeFlags.Service
     const http = HttpClient.filterStatusOk(withTransientReadRetry(yield* HttpClient.HttpClient))
-    const globalFiles = [
-      path.join(global.config, "AGENTS.md"),
+    const globalConfigDirectories = [global.config, ...global.extraConfigDirs]
+    const globalInstructionFiles = [
+      ...globalConfigDirectories.toReversed().map((directory) => path.join(directory, "AGENTS.md")),
       ...(!flags.disableClaudeCodePrompt ? [path.join(global.home, ".claude", "CLAUDE.md")] : []),
     ]
     const instructionFiles = [
@@ -78,14 +79,17 @@ export const layer: Layer.Layer<
 
     const relative = Effect.fnUntraced(function* (instruction: string) {
       const ctx = yield* InstanceState.context
-      if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-        return yield* fs
-          .globUp(instruction, ctx.directory, ctx.worktree)
-          .pipe(Effect.catch(() => Effect.succeed([] as string[])))
-      }
-      return yield* fs
-        .globUp(instruction, global.config, global.config)
+      const globalMatches = yield* Effect.forEach(
+        globalConfigDirectories,
+        (directory) => fs.globUp(instruction, directory, directory).pipe(Effect.catch(() => Effect.succeed([]))),
+        { concurrency: "unbounded" },
+      ).pipe(Effect.map((matches) => matches.flat()))
+      if (Flag.OPENCODE_DISABLE_PROJECT_CONFIG) return globalMatches
+
+      const projectMatches = yield* fs
+        .globUp(instruction, ctx.directory, ctx.worktree)
         .pipe(Effect.catch(() => Effect.succeed([] as string[])))
+      return [...projectMatches, ...globalMatches]
     })
 
     const read = Effect.fnUntraced(function* (filepath: string) {
@@ -112,7 +116,7 @@ export const layer: Layer.Layer<
       const ctx = yield* InstanceState.context
       const paths = new Set<string>()
 
-      for (const file of globalFiles) {
+      for (const file of globalInstructionFiles) {
         if (yield* fs.existsSafe(file)) {
           paths.add(path.resolve(file))
           break

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1895,6 +1895,28 @@ describe("OPENCODE_DISABLE_PROJECT_CONFIG", () => {
       }),
     { config: { model: "project/model" } },
   )
+
+  it.instance(
+    "OPENCODE_CONFIG_DIR overrides OPENCODE_CONFIG_DIRS when both are set",
+    () =>
+      Effect.gen(function* () {
+        const firstConfigDir = yield* tmpdirScoped({ config: { model: "first/model" } })
+        const secondConfigDir = yield* tmpdirScoped({ config: { model: "second/model" } })
+        const singularConfigDir = yield* tmpdirScoped({ config: { model: "singular/model" } })
+        yield* withProcessEnvs(
+          {
+            OPENCODE_DISABLE_PROJECT_CONFIG: "true",
+            OPENCODE_CONFIG_DIR: singularConfigDir,
+            OPENCODE_CONFIG_DIRS: [firstConfigDir, secondConfigDir].join(path.delimiter),
+          },
+          Effect.gen(function* () {
+            const config = yield* Config.use.get()
+            expect(config.model).toBe("singular/model")
+          }),
+        )
+      }),
+    { config: { model: "project/model" } },
+  )
 })
 
 // Regression for #28206: malformed OPENCODE_PERMISSION JSON used to crash

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1874,6 +1874,27 @@ describe("OPENCODE_DISABLE_PROJECT_CONFIG", () => {
       }),
     { config: { model: "project/model" } },
   )
+
+  it.instance(
+    "OPENCODE_CONFIG_DIRS works when flag is set",
+    () =>
+      Effect.gen(function* () {
+        const firstConfigDir = yield* tmpdirScoped({ config: { model: "first/model" } })
+        const secondConfigDir = yield* tmpdirScoped({ config: { model: "second/model" } })
+        yield* withProcessEnvs(
+          {
+            OPENCODE_DISABLE_PROJECT_CONFIG: "true",
+            OPENCODE_CONFIG_DIR: undefined,
+            OPENCODE_CONFIG_DIRS: [firstConfigDir, secondConfigDir].join(path.delimiter),
+          },
+          Effect.gen(function* () {
+            const config = yield* Config.use.get()
+            expect(config.model).toBe("second/model")
+          }),
+        )
+      }),
+    { config: { model: "project/model" } },
+  )
 })
 
 // Regression for #28206: malformed OPENCODE_PERMISSION JSON used to crash

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -166,6 +166,37 @@ it.instance("loads tui config from OPENCODE_CONFIG_DIRS in order", () =>
   ),
 )
 
+it.instance("loads tui config from OPENCODE_CONFIG_DIR after OPENCODE_CONFIG_DIRS", () =>
+  withCleanState(
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const test = yield* TestInstance
+      const firstConfigDir = path.join(test.directory, "config-a")
+      const secondConfigDir = path.join(test.directory, "config-b")
+      const singularConfigDir = path.join(test.directory, "config-singular")
+
+      yield* fs.writeWithDirs(path.join(firstConfigDir, "tui.json"), JSON.stringify({ theme: "first" }, null, 2))
+      yield* fs.writeWithDirs(path.join(secondConfigDir, "tui.json"), JSON.stringify({ theme: "second" }, null, 2))
+      yield* fs.writeWithDirs(
+        path.join(singularConfigDir, "tui.json"),
+        JSON.stringify({ theme: "singular", diff_style: "stacked" }, null, 2),
+      )
+
+      const config = yield* withEnv(
+        "OPENCODE_CONFIG_DIR",
+        singularConfigDir,
+        withEnv(
+          "OPENCODE_CONFIG_DIRS",
+          [firstConfigDir, secondConfigDir].join(path.delimiter),
+          getTuiConfig(test.directory),
+        ),
+      )
+      expect(config.theme).toBe("singular")
+      expect(config.diff_style).toBe("stacked")
+    }),
+  ),
+)
+
 it.instance("resolves attention config defaults and overrides", () =>
   withCleanState(
     Effect.gen(function* () {

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -21,6 +21,8 @@ const globalConfigFiles = ["opencode.json", "opencode.jsonc", "tui.json", "tui.j
 const cleanState = Effect.gen(function* () {
   const fs = yield* FSUtil.Service
   delete process.env.OPENCODE_CONFIG
+  delete process.env.OPENCODE_CONFIG_DIR
+  delete process.env.OPENCODE_CONFIG_DIRS
   delete process.env.OPENCODE_TUI_CONFIG
   yield* Effect.forEach(globalConfigFiles, (file) => fs.remove(file, { force: true }).pipe(Effect.ignore), {
     discard: true,
@@ -130,6 +132,35 @@ it.instance("loads tui config with the same precedence order as server config pa
 
       const config = yield* getTuiConfig(test.directory)
       expect(config.theme).toBe("local")
+      expect(config.diff_style).toBe("stacked")
+    }),
+  ),
+)
+
+it.instance("loads tui config from OPENCODE_CONFIG_DIRS in order", () =>
+  withCleanState(
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const test = yield* TestInstance
+      const firstConfigDir = path.join(test.directory, "config-a")
+      const secondConfigDir = path.join(test.directory, "config-b")
+
+      yield* fs.writeWithDirs(path.join(firstConfigDir, "tui.json"), JSON.stringify({ theme: "first" }, null, 2))
+      yield* fs.writeWithDirs(
+        path.join(secondConfigDir, "tui.json"),
+        JSON.stringify({ theme: "second", diff_style: "stacked" }, null, 2),
+      )
+
+      const config = yield* withEnv(
+        "OPENCODE_CONFIG_DIR",
+        undefined,
+        withEnv(
+          "OPENCODE_CONFIG_DIRS",
+          [firstConfigDir, secondConfigDir].join(path.delimiter),
+          getTuiConfig(test.directory),
+        ),
+      )
+      expect(config.theme).toBe("second")
       expect(config.diff_style).toBe("stacked")
     }),
   ),

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -8,7 +8,6 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 
 import { Instruction } from "../../src/session/instruction"
-import type { MessageV2 } from "../../src/session/message-v2"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { Global } from "@opencode-ai/core/global"
 import { RuntimeFlags } from "../../src/effect/runtime-flags"
@@ -17,14 +16,17 @@ import { testEffect } from "../lib/effect"
 import { TestConfig } from "../fixture/config"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import type { Config } from "../../src/config/config"
 
 const it = testEffect(Layer.mergeAll(CrossSpawnSpawner.defaultLayer, NodeFileSystem.layer, testInstanceStoreLayer))
 
-const configLayer = TestConfig.layer()
-
-const instructionLayer = (global: Partial<Global.Interface>, flags: Partial<RuntimeFlags.Info> = {}) =>
+const instructionLayer = (
+  global: Partial<Global.Interface>,
+  flags: Partial<RuntimeFlags.Info> = {},
+  config: Partial<Config.Interface> = {},
+) =>
   Instruction.layer.pipe(
-    Layer.provide(configLayer),
+    Layer.provide(TestConfig.layer(config)),
     Layer.provide(FSUtil.defaultLayer),
     Layer.provide(FetchHttpClient.layer),
     Layer.provide(Global.layerWith(global)),
@@ -32,9 +34,9 @@ const instructionLayer = (global: Partial<Global.Interface>, flags: Partial<Runt
   )
 
 const provideInstruction =
-  (global: Partial<Global.Interface>, flags?: Partial<RuntimeFlags.Info>) =>
+  (global: Partial<Global.Interface>, flags?: Partial<RuntimeFlags.Info>, config?: Partial<Config.Interface>) =>
   <A, E, R>(self: Effect.Effect<A, E, R>) =>
-    self.pipe(Effect.provide(instructionLayer(global, flags)))
+    self.pipe(Effect.provide(instructionLayer(global, flags, config)))
 
 const write = (filepath: string, content: string) =>
   Effect.gen(function* () {
@@ -251,6 +253,46 @@ describe("Instruction.systemPaths global config", () => {
         const paths = yield* svc.systemPaths()
         expect(paths.has(path.join(globalTmp, "AGENTS.md"))).toBe(true)
       }).pipe(provideInstance(projectTmp), provideInstruction({ home: globalTmp, config: globalTmp }))
+    }),
+  )
+
+  it.live("uses highest-priority extra config directory AGENTS.md", () =>
+    Effect.gen(function* () {
+      const globalTmp = yield* tmpWithFiles({ "AGENTS.md": "# Global Instructions" })
+      const baseTmp = yield* tmpWithFiles({ "AGENTS.md": "# Base Instructions" })
+      const teamTmp = yield* tmpWithFiles({ "AGENTS.md": "# Team Instructions" })
+      const projectTmp = yield* tmpdirScoped()
+
+      yield* Effect.gen(function* () {
+        const svc = yield* Instruction.Service
+        expect(yield* svc.system()).toEqual([
+          `Instructions from: ${path.join(teamTmp, "AGENTS.md")}\n# Team Instructions`,
+        ])
+      }).pipe(
+        provideInstance(projectTmp),
+        provideInstruction({ home: globalTmp, config: globalTmp, extraConfigDirs: [baseTmp, teamTmp] }),
+      )
+    }),
+  )
+
+  it.live("finds relative configured instructions in extra config directories", () =>
+    Effect.gen(function* () {
+      const globalTmp = yield* tmpWithFiles({})
+      const baseTmp = yield* tmpWithFiles({ "CUSTOM.md": "# Base Custom" })
+      const teamTmp = yield* tmpWithFiles({ "CUSTOM.md": "# Team Custom" })
+      const projectTmp = yield* tmpdirScoped()
+
+      yield* Effect.gen(function* () {
+        const svc = yield* Instruction.Service
+        const rules = yield* svc.system()
+        expect(rules).toContain(`Instructions from: ${path.join(baseTmp, "CUSTOM.md")}\n# Base Custom`)
+        expect(rules).toContain(`Instructions from: ${path.join(teamTmp, "CUSTOM.md")}\n# Team Custom`)
+      }).pipe(
+        provideInstance(projectTmp),
+        provideInstruction({ home: globalTmp, config: globalTmp, extraConfigDirs: [baseTmp, teamTmp] }, undefined, {
+          get: () => Effect.succeed({ instructions: ["CUSTOM.md"] }),
+        }),
+      )
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #32825
Fixes #28658
Closes #26051

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a config resolution regression from the v1/v2 split: the old app config loader treated `OPENCODE_CONFIG_DIR` as an extra config layer, but the v2/core path used it as a replacement for the XDG global config directory through `Global.config`. That could make app-level config output show values that v2/core services, including references, did not see.

This keeps `Global.config` pinned to the real XDG global config path and models env-provided config directories as explicit additive layers instead. `OPENCODE_CONFIG_DIR` remains supported for compatibility.

It also adds `OPENCODE_CONFIG_DIRS` for multiple extra config directories. The value is parsed like `PATH` with `path.delimiter`, trims entries, and ignores empty entries, so POSIX uses `dirA:dirB` and Windows uses `dirA;dirB`.

Config order is now lowest to highest priority:

1. XDG global config
2. project config files
3. discovered `.opencode` directories
4. `OPENCODE_CONFIG_DIRS` entries from left to right
5. `OPENCODE_CONFIG_DIR` last as the highest-priority legacy/custom override

The old app config path discovery, TUI config loader, v1 instruction service, and v2 instruction context now use the same extra directory ordering. That means `AGENTS.md` and relative configured `instructions` can also come from custom config directories.

Compared with #30821, this keeps the original XDG global config visible instead of replacing it, centralizes env directory parsing, preserves existing config loader behavior, and adds coverage for both old and v2 instruction paths.

### How did you verify your code works?

- `bun test test/config/config.test.ts test/global.test.ts test/instruction-context.test.ts` from `packages/core`
- `bun test test/config/config.test.ts test/config/tui.test.ts test/session/instruction.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/core`
- `bun typecheck` from `packages/opencode`
- `bun prettier --check packages/core/src/config.ts packages/core/src/flag/flag.ts packages/core/src/global.ts packages/core/src/instruction-context.ts packages/core/test/config/config.test.ts packages/core/test/global.test.ts packages/core/test/instruction-context.test.ts packages/opencode/src/config/config.ts packages/opencode/src/config/paths.ts packages/opencode/src/config/tui.ts packages/opencode/src/session/instruction.ts packages/opencode/test/config/config.test.ts packages/opencode/test/config/tui.test.ts packages/opencode/test/session/instruction.test.ts`
- Pre-push hook ran `bun turbo typecheck` successfully

### Screenshots / recordings

N/A - non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
