### PR TITLE
fix(app): insert newline on Enter for mobile prompt input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -42,6 +42,7 @@ import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Select } from "@opencode-ai/ui/select"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { createMediaQuery } from "@solid-primitives/media"
 import { ModelSelectorPopover } from "@/components/dialog-select-model"
 import { useCommand } from "@/context/command"
 import { Persist, persisted } from "@/utils/persist"
@@ -1184,6 +1185,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return permission.isAutoAccepting(id, sdk().directory)
   })
 
+  const touch = createMediaQuery("(hover: none)")
+
   const { abort, handleSubmit } =
     props.submission ??
     createPromptSubmit({
@@ -1350,6 +1353,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       if (navigateHistory(direction)) {
         event.preventDefault()
       }
+      return
+    }
+
+    // Mobile virtual keyboards have no Shift key, so Enter inserts a newline; send button submits. Fixes #20965.
+    if (touch() && event.key === "Enter" && !event.shiftKey) {
+      addPart({ type: "text", content: "\n", start: 0, end: 0 })
+      event.preventDefault()
       return
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #20965

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Mobile virtual keyboards have no Shift key, so the existing `Shift+Enter → newline` / `Enter → submit` contract leaves mobile users with no way to insert newlines — every Enter press submits.

This adds one branch in `handleKeyDown` (`packages/app/src/components/prompt-input.tsx`) that detects touch-only devices via `createMediaQuery("(hover: none)")` — the same primitive already used in `sidebar-workspace.tsx` — and routes `Enter` to the existing newline-insertion path on those devices. The send button (`IconButton type="submit"`) remains the submit path on touch.

Desktop behavior is unchanged: `Enter` still submits, `Shift+Enter` still inserts a newline. The new branch sits AFTER the popover-navigation block so popover-Enter (e.g., `@`-mention selection) still works on mobile.

Prior attempt: #9362 (closed for inactivity, confirmed working by users) used UA sniffing; this PR uses the codebase's existing media-query pattern instead.

### How did you verify your code works?

- `bun lint` — clean
- `bun typecheck` in `packages/app/` — clean
- `bun test` in `packages/app/` — no regressions
- Manual: Chrome DevTools device mode (iPhone profile) — Enter inserts newline, send button submits. With device mode off, Enter submits as before.

### Screenshots / recordings

Happy to record a before/after demo on request.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
