### PR TITLE
fix(mcp): recover HTTP sessions on missing-session 400

### DIFF
--- a/packages/opencode/test/fixture/mcp-session-recovery.ts
+++ b/packages/opencode/test/fixture/mcp-session-recovery.ts
@@ -3,6 +3,8 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
 
 const posts: Array<{ method: string; session: string | null }> = []
+const recoveryStatus = Number(process.env.MCP_RECOVERY_STATUS ?? "404")
+const recoveryBody = process.env.MCP_RECOVERY_BODY ?? "Session not found"
 let initializeCount = 0
 let pingCount = 0
 const server = Bun.serve({
@@ -34,7 +36,7 @@ const server = Bun.serve({
     if (message.method === "notifications/initialized") return new Response(null, { status: 202 })
 
     pingCount++
-    if (pingCount === 1) return new Response("Session not found", { status: 404 })
+    if (pingCount === 1) return new Response(recoveryBody, { status: recoveryStatus })
     return Response.json({ jsonrpc: "2.0", id: message.id, result: {} })
   },
 })

--- a/packages/opencode/test/mcp/session-recovery.test.ts
+++ b/packages/opencode/test/mcp/session-recovery.test.ts
@@ -1,27 +1,39 @@
 import path from "node:path"
 import { describe, expect, test } from "bun:test"
 
+async function runFixture(env: Record<string, string> = {}) {
+  const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "../fixture/mcp-session-recovery.ts")], {
+    cwd: path.join(import.meta.dir, "../.."),
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [code, stdout, stderr] = await Promise.all([
+    child.exited,
+    Bun.readableStreamToText(child.stdout),
+    Bun.readableStreamToText(child.stderr),
+  ])
+
+  expect(code, stderr).toBe(0)
+  expect(JSON.parse(stdout)).toEqual([
+    { method: "initialize", session: null },
+    { method: "notifications/initialized", session: "expired" },
+    { method: "ping", session: "expired" },
+    { method: "initialize", session: null },
+    { method: "notifications/initialized", session: "replacement" },
+    { method: "ping", session: "replacement" },
+  ])
+}
+
 describe("mcp session recovery", () => {
   test("reinitializes and retries once after a session-bound POST returns 404", async () => {
-    const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "../fixture/mcp-session-recovery.ts")], {
-      cwd: path.join(import.meta.dir, "../.."),
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    const [code, stdout, stderr] = await Promise.all([
-      child.exited,
-      Bun.readableStreamToText(child.stdout),
-      Bun.readableStreamToText(child.stderr),
-    ])
+    await runFixture()
+  })
 
-    expect(code, stderr).toBe(0)
-    expect(JSON.parse(stdout)).toEqual([
-      { method: "initialize", session: null },
-      { method: "notifications/initialized", session: "expired" },
-      { method: "ping", session: "expired" },
-      { method: "initialize", session: null },
-      { method: "notifications/initialized", session: "replacement" },
-      { method: "ping", session: "replacement" },
-    ])
+  test("reinitializes and retries once after a session-bound POST returns a missing-session 400", async () => {
+    await runFixture({
+      MCP_RECOVERY_STATUS: "400",
+      MCP_RECOVERY_BODY: "Bad Request: No valid session ID provided",
+    })
   })
 })

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -163,7 +163,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..c362ae5fe6c62c8c8eae7e2e61de1eed
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -310,11 +342,20 @@ class StreamableHTTPClientTransport {
+@@ -310,11 +342,23 @@ class StreamableHTTPClientTransport {
              const response = await (this._fetch ?? fetch)(this._url, init);
              // Handle session ID received during initialization
              const sessionId = response.headers.get('mcp-session-id');
@@ -173,7 +173,10 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..c362ae5fe6c62c8c8eae7e2e61de1eed
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId && !isSessionRetry && !(0, types_js_1.isInitializedNotification)(message)) {
++                const recoverableSessionError = response.status === 404 ||
++                    (response.status === 400 && text?.toLowerCase().includes('session') &&
++                        (text.toLowerCase().includes('missing') || text.toLowerCase().includes('no valid') || text.toLowerCase().includes('invalid')));
++                if (recoverableSessionError && requestSessionId && !isSessionRetry && !(0, types_js_1.isInitializedNotification)(message)) {
 +                    const recovered = await this._recoverSession(requestSessionId);
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');
@@ -185,7 +188,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..c362ae5fe6c62c8c8eae7e2e61de1eed
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -335,7 +376,7 @@ class StreamableHTTPClientTransport {
+@@ -335,7 +379,7 @@ class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -194,7 +197,7 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..c362ae5fe6c62c8c8eae7e2e61de1eed
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = (0, auth_js_1.extractWWWAuthenticateParams)(response);
-@@ -362,7 +403,7 @@ class StreamableHTTPClientTransport {
+@@ -362,7 +406,7 @@ class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new auth_js_1.UnauthorizedError();
                          }
@@ -367,7 +370,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..ac75b14545fda44aff7ff4d97cc5da88
              headers.set('content-type', 'application/json');
              headers.set('accept', 'application/json, text/event-stream');
              const init = {
-@@ -306,11 +338,20 @@ export class StreamableHTTPClientTransport {
+@@ -306,11 +338,23 @@ export class StreamableHTTPClientTransport {
              const response = await (this._fetch ?? fetch)(this._url, init);
              // Handle session ID received during initialization
              const sessionId = response.headers.get('mcp-session-id');
@@ -377,7 +380,10 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..ac75b14545fda44aff7ff4d97cc5da88
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId && !isSessionRetry && !isInitializedNotification(message)) {
++                const recoverableSessionError = response.status === 404 ||
++                    (response.status === 400 && text?.toLowerCase().includes('session') &&
++                        (text.toLowerCase().includes('missing') || text.toLowerCase().includes('no valid') || text.toLowerCase().includes('invalid')));
++                if (recoverableSessionError && requestSessionId && !isSessionRetry && !isInitializedNotification(message)) {
 +                    const recovered = await this._recoverSession(requestSessionId);
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');
@@ -389,7 +395,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..ac75b14545fda44aff7ff4d97cc5da88
                  if (response.status === 401 && this._authProvider) {
                      // Prevent infinite recursion when server returns 401 after successful auth
                      if (this._hasCompletedAuthFlow) {
-@@ -331,7 +372,7 @@ export class StreamableHTTPClientTransport {
+@@ -331,7 +375,7 @@ export class StreamableHTTPClientTransport {
                      // Mark that we completed auth flow
                      this._hasCompletedAuthFlow = true;
                      // Purposely _not_ awaited, so we don't call onerror twice
@@ -398,7 +404,7 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..ac75b14545fda44aff7ff4d97cc5da88
                  }
                  if (response.status === 403 && this._authProvider) {
                      const { resourceMetadataUrl, scope, error } = extractWWWAuthenticateParams(response);
-@@ -358,7 +399,7 @@ export class StreamableHTTPClientTransport {
+@@ -358,7 +402,7 @@ export class StreamableHTTPClientTransport {
                          if (result !== 'AUTHORIZED') {
                              throw new UnauthorizedError();
                          }


### PR DESCRIPTION
### Issue for this PR

Closes #32809

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Streamable HTTP MCP session recovery already retried when a session-bound POST returned 404. Some MCP servers report the same expired-session condition as HTTP 400 with text such as `No valid session ID provided`. This PR treats only those explicit session-related 400 responses as recoverable, then reinitializes and retries once using the replacement session.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/mcp/session-recovery.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
