### PR TITLE
fix(flock): log heartbeat update failures

### DIFF
--- a/packages/core/src/util/flock.ts
+++ b/packages/core/src/util/flock.ts
@@ -227,7 +227,9 @@ export namespace Flock {
       // Heartbeat prevents long critical sections from being evicted as stale.
       timer = setInterval(() => {
         const t = new Date()
-        void utimes(heartbeatPath, t, t).catch(() => undefined)
+        void utimes(heartbeatPath, t, t).catch((err) => {
+          console.warn("lock heartbeat failed:", err)
+        })
       }, intervalMs)
       timer.unref?.()
     }

--- a/packages/core/test/util/flock.test.ts
+++ b/packages/core/test/util/flock.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, mock, test } from "bun:test"
 import fs from "fs/promises"
 import { spawn } from "child_process"
 import path from "path"
@@ -357,6 +357,35 @@ describe("util.flock", () => {
     }
 
     expect(await exists(lockDir)).toBe(false)
+  })
+
+  test("logs heartbeat update failures", async () => {
+    await using tmp = await tmpdir()
+    const dir = path.join(tmp.path, "locks")
+    const key = "flock:heartbeat-failure"
+    const heartbeat = path.join(lock(dir, key), "heartbeat")
+    const warn = mock(() => {})
+    const originalWarn = console.warn
+    console.warn = warn
+
+    try {
+      await using _ = await Flock.acquire(key, {
+        dir,
+        staleMs: 300,
+        timeoutMs: 3_000,
+      })
+
+      await fs.rm(heartbeat)
+      const stop = Date.now() + 2_000
+      while (warn.mock.calls.length === 0 && Date.now() < stop) {
+        await sleep(20)
+      }
+
+      expect(warn).toHaveBeenCalled()
+      expect(warn.mock.calls[0]?.[0]).toBe("lock heartbeat failed:")
+    } finally {
+      console.warn = originalWarn
+    }
   })
 
   test("refuses token mismatch release and recovers from stale", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #32657

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The file-lock heartbeat timer previously ignored filesystem errors from `utimes`, which could hide a broken heartbeat while the lock holder was still running. This PR logs heartbeat update failures and adds a regression test that removes the heartbeat file while a lease is held.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/core test test/util/flock.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
