### PR TITLE
fix(mcp): log child process kill failures

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -522,7 +522,9 @@ export const layer = Layer.effect(
                     for (const dpid of pids) {
                       try {
                         process.kill(dpid, "SIGTERM")
-                      } catch {}
+                      } catch (cause) {
+                        yield* Effect.logWarning("failed to terminate MCP child process", { pid: dpid, cause })
+                      }
                     }
                   }
                   yield* Effect.tryPromise(() => client.close()).pipe(Effect.ignore)


### PR DESCRIPTION
### Issue for this PR

Closes #32655

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP cleanup terminates descendant processes for stdio transports before closing the client. If `process.kill` failed, the error was swallowed. This PR logs a structured warning with the descendant PID and original cause so cleanup failures are visible.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/mcp`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
