### PR TITLE
fix(runtime): catch model info task failures

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.ts
@@ -427,31 +427,33 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
     void Promise.resolve(input.afterPaint(ctx)).catch(() => {})
   }
 
-  void modelTask.then((info) => {
-    state.providers = info.providers
-    state.variants = variantsFor(state.providers, state.model)
-    state.limits = info.limits
+  void modelTask
+    .then((info) => {
+      state.providers = info.providers
+      state.variants = variantsFor(state.providers, state.model)
+      state.limits = info.limits
 
-    const next = resolveVariant(ctx.variant, session.variant, savedVariant, state.variants)
-    if (next !== state.activeVariant) {
-      state.activeVariant = next
-    }
+      const next = resolveVariant(ctx.variant, session.variant, savedVariant, state.variants)
+      if (next !== state.activeVariant) {
+        state.activeVariant = next
+      }
 
-    if (footer.isClosed) {
-      return
-    }
+      if (footer.isClosed) {
+        return
+      }
 
-    footer.event({ type: "models", providers: info.providers })
-    footer.event({ type: "variants", variants: state.variants, current: state.activeVariant })
-    if (!state.model) {
-      return
-    }
+      footer.event({ type: "models", providers: info.providers })
+      footer.event({ type: "variants", variants: state.variants, current: state.activeVariant })
+      if (!state.model) {
+        return
+      }
 
-    footer.event({
-      type: "model",
-      model: formatModelLabel(state.model, state.activeVariant, state.providers),
+      footer.event({
+        type: "model",
+        model: formatModelLabel(state.model, state.activeVariant, state.providers),
+      })
     })
-  })
+    .catch(() => {})
 
   const streamTask = deps.streamTransport ?? import("./stream.transport")
   const ensureStream = () => {


### PR DESCRIPTION
### Issue for this PR

Closes #32653

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The startup model info task was used as a fire-and-forget promise but did not have a catch handler, unlike nearby startup tasks. This PR adds the missing catch so a rejected model info task cannot surface as an unhandled promise rejection.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/cli/run/runtime.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
