### PR TITLE
fix(compaction): reserve full output budget

### DIFF
--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -5,15 +5,11 @@ import type { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import type { MessageV2 } from "./message-v2"
 
-const COMPACTION_BUFFER = 20_000
-
 export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outputTokenMax?: number }) {
   const context = input.model.limit.context
   if (context === 0) return 0
 
-  const reserved =
-    input.cfg.compaction?.reserved ??
-    Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+  const reserved = input.cfg.compaction?.reserved ?? ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax)
   return input.model.limit.input
     ? Math.max(0, input.model.limit.input - reserved)
     : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -535,6 +535,19 @@ describe("session.compaction.isOverflow", () => {
   )
 
   it.live(
+    "reserves the full output budget for models with input caps",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const compact = yield* SessionCompaction.Service
+        const model = createModel({ context: 200_000, input: 200_000, output: 32_000 })
+        const tokens = { input: 170_000, output: 4_000, reasoning: 0, cache: { read: 1_000, write: 0 } }
+
+        expect(yield* compact.isOverflow({ tokens, model })).toBe(true)
+      }),
+    ),
+  )
+
+  it.live(
     "returns false when model context limit is 0",
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #32656

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

For models with `limit.input`, compaction reserved at most 20K tokens for the next response even when the model output budget was larger. This PR reserves the full configured/model output budget and adds a boundary test for a 200K input / 32K output model.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/session/compaction.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
