### PR TITLE
docs: add Olostep MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,38 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### Olostep
+
+Add the [Olostep MCP server](https://github.com/olostep/olostep-mcp-server) to give OpenCode web data tools — search the web, scrape any URL into clean Markdown, crawl entire sites, and get cited answers.
+
+```json title="opencode.json" {4-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "olostep": {
+      "type": "local",
+      "command": ["npx", "-y", "olostep-mcp"],
+      "environment": {
+        "OLOSTEP_API_KEY": "{env:OLOSTEP_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+You'll need an Olostep API key — get a free one at [olostep.com](https://www.olostep.com/auth). Here we are assuming you have the `OLOSTEP_API_KEY` environment variable set.
+
+Add `use olostep` to your prompts to use the Olostep MCP server.
+
+```txt "use olostep"
+Find the latest pricing from these three competitor pages and summarize it. use olostep
+```
+
+Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/).
+
+```md title="AGENTS.md"
+When you need to search the web or read a page's content, use `olostep` tools.
+```


### PR DESCRIPTION
### Issue for this PR

N/A — docs addition, no related issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Olostep as an example MCP server in the MCP servers docs, alongside the existing Context7 and Grep examples. It's a local stdio server run via `npx -y olostep-mcp` with an `OLOSTEP_API_KEY` env var, so the config follows the same shape as the other local-server examples already in the docs. I work on Olostep and am adding it as the maintainer of the server.

### How did you verify your code works?

This is a docs-only change. I verified the config block matches opencode's documented local MCP server schema and follows the same format as the existing Context7 and Grep examples. The olostep-mcp package is published on npm and runs via npx.

### Screenshots / recordings

N/A — docs only, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR