### PR TITLE
feat(tui): add directory + project session filter modes

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -910,13 +910,10 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       },
       {
         name: "app.toggle.session_directory_filter",
-        title: kv.get("session_directory_filter_enabled", true)
-          ? "Disable session directory filtering"
-          : "Enable session directory filtering",
+        title: `Session filter: ${sync.session.filter.get()} (cycle: hierarchical → directory → project)`,
         category: "System",
         run: async () => {
-          kv.set("session_directory_filter_enabled", !kv.get("session_directory_filter_enabled", true))
-          await sync.session.refresh()
+          await sync.session.filter.cycle()
           dialog.clear()
         },
       },

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -37,6 +37,22 @@ const emptyConsoleState: ConsoleState = {
   switchableOrgCount: 0,
 }
 
+// How the session list is scoped to the working directory:
+//   hierarchical - current directory and its descendants (default)
+//   directory    - exactly the current directory (isolates sibling worktrees)
+//   project      - every session in the project, regardless of directory
+export const SESSION_FILTER_MODES = ["hierarchical", "directory", "project"] as const
+export type SessionFilterMode = (typeof SESSION_FILTER_MODES)[number]
+
+export function isSessionFilterMode(value: unknown): value is SessionFilterMode {
+  return typeof value === "string" && (SESSION_FILTER_MODES as readonly string[]).includes(value)
+}
+
+export function nextSessionFilterMode(current: SessionFilterMode): SessionFilterMode {
+  const idx = SESSION_FILTER_MODES.indexOf(current)
+  return SESSION_FILTER_MODES[(idx + 1) % SESSION_FILTER_MODES.length] ?? "hierarchical"
+}
+
 function search<T>(items: T[], target: string, key: (item: T) => string) {
   let left = 0
   let right = items.length - 1
@@ -149,13 +165,26 @@ export const {
       hydratingSessions.get(sessionID)?.parts.add(partID)
     }
 
-    function sessionListQuery(): { scope?: "project"; path?: string } {
-      if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
-      if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
-      return {
-        path: path
-          .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)
-          .replaceAll("\\", "/"),
+    function sessionFilterMode(): SessionFilterMode {
+      const stored = kv.get("session_filter_mode")
+      if (isSessionFilterMode(stored)) return stored
+      // Back-compat: honor the previous boolean flag until the user picks a mode.
+      return kv.get("session_directory_filter_enabled", true) ? "hierarchical" : "project"
+    }
+
+    function sessionListQuery(): { scope?: "project"; path?: string; directory?: string } {
+      const { worktree, directory } = project.data.instance.path
+      switch (sessionFilterMode()) {
+        // Whole project: every session across all of the project's directories/worktrees.
+        case "project":
+          return { scope: "project" }
+        // Exact: only sessions whose directory equals the current one (isolates worktrees).
+        case "directory":
+          return directory ? { directory } : { scope: "project" }
+        // Hierarchical (default): current directory plus its descendants.
+        default:
+          if (!worktree || !directory) return { scope: "project" }
+          return { path: path.relative(path.resolve(worktree), directory).replaceAll("\\", "/") }
       }
     }
 
@@ -559,6 +588,17 @@ export const {
         },
         query() {
           return sessionListQuery()
+        },
+        filter: {
+          get(): SessionFilterMode {
+            return sessionFilterMode()
+          },
+          async cycle(): Promise<SessionFilterMode> {
+            const next = nextSessionFilterMode(sessionFilterMode())
+            kv.set("session_filter_mode", next)
+            await result.session.refresh()
+            return next
+          },
         },
         async refresh() {
           const list = await listSessions()

--- a/packages/tui/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync.test.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import { describe, expect, test } from "bun:test"
 import { tmpdir } from "../../../fixture/fixture"
-import { mount, wait } from "./sync-fixture"
+import { mount, wait, directory } from "./sync-fixture"
 import type { GlobalEvent } from "@opencode-ai/sdk/v2"
 
 function branchEvent(branch: string, workspace?: string): GlobalEvent {
@@ -18,21 +18,51 @@ function branchEvent(branch: string, workspace?: string): GlobalEvent {
 }
 
 describe("tui sync", () => {
-  test("refresh scopes sessions by default and lists project sessions when disabled", async () => {
+  test("session list query reflects the filter mode", async () => {
     await using tmp = await tmpdir()
     await Bun.write(`${tmp.path}/kv.json`, "{}")
     const { app, kv, sync, session } = await mount(undefined, tmp.path)
 
     try {
-      expect(kv.get("session_directory_filter_enabled", true)).toBe(true)
+      // Default (hierarchical): current directory plus its descendants (relative path).
       expect(session.at(-1)?.searchParams.get("scope")).toBeNull()
+      expect(session.at(-1)?.searchParams.get("directory")).toBeNull()
       expect(session.at(-1)?.searchParams.get("path")).toBe("packages/tui")
 
-      kv.set("session_directory_filter_enabled", false)
+      // directory: exactly the current directory (isolates sibling worktrees).
+      kv.set("session_filter_mode", "directory")
       await sync.session.refresh()
+      expect(session.at(-1)?.searchParams.get("directory")).toBe(directory)
+      expect(session.at(-1)?.searchParams.get("path")).toBeNull()
+      expect(session.at(-1)?.searchParams.get("scope")).toBeNull()
 
+      // project: every session in the project, regardless of directory.
+      kv.set("session_filter_mode", "project")
+      await sync.session.refresh()
       expect(session.at(-1)?.searchParams.get("scope")).toBe("project")
       expect(session.at(-1)?.searchParams.get("path")).toBeNull()
+      expect(session.at(-1)?.searchParams.get("directory")).toBeNull()
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("honors the legacy session_directory_filter_enabled flag until a mode is set", async () => {
+    await using tmp = await tmpdir()
+    // A user who had explicitly disabled directory filtering (whole-project view).
+    await Bun.write(`${tmp.path}/kv.json`, JSON.stringify({ session_directory_filter_enabled: false }))
+    const { app, kv, sync, session } = await mount(undefined, tmp.path)
+
+    try {
+      // Legacy "disabled" maps to whole-project scope.
+      expect(session.at(-1)?.searchParams.get("scope")).toBe("project")
+      expect(session.at(-1)?.searchParams.get("path")).toBeNull()
+
+      // Choosing a mode takes precedence over the legacy flag.
+      kv.set("session_filter_mode", "directory")
+      await sync.session.refresh()
+      expect(session.at(-1)?.searchParams.get("directory")).toBe(directory)
+      expect(session.at(-1)?.searchParams.get("scope")).toBeNull()
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/cli/tui/session-filter.test.ts
+++ b/packages/tui/test/cli/tui/session-filter.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { SESSION_FILTER_MODES, isSessionFilterMode, nextSessionFilterMode } from "../../../src/context/sync"
+
+describe("isSessionFilterMode", () => {
+  test("accepts every known mode", () => {
+    for (const mode of SESSION_FILTER_MODES) expect(isSessionFilterMode(mode)).toBe(true)
+  })
+
+  test("rejects unknown strings and non-string values", () => {
+    expect(isSessionFilterMode("global")).toBe(false)
+    expect(isSessionFilterMode(undefined)).toBe(false)
+    expect(isSessionFilterMode(null)).toBe(false)
+    expect(isSessionFilterMode(true)).toBe(false)
+  })
+})
+
+describe("nextSessionFilterMode", () => {
+  test("cycles hierarchical -> directory -> project -> hierarchical", () => {
+    expect(nextSessionFilterMode("hierarchical")).toBe("directory")
+    expect(nextSessionFilterMode("directory")).toBe("project")
+    expect(nextSessionFilterMode("project")).toBe("hierarchical")
+  })
+})


### PR DESCRIPTION
## Problem

The TUI session-list directory filter is a single boolean (`session_directory_filter_enabled`): either **hierarchical** (current directory + all descendants) or **whole project**. There is no way to scope the list to *exactly* the current directory.

For anyone working in multiple git worktrees of the same repo, this is a real pain: sibling worktrees share a `project_id`, so the hierarchical/project modes always fold every worktree's sessions into each other's lists. There's no exact-match mode to keep them separate. (Refs #26099, which calls out this missing exact-match mode.)

## Solution

Replace the boolean with a three-state mode stored in kv as `session_filter_mode`:

- `hierarchical` — current directory and its descendants (**default; unchanged behavior**)
- `directory` — exactly the current directory (isolates sibling worktrees)
- `project` — every session in the project, regardless of directory

Details:

- **TUI-only change.** The server already accepts all three list query shapes (`{ path }`, `{ directory }`, `{ scope: "project" }`) — this just selects which one to send. No server, config-schema, or SDK changes.
- **Back-compat.** The old `session_directory_filter_enabled` boolean is still honored when `session_filter_mode` is unset (enabled → `hierarchical`, disabled → `project`), so no existing user loses their preference.
- **Default preserved.** With neither key set, behavior is identical to today.
- **Follows the existing `thinking.ts` pattern** — literal-union + `isSessionFilterMode` type guard + `nextSessionFilterMode` cycle helper.
- The command-palette entry (`app.toggle.session_directory_filter`, name unchanged so existing keybinds keep working) now **cycles** through the three modes.

## Why this shape

A few deliberate tradeoffs, in case it helps reviewers weigh this against related work:

- **Smallest surface that closes the gap.** One source file + tests; the server already supports the query shapes, so nothing downstream changes.
- **Keeps `hierarchical` as the default.** Monorepo users who rely on current-dir-plus-descendants see no change unless they opt in.
- **Zero migration risk.** Honors the legacy flag lazily; nothing is rewritten on disk.

## Relationship to other PRs / issues

- **#31210** (fixes the non-git `worktree = "/"` path case) is complementary — it's a targeted bug fix and doesn't add a user-facing exact-directory mode for normal git repos.
- **#29026** targets the pre-refactor TUI layout (`packages/opencode/src/cli/cmd/tui/…`) from before the move to `packages/tui/`, and has a larger surface (server + tests); it likely needs a rebase onto the current tree.
- **#32750** adds a `local → project → global` cycle (new `ctrl+g` keybind in the `/sessions` dialog). It overlaps in spirit but on a different axis: it drops `hierarchical` and adds cross-project `global`. This PR instead keeps `hierarchical` (today's default) and stays in the existing command-palette entry. The two are composable — `global` could be added here as a fourth mode if desired. Happy to converge on whichever direction maintainers prefer.

## Testing

- Extended `packages/tui/test/cli/cmd/tui/sync.test.tsx` to assert the list-query shape for each mode (`path` / `directory` / `scope=project`) and the legacy-flag fallback.
- Added `packages/tui/test/cli/tui/session-filter.test.ts` unit-testing `isSessionFilterMode` and `nextSessionFilterMode`.

Refs #26099