### PR TITLE
feat(llm): support inline `<|END_THINKING|>` reasoning tags in openai-chat stream

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -19,6 +19,7 @@ import {
 import { isRecord, JsonObject, optionalArray, optionalNull, ProviderShared } from "./shared"
 import { OpenAIOptions } from "./utils/openai-options"
 import { Lifecycle } from "./utils/lifecycle"
+import { ReasoningTags } from "./utils/reasoning-tags"
 import { ToolStream } from "./utils/tool-stream"
 
 const ADAPTER = "openai-chat"
@@ -164,6 +165,11 @@ interface ParserState {
   readonly usage?: Usage
   readonly finishReason?: FinishReason
   readonly lifecycle: Lifecycle.State
+  // Inline reasoning-tag extraction for servers that stream chain-of-thought as
+  // plain `content` (e.g. mlx-vlm serving Cohere models). Undefined `tags`
+  // means the stream is passed through untouched.
+  readonly thinkingTags?: ReasoningTags.Tags
+  readonly thinking: ReasoningTags.State
 }
 
 const invalid = ProviderShared.invalidRequest
@@ -407,11 +413,31 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
     let tools = state.tools
 
     let lifecycle = state.lifecycle
+    let thinking = state.thinking
 
     if (delta?.reasoning_content)
       lifecycle = Lifecycle.reasoningDelta(lifecycle, events, "reasoning-0", delta.reasoning_content)
 
-    if (delta?.content) lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
+    if (delta?.content) {
+      if (state.thinkingTags) {
+        // Split inline `<think>`-style markers out of the content stream so the
+        // chain-of-thought lands in a reasoning block instead of leaking as text.
+        const split = ReasoningTags.step(thinking, delta.content, state.thinkingTags)
+        thinking = split.state
+        for (const segment of split.segments) {
+          if (segment.kind === "reasoning") {
+            lifecycle = Lifecycle.reasoningDelta(lifecycle, events, "reasoning-0", segment.text)
+          } else {
+            // Idempotent once closed: ends the reasoning block on the first text
+            // segment after the thinking marker, then streams the answer as text.
+            lifecycle = Lifecycle.reasoningEnd(lifecycle, events, "reasoning-0")
+            lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", segment.text)
+          }
+        }
+      } else {
+        lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
+      }
+    }
 
     for (const tool of toolDeltas) {
       const result = ToolStream.appendOrStart(
@@ -441,6 +467,8 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
         usage,
         finishReason,
         lifecycle,
+        thinkingTags: state.thinkingTags,
+        thinking,
       },
       events,
     ] as const
@@ -448,9 +476,13 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
 
 const finishEvents = (state: ParserState): ReadonlyArray<LLMEvent> => {
   const events: LLMEvent[] = []
+  // Drain any trailing text withheld by the reasoning-tag splitter before the
+  // stream closes its blocks.
+  const tail = state.thinkingTags ? ReasoningTags.flush(state.thinking) : undefined
+  let lifecycle = tail ? Lifecycle.textDelta(state.lifecycle, events, "text-0", tail.text) : state.lifecycle
   const hasToolCalls = state.toolCallEvents.length > 0
   const reason = state.finishReason === "stop" && hasToolCalls ? "tool-calls" : state.finishReason
-  const lifecycle = state.toolCallEvents.length ? Lifecycle.stepStart(state.lifecycle, events) : state.lifecycle
+  if (state.toolCallEvents.length) lifecycle = Lifecycle.stepStart(lifecycle, events)
   events.push(...state.toolCallEvents)
   if (reason) Lifecycle.finish(lifecycle, events, { reason, usage: state.usage })
   return events
@@ -473,7 +505,16 @@ export const protocol = Protocol.make({
   },
   stream: {
     event: Protocol.jsonEvent(OpenAIChatEvent),
-    initial: () => ({ tools: ToolStream.empty<number>(), toolCallEvents: [], lifecycle: Lifecycle.initial() }),
+    initial: (request) => {
+      const thinkingTags = ReasoningTags.detect(request)
+      return {
+        tools: ToolStream.empty<number>(),
+        toolCallEvents: [],
+        lifecycle: Lifecycle.initial(),
+        thinkingTags,
+        thinking: ReasoningTags.initial(thinkingTags),
+      }
+    },
     step,
     onHalt: finishEvents,
   },

--- a/packages/llm/src/protocols/utils/reasoning-tags.ts
+++ b/packages/llm/src/protocols/utils/reasoning-tags.ts
@@ -1,0 +1,130 @@
+import type { LLMRequest } from "../../schema"
+
+/**
+ * Inline reasoning-tag extraction for OpenAI-compatible servers that stream a
+ * model's chain-of-thought as plain `content` rather than a separate
+ * `reasoning_content` field.
+ *
+ * Some local runtimes (e.g. mlx-vlm serving Cohere North / Command models)
+ * emit the thinking block inline, delimited by special tokens, and — because
+ * the chat template pre-opens the block — the stream begins *inside* the
+ * thinking block, so only the closing marker is ever seen on the wire:
+ *
+ *   "The user asks ... provide \"four\".<|END_THINKING|>four"
+ *
+ * Without extraction that whole string is rendered as assistant text and the
+ * reasoning leaks into the UI. This module splits a streamed `content` chunk
+ * into ordered text/reasoning segments and strips the marker tokens, with the
+ * markers allowed to straddle chunk boundaries.
+ */
+export interface Tags {
+  /** Marker that opens a thinking block, e.g. `<|START_THINKING|>`. */
+  readonly open: string
+  /** Marker that closes a thinking block, e.g. `<|END_THINKING|>`. */
+  readonly close: string
+  /**
+   * `true` when the model's chat template pre-opens the thinking block, so the
+   * stream starts inside reasoning and never emits `open` on the wire.
+   */
+  readonly startInside: boolean
+}
+
+export interface State {
+  /** Whether the cursor is currently inside a thinking block. */
+  readonly inside: boolean
+  /**
+   * Trailing bytes withheld from emission because they may be the leading
+   * prefix of a marker that is split across stream chunks. Always a proper
+   * prefix of `open` or `close` by construction.
+   */
+  readonly buffer: string
+}
+
+export interface Segment {
+  readonly kind: "text" | "reasoning"
+  readonly text: string
+}
+
+export const initial = (tags: Tags | undefined): State => ({
+  inside: tags?.startInside ?? false,
+  buffer: "",
+})
+
+// Longest suffix of `s` that is a proper prefix of `marker` (0 when none). This
+// is the slice we must withhold: it could be the start of a marker whose
+// remaining bytes arrive in the next chunk.
+const partialSuffix = (s: string, marker: string): number => {
+  const max = Math.min(s.length, marker.length - 1)
+  for (let n = max; n > 0; n--) {
+    if (marker.startsWith(s.slice(s.length - n))) return n
+  }
+  return 0
+}
+
+/**
+ * Consume one streamed `content` chunk, returning the marker-stripped segments
+ * to emit and the next state. Withholds a trailing partial marker so the next
+ * chunk can complete it.
+ */
+export const step = (state: State, chunk: string, tags: Tags): { readonly segments: Segment[]; readonly state: State } => {
+  let inside = state.inside
+  let work = state.buffer + chunk
+  const segments: Segment[] = []
+  const push = (text: string) => {
+    if (text) segments.push({ kind: inside ? "reasoning" : "text", text })
+  }
+  for (;;) {
+    const marker = inside ? tags.close : tags.open
+    const idx = work.indexOf(marker)
+    if (idx === -1) {
+      const hold = partialSuffix(work, marker)
+      push(work.slice(0, work.length - hold))
+      return { segments, state: { inside, buffer: hold === 0 ? "" : work.slice(work.length - hold) } }
+    }
+    push(work.slice(0, idx))
+    work = work.slice(idx + marker.length)
+    inside = !inside
+  }
+}
+
+/**
+ * Drain the withheld buffer when the stream ends. A buffer left while *inside*
+ * a thinking block is an incomplete close marker — drop it as noise. A buffer
+ * left while *outside* is real trailing text that merely looked like the start
+ * of an open marker — emit it.
+ */
+export const flush = (state: State): Segment | undefined =>
+  !state.inside && state.buffer ? { kind: "text", text: state.buffer } : undefined
+
+const isTags = (v: unknown): v is Tags =>
+  !!v &&
+  typeof v === "object" &&
+  typeof (v as Record<string, unknown>).open === "string" &&
+  typeof (v as Record<string, unknown>).close === "string" &&
+  typeof (v as Record<string, unknown>).startInside === "boolean"
+
+// Cohere North / Command thinking template. The chat template pre-opens
+// <|START_THINKING|>, so the stream begins inside the block and only the close
+// marker is seen — hence `startInside: true`.
+const COHERE_THINKING: Tags = {
+  open: "<|START_THINKING|>",
+  close: "<|END_THINKING|>",
+  startInside: true,
+}
+
+/**
+ * Resolve the reasoning tags for a request, or `undefined` to leave the stream
+ * untouched (the default for every provider that already reports reasoning
+ * natively). An explicit `providerOptions[ns].reasoningTags` object wins;
+ * otherwise a built-in default is applied to Cohere North / Command models.
+ */
+export const detect = (request: LLMRequest): Tags | undefined => {
+  for (const ns of Object.values(request.providerOptions ?? {})) {
+    const override = (ns as Record<string, unknown>)?.reasoningTags
+    if (isTags(override)) return override
+  }
+  if (/north|command-a/i.test(String(request.model.id))) return COHERE_THINKING
+  return undefined
+}
+
+export * as ReasoningTags from "./reasoning-tags"

--- a/packages/llm/test/reasoning-tags.test.ts
+++ b/packages/llm/test/reasoning-tags.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test"
+import { ReasoningTags } from "../src/protocols/utils/reasoning-tags"
+
+const COHERE: ReasoningTags.Tags = {
+  open: "<|START_THINKING|>",
+  close: "<|END_THINKING|>",
+  startInside: true,
+}
+
+// Feed a sequence of streamed content chunks through the splitter and collect
+// the concatenated reasoning and text, mirroring how the protocol drives it.
+const run = (chunks: string[], tags: ReasoningTags.Tags) => {
+  let state = ReasoningTags.initial(tags)
+  let reasoning = ""
+  let text = ""
+  for (const chunk of chunks) {
+    const result = ReasoningTags.step(state, chunk, tags)
+    state = result.state
+    for (const segment of result.segments) {
+      if (segment.kind === "reasoning") reasoning += segment.text
+      else text += segment.text
+    }
+  }
+  const tail = ReasoningTags.flush(state)
+  if (tail) text += tail.text
+  return { reasoning, text }
+}
+
+describe("ReasoningTags", () => {
+  it("splits a pre-opened thinking block from the answer in one chunk", () => {
+    const out = run(['The user asks. Provide "four".<|END_THINKING|>four'], COHERE)
+    expect(out.reasoning).toBe('The user asks. Provide "four".')
+    expect(out.text).toBe("four")
+  })
+
+  it("handles the close marker split across chunks", () => {
+    const out = run(["thinking part<|END_", "THINKING|>answer"], COHERE)
+    expect(out.reasoning).toBe("thinking part")
+    expect(out.text).toBe("answer")
+  })
+
+  it("handles the marker split one byte at a time", () => {
+    const chunks = ["think", ...["<|END_THINKING|>"].join("").split(""), "done"]
+    const out = run(chunks, COHERE)
+    expect(out.reasoning).toBe("think")
+    expect(out.text).toBe("done")
+  })
+
+  it("treats a stream with no marker as pure reasoning when started inside", () => {
+    const out = run(["still thinking, never finished"], COHERE)
+    expect(out.reasoning).toBe("still thinking, never finished")
+    expect(out.text).toBe("")
+  })
+
+  it("supports an explicit open marker when not pre-opened", () => {
+    const tags: ReasoningTags.Tags = { open: "<think>", close: "</think>", startInside: false }
+    const out = run(["preamble <think>secret</think> visible"], tags)
+    expect(out.reasoning).toBe("secret")
+    expect(out.text).toBe("preamble  visible")
+  })
+
+  it("does not drop trailing answer text that resembles a marker prefix", () => {
+    const out = run(['<|END_THINKING|>value is <', "| not a marker"], COHERE)
+    expect(out.reasoning).toBe("")
+    expect(out.text).toBe("value is <| not a marker")
+  })
+
+  it("detects Cohere North models by id and ignores others", () => {
+    const tagsFor = (id: string) =>
+      ReasoningTags.detect({ model: { id }, providerOptions: undefined } as never)
+    expect(tagsFor("mlx-community/North-Mini-Code-1.0-6bit")).toEqual(COHERE)
+    expect(tagsFor("gpt-4o")).toBeUndefined()
+  })
+
+  it("honors an explicit providerOptions override", () => {
+    const override: ReasoningTags.Tags = { open: "<r>", close: "</r>", startInside: false }
+    const tags = ReasoningTags.detect({
+      model: { id: "gpt-4o" },
+      providerOptions: { "openai-compatible": { reasoningTags: override } },
+    } as never)
+    expect(tags).toEqual(override)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes # N/A (no tracked issue)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some OpenAI-compatible servers (e.g. mlx-vlm serving Cohere North/Command models) stream the model's reasoning inline in `content` instead of a separate `reasoning_content` field. The markers are `<|START_THINKING|>` / `<|END_THINKING|>`, and because the chat template pre-opens the block, the stream starts *inside* thinking and only the close marker reaches the wire:

```
...provide "four".<|END_THINKING|>four
```

Today the openai-chat stream parser sends all of `delta.content` to a text block, so the whole thought leaks into the UI as the assistant message.

This adds `utils/reasoning-tags.ts`, a small splitter wired into the openai-chat stream step. It routes content before the close marker into a reasoning block, strips the markers, and emits the rest as text. Markers may be split across SSE chunks, so only a partial-marker suffix is withheld between chunks. It's opt-in: an explicit `providerOptions.<ns>.reasoningTags` object, or a built-in default for `north`/`command-a` model ids. When no tags are detected the content path is unchanged, so other providers are unaffected.

### How did you verify your code works?

Added `test/reasoning-tags.test.ts` (8 cases) and ran it with bun: one-chunk extraction, close marker split across and within chunks, start-inside with no marker, explicit `<think>` tags, trailing text resembling a marker prefix, and id detection / providerOptions override. I reproduced the original leak against a local mlx-vlm server (North-Mini-Code-1.0) and confirmed the markers it streams. I did not run the full monorepo test suite/typecheck locally (dependency install was impractical in my environment) — relying on CI for that.

### Screenshots / recordings

<img width="2532" height="1456" alt="image" src="https://github.com/user-attachments/assets/9413698e-064e-4ef9-8e80-1f826b1b4d57" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR