### PR TITLE
fix(core): support reference refs

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -58,8 +58,14 @@ export interface Interface {
     depth?: number
   }) => Effect.Effect<Result, AppProcess.AppProcessError>
   readonly fetch: (directory: string) => Effect.Effect<Result, AppProcess.AppProcessError>
+  readonly fetchRef: (
+    directory: string,
+    source: string,
+    destination: string,
+  ) => Effect.Effect<Result, AppProcess.AppProcessError>
   readonly fetchBranch: (directory: string, branch: string) => Effect.Effect<Result, AppProcess.AppProcessError>
   readonly checkout: (directory: string, branch: string) => Effect.Effect<Result, AppProcess.AppProcessError>
+  readonly checkoutRef: (directory: string, ref: string) => Effect.Effect<Result, AppProcess.AppProcessError>
   readonly reset: (directory: string, target: string) => Effect.Effect<Result, AppProcess.AppProcessError>
   readonly patch: (directory: AbsolutePath) => Effect.Effect<string, PatchError>
   readonly applyPatch: (input: { directory: AbsolutePath; patch: string }) => Effect.Effect<void, PatchError>
@@ -164,12 +170,20 @@ export const layer = Layer.effect(
 
     const fetch = Effect.fn("Git.fetch")((directory: string) => execute(directory, proc)(["fetch", "--all", "--prune"]))
 
+    const fetchRef = Effect.fn("Git.fetchRef")((directory: string, source: string, destination: string) =>
+      execute(directory, proc)(["fetch", "origin", `+${source}:${destination}`]),
+    )
+
     const fetchBranch = Effect.fn("Git.fetchBranch")((directory: string, branch: string) =>
-      execute(directory, proc)(["fetch", "origin", `+refs/heads/${branch}:refs/remotes/origin/${branch}`]),
+      fetchRef(directory, `refs/heads/${branch}`, `refs/remotes/origin/${branch}`),
     )
 
     const checkout = Effect.fn("Git.checkout")((directory: string, branch: string) =>
       execute(directory, proc)(["checkout", "-B", branch, `origin/${branch}`]),
+    )
+
+    const checkoutRef = Effect.fn("Git.checkoutRef")((directory: string, ref: string) =>
+      execute(directory, proc)(["checkout", "--detach", ref]),
     )
 
     const reset = Effect.fn("Git.reset")((directory: string, target: string) =>
@@ -386,8 +400,10 @@ export const layer = Layer.effect(
       remoteHead,
       clone,
       fetch,
+      fetchRef,
       fetchBranch,
       checkout,
+      checkoutRef,
       reset,
       patch,
       applyPatch,

--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -210,8 +210,8 @@ keyed by the alias used in `@` autocomplete:
 
 Local `path` values may be relative to the declaring config, absolute, or use
 `~/`. Git `repository` values accept Git URLs, host/path references, and GitHub
-`owner/repo` shorthand; `branch` is optional. Both forms support optional
-`description` and `hidden` fields.
+`owner/repo` shorthand; `branch` accepts a branch, tag, or full ref and is
+optional. Both forms support optional `description` and `hidden` fields.
 
 - Only references with a `description` are advertised to agents in system context.
 - `hidden: true` removes a reference from TUI `@` autocomplete only. It remains available to agents and by direct path.

--- a/packages/core/src/repository-cache.ts
+++ b/packages/core/src/repository-cache.ts
@@ -131,6 +131,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | E
       return Service.of({
         ensure: Effect.fn("RepositoryCache.ensure")(function* (input) {
           if (input.branch) yield* validateBranch(input.branch)
+          const requestedRef = input.branch ? parseRequestedRef(input.branch) : undefined
 
           const repository = input.reference.label
           const localPath = Repository.cachePath(global.repos, input.reference)
@@ -154,12 +155,12 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | E
                 const status = statusForRepository({
                   reuse,
                   refresh: input.refresh,
-                  branchMatches: input.branch ? currentBranch === input.branch : undefined,
+                  branchMatches: requestedRef ? refMatchesCurrentBranch(requestedRef, currentBranch) : undefined,
                 })
 
                 if (status === "cloned") {
                   const result = yield* git
-                    .clone({ remote: input.reference.remote, target: localPath, branch: input.branch })
+                    .clone({ remote: input.reference.remote, target: localPath, branch: cloneBranchFor(requestedRef) })
                     .pipe(
                       Effect.mapError((error) => new CloneFailedError({ repository, message: errorMessage(error) })),
                     )
@@ -183,42 +184,19 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | E
                       message: resultMessage(fetch, `Failed to refresh ${repository}`),
                     })
                   }
+                }
 
-                  if (input.branch) {
-                    const requestedBranch = input.branch
-                    const fetchBranch = yield* git
-                      .fetchBranch(localPath, requestedBranch)
-                      .pipe(
-                        Effect.mapError((error) => new FetchFailedError({ repository, message: errorMessage(error) })),
-                      )
-                    if (fetchBranch.exitCode !== 0) {
-                      return yield* new FetchFailedError({
-                        repository,
-                        message: resultMessage(fetchBranch, `Failed to fetch ${requestedBranch}`),
-                      })
-                    }
+                if (
+                  requestedRef &&
+                  (status === "refreshed" ||
+                    (status === "cloned" && (requestedRef.type === "tag" || requestedRef.type === "full")))
+                ) {
+                  yield* syncRequestedRef(git, localPath, repository, requestedRef)
+                }
 
-                    const checkout = yield* git.checkout(localPath, requestedBranch).pipe(
-                      Effect.mapError(
-                        (error) =>
-                          new CheckoutFailedError({
-                            repository,
-                            branch: requestedBranch,
-                            message: errorMessage(error),
-                          }),
-                      ),
-                    )
-                    if (checkout.exitCode !== 0) {
-                      return yield* new CheckoutFailedError({
-                        repository,
-                        branch: requestedBranch,
-                        message: resultMessage(checkout, `Failed to checkout ${requestedBranch}`),
-                      })
-                    }
-                  }
-
+                if (status === "refreshed" && !requestedRef) {
                   const reset = yield* git
-                    .reset(localPath, yield* resetTarget(git, localPath, input.branch))
+                    .reset(localPath, yield* resetTarget(git, localPath))
                     .pipe(
                       Effect.mapError((error) => new ResetFailedError({ repository, message: errorMessage(error) })),
                     )
@@ -275,8 +253,166 @@ function cacheOperation<A, E, R>(effect: Effect.Effect<A, E, R>, operation: stri
   )
 }
 
-const resetTarget = Effect.fnUntraced(function* (git: Git.Interface, cwd: string, requestedBranch?: string) {
-  if (requestedBranch) return `origin/${requestedBranch}`
+type RequestedRef =
+  | { readonly type: "branch"; readonly input: string; readonly name: string }
+  | { readonly type: "tag"; readonly input: string; readonly name: string }
+  | { readonly type: "full"; readonly input: string; readonly source: string; readonly destination: string }
+  | { readonly type: "named"; readonly input: string; readonly name: string }
+
+function parseRequestedRef(input: string): RequestedRef {
+  const branch = removePrefix(input, "refs/heads/")
+  if (branch) return { type: "branch", input, name: branch }
+
+  const tag = removePrefix(input, "refs/tags/")
+  if (tag) return { type: "tag", input, name: tag }
+
+  if (input.startsWith("refs/")) {
+    return { type: "full", input, source: input, destination: `refs/opencode/${input.slice("refs/".length)}` }
+  }
+
+  return { type: "named", input, name: input }
+}
+
+function removePrefix(input: string, prefix: string) {
+  if (!input.startsWith(prefix)) return
+  const value = input.slice(prefix.length)
+  return value || undefined
+}
+
+function refMatchesCurrentBranch(ref: RequestedRef, currentBranch: string | undefined) {
+  if (ref.type === "branch" || ref.type === "named") return currentBranch === ref.name
+  return false
+}
+
+function cloneBranchFor(ref: RequestedRef | undefined) {
+  if (!ref || ref.type === "tag" || ref.type === "full") return
+  return ref.name
+}
+
+const syncRequestedRef = Effect.fnUntraced(function* (
+  git: Git.Interface,
+  cwd: string,
+  repository: string,
+  requested: RequestedRef,
+) {
+  if (requested.type === "branch") {
+    const fetch = yield* git
+      .fetchBranch(cwd, requested.name)
+      .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: errorMessage(error) })))
+    if (fetch.exitCode !== 0) {
+      return yield* new FetchFailedError({
+        repository,
+        message: resultMessage(fetch, `Failed to fetch ${requested.input}`),
+      })
+    }
+    return yield* checkoutBranchRef(git, cwd, repository, requested.input, requested.name)
+  }
+
+  if (requested.type === "tag") {
+    const target = tagRef(requested.name)
+    const fetch = yield* git
+      .fetchRef(cwd, target, target)
+      .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: errorMessage(error) })))
+    if (fetch.exitCode !== 0) {
+      return yield* new FetchFailedError({
+        repository,
+        message: resultMessage(fetch, `Failed to fetch ${requested.input}`),
+      })
+    }
+    return yield* checkoutDetachedRef(git, cwd, repository, requested.input, target)
+  }
+
+  if (requested.type === "full") {
+    const fetch = yield* git
+      .fetchRef(cwd, requested.source, requested.destination)
+      .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: errorMessage(error) })))
+    if (fetch.exitCode !== 0) {
+      return yield* new FetchFailedError({
+        repository,
+        message: resultMessage(fetch, `Failed to fetch ${requested.input}`),
+      })
+    }
+    return yield* checkoutDetachedRef(git, cwd, repository, requested.input, requested.destination)
+  }
+
+  const branchFetch = yield* git
+    .fetchBranch(cwd, requested.name)
+    .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: errorMessage(error) })))
+  if (branchFetch.exitCode === 0) {
+    return yield* checkoutBranchRef(git, cwd, repository, requested.input, requested.name)
+  }
+
+  const target = tagRef(requested.name)
+  const tagFetch = yield* git
+    .fetchRef(cwd, target, target)
+    .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: errorMessage(error) })))
+  if (tagFetch.exitCode === 0) return yield* checkoutDetachedRef(git, cwd, repository, requested.input, target)
+
+  return yield* new FetchFailedError({
+    repository,
+    message: resultMessage(tagFetch, resultMessage(branchFetch, `Failed to fetch ${requested.input}`)),
+  })
+})
+
+const checkoutBranchRef = Effect.fnUntraced(function* (
+  git: Git.Interface,
+  cwd: string,
+  repository: string,
+  input: string,
+  branch: string,
+) {
+  const checkout = yield* git.checkout(cwd, branch).pipe(
+    Effect.mapError((error) => new CheckoutFailedError({ repository, branch: input, message: errorMessage(error) })),
+  )
+  if (checkout.exitCode !== 0) {
+    return yield* new CheckoutFailedError({
+      repository,
+      branch: input,
+      message: resultMessage(checkout, `Failed to checkout ${input}`),
+    })
+  }
+
+  return yield* resetToTarget(git, cwd, repository, `origin/${branch}`)
+})
+
+const checkoutDetachedRef = Effect.fnUntraced(function* (
+  git: Git.Interface,
+  cwd: string,
+  repository: string,
+  input: string,
+  target: string,
+) {
+  const checkout = yield* git.checkoutRef(cwd, target).pipe(
+    Effect.mapError((error) => new CheckoutFailedError({ repository, branch: input, message: errorMessage(error) })),
+  )
+  if (checkout.exitCode !== 0) {
+    return yield* new CheckoutFailedError({
+      repository,
+      branch: input,
+      message: resultMessage(checkout, `Failed to checkout ${input}`),
+    })
+  }
+
+  return yield* resetToTarget(git, cwd, repository, target)
+})
+
+const resetToTarget = Effect.fnUntraced(function* (git: Git.Interface, cwd: string, repository: string, target: string) {
+  const reset = yield* git
+    .reset(cwd, target)
+    .pipe(Effect.mapError((error) => new ResetFailedError({ repository, message: errorMessage(error) })))
+  if (reset.exitCode !== 0) {
+    return yield* new ResetFailedError({
+      repository,
+      message: resultMessage(reset, `Failed to reset ${repository}`),
+    })
+  }
+})
+
+function tagRef(tag: string) {
+  return `refs/tags/${tag}`
+}
+
+const resetTarget = Effect.fnUntraced(function* (git: Git.Interface, cwd: string) {
   const remoteHead = yield* git.remoteHead(cwd)
   if (remoteHead) return remoteHead
   const currentBranch = yield* git.branch(cwd)

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -103,10 +103,10 @@ export function parseRemote(input: string): RemoteReference {
 }
 
 export function validateBranch(branch: string): void {
-  if (/^[A-Za-z0-9/_.-]+$/.test(branch) && !branch.startsWith("-") && !branch.includes("..")) return
+  if (isSafeRef(branch)) return
   throw new InvalidBranchError({
     branch,
-    message: "Branch must contain only alphanumeric characters, /, _, ., and -, and cannot start with - or contain ..",
+    message: "Branch must be a valid Git branch, tag, or full ref name",
   })
 }
 
@@ -159,6 +159,28 @@ function safeSegment(input: string) {
 
 function hostLike(input: string) {
   return input.includes(".") || input.includes(":") || input === "localhost"
+}
+
+function isSafeRef(input: string) {
+  const parts = input.split("/")
+  return (
+    input.length > 0 &&
+    !input.startsWith("-") &&
+    !input.endsWith("/") &&
+    !input.includes("//") &&
+    !input.includes("..") &&
+    !input.includes("@{") &&
+    input !== "@" &&
+    !/[\x00-\x20~^:?*[\\]/.test(input) &&
+    parts.every(
+      (part) =>
+        part !== "" &&
+        part !== "." &&
+        !part.startsWith(".") &&
+        !part.endsWith(".") &&
+        !part.endsWith(".lock"),
+    )
+  )
 }
 
 function withSlash(input: string) {

--- a/packages/core/test/fixture/git.ts
+++ b/packages/core/test/fixture/git.ts
@@ -44,6 +44,14 @@ export async function branch(source: string, name: string, content: string) {
   await git(source, "push", "-u", "origin", name)
 }
 
+export async function tag(source: string, name: string, content: string) {
+  await fs.writeFile(path.join(source, "README.md"), content)
+  await git(source, "add", "README.md")
+  await git(source, "commit", "-m", name)
+  await git(source, "tag", name)
+  await git(source, "push", "origin", `refs/tags/${name}`)
+}
+
 export async function git(cwd: string, ...args: string[]) {
   await exec("git", args, { cwd })
 }

--- a/packages/core/test/repository-cache.test.ts
+++ b/packages/core/test/repository-cache.test.ts
@@ -9,7 +9,7 @@ import { Global } from "@opencode-ai/core/global"
 import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
 import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
-import { git, gitRemote } from "./fixture/git"
+import { branch, git, gitRemote, tag } from "./fixture/git"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
@@ -63,6 +63,47 @@ describe("RepositoryCache", () => {
 
         expect(replaced.status).toBe("cloned")
         expect(yield* exists(path.join(replaced.localPath, "stale.txt"))).toBe(false)
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("checks out configured branches on first materialization", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => branch(fixture.source, "feature/docs", "feature\n"))
+
+        const result = yield* (yield* RepositoryCache.Service).ensure({
+          reference: fixture.reference,
+          branch: "feature/docs",
+        })
+
+        expect(result.status).toBe("cloned")
+        expect(result.branch).toBe("feature/docs")
+        expect(yield* read(path.join(result.localPath, "README.md"))).toBe("feature\n")
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("checks out configured tags and full tag refs", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => tag(fixture.source, "effect@4.0.0-beta.65", "tagged\n"))
+        const cache = yield* RepositoryCache.Service
+
+        const tagResult = yield* cache.ensure({
+          reference: fixture.reference,
+          branch: "effect@4.0.0-beta.65",
+        })
+        const fullRefResult = yield* cache.ensure({
+          reference: fixture.reference,
+          branch: "refs/tags/effect@4.0.0-beta.65",
+        })
+
+        expect(tagResult.status).toBe("cloned")
+        expect(tagResult.branch).toBeUndefined()
+        expect(fullRefResult.status).toBe("refreshed")
+        expect(fullRefResult.branch).toBeUndefined()
+        expect(yield* read(path.join(fullRefResult.localPath, "README.md"))).toBe("tagged\n")
       }).pipe(Effect.provide(cacheLayer(fixture.root))),
     ),
   )

--- a/packages/core/test/repository.test.ts
+++ b/packages/core/test/repository.test.ts
@@ -51,8 +51,11 @@ describe("Repository", () => {
     expect(() => Repository.parseRemote("not-a-repo")).toThrow(Repository.InvalidReferenceError)
     expect(() => Repository.parseRemote("git@github.com:../../../etc/passwd")).toThrow(Repository.InvalidReferenceError)
     expect(() => Repository.validateBranch("feature/docs.v1")).not.toThrow()
+    expect(() => Repository.validateBranch("effect@4.0.0-beta.65")).not.toThrow()
+    expect(() => Repository.validateBranch("refs/tags/effect@4.0.0-beta.65")).not.toThrow()
     expect(() => Repository.validateBranch("-bad")).toThrow(Repository.InvalidBranchError)
     expect(() => Repository.validateBranch("bad..branch")).toThrow(Repository.InvalidBranchError)
+    expect(() => Repository.validateBranch("bad.")).toThrow(Repository.InvalidBranchError)
     expect(() => Repository.validateBranch("bad branch")).toThrow(Repository.InvalidBranchError)
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #32861

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

References can now materialize branches, tags, and full refs. The cache fetches exact tag/full refs instead of treating every configured `branch` as `refs/heads/*`, then checks non-branch refs out detached.

Also updates reference docs and regression tests for tag/full-ref checkout.

### How did you verify your code works?

- `bun test test/repository.test.ts test/repository-cache.test.ts test/git.test.ts` from `packages/core`
- `bun run typecheck` from `packages/core`
- `bun run lint` from repo root: 0 errors, existing warnings
- pre-push `bun turbo typecheck` with bun 1.3.14

### Screenshots / recordings

N/A, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR