### PR TITLE
fix(plugin): index hooks for trigger dispatch

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -34,6 +34,7 @@ import { InstallationChannel } from "@opencode-ai/core/installation/version"
 
 type State = {
   hooks: Hooks[]
+  hooksByName: Map<keyof Hooks, Hooks[]>
 }
 
 // Hook names that follow the (input, output) => Promise<void> trigger pattern
@@ -105,6 +106,19 @@ function getLegacyPlugins(mod: Record<string, unknown>) {
   }
 
   return result
+}
+
+function indexHooks(hooks: Hooks[]) {
+  const hooksByName = new Map<keyof Hooks, Hooks[]>()
+  for (const hook of hooks) {
+    for (const name of Object.keys(hook) as (keyof Hooks)[]) {
+      if (typeof hook[name] !== "function") continue
+      const matches = hooksByName.get(name)
+      if (matches) matches.push(hook)
+      else hooksByName.set(name, [hook])
+    }
+  }
+  return hooksByName
 }
 
 async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[]) {
@@ -248,15 +262,19 @@ export const layer = Layer.effect(
           )
         }
 
-        const unsubscribe = yield* events.listen((event) => {
-          if (event.location?.directory !== ctx.directory) return Effect.void
-          return Effect.sync(() => {
-            for (const hook of hooks) {
-              void hook["event"]?.({ event: { id: event.id, type: event.type, properties: event.data } as any })
-            }
+        const hooksByName = indexHooks(hooks)
+        const eventHooks = hooksByName.get("event") ?? []
+        if (eventHooks.length > 0) {
+          const unsubscribe = yield* events.listen((event) => {
+            if (event.location?.directory !== ctx.directory) return Effect.void
+            return Effect.sync(() => {
+              for (const hook of eventHooks) {
+                void hook.event?.({ event: { id: event.id, type: event.type, properties: event.data } as any })
+              }
+            })
           })
-        })
-        yield* Effect.addFinalizer(() => unsubscribe)
+          yield* Effect.addFinalizer(() => unsubscribe)
+        }
 
         yield* Effect.addFinalizer(() =>
           Effect.forEach(
@@ -273,7 +291,7 @@ export const layer = Layer.effect(
           ),
         )
 
-        return { hooks }
+        return { hooks, hooksByName }
       }),
     )
 
@@ -284,9 +302,9 @@ export const layer = Layer.effect(
     >(name: Name, input: Input, output: Output) {
       if (!name) return output
       const s = yield* InstanceState.get(state)
-      for (const hook of s.hooks) {
+      const hooks = s.hooksByName.get(name) ?? []
+      for (const hook of hooks) {
         const fn = hook[name] as any
-        if (!fn) continue
         yield* Effect.promise(async () => fn(input, output))
       }
       return output

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -42,19 +42,23 @@ const it = testEffect(
 const systemHook = "experimental.chat.system.transform"
 
 function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+  return withPlugins([source], self)
+}
+
+function withPlugins<A, E, R>(sources: string[], self: Effect.Effect<A, E, R>) {
   return Effect.gen(function* () {
     const test = yield* TestInstance
-    const file = path.join(test.directory, "plugin.ts")
+    const files = sources.map((_, index) => path.join(test.directory, `plugin-${index}.ts`))
     yield* Effect.all(
       [
-        Effect.promise(() => Bun.write(file, source)),
+        ...sources.map((source, index) => Effect.promise(() => Bun.write(files[index]!, source))),
         Effect.promise(() =>
           Bun.write(
             path.join(test.directory, "opencode.json"),
             JSON.stringify(
               {
                 $schema: "https://opencode.ai/config.json",
-                plugin: [pathToFileURL(file).href],
+                plugin: files.map((file) => pathToFileURL(file).href),
               },
               null,
               2,
@@ -114,6 +118,40 @@ describe("plugin.trigger", () => {
       ].join("\n"),
       Effect.gen(function* () {
         expect(yield* triggerSystemTransform()).toEqual(["async"])
+      }),
+    ),
+  )
+
+  it.instance("dispatches only matching hooks while preserving plugin order", () =>
+    withPlugins(
+      [
+        [
+          "export default async () => ({",
+          `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+          '    output.system.push("first")',
+          "  },",
+          "})",
+          "",
+        ].join("\n"),
+        [
+          "export default async () => ({",
+          '  "chat.message": (_input, output) => {',
+          '    output.parts.push({ type: "text", text: "ignored" })',
+          "  },",
+          "})",
+          "",
+        ].join("\n"),
+        [
+          "export default async () => ({",
+          `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+          '    output.system.push("second")',
+          "  },",
+          "})",
+          "",
+        ].join("\n"),
+      ],
+      Effect.gen(function* () {
+        expect(yield* triggerSystemTransform()).toEqual(["first", "second"])
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #32819

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Builds a hook dispatch table when plugins are loaded so trigger calls only iterate hooks that implement the requested hook name. It also skips registering the global event listener when no plugin defines an event hook, while preserving plugin execution order.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/plugin/trigger.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
