### PR TITLE
fix(glob): include explicit dot directories

### DIFF
--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -76,6 +76,7 @@ export const layer = Layer.effectDiscard(
                   cwd,
                   pattern: input.pattern,
                   limit: input.limit ?? Number.MAX_SAFE_INTEGER,
+                  hidden: true,
                 })
                 .pipe(
                   Effect.map((result) =>

--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -47,7 +47,7 @@ export const GlobTool = Tool.define(
           })
 
           const limit = 100
-          const files = yield* ripgrep.glob({ cwd: search, pattern: params.pattern, limit })
+          const files = yield* ripgrep.glob({ cwd: search, pattern: params.pattern, limit, hidden: true })
           const truncated = files.length === limit
 
           const output = []

--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -1,5 +1,6 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { describe, expect } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { Cause, Effect, Exit, Layer } from "effect"
 import { GlobTool } from "../../src/tool/glob"
@@ -107,6 +108,26 @@ describe("tool.glob", () => {
       expect(result.metadata.count).toBe(1)
       expect(result.output).toContain(path.join(test.directory, "a.ts"))
       expect(result.output).not.toContain(path.join(test.directory, "b.txt"))
+    }),
+  )
+
+  it.instance("matches files under explicit dot directories", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const hiddenDir = path.join(test.directory, ".ai")
+      yield* Effect.promise(() => fs.mkdir(hiddenDir, { recursive: true }))
+      yield* Effect.promise(() => Bun.write(path.join(hiddenDir, "current-task.md"), "content\n"))
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      const result = yield* glob.execute(
+        {
+          pattern: ".ai/*.md",
+          path: test.directory,
+        },
+        ctx,
+      )
+      expect(result.metadata.count).toBe(1)
+      expect(result.output).toContain(path.join(hiddenDir, "current-task.md"))
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #32669

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows the Glob tool to return files under hidden directories when the pattern explicitly targets them, such as `.ai/*.md`. The same behavior is applied to the newer core glob tool path so both implementations stay consistent.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/tool/glob.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
