### PR TITLE
fix(mcp): preserve image content with structured output

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -75,7 +75,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
       if (result.structuredContent === undefined || result.structuredContent === null) return result
       return {
         ...result,
-        content: [{ type: "text" as const, text: JSON.stringify(result.structuredContent) }],
+        content: [...result.content, { type: "text" as const, text: JSON.stringify(result.structuredContent) }],
       }
     },
   })

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import type { Tool as MCPToolDef } from "@modelcontextprotocol/sdk/types.js"
+import { convertTool } from "../../src/mcp/catalog"
+
+type ExecutableTool = {
+  execute: (args: unknown, options: { abortSignal?: AbortSignal }) => Promise<any>
+}
+
+describe("MCP catalog", () => {
+  test("preserves image content when structured content is present", async () => {
+    const image = {
+      type: "image" as const,
+      data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+      mimeType: "image/png",
+    }
+    const client = {
+      callTool: async () => ({
+        content: [image],
+        structuredContent: { ok: true },
+        isError: false,
+      }),
+    } as unknown as Client
+    const definition = {
+      name: "image_only_result",
+      inputSchema: { type: "object", properties: {} },
+    } as MCPToolDef
+
+    const tool = convertTool(definition, client) as ExecutableTool
+    const result = await tool.execute({}, {})
+
+    expect(result.content).toEqual([image, { type: "text", text: JSON.stringify({ ok: true }) }])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32832

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves original MCP tool result content when `structuredContent` is also present. Structured content is still exposed as a text part, but image/resource content is no longer dropped before session tool handling can turn it into attachments.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/mcp/catalog.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
