### PR TITLE
fix(mcp): preserve image tool results

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -75,7 +75,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
       if (result.structuredContent === undefined || result.structuredContent === null) return result
       return {
         ...result,
-        content: [{ type: "text" as const, text: JSON.stringify(result.structuredContent) }],
+        content: [...result.content, { type: "text" as const, text: JSON.stringify(result.structuredContent) }],
       }
     },
   })

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test"
+import { McpCatalog } from "../../src/mcp/catalog"
+
+describe("McpCatalog.convertTool", () => {
+  test("preserves image content when structuredContent is present", async () => {
+    const client = {
+      callTool: async () => ({
+        content: [
+          {
+            type: "image" as const,
+            data: "iVBORw0KGgo=",
+            mimeType: "image/png",
+          },
+        ],
+        structuredContent: { ok: true },
+        isError: false,
+      }),
+    }
+
+    const tool = McpCatalog.convertTool(
+      {
+        name: "image_only_result",
+        description: "returns an image",
+        inputSchema: { type: "object", properties: {} },
+      },
+      client as any,
+    )
+
+    const result = await (tool as any).execute({}, { abortSignal: new AbortController().signal })
+
+    expect(result.content).toEqual([
+      {
+        type: "image",
+        data: "iVBORw0KGgo=",
+        mimeType: "image/png",
+      },
+      {
+        type: "text",
+        text: JSON.stringify({ ok: true }),
+      },
+    ])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32832

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves the original MCP tool result content when `structuredContent` is present. Previously the converter replaced the entire content array with the structured JSON text, which dropped image/resource parts before the model could see them.

### How did you verify your code works?

- `npx --yes bun@1.3.14 --cwd packages/opencode test test/mcp/catalog.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
