### PR TITLE
fix(opencode): handle text MCP resource blobs

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -31,7 +31,7 @@ import { MessageTable, PartTable, SessionTable } from "@opencode-ai/core/session
 import { ProviderError } from "@/provider/error"
 import { iife } from "@/util/iife"
 import { errorMessage } from "@/util/error"
-import { isMedia } from "@/util/media"
+import { isMedia, isTextMime } from "@/util/media"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
 import { Effect, Schema } from "effect"
@@ -177,14 +177,30 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         type: "content",
         value: [
           ...(outputObject.text ? [{ type: "text", text: outputObject.text }] : []),
-          ...attachments.map((attachment) => ({
-            type: "media",
-            mediaType: attachment.mime,
-            data: iife(() => {
+          ...attachments.flatMap((attachment): Array<{ type: string; [key: string]: string }> => {
+            // Images and PDFs are supported as media by providers
+            if (isMedia(attachment.mime)) {
+              return [
+                {
+                  type: "media",
+                  mediaType: attachment.mime,
+                  data: iife(() => {
+                    const commaIndex = attachment.url.indexOf(",")
+                    return commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
+                  }),
+                },
+              ]
+            }
+            // Text-based files (csv, json, xml, etc.) decoded to text to avoid
+            // unsupported file-data content parts in providers like Anthropic
+            if (isTextMime(attachment.mime)) {
               const commaIndex = attachment.url.indexOf(",")
-              return commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
-            }),
-          })),
+              const base64 = commaIndex === -1 ? attachment.url : attachment.url.slice(commaIndex + 1)
+              return [{ type: "text", text: Buffer.from(base64, "base64").toString("utf-8") }]
+            }
+            // Other binary files cannot be sent as media; use a placeholder
+            return [{ type: "text", text: `[Binary file: ${attachment.mime}]` }]
+          }),
         ],
       }
     }

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -38,6 +38,7 @@ import { LLM } from "./llm"
 import { Shell } from "@opencode-ai/core/shell"
 import { ShellID } from "@/tool/shell/id"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { isTextMime } from "@/util/media"
 import { Truncate } from "@/tool/truncate"
 import { Image } from "@/image/image"
 import { decodeDataUrl } from "@/util/data-url"
@@ -731,16 +732,6 @@ const layer = Layer.effect(
                   const mime = "mimeType" in c && typeof c.mimeType === "string" ? c.mimeType : part.mime
                   const filename = "uri" in c && typeof c.uri === "string" ? c.uri : part.filename
                   const size = mcpResourceBase64Size(c.blob)
-                  if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
-                    pieces.push({
-                      messageID: info.id,
-                      sessionID: input.sessionID,
-                      type: "text",
-                      synthetic: true,
-                      text: `[Binary MCP resource omitted: ${filename ?? uri} (${mime}, ${formatMcpResourceBytes(size)}) is not a supported attachment type]`,
-                    })
-                    continue
-                  }
                   if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
                     pieces.push({
                       messageID: info.id,
@@ -748,6 +739,26 @@ const layer = Layer.effect(
                       type: "text",
                       synthetic: true,
                       text: `[Binary MCP resource omitted: ${filename ?? uri} (${mime}, ${formatMcpResourceBytes(size)}) exceeds ${formatMcpResourceBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
+                    })
+                    continue
+                  }
+                  if (isTextMime(mime)) {
+                    pieces.push({
+                      messageID: info.id,
+                      sessionID: input.sessionID,
+                      type: "text",
+                      synthetic: true,
+                      text: Buffer.from(c.blob, "base64").toString("utf-8"),
+                    })
+                    continue
+                  }
+                  if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
+                    pieces.push({
+                      messageID: info.id,
+                      sessionID: input.sessionID,
+                      type: "text",
+                      synthetic: true,
+                      text: `[Binary MCP resource omitted: ${filename ?? uri} (${mime}, ${formatMcpResourceBytes(size)}) is not a supported attachment type]`,
                     })
                     continue
                   }

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -11,6 +11,7 @@ import { ToolRegistry } from "@/tool/registry"
 import { Truncate } from "@/tool/truncate"
 
 import { Plugin } from "@/plugin"
+import { isTextMime } from "@/util/media"
 import type { TaskPromptOps } from "@/tool/task"
 import { type Tool as AITool, tool, jsonSchema, type ToolExecutionOptions, asSchema } from "ai"
 import { Effect } from "effect"
@@ -439,15 +440,19 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               if (resource.blob) {
                 const mime = resource.mimeType ?? "application/octet-stream"
                 const size = base64Size(resource.blob)
-                if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
-                  textParts.push(
-                    `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
-                  )
-                  continue
-                }
                 if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
                   textParts.push(
                     `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) exceeds ${formatBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
+                  )
+                  continue
+                }
+                if (isTextMime(mime)) {
+                  textParts.push(Buffer.from(resource.blob, "base64").toString("utf-8"))
+                  continue
+                }
+                if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
+                  textParts.push(
+                    `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
                   )
                   continue
                 }
@@ -544,15 +549,19 @@ function formatMcpResourceContent(server: string, uri: string, content: { conten
     }
     if (typeof item.blob === "string") {
       const size = base64Size(item.blob)
-      if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
-        text.push(
-          `[Binary MCP resource omitted: ${itemUri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
-        )
-        continue
-      }
       if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
         text.push(
           `[Binary MCP resource omitted: ${itemUri} (${mime}, ${formatBytes(size)}) exceeds ${formatBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
+        )
+        continue
+      }
+      if (isTextMime(mime)) {
+        text.push(`Resource: ${itemUri}\nMIME: ${mime}\n${Buffer.from(item.blob, "base64").toString("utf-8")}`)
+        continue
+      }
+      if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
+        text.push(
+          `[Binary MCP resource omitted: ${itemUri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
         )
         continue
       }

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -12,6 +12,28 @@ export function isImageAttachment(mime: string) {
   return mime.startsWith("image/") && mime !== "image/svg+xml" && mime !== "image/vnd.fastbidsheet"
 }
 
+export function isTextMime(mime: string) {
+  if (mime.startsWith("text/")) return true
+  const textTypes = [
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/typescript",
+    "application/x-yaml",
+    "application/yaml",
+    "application/toml",
+    "application/x-sh",
+    "application/sql",
+    "application/graphql",
+    "application/x-httpd-php",
+    "application/xhtml+xml",
+    "application/ld+json",
+  ]
+  if (textTypes.includes(mime)) return true
+  if (mime.endsWith("+xml") || mime.endsWith("+json")) return true
+  return false
+}
+
 export function sniffAttachmentMime(bytes: Uint8Array, fallback: string) {
   if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png"
   if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg"

--- a/packages/opencode/test/util/media.test.ts
+++ b/packages/opencode/test/util/media.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test"
+import { isTextMime, isMedia } from "../../src/util/media"
+
+describe("isTextMime", () => {
+  test("detects text/* types", () => {
+    expect(isTextMime("text/csv")).toBe(true)
+    expect(isTextMime("text/plain")).toBe(true)
+    expect(isTextMime("text/html")).toBe(true)
+    expect(isTextMime("text/xml")).toBe(true)
+  })
+
+  test("detects common application text types", () => {
+    expect(isTextMime("application/json")).toBe(true)
+    expect(isTextMime("application/xml")).toBe(true)
+    expect(isTextMime("application/x-yaml")).toBe(true)
+    expect(isTextMime("application/yaml")).toBe(true)
+    expect(isTextMime("application/javascript")).toBe(true)
+    expect(isTextMime("application/sql")).toBe(true)
+    expect(isTextMime("application/ld+json")).toBe(true)
+  })
+
+  test("detects +xml and +json suffixes", () => {
+    expect(isTextMime("application/vnd.api+json")).toBe(true)
+    expect(isTextMime("application/svg+xml")).toBe(true)
+    expect(isTextMime("application/atom+xml")).toBe(true)
+  })
+
+  test("rejects images and PDFs", () => {
+    expect(isTextMime("image/png")).toBe(false)
+    expect(isTextMime("image/jpeg")).toBe(false)
+    expect(isTextMime("application/pdf")).toBe(false)
+  })
+
+  test("rejects binary application types", () => {
+    expect(isTextMime("application/octet-stream")).toBe(false)
+    expect(isTextMime("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")).toBe(false)
+    expect(isTextMime("application/zip")).toBe(false)
+  })
+})
+
+describe("MCP resource blob routing", () => {
+  test("text/csv blob is decoded to text instead of binary attachment", () => {
+    const csvContent = "name,age,city\nAlice,30,Seattle\nBob,25,Portland"
+    const blob = Buffer.from(csvContent).toString("base64")
+    const mime = "text/csv"
+
+    // Simulates the tools.ts path: text blobs go to textParts
+    expect(isTextMime(mime)).toBe(true)
+    expect(Buffer.from(blob, "base64").toString("utf-8")).toBe(csvContent)
+  })
+
+  test("image blobs remain as media attachments", () => {
+    expect(isMedia("image/png")).toBe(true)
+    expect(isTextMime("image/png")).toBe(false)
+  })
+
+  test("PDF blobs remain as media attachments", () => {
+    expect(isMedia("application/pdf")).toBe(true)
+    expect(isTextMime("application/pdf")).toBe(false)
+  })
+
+  test("unknown binary blobs are not classified as text", () => {
+    const mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    expect(isMedia(mime)).toBe(false)
+    expect(isTextMime(mime)).toBe(false)
+  })
+})
+
+describe("toModelOutput attachment routing", () => {
+  test("text attachments are decoded to text content parts", () => {
+    const csvContent = "id,value\n1,foo"
+    const url = `data:text/csv;base64,${Buffer.from(csvContent).toString("base64")}`
+    const mime = "text/csv"
+
+    // Simulates message-v2.ts routing: text mime → decode base64 → text part
+    expect(isTextMime(mime)).toBe(true)
+    const commaIndex = url.indexOf(",")
+    const base64 = url.slice(commaIndex + 1)
+    expect(Buffer.from(base64, "base64").toString("utf-8")).toBe(csvContent)
+  })
+
+  test("binary attachments produce placeholder text, not file-data", () => {
+    const mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    expect(isMedia(mime)).toBe(false)
+    expect(isTextMime(mime)).toBe(false)
+    // In the real code this becomes: [Binary file: <mime>]
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #30249

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP text resource blobs, such as `text/csv`, were being replayed as binary file attachments. Anthropic rejects those `file-data` parts unless they are PDFs.

This decodes text-based MCP blobs into text, keeps images/PDFs as media, and uses a placeholder for unsupported binary attachments.

### How did you verify your code works?

From `packages/opencode`:

- `bun test --timeout 30000 test/util/media.test.ts`
- `bun typecheck`

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
