### PR TITLE
fix(tui): improve light mode code block contrast

### DIFF
--- a/packages/tui/src/theme/index.ts
+++ b/packages/tui/src/theme/index.ts
@@ -872,6 +872,7 @@ function getSyntaxRules(theme: Theme) {
       scope: ["markup.raw", "markup.raw.block"],
       style: {
         foreground: theme.markdownCode,
+        background: theme.backgroundElement,
       },
     },
     {


### PR DESCRIPTION
### Issue for this PR

Closes #17935

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the themed element background to fenced code block syntax rules so markdown code blocks remain readable in light terminal themes.

### How did you verify your code works?

- `bun run typecheck` from `packages/tui`
- `bun run lint packages/tui/src/theme/index.ts`
- full pre-push `bun turbo typecheck`

### Screenshots / recordings

Not captured; terminal theme rendering change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR