### PR TITLE
ci: update docs workflow repository references

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   update-docs:
-    if: github.repository == 'sst/opencode'
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write
@@ -43,7 +43,7 @@ jobs:
 
       - name: Run opencode
         if: steps.commits.outputs.has_commits == 'true'
-        uses: sst/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
+        uses: anomalyco/opencode/github@2c14fc5586fe0b88e5c04732d2e846769cc35671 # latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:


### PR DESCRIPTION
### Issue for this PR

Closes #16045

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the docs-update workflow repository guard and pinned action owner from the previous repository location to `anomalyco/opencode`.

### How did you verify your code works?

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs-update.yml"); puts "ok"'`\n- `rg -n "sst/opencode|anomalyco/opencode" .github/workflows/docs-update.yml`\n- full pre-push `bun turbo typecheck`\n\n### Screenshots / recordings\n\nNot a UI change.\n\n### Checklist\n\n- [x] I have tested my changes locally\n- [x] I have not included unrelated changes in this PR