### PR TITLE
docs: link official IDE extension listings

### DIFF
--- a/packages/web/src/content/docs/ide.mdx
+++ b/packages/web/src/content/docs/ide.mdx
@@ -30,7 +30,10 @@ If on the other hand you want to use your own IDE when you run `/editor` or `/ex
 
 ### Manual Install
 
-Search for **OpenCode** in the Extension Marketplace and click **Install**.
+Install the official extension directly:
+
+- VS Code Marketplace: [`sst-dev.opencode`](https://marketplace.visualstudio.com/items?itemName=sst-dev.opencode)
+- Open VSX: [`sst-dev.opencode`](https://open-vsx.org/extension/sst-dev/opencode)
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #16217
Closes #10517

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Replaces the manual install search instruction with direct links to the official VS Code Marketplace and Open VSX extension listings.

### How did you verify your code works?

- `bun run build` from `packages/web`
- `rg -n "sst-dev\.opencode|open-vsx\.org/extension/sst-dev/opencode|marketplace\.visualstudio\.com/items\?itemName=sst-dev\.opencode" packages/web/src/content/docs/ide.mdx`
- full pre-push `bun turbo typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR