### PR TITLE
docs: correct tool details keybind

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -99,11 +99,9 @@ Compact the current session. _Alias_: `/summarize`
 
 ### details
 
-Toggle tool execution details.
+Toggle tool execution details. This is available through the `tool_details` keybind, which is unbound by default. [Learn more](/docs/keybinds).
 
-```bash frame="none"
-/details
-```
+**Keybind:** `tool_details`
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #16062

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Removes the stale `/details` slash command reference and documents tool details as the `tool_details` keybind, which is unbound by default.

### How did you verify your code works?

- `rg -n "/details|tool_details|### details" packages/web/src/content/docs/tui.mdx`
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR