### PR TITLE
docs: clarify TUI exit and interrupt keys

### DIFF
--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -196,6 +196,8 @@ You don't need to use a leader key for your keybinds but we recommend doing so.
 
 Some navigation keybinds intentionally do not use the leader key by default. For subagent sessions, the defaults are `session_child_first` = `<leader>down`, `session_child_cycle` = `right`, `session_child_cycle_reverse` = `left`, and `session_parent` = `up`.
 
+`app_exit` closes the TUI. `input_clear` clears the prompt text. Both include `ctrl+c` by default, so `ctrl+c` clears input when the prompt has text and exits when the prompt is empty. Use `session_interrupt` (`escape` by default) to interrupt in-progress work without closing OpenCode.
+
 `leader_timeout` controls how long OpenCode waits for the next key after the leader key. It defaults to `2000` milliseconds.
 
 ---

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -129,6 +129,8 @@ Exit OpenCode. _Aliases_: `/quit`, `/q`
 
 **Keybind:** `ctrl+x q`
 
+`/exit`, `/quit`, and `ctrl+x q` close the TUI. `ctrl+c` also exits when the prompt is empty, but clears the current input when text is present. Press `Esc` to interrupt in-progress work without closing OpenCode.
+
 ---
 
 ### export


### PR DESCRIPTION
## Summary
- document how `/exit`, `/quit`, and the exit keybind close the TUI
- clarify that `ctrl+c` clears prompt text when input is present and exits when the prompt is empty
- point users to `escape` for interrupting in-progress work

Closes #23478

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`