### PR TITLE
docs: clarify MCP timeout scope

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -123,7 +123,7 @@ Here are all the options for configuring a local MCP server.
 | `cwd`         | String  |          | Working directory for the MCP server process. Relative paths resolve from the workspace. |
 | `environment` | Object  |          | Environment variables to set when running the server.                                    |
 | `enabled`     | Boolean |          | Enable or disable the MCP server on startup.                                             |
-| `timeout`     | Number  |          | Timeout in ms for fetching tools from the MCP server. Defaults to 5000 (5 seconds).      |
+| `timeout`     | Number  |          | Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds).                    |
 
 ---
 
@@ -160,7 +160,7 @@ The `url` is the URL of the remote MCP server and with the `headers` option you 
 | `enabled` | Boolean |          | Enable or disable the MCP server on startup.                                        |
 | `headers` | Object  |          | Headers to send with the request.                                                   |
 | `oauth`   | Object  |          | OAuth authentication configuration. See [OAuth](#oauth) section below.              |
-| `timeout` | Number  |          | Timeout in ms for fetching tools from the MCP server. Defaults to 5000 (5 seconds). |
+| `timeout` | Number  |          | Timeout in ms for MCP server requests. Defaults to 5000 (5 seconds).               |
 
 ---
 


### PR DESCRIPTION
## Summary
- update local and remote MCP option tables to describe `timeout` as applying to MCP server requests
- align docs wording with the config schema description

Closes #23648

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`