### PR TITLE
docs: document models path env var

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -702,6 +702,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
 | `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
 | `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
+| `OPENCODE_MODELS_PATH`                | string  | Path to a local models JSON file                  |
 | `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
 
 ---


### PR DESCRIPTION
## Summary
- add `OPENCODE_MODELS_PATH` to the CLI environment variables table
- describe it as the local models JSON file path used by the models catalog loader

Closes #13886

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`