### PR TITLE
docs: clarify GitHub token configuration

### DIFF
--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -67,10 +67,11 @@ Or you can set it up manually.
            uses: anomalyco/opencode/github@latest
            env:
              ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+             # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
            with:
              model: anthropic/claude-sonnet-4-20250514
              # share: true
-             # github_token: xxxx
+             # use_github_token: true
    ```
 
 3. **Store the API keys in secrets**
@@ -85,9 +86,9 @@ Or you can set it up manually.
 - `agent`: The agent to use. Must be a primary agent. Falls back to `default_agent` from config or `"build"` if not found.
 - `share`: Whether to share the OpenCode session. Defaults to **true** for public repositories.
 - `prompt`: Optional custom prompt to override the default behavior. Use this to customize how OpenCode processes requests.
-- `token`: Optional GitHub access token for performing operations such as creating comments, committing changes, and opening pull requests. By default, OpenCode uses the installation access token from the OpenCode GitHub App, so commits, comments, and pull requests appear as coming from the app.
+- `use_github_token`: Use the GitHub Action runner's [built-in `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token) instead of the OpenCode GitHub App token exchange. Set `GITHUB_TOKEN` in `env` and set this input to `true`. By default, OpenCode uses the installation access token from the OpenCode GitHub App, so commits, comments, and pull requests appear as coming from the app.
 
-  Alternatively, you can use the GitHub Action runner's [built-in `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token) without installing the OpenCode GitHub App. Just make sure to grant the required permissions in your workflow:
+  Make sure to grant the required permissions in your workflow when using `GITHUB_TOKEN`:
 
   ```yaml
   permissions:
@@ -97,7 +98,7 @@ Or you can set it up manually.
     issues: write
   ```
 
-  You can also use a [personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)(PAT) if preferred.
+  If you prefer a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens), store it as a secret and pass it through the `GITHUB_TOKEN` environment variable with `use_github_token: true`.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace the stale `github_token` example with `use_github_token`
- document that `use_github_token` reads `GITHUB_TOKEN` from the action environment
- clarify how to pass a personal access token through the same environment variable

Closes #23487

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`