### PR TITLE
docs: document plugin spec forms

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -777,12 +777,12 @@ You can configure MCP servers you want to use through the `mcp` option.
 
 [Plugins](/docs/plugins) extend OpenCode with custom tools, hooks, and integrations.
 
-Place plugin files in `.opencode/plugins/` or `~/.config/opencode/plugins/`. You can also load plugins from npm through the `plugin` option.
+Place plugin files in `.opencode/plugins/` or `~/.config/opencode/plugins/`. You can also load plugins through the `plugin` option with npm package specs, git-backed package specs, or `file://` URLs.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-helicone-session", "@my-org/custom-plugin"]
+  "plugin": ["opencode-helicone-session", "@my-org/custom-plugin", "file:///absolute/path/to/my-plugin.ts"]
 }
 ```
 

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -24,16 +24,30 @@ Place JavaScript or TypeScript files in the plugin directory.
 
 Files in these directories are automatically loaded at startup.
 
----
-
-### From npm
-
-Specify npm packages in your config file.
+You can also reference a specific local plugin file from your config with a `file://` URL.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-helicone-session", "opencode-wakatime", "@my-org/custom-plugin"]
+  "plugin": ["file:///absolute/path/to/my-plugin.ts"]
+}
+```
+
+---
+
+### From npm
+
+Specify npm packages in your config file. Bun package specifiers are supported, including scoped packages and git-backed packages.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "opencode-helicone-session",
+    "opencode-wakatime",
+    "@my-org/custom-plugin",
+    "opencode-scheduler@git+https://github.com/different-ai/opencode-scheduler.git"
+  ]
 }
 ```
 


### PR DESCRIPTION
## Summary
- document direct `file://` plugin specs for local plugin files
- show a git-backed package spec in the plugin config example
- update config docs to describe npm specs, git-backed specs, and `file://` URLs

Closes #16669

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`