### PR TITLE
docs: clarify project config locations

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -46,8 +46,8 @@ Config sources are loaded in this order (later sources override earlier ones):
 1. **Remote config** (from `.well-known/opencode`) - organizational defaults
 2. **Global config** (`~/.config/opencode/opencode.json`) - user preferences
 3. **Custom config** (`OPENCODE_CONFIG` env var) - custom overrides
-4. **Project config** (`opencode.json` in project) - project-specific settings
-5. **`.opencode` directories** - agents, commands, plugins
+4. **Project config** (`opencode.json` or `opencode.jsonc` in project) - project-specific settings
+5. **`.opencode` directories** - config files, agents, commands, plugins
 6. **Inline config** (`OPENCODE_CONFIG_CONTENT` env var) - runtime overrides
 7. **Managed config files** (`/Library/Application Support/opencode/` on macOS) - admin-controlled
 8. **macOS managed preferences** (`.mobileconfig` via MDM) - highest priority, not user-overridable
@@ -108,9 +108,11 @@ Global config overrides remote organizational defaults.
 
 ### Per project
 
-Add `opencode.json` in your project root. Project config has the highest precedence among standard config files - it overrides both global and remote configs.
+Add `opencode.json` or `opencode.jsonc` in your project root. Project config has the highest precedence among standard config files - it overrides both global and remote configs.
 
-For project-specific TUI settings, add `tui.json` alongside it.
+You can also put project config in `.opencode/opencode.json` or `.opencode/opencode.jsonc`. These files are loaded with the rest of the `.opencode` directory sources, after root project config.
+
+For project-specific TUI settings, add `tui.json` alongside the root project config or in `.opencode/tui.json`.
 
 :::tip
 Place project specific config in the root of your project.


### PR DESCRIPTION
## Summary
- document that project config can be `opencode.json` or `opencode.jsonc`
- clarify that `.opencode/opencode.json` and `.opencode/opencode.jsonc` are also loaded
- mention `.opencode/tui.json` for project-specific TUI config

Closes #28291

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`