### PR TITLE
docs: clarify LSP tool enablement

### DIFF
--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -156,7 +156,7 @@ Search for files using glob patterns like `**/*.js` or `src/**/*.ts`. Returns ma
 Interact with your configured LSP servers to get code intelligence features like definitions, references, hover info, and call hierarchy.
 
 :::note
-This tool is only available when `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` (or `OPENCODE_EXPERIMENTAL=true`).
+This tool is only available when `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` (or `OPENCODE_EXPERIMENTAL=true`). That flag exposes the tool; LSP servers are enabled separately with the `lsp` config option.
 :::
 
 ```json title="opencode.json" {4}
@@ -170,7 +170,7 @@ This tool is only available when `OPENCODE_EXPERIMENTAL_LSP_TOOL=true` (or `OPEN
 
 Supported operations include `goToDefinition`, `findReferences`, `hover`, `documentSymbol`, `workspaceSymbol`, `goToImplementation`, `prepareCallHierarchy`, `incomingCalls`, and `outgoingCalls`.
 
-To configure which LSP servers are available for your project, see [LSP Servers](/docs/lsp).
+To enable LSP and configure which servers are available for your project, see [LSP Servers](/docs/lsp).
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that `OPENCODE_EXPERIMENTAL_LSP_TOOL` exposes the experimental `lsp` tool
- point readers to the `lsp` config option for enabling and configuring LSP servers

Closes #30954

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`