### PR TITLE
docs: document non-interactive MCP add

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -240,6 +240,20 @@ opencode mcp add
 
 This command will guide you through adding either a local or remote MCP server.
 
+You can also add a server non-interactively by passing a name and either `--url` for a remote server or a local command after `--`.
+
+```bash
+opencode mcp add github --url https://api.githubcopilot.com/mcp --header "Authorization=Bearer {env:GITHUB_TOKEN}"
+```
+
+##### Flags
+
+| Flag                                  | Description                                  |
+| ------------------------------------- | -------------------------------------------- |
+| <nobr><code>{"--url"}</code></nobr>   | URL for a remote MCP server                  |
+| <nobr><code>{"--header"}</code></nobr> | HTTP header for a remote MCP server          |
+| <nobr><code>{"--env"}</code></nobr>   | Environment variable for a local MCP server |
+
 ---
 
 #### list


### PR DESCRIPTION
## Summary
- document non-interactive `opencode mcp add` usage
- add a remote MCP server example using `--url` and `--header`
- list the related `--url`, `--header`, and `--env` flags

Closes #32259

## Verification
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`