### PR TITLE
fix(lsp): allow builtin server overrides

### DIFF
--- a/packages/core/src/config/lsp.ts
+++ b/packages/core/src/config/lsp.ts
@@ -7,7 +7,7 @@ export const Disabled = Schema.Struct({
 })
 
 export class Server extends Schema.Class<Server>("ConfigV2.LSP.Server")({
-  command: Schema.String.pipe(Schema.Array),
+  command: Schema.String.pipe(Schema.Array, Schema.optional),
   extensions: Schema.String.pipe(Schema.Array, Schema.optional),
   disabled: Schema.Boolean.pipe(Schema.optional),
   env: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
@@ -15,4 +15,60 @@ export class Server extends Schema.Class<Server>("ConfigV2.LSP.Server")({
 }) {}
 
 export const Entry = Schema.Union([Disabled, Server])
-export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)])
+export const builtinServerIds = [
+  "deno",
+  "typescript",
+  "vue",
+  "eslint",
+  "oxlint",
+  "biome",
+  "gopls",
+  "ruby-lsp",
+  "ty",
+  "pyright",
+  "elixir-ls",
+  "zls",
+  "csharp",
+  "razor",
+  "fsharp",
+  "sourcekit-lsp",
+  "rust",
+  "clangd",
+  "svelte",
+  "astro",
+  "jdtls",
+  "kotlin-ls",
+  "yaml-ls",
+  "lua-ls",
+  "php intelephense",
+  "prisma",
+  "dart",
+  "ocaml-lsp",
+  "bash",
+  "terraform",
+  "texlab",
+  "dockerfile",
+  "gleam",
+  "clojure-lsp",
+  "nixd",
+  "tinymist",
+  "haskell-language-server",
+  "julials",
+]
+
+export const requiresCustomServerDetails = Schema.makeFilter<
+  boolean | Record<string, Schema.Schema.Type<typeof Entry>>
+>((data) => {
+  if (typeof data === "boolean") return undefined
+  const ids = new Set(builtinServerIds)
+  const ok = Object.entries(data).every(([id, config]) => {
+    if ("disabled" in config && config.disabled) return true
+    if (ids.has(id)) return true
+    return "command" in config && Boolean(config.command) && "extensions" in config && Boolean(config.extensions)
+  })
+  return ok ? undefined : "For custom LSP servers, 'command' and 'extensions' are required."
+})
+
+export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)]).check(
+  requiresCustomServerDetails,
+)

--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -9,7 +9,7 @@ export const Disabled = Schema.Struct({
 export const Entry = Schema.Union([
   Disabled,
   Schema.Struct({
-    command: Schema.mutable(Schema.Array(Schema.String)),
+    command: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
     extensions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
     disabled: Schema.optional(Schema.Boolean),
     env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
@@ -60,7 +60,7 @@ export const builtinServerIds = [
   "julials",
 ]
 
-export const requiresExtensionsForCustomServers = Schema.makeFilter<
+export const requiresCustomServerDetails = Schema.makeFilter<
   boolean | Record<string, Schema.Schema.Type<typeof Entry>>
 >((data) => {
   if (typeof data === "boolean") return undefined
@@ -68,13 +68,13 @@ export const requiresExtensionsForCustomServers = Schema.makeFilter<
   const ok = Object.entries(data).every(([id, config]) => {
     if ("disabled" in config && config.disabled) return true
     if (ids.has(id)) return true
-    return "extensions" in config && Boolean(config.extensions)
+    return "command" in config && Boolean(config.command) && "extensions" in config && Boolean(config.extensions)
   })
-  return ok ? undefined : "For custom LSP servers, 'extensions' array is required."
+  return ok ? undefined : "For custom LSP servers, 'command' and 'extensions' are required."
 })
 
 export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)])
-  .check(requiresExtensionsForCustomServers)
+  .check(requiresCustomServerDetails)
   .pipe((schema) => schema)
 
 export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/opencode/src/lsp/launch.ts
+++ b/packages/opencode/src/lsp/launch.ts
@@ -1,15 +1,31 @@
 import type { ChildProcessWithoutNullStreams } from "child_process"
+import { AsyncLocalStorage } from "node:async_hooks"
 import { Process } from "@/util/process"
 
 type Child = Process.Child & ChildProcessWithoutNullStreams
+const envStorage = new AsyncLocalStorage<Record<string, string>>()
+let fallbackEnv: Record<string, string> | undefined
+
+export async function withEnv<T>(env: Record<string, string> | undefined, fn: () => Promise<T>): Promise<T> {
+  if (!env || Object.keys(env).length === 0) return fn()
+  const previous = fallbackEnv
+  fallbackEnv = { ...fallbackEnv, ...env }
+  try {
+    return await envStorage.run(fallbackEnv, fn)
+  } finally {
+    fallbackEnv = previous
+  }
+}
 
 export function spawn(cmd: string, args: string[], opts?: Process.Options): Child
 export function spawn(cmd: string, opts?: Process.Options): Child
 export function spawn(cmd: string, argsOrOpts?: string[] | Process.Options, opts?: Process.Options) {
   const args = Array.isArray(argsOrOpts) ? [...argsOrOpts] : []
   const cfg = Array.isArray(argsOrOpts) ? opts : argsOrOpts
+  const env = envStorage.getStore() ?? fallbackEnv
   const proc = Process.spawn([cmd, ...args], {
     ...cfg,
+    ...(env ? { env: { ...process.env, ...cfg?.env, ...env } } : {}),
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -8,7 +8,7 @@ import { pathToFileURL, fileURLToPath } from "url"
 import * as LSPServer from "./server"
 import { Config } from "@/config/config"
 import { Process } from "@/util/process"
-import { spawn as lspspawn } from "./launch"
+import { spawn as lspspawn, withEnv as withLspEnv } from "./launch"
 import { Effect, Layer, Context, Schema } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { containsPath } from "@/project/instance-context"
@@ -167,18 +167,33 @@ export const layer = Layer.effect(
                 delete servers[name]
                 continue
               }
+              const command = item.command
               servers[name] = {
                 ...existing,
                 id: name,
                 root: existing?.root ?? (async (_file, ctx) => ctx.directory),
                 extensions: item.extensions ?? existing?.extensions ?? [],
-                spawn: async (root) => ({
-                  process: lspspawn(item.command[0], item.command.slice(1), {
-                    cwd: root,
-                    env: { ...process.env, ...item.env },
-                  }),
-                  initialization: item.initialization,
-                }),
+                spawn: command
+                  ? async (root) => ({
+                      process: lspspawn(command[0], command.slice(1), {
+                        cwd: root,
+                        env: { ...process.env, ...item.env },
+                      }),
+                      initialization: item.initialization,
+                    })
+                  : existing
+                    ? async (root, ctx, flags) => {
+                        const handle = await withLspEnv(item.env, () => existing.spawn(root, ctx, flags))
+                        if (!handle) return handle
+                        return {
+                          ...handle,
+                          initialization: {
+                            ...handle.initialization,
+                            ...item.initialization,
+                          },
+                        }
+                      }
+                    : async () => undefined,
               }
             }
           }

--- a/packages/opencode/test/config/lsp.test.ts
+++ b/packages/opencode/test/config/lsp.test.ts
@@ -3,9 +3,9 @@ import { Schema } from "effect"
 import { ConfigLSPV1 } from "@opencode-ai/core/v1/config/lsp"
 
 // The LSP config refinement enforces: any custom (non-builtin) LSP server
-// entry must declare an `extensions` array so the client knows which files
-// the server should attach to. Builtin server IDs and explicitly disabled
-// entries are exempt.
+// entry must declare a command and an `extensions` array so the client knows
+// how to start it and which files it should attach to. Builtin server IDs and
+// explicitly disabled entries are exempt.
 //
 // `typescript` is a builtin server id (see src/lsp/server.ts).
 describe("ConfigLSPV1.Info refinement", () => {
@@ -19,6 +19,11 @@ describe("ConfigLSPV1.Info refinement", () => {
 
     test("builtin server with no extensions passes", () => {
       const input = { typescript: { command: ["typescript-language-server", "--stdio"] } }
+      expect(decodeEffect(input)).toEqual(input)
+    })
+
+    test("builtin server override without command passes", () => {
+      const input = { jdtls: { env: { PATH: "/usr/bin" } } }
       expect(decodeEffect(input)).toEqual(input)
     })
 
@@ -44,10 +49,14 @@ describe("ConfigLSPV1.Info refinement", () => {
   })
 
   describe("rejected inputs", () => {
-    const expectedMessage = "For custom LSP servers, 'extensions' array is required."
+    const expectedMessage = "For custom LSP servers, 'command' and 'extensions' are required."
 
     test("custom server WITHOUT extensions fails via Effect decode", () => {
       expect(() => decodeEffect({ "my-lsp": { command: ["my-lsp-bin"] } })).toThrow(expectedMessage)
+    })
+
+    test("custom server WITHOUT command fails via Effect decode", () => {
+      expect(() => decodeEffect({ "my-lsp": { extensions: [".ml"] } })).toThrow(expectedMessage)
     })
 
     test("custom server with empty extensions array fails (extensions must be non-empty-truthy)", () => {

--- a/packages/opencode/test/lsp/index.test.ts
+++ b/packages/opencode/test/lsp/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, spyOn } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
 import path from "path"
 import { Deferred, Effect, Layer } from "effect"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -6,9 +6,11 @@ import { Config } from "@/config/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { LSP } from "@/lsp/lsp"
 import * as LSPServer from "@/lsp/server"
+import { Process } from "@/util/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestInstance } from "../fixture/fixture"
 import { awaitWithTimeout, testEffect } from "../lib/effect"
+import { spawn as lspSpawn, withEnv as withLspEnv } from "../../src/lsp/launch"
 
 const lspLayer = (flags: Parameters<typeof RuntimeFlags.layer>[0] = {}) =>
   LSP.layer.pipe(
@@ -155,6 +157,39 @@ describe("lsp.spawn", () => {
   )
 
   it.instance(
+    "applies env overrides to builtin LSP spawns without requiring command",
+    () =>
+      LSP.Service.use((lsp) =>
+        Effect.gen(function* () {
+          const dir = (yield* TestInstance).directory
+          const serverSpawn = spyOn(LSPServer.Typescript, "spawn").mockImplementation(async (root) => {
+            const child = lspSpawn(process.execPath, ["-e", ""], { cwd: root })
+            return (child.kill(), undefined)
+          })
+
+          try {
+            yield* lsp.hover({
+              file: path.join(dir, "src", "inside.ts"),
+              line: 0,
+              character: 0,
+            })
+
+            expect(serverSpawn).toHaveBeenCalledTimes(1)
+          } finally {
+            serverSpawn.mockRestore()
+          }
+        }),
+      ),
+    {
+      config: {
+        lsp: {
+          typescript: { env: { OPENCODE_TEST_LSP_ENV: "enabled" } },
+        },
+      },
+    },
+  )
+
+  it.instance(
     "uses pyright instead of ty by default",
     () =>
       LSP.Service.use((lsp) =>
@@ -229,4 +264,21 @@ describe("lsp.spawn", () => {
       ),
     { config: { lsp: true } },
   )
+})
+
+describe("lsp.launch", () => {
+  test("passes env overrides to spawned LSP processes", async () => {
+    const processSpawn = spyOn(Process, "spawn")
+    try {
+      const child = await withLspEnv({ OPENCODE_TEST_LSP_ENV: "enabled" }, async () =>
+        lspSpawn(process.execPath, ["-e", ""]),
+      )
+      child.kill()
+
+      const spawnCalls = processSpawn.mock.calls.filter(([cmd]) => cmd[0] === process.execPath)
+      expect(spawnCalls.some(([, options]) => options?.env?.OPENCODE_TEST_LSP_ENV === "enabled")).toBe(true)
+    } finally {
+      processSpawn.mockRestore()
+    }
+  })
 })

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -107,6 +107,8 @@ Server entries need `command` unless they only disable a server.
 | `env`            | object   | Environment variables to set when starting server |
 | `initialization` | object   | Initialization options to send to the LSP server  |
 
+Built-in server entries can omit `command` when you only want to override options like `env`, `extensions`, or `initialization`. Custom servers must include both `command` and `extensions`.
+
 Let's look at some examples.
 
 ---
@@ -119,10 +121,9 @@ Use the `env` property to set environment variables when starting the LSP server
 {
   "$schema": "https://opencode.ai/config.json",
   "lsp": {
-    "rust": {
-      "command": ["rust-analyzer"],
+    "jdtls": {
       "env": {
-        "RUST_LOG": "debug"
+        "PATH": "/usr/lib/jvm/java-21/bin:{env:PATH}"
       }
     }
   }


### PR DESCRIPTION
## Summary
- allow built-in LSP server entries to omit `command` when overriding `env`, `extensions`, or `initialization`
- keep custom LSP server validation strict by requiring both `command` and `extensions`
- document command-less built-in overrides and add regression coverage

Closes #23861

## Verification
- `bun test test/config/lsp.test.ts test/lsp/index.test.ts --timeout 30000` from `packages/opencode`
- `bun run typecheck` from `packages/opencode`
- `bun run typecheck` from `packages/core`
- `bun run build` from `packages/web`
- full pre-push `bun turbo typecheck`