### PR TITLE
fix(glob): include dot directories

### DIFF
--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -76,6 +76,7 @@ export const layer = Layer.effectDiscard(
                   cwd,
                   pattern: input.pattern,
                   limit: input.limit ?? Number.MAX_SAFE_INTEGER,
+                  hidden: true,
                 })
                 .pipe(
                   Effect.map((result) =>

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -27,6 +27,17 @@ describe("Ripgrep", () => {
     ),
   )
 
+  it.live("globs files under explicit dot directories", () =>
+    withTmp((cwd) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => fs.mkdir(path.join(cwd, ".ai")))
+        yield* Effect.promise(() => fs.writeFile(path.join(cwd, ".ai", "current-task.md"), "needle\n"))
+        const result = yield* (yield* Ripgrep.Service).glob({ cwd, pattern: ".ai/**/*.md", hidden: true, limit: 10 })
+        expect(result.map((item) => item.path)).toEqual([RelativePath.make(".ai/current-task.md")])
+      }),
+    ),
+  )
+
   it.live("greps files with include filtering", () =>
     withTmp((cwd) =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- include hidden paths when the glob tool delegates to ripgrep
- add coverage for matching files under an explicit dot directory pattern

Closes #32669

## Verification
- `bun test test/filesystem/search.test.ts --timeout 30000` from `packages/core`
- `bun run typecheck` from `packages/core`
- full pre-push `bun turbo typecheck`