### PR TITLE
fix(session): preserve explicit title updates

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -231,6 +231,8 @@ export const layer = Layer.effect(
         .find((line) => line.length > 0)
       if (!cleaned) return
       const t = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
+      const latest = yield* sessions.get(input.session.id)
+      if (!Session.isDefaultTitle(latest.title)) return
       yield* sessions
         .setTitle({ sessionID: input.session.id, title: t })
         .pipe(Effect.catchCause((cause) => Effect.logError("failed to generate title", { error: Cause.squash(cause) })))


### PR DESCRIPTION
## Summary
- re-read the session title immediately before writing an auto-generated title
- skip the auto-title write if another path already set an explicit title during the turn

Closes #32710

## Verification
- `bun run typecheck` from `packages/opencode`
- full pre-push `bun turbo typecheck`