### PR TITLE
fix(opencode): recover MCP sessions on session 400

### DIFF
--- a/packages/opencode/test/fixture/mcp-session-recovery.ts
+++ b/packages/opencode/test/fixture/mcp-session-recovery.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
 
+const mode = process.argv[2] ?? "404"
 const posts: Array<{ method: string; session: string | null }> = []
 let initializeCount = 0
 let pingCount = 0
@@ -34,7 +35,17 @@ const server = Bun.serve({
     if (message.method === "notifications/initialized") return new Response(null, { status: 202 })
 
     pingCount++
-    if (pingCount === 1) return new Response("Session not found", { status: 404 })
+    if (pingCount === 1) {
+      if (mode === "400-text") return new Response("Bad Request: No valid session ID provided", { status: 400 })
+      if (mode === "400-json") {
+        return Response.json(
+          { jsonrpc: "2.0", id: "server-error", error: { code: -32600, message: "Bad Request: Missing session ID" } },
+          { status: 400 },
+        )
+      }
+      if (mode === "400-other") return new Response("Bad Request: invalid tool arguments", { status: 400 })
+      return new Response("Session not found", { status: 404 })
+    }
     return Response.json({ jsonrpc: "2.0", id: message.id, result: {} })
   },
 })
@@ -43,7 +54,9 @@ const client = new Client({ name: "test", version: "1" })
 try {
   await client.connect(new StreamableHTTPClientTransport(server.url))
   await client.ping()
-  process.stdout.write(JSON.stringify(posts))
+  process.stdout.write(JSON.stringify({ ok: true, posts }))
+} catch (error) {
+  process.stdout.write(JSON.stringify({ ok: false, error: error instanceof Error ? error.message : String(error), posts }))
 } finally {
   await client.close()
   server.stop(true)

--- a/packages/opencode/test/mcp/session-recovery.test.ts
+++ b/packages/opencode/test/mcp/session-recovery.test.ts
@@ -1,27 +1,61 @@
 import path from "node:path"
 import { describe, expect, test } from "bun:test"
 
+async function runFixture(mode: string) {
+  const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "../fixture/mcp-session-recovery.ts"), mode], {
+    cwd: path.join(import.meta.dir, "../.."),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [code, stdout, stderr] = await Promise.all([
+    child.exited,
+    Bun.readableStreamToText(child.stdout),
+    Bun.readableStreamToText(child.stderr),
+  ])
+
+  expect(code, stderr).toBe(0)
+  return JSON.parse(stdout) as {
+    ok: boolean
+    error?: string
+    posts: Array<{ method: string; session: string | null }>
+  }
+}
+
+const recoveredPosts = [
+  { method: "initialize", session: null },
+  { method: "notifications/initialized", session: "expired" },
+  { method: "ping", session: "expired" },
+  { method: "initialize", session: null },
+  { method: "notifications/initialized", session: "replacement" },
+  { method: "ping", session: "replacement" },
+]
+
 describe("mcp session recovery", () => {
   test("reinitializes and retries once after a session-bound POST returns 404", async () => {
-    const child = Bun.spawn([process.execPath, path.join(import.meta.dir, "../fixture/mcp-session-recovery.ts")], {
-      cwd: path.join(import.meta.dir, "../.."),
-      stdout: "pipe",
-      stderr: "pipe",
-    })
-    const [code, stdout, stderr] = await Promise.all([
-      child.exited,
-      Bun.readableStreamToText(child.stdout),
-      Bun.readableStreamToText(child.stderr),
-    ])
+    const result = await runFixture("404")
 
-    expect(code, stderr).toBe(0)
-    expect(JSON.parse(stdout)).toEqual([
+    expect(result.ok).toBe(true)
+    expect(result.posts).toEqual(recoveredPosts)
+  })
+
+  test("reinitializes and retries once after a POST returns a 400 missing-session error", async () => {
+    for (const mode of ["400-text", "400-json"]) {
+      const result = await runFixture(mode)
+
+      expect(result.ok).toBe(true)
+      expect(result.posts).toEqual(recoveredPosts)
+    }
+  })
+
+  test("does not retry unrelated 400 responses", async () => {
+    const result = await runFixture("400-other")
+
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain("Error POSTing to endpoint")
+    expect(result.posts).toEqual([
       { method: "initialize", session: null },
       { method: "notifications/initialized", session: "expired" },
       { method: "ping", session: "expired" },
-      { method: "initialize", session: null },
-      { method: "notifications/initialized", session: "replacement" },
-      { method: "ping", session: "replacement" },
     ])
   })
 })

--- a/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
+++ b/patches/@modelcontextprotocol%2Fsdk@1.29.0.patch
@@ -173,7 +173,9 @@ index a29a7d3a0f14d9cd800ef5b296485237350c666f..c362ae5fe6c62c8c8eae7e2e61de1eed
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId && !isSessionRetry && !(0, types_js_1.isInitializedNotification)(message)) {
++                const sessionExpired = response.status === 404 ||
++                    (response.status === 400 && typeof text === 'string' && /(?:no valid|missing|invalid)[\s-]+session id|session id[\s-]+(?:missing|invalid)/i.test(text));
++                if (sessionExpired && requestSessionId && !isSessionRetry && !(0, types_js_1.isInitializedNotification)(message)) {
 +                    const recovered = await this._recoverSession(requestSessionId);
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');
@@ -377,7 +379,9 @@ index 624172aa24ae255a67c083f9c19053343e4a0581..ac75b14545fda44aff7ff4d97cc5da88
              }
              if (!response.ok) {
                  const text = await response.text().catch(() => null);
-+                if (response.status === 404 && requestSessionId && !isSessionRetry && !isInitializedNotification(message)) {
++                const sessionExpired = response.status === 404 ||
++                    (response.status === 400 && typeof text === 'string' && /(?:no valid|missing|invalid)[\s-]+session id|session id[\s-]+(?:missing|invalid)/i.test(text));
++                if (sessionExpired && requestSessionId && !isSessionRetry && !isInitializedNotification(message)) {
 +                    const recovered = await this._recoverSession(requestSessionId);
 +                    if (options?.isRequestActive?.() === false) {
 +                        throw new Error('Request is no longer active');


### PR DESCRIPTION
### Issue for this PR

Closes #32809

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extends Streamable HTTP MCP session recovery to cover HTTP 400 responses that clearly indicate a missing, invalid, or not-valid MCP session id. The existing 404 recovery path is preserved, and unrelated 400 responses continue to fail without retrying.

The recovery fixture now covers:

- existing 404 stale-session recovery
- plain-text 400 missing-session responses
- JSON-RPC 400 missing-session responses
- unrelated 400 responses that should not retry

### How did you verify your code works?

- `npx --yes bun@1.3.14 test test/mcp/session-recovery.test.ts` in `packages/opencode`
- `npx --yes bun@1.3.14 run typecheck` in `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
