### PR TITLE
docs: add Vestige MCP example

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -26,6 +26,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-devcontainers](https://github.com/athal7/opencode-devcontainers)                         | Multi-branch devcontainer isolation with shallow clones and auto-assigned ports                    |
 | [opencode-google-antigravity-auth](https://github.com/shekohex/opencode-google-antigravity-auth)   | Google Antigravity OAuth Plugin, with support for Google Search, and more robust API handling      |
 | [opencode-dynamic-context-pruning](https://github.com/Tarquinen/opencode-dynamic-context-pruning)  | Optimize token usage by pruning obsolete tool outputs                                              |
+| [Vestige](https://github.com/samvallad33/vestige)                                                  | Local-first MCP memory server for saving and recalling project context across sessions             |
 | [opencode-vibeguard](https://github.com/inkdust2021/opencode-vibeguard)                            | Redact secrets/PII into VibeGuard-style placeholders before LLM calls; restore locally             |
 | [opencode-websearch-cited](https://github.com/ghoulr/opencode-websearch-cited.git)                 | Add native websearch support for supported providers with Google grounded style                    |
 | [opencode-pty](https://github.com/shekohex/opencode-pty.git)                                       | Enables AI agents to run background processes in a PTY, send interactive input to them.            |

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -110,6 +110,22 @@ And to use it I can add `use the mcp_everything tool` to my prompts.
 use the mcp_everything tool to add the number 3 and 4
 ```
 
+For a local memory server, you can add [Vestige](https://github.com/samvallad33/vestige) with an extended startup timeout:
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "vestige": {
+      "type": "local",
+      "command": ["npx", "-y", "-p", "vestige-mcp-server@latest", "vestige-mcp"],
+      "enabled": true,
+      "timeout": 60000,
+    },
+  },
+}
+```
+
 ---
 
 #### Options


### PR DESCRIPTION
## Summary
- add Vestige as a local MCP server example with the tested npx command
- list Vestige in the ecosystem plugins table

Closes #31402

## Verification
- bun run build
- bun turbo typecheck