### PR TITLE
fix(tool): hide unavailable tool guidance

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -301,13 +301,17 @@ const layer = Layer.effect(
         ? yield* describeCodeMode(input)
         : undefined
       const visible = filtered.filter((tool) => tool.id !== "execute" || codeModeDescription)
-      const available = new Set(visible.map((tool) => tool.id))
+      const disabled = Permission.disabled(
+        visible.map((tool) => tool.id),
+        input.agent.permission,
+      )
+      const available = new Set(visible.map((tool) => tool.id).filter((id) => !disabled.has(id)))
 
       return yield* Effect.forEach(
         visible,
         Effect.fnUntraced(function* (tool: Tool.Def) {
           const output = {
-            description: tool.description,
+            description: describeAvailableTools(tool.id, tool.description, available),
             parameters: tool.parameters,
             jsonSchema: tool.jsonSchema,
           }

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -42,6 +42,7 @@ import { Question } from "../question"
 import { Todo } from "../session/todo"
 import { LSP } from "@/lsp/lsp"
 import { Instruction } from "../session/instruction"
+import { ShellID } from "./shell/id"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Agent } from "../agent/agent"
@@ -296,11 +297,11 @@ const layer = Layer.effect(
 
         return true
       })
-
       const codeModeDescription = filtered.some((tool) => tool.id === "execute")
         ? yield* describeCodeMode(input)
         : undefined
       const visible = filtered.filter((tool) => tool.id !== "execute" || codeModeDescription)
+      const available = new Set(visible.map((tool) => tool.id))
 
       return yield* Effect.forEach(
         visible,
@@ -318,7 +319,7 @@ const layer = Layer.effect(
           return {
             id: tool.id,
             description: [
-              output.description,
+              describeAvailableTools(tool.id, output.description, available),
               tool.id === TaskTool.id ? yield* describeTask(input.agent) : undefined,
               tool.id === "execute" ? codeModeDescription : undefined,
             ]
@@ -417,6 +418,52 @@ function normalizeZodJsonSchema(value: unknown): unknown {
 
 function isJsonSchemaObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function describeAvailableTools(toolID: string, description: string, available: ReadonlySet<string>) {
+  if (toolID === ShellID.ToolID) return filterShellToolHints(description, available)
+  if (toolID === TaskTool.id) return filterTaskToolHints(description, available)
+  return description
+}
+
+function filterShellToolHints(description: string, available: ReadonlySet<string>) {
+  return description
+    .split("\n")
+    .filter((line) => {
+      const match = line.match(/^\s*-\s+(?:File search|Content search|Read files|Edit files|Write files): Use (\w+)/)
+      if (!match) return true
+      return available.has(toolName(match[1]))
+    })
+    .join("\n")
+}
+
+function filterTaskToolHints(description: string, available: ReadonlySet<string>) {
+  return description
+    .split("\n")
+    .filter((line) => {
+      if (/use the Read or Glob tool instead/i.test(line)) return available.has("read") || available.has("glob")
+      if (/use the Grep tool instead/i.test(line)) return available.has("grep")
+      if (/use the Read tool instead/i.test(line)) return available.has("read")
+      return true
+    })
+    .join("\n")
+}
+
+function toolName(name: string) {
+  switch (name.toLowerCase()) {
+    case "glob":
+      return "glob"
+    case "grep":
+      return "grep"
+    case "read":
+      return "read"
+    case "edit":
+      return "edit"
+    case "write":
+      return "write"
+    default:
+      return name.toLowerCase()
+  }
 }
 
 export const node = LayerNode.make({

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -50,6 +50,31 @@ const brokenPluginLayer = Layer.succeed(
   }),
 )
 
+let observedToolDefinitionDescription: string | undefined
+const observingPluginLayer = Layer.succeed(
+  Plugin.Service,
+  Plugin.Service.of({
+    init: () => Effect.void,
+    trigger: ((_name: unknown, input: unknown, output: unknown) => {
+      if (
+        _name === "tool.definition" &&
+        typeof input === "object" &&
+        input !== null &&
+        "toolID" in input &&
+        input.toolID === "bash" &&
+        typeof output === "object" &&
+        output !== null &&
+        "description" in output &&
+        typeof output.description === "string"
+      ) {
+        observedToolDefinitionDescription = output.description
+      }
+      return Effect.succeed(output)
+    }) as Plugin.Interface["trigger"],
+    list: () => Effect.succeed([]),
+  }),
+)
+
 const root = LayerNode.group([ToolRegistry.node, Agent.node])
 const replacements = [
   [Config.node, configLayer],
@@ -94,6 +119,9 @@ const withEmptyCodeMode = testEffect(
   ]),
 )
 const withBrokenPlugin = testEffect(LayerNode.compile(root, [...replacements, [Plugin.node, brokenPluginLayer]]))
+const withObservingPlugin = testEffect(
+  LayerNode.compile(root, [...replacements, [Plugin.node, observingPluginLayer]]),
+)
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -118,6 +146,53 @@ describe("tool.registry", () => {
       expect(shell?.description).toContain("Use Read")
       expect(shell?.description).not.toContain("Use Edit")
       expect(shell?.description).not.toContain("Use Write")
+    }),
+  )
+
+  it.instance("removes permission-denied shell tool hints for non-GPT models", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const agent = yield* Agent.Service
+      const build = yield* agent.get("build")
+      if (!build) throw new Error("build agent not found")
+
+      const shell = (yield* registry.tools({
+        providerID: ProviderV2.ID.opencode,
+        modelID: ModelV2.ID.make("claude-sonnet-4"),
+        agent: {
+          ...build,
+          permission: [...build.permission, { permission: "edit", pattern: "*", action: "deny" }],
+        },
+      })).find((tool) => tool.id === "bash")
+
+      expect(shell?.description).toContain("Use Glob")
+      expect(shell?.description).toContain("Use Grep")
+      expect(shell?.description).toContain("Use Read")
+      expect(shell?.description).not.toContain("Use Edit")
+      expect(shell?.description).not.toContain("Use Write")
+    }),
+  )
+
+  withObservingPlugin.instance("filters unavailable tool hints before tool.definition plugins observe them", () =>
+    Effect.gen(function* () {
+      observedToolDefinitionDescription = undefined
+      const registry = yield* ToolRegistry.Service
+      const agent = yield* Agent.Service
+      const build = yield* agent.get("build")
+      if (!build) throw new Error("build agent not found")
+
+      yield* registry.tools({
+        providerID: ProviderV2.ID.opencode,
+        modelID: ModelV2.ID.make("claude-sonnet-4"),
+        agent: {
+          ...build,
+          permission: [...build.permission, { permission: "edit", pattern: "*", action: "deny" }],
+        },
+      })
+
+      expect(observedToolDefinitionDescription).toBeDefined()
+      expect(observedToolDefinitionDescription).not.toContain("Use Edit")
+      expect(observedToolDefinitionDescription).not.toContain("Use Write")
     }),
   )
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -4,7 +4,7 @@ import fs from "fs/promises"
 import { fileURLToPath, pathToFileURL } from "url"
 import { Effect, Layer, Result, Schema } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { ToolRegistry } from "@/tool/registry"
+import { describeAvailableTools, ToolRegistry } from "@/tool/registry"
 import { Tool } from "@/tool/tool"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -100,6 +100,43 @@ afterEach(async () => {
 })
 
 describe("tool.registry", () => {
+  it.instance("removes unavailable shell tool hints from model-facing descriptions", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const agent = yield* Agent.Service
+      const build = yield* agent.get("build")
+      if (!build) throw new Error("build agent not found")
+
+      const shell = (yield* registry.tools({
+        providerID: ProviderV2.ID.opencode,
+        modelID: ModelV2.ID.make("gpt-5"),
+        agent: build,
+      })).find((tool) => tool.id === "bash")
+
+      expect(shell?.description).toContain("Use Glob")
+      expect(shell?.description).toContain("Use Grep")
+      expect(shell?.description).toContain("Use Read")
+      expect(shell?.description).not.toContain("Use Edit")
+      expect(shell?.description).not.toContain("Use Write")
+    }),
+  )
+
+  it.instance("removes unavailable task tool hints from model-facing descriptions", () =>
+    Effect.gen(function* () {
+      const description = [
+        "- If you want to read a specific file path, use the Read or Glob tool instead of the Task tool",
+        '- If you are searching for a specific class definition like "class Foo", use the Grep tool instead',
+        "- If you are searching for code within a specific file or set of 2-3 files, use the Read tool instead",
+      ].join("\n")
+
+      expect(describeAvailableTools("task", description, new Set(["task", "glob"]))).toContain("Read or Glob")
+      const filtered = describeAvailableTools("task", description, new Set(["task"]))
+      expect(filtered).not.toContain("Read or Glob")
+      expect(filtered).not.toContain("Grep tool")
+      expect(filtered).not.toContain("Read tool")
+    }),
+  )
+
   it.instance("does not expose task_status", () =>
     Effect.gen(function* () {
       const registry = yield* ToolRegistry.Service


### PR DESCRIPTION
### Issue for this PR

Closes #32704

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Filters model-facing tool descriptions after model/tool availability has been resolved, so shell and task descriptions no longer tell the model to use tools that are not actually exposed.

This keeps the existing shell guidance for available tools, but removes lines such as `Use Edit` / `Use Write` for GPT-style tool sets where `apply_patch` replaces edit/write. Task guidance also drops direct `Read` / `Grep` / `Glob` recommendations when those tools are unavailable.

### How did you verify your code works?

- `npx --yes bun@1.3.14 test test/tool/registry.test.ts` in `packages/opencode`
- `npx --yes bun@1.3.14 run typecheck` in `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
