### PR TITLE
fix(config): normalize Windows env paths in config tokens

### DIFF
--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -34,7 +34,7 @@ function dir(input: ParseSource) {
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
   let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-    return (input.env?.[varName] ?? process.env[varName]) || ""
+    return normalizePathEnvValue((input.env?.[varName] ?? process.env[varName]) || "")
   })
 
   const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))
@@ -88,4 +88,9 @@ export async function substitute(input: SubstituteInput) {
 
   out += text.slice(cursor)
   return out
+}
+
+function normalizePathEnvValue(value: string) {
+  if (/^[A-Za-z]:\\/.test(value) || value.startsWith("\\\\")) return value.replaceAll("\\", "/")
+  return value
 }

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -515,6 +515,32 @@ it.instance("handles environment variable substitution", () =>
   ),
 )
 
+it.instance("normalizes Windows path env variables before parsing permission keys", () =>
+  withProcessEnv(
+    "TEST_PERMISSION_DIR",
+    String.raw`C:\Users\me\AppData\Roaming\MyApp\config`,
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* FSUtil.use.writeWithDirs(
+        path.join(test.directory, "opencode.json"),
+        `{
+          "$schema": "https://opencode.ai/config.json",
+          "permission": {
+            "external_directory": {
+              "{env:TEST_PERMISSION_DIR}/**": "allow"
+            }
+          }
+        }`,
+      )
+
+      const config = yield* Config.use.get()
+      expect(config.permission?.external_directory).toEqual({
+        "C:/Users/me/AppData/Roaming/MyApp/config/**": "allow",
+      })
+    }),
+  ),
+)
+
 it.instance("preserves env variables when adding $schema to config", () =>
   withProcessEnv(
     "PRESERVE_VAR",


### PR DESCRIPTION
### Issue for this PR

Closes #32695

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Normalizes native Windows path separators in `{env:...}` config substitutions before JSONC parsing sees them. This keeps permission keys such as `{env:MYDIR}/**` parseable when `MYDIR` is set to a Windows path like `C:\Users\me\...`, while leaving non-path env values unchanged.

Adds a regression test that loads a config with a Windows-style env var inside `permission.external_directory` and verifies the resulting rule uses forward slashes.

### How did you verify your code works?

- `npx --yes bun@1.3.14 test test/config/config.test.ts`
- `npx --yes bun@1.3.14 run typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR