### PR TITLE
fix(glob): match explicitly requested dot directories

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -47,7 +47,13 @@ export const GlobTool = Tool.define(
           })
 
           const limit = 100
-          const files = yield* ripgrep.glob({ cwd: search, pattern: params.pattern, limit })
+          const files = yield* ripgrep.glob({
+            cwd: search,
+            pattern: params.pattern,
+            limit,
+            hidden:
+              includesDotPathSegment(params.pattern) || includesDotPathSegment(path.relative(ins.directory, search)),
+          })
           const truncated = files.length === limit
 
           const output = []
@@ -74,3 +80,10 @@ export const GlobTool = Tool.define(
     }
   }),
 )
+
+function includesDotPathSegment(value: string) {
+  return value
+    .replaceAll("\\", "/")
+    .split("/")
+    .some((segment) => segment.startsWith(".") && segment !== "." && segment !== "..")
+}

--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -110,6 +110,25 @@ describe("tool.glob", () => {
     }),
   )
 
+  it.instance("matches files under explicitly requested dot directories", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const target = path.join(test.directory, ".ai", "current-task.md")
+      yield* Effect.promise(() => Bun.write(target, "ship it\n"))
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      const result = yield* glob.execute(
+        {
+          pattern: ".ai/**/*.md",
+          path: test.directory,
+        },
+        ctx,
+      )
+      expect(result.metadata.count).toBe(1)
+      expect(result.output).toContain(target)
+    }),
+  )
+
   it.instance("rejects exact file paths", () =>
     Effect.gen(function* () {
       const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #32669

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows the Glob tool to match files under dot directories when the user explicitly asks for one, such as `.ai/**/*.md` or a search path inside `.ai`.

The tool now enables ripgrep hidden-file scanning only when the requested glob pattern or search path includes a dot-directory segment, so ordinary patterns like `*.md` keep the previous default behavior.

### How did you verify your code works?

- `npx --yes bun@1.3.14 test test/tool/glob.test.ts`
- `npx --yes bun@1.3.14 run typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR