### PR TITLE
perf(plugin): index trigger hooks by name

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -34,6 +34,7 @@ import { InstallationChannel } from "@opencode-ai/core/installation/version"
 
 type State = {
   hooks: Hooks[]
+  hooksByName: Map<string, Hooks[]>
 }
 
 // Hook names that follow the (input, output) => Promise<void> trigger pattern
@@ -118,6 +119,19 @@ async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks:
   for (const server of getLegacyPlugins(load.mod)) {
     hooks.push(await server(input, load.options))
   }
+}
+
+function buildHooksByName(hooks: Hooks[]) {
+  const result = new Map<string, Hooks[]>()
+  for (const hook of hooks) {
+    for (const [name, fn] of Object.entries(hook)) {
+      if (typeof fn !== "function") continue
+      const list = result.get(name)
+      if (list) list.push(hook)
+      else result.set(name, [hook])
+    }
+  }
+  return result
 }
 
 export const layer = Layer.effect(
@@ -248,15 +262,19 @@ export const layer = Layer.effect(
           )
         }
 
-        const unsubscribe = yield* events.listen((event) => {
-          if (event.location?.directory !== ctx.directory) return Effect.void
-          return Effect.sync(() => {
-            for (const hook of hooks) {
-              void hook["event"]?.({ event: { id: event.id, type: event.type, properties: event.data } as any })
-            }
+        const hooksByName = buildHooksByName(hooks)
+        const eventHooks = hooksByName.get("event")
+        if (eventHooks?.length) {
+          const unsubscribe = yield* events.listen((event) => {
+            if (event.location?.directory !== ctx.directory) return Effect.void
+            return Effect.sync(() => {
+              for (const hook of eventHooks) {
+                void hook.event?.({ event: { id: event.id, type: event.type, properties: event.data } as any })
+              }
+            })
           })
-        })
-        yield* Effect.addFinalizer(() => unsubscribe)
+          yield* Effect.addFinalizer(() => unsubscribe)
+        }
 
         yield* Effect.addFinalizer(() =>
           Effect.forEach(
@@ -273,7 +291,7 @@ export const layer = Layer.effect(
           ),
         )
 
-        return { hooks }
+        return { hooks, hooksByName }
       }),
     )
 
@@ -284,9 +302,10 @@ export const layer = Layer.effect(
     >(name: Name, input: Input, output: Output) {
       if (!name) return output
       const s = yield* InstanceState.get(state)
-      for (const hook of s.hooks) {
+      const hooks = s.hooksByName.get(name as string)
+      if (!hooks) return output
+      for (const hook of hooks) {
         const fn = hook[name] as any
-        if (!fn) continue
         yield* Effect.promise(async () => fn(input, output))
       }
       return output

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -41,20 +41,21 @@ const it = testEffect(
 )
 const systemHook = "experimental.chat.system.transform"
 
-function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+function withProject<A, E, R>(source: string | string[], self: Effect.Effect<A, E, R>) {
   return Effect.gen(function* () {
     const test = yield* TestInstance
-    const file = path.join(test.directory, "plugin.ts")
+    const sources = Array.isArray(source) ? source : [source]
+    const files = sources.map((_, index) => path.join(test.directory, `plugin-${index}.ts`))
     yield* Effect.all(
       [
-        Effect.promise(() => Bun.write(file, source)),
+        ...sources.map((item, index) => Effect.promise(() => Bun.write(files[index]!, item))),
         Effect.promise(() =>
           Bun.write(
             path.join(test.directory, "opencode.json"),
             JSON.stringify(
               {
                 $schema: "https://opencode.ai/config.json",
-                plugin: [pathToFileURL(file).href],
+                plugin: files.map((file) => pathToFileURL(file).href),
               },
               null,
               2,
@@ -114,6 +115,33 @@ describe("plugin.trigger", () => {
       ].join("\n"),
       Effect.gen(function* () {
         expect(yield* triggerSystemTransform()).toEqual(["async"])
+      }),
+    ),
+  )
+
+  it.instance("runs matching hooks in plugin order", () =>
+    withProject(
+      [
+        [
+          "export default async () => ({",
+          `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+          '    output.system.push("first")',
+          "  },",
+          "})",
+          "",
+        ].join("\n"),
+        [
+          "export default async () => ({",
+          '  event: () => { throw new Error("should not run during trigger") },',
+          `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+          '    output.system.push("second")',
+          "  },",
+          "})",
+          "",
+        ].join("\n"),
+      ],
+      Effect.gen(function* () {
+        expect(yield* triggerSystemTransform()).toEqual(["first", "second"])
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #32819

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Builds a plugin hook dispatch table once during plugin initialization so `plugin.trigger(...)` can look up matching hooks directly instead of scanning every loaded plugin on each trigger call.

It also reuses the same index to subscribe to the event bridge only when at least one plugin has an `event` hook. Projects without event listeners no longer attach an unused event subscription.

Hook execution order is preserved. A regression test covers multiple plugins with matching and unrelated hooks.

### How did you verify your code works?

- `npx --yes bun@1.3.14 test test/plugin/trigger.test.ts`
- `npx --yes bun@1.3.14 run typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR