### PR TITLE
fix(session): keep AI SDK tool result names

### DIFF
--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -233,7 +233,7 @@ export function toLLMEvents(
 
     case "tool-result":
       return Effect.sync(() => {
-        const name = state.toolNames[event.toolCallId] ?? "unknown"
+        const name = state.toolNames[event.toolCallId] ?? ("toolName" in event ? event.toolName : "unknown")
         delete state.toolNames[event.toolCallId]
         return [
           LLMEvent.toolResult({

--- a/packages/opencode/test/session/llm-ai-sdk.test.ts
+++ b/packages/opencode/test/session/llm-ai-sdk.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { LLMAISDK } from "@/session/llm/ai-sdk"
+
+describe("session.llm.ai-sdk adapter", () => {
+  type AISDKAdapterEvent = Parameters<typeof LLMAISDK.toLLMEvents>[1]
+
+  const adapt = (events: ReadonlyArray<AISDKAdapterEvent>) => {
+    const state = LLMAISDK.adapterState()
+    return Effect.runPromise(
+      Effect.forEach(events, (event) => LLMAISDK.toLLMEvents(state, event)).pipe(Effect.map((items) => items.flat())),
+    )
+  }
+
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- tests defensive adapter branches outside AI SDK's current typed surface
+  const uncheckedAdapterEvent = (input: unknown) => input as AISDKAdapterEvent
+
+  test("keeps the AI SDK tool-result name when the local name cache is missing", async () => {
+    const events = await adapt([
+      uncheckedAdapterEvent({
+        type: "tool-result",
+        toolCallId: "call_123",
+        toolName: "bash",
+        output: { title: "Bash", output: "done", metadata: {} },
+      }),
+    ])
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      type: "tool-result",
+      id: "call_123",
+      name: "bash",
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31646

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the AI SDK emits a `tool-result` event after the local tool-call name cache misses, opencode currently labels the result as `unknown`. The event still carries `toolName`, so this uses that value before falling back to `unknown`.

This keeps the tool result paired with the real tool name and avoids feeding an `unknown` tool result back into the session history.

### How did you verify your code works?

- `bun test test/session/llm-ai-sdk.test.ts`
- `bun test test/session/llm.test.ts`
- `bun test test/session/processor-effect.test.ts`
- `bun prettier --check packages/opencode/src/session/llm/ai-sdk.ts packages/opencode/test/session/llm-ai-sdk.test.ts`
- `git diff --check`

I also ran the local path lint command; it exited 0 with existing warnings in `ai-sdk.ts`.

The pre-push hook runs full monorepo typecheck and currently fails in unrelated `packages/ui` / `packages/enterprise` files before this change. This PR only changes the AI SDK adapter and its focused test.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR