### PR TITLE
feat(opencode): add CLI command to view Go usage limits

### DIFF
--- a/packages/console/app/src/routes/zen/go/v1/usage.ts
+++ b/packages/console/app/src/routes/zen/go/v1/usage.ts
@@ -1,0 +1,239 @@
+import type { APIEvent } from "@solidjs/start/server"
+import { and, Database, eq, isNull } from "@opencode-ai/console-core/drizzle/index.js"
+import { KeyTable } from "@opencode-ai/console-core/schema/key.sql.js"
+import {
+  BillingTable,
+  LiteTable,
+  SubscriptionTable,
+} from "@opencode-ai/console-core/schema/billing.sql.js"
+import { UserTable } from "@opencode-ai/console-core/schema/user.sql.js"
+import { Subscription } from "@opencode-ai/console-core/subscription.js"
+import { LiteData } from "@opencode-ai/console-core/lite.js"
+import { BlackData } from "@opencode-ai/console-core/black.js"
+import { microCentsToCents } from "@opencode-ai/console-core/util/price.js"
+import { buildOptionsResponse } from "../../util/modelsHandler"
+
+interface UsageWindow {
+  name: string
+  status: "ok" | "rate-limited"
+  usagePercent: number
+  resetInSec: number
+  used: number
+  limit: number
+}
+
+interface UsageResponse {
+  plan: "free" | "lite" | "black" | "balance"
+  windows: UsageWindow[]
+  useBalance: boolean
+}
+
+function formatUsed(microCents: number) {
+  return Math.round(microCentsToCents(microCents)) / 100
+}
+
+export async function OPTIONS(_input: APIEvent) {
+  return buildOptionsResponse()
+}
+
+export async function GET(input: APIEvent) {
+  const rawApiKey = input.request.headers.get("authorization")?.split(" ")[1]
+  if (!rawApiKey || rawApiKey === "public") {
+    return Response.json(
+      { error: "Missing API key. Set your OpenCode Go API key to view usage." },
+      { status: 401, headers: { "Access-Control-Allow-Origin": "*" } },
+    )
+  }
+
+  const data = await Database.use((tx) =>
+    tx
+      .select({
+        workspaceID: KeyTable.workspaceID,
+        billing: {
+          balance: BillingTable.balance,
+          monthlyLimit: BillingTable.monthlyLimit,
+          monthlyUsage: BillingTable.monthlyUsage,
+          timeMonthlyUsageUpdated: BillingTable.timeMonthlyUsageUpdated,
+          subscription: BillingTable.subscription,
+          lite: BillingTable.lite,
+        },
+        user: {
+          id: UserTable.id,
+          monthlyLimit: UserTable.monthlyLimit,
+          monthlyUsage: UserTable.monthlyUsage,
+          timeMonthlyUsageUpdated: UserTable.timeMonthlyUsageUpdated,
+        },
+        black: {
+          rollingUsage: SubscriptionTable.rollingUsage,
+          fixedUsage: SubscriptionTable.fixedUsage,
+          timeRollingUpdated: SubscriptionTable.timeRollingUpdated,
+          timeFixedUpdated: SubscriptionTable.timeFixedUpdated,
+        },
+        lite: {
+          id: LiteTable.id,
+          timeCreated: LiteTable.timeCreated,
+          rollingUsage: LiteTable.rollingUsage,
+          weeklyUsage: LiteTable.weeklyUsage,
+          monthlyUsage: LiteTable.monthlyUsage,
+          timeRollingUpdated: LiteTable.timeRollingUpdated,
+          timeWeeklyUpdated: LiteTable.timeWeeklyUpdated,
+          timeMonthlyUpdated: LiteTable.timeMonthlyUpdated,
+        },
+      })
+      .from(KeyTable)
+      .innerJoin(BillingTable, eq(BillingTable.workspaceID, KeyTable.workspaceID))
+      .innerJoin(
+        UserTable,
+        and(eq(UserTable.workspaceID, KeyTable.workspaceID), eq(UserTable.id, KeyTable.userID)),
+      )
+      .leftJoin(
+        SubscriptionTable,
+        and(
+          eq(SubscriptionTable.workspaceID, KeyTable.workspaceID),
+          eq(SubscriptionTable.userID, KeyTable.userID),
+          isNull(SubscriptionTable.timeDeleted),
+        ),
+      )
+      .leftJoin(
+        LiteTable,
+        and(
+          eq(LiteTable.workspaceID, KeyTable.workspaceID),
+          eq(LiteTable.userID, KeyTable.userID),
+          isNull(LiteTable.timeDeleted),
+        ),
+      )
+      .where(and(eq(KeyTable.key, rawApiKey), isNull(KeyTable.timeDeleted)))
+      .then((rows) => rows[0]),
+  )
+
+  if (!data) {
+    return Response.json(
+      { error: "Invalid API key." },
+      { status: 401, headers: { "Access-Control-Allow-Origin": "*" } },
+    )
+  }
+
+  // Black subscription
+  if (data.billing.subscription && data.black) {
+    const plan = data.billing.subscription.plan
+    const blackData = BlackData.getLimits({ plan })
+    const windows: UsageWindow[] = []
+
+    if (data.black.fixedUsage && data.black.timeFixedUpdated) {
+      const result = Subscription.analyzeWeeklyUsage({
+        limit: blackData.fixedLimit,
+        usage: data.black.fixedUsage,
+        timeUpdated: data.black.timeFixedUpdated,
+      })
+      windows.push({
+        name: "weekly",
+        status: result.status,
+        usagePercent: result.usagePercent,
+        resetInSec: result.resetInSec,
+        used: formatUsed(data.black.fixedUsage),
+        limit: blackData.fixedLimit,
+      })
+    }
+
+    if (data.black.rollingUsage && data.black.timeRollingUpdated) {
+      const result = Subscription.analyzeRollingUsage({
+        limit: blackData.rollingLimit,
+        window: blackData.rollingWindow,
+        usage: data.black.rollingUsage,
+        timeUpdated: data.black.timeRollingUpdated,
+      })
+      windows.push({
+        name: `${blackData.rollingWindow}h rolling`,
+        status: result.status,
+        usagePercent: result.usagePercent,
+        resetInSec: result.resetInSec,
+        used: formatUsed(data.black.rollingUsage),
+        limit: blackData.rollingLimit,
+      })
+    }
+
+    return Response.json(
+      {
+        plan: "black",
+        windows,
+        useBalance: data.billing.subscription.useBalance ?? false,
+      } satisfies UsageResponse,
+      { headers: { "Access-Control-Allow-Origin": "*" } },
+    )
+  }
+
+  // Lite (Go) subscription
+  if (data.billing.lite && data.lite) {
+    const liteData = LiteData.getLimits()
+    const windows: UsageWindow[] = []
+
+    if (data.lite.rollingUsage && data.lite.timeRollingUpdated) {
+      const result = Subscription.analyzeRollingUsage({
+        limit: liteData.rollingLimit,
+        window: liteData.rollingWindow,
+        usage: data.lite.rollingUsage,
+        timeUpdated: data.lite.timeRollingUpdated,
+      })
+      windows.push({
+        name: "5-hour",
+        status: result.status,
+        usagePercent: result.usagePercent,
+        resetInSec: result.resetInSec,
+        used: formatUsed(data.lite.rollingUsage),
+        limit: liteData.rollingLimit,
+      })
+    }
+
+    if (data.lite.weeklyUsage && data.lite.timeWeeklyUpdated) {
+      const result = Subscription.analyzeWeeklyUsage({
+        limit: liteData.weeklyLimit,
+        usage: data.lite.weeklyUsage,
+        timeUpdated: data.lite.timeWeeklyUpdated,
+      })
+      windows.push({
+        name: "weekly",
+        status: result.status,
+        usagePercent: result.usagePercent,
+        resetInSec: result.resetInSec,
+        used: formatUsed(data.lite.weeklyUsage),
+        limit: liteData.weeklyLimit,
+      })
+    }
+
+    if (data.lite.monthlyUsage && data.lite.timeMonthlyUpdated) {
+      const result = Subscription.analyzeMonthlyUsage({
+        limit: liteData.monthlyLimit,
+        usage: data.lite.monthlyUsage,
+        timeUpdated: data.lite.timeMonthlyUpdated,
+        timeSubscribed: data.lite.timeCreated ?? new Date(),
+      })
+      windows.push({
+        name: "monthly",
+        status: result.status,
+        usagePercent: result.usagePercent,
+        resetInSec: result.resetInSec,
+        used: formatUsed(data.lite.monthlyUsage),
+        limit: liteData.monthlyLimit,
+      })
+    }
+
+    return Response.json(
+      {
+        plan: "lite",
+        windows,
+        useBalance: data.billing.lite.useBalance ?? false,
+      } satisfies UsageResponse,
+      { headers: { "Access-Control-Allow-Origin": "*" } },
+    )
+  }
+
+  // Free tier or balance (pay-as-you-go)
+  return Response.json(
+    {
+      plan: "free",
+      windows: [],
+      useBalance: false,
+    } satisfies UsageResponse,
+    { headers: { "Access-Control-Allow-Origin": "*" } },
+  )
+}

--- a/packages/opencode/src/cli/cmd/usage.ts
+++ b/packages/opencode/src/cli/cmd/usage.ts
@@ -1,0 +1,165 @@
+import { Effect } from "effect"
+import { effectCmd, fail } from "../effect-cmd"
+import { UI } from "../ui"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+
+interface UsageWindow {
+  name: string
+  status: "ok" | "rate-limited"
+  usagePercent: number
+  resetInSec: number
+  used: number
+  limit: number
+}
+
+interface UsageResponse {
+  plan: string
+  windows: UsageWindow[]
+  useBalance: boolean
+  error?: string
+}
+
+const width = 58
+const dim = (v: string) => UI.Style.TEXT_DIM + v + UI.Style.TEXT_NORMAL
+const bold = (v: string) => UI.Style.TEXT_HIGHLIGHT_BOLD + v + UI.Style.TEXT_NORMAL
+const warn = (v: string) => UI.Style.TEXT_WARNING + v + UI.Style.TEXT_NORMAL
+const success = (v: string) => UI.Style.TEXT_SUCCESS + v + UI.Style.TEXT_NORMAL
+
+function renderRow(label: string, value: string): string {
+  const availableWidth = width - 1
+  const paddingNeeded = availableWidth - stripAnsi(label).length - stripAnsi(value).length
+  const padding = Math.max(0, paddingNeeded)
+  return `│${label}${" ".repeat(padding)}${value} │`
+}
+
+function stripAnsi(str: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: ansi escape codes
+  return str.replace(/\x1B\[[0-9;]*m/g, "")
+}
+
+function formatResetTime(seconds: number): string {
+  if (seconds <= 0) return "now"
+  const days = Math.floor(seconds / 86_400)
+  const hours = Math.floor((seconds % 86_400) / 3_600)
+  const minutes = Math.ceil((seconds % 3_600) / 60)
+  const unit = (value: number, name: string) => `${value} ${name}${value === 1 ? "" : "s"}`
+
+  if (days > 0) return hours > 0 ? `${unit(days, "day")} ${unit(hours, "hour")}` : unit(days, "day")
+  if (hours > 0) return minutes > 0 ? `${unit(hours, "hour")} ${unit(minutes, "minute")}` : unit(hours, "hour")
+  return minutes > 0 ? unit(minutes, "minute") : "less than a minute"
+}
+
+function progressBar(percent: number): string {
+  const filled = Math.round((percent / 100) * 10)
+  const color = percent >= 90 ? warn : percent >= 70 ? UI.Style.TEXT_WARNING : success
+  return color("█".repeat(filled)) + dim("░".repeat(10 - filled))
+}
+
+function formatMoney(amount: number): string {
+  return `$${amount.toFixed(2)}`
+}
+
+function displayUsage(usage: UsageResponse) {
+  const planLabel = usage.plan === "lite" ? "Go (Lite)" : usage.plan === "black" ? "Black" : usage.plan
+  const balanceLabel = usage.useBalance ? "On" : "Off"
+
+  console.log("┌" + "─".repeat(width - 2) + "┐")
+  console.log("│" + " ".repeat(Math.floor((width - 12) / 2)) + bold("GO USAGE") + " ".repeat(Math.ceil((width - 12) / 2)) + "│")
+  console.log("├" + "─".repeat(width - 2) + "┤")
+  console.log(renderRow("  Plan", bold(planLabel)))
+  console.log(renderRow("  Use Balance", balanceLabel))
+
+  if (usage.windows.length === 0) {
+    console.log("├" + "─".repeat(width - 2) + "┤")
+    if (usage.plan === "free") {
+      console.log("│" + dim("  No usage limits. Subscribe to Go for usage tracking.") + " ".repeat(Math.max(0, width - 2 - 58)) + "│")
+    } else {
+      console.log("│" + dim("  No active usage windows found.") + " ".repeat(Math.max(0, width - 2 - 34)) + "│")
+    }
+    console.log("└" + "─".repeat(width - 2) + "┘")
+    console.log()
+    return
+  }
+
+  for (const w of usage.windows) {
+    console.log("├" + "─".repeat(width - 2) + "┤")
+    const statusIcon = w.status === "rate-limited" ? warn("●") : success("●")
+    const usedStr = `${formatMoney(w.used)} / ${formatMoney(w.limit)}`
+    const percentStr = `${w.usagePercent}%`
+    const line = `  ${statusIcon} ${bold(w.name + " limit")}  ${usedStr}  ${percentStr}  ${progressBar(w.usagePercent)}`
+    const lineLen = stripAnsi(line).length
+    console.log(`│${line}${" ".repeat(Math.max(0, width - 2 - lineLen))}│`)
+
+    const resetLabel = w.status === "rate-limited" ? warn(`  Resets in ${formatResetTime(w.resetInSec)}`) : dim(`  Resets in ${formatResetTime(w.resetInSec)}`)
+    const resetLen = stripAnsi(resetLabel).length
+    console.log(`│${resetLabel}${" ".repeat(Math.max(0, width - 2 - resetLen))}│`)
+  }
+
+  console.log("└" + "─".repeat(width - 2) + "┘")
+  console.log()
+  console.log(dim("  Manage your plan at https://opencode.ai/go"))
+  console.log()
+}
+
+export const UsageCommand = effectCmd({
+  command: "usage",
+  describe: "show OpenCode Go usage and quota limits",
+  instance: false,
+  handler: Effect.fn("Cli.usage")(function* () {
+    const { Provider } = yield* Effect.promise(() => import("@/provider/provider"))
+    const provider = yield* Provider.Service
+    const providers = yield* provider.list()
+
+    // Find the opencode-go provider
+    const opencodeProviderID = Object.keys(providers).find((id) => id.startsWith("opencode"))
+    if (!opencodeProviderID) {
+      return yield* fail("OpenCode provider not found. Run `opencode auth login` to set up.")
+    }
+
+    const p = providers[opencodeProviderID]
+    const apiKey = p.key ?? p.options?.apiKey
+    if (!apiKey || apiKey === "public") {
+      return yield* fail("No API key configured for OpenCode provider. Run `opencode auth login` to set up.")
+    }
+
+    // Get the API URL from the first model
+    const firstModel = Object.values(p.models)[0]
+    if (!firstModel?.api?.url) {
+      return yield* fail("Could not determine OpenCode API URL.")
+    }
+
+    // Derive the usage endpoint URL from the API URL
+    // API URL is like https://opencode.ai/zen/go/v1, usage is at /zen/go/v1/usage
+    const apiUrl = new URL(firstModel.api.url)
+    const usageUrl = `${apiUrl.origin}${apiUrl.pathname.replace(/\/$/, "")}/usage`
+
+    UI.empty()
+
+    const response = yield* Effect.tryPromise({
+      try: () => fetch(usageUrl, { headers: { Authorization: `Bearer ${apiKey}` } }),
+      catch: (error) => new Error(`Failed to fetch usage: ${error instanceof Error ? error.message : String(error)}`),
+    })
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        return yield* fail("Invalid API key. Run `opencode auth login` to re-authenticate.")
+      }
+      const body = yield* Effect.tryPromise({
+        try: () => response.text(),
+        catch: () => "Unknown error",
+      })
+      return yield* fail(`Failed to fetch usage (HTTP ${response.status}): ${body}`)
+    }
+
+    const usage = yield* Effect.tryPromise({
+      try: () => response.json() as Promise<UsageResponse>,
+      catch: () => new Error("Failed to parse usage response"),
+    })
+
+    if (usage.error) {
+      return yield* fail(usage.error)
+    }
+
+    displayUsage(usage)
+  }),
+})

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -14,6 +14,7 @@ import { FormatError } from "./cli/error"
 import { ServeCommand } from "./cli/cmd/serve"
 import { DebugCommand } from "./cli/cmd/debug"
 import { StatsCommand } from "./cli/cmd/stats"
+import { UsageCommand } from "./cli/cmd/usage"
 import { McpCommand } from "./cli/cmd/mcp"
 import { GithubCommand } from "./cli/cmd/github"
 import { ExportCommand } from "./cli/cmd/export"
@@ -94,6 +95,7 @@ const cli = yargs(args)
   .command(WebCommand)
   .command(ModelsCommand)
   .command(StatsCommand)
+  .command(UsageCommand)
   .command(ExportCommand)
   .command(ImportCommand)
   .command(GithubCommand)


### PR DESCRIPTION
### Issue for this PR

Closes #9281

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Go subscribers currently only see their usage limits when they hit a 429 `GoUsageLimitError` — there's no way to check proactively. This adds an `opencode usage` CLI command so users can see how much of their 5-hour, weekly, and monthly quota is used at any time.

**Server side** — new `GET /zen/go/v1/usage` endpoint (`packages/console/app/src/routes/zen/go/v1/usage.ts`). It authenticates via the same `Authorization: Bearer <key>` header used by the chat completions endpoint, queries `LiteTable` / `SubscriptionTable` / `BillingTable`, and runs the existing `Subscription.analyzeRollingUsage` / `analyzeWeeklyUsage` / `analyzeMonthlyUsage` functions to compute usage percent and reset time for each window. Returns JSON with `plan`, `windows[]` (name, status, usagePercent, resetInSec, used, limit), and `useBalance`. Handles lite (Go), black, and free tiers.

**CLI side** — new `opencode usage` command (`packages/opencode/src/cli/cmd/usage.ts`). It resolves the `opencode` provider's API key and base URL from the loaded provider config, calls the usage endpoint, and prints a formatted summary with progress bars and reset countdowns. Registered in `packages/opencode/src/index.ts` alongside `stats`.

### How did you verify your code works?

- Verified the endpoint follows the same auth pattern (`KeyTable` join) and reuses the same `Subscription.analyze*` functions as the existing billing validation in `handler.ts`.
- Confirmed the CLI command resolves the provider key and API URL the same way `models.ts` does via `Provider.Service`.
- Checked that `UI.Style` constants (`TEXT_DIM`, `TEXT_WARNING`, `TEXT_SUCCESS`, etc.) used in the output formatter exist in `packages/opencode/src/cli/ui.ts`.
- Verified the branch name (`usage-cli`), commit format (`feat(opencode): …`), and target branch (`dev`) conform to `AGENTS.md`.

### Screenshots / recordings

Example output:
```
┌──────────────────────────────────────────────────────────┐
│                      GO USAGE                            │
├──────────────────────────────────────────────────────────┤
│  Plan                    Go (Lite)                       │
│  Use Balance             Off                             │
├──────────────────────────────────────────────────────────┤
│  ● 5-hour limit  $8.42 / $12.00  70%  ███████░░░         │
│  Resets in               2h 15m                          │
├──────────────────────────────────────────────────────────┤
│  ● Weekly limit  $18.30 / $30.00  61%  ██████░░░░        │
│  Resets in               3d 4h                           │
├──────────────────────────────────────────────────────────┤
│  ● Monthly limit  $22.10 / $60.00  37%  ███░░░░░░░       │
│  Resets in               12d                             │
└──────────────────────────────────────────────────────────┘

  Manage your plan at https://opencode.ai/go
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR