### PR TITLE
feat(provider): add noumena provider

### DIFF
--- a/packages/core/src/plugin/provider.ts
+++ b/packages/core/src/plugin/provider.ts
@@ -18,6 +18,7 @@ import { KiloPlugin } from "./provider/kilo"
 import { LLMGatewayPlugin } from "./provider/llmgateway"
 import { MistralPlugin } from "./provider/mistral"
 import { NvidiaPlugin } from "./provider/nvidia"
+import { NoumenaPlugin } from "./provider/noumena"
 import { OpenAIPlugin } from "./provider/openai"
 import { SnowflakeCortexPlugin } from "./provider/snowflake-cortex"
 import { OpenAICompatiblePlugin } from "./provider/openai-compatible"
@@ -53,6 +54,7 @@ export const ProviderPlugins = [
   LLMGatewayPlugin,
   MistralPlugin,
   NvidiaPlugin,
+  NoumenaPlugin,
   OpencodePlugin,
   SnowflakeCortexPlugin,
   OpenAICompatiblePlugin,

--- a/packages/core/src/plugin/provider/noumena-auth.ts
+++ b/packages/core/src/plugin/provider/noumena-auth.ts
@@ -1,0 +1,218 @@
+import { createServer } from "node:http"
+import { Deferred, Effect } from "effect"
+import { Credential } from "../../credential"
+import { InstallationVersion } from "../../installation/version"
+import { Integration } from "../../integration"
+
+const defaultAuthorizeURL = "https://code.noumena.com/oauth/authorize"
+const defaultTokenURL = "https://api.noumena.com/oauth/token"
+const defaultClientID = "noumena-code"
+const callbackPort = 1456
+const scopes = "user:profile user:inference user:sessions:ncode user:mcp_servers user:file_upload"
+export const oauthBetaHeader = "oauth-2025-04-20"
+
+type Pkce = {
+  verifier: string
+  challenge: string
+}
+
+type TokenResponse = {
+  access_token: string
+  refresh_token?: string
+  expires_in?: number
+}
+
+const browserMethodID = Integration.MethodID.make("noumena-browser")
+const manualMethodID = Integration.MethodID.make("noumena-code")
+
+export const browser = {
+  integrationID: Integration.ID.make("noumena"),
+  method: {
+    id: browserMethodID,
+    type: "oauth",
+    label: "Noumena Code (browser)",
+  },
+  authorize: () =>
+    Effect.gen(function* () {
+      const pkce = yield* Effect.promise(generatePKCE)
+      const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
+      const code = yield* Deferred.make<string, Error>()
+      const redirect = `http://localhost:${callbackPort}/callback`
+      const server = createServer((request, response) => {
+        const url = new URL(request.url ?? "/", `http://localhost:${callbackPort}`)
+        if (url.pathname !== "/callback") {
+          response.writeHead(404).end("Not found")
+          return
+        }
+        const error = url.searchParams.get("error_description") ?? url.searchParams.get("error")
+        const value = url.searchParams.get("code")
+        if (error) {
+          Effect.runFork(Deferred.fail(code, new Error(error)))
+          response.writeHead(400, { "Content-Type": "text/html" }).end(errorPage(error))
+          return
+        }
+        if (!value || url.searchParams.get("state") !== state) {
+          const message = value ? "Invalid OAuth state" : "Missing authorization code"
+          Effect.runFork(Deferred.fail(code, new Error(message)))
+          response.writeHead(400, { "Content-Type": "text/html" }).end(errorPage(message))
+          return
+        }
+        Effect.runFork(Deferred.succeed(code, value))
+        response.writeHead(200, { "Content-Type": "text/html" }).end(successPage)
+      })
+      yield* Effect.callback<void, Error>((resume) => {
+        server.once("error", (error) => resume(Effect.fail(error)))
+        server.listen(callbackPort, "localhost", () => resume(Effect.void))
+      })
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          server.close()
+        }),
+      )
+      return {
+        mode: "auto" as const,
+        url: authorizeURL(redirect, pkce, state),
+        instructions: "Complete authorization in your browser. This window will close automatically.",
+        callback: Deferred.await(code).pipe(
+          Effect.flatMap((value) => exchange(value, redirect, pkce, state)),
+          Effect.map((tokens) => credential(browserMethodID, tokens)),
+        ),
+      }
+    }),
+  refresh: (value) => refresh(value),
+} satisfies Integration.OAuthImplementation
+
+export const manual = {
+  integrationID: Integration.ID.make("noumena"),
+  method: {
+    id: manualMethodID,
+    type: "oauth",
+    label: "Noumena Code (manual code)",
+  },
+  authorize: () =>
+    Effect.gen(function* () {
+      const pkce = yield* Effect.promise(generatePKCE)
+      const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
+      const redirect = manualRedirectURL()
+      return {
+        mode: "code" as const,
+        url: authorizeURL(redirect, pkce, state),
+        instructions: "Open the URL, complete authorization, then paste the authorization code.",
+        callback: (code: string) =>
+          exchange(code, redirect, pkce, state).pipe(Effect.map((tokens) => credential(manualMethodID, tokens))),
+      }
+    }),
+  refresh: (value) => refresh(value),
+} satisfies Integration.OAuthImplementation
+
+export function tokenURL() {
+  const issuer = process.env.NOUMENA_ISSUER_BASE_URL?.trim().replace(/\/$/, "")
+  return issuer ? `${issuer}/oauth/token` : defaultTokenURL
+}
+
+function authorizeBaseURL() {
+  const web = process.env.NOUMENA_OAUTH_WEB_BASE_URL?.trim().replace(/\/$/, "")
+  return web ? `${web}/oauth/authorize` : defaultAuthorizeURL
+}
+
+function manualRedirectURL() {
+  const web = process.env.NOUMENA_OAUTH_WEB_BASE_URL?.trim().replace(/\/$/, "")
+  return web ? `${web}/oauth/code/callback?app=noumena-code` : "https://code.noumena.com/oauth/code/callback?app=noumena-code"
+}
+
+function clientID() {
+  return process.env.NOUMENA_OAUTH_CLIENT_ID || defaultClientID
+}
+
+function headers(contentType: string) {
+  return {
+    "Content-Type": contentType,
+    "User-Agent": `opencode/${InstallationVersion}`,
+    "anthropic-beta": oauthBetaHeader,
+  }
+}
+
+function exchange(code: string, redirect: string, pkce: Pkce, state: string) {
+  return request<TokenResponse>(tokenURL(), {
+    method: "POST",
+    headers: headers("application/x-www-form-urlencoded"),
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirect,
+      client_id: clientID(),
+      code_verifier: pkce.verifier,
+      state,
+    }).toString(),
+  })
+}
+
+function refresh(value: Credential.OAuth) {
+  return request<TokenResponse>(tokenURL(), {
+    method: "POST",
+    headers: headers("application/x-www-form-urlencoded"),
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: value.refresh,
+      client_id: clientID(),
+      scope: scopes,
+    }).toString(),
+  }).pipe(
+    Effect.map((tokens) =>
+      credential(value.methodID, {
+        ...tokens,
+        refresh_token: tokens.refresh_token ?? value.refresh,
+      }),
+    ),
+  )
+}
+
+function request<A>(url: string, init: RequestInit) {
+  return Effect.tryPromise({
+    try: async (signal) => {
+      const response = await fetch(url, { ...init, signal })
+      if (!response.ok) throw new Error(`Request failed: ${response.status}`)
+      return response.json() as Promise<A>
+    },
+    catch: (cause) => cause,
+  })
+}
+
+function credential(methodID: Integration.MethodID, tokens: TokenResponse) {
+  return new Credential.OAuth({
+    type: "oauth",
+    methodID,
+    refresh: tokens.refresh_token ?? "",
+    access: tokens.access_token,
+    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+  })
+}
+
+function authorizeURL(redirect: string, pkce: Pkce, state: string) {
+  return `${authorizeBaseURL()}?${new URLSearchParams({
+    code: "true",
+    response_type: "code",
+    client_id: clientID(),
+    redirect_uri: redirect,
+    scope: scopes,
+    code_challenge: pkce.challenge,
+    code_challenge_method: "S256",
+    state,
+  })}`
+}
+
+async function generatePKCE(): Promise<Pkce> {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+  const verifier = Array.from(crypto.getRandomValues(new Uint8Array(43)), (byte) => chars[byte % chars.length]).join("")
+  const challenge = base64UrlEncode(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)))
+  return { verifier, challenge }
+}
+
+function base64UrlEncode(buffer: ArrayBuffer) {
+  return Buffer.from(buffer).toString("base64url")
+}
+
+const successPage =
+  "<!doctype html><title>OpenCode</title><h1>Authorization successful</h1><p>You can close this window.</p>"
+const errorPage = (message: string) =>
+  `<!doctype html><title>OpenCode</title><h1>Authorization failed</h1><p>${message.replace(/[&<>\"']/g, "")}</p>`

--- a/packages/core/src/plugin/provider/noumena.ts
+++ b/packages/core/src/plugin/provider/noumena.ts
@@ -1,0 +1,16 @@
+import { Effect } from "effect"
+import { Integration } from "../../integration"
+import { PluginV2 } from "../../plugin"
+import { browser, manual } from "./noumena-auth"
+
+export const NoumenaPlugin = PluginV2.define({
+  id: PluginV2.ID.make("noumena"),
+  effect: Effect.gen(function* () {
+    const integrations = yield* Integration.Service
+    yield* integrations.update((editor) => {
+      editor.method.update(browser)
+      editor.method.update(manual)
+    })
+    return {}
+  }),
+})

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -9,6 +9,7 @@ export const ID = Schema.String.pipe(
     // Well-known providers
     opencode: schema.make("opencode"),
     anthropic: schema.make("anthropic"),
+    noumena: schema.make("noumena"),
     openai: schema.make("openai"),
     google: schema.make("google"),
     googleVertex: schema.make("google-vertex"),

--- a/packages/core/test/plugin/provider-noumena.test.ts
+++ b/packages/core/test/plugin/provider-noumena.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { Credential } from "@opencode-ai/core/credential"
+import { Integration } from "@opencode-ai/core/integration"
+import { PluginV2 } from "@opencode-ai/core/plugin"
+import { NoumenaPlugin } from "@opencode-ai/core/plugin/provider/noumena"
+import { manual } from "@opencode-ai/core/plugin/provider/noumena-auth"
+import { it, withEnv } from "./provider-helper"
+
+function add(plugin: PluginV2.Interface, integrations: Integration.Interface) {
+  return plugin.add({
+    ...NoumenaPlugin,
+    effect: NoumenaPlugin.effect.pipe(Effect.provideService(Integration.Service, integrations)),
+  })
+}
+
+describe("NoumenaPlugin", () => {
+  it.effect("registers browser and manual OAuth methods", () =>
+    Effect.gen(function* () {
+      const plugin = yield* PluginV2.Service
+      yield* add(plugin, yield* Integration.Service)
+      expect((yield* (yield* Integration.Service).get(Integration.ID.make("noumena")))?.methods).toEqual([
+        {
+          id: Integration.MethodID.make("noumena-browser"),
+          type: "oauth",
+          label: "Noumena Code (browser)",
+        },
+        {
+          id: Integration.MethodID.make("noumena-code"),
+          type: "oauth",
+          label: "Noumena Code (manual code)",
+        },
+      ])
+    }),
+  )
+
+  it.effect("uses ncode-compatible env overrides in manual OAuth flow", () =>
+    withEnv(
+      {
+        NOUMENA_ISSUER_BASE_URL: "https://issuer.noumena.test/",
+        NOUMENA_OAUTH_WEB_BASE_URL: "https://code.noumena.test/",
+        NOUMENA_OAUTH_CLIENT_ID: "custom-client",
+      },
+      () =>
+        withFetch(async (input, init) => {
+          expect(input).toBe("https://issuer.noumena.test/oauth/token")
+          expect(init?.headers).toMatchObject({ "anthropic-beta": "oauth-2025-04-20" })
+          const body = new URLSearchParams(String(init?.body))
+          expect(body.get("grant_type")).toBe("authorization_code")
+          expect(body.get("code")).toBe("pasted-code")
+          expect(body.get("client_id")).toBe("custom-client")
+          expect(body.get("redirect_uri")).toBe("https://code.noumena.test/oauth/code/callback?app=noumena-code")
+          expect(body.get("code_verifier")).toBeTruthy()
+          expect(body.get("state")).toBeTruthy()
+          return new Response(JSON.stringify({ access_token: "access", refresh_token: "refresh", expires_in: 60 }))
+        }, () =>
+          Effect.gen(function* () {
+            const authorization = yield* manual.authorize()
+            expect(authorization.mode).toBe("code")
+            const url = new URL(authorization.url)
+            expect(url.origin + url.pathname).toBe("https://code.noumena.test/oauth/authorize")
+            expect(url.searchParams.get("client_id")).toBe("custom-client")
+            expect(url.searchParams.get("scope")).toBe(
+              "user:profile user:inference user:sessions:ncode user:mcp_servers user:file_upload",
+            )
+            if (authorization.mode !== "code") throw new Error("expected code mode")
+            const credential = yield* authorization.callback("pasted-code")
+            expect(credential).toMatchObject({ type: "oauth", access: "access", refresh: "refresh" })
+          }),
+        ),
+    ),
+  )
+
+  it.effect("refreshes OAuth tokens with refresh-token grant", () =>
+    withFetch(async (input, init) => {
+      expect(input).toBe("https://api.noumena.com/oauth/token")
+      const body = new URLSearchParams(String(init?.body))
+      expect(body.get("grant_type")).toBe("refresh_token")
+      expect(body.get("refresh_token")).toBe("old-refresh")
+      expect(body.get("client_id")).toBe("noumena-code")
+      expect(body.get("scope")).toBe("user:profile user:inference user:sessions:ncode user:mcp_servers user:file_upload")
+      return new Response(JSON.stringify({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 60 }))
+    }, () =>
+      Effect.gen(function* () {
+        const refreshed = yield* manual.refresh!(
+          new Credential.OAuth({
+            type: "oauth",
+            methodID: Integration.MethodID.make("noumena-code"),
+            access: "old-access",
+            refresh: "old-refresh",
+            expires: Date.now() - 1,
+          }),
+        )
+        expect(refreshed.access).toBe("new-access")
+        expect(refreshed.refresh).toBe("new-refresh")
+      }),
+    ),
+  )
+
+})
+
+function withFetch<A, E, R>(
+  fetch: (input: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1]) => Promise<Response>,
+  fx: () => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = globalThis.fetch
+      globalThis.fetch = Object.assign(fetch, { preconnect: previous.preconnect }) as typeof globalThis.fetch
+      return previous
+    }),
+    () => fx(),
+    (previous) =>
+      Effect.sync(() => {
+        globalThis.fetch = previous
+      }),
+  )
+}

--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -300,7 +300,7 @@ export const ProvidersLoginCommand = effectCmd({
   command: "login [url]",
   describe: "log in to a provider",
   // URL login skips instance bootstrap, which would load remote config with the stale token and crash before re-auth.
-  instance: (args) => !args.url,
+  instance: (args) => !isProviderMetadataURL(args.url),
   builder: (yargs: Argv) =>
     yargs
       .positional("url", {
@@ -322,7 +322,7 @@ export const ProvidersLoginCommand = effectCmd({
 
     UI.empty()
     yield* Prompt.intro("Add credential")
-    if (args.url) {
+    if (isProviderMetadataURL(args.url)) {
       const url = args.url.replace(/\/+$/, "")
       const wellknown = (yield* cliTry(`Failed to load auth provider metadata from ${url}: `, () =>
         fetch(`${url}/.well-known/opencode`).then((x) => x.json()),
@@ -409,8 +409,9 @@ export const ProvidersLoginCommand = effectCmd({
     ]
 
     let provider: string
-    if (args.provider) {
-      const input = args.provider
+    const providerInput = args.provider ?? args.url
+    if (providerInput) {
+      const input = providerInput
       const byID = options.find((x) => x.value === input)
       const byName = options.find((x) => x.label.toLowerCase() === input.toLowerCase())
       const match = byID ?? byName
@@ -487,6 +488,10 @@ export const ProvidersLoginCommand = effectCmd({
     yield* Prompt.outro("Done")
   }),
 })
+
+function isProviderMetadataURL(value: string | undefined): value is string {
+  return Boolean(value?.match(/^[a-z][a-z0-9+.-]*:\/\//i))
+}
 
 export const ProvidersLogoutCommand = effectCmd({
   command: "logout [provider]",

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -20,6 +20,7 @@ import { AzureAuthPlugin } from "./azure"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
 import { XaiAuthPlugin } from "./xai"
 import { SnowflakeCortexAuthPlugin } from "./snowflake-cortex"
+import { NoumenaAuthPlugin } from "./noumena"
 import { Effect, Layer, Context } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
@@ -77,6 +78,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     AzureAuthPlugin,
     DigitalOceanAuthPlugin,
     SnowflakeCortexAuthPlugin,
+    NoumenaAuthPlugin,
     XaiAuthPlugin,
   ]
 }

--- a/packages/opencode/src/plugin/noumena.ts
+++ b/packages/opencode/src/plugin/noumena.ts
@@ -1,0 +1,265 @@
+import { createServer } from "node:http"
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import { OAUTH_DUMMY_KEY } from "../auth"
+
+const AUTHORIZE_URL = "https://code.noumena.com/oauth/authorize"
+const TOKEN_URL = "https://api.noumena.com/oauth/token"
+const OAUTH_BETA_HEADER = "oauth-2025-04-20"
+const SCOPES = "user:profile user:inference user:sessions:ncode user:mcp_servers user:file_upload"
+
+type Pkce = {
+  verifier: string
+  challenge: string
+}
+
+type TokenResponse = {
+  access_token: string
+  refresh_token?: string
+  expires_in?: number
+}
+
+type RefreshResult = {
+  access: string
+  refresh: string
+  expires: number
+}
+
+export async function NoumenaAuthPlugin(input: PluginInput): Promise<Hooks> {
+  return {
+    auth: {
+      provider: "noumena",
+      methods: [
+        {
+          type: "oauth",
+          label: "Noumena Code (browser)",
+          async authorize() {
+            const pkce = await generatePKCE()
+            const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
+            const server = await startOAuthServer(state)
+            return {
+              method: "auto",
+              url: authorizeURL(server.redirect, pkce, state),
+              instructions: "Complete authorization in your browser. This window will close automatically.",
+              async callback() {
+                try {
+                  const code = await server.code
+                  return success(await exchangeCode(code, server.redirect, pkce, state))
+                } finally {
+                  server.close()
+                }
+              },
+            }
+          },
+        },
+        {
+          type: "oauth",
+          label: "Noumena Code (manual code)",
+          async authorize() {
+            const pkce = await generatePKCE()
+            const state = base64UrlEncode(crypto.getRandomValues(new Uint8Array(32)).buffer)
+            const redirect = manualRedirectURL()
+            return {
+              method: "code",
+              url: authorizeURL(redirect, pkce, state),
+              instructions: "Open the URL, complete authorization, then paste the authorization code.",
+              async callback(code: string) {
+                return success(await exchangeCode(code, redirect, pkce, state))
+              },
+            }
+          },
+        },
+      ],
+      async loader(getAuth) {
+        const auth = await getAuth()
+        if (auth.type !== "oauth") return {}
+
+        let refreshPromise: Promise<RefreshResult> | undefined
+
+        return {
+          apiKey: OAUTH_DUMMY_KEY,
+          async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
+            let currentAuth = await getAuth()
+            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
+
+            if (!currentAuth.access || currentAuth.expires <= Date.now()) {
+              if (!refreshPromise) {
+                const refreshToken = currentAuth.refresh
+                refreshPromise = refreshAccessToken(refreshToken)
+                  .then(async (tokens) => {
+                    const refreshed = {
+                      access: tokens.access_token,
+                      refresh: tokens.refresh_token ?? refreshToken,
+                      expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                    }
+                    await input.client.auth.set({
+                      path: { id: "noumena" },
+                      body: {
+                        type: "oauth",
+                        access: refreshed.access,
+                        refresh: refreshed.refresh,
+                        expires: refreshed.expires,
+                      },
+                    })
+                    return refreshed
+                  })
+                  .finally(() => {
+                    refreshPromise = undefined
+                  })
+              }
+
+              currentAuth = { ...currentAuth, ...(await refreshPromise) }
+            }
+
+            const headers = new Headers(init?.headers)
+            headers.delete("authorization")
+            headers.delete("Authorization")
+            headers.delete("x-api-key")
+            headers.delete("X-Api-Key")
+            headers.set("Authorization", `Bearer ${currentAuth.access}`)
+            headers.set("anthropic-beta", OAUTH_BETA_HEADER)
+
+            return fetch(requestInput, { ...init, headers })
+          },
+        }
+      },
+    },
+  }
+}
+
+function authorizeBaseURL() {
+  const web = process.env.NOUMENA_OAUTH_WEB_BASE_URL?.trim().replace(/\/$/, "")
+  return web ? `${web}/oauth/authorize` : AUTHORIZE_URL
+}
+
+function manualRedirectURL() {
+  const web = process.env.NOUMENA_OAUTH_WEB_BASE_URL?.trim().replace(/\/$/, "")
+  return web ? `${web}/oauth/code/callback?app=noumena-code` : "https://code.noumena.com/oauth/code/callback?app=noumena-code"
+}
+
+function tokenURL() {
+  const issuer = process.env.NOUMENA_ISSUER_BASE_URL?.trim().replace(/\/$/, "")
+  return issuer ? `${issuer}/oauth/token` : TOKEN_URL
+}
+
+function clientID() {
+  return process.env.NOUMENA_OAUTH_CLIENT_ID || "noumena-code"
+}
+
+function authorizeURL(redirect: string, pkce: Pkce, state: string) {
+  return `${authorizeBaseURL()}?${new URLSearchParams({
+    code: "true",
+    response_type: "code",
+    client_id: clientID(),
+    redirect_uri: redirect,
+    scope: SCOPES,
+    code_challenge: pkce.challenge,
+    code_challenge_method: "S256",
+    state,
+  })}`
+}
+
+async function startOAuthServer(state: string) {
+  const server = createServer()
+  const callback = new Promise<string>((resolve, reject) => {
+    server.on("request", (request, response) => {
+      const url = new URL(request.url ?? "/", "http://localhost")
+      if (url.pathname !== "/callback") {
+        response.writeHead(404).end("Not found")
+        return
+      }
+      const error = url.searchParams.get("error_description") ?? url.searchParams.get("error")
+      const value = url.searchParams.get("code")
+      if (error) {
+        reject(new Error(error))
+        response.writeHead(400, { "Content-Type": "text/html" }).end(errorPage(error))
+        return
+      }
+      if (!value || url.searchParams.get("state") !== state) {
+        const message = value ? "Invalid OAuth state" : "Missing authorization code"
+        reject(new Error(message))
+        response.writeHead(400, { "Content-Type": "text/html" }).end(errorPage(message))
+        return
+      }
+      resolve(value)
+      response.writeHead(200, { "Content-Type": "text/html" }).end(successPage)
+    })
+    server.once("error", reject)
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, "localhost", () => resolve())
+    server.once("error", reject)
+  })
+  const address = server.address()
+  if (typeof address !== "object" || !address) {
+    server.close()
+    throw new Error("Failed to allocate OAuth callback port")
+  }
+  return {
+    redirect: `http://localhost:${address.port}/callback`,
+    code: callback,
+    close: () => server.close(),
+  }
+}
+
+async function exchangeCode(code: string, redirect: string, pkce: Pkce, state: string): Promise<TokenResponse> {
+  const response = await fetch(tokenURL(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "anthropic-beta": OAUTH_BETA_HEADER,
+    },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirect,
+      client_id: clientID(),
+      code_verifier: pkce.verifier,
+      state,
+    }),
+  })
+  if (!response.ok) throw new Error(`Noumena OAuth exchange failed: ${response.status}`)
+  return response.json()
+}
+
+function success(tokens: TokenResponse) {
+  return {
+    type: "success" as const,
+    access: tokens.access_token,
+    refresh: tokens.refresh_token ?? "",
+    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+  }
+}
+
+async function generatePKCE(): Promise<Pkce> {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+  const verifier = Array.from(crypto.getRandomValues(new Uint8Array(43)), (byte) => chars[byte % chars.length]).join("")
+  const challenge = base64UrlEncode(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier)))
+  return { verifier, challenge }
+}
+
+function base64UrlEncode(buffer: ArrayBuffer) {
+  return Buffer.from(buffer).toString("base64url")
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<TokenResponse> {
+  const response = await fetch(tokenURL(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "anthropic-beta": OAUTH_BETA_HEADER,
+    },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientID(),
+      scope: SCOPES,
+    }),
+  })
+  if (!response.ok) throw new Error(`Noumena OAuth refresh failed: ${response.status}`)
+  return response.json()
+}
+
+const successPage =
+  "<!doctype html><title>OpenCode</title><h1>Authorization successful</h1><p>You can close this window.</p>"
+const errorPage = (message: string) =>
+  `<!doctype html><title>OpenCode</title><h1>Authorization failed</h1><p>${message.replace(/[&<>\"']/g, "")}</p>`

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -33,6 +33,8 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
+const NOUMENA_BASE_URL_DEFAULT = "https://api.noumena.com/v1"
+const NOUMENA_KIMI_MODEL_ID = "/data/models/hf/moonshotai__Kimi-K2.7-Code"
 
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
@@ -176,6 +178,32 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    noumena: Effect.fnUntraced(function* (input: Info) {
+      const auth = yield* dep.auth(input.id)
+      const env = yield* dep.env()
+      const apiKey = env["NOUMENA_API_KEY"] ?? (auth?.type === "api" ? auth.key : undefined)
+      const baseURL = noumenaBaseURL((yield* dep.get("NOUMENA_BASE_URL")) ?? "https://api.noumena.com")
+      return {
+        autoload: auth?.type === "oauth",
+        options: {
+          baseURL,
+          ...(auth?.type === "oauth" ? { headers: { "anthropic-beta": "oauth-2025-04-20" } } : {}),
+          ...(apiKey
+            ? {
+                fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+                  const headers = new Headers(init?.headers)
+                  headers.delete("authorization")
+                  headers.delete("Authorization")
+                  headers.delete("x-api-key")
+                  headers.delete("X-Api-Key")
+                  headers.set("x-api-key", apiKey)
+                  return fetch(input, { ...init, headers })
+                },
+              }
+            : {}),
+        },
+      }
+    }),
     opencode: Effect.fnUntraced(function* (input: Info) {
       const env = yield* dep.env()
       const hasKey = iife(() => {
@@ -1253,6 +1281,54 @@ export function fromModelsDevProvider(provider: ModelsDev.Provider): Info {
   }
 }
 
+function withNoumenaModels(modelsDev: Record<string, ModelsDev.Provider>): Record<string, ModelsDev.Provider> {
+  if (modelsDev.noumena) return modelsDev
+  const noumena: ModelsDev.Provider = {
+    id: "noumena",
+    name: "Noumena",
+    api: NOUMENA_BASE_URL_DEFAULT,
+    npm: "@ai-sdk/openai-compatible",
+    env: ["NOUMENA_API_KEY"],
+    models: {
+      "kimi-2.7-coder": {
+        id: NOUMENA_KIMI_MODEL_ID,
+        name: "Kimi 2.7 Coder",
+        release_date: "",
+        attachment: false,
+        reasoning: true,
+        temperature: true,
+        tool_call: true,
+        cost: {
+          input: 0,
+          output: 0,
+        },
+        limit: {
+          context: 200000,
+          output: 256000,
+        },
+        modalities: {
+          input: ["text"],
+          output: ["text"],
+        },
+        provider: {
+          api: NOUMENA_BASE_URL_DEFAULT,
+          npm: "@ai-sdk/openai-compatible",
+        },
+      },
+    },
+  }
+  return {
+    ...modelsDev,
+    noumena,
+  }
+}
+
+function noumenaBaseURL(value: string) {
+  const url = value.replace(/\/+$/, "")
+  if (url.endsWith("/v1")) return url
+  return `${url}/v1`
+}
+
 function modelSuggestions(provider: Info | undefined, modelID: ModelV2.ID, enableExperimentalModels: boolean) {
   const available = provider
     ? Object.keys(provider.models).filter((id) => {
@@ -1297,7 +1373,7 @@ export const layer = Layer.effect(
       Effect.gen(function* () {
         const bridge = yield* EffectBridge.make()
         const cfg = yield* config.get()
-        const modelsDev = yield* modelsDevSvc.get()
+        const modelsDev = withNoumenaModels(yield* modelsDevSvc.get())
         const catalog = mapValues(modelsDev, fromModelsDevProvider)
         const database = mapValues(catalog, toPublicInfo)
 

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -52,12 +52,12 @@ function statusWithFetch(
   fetch: typeof globalThis.fetch | undefined,
 ): RuntimeStatus {
   const providerID = input.model.providerID
-  if (providerID !== "openai" && providerID !== "anthropic" && !providerID.startsWith("opencode"))
-    return { type: "unsupported", reason: "provider is not openai, opencode, or anthropic" }
+  if (providerID !== "openai" && providerID !== "anthropic" && providerID !== "noumena" && !providerID.startsWith("opencode"))
+    return { type: "unsupported", reason: "provider is not openai, opencode, anthropic, or noumena" }
   const npm = input.model.api.npm
   if (npm !== "@ai-sdk/openai" && npm !== "@ai-sdk/openai-compatible" && npm !== "@ai-sdk/anthropic")
     return { type: "unsupported", reason: "provider package is not OpenAI, OpenAI-compatible, or Anthropic" }
-  if (input.auth?.type === "oauth" && !(input.provider.id === "openai" && fetch)) {
+  if (input.auth?.type === "oauth" && !((input.provider.id === "openai" || input.provider.id === "noumena") && fetch)) {
     return { type: "unsupported", reason: "OAuth auth requires a provider fetch override" }
   }
 
@@ -146,7 +146,8 @@ export function stream(input: StreamInput): StreamResult {
 }
 
 function providerFetch(input: Pick<StreamInput, "provider" | "auth">): typeof globalThis.fetch | undefined {
-  if (input.provider.id !== "openai" || input.auth?.type !== "oauth") return undefined
+  if (input.provider.id === "openai" && input.auth?.type !== "oauth") return undefined
+  if (input.provider.id !== "openai" && input.provider.id !== "noumena") return undefined
   const value: unknown = input.provider.options.fetch
   if (typeof value !== "function") return undefined
   return value as typeof globalThis.fetch

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -47,6 +47,23 @@ const remove = (k: string) =>
     yield* Env.use.remove(k)
   })
 
+const withGlobalFetch = <A, E, R>(
+  fetch: (input: Parameters<typeof globalThis.fetch>[0], init?: Parameters<typeof globalThis.fetch>[1]) => Promise<Response>,
+  fx: () => Effect.Effect<A, E, R>,
+) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = globalThis.fetch
+      globalThis.fetch = Object.assign(fetch, { preconnect: previous.preconnect }) as typeof globalThis.fetch
+      return previous
+    }),
+    () => fx(),
+    (previous) =>
+      Effect.sync(() => {
+        globalThis.fetch = previous
+      }),
+  )
+
 afterEach(async () => {
   for (const [key, value] of originalEnv) {
     if (value === undefined) delete process.env[key]
@@ -112,6 +129,94 @@ it.instance("provider loaded from env variable", () =>
     expect(providers[ProviderV2.ID.anthropic].source).toBe("env")
     expect(providers[ProviderV2.ID.anthropic].options.headers["anthropic-beta"]).toBeDefined()
   }),
+)
+
+it.instance("noumena provider is loaded from env variable with known kimi model", () =>
+  Effect.gen(function* () {
+    yield* setProcessEnv("NOUMENA_API_KEY", "test-api-key")
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.noumena]).toBeDefined()
+    expect(providers[ProviderV2.ID.noumena].source).toBe("env")
+    expect(providers[ProviderV2.ID.noumena].env).toEqual(["NOUMENA_API_KEY"])
+    expect(providers[ProviderV2.ID.noumena].options.baseURL).toBe("https://api.noumena.com/v1")
+    expect(providers[ProviderV2.ID.noumena].models["kimi-2.7-coder"]).toBeDefined()
+    expect(providers[ProviderV2.ID.noumena].models["kimi-2.7-coder"].api.id).toBe(
+      "/data/models/hf/moonshotai__Kimi-K2.7-Code",
+    )
+    expect(providers[ProviderV2.ID.noumena].models["kimi-2.7-coder"].api.npm).toBe("@ai-sdk/openai-compatible")
+    expect(providers[ProviderV2.ID.noumena].models["claude-sonnet-4-20250514"]).toBeUndefined()
+  }),
+)
+
+it.instance("noumena provider respects NOUMENA_BASE_URL", () =>
+  Effect.gen(function* () {
+    yield* setProcessEnv("NOUMENA_API_KEY", "test-api-key")
+    yield* set("NOUMENA_BASE_URL", "https://api.noumena.test")
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.noumena].options.baseURL).toBe("https://api.noumena.test/v1")
+  }),
+)
+
+it.instance("noumena direct API key fetch sends x-api-key header", () =>
+  withGlobalFetch(
+    async (_input, init) => {
+      const headers = new Headers(init?.headers)
+      expect(headers.get("authorization")).toBeNull()
+      expect(headers.get("x-api-key")).toBe("direct-key")
+      return new Response("{}")
+    },
+    () =>
+      Effect.gen(function* () {
+        yield* setProcessEnv("NOUMENA_API_KEY", "direct-key")
+        const providers = yield* list
+        const fetch = providers[ProviderV2.ID.noumena].options.fetch
+        expect(fetch).toBeFunction()
+        yield* Effect.promise(() =>
+          fetch("https://api.noumena.com/v1/chat/completions", {
+            headers: {
+              Authorization: "Bearer sdk-token",
+            },
+          }),
+        )
+      }),
+  ),
+)
+
+it.instance("noumena OAuth fetch strips SDK auth headers and sends bearer beta headers", () =>
+  withGlobalFetch(
+    async (_input, init) => {
+      const headers = new Headers(init?.headers)
+      expect(headers.get("authorization")).toBe("Bearer oauth-access")
+      expect(headers.get("x-api-key")).toBeNull()
+      expect(headers.get("anthropic-beta")).toBe("oauth-2025-04-20")
+      return new Response("{}")
+    },
+    () =>
+      Effect.gen(function* () {
+        yield* setProcessEnv(
+          "OPENCODE_AUTH_CONTENT",
+          JSON.stringify({
+            noumena: {
+              type: "oauth",
+              access: "oauth-access",
+              refresh: "oauth-refresh",
+              expires: Date.now() + 60_000,
+            },
+          }),
+        )
+        const providers = yield* list
+        const fetch = providers[ProviderV2.ID.noumena].options.fetch
+        expect(fetch).toBeFunction()
+        yield* Effect.promise(() =>
+          fetch("https://api.noumena.com/v1/chat/completions", {
+            headers: {
+              Authorization: "Bearer sdk-token",
+              "x-api-key": "sdk-key",
+            },
+          }),
+        )
+      }),
+  ),
 )
 
 it.instance(


### PR DESCRIPTION
## Summary

- Add Noumena as a first-class provider with browser and manual OAuth flows.
- Add `kimi-2.7-coder` as the local Noumena model using OpenAI-compatible transport.
- Support `NOUMENA_API_KEY`, `NOUMENA_BASE_URL`, OAuth refresh, and auth header overrides.
- Fix `auth login noumena` so provider IDs are not treated as well-known metadata URLs.

## Testing

- `cd packages/core && bun test test/plugin/provider-noumena.test.ts`
- `cd packages/core && bun typecheck`
- `cd packages/opencode && bun test test/provider/provider.test.ts`
- `cd packages/opencode && bun typecheck`
