### PR TITLE
fix: /unshare does not remove share link from TUI display

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -654,6 +654,16 @@ export function MessageTimeline(props: {
 
   const shareMutation = useMutation(() => ({
     mutationFn: (id: string) => serverSDK().client.session.share({ sessionID: id, directory: sdk().directory }),
+    onSuccess: (result, id) => {
+      const url = (result as { data?: { share?: { url?: string } } })?.data?.share?.url
+      if (!url) return
+      sync().set(
+        produce((draft) => {
+          const index = draft.session.findIndex((s) => s.id === id)
+          if (index !== -1) draft.session[index].share = { url }
+        }),
+      )
+    },
     onError: (err) => {
       console.error("Failed to share session", err)
     },
@@ -661,6 +671,14 @@ export function MessageTimeline(props: {
 
   const unshareMutation = useMutation(() => ({
     mutationFn: (id: string) => serverSDK().client.session.unshare({ sessionID: id, directory: sdk().directory }),
+    onSuccess: (_, id) => {
+      sync().set(
+        produce((draft) => {
+          const index = draft.session.findIndex((s) => s.id === id)
+          if (index !== -1) draft.session[index].share = undefined
+        }),
+      )
+    },
     onError: (err) => {
       console.error("Failed to unshare session", err)
     },

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -852,7 +852,14 @@ export const RunCommand = effectCmd({
             fetch: fetchFn,
             resolveAgent: localAgent,
             session,
-            share,
+            share: async (sdk, sessionID) => {
+              // Auto-share eagerly to pre-warm the share-next service, but
+              // don't print the URL to stderr — in TUI mode stderr bypasses
+              // the scrollback and leaves orphaned terminal output that
+              // persists after /unshare.  The user can share explicitly via
+              // the LLM if they want the URL in the conversation.
+              await sdk.session.share({ sessionID }).catch(() => {})
+            },
             createSession: createFreshSession,
             agent: args.agent,
             model,


### PR DESCRIPTION
## Summary

Fixes the share link persisting in the UI after running `/unshare` by ensuring the local sync store reflects share state changes immediately and preventing orphaned stderr output in the interactive TUI.

## Changes

- **message-timeline.tsx**: Added `onSuccess` handlers to both `shareMutation` and `unshareMutation` to update the local sync store immediately after API calls, so the share popover state reflects the current share status without waiting for the SSE event round-trip.
- **run.ts**: Replaced the interactive TUI auto-share (which printed the URL to `process.stderr` via `UI.println`) with a silent pre-warm that creates the share link without writing to stderr. In TUI mode stderr bypasses the scrollback and leaves orphaned terminal output that persists after `/unshare`. Users can explicitly request the share URL from the LLM.

## Testing

- [ ] Verified TypeScript compilation has no new errors (all errors are pre-existing dependency resolution issues)
- [ ] Web app: mutations update the sync store immediately via `sync().set(produce(...))`
- [ ] CLI TUI: auto-share no longer prints URL to stderr

## Related

- Fixes #32912