### PR TITLE
feat(tui): surface compaction progress and context usage indicators

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -7,6 +7,7 @@ import { Provider } from "@/provider/provider"
 import { MessageV2 } from "./message-v2"
 import { Token } from "@/util/token"
 import { SessionProcessor } from "./processor"
+import { SessionStatus } from "./status"
 import { Agent } from "@/agent/agent"
 import { Plugin } from "@/plugin"
 import { Config } from "@/config/config"
@@ -174,6 +175,7 @@ export const layer = Layer.effect(
     const provider = yield* Provider.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
+    const status = yield* SessionStatus.Service
 
     const isOverflow = Effect.fn("SessionCompaction.isOverflow")(function* (input: {
       tokens: SessionV1.Assistant["tokens"]
@@ -296,6 +298,14 @@ export const layer = Layer.effect(
       }
     })
 
+    const restoreCompactingStatus = Effect.fn("SessionCompaction.restoreCompactingStatus")(function* (
+      sessionID: SessionID,
+    ) {
+      if (!flags.experimentalEventSystem) return
+      if ((yield* status.get(sessionID)).type !== "compacting") return
+      yield* status.set(sessionID, { type: "busy" })
+    })
+
     const processCompaction = Effect.fn("SessionCompaction.process")(function* (input: {
       parentID: MessageID
       messages: SessionV1.WithParts[]
@@ -303,252 +313,254 @@ export const layer = Layer.effect(
       auto: boolean
       overflow?: boolean
     }) {
-      const parent = input.messages.findLast((m) => m.info.id === input.parentID)
-      if (!parent || parent.info.role !== "user") {
-        throw new Error(`Compaction parent must be a user message: ${input.parentID}`)
-      }
-      const userMessage = parent.info
-      const compactionPart = parent.parts.find((part): part is SessionV1.CompactionPart => part.type === "compaction")
+      return yield* Effect.gen(function* () {
+        const parent = input.messages.findLast((m) => m.info.id === input.parentID)
+        if (!parent || parent.info.role !== "user") {
+          throw new Error(`Compaction parent must be a user message: ${input.parentID}`)
+        }
+        const userMessage = parent.info
+        const compactionPart = parent.parts.find((part): part is SessionV1.CompactionPart => part.type === "compaction")
 
-      let messages = input.messages
-      let replay:
-        | {
-            info: SessionV1.User
-            parts: SessionV1.Part[]
+        let messages = input.messages
+        let replay:
+          | {
+              info: SessionV1.User
+              parts: SessionV1.Part[]
+            }
+          | undefined
+        if (input.overflow) {
+          const idx = input.messages.findIndex((m) => m.info.id === input.parentID)
+          for (let i = idx - 1; i >= 0; i--) {
+            const msg = input.messages[i]
+            if (msg.info.role === "user" && !msg.parts.some((p) => p.type === "compaction")) {
+              replay = { info: msg.info, parts: msg.parts }
+              messages = input.messages.slice(0, i)
+              break
+            }
           }
-        | undefined
-      if (input.overflow) {
-        const idx = input.messages.findIndex((m) => m.info.id === input.parentID)
-        for (let i = idx - 1; i >= 0; i--) {
-          const msg = input.messages[i]
-          if (msg.info.role === "user" && !msg.parts.some((p) => p.type === "compaction")) {
-            replay = { info: msg.info, parts: msg.parts }
-            messages = input.messages.slice(0, i)
-            break
+          const hasContent =
+            replay && messages.some((m) => m.info.role === "user" && !m.parts.some((p) => p.type === "compaction"))
+          if (!hasContent) {
+            replay = undefined
+            messages = input.messages
           }
         }
-        const hasContent =
-          replay && messages.some((m) => m.info.role === "user" && !m.parts.some((p) => p.type === "compaction"))
-        if (!hasContent) {
-          replay = undefined
-          messages = input.messages
-        }
-      }
 
-      const agent = yield* agents.get("compaction")
-      const model = agent.model
-        ? yield* provider.getModel(agent.model.providerID, agent.model.modelID).pipe(Effect.orDie)
-        : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID).pipe(Effect.orDie)
-      const cfg = yield* config.get()
-      const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
-      const prior = completedCompactions(history)
-      const hidden = new Set(prior.flatMap((item) => [item.userIndex, item.assistantIndex]))
-      const previousSummary = prior.at(-1)?.summary
-      const selected = yield* select({
-        messages: history.filter((_, index) => !hidden.has(index)),
-        cfg,
-        model,
-      })
-      // Allow plugins to inject context or replace compaction prompt.
-      const compacting = yield* plugin.trigger(
-        "experimental.session.compacting",
-        { sessionID: input.sessionID },
-        { context: [], prompt: undefined },
-      )
-      const nextPrompt = compacting.prompt ?? buildPrompt({ previousSummary, context: compacting.context })
-      const msgs = structuredClone(selected.head)
-      yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
-      const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, {
-        stripMedia: true,
-        toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
-      })
-      const tailIndex = selected.tail_start_id
-        ? history.findIndex((message) => message.info.id === selected.tail_start_id)
-        : -1
-      const recent =
-        tailIndex < 0
-          ? ""
-          : JSON.stringify(
-              yield* MessageV2.toModelMessagesEffect(history.slice(tailIndex), model, {
-                stripMedia: true,
-                toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
-              }),
-            )
-      const ctx = yield* InstanceState.context
-      const msg: SessionV1.Assistant = {
-        id: MessageID.ascending(),
-        role: "assistant",
-        parentID: input.parentID,
-        sessionID: input.sessionID,
-        mode: "compaction",
-        agent: "compaction",
-        variant: userMessage.model.variant,
-        summary: true,
-        path: {
-          cwd: ctx.directory,
-          root: ctx.worktree,
-        },
-        cost: 0,
-        tokens: {
-          output: 0,
-          input: 0,
-          reasoning: 0,
-          cache: { read: 0, write: 0 },
-        },
-        modelID: model.id,
-        providerID: model.providerID,
-        time: {
-          created: Date.now(),
-        },
-      }
-      yield* session.updateMessage(msg)
-      const processor = yield* processors.create({
-        assistantMessage: msg,
-        sessionID: input.sessionID,
-        model,
-      })
-      const result = yield* processor.process({
-        user: userMessage,
-        agent,
-        sessionID: input.sessionID,
-        tools: {},
-        system: [],
-        messages: [
-          ...modelMessages,
-          {
-            role: "user",
-            content: [{ type: "text", text: nextPrompt }],
-          },
-        ],
-        model,
-      })
-
-      if (result === "compact") {
-        processor.message.error = new SessionV1.ContextOverflowError({
-          message: replay
-            ? "Conversation history too large to compact - exceeds model context limit"
-            : "Session too large to compact - context exceeds model limit even after stripping media",
-        }).toObject()
-        processor.message.finish = "error"
-        yield* session.updateMessage(processor.message)
-        return "stop"
-      }
-
-      if (compactionPart && selected.tail_start_id && compactionPart.tail_start_id !== selected.tail_start_id) {
-        yield* session.updatePart({
-          ...compactionPart,
-          tail_start_id: selected.tail_start_id,
+        const agent = yield* agents.get("compaction")
+        const model = agent.model
+          ? yield* provider.getModel(agent.model.providerID, agent.model.modelID).pipe(Effect.orDie)
+          : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID).pipe(Effect.orDie)
+        const cfg = yield* config.get()
+        const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
+        const prior = completedCompactions(history)
+        const hidden = new Set(prior.flatMap((item) => [item.userIndex, item.assistantIndex]))
+        const previousSummary = prior.at(-1)?.summary
+        const selected = yield* select({
+          messages: history.filter((_, index) => !hidden.has(index)),
+          cfg,
+          model,
         })
-      }
+        // Allow plugins to inject context or replace compaction prompt.
+        const compacting = yield* plugin.trigger(
+          "experimental.session.compacting",
+          { sessionID: input.sessionID },
+          { context: [], prompt: undefined },
+        )
+        const nextPrompt = compacting.prompt ?? buildPrompt({ previousSummary, context: compacting.context })
+        const msgs = structuredClone(selected.head)
+        yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+        const modelMessages = yield* MessageV2.toModelMessagesEffect(msgs, model, {
+          stripMedia: true,
+          toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
+        })
+        const tailIndex = selected.tail_start_id
+          ? history.findIndex((message) => message.info.id === selected.tail_start_id)
+          : -1
+        const recent =
+          tailIndex < 0
+            ? ""
+            : JSON.stringify(
+                yield* MessageV2.toModelMessagesEffect(history.slice(tailIndex), model, {
+                  stripMedia: true,
+                  toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
+                }),
+              )
+        const ctx = yield* InstanceState.context
+        const msg: SessionV1.Assistant = {
+          id: MessageID.ascending(),
+          role: "assistant",
+          parentID: input.parentID,
+          sessionID: input.sessionID,
+          mode: "compaction",
+          agent: "compaction",
+          variant: userMessage.model.variant,
+          summary: true,
+          path: {
+            cwd: ctx.directory,
+            root: ctx.worktree,
+          },
+          cost: 0,
+          tokens: {
+            output: 0,
+            input: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          modelID: model.id,
+          providerID: model.providerID,
+          time: {
+            created: Date.now(),
+          },
+        }
+        yield* session.updateMessage(msg)
+        const processor = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: input.sessionID,
+          model,
+        })
+        const result = yield* processor.process({
+          user: userMessage,
+          agent,
+          sessionID: input.sessionID,
+          tools: {},
+          system: [],
+          messages: [
+            ...modelMessages,
+            {
+              role: "user",
+              content: [{ type: "text", text: nextPrompt }],
+            },
+          ],
+          model,
+        })
 
-      if (result === "continue" && input.auto) {
-        if (replay) {
-          const original = replay.info
-          const replayMsg = yield* session.updateMessage({
-            id: MessageID.ascending(),
-            role: "user",
-            sessionID: input.sessionID,
-            time: { created: Date.now() },
-            agent: original.agent,
-            model: original.model,
-            format: original.format,
-            tools: original.tools,
-            system: original.system,
-          })
-          for (const part of replay.parts) {
-            if (part.type === "compaction") continue
-            const replayPart =
-              part.type === "file" && MessageV2.isMedia(part.mime)
-                ? { type: "text" as const, text: `[Attached ${part.mime}: ${part.filename ?? "file"}]` }
-                : part
-            yield* session.updatePart({
-              ...replayPart,
-              id: PartID.ascending(),
-              messageID: replayMsg.id,
-              sessionID: input.sessionID,
-            })
-          }
+        if (result === "compact") {
+          processor.message.error = new SessionV1.ContextOverflowError({
+            message: replay
+              ? "Conversation history too large to compact - exceeds model context limit"
+              : "Session too large to compact - context exceeds model limit even after stripping media",
+          }).toObject()
+          processor.message.finish = "error"
+          yield* session.updateMessage(processor.message)
+          return "stop"
         }
 
-        if (!replay) {
-          const info = yield* provider.getProvider(userMessage.model.providerID)
-          if (
-            (yield* plugin.trigger(
-              "experimental.compaction.autocontinue",
-              {
-                sessionID: input.sessionID,
-                agent: userMessage.agent,
-                model: yield* provider
-                  .getModel(userMessage.model.providerID, userMessage.model.modelID)
-                  .pipe(Effect.orDie),
-                provider: {
-                  source: info.source,
-                  info,
-                  options: info.options,
-                },
-                message: userMessage,
-                overflow: input.overflow === true,
-              },
-              { enabled: true },
-            )).enabled
-          ) {
-            const continueMsg = yield* session.updateMessage({
+        if (compactionPart && selected.tail_start_id && compactionPart.tail_start_id !== selected.tail_start_id) {
+          yield* session.updatePart({
+            ...compactionPart,
+            tail_start_id: selected.tail_start_id,
+          })
+        }
+
+        if (result === "continue" && input.auto) {
+          if (replay) {
+            const original = replay.info
+            const replayMsg = yield* session.updateMessage({
               id: MessageID.ascending(),
               role: "user",
               sessionID: input.sessionID,
               time: { created: Date.now() },
-              agent: userMessage.agent,
-              model: userMessage.model,
+              agent: original.agent,
+              model: original.model,
+              format: original.format,
+              tools: original.tools,
+              system: original.system,
             })
-            const text =
-              (input.overflow
-                ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
-                : "") +
-              "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
-            yield* session.updatePart({
-              id: PartID.ascending(),
-              messageID: continueMsg.id,
-              sessionID: input.sessionID,
-              type: "text",
-              // Internal marker for auto-compaction followups so provider plugins
-              // can distinguish them from manual post-compaction user prompts.
-              // This is not a stable plugin contract and may change or disappear.
-              metadata: { compaction_continue: true },
-              synthetic: true,
-              text,
-              time: {
-                start: Date.now(),
-                end: Date.now(),
-              },
-            })
+            for (const part of replay.parts) {
+              if (part.type === "compaction") continue
+              const replayPart =
+                part.type === "file" && MessageV2.isMedia(part.mime)
+                  ? { type: "text" as const, text: `[Attached ${part.mime}: ${part.filename ?? "file"}]` }
+                  : part
+              yield* session.updatePart({
+                ...replayPart,
+                id: PartID.ascending(),
+                messageID: replayMsg.id,
+                sessionID: input.sessionID,
+              })
+            }
+          }
+
+          if (!replay) {
+            const info = yield* provider.getProvider(userMessage.model.providerID)
+            if (
+              (yield* plugin.trigger(
+                "experimental.compaction.autocontinue",
+                {
+                  sessionID: input.sessionID,
+                  agent: userMessage.agent,
+                  model: yield* provider
+                    .getModel(userMessage.model.providerID, userMessage.model.modelID)
+                    .pipe(Effect.orDie),
+                  provider: {
+                    source: info.source,
+                    info,
+                    options: info.options,
+                  },
+                  message: userMessage,
+                  overflow: input.overflow === true,
+                },
+                { enabled: true },
+              )).enabled
+            ) {
+              const continueMsg = yield* session.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID: input.sessionID,
+                time: { created: Date.now() },
+                agent: userMessage.agent,
+                model: userMessage.model,
+              })
+              const text =
+                (input.overflow
+                  ? "The previous request exceeded the provider's size limit due to large media attachments. The conversation was compacted and media files were removed from context. If the user was asking about attached images or files, explain that the attachments were too large to process and suggest they try again with smaller or fewer files.\n\n"
+                  : "") +
+                "Continue if you have next steps, or stop and ask for clarification if you are unsure how to proceed."
+              yield* session.updatePart({
+                id: PartID.ascending(),
+                messageID: continueMsg.id,
+                sessionID: input.sessionID,
+                type: "text",
+                // Internal marker for auto-compaction followups so provider plugins
+                // can distinguish them from manual post-compaction user prompts.
+                // This is not a stable plugin contract and may change or disappear.
+                metadata: { compaction_continue: true },
+                synthetic: true,
+                text,
+                time: {
+                  start: Date.now(),
+                  end: Date.now(),
+                },
+              })
+            }
           }
         }
-      }
 
-      if (processor.message.error) return "stop"
-      if (result === "continue") {
-        const summary = summaryText(
-          (yield* session.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
-            (item) => item.info.id === msg.id,
-          ) ?? {
-            info: msg,
-            parts: [],
-          },
-        )
-        if (flags.experimentalEventSystem) {
-          if (summary)
-            yield* events.publish(SessionEvent.Compaction.Ended, {
-              sessionID: input.sessionID,
-              messageID: SessionMessage.ID.make(input.parentID),
-              timestamp: DateTime.makeUnsafe(Date.now()),
-              reason: input.auto ? "auto" : "manual",
-              text: summary ?? "",
-              recent,
-            })
+        if (processor.message.error) return "stop"
+        if (result === "continue") {
+          const summary = summaryText(
+            (yield* session.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
+              (item) => item.info.id === msg.id,
+            ) ?? {
+              info: msg,
+              parts: [],
+            },
+          )
+          if (flags.experimentalEventSystem) {
+            if (summary)
+              yield* events.publish(SessionEvent.Compaction.Ended, {
+                sessionID: input.sessionID,
+                messageID: SessionMessage.ID.make(input.parentID),
+                timestamp: DateTime.makeUnsafe(Date.now()),
+                reason: input.auto ? "auto" : "manual",
+                text: summary ?? "",
+                recent,
+              })
+          }
+          yield* events.publish(Event.Compacted, { sessionID: input.sessionID })
         }
-        yield* events.publish(Event.Compacted, { sessionID: input.sessionID })
-      }
-      return result
+        return result
+      }).pipe(Effect.ensuring(restoreCompactingStatus(input.sessionID)))
     })
 
     const create = Effect.fn("SessionCompaction.create")(function* (input: {
@@ -575,6 +587,7 @@ export const layer = Layer.effect(
         overflow: input.overflow,
       })
       if (flags.experimentalEventSystem) {
+        yield* status.set(input.sessionID, { type: "compacting", startedAt: Date.now() })
         yield* events.publish(SessionEvent.Compaction.Started, {
           sessionID: input.sessionID,
           messageID: SessionMessage.ID.make(msg.id),
@@ -597,6 +610,7 @@ export const defaultLayer = Layer.suspend(() =>
   layer.pipe(
     Layer.provide(Provider.defaultLayer),
     Layer.provide(Session.defaultLayer),
+    Layer.provide(SessionStatus.defaultLayer),
     Layer.provide(SessionProcessor.defaultLayer),
     Layer.provide(Agent.defaultLayer),
     Layer.provide(Plugin.defaultLayer),
@@ -609,6 +623,7 @@ export const defaultLayer = Layer.suspend(() =>
 export const node = LayerNode.make(layer, [
   Config.node,
   Session.node,
+  SessionStatus.node,
   Agent.node,
   Plugin.node,
   SessionProcessor.node,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -30,7 +30,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import * as DateTime from "effect/DateTime"
 import { RuntimeFlags } from "@/effect/runtime-flags"
-import { ToolOutput, Usage, type LLMEvent } from "@opencode-ai/llm"
+import { Usage, type LLMEvent } from "@opencode-ai/llm"
 
 const DOOM_LOOP_THRESHOLD = 3
 export type Result = "compact" | "stop" | "continue"
@@ -970,7 +970,9 @@ export const layer = Layer.effect(
             ctx.currentText = undefined
             ctx.currentTextID = undefined
             ctx.reasoningMap = {}
-            yield* status.set(ctx.sessionID, { type: "busy" })
+            if ((yield* status.get(ctx.sessionID)).type !== "compacting") {
+              yield* status.set(ctx.sessionID, { type: "busy" })
+            }
             const stream = llm.stream(streamInput)
 
             yield* stream.pipe(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1139,7 +1139,9 @@ export const layer = Layer.effect(
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
-          yield* status.set(sessionID, { type: "busy" })
+          if ((yield* status.get(sessionID)).type !== "compacting") {
+            yield* status.set(sessionID, { type: "busy" })
+          }
           yield* Effect.logInfo("loop", { "session.id": sessionID, step })
 
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID).pipe(
@@ -1200,6 +1202,9 @@ export const layer = Layer.effect(
           }
 
           if (task?.type === "compaction") {
+            if (flags.experimentalEventSystem && (yield* status.get(sessionID)).type !== "compacting") {
+              yield* status.set(sessionID, { type: "compacting", startedAt: Date.now() })
+            }
             const result = yield* compaction.process({
               messages: msgs,
               parentID: lastUser.id,

--- a/packages/opencode/src/session/status.ts
+++ b/packages/opencode/src/session/status.ts
@@ -29,6 +29,10 @@ export const Info = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("busy"),
   }),
+  Schema.Struct({
+    type: Schema.Literal("compacting"),
+    startedAt: Schema.optional(NonNegativeInt),
+  }),
 ]).annotate({ identifier: "SessionStatus" })
 export type Info = Schema.Schema.Type<typeof Info>
 

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -866,6 +866,71 @@ describe("session.compaction.process", () => {
   )
 
   itCompaction.instance(
+    "keeps compacting visible while the compaction stream is busy",
+    () => {
+      let startStream = () => {}
+      let finishStream = () => {}
+      const streamStarted = new Promise<void>((resolve) => {
+        startStream = resolve
+      })
+      const streamFinished = new Promise<void>((resolve) => {
+        finishStream = resolve
+      })
+      const stub = llm()
+      stub.push(
+        Stream.fromAsyncIterable(
+          {
+            async *[Symbol.asyncIterator]() {
+              startStream()
+              await streamFinished
+              yield LLMEvent.textStart({ id: "txt-0" })
+              yield LLMEvent.textDelta({ id: "txt-0", text: "summary" })
+              yield LLMEvent.textEnd({ id: "txt-0" })
+              yield LLMEvent.stepFinish({ index: 0, reason: "stop", usage: basicUsage() })
+              yield LLMEvent.finish({ reason: "stop", usage: basicUsage() })
+            },
+          },
+          (err) => err,
+        ),
+      )
+
+      return Effect.gen(function* () {
+        const status = yield* SessionStatus.Service
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "hello")
+        const statuses = yield* recordStatusEvents(session.id)
+
+        yield* createSummaryCompaction(session.id)
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        const fiber = yield* SessionCompaction.use
+          .process({
+            parentID: parent!,
+            messages: msgs,
+            sessionID: session.id,
+            auto: false,
+          })
+          .pipe(Effect.forkChild)
+
+        yield* Effect.promise(() => streamStarted).pipe(Effect.timeout("1 second"))
+        expect(statuses.map((item) => item.type)).toStrictEqual(["compacting"])
+        expect(yield* status.get(session.id)).toMatchObject({ type: "compacting" })
+
+        yield* Effect.sync(() => finishStream())
+        const exit = yield* Fiber.await(fiber).pipe(Effect.timeout("1 second"))
+
+        expect(Exit.isSuccess(exit)).toBe(true)
+        if (Exit.isSuccess(exit)) expect(exit.value).toBe("continue")
+        expect(statuses.map((item) => item.type)).toStrictEqual(["compacting", "busy"])
+        expect(yield* status.get(session.id)).toMatchObject({ type: "busy" })
+      }).pipe(Effect.ensuring(Effect.sync(() => finishStream())), withCompaction({ llm: stub.layer }))
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
     "emits compacting then restores busy for auto compaction",
     () => {
       const stub = llm()

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -231,6 +231,7 @@ const deps = Layer.mergeAll(
   Agent.defaultLayer,
   Plugin.defaultLayer,
   EventV2Bridge.defaultLayer,
+  SessionStatus.defaultLayer,
   Config.defaultLayer,
   RuntimeFlags.layer({ experimentalEventSystem: true }),
   Database.defaultLayer,
@@ -241,6 +242,7 @@ const env = Layer.mergeAll(
   SessionNs.defaultLayer,
   Database.defaultLayer,
   EventV2Bridge.defaultLayer,
+  SessionStatus.defaultLayer,
   CrossSpawnSpawner.defaultLayer,
   SessionCompaction.layer.pipe(Layer.provide(SessionNs.defaultLayer), Layer.provideMerge(deps)),
 )
@@ -261,6 +263,7 @@ type CompactionProcessOptions = {
   plugin?: Layer.Layer<Plugin.Service>
   provider?: ReturnType<typeof ProviderTest.fake>
   config?: Layer.Layer<Config.Service>
+  experimentalEventSystem?: boolean
 }
 
 function withCompaction(options?: CompactionProcessOptions) {
@@ -270,11 +273,12 @@ function withCompaction(options?: CompactionProcessOptions) {
 function compactionProcessLayer(options?: CompactionProcessOptions) {
   const events = EventV2Bridge.defaultLayer
   const status = SessionStatus.layer.pipe(Layer.provide(events))
+  const flags = RuntimeFlags.layer({ experimentalEventSystem: options?.experimentalEventSystem ?? true })
   const processor = options?.llm
     ? SessionProcessorModule.SessionProcessor.layer.pipe(
         Layer.provide(summary),
         Layer.provide(Image.defaultLayer),
-        Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+        Layer.provide(flags),
         Layer.provide(status),
       )
     : layer(options?.result ?? "continue")
@@ -289,7 +293,7 @@ function compactionProcessLayer(options?: CompactionProcessOptions) {
     Layer.provide(status),
     Layer.provide(events),
     Layer.provide(options?.config ?? Config.defaultLayer),
-    Layer.provide(RuntimeFlags.layer({ experimentalEventSystem: true })),
+    Layer.provide(flags),
     Layer.provide(EventV2Bridge.defaultLayer),
   )
 }
@@ -380,6 +384,19 @@ function autocontinue(enabled: boolean) {
     init: () => Effect.void,
   })
 }
+
+const recordStatusEvents = Effect.fn("TestSessionCompaction.recordStatusEvents")(function* (sessionID: SessionID) {
+  const events = yield* EventV2Bridge.Service
+  const statuses: SessionStatus.Info[] = []
+  const off = yield* events.listen((evt) => {
+    if (evt.type !== SessionStatus.Event.Status.type) return Effect.void
+    const data = evt.data as typeof SessionStatus.Event.Status.data.Type
+    if (data.sessionID === sessionID) statuses.push(data.status)
+    return Effect.void
+  })
+  yield* Effect.addFinalizer(() => off)
+  return statuses
+})
 
 describe("session.compaction.isOverflow", () => {
   it.live(
@@ -815,6 +832,128 @@ describe("session.compaction.prune", () => {
 })
 
 describe("session.compaction.process", () => {
+  itCompaction.instance(
+    "emits compacting then restores busy for manual compaction",
+    () => {
+      const stub = llm()
+      stub.push(reply("summary"))
+
+      return Effect.gen(function* () {
+        const status = yield* SessionStatus.Service
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "hello")
+        const statuses = yield* recordStatusEvents(session.id)
+
+        yield* createSummaryCompaction(session.id)
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        const result = yield* SessionCompaction.use.process({
+          parentID: parent!,
+          messages: msgs,
+          sessionID: session.id,
+          auto: false,
+        })
+
+        expect(result).toBe("continue")
+        expect(statuses.map((item) => item.type)).toStrictEqual(["compacting", "busy"])
+        expect(statuses[0]).toMatchObject({ type: "compacting", startedAt: expect.any(Number) })
+        expect(yield* status.get(session.id)).toMatchObject({ type: "busy" })
+      }).pipe(withCompaction({ llm: stub.layer }))
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "emits compacting then restores busy for auto compaction",
+    () => {
+      const stub = llm()
+      stub.push(reply("summary"))
+
+      return Effect.gen(function* () {
+        const status = yield* SessionStatus.Service
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "hello")
+        const statuses = yield* recordStatusEvents(session.id)
+
+        yield* SessionCompaction.use.create({ sessionID: session.id, agent: "build", model: ref, auto: true })
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        const result = yield* SessionCompaction.use.process({
+          parentID: parent!,
+          messages: msgs,
+          sessionID: session.id,
+          auto: true,
+        })
+
+        expect(result).toBe("continue")
+        expect(statuses.map((item) => item.type)).toStrictEqual(["compacting", "busy"])
+        expect(statuses[0]).toMatchObject({ type: "compacting", startedAt: expect.any(Number) })
+        expect(yield* status.get(session.id)).toMatchObject({ type: "busy" })
+      }).pipe(withCompaction({ llm: stub.layer }))
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "restores busy when compaction overflows again",
+    Effect.gen(function* () {
+      const status = yield* SessionStatus.Service
+      const ssn = yield* SessionNs.Service
+      const session = yield* ssn.create({})
+      yield* createUserMessage(session.id, "hello")
+      const statuses = yield* recordStatusEvents(session.id)
+
+      yield* createSummaryCompaction(session.id)
+      const msgs = yield* ssn.messages({ sessionID: session.id })
+      const parent = msgs.at(-1)?.info.id
+      expect(parent).toBeTruthy()
+      const result = yield* SessionCompaction.use.process({
+        parentID: parent!,
+        messages: msgs,
+        sessionID: session.id,
+        auto: false,
+      })
+
+      expect(result).toBe("stop")
+      expect(statuses.map((item) => item.type)).toStrictEqual(["compacting", "busy"])
+      expect(yield* status.get(session.id)).toMatchObject({ type: "busy" })
+    }).pipe(withCompaction({ result: "compact" })),
+  )
+
+  itCompaction.instance(
+    "does not emit compacting when experimental event system is disabled",
+    () => {
+      const stub = llm()
+      stub.push(reply("summary"))
+
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "hello")
+        const statuses = yield* recordStatusEvents(session.id)
+
+        yield* createSummaryCompaction(session.id)
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        const result = yield* SessionCompaction.use.process({
+          parentID: parent!,
+          messages: msgs,
+          sessionID: session.id,
+          auto: false,
+        })
+
+        expect(result).toBe("continue")
+        expect(statuses.map((item) => item.type)).toStrictEqual(["busy"])
+      }).pipe(withCompaction({ llm: stub.layer, experimentalEventSystem: false }))
+    },
+    { git: true },
+  )
+
   it.instance(
     "throws when parent is not a user message",
     Effect.gen(function* () {

--- a/packages/opencode/test/session/schema-decoding.test.ts
+++ b/packages/opencode/test/session/schema-decoding.test.ts
@@ -229,6 +229,11 @@ describe("SessionStatus.Info", () => {
     expect(decode({ type: "busy" })).toEqual({ type: "busy" })
   })
 
+  test("compacting carries optional startedAt", () => {
+    expect(decode({ type: "compacting" })).toEqual({ type: "compacting" })
+    expect(decode({ type: "compacting", startedAt: 123 })).toEqual({ type: "compacting", startedAt: 123 })
+  })
+
   test("retry carries attempt/message/action/next", () => {
     const input = {
       type: "retry" as const,

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -463,6 +463,10 @@ export type SessionStatus =
   | {
       type: "busy"
     }
+  | {
+      type: "compacting"
+      startedAt?: number
+    }
 
 export type EventSessionStatus = {
   type: "session.status"

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -689,6 +689,10 @@ export type SessionStatus =
   | {
       type: "busy"
     }
+  | {
+      type: "compacting"
+      startedAt?: number
+    }
 
 export type QuestionOption = {
   /**

--- a/packages/tui/src/component/compaction-progress.tsx
+++ b/packages/tui/src/component/compaction-progress.tsx
@@ -1,0 +1,55 @@
+import { createMemo, Show } from "solid-js"
+import { useKV } from "../context/kv"
+import { useTheme } from "../context/theme"
+import { Spinner } from "./spinner"
+
+const DEFAULT_LABEL = "Compacting conversation..."
+const MIN_BAR_WIDTH = 6
+const MAX_SEGMENT_WIDTH = 8
+
+export type CompactionProgressProps = {
+  active: boolean
+  elapsedSeconds: number
+  width: number
+  label?: string
+}
+
+export function CompactionProgress(props: CompactionProgressProps) {
+  const { theme } = useTheme()
+  const kv = useKV()
+  const animationsEnabled = () => kv.get("animations_enabled", true)
+  const elapsed = createMemo(() => `${Math.max(0, Math.floor(props.elapsedSeconds))}s`)
+  const barWidth = createMemo(() => Math.max(0, Math.floor(props.width)))
+  const segmentWidth = createMemo(() => Math.min(MAX_SEGMENT_WIDTH, Math.max(1, Math.floor(barWidth() / 3))))
+  const segmentStart = createMemo(() => {
+    if (!animationsEnabled()) return 0
+    return Math.max(0, Math.floor(props.elapsedSeconds)) % Math.max(1, barWidth() - segmentWidth() + 1)
+  })
+  const bar = createMemo(() => ({
+    before: "─".repeat(segmentStart()),
+    segment: "━".repeat(segmentWidth()),
+    after: "─".repeat(Math.max(0, barWidth() - segmentStart() - segmentWidth())),
+  }))
+
+  return (
+    <Show when={props.active}>
+      <box gap={0}>
+        <box flexDirection="row" gap={1}>
+          <Spinner color={theme.accent}>
+            <span style={{ fg: theme.textMuted }}>{props.label ?? DEFAULT_LABEL}</span>
+          </Spinner>
+          <text fg={theme.textMuted} wrapMode="none">
+            {elapsed()}
+          </text>
+        </box>
+        <Show when={barWidth() >= MIN_BAR_WIDTH}>
+          <text wrapMode="none" width={barWidth()}>
+            <span style={{ fg: theme.textMuted }}>{bar().before}</span>
+            <span style={{ fg: theme.accent }}>{bar().segment}</span>
+            <span style={{ fg: theme.textMuted }}>{bar().after}</span>
+          </text>
+        </Show>
+      </box>
+    </Show>
+  )
+}

--- a/packages/tui/src/component/context-countdown.tsx
+++ b/packages/tui/src/component/context-countdown.tsx
@@ -1,0 +1,55 @@
+import { createMemo, Show } from "solid-js"
+import { useTheme } from "../context/theme"
+
+const MIN_BAR_WIDTH = 6
+const WARNING_DISTANCE = 5
+const NEAR_FULL_PERCENT = 90
+
+export type ContextCountdownProps = {
+  used: number
+  window: number
+  threshold?: number
+  width: number
+}
+
+export function ContextCountdown(props: ContextCountdownProps) {
+  const { theme } = useTheme()
+  const percent = createMemo(() => clampPercent(Math.round((props.used / props.window) * 100)))
+  const thresholdPercent = createMemo(() => {
+    if (props.threshold === undefined) return
+    return clampPercent(Math.round((props.threshold / props.window) * 100))
+  })
+  const label = createMemo(() => {
+    const threshold = thresholdPercent()
+    if (threshold === undefined) return `Context ${percent()}%`
+    return `Context ${percent()}% · auto-compact ~${threshold}%`
+  })
+  const barWidth = createMemo(() => Math.max(0, Math.floor(props.width)))
+  const fillWidth = createMemo(() => Math.min(barWidth(), Math.max(0, Math.round((barWidth() * percent()) / 100))))
+  const trackWidth = createMemo(() => Math.max(0, barWidth() - fillWidth()))
+  const fillColor = createMemo(() => {
+    const threshold = thresholdPercent()
+    if (threshold !== undefined) return percent() >= Math.max(0, threshold - WARNING_DISTANCE) ? theme.warning : theme.accent
+    return percent() >= NEAR_FULL_PERCENT ? theme.warning : theme.accent
+  })
+
+  return (
+    <Show when={props.window > 0}>
+      <box gap={0}>
+        <text fg={theme.textMuted} wrapMode="none">
+          {label()}
+        </text>
+        <Show when={barWidth() >= MIN_BAR_WIDTH}>
+          <text wrapMode="none" width={barWidth()}>
+            <span style={{ fg: fillColor() }}>{"━".repeat(fillWidth())}</span>
+            <span style={{ fg: theme.textMuted }}>{"─".repeat(trackWidth())}</span>
+          </text>
+        </Show>
+      </box>
+    </Show>
+  )
+}
+
+function clampPercent(value: number) {
+  return Math.min(100, Math.max(0, value))
+}

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -18,6 +18,8 @@ import { errorMessage } from "../util/error"
 import { DialogSessionDeleteFailed } from "./dialog-session-delete-failed"
 import { useCommandShortcut } from "../keymap"
 
+const workingSessionStatusTypes = ["busy", "retry", "compacting"]
+
 export function DialogSessionList() {
   const dialog = useDialog()
   const route = useRoute()
@@ -179,7 +181,7 @@ export function DialogSessionList() {
 
       const isDeleting = toDelete() === x.id
       const status = sync.data.session_status?.[x.id]
-      const isWorking = status?.type === "busy" || status?.type === "retry"
+      const isWorking = workingSessionStatusTypes.includes(status?.type ?? "")
       const slot = slotByID.get(x.id)
       const gutter = isWorking
         ? () => <Spinner />

--- a/packages/tui/src/feature-plugins/system/notifications.ts
+++ b/packages/tui/src/feature-plugins/system/notifications.ts
@@ -3,6 +3,7 @@ import type { TuiAttentionSoundName, TuiPlugin, TuiPluginApi } from "@opencode-a
 import type { BuiltinTuiPlugin } from "../builtins"
 
 const id = "internal:notifications"
+const activeSessionStatusTypes = ["busy", "retry", "compacting"]
 
 type SessionError = Extract<Event, { type: "session.error" }>["properties"]["error"]
 
@@ -58,7 +59,7 @@ const tui: TuiPlugin = async (api) => {
 
   api.event.on("session.status", (event) => {
     const sessionID = event.properties.sessionID
-    if (event.properties.status.type === "busy" || event.properties.status.type === "retry") {
+    if (activeSessionStatusTypes.includes(event.properties.status.type)) {
       active.add(sessionID)
       errored.delete(sessionID)
       return

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -24,6 +24,8 @@ import { useEvent } from "../../context/event"
 import { SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { Spinner } from "../../component/spinner"
+import { CompactionProgress } from "../../component/compaction-progress"
+import { ContextCountdown } from "../../component/context-countdown"
 import { createSyntaxStyleMemo, generateSubtleSyntax, selectedForeground, useTheme } from "../../context/theme"
 import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA } from "@opentui/core"
 import { Prompt, type PromptRef } from "../../component/prompt"
@@ -90,6 +92,8 @@ const GO_UPSELL_ACCOUNT_RATE_LIMIT_LAST_SEEN_AT = "go_upsell_account_rate_limit_
 const GO_UPSELL_ACCOUNT_RATE_LIMIT_DONT_SHOW = "go_upsell_account_rate_limit_dont_show"
 const GO_UPSELL_WINDOW = 86_400_000 // 24 hrs
 const GO_UPSELL_PROVIDERS = new Set(["opencode", "opencode-go"])
+const COMPACTION_BUFFER = 20_000
+const OUTPUT_TOKEN_MAX = 32_000
 
 type RetryAction = Extract<SessionStatus, { type: "retry" }>["action"]
 
@@ -269,6 +273,59 @@ export function Session() {
   })
   const showTimestamps = createMemo(() => timestamps() === "show")
   const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const visibleSessionStatus = createMemo(() => {
+    if (session()?.parentID) return
+    return sync.data.session_status?.[route.sessionID]
+  })
+  const compactingStatus = createMemo(() => {
+    const status = visibleSessionStatus()
+    if (status?.type !== "compacting") return
+    return status
+  })
+  const [compactionFallback, setCompactionFallback] = createSignal<{ sessionID: string; startedAt: number }>()
+  const [compactionNow, setCompactionNow] = createSignal(Date.now())
+  const compactionElapsedSeconds = createMemo(() => {
+    const status = compactingStatus()
+    if (!status) return 0
+    const fallback = compactionFallback()
+    const startedAt = status.startedAt ?? (fallback?.sessionID === route.sessionID ? fallback.startedAt : compactionNow())
+    return Math.max(0, Math.floor((compactionNow() - startedAt) / 1000))
+  })
+  const contextUsage = createMemo(() => {
+    if (session()?.parentID) return
+    const last = messages().findLast(
+      (item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0 && !item.summary,
+    )
+    if (!last) return
+
+    const used =
+      last.tokens.total ??
+      last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
+    if (!Number.isFinite(used) || used <= 0) return
+
+    const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    if (!model) return
+    const window = model.limit.context
+    if (!Number.isFinite(window) || window <= 0) return
+
+    const outputTokenMax =
+      Number.isFinite(model.limit.output) && model.limit.output > 0
+        ? Math.min(model.limit.output, OUTPUT_TOKEN_MAX)
+        : undefined
+    const reserved = sync.data.config.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, outputTokenMax ?? COMPACTION_BUFFER)
+    const usable = model.limit.input
+      ? Math.max(0, model.limit.input - reserved)
+      : outputTokenMax
+        ? Math.max(0, window - outputTokenMax)
+        : undefined
+    const threshold =
+      sync.data.config.compaction?.auto === false || usable === undefined || usable <= 0 || usable >= window
+        ? undefined
+        : usable
+
+    // Mirrors packages/opencode/src/session/overflow.ts usable(); with unknown output, keep the input-limit buffer fallback honest but omit no-input-limit thresholds.
+    return { used, window, threshold }
+  })
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
@@ -1139,6 +1196,23 @@ export function Session() {
     }
   })
 
+  createEffect(() => {
+    const status = compactingStatus()
+    if (!status) {
+      setCompactionFallback(undefined)
+      return
+    }
+    const now = Date.now()
+    const fallback = untrack(compactionFallback)
+    if (status.startedAt === undefined && fallback?.sessionID !== route.sessionID) {
+      setCompactionFallback({ sessionID: route.sessionID, startedAt: now })
+    }
+    if (status.startedAt !== undefined && fallback !== undefined) setCompactionFallback(undefined)
+    setCompactionNow(now)
+    const timer = setInterval(() => setCompactionNow(Date.now()), 1000)
+    onCleanup(() => clearInterval(timer))
+  })
+
   // snap to bottom when session changes
   createEffect(on(() => route.sessionID, toBottom))
 
@@ -1295,6 +1369,25 @@ export function Session() {
                 </Show>
                 <Show when={session()?.parentID}>
                   <SubagentFooter />
+                </Show>
+                <Show when={visibleSessionStatus()?.type === "compacting"}>
+                  <CompactionProgress active={true} elapsedSeconds={compactionElapsedSeconds()} width={contentWidth()} />
+                </Show>
+                <Show when={contextUsage()}>
+                  {(usage) => {
+                    const current = usage()
+                    if (current.threshold === undefined) {
+                      return <ContextCountdown used={current.used} window={current.window} width={contentWidth()} />
+                    }
+                    return (
+                      <ContextCountdown
+                        used={current.used}
+                        window={current.window}
+                        threshold={current.threshold}
+                        width={contentWidth()}
+                      />
+                    )
+                  }}
                 </Show>
                 <Show when={visible()}>
                   <pluginRuntime.Slot

--- a/packages/tui/test/cli/cmd/tui/notifications.test.ts
+++ b/packages/tui/test/cli/cmd/tui/notifications.test.ts
@@ -165,6 +165,32 @@ describe("internal notifications TUI plugin", () => {
     ])
   })
 
+  test("treats compacting as active until idle", async () => {
+    const harness = await setup()
+
+    harness.emit({
+      id: "event-1",
+      type: "session.status",
+      properties: { sessionID: "session", status: { type: "compacting", startedAt: 123 } },
+    })
+    expect(harness.notifications).toEqual([])
+
+    harness.emit({
+      id: "event-2",
+      type: "session.status",
+      properties: { sessionID: "session", status: { type: "idle" } },
+    })
+
+    expect(harness.notifications).toEqual([
+      {
+        title: "Demo session",
+        message: "Session done",
+        notification: { when: "blurred" },
+        sound: { name: "done", when: "always" },
+      },
+    ])
+  })
+
   test("uses sound-only notifications and subagent_done sound for subagent sessions", async () => {
     const harness = await setup()
 

--- a/packages/tui/test/component/compaction-indicators.test.tsx
+++ b/packages/tui/test/component/compaction-indicators.test.tsx
@@ -1,0 +1,148 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { testRender, type JSX } from "@opentui/solid"
+import { onMount, type ParentProps } from "solid-js"
+import { tmpdir } from "../fixture/fixture"
+import { createTuiResolvedConfig } from "../fixture/tui-runtime"
+import { TestTuiContexts } from "../fixture/tui-environment"
+import { TuiConfigProvider } from "../../src/config"
+import { KVProvider, useKV } from "../../src/context/kv"
+import { ThemeProvider, useTheme } from "../../src/context/theme"
+import { CompactionProgress } from "../../src/component/compaction-progress"
+import { ContextCountdown } from "../../src/component/context-countdown"
+
+const spinnerFrames = /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/
+
+describe("compaction indicators", () => {
+  test("renders active compaction progress with fixed elapsed seconds", async () => {
+    const frame = await renderFrame(() => <CompactionProgress active={true} elapsedSeconds={12} width={40} />)
+
+    expect(frame).toContain("Compacting conversation")
+    expect(frame).toContain("12s")
+  })
+
+  test("renders nothing when compaction progress is inactive", async () => {
+    const frame = await renderFrame(() => <CompactionProgress active={false} elapsedSeconds={12} width={40} />)
+
+    expect(frame).not.toContain("Compacting")
+    expect(visibleLines(frame)).toEqual([])
+  })
+
+  test("renders static compaction progress when animations are disabled", async () => {
+    const frame = await renderFrame(() => <CompactionProgress active={true} elapsedSeconds={12} width={40} />, {
+      animationsEnabled: false,
+    })
+
+    expect(frame).toContain("⋯ Compacting conversation... 12s")
+    expect(frame).toContain("━━━━━━━━")
+    expect(frame).not.toMatch(spinnerFrames)
+  })
+
+  test("renders safely at narrow widths", async () => {
+    const medium = await renderFrame(() => <CompactionProgress active={true} elapsedSeconds={12} width={30} />)
+    const narrow4 = await renderFrame(() => <CompactionProgress active={true} elapsedSeconds={12} width={4} />)
+
+    expect(medium).toContain("Compacting conversation")
+    expect(visibleLines(medium)).toHaveLength(2)
+    expect(medium).toMatch(/[━─]{2,}/)
+    expect(narrow4).toContain("Compacting conversation")
+    expect(visibleLines(narrow4)).toHaveLength(1)
+  })
+
+  test("renders context countdown percentage from fixed token counts", async () => {
+    const frame = await renderFrame(() => <ContextCountdown used={800} window={1000} width={40} />)
+
+    expect(visibleLines(frame)[0]).toBe("Context 80%")
+  })
+
+  test("renders context countdown auto-compact marker when threshold is provided", async () => {
+    const frame = await renderFrame(() => <ContextCountdown used={900} window={1000} threshold={900} width={40} />)
+
+    expect(frame).toContain("Context 90%")
+    expect(frame).toContain("auto-compact ~90%")
+  })
+
+  test("clamps context countdown above the window", async () => {
+    const frame = await renderFrame(() => <ContextCountdown used={1200} window={1000} width={40} />)
+
+    expect(visibleLines(frame)[0]).toBe("Context 100%")
+  })
+
+  test("renders nothing when context window is unavailable", async () => {
+    const frame = await renderFrame(() => <ContextCountdown used={800} window={0} width={40} />)
+
+    expect(frame).not.toContain("Context")
+    expect(visibleLines(frame)).toEqual([])
+  })
+})
+
+async function renderFrame(component: () => JSX.Element, input: RenderInput = {}) {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, JSON.stringify({}))
+
+  let resolveReady: () => void
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve
+  })
+
+  const app = await testRender(
+    () =>
+      withTuiContexts(
+        () => (
+          <ReadySignal animationsEnabled={input.animationsEnabled} onReady={resolveReady}>
+            {component()}
+          </ReadySignal>
+        ),
+        tmp.path,
+      ),
+    { width: input.width ?? 80, height: input.height ?? 6 },
+  )
+
+  try {
+    await app.renderOnce()
+    await ready
+    await app.renderOnce()
+    return app.captureCharFrame()
+  } finally {
+    app.renderer.destroy()
+  }
+}
+
+function withTuiContexts(component: () => JSX.Element, state: string) {
+  return (
+    <TestTuiContexts paths={{ state }}>
+      <TuiConfigProvider config={createTuiResolvedConfig()}>
+        <KVProvider>
+          <ThemeProvider mode="dark" source={{ discover: async () => ({}) }}>
+            {component()}
+          </ThemeProvider>
+        </KVProvider>
+      </TuiConfigProvider>
+    </TestTuiContexts>
+  )
+}
+
+function ReadySignal(props: ParentProps<{ animationsEnabled?: boolean; onReady: () => void }>) {
+  useTheme()
+  const kv = useKV()
+
+  onMount(() => {
+    if (props.animationsEnabled !== undefined) kv.set("animations_enabled", props.animationsEnabled)
+    props.onReady()
+  })
+
+  return <>{props.children}</>
+}
+
+function visibleLines(frame: string) {
+  return frame
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0)
+}
+
+type RenderInput = {
+  animationsEnabled?: boolean
+  height?: number
+  width?: number
+}


### PR DESCRIPTION
DRAFT: opening as DRAFT pending design approval for the linked feature request. Fixes #32926

Maintainer disclosure: I maintain oh-my-openagent, a community OpenCode plugin. This is a community contribution, not an OpenCode team change.

## What and why

Compaction can make the TUI look frozen today, especially during `/compact` or auto-compaction. This PR adds two honest indicators: an always-on context countdown from existing token and model-window data, and a compaction operation indicator while compaction is running. When the threshold is computable, the countdown renders `Context NN% · auto-compact ~MM%`, mirroring `overflow.ts` `usable()` with the default reserved buffer. The operation indicator is gated behind `experimentalEventSystem`, so default UX is unchanged when the flag is off. It shows elapsed time and an indeterminate bar, not a fake operation percent or ETA.

## What's in this PR

1. `feat(core): add compacting session status variant`
   - Adds the `compacting` status variant in `status.ts`.
   - Updates consumers and regenerates the SDK type output.
2. `feat(opencode): emit compacting status across compaction lifecycle`
   - Sets and restores status across manual and auto compaction.
   - Uses lifecycle-safe restore via `Effect.ensuring`.
   - Guards busy writes so compaction is not overwritten mid-stream.
   - Keeps emission behind `experimentalEventSystem`.
3. `feat(tui): add compaction progress and context countdown indicators`
   - Adds two opentui components.
   - Wires both into the session bottom area.
   - Shows `Context NN% · auto-compact ~MM%` when the threshold can be computed.
4. `test(opencode): cover compaction status lifecycle and TUI indicators`
   - Adds server lifecycle coverage.
   - Adds deterministic opentui buffer tests for both indicators.

## How I verified it

- `cd packages/opencode && bun typecheck`
  - Exit 0.
- `cd packages/tui && bun typecheck`
  - Exit 0.
- `cd packages/opencode && bun test test/session/compaction.test.ts`
  - Passes. The lifecycle suite covers manual compaction, auto compaction, failure restore with no stuck status, flag-off behavior, and the busy-overwrite guard.
  - I also verified the busy-overwrite guard with a negative control by temporarily removing the processor stream-start guard and confirming the new test failed before restoring the source.
- `cd packages/opencode && bun test test/session/`
  - Passes: 368 pass, 7 skip, 0 fail.
- `cd packages/tui && bun test test/component/compaction-indicators.test.tsx`
  - Passes: 7 pass.
  - Covers active and inactive states, animations-off fallback, narrow-width bar drop, `Context 80%`, the marker `Context 90% · auto-compact ~90%`, clamp to `Context 100%`, and hidden output when the model window is unknown.
- `cd packages/opencode && bun test`
  - Full package run was executed. Compaction and status tests passed. The remaining httpapi PTY timeout is proven pre-existing on base `5d0f866` and sits outside this change.
- `cd packages/tui && bun test`
  - Full package run was executed. The compaction indicator tests were not among failures. The sync failures are proven pre-existing on base `5d0f866`; for example, `sync.test.tsx` reports 0 pass and 2 fail on base from unrelated SolidJS context-provider issues. This branch never touched those files, so it introduces zero new failures.
- `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM=1 bun dev`
  - Live TUI was driven through tmux.
  - Sent `say hi`, saw the model reply, token usage, spend, and the `Context 5% · auto-compact ~97%` countdown.
  - Ran `/compact` and captured both indicators in the same real TUI frame: the operation indicator counting `Compacting conversation... 3s` then `4s` with the indeterminate bar, alongside the countdown.
  - After compaction, the completed `Compaction, Claude Opus 4.8 (1M Max), 6.4s` line appeared. The full sequence is in the recording under UI evidence.

Note: the live run and recording used `bun dev`, which CONTRIBUTING documents as the development equivalent of the CLI.

## UI evidence

Live screen recording of the real TUI during `/compact`, captured with asciinema and agg from an `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM=1 bun dev` session:

![compaction progress and context countdown in the opencode TUI](https://github.com/MoerAI/opencode/releases/download/demo-compaction-progress/compaction-demo.gif)

The recording shows the operation indicator ticking `Compacting conversation... 3s` then `4s` with the indeterminate bar, the completed `Compaction, Claude Opus 4.8 (1M Max), 6.4s` line, and the always-on `Context 5% · auto-compact ~97%` countdown throughout.

## Branch and commit recap

- Branch: `compaction-progress`, based on `dev`.
- Commits: 4 focused commits on `dev`.
- Target branch: `dev`, not `master`.
- This is a draft PR linked to the feature request. I am not asking for merge before design approval.
