### PR TITLE
fix(core): prevent hang when inotify watches are exhausted

### DIFF
--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -4,6 +4,8 @@ export * as Watcher from "./watcher"
 import { createWrapper } from "@parcel/watcher/wrapper"
 import type ParcelWatcher from "@parcel/watcher"
 import { Cause, Context, Effect, Layer, Schema } from "effect"
+import fs from "fs"
+import os from "os"
 import path from "path"
 import { Config } from "../config"
 import { EventV2 } from "../event"
@@ -47,6 +49,35 @@ function getBackend() {
   if (process.platform === "linux") return "inotify"
 }
 
+function canWatch(): Promise<boolean> {
+  return new Promise((resolve) => {
+    let dir: string | undefined
+    let w: fs.FSWatcher | undefined
+    let settled = false
+
+    const cleanup = () => {
+      try { w?.close() } catch {}
+      if (dir) fs.rmSync(dir, { recursive: true, force: true })
+    }
+
+    const done = (ok: boolean) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(ok)
+    }
+
+    try {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), "watcher-check-"))
+      w = fs.watch(dir, { persistent: false })
+      w.on("error", () => done(false))
+      setTimeout(() => done(true), 100)
+    } catch {
+      done(false)
+    }
+  })
+}
+
 function protecteds(dir: string) {
   return Protected.paths().filter((item) => {
     const relative = path.relative(dir, item)
@@ -78,15 +109,25 @@ export const layer = Layer.effect(
     const w = watcher()
     if (!w) return Service.of({})
 
+    if (!(yield* Effect.promise(() => canWatch()))) {
+      yield* Effect.logWarning("watcher: file watching unavailable on this system, file watching disabled", {
+        directory: location.directory,
+        backend,
+      })
+      return Service.of({})
+    }
+
     yield* Effect.logInfo("watcher backend", { directory: location.directory, platform: process.platform, backend })
     const events = yield* EventV2.Service
-    const fs = yield* FSUtil.Service
+    const fsService = yield* FSUtil.Service
     const git = yield* Git.Service
     const context = yield* Effect.context()
     const runFork = Effect.runForkWith(context)
     const subscriptions: ParcelWatcher.AsyncSubscription[] = []
     yield* Effect.addFinalizer(() =>
-      Effect.promise(() => Promise.allSettled(subscriptions.map((subscription) => subscription.unsubscribe()))),
+      Effect.promise(() =>
+        Promise.allSettled(subscriptions.map((subscription) => subscription.unsubscribe().catch(() => {}))),
+      ),
     )
 
     const callback: ParcelWatcher.SubscribeCallback = (_error, updates) => {
@@ -119,14 +160,29 @@ export const layer = Layer.effect(
     }
 
     if (location.vcs?.type === "git") {
-      const resolved = yield* git.dir(location.directory)
-      const vcs = resolved ? yield* fs.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved))) : undefined
-      if (vcs && !config.includes(".git") && !config.includes(vcs) && (!resolved || !config.includes(resolved))) {
-        const ignore = (yield* fs.readDirectoryEntries(vcs).pipe(Effect.catch(() => Effect.succeed([])))).flatMap(
-          (entry) => (entry.name === "HEAD" ? [] : [entry.name]),
-        )
-        yield* Effect.forkScoped(subscribe(vcs, ignore))
-      }
+      yield* Effect.forkScoped(
+        Effect.gen(function* () {
+          const resolved = yield* git.dir(location.directory)
+          const vcs = resolved
+            ? yield* fsService.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved)))
+            : undefined
+          if (!vcs || config.includes(".git") || config.includes(vcs) || (resolved && config.includes(resolved)))
+            return
+          const head = path.join(vcs, "HEAD")
+          if (!fs.existsSync(head)) return
+          const w = fs.watch(head, { persistent: false })
+          yield* Effect.addFinalizer(() => Effect.sync(() => w.close()))
+          w.on("change", () => runFork(events.publish(Event.Updated, { file: head, event: "change" })))
+          w.on("error", () => {})
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("watcher: git HEAD tracking failed, continuing without git HEAD tracking", {
+              directory: location.directory,
+              cause: Cause.pretty(cause),
+            }),
+          ),
+        ),
+      )
     }
 
     return Service.of({})

--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -170,9 +170,10 @@ export const layer = Layer.effect(
             return
           const head = path.join(vcs, "HEAD")
           if (!fs.existsSync(head)) return
-          const w = fs.watch(head, { persistent: false })
+          const w = fs.watch(vcs, { persistent: false }, (_eventType, filename) => {
+            if (filename === "HEAD") runFork(events.publish(Event.Updated, { file: head, event: "change" }))
+          })
           yield* Effect.addFinalizer(() => Effect.sync(() => w.close()))
-          w.on("change", () => runFork(events.publish(Event.Updated, { file: head, event: "change" })))
           w.on("error", () => {})
         }).pipe(
           Effect.catchCause((cause) =>

--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -5,7 +5,6 @@ import { createWrapper } from "@parcel/watcher/wrapper"
 import type ParcelWatcher from "@parcel/watcher"
 import { Cause, Context, Effect, Layer, Schema } from "effect"
 import fs from "fs"
-import os from "os"
 import path from "path"
 import { Config } from "../config"
 import { EventV2 } from "../event"
@@ -49,35 +48,6 @@ function getBackend() {
   if (process.platform === "linux") return "inotify"
 }
 
-function canWatch(): Promise<boolean> {
-  return new Promise((resolve) => {
-    let dir: string | undefined
-    let w: fs.FSWatcher | undefined
-    let settled = false
-
-    const cleanup = () => {
-      try { w?.close() } catch {}
-      if (dir) fs.rmSync(dir, { recursive: true, force: true })
-    }
-
-    const done = (ok: boolean) => {
-      if (settled) return
-      settled = true
-      cleanup()
-      resolve(ok)
-    }
-
-    try {
-      dir = fs.mkdtempSync(path.join(os.tmpdir(), "watcher-check-"))
-      w = fs.watch(dir, { persistent: false })
-      w.on("error", () => done(false))
-      setTimeout(() => done(true), 100)
-    } catch {
-      done(false)
-    }
-  })
-}
-
 function protecteds(dir: string) {
   return Protected.paths().filter((item) => {
     const relative = path.relative(dir, item)
@@ -108,14 +78,6 @@ export const layer = Layer.effect(
 
     const w = watcher()
     if (!w) return Service.of({})
-
-    if (!(yield* Effect.promise(() => canWatch()))) {
-      yield* Effect.logWarning("watcher: file watching unavailable on this system, file watching disabled", {
-        directory: location.directory,
-        backend,
-      })
-      return Service.of({})
-    }
 
     yield* Effect.logInfo("watcher backend", { directory: location.directory, platform: process.platform, backend })
     const events = yield* EventV2.Service
@@ -170,11 +132,21 @@ export const layer = Layer.effect(
             return
           const head = path.join(vcs, "HEAD")
           if (!fs.existsSync(head)) return
-          const w = fs.watch(vcs, { persistent: false }, (_eventType, filename) => {
-            if (filename === "HEAD") runFork(events.publish(Event.Updated, { file: head, event: "change" }))
+
+          let prev = ""
+          try { prev = fs.readFileSync(head, "utf8") } catch {}
+
+          fs.watchFile(head, { interval: 2000 }, () => {
+            try {
+              const next = fs.readFileSync(head, "utf8")
+              if (next !== prev) {
+                prev = next
+                runFork(events.publish(Event.Updated, { file: head, event: "change" }))
+              }
+            } catch {}
           })
-          yield* Effect.addFinalizer(() => Effect.sync(() => w.close()))
-          w.on("error", () => {})
+
+          yield* Effect.addFinalizer(() => Effect.sync(() => fs.unwatchFile(head)))
         }).pipe(
           Effect.catchCause((cause) =>
             Effect.logWarning("watcher: git HEAD tracking failed, continuing without git HEAD tracking", {

--- a/packages/core/test/filesystem/watcher.test.ts
+++ b/packages/core/test/filesystem/watcher.test.ts
@@ -237,6 +237,25 @@ describeWatcher("Watcher", () => {
     ),
   )
 
+  it.live("does not crash when .git/HEAD is missing", () =>
+    withTmp(
+      (directory) =>
+        Effect.gen(function* () {
+          const fs = yield* FSUtil.Service
+          yield* ready(directory)
+          const head = path.join(directory, ".git", "HEAD")
+          yield* fs.remove(head, { force: true })
+          yield* Effect.sleep("100 millis")
+        }),
+      {
+        git: true,
+        init: async (directory) => {
+          await fs.unlink(path.join(directory, ".git", "HEAD"))
+        },
+      },
+    ),
+  )
+
   const describeSymlink = process.platform !== "win32" ? describe : describe.skip
   describeSymlink("symlinked .git", () => {
     it.live("publishes .git/HEAD events through a symlinked .git directory", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #16610

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `.git` watcher used `@parcel/watcher.subscribe()` on the entire `.git/` directory tree, which needs ~228 inotify watches. On Linux systems where inotify resources are exhausted or unreliable (overlayfs containers, low `max_user_watches`, other processes consuming watches), this causes two failure modes:

1. **Hang**: When `inotify_init1()` fails (exhausted instances), `@parcel/watcher`s `Backend::run()` blocks forever on `mStartedSignal.wait()` because `InotifyBackend::start()` throws before calling `notifyStarted()`. The main thread is blocked — no JS timeout can recover.

2. **Crash**: When `inotify_add_watch()` fails (ENOSPC — exhausted watches), `subscribe()` throws a `WatcherError` that is not a subclass of `std::exception`, so it escapes all `catch (std::exception&)` blocks and triggers `std::terminate()`.

3. **Silent failure on overlayfs**: `inotify_add_watch()` can fail with ENOSPC even when the watch count is far below `max_user_watches` (observed: 7119/65536). `fs.watch()` may also succeed but silently never fire events.

The fix replaces the `.git` watchers `@parcel/watcher.subscribe()` with `fs.watchFile()` on `.git/HEAD`. This uses `stat` polling internally — zero inotify watches, works on any filesystem, and handles atomic file replacement (git writes to `HEAD.lock` then renames). The VCS service only listens for HEAD changes for branch tracking (`vcs.ts:325-336` filters `if (!data.file.endsWith("HEAD")) return`), so watching the entire `.git/` tree was unnecessary.

The root watcher (behind `OPENCODE_EXPERIMENTAL_FILEWATCHER`) continues using `@parcel/watcher` unchanged — its opt-in and experimental.

### How did you verify your code works?

- All 7 watcher tests pass (`bun test test/filesystem/watcher.test.ts`), including a new test for missing `.git/HEAD`
- All 36 filesystem tests pass (`bun test test/filesystem/`)
- Typecheck passes (`bun typecheck`)
- Reproduced the hang using `LD_PRELOAD` to intercept `inotify_init1()` — confirmed `subscribe()` blocks the main thread forever
- C diagnostic on the affected machine confirmed `inotify_add_watch()` fails with ENOSPC despite only 7119/65536 watches in use (overlayfs quirk)
- Built a standalone binary and tested on the affected machine — opencode starts normally instead of hanging, and branch switching is detected within ~2 seconds via `fs.watchFile` polling

### Screenshots / recordings

N/A — no UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR