### PR TITLE
fix(snapshot): handle git subdirectory launches

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -120,7 +120,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               "-z",
             ],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -136,7 +136,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
             ],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -147,7 +147,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           const result = yield* git(
             [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -236,10 +236,10 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           const [diff, other] = yield* Effect.all(
             [
               git([...quote, ...args(["diff-files", "--name-only", "-z", "--", "."])], {
-                cwd: state.directory,
+                cwd: state.worktree,
               }),
               git([...quote, ...args(["ls-files", "--others", "--exclude-standard", "-z", "--", "."])], {
-                cwd: state.directory,
+                cwd: state.worktree,
               }),
             ],
             { concurrency: 2 },
@@ -277,7 +277,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             (yield* Effect.all(
               allow.map((item) =>
                 fs
-                  .stat(path.join(state.directory, item))
+                  .stat(path.join(state.worktree, item))
                   .pipe(Effect.catch(() => Effect.void))
                   .pipe(
                     Effect.map((stat) => {
@@ -352,7 +352,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               const result = yield* git(
                 [...quote, ...args(["diff", "--cached", "--no-ext-diff", "--name-only", hash, "--", "."])],
                 {
-                  cwd: state.directory,
+                  cwd: state.worktree,
                 },
               )
               if (result.code !== 0) {
@@ -685,7 +685,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
               const statuses = yield* git(
                 [...quote, ...args(["diff", "--no-ext-diff", "--name-status", "--no-renames", from, to, "--", "."])],
-                { cwd: state.directory },
+                { cwd: state.worktree },
               )
 
               for (const line of statuses.text.trim().split("\n")) {
@@ -698,7 +698,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               const numstat = yield* git(
                 [...quote, ...args(["diff", "--no-ext-diff", "--no-renames", "--numstat", from, to, "--", "."])],
                 {
-                  cwd: state.directory,
+                  cwd: state.worktree,
                 },
               )
 

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -138,6 +138,24 @@ it.instance(
   { git: true },
 )
 
+it.live(
+  "tracks files when opened from a git subdirectory",
+  Effect.gen(function* () {
+    const dir = yield* scopedGitTmpdir()
+    const subdir = `${dir}/src`
+    yield* mkdirp(subdir)
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const file = fwd(dir, "src", "date.txt")
+      yield* write(file, "initial")
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(file, "changed")
+      expect((yield* snapshot.patch(before!)).files).toContain(file)
+    }).pipe(provideInstance(subdir))
+  }),
+)
+
 it.instance(
   "multiple file operations",
   withTrackedSnapshot(({ tmp, snapshot, before }) =>


### PR DESCRIPTION
### Issue for this PR

Closes #27688

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Snapshot paths are collected relative to the git worktree, but several snapshot git commands still ran from the directory where opencode was launched. When opencode starts from a repository subdirectory, those worktree-relative paths can be resolved against the wrong cwd and the snapshot misses changed files.

This changes the snapshot operations that consume worktree-relative paths to run from `state.worktree`, and adds a regression test that launches an instance from `src/` and verifies a changed file is tracked.

### How did you verify your code works?

- `bun test --timeout 30000 test/snapshot/snapshot.test.ts -t 'tracks files when opened from a git subdirectory'`
- `bun test --timeout 30000 test/snapshot/snapshot.test.ts`
- `git diff --check`

I also ran `bun run typecheck`; it currently fails in unrelated `src/mcp/catalog.ts` type errors, which this PR does not touch.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
