### PR TITLE
fix(cli): ignore browser opener failures

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -6,6 +6,16 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
 
+type BrowserOpener = (target: string) => Promise<unknown>
+
+export function openBrowser(target: string, opener: BrowserOpener = open) {
+  try {
+    return Promise.resolve(opener(target)).catch(() => {})
+  } catch {
+    return Promise.resolve()
+  }
+}
+
 function getNetworkIPs() {
   const nets = networkInterfaces()
   const results: string[] = []
@@ -72,11 +82,11 @@ export const WebCommand = effectCmd({
       }
 
       // Open localhost in browser
-      open(localhostUrl).catch(() => {})
+      void openBrowser(localhostUrl)
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      void openBrowser(displayUrl)
     }
 
     yield* Effect.never

--- a/packages/opencode/test/cli/web.test.ts
+++ b/packages/opencode/test/cli/web.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { openBrowser } from "../../src/cli/cmd/web"
+
+describe("cli web", () => {
+  test("ignores browser opener failures", async () => {
+    expect(() => {
+      openBrowser("http://127.0.0.1:55555", () => {
+        throw new Error("spawn failed")
+      })
+    }).not.toThrow()
+
+    await expect(
+      openBrowser("http://127.0.0.1:55555", () => Promise.reject(new Error("spawn failed"))),
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31630

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode web` prints the server URL and then asks the platform browser opener to open it. In WSL setups with Windows interop disabled, that opener can throw while spawning PowerShell, which interrupts the command even though the server URL is already available.

This wraps the browser opener so both synchronous throws and async rejections are ignored. The web command still prints the URL and keeps the server running.

### How did you verify your code works?

- `bun test test/cli/web.test.ts`
- `git diff --check`
- Attempted `bun run typecheck`; current dev snapshot fails in unrelated `src/mcp/catalog.ts` errors.

### Screenshots / recordings

Not a UI rendering change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR