### PR TITLE
fix: suppress unknown JSON Schema format warnings from MCP tool schemas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -557,6 +557,8 @@
         "@zip.js/zip.js": "2.7.62",
         "ai": "catalog:",
         "ai-gateway-provider": "3.1.2",
+        "ajv": "8.20.0",
+        "ajv-formats": "3.0.1",
         "bonjour-service": "1.3.0",
         "chokidar": "4.0.3",
         "cross-spawn": "catalog:",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -109,6 +109,8 @@
     "@zip.js/zip.js": "2.7.62",
     "ai": "catalog:",
     "ai-gateway-provider": "3.1.2",
+    "ajv": "8.20.0",
+    "ajv-formats": "3.0.1",
     "bonjour-service": "1.3.0",
     "chokidar": "4.0.3",
     "cross-spawn": "catalog:",

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -11,6 +11,31 @@ import { Effect } from "effect"
 const DEFAULT_TIMEOUT = 30_000
 const MAX_LIST_PAGES = 1_000
 
+const KNOWN_FORMATS = new Set([
+  "date-time", "date", "time", "duration",
+  "email", "idn-email",
+  "hostname", "idn-hostname", "ipv4", "ipv6",
+  "uri", "uri-reference", "uri-template", "iri", "iri-reference",
+  "json-pointer", "relative-json-pointer",
+  "regex", "uuid",
+])
+
+function stripUnknownFormats(schema: JSONSchema7): JSONSchema7 {
+  if (typeof schema !== "object" || schema === null) return schema
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "format" && typeof value === "string" && !KNOWN_FORMATS.has(value)) continue
+    if (Array.isArray(value)) {
+      result[key] = value.map((v) => stripUnknownFormats(v as JSONSchema7))
+    } else if (typeof value === "object" && value !== null) {
+      result[key] = stripUnknownFormats(value as JSONSchema7)
+    } else {
+      result[key] = value
+    }
+  }
+  return result as JSONSchema7
+}
+
 const TolerantListToolsResultSchema = ListToolsResultSchema.extend({
   tools: ToolSchema.omit({ outputSchema: true }).array(),
 })
@@ -49,7 +74,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
 
   return dynamicTool({
     description: mcpTool.description ?? "",
-    inputSchema: jsonSchema(inputSchema),
+    inputSchema: jsonSchema(stripUnknownFormats(inputSchema)),
     execute: async (args: unknown, options) => {
       const result = await client.callTool(
         {

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -5,6 +5,9 @@ import { type Tool } from "ai"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { Client, type ClientOptions } from "@modelcontextprotocol/sdk/client/index.js"
+import Ajv from "ajv"
+import addFormats from "ajv-formats"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
@@ -37,6 +40,8 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { McpCatalog } from "./catalog"
 
 const DEFAULT_TIMEOUT = 30_000
+const ajv = new Ajv({ strict: false, validateFormats: false })
+addFormats(ajv)
 const CLIENT_OPTIONS = {
   capabilities: {
     // https://github.com/anomalyco/opencode/issues/11948
@@ -48,6 +53,7 @@ const CLIENT_OPTIONS = {
     // https://github.com/anomalyco/opencode/issues/28567
     // tasks: {},
   },
+  jsonSchemaValidator: new AjvJsonSchemaValidator(ajv),
 } satisfies ClientOptions
 
 export const Resource = Schema.Struct({


### PR DESCRIPTION
### Issue for this PR

Closes #32950

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**How we got here:** Discovered while setting up the Google Cloud Pub/Sub MCP server. On startup, dozens of `unknown format` warnings flooded stderr — one for each tool schema property using `google-duration`, `uint64`, `int64`, `google-field-mask`, etc. Tracing backward revealed two independent warning sources.

**Root cause:** The MCP `Client` internally creates an AJV instance with `validateFormats: true`. Non-standard `format` values in tool `outputSchema` trigger `console.warn("unknown format ...")`. Separately, the AI SDK's `jsonSchema()` function receives schemas with these non-standard formats, triggering `[WARN opencode::mcp::registry]`.

**Fix (two layers):**

1. **packages/opencode/src/mcp/index.ts** — Create an AJV instance with `validateFormats: false` and inject it via the `jsonSchemaValidator` option on the MCP `Client`. This suppresses AJV's warnings when compiling tool `outputSchema`.

2. **packages/opencode/src/mcp/catalog.ts** — Add `stripUnknownFormats()` which recursively removes non-standard `format` values (only JSON Schema Validation spec formats are kept) from tool input schemas before passing them to `jsonSchema()`. This prevents the structured `opencode::mcp::registry` warning and keeps the AI SDK's schema processing clean.

### How did you verify your code works?

1. Built with `bun run build --single` → `opencode-windows-x64` binary produced
2. Replaced the global opencode binary
3. Ran `opencode` and connected to a Google Cloud Pub/Sub MCP server (which uses `google-duration`, `uint64`, etc.)
4. Observed **zero** `unknown format` warnings in stderr (previously dozens of warnings appeared)
5. Tool execution and MCP functionality worked correctly

### Screenshots / recordings

N/A — CLI change, not UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
