### PR TITLE
fix(plugin): fall back from unauthorized live client

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -7,7 +7,7 @@ import type {
   WorkspaceAdapter as PluginWorkspaceAdapter,
 } from "@opencode-ai/plugin"
 import { Config } from "@/config/config"
-import { createOpencodeClient } from "@opencode-ai/sdk"
+import { createOpencodeClient, createUnauthorizedFallbackFetch } from "@opencode-ai/sdk"
 import { ServerAuth } from "@/server/auth"
 import { CodexAuthPlugin } from "./openai/codex"
 import { Session } from "@/session/session"
@@ -139,11 +139,12 @@ export const layer = Layer.effect(
         const { Server } = yield* Effect.promise(() => import("../server/server"))
 
         const serverUrl = Server.url
+        const fallbackFetch = async (request: Request) => Server.Default().app.fetch(request)
         const client = createOpencodeClient({
           baseUrl: serverUrl?.toString() ?? "http://localhost:4096",
           directory: ctx.directory,
           headers: ServerAuth.headers(),
-          ...(serverUrl ? {} : { fetch: async (...args) => Server.Default().app.fetch(...args) }),
+          fetch: serverUrl ? createUnauthorizedFallbackFetch({ fallbackFetch }) : fallbackFetch,
         })
         const cfg = yield* config.get()
         const input: PluginInput = {

--- a/packages/sdk/js/src/client.test.ts
+++ b/packages/sdk/js/src/client.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { createUnauthorizedFallbackFetch } from "./client"
+
+describe("createUnauthorizedFallbackFetch", () => {
+  for (const status of [401, 403]) {
+    test(`falls back after live ${status} responses without losing the request body`, async () => {
+      let liveCalls = 0
+      const fallbackRequests: Request[] = []
+
+      const fetcher = createUnauthorizedFallbackFetch({
+        liveFetch: async (request) => {
+          liveCalls++
+          expect(await request.text()).toBe("payload")
+          return new Response("unauthorized", { status })
+        },
+        fallbackFetch: async (request) => {
+          fallbackRequests.push(request.clone())
+          return new Response(
+            JSON.stringify({
+              body: await request.text(),
+              header: request.headers.get("x-plugin"),
+            }),
+            { headers: { "content-type": "application/json" } },
+          )
+        },
+      })
+
+      const first = await fetcher(
+        new Request("http://live.test/api/config", {
+          method: "POST",
+          headers: { "x-plugin": "server" },
+          body: "payload",
+        }),
+      )
+      await expect(first.json()).resolves.toEqual({ body: "payload", header: "server" })
+
+      const second = await fetcher(new Request("http://live.test/api/config"))
+
+      expect(second.status).toBe(200)
+      expect(liveCalls).toBe(1)
+      expect(fallbackRequests).toHaveLength(2)
+    })
+  }
+
+  test("keeps using live fetch for non-auth failures", async () => {
+    let liveCalls = 0
+    let fallbackCalls = 0
+    const fetcher = createUnauthorizedFallbackFetch({
+      liveFetch: async () => {
+        liveCalls++
+        return new Response("server error", { status: 500 })
+      },
+      fallbackFetch: async () => {
+        fallbackCalls++
+        return new Response("fallback")
+      },
+    })
+
+    expect((await fetcher(new Request("http://live.test/api/config"))).status).toBe(500)
+    expect((await fetcher(new Request("http://live.test/api/config"))).status).toBe(500)
+    expect(liveCalls).toBe(2)
+    expect(fallbackCalls).toBe(0)
+  })
+})

--- a/packages/sdk/js/src/client.ts
+++ b/packages/sdk/js/src/client.ts
@@ -30,16 +30,38 @@ function rewrite(request: Request, directory?: string) {
   return next
 }
 
+function defaultFetch(request: Request) {
+  const req = request as Request & { timeout?: boolean }
+  req.timeout = false
+  return fetch(req)
+}
+
+export function createUnauthorizedFallbackFetch(input: {
+  liveFetch?: (request: Request) => ReturnType<typeof fetch>
+  fallbackFetch: (request: Request) => ReturnType<typeof fetch>
+}) {
+  let fallback = false
+  const liveFetch = input.liveFetch ?? defaultFetch
+
+  return async (request: Request) => {
+    if (fallback) return input.fallbackFetch(request)
+
+    const retryRequest = request.clone()
+    const response = await liveFetch(request)
+    if (response.status === 401 || response.status === 403) {
+      fallback = true
+      return input.fallbackFetch(retryRequest)
+    }
+
+    return response
+  }
+}
+
 export function createOpencodeClient(config?: Config & { directory?: string }) {
   if (!config?.fetch) {
-    const customFetch: any = (req: any) => {
-      // @ts-ignore
-      req.timeout = false
-      return fetch(req)
-    }
     config = {
       ...config,
-      fetch: customFetch,
+      fetch: defaultFetch,
     }
   }
 


### PR DESCRIPTION
## Summary
- fall back to the in-process server fetch when the live plugin client receives 401/403
- clone requests before the live attempt so POST bodies can be replayed through fallback
- keep non-auth live failures on the live transport

Closes #31237

## Test
- bun test src/client.test.ts