### PR TITLE
fix(tui): correct day and hour math in duration() past 24h

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -53,8 +53,8 @@ export function duration(input: number) {
     const minutes = Math.floor((input % 3600000) / 60000)
     return `${hours}h ${minutes}m`
   }
-  const hours = Math.floor(input / 3600000)
-  const days = Math.floor((input % 3600000) / 86400000)
+  const days = Math.floor(input / 86400000)
+  const hours = Math.floor((input % 86400000) / 3600000)
   return `${days}d ${hours}h`
 }
 

--- a/packages/tui/test/util/locale.test.ts
+++ b/packages/tui/test/util/locale.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { duration } from "../../src/util/locale"
+
+describe("util.locale", () => {
+  describe("duration", () => {
+    test("formats milliseconds, seconds, and minutes", () => {
+      expect(duration(500)).toBe("500ms")
+      expect(duration(1_500)).toBe("1.5s")
+      expect(duration(90_000)).toBe("1m 30s")
+    })
+
+    test("formats hours and minutes under a day", () => {
+      expect(duration(3_600_000)).toBe("1h 0m")
+      expect(duration(12_600_000)).toBe("3h 30m")
+    })
+
+    test("formats days and hours at and above a day", () => {
+      expect(duration(86_400_000)).toBe("1d 0h")
+      expect(duration(183_600_000)).toBe("2d 3h")
+      expect(duration(187_200_000)).toBe("2d 4h")
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32956

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The days/hours branch of `duration()` was wrong for anything 24h or longer. It took days from the sub-hour remainder divided by a day (always 0) and left hours as the uncapped total, so 2d 3h printed as `0d 51h` and one day as `0d 24h`.

This uses the same approach the minutes/hours branch right above it already uses: days from `input / 86400000`, hours from the within-day remainder.

### How did you verify your code works?

Added `packages/tui/test/util/locale.test.ts` covering the day/hour branch plus the ms/s/m/h branches. It fails on the old code and passes with the fix. Ran the tui test suite (no new failures) and `bun typecheck` is clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
