### PR TITLE
fix(tui): unify todo panel label to Todos

### DIFF
--- a/packages/tui/src/feature-plugins/sidebar/todo.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/todo.tsx
@@ -19,7 +19,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
             <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
           </Show>
           <text fg={theme().text}>
-            <b>Todo</b>
+            <b>Todos</b>
           </text>
         </box>
         <Show when={list().length <= 2 || open()}>


### PR DESCRIPTION
### Issue for this PR

Closes #32967

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an inconsistency in the TUI todo panel title. The sidebar todo widget displayed "Todo" while the main session view displayed "Todos". This change unifies both labels to "Todos".

### How did you verify your code works?

- Verified the single text label in `packages/tui/src/feature-plugins/sidebar/todo.tsx` is updated.

### Screenshots / recordings

_No screenshot provided._

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR