### PR TITLE
fix(session): stop after permission rejection feedback

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -238,7 +238,11 @@ export const layer = Layer.effect(
             time: { start: match.part.state.time.start, end: Date.now() },
           },
         })
-        if (error instanceof PermissionV1.RejectedError || error instanceof Question.RejectedError) {
+        if (
+          error instanceof PermissionV1.RejectedError ||
+          error instanceof PermissionV1.CorrectedError ||
+          error instanceof Question.RejectedError
+        ) {
           ctx.blocked = ctx.shouldBreak
         }
         yield* settleToolCall(toolCallID)

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,4 +1,5 @@
 import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -208,6 +209,31 @@ const providerErrorEnv = LayerNode.buildLayer(root, {
   replacements: [...replacements, LayerNode.replace(LLM.node, providerErrorLLM)],
 })
 const itProviderError = testEffect(providerErrorEnv)
+
+const correctedPermissionLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () =>
+      Stream.make(
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.toolInputStart({ id: "call-1", name: "bash" }),
+        LLMEvent.toolInputEnd({ id: "call-1", name: "bash" }),
+        LLMEvent.toolCall({ id: "call-1", name: "bash", input: { cmd: "rm -rf /tmp/demo" } }),
+        LLMEvent.toolError({
+          id: "call-1",
+          name: "bash",
+          message: "The user rejected permission to use this specific tool call with the following feedback: use ls",
+          error: new PermissionV1.CorrectedError({ feedback: "use ls" }),
+        }),
+        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+        LLMEvent.finish({ reason: "stop" }),
+      ),
+  }),
+)
+const correctedPermissionEnv = LayerNode.buildLayer(root, {
+  replacements: [...replacements, LayerNode.replace(LLM.node, correctedPermissionLLM)],
+})
+const itCorrectedPermission = testEffect(correctedPermissionEnv)
 
 const fragmentFailureLLM = Layer.succeed(
   LLM.Service,
@@ -1015,6 +1041,46 @@ itProviderError.live("session.processor effect tests fail provider-executed erro
           result: { type: "error", value: "provider boom" },
           provider: { executed: true },
         })
+      }),
+    { config: cfg },
+  ),
+)
+
+itCorrectedPermission.live("session.processor effect tests stop after permission rejection with feedback", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "permission feedback")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+
+        const result = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "permission feedback" }],
+          tools: {},
+        })
+
+        const parts = yield* MessageV2.parts(msg.id)
+        const call = parts.find((part): part is SessionV1.ToolPart => part.type === "tool")
+
+        expect(result).toBe("stop")
+        expect(call?.state.status).toBe("error")
+        if (call?.state.status === "error") expect(call.state.error).toContain("use ls")
       }),
     { config: cfg },
   ),


### PR DESCRIPTION
### Issue for this PR

Closes #28793

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a permission prompt is rejected with feedback, the permission layer raises `PermissionV1.CorrectedError` and includes the feedback in the error message. The session processor was only treating plain permission rejections and rejected questions as blocking failures, so a rejected tool call with feedback could still let the turn advance.

This makes `CorrectedError` follow the same stop path as the other user-blocked cases, while preserving the feedback text on the failed tool part. The PR is draft because unrelated workflow PRs also touch `packages/opencode/src/session/processor.ts`.

### How did you verify your code works?

- `bun test test/session/processor-effect.test.ts --test-name-pattern "permission rejection with feedback"`
- `bun test test/session/processor-effect.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR