### PR TITLE
fix(provider): flatten tool message content for MiMo/GLM/Xiaomi

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -22,6 +22,15 @@ export const OUTPUT_TOKEN_MAX = 32_000
 // branch that requests it stays in lockstep.
 const INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"] as const
 
+// Providers that require tool message content as a plain string, not ContentPart[].
+// These providers reject array-format tool content with 400 errors.
+// Extend by adding (id: string) => id.includes("provider-id") to the list.
+const FLATTEN_TOOL_CONTENT_PROVIDERS = [
+  (id: string) => id.includes("mimo"),
+  (id: string) => id.includes("glm"),
+  (id: string) => id.includes("xiaomi"),
+] as const
+
 export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
 }
@@ -280,6 +289,24 @@ function normalizeMessages(
           { type: "reasoning" as const, text: "" },
         ],
       }
+    })
+  }
+
+  // Flatten tool message content for providers that require string-only content.
+  // These providers reject ContentPart[] array format for role=tool messages.
+  if (FLATTEN_TOOL_CONTENT_PROVIDERS.some((fn) => fn(model.api.id.toLowerCase()))) {
+    msgs = msgs.map((msg) => {
+      if (msg.role !== "tool") return msg
+      if (!Array.isArray(msg.content)) return msg
+      // Flatten single text/error-text tool-result to string; pass multi-part through
+      if (
+        msg.content.length === 1 &&
+        msg.content[0].type === "tool-result" &&
+        (msg.content[0].output.type === "text" || msg.content[0].output.type === "error-text")
+      ) {
+        return { ...msg, content: String(msg.content[0].output.value) } as unknown as ModelMessage
+      }
+      return msg
     })
   }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4406,3 +4406,155 @@ describe("ProviderTransform.providerOptions - ai-gateway-provider", () => {
     expect(result).toEqual({ openaiCompatible: { reasoningEffort: "high" } })
   })
 })
+
+describe("ProviderTransform.message - tool content flattening", () => {
+  const createModel = (overrides: Partial<any> = {}) =>
+    ({
+      id: "test/model",
+      providerID: "openai-compatible",
+      api: {
+        id: "test-model",
+        url: "https://api.test.com",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: {
+        toolcall: true,
+        temperature: true,
+        reasoning: false,
+        attachment: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: true },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 1, output: 1, cache: { read: 0, write: 0 } },
+      limit: { context: 1_000_000, output: 128_000 },
+      status: "active",
+      options: {},
+      headers: {},
+      ...overrides,
+    }) as any
+
+  test("flattens single text tool-result to string for MiMo", () => {
+    const model = createModel({ api: { id: "mimo-v2.5" } })
+    const msgs = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            output: { type: "text" as const, value: "The weather is sunny" },
+            toolCallId: "call_1",
+            toolName: "get_weather",
+          },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(result[0].content).toBe("The weather is sunny")
+  })
+
+  test("flattens single error tool-result to string for MiMo", () => {
+    const model = createModel({ api: { id: "mimo-v2.5" } })
+    const msgs = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            output: { type: "error-text" as const, value: "Tool failed" },
+          },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(result[0].content).toBe("Tool failed")
+  })
+
+  test("preserves multi-part tool content as array for MiMo", () => {
+    const model = createModel({ api: { id: "mimo-v2.5" } })
+    const msgs = [
+      {
+        role: "tool" as const,
+        content: [
+          { type: "tool-result" as const, output: { type: "text", value: "done" } },
+          { type: "tool-call" as const, id: "call_1", name: "get_weather", input: {} },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(Array.isArray(result[0].content)).toBe(true)
+  })
+
+  test("preserves tool content array with multiple tool-results for MiMo", () => {
+    const model = createModel({ api: { id: "mimo-v2.5" } })
+    const msgs = [
+      {
+        role: "tool" as const,
+        content: [
+          { type: "tool-result" as const, output: { type: "text", value: "result1" } },
+          { type: "tool-result" as const, output: { type: "text", value: "result2" } },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(Array.isArray(result[0].content)).toBe(true)
+    expect((result[0].content as any[]).length).toBe(2)
+  })
+
+  test("does not flatten assistant messages for MiMo", () => {
+    const model = createModel({ api: { id: "mimo-v2.5" } })
+    const msgs = [
+      { role: "assistant" as const, content: [{ type: "text" as const, text: "hello" }] },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(Array.isArray(result[0].content)).toBe(true)
+  })
+
+  test("does not flatten for unlisted providers (e.g. OpenAI)", () => {
+    const model = createModel({ providerID: "openai", api: { id: "gpt-4o" } })
+    const msgs = [
+      {
+        role: "tool" as const,
+        content: [
+          { type: "tool-result" as const, output: { type: "text", value: "done" } },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(Array.isArray(result[0].content)).toBe(true)
+  })
+
+  test("flattens single text tool-result to string for GLM", () => {
+    const model = createModel({ api: { id: "glm-5.2" } })
+    const msgs = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            output: { type: "text" as const, value: "result" },
+          },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(result[0].content).toBe("result")
+  })
+
+  test("flattens tool content for Xiaomi provider", () => {
+    const model = createModel({ api: { id: "xiaomi-model" } })
+    const msgs = [
+      {
+        role: "tool" as const,
+        content: [
+          {
+            type: "tool-result" as const,
+            output: { type: "text" as const, value: "done" },
+          },
+        ],
+      },
+    ]
+    const result = ProviderTransform.message(msgs as any, model, {})
+    expect(result[0].content).toBe("done")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32613


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

MiMo, GLM-5.2, and Xiaomi models (via OpenAI-compatible endpoint) reject tool role messages where \`content\` is a \`ContentPart[]\` array. They require \`messages[].content\` to be a plain string. This PR adds a provider-specific transform that flattens single-part tool results to strings for affected providers.

Changes:
- Added \`FLATTEN_TOOL_CONTENT_PROVIDERS\` tuple with predicates for \`mimo\`, \`glm\`, and \`xiaomi\` model IDs
- Added message transform in \`normalizeMessages()\` that converts single text/error tool-result parts to plain strings
- Multi-part tool content is left as array (providers that reject arrays will error on it, preserving the signal)
- \`AssistantModelMessage\` and other roles are unaffected

Extension point: add \`(id: string) => id.includes(\"new-provider\")\` to the tuple.

**If you do not follow this template your PR will be automatically rejected.**

### How did you verify your code works?

- \`bun typecheck\` — pass
- \`bun test test/provider/transform.test.ts\` — 277 pass, 0 fail (8 new tests added)

Tests added:
- Single text/error tool-result flattening for MiMo, GLM, Xiaomi
- Multi-part tool content preservation (not flattened)
- Assistant messages unaffected
- Unlisted providers (OpenAI) unaffected

### Screenshots / recordings

N/A — non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR