### PR TITLE
fix(session): cap OpenAI Responses tool count to avoid 500 server_error loop

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -112,6 +112,25 @@ const live: Layer.Layer<
         isWorkflow,
       })
 
+      // The OpenAI Responses backend (including the ChatGPT/Codex OAuth path) rejects
+      // requests that carry too many tool definitions with a generic 500 server_error,
+      // which the retry policy then loops on indefinitely. Cap the tool set so the
+      // request is accepted. Built-in/core tools are registered first, so the slice
+      // preserves them and drops the long tail of MCP tools.
+      if (input.model.api.npm === "@ai-sdk/openai") {
+        const OPENAI_RESPONSES_TOOL_LIMIT = 128
+        const toolNames = Object.keys(prepared.tools)
+        if (toolNames.length > OPENAI_RESPONSES_TOOL_LIMIT) {
+          const kept = new Set(toolNames.slice(0, OPENAI_RESPONSES_TOOL_LIMIT))
+          yield* Effect.logWarning("tool count exceeds OpenAI Responses limit; capping", {
+            modelID: input.model.id,
+            total: toolNames.length,
+            kept: kept.size,
+          })
+          prepared.tools = Object.fromEntries(Object.entries(prepared.tools).filter(([name]) => kept.has(name)))
+        }
+      }
+
       // Wire up toolExecutor for DWS workflow models so that tool calls
       // from the workflow service are executed via opencode's tool system
       // and results sent back over the WebSocket.


### PR DESCRIPTION
### Issue for this PR

Closes #33006

### Type of change

- [x] Bug fix

### What does this PR do?

When many tools are enabled (lots of MCP servers), opencode sends every tool definition in a single OpenAI Responses request. The ChatGPT/Codex OAuth backend rejects requests carrying too many tools with a generic 500 `server_error`, and because the retry policy has no attempt cap for 5xx it loops indefinitely — which makes gpt-5.5 effectively unusable.

This caps the tool set at 128 (OpenAI's documented function ceiling) for `@ai-sdk/openai` models, right after `LLMRequestPrep.prepare`. Built-in/core tools are registered first, so the slice keeps those and drops the long MCP tail, logging a warning when it trims. 128 is conservative — happy to change the number or make it provider-configurable.

Note: the experimental native runtime (`openai-responses.ts`) uses `input.tools` rather than `prepared.tools`, so it isn't covered here — can extend if wanted. A complementary fix would be a max-attempt cap for 5xx in the retry policy so any future provider 500 can't loop forever.

### How did you verify your code works?

Reproduced with gpt-5.5 + 876 tool definitions: 5 `server_error`s and a stuck loop. The same prompt with `--pure` (11 tools) works, confirming tool count is the trigger (not schema, size, or reasoning threading). After the cap: `bun typecheck` clean in `packages/opencode`, and running from source against the same 876-tool setup logs `capping total=876 kept=128`, completes a full tool round-trip, and exits with `server_errors=0`.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
