### PR TITLE
fix(llm): pass topK to Bedrock Converse via additionalModelRequestFields

### DIFF
--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -412,6 +412,9 @@ const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request:
             stopSequences: generation?.stop,
           },
     toolConfig,
+    // Converse's base inferenceConfig has no topK; Anthropic/Nova accept it
+    // as a model-specific field, so it goes through additionalModelRequestFields.
+    additionalModelRequestFields: generation?.topK === undefined ? undefined : { top_k: generation.topK },
   }
 })
 

--- a/packages/llm/test/provider/bedrock-converse.test.ts
+++ b/packages/llm/test/provider/bedrock-converse.test.ts
@@ -83,6 +83,26 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
+  it.effect("passes topK through additionalModelRequestFields as top_k", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(
+        LLM.updateRequest(baseRequest, { generation: { maxTokens: 64, temperature: 0, topK: 40 } }),
+      )
+
+      // Converse's inferenceConfig has no topK; Anthropic/Nova read it from
+      // additionalModelRequestFields as top_k.
+      expect(prepared.body.inferenceConfig).toEqual({ maxTokens: 64, temperature: 0 })
+      expect(prepared.body.additionalModelRequestFields).toEqual({ top_k: 40 })
+    }),
+  )
+
+  it.effect("omits additionalModelRequestFields when topK is unset", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(baseRequest)
+      expect(prepared.body.additionalModelRequestFields).toBeUndefined()
+    }),
+  )
+
   it.effect("lowers chronological system updates to wrapped user text in order", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(


### PR DESCRIPTION
Bedrock Converse dropped the `topK` generation option. The Anthropic Messages path already maps it (`top_k: generation?.topK`), so this brings Converse to parity by routing `topK` through `additionalModelRequestFields` as `top_k` — which is where the AWS Converse API expects model-specific params, and the Converse body schema already declared the field.

Closes #33003

## Verification

- Added two tests in `packages/llm/test/provider/bedrock-converse.test.ts`: `topK` lands in `additionalModelRequestFields: { top_k }`, and the field is omitted when `topK` is unset. Reverting the one-line fix makes the first test fail.
- From `packages/llm`: `bun test test/provider/bedrock-converse.test.ts` (28 pass), `bun typecheck`, `oxlint`, and `prettier --check` all clean.

_AI-assisted (Claude Code); changes, rationale, and tests reviewed by a human before submission._
