### PR TITLE
fix(opencode): fall back to fresh session when task_id is invalid

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,7 +10,7 @@ import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
-import { Effect, Exit, Schema, Scope } from "effect"
+import { Effect, Exit, Option, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Database } from "@opencode-ai/core/database/database"
@@ -118,8 +118,13 @@ export const TaskTool = Tool.define(
         return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
       }
 
-      const session = params.task_id
-        ? yield* sessions.get(SessionID.make(params.task_id)).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
+      // Non-Anthropic models (e.g. grok-composer, GLM-4.7) fabricate arbitrary task_id values.
+      // SessionID.make throws synchronously on a non-"ses" value, which escapes Effect.catchCause
+      // and crashes the subagent launch. Validate with decodeUnknownOption so invalid IDs fall
+      // through to creating a fresh child session. https://github.com/anomalyco/opencode/issues/16755
+      const resumedID = params.task_id ? Schema.decodeUnknownOption(SessionID)(params.task_id) : Option.none<SessionID>()
+      const session = Option.isSome(resumedID)
+        ? yield* sessions.get(resumedID.value).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
         : undefined
       const parent = yield* sessions.get(ctx.sessionID)
       const childPermission = deriveSubagentSessionPermission({

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -381,6 +381,46 @@ describe("tool.task", () => {
     }),
   )
 
+  // Non-Anthropic models fabricate arbitrary task_id values that lack the "ses" prefix.
+  // SessionID.make threw synchronously on such values, escaping catchCause and crashing
+  // every subagent launch. The tool must fall through to a fresh child instead.
+  it.instance("execute creates a child when task_id is not a valid session id", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      let seen: SessionPrompt.PromptInput | undefined
+      const promptOps = stubOps({ text: "created", onPrompt: (input) => (seen = input) })
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          // Mimics grok-composer / GLM-4.7 fabricating a UUID as task_id
+          task_id: "4178c106-bf3c-4a14-89e4-07d68188bdd8",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      const kids = yield* sessions.children(chat.id)
+      expect(kids).toHaveLength(1)
+      expect(kids[0]?.id).toBe(result.metadata.sessionId)
+      expect(result.output).toContain(`<task id="${result.metadata.sessionId}" state="completed">`)
+      expect(seen?.sessionID).toBe(result.metadata.sessionId)
+    }),
+  )
+
   it.instance(
     "execute shapes child permissions for task, todowrite, and primary tools",
     () =>


### PR DESCRIPTION
### Issue for this PR

Closes #16755

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`task_id` is optional, but non-Anthropic models (grok-composer, GLM-4.7) fabricate arbitrary values on the first task call. `SessionID.make()` throws synchronously on any non-`ses` value. Inside `Effect.gen` that throw becomes a `Die` defect at the generator level, which sits outside the `Effect.catchCause(() => …)` wrapper on the resume branch — so the intended "invalid id → create a fresh child" fallback never runs, and every subagent launch crashes.

This replaces the throwing `SessionID.make()` with `Schema.decodeUnknownOption(SessionID)`, which returns `Option<SessionID>` without throwing. Invalid ids now fall through to `Session.create`; real `ses_` ids still resume.

### How did you verify your code works?

Added `execute creates a child when task_id is not a valid session id`, which passes a fabricated UUID as `task_id`. It fails against the old code (reproduces the crash) and passes with the fix. Full `packages/opencode` tool suite (282 tests) passes; `bun typecheck` clean.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
