### PR TITLE
feat(tui): add inline skill picker

### DIFF
--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -186,6 +186,20 @@ export const AgentPart = Schema.Struct({
 }).annotate({ identifier: "AgentPart" })
 export type AgentPart = Types.DeepMutable<Schema.Schema.Type<typeof AgentPart>>
 
+export const SkillPart = Schema.Struct({
+  ...partBase,
+  type: Schema.Literal("skill"),
+  name: Schema.String,
+  source: Schema.optional(
+    Schema.Struct({
+      value: Schema.String,
+      start: NonNegativeInt,
+      end: NonNegativeInt,
+    }),
+  ),
+}).annotate({ identifier: "SkillPart" })
+export type SkillPart = Types.DeepMutable<Schema.Schema.Type<typeof SkillPart>>
+
 export const CompactionPart = Schema.Struct({
   ...partBase,
   type: Schema.Literal("compaction"),
@@ -367,6 +381,7 @@ export const Part = Schema.Union([
   SnapshotPart,
   PatchPart,
   AgentPart,
+  SkillPart,
   RetryPart,
   CompactionPart,
 ]).annotate({ discriminator: "type", identifier: "Part" })
@@ -381,6 +396,7 @@ export type Part =
   | SnapshotPart
   | PatchPart
   | AgentPart
+  | SkillPart
   | RetryPart
   | CompactionPart
 
@@ -435,6 +451,20 @@ export const AgentPartInput = Schema.Struct({
   ),
 }).annotate({ identifier: "AgentPartInput" })
 export type AgentPartInput = Types.DeepMutable<Schema.Schema.Type<typeof AgentPartInput>>
+
+export const SkillPartInput = Schema.Struct({
+  id: Schema.optional(PartID),
+  type: Schema.Literal("skill"),
+  name: Schema.String,
+  source: Schema.optional(
+    Schema.Struct({
+      value: Schema.String,
+      start: NonNegativeInt,
+      end: NonNegativeInt,
+    }),
+  ),
+}).annotate({ identifier: "SkillPartInput" })
+export type SkillPartInput = Types.DeepMutable<Schema.Schema.Type<typeof SkillPartInput>>
 
 export const SubtaskPartInput = Schema.Struct({
   id: Schema.optional(PartID),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -975,6 +975,8 @@ export const layer = Layer.effect(
         }
 
         if (part.type === "skill") {
+          const perm = Permission.evaluate("skill", part.name, ag.permission)
+          if (perm.action === "deny") return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
           const found = yield* skill.get(part.name)
           if (!found) return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
           return [

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -60,6 +60,7 @@ import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { Skill } from "@/skill"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -121,6 +122,7 @@ export const layer = Layer.effect(
     const summary = yield* SessionSummary.Service
     const sys = yield* SystemPrompt.Service
     const llm = yield* LLM.Service
+    const skill = yield* Skill.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
@@ -972,10 +974,32 @@ export const layer = Layer.effect(
           ]
         }
 
+        if (part.type === "skill") {
+          const found = yield* skill.get(part.name)
+          if (!found) return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
+          return [
+            { ...part, messageID: info.id, sessionID: input.sessionID },
+            {
+              messageID: info.id,
+              sessionID: input.sessionID,
+              type: "text",
+              synthetic: true,
+              text: `## Skill: ${found.name}\n\n${found.content.trim()}`,
+            },
+          ]
+        }
+
         return [{ ...part, messageID: info.id, sessionID: input.sessionID }]
       })
 
-      const resolvedParts = yield* Effect.forEach(input.parts, resolvePart, { concurrency: "unbounded" }).pipe(
+      const seenSkills = new Set<string>()
+      const promptParts = input.parts.filter((part) => {
+        if (part.type !== "skill") return true
+        if (seenSkills.has(part.name)) return false
+        seenSkills.add(part.name)
+        return true
+      })
+      const resolvedParts = yield* Effect.forEach(promptParts, resolvePart, { concurrency: "unbounded" }).pipe(
         Effect.map((x) => x.flat().map(assign)),
       )
 
@@ -1579,6 +1603,7 @@ export const defaultLayer = Layer.suspend(() =>
         Database.defaultLayer,
         SystemPrompt.defaultLayer,
         LLM.defaultLayer,
+        Skill.defaultLayer,
         CrossSpawnSpawner.defaultLayer,
         RuntimeFlags.defaultLayer,
         EventV2Bridge.defaultLayer,
@@ -1609,6 +1634,7 @@ export const PromptInput = Schema.Struct({
       SessionV1.TextPartInput,
       SessionV1.FilePartInput,
       SessionV1.AgentPartInput,
+      SessionV1.SkillPartInput,
       SessionV1.SubtaskPartInput,
     ]).annotate({ discriminator: "type" }),
   ),
@@ -1707,6 +1733,7 @@ export const node = LayerNode.make(layer, [
   ToolRegistry.node,
   Truncate.node,
   Image.node,
+  Skill.node,
   CrossSpawnSpawner.node,
   Instruction.node,
   SessionRunState.node,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -54,6 +54,7 @@ import { SessionMessage } from "@opencode-ai/core/session/message"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { AgentAttachment, FileAttachment, Prompt, Source } from "@opencode-ai/core/session/prompt"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import * as DateTime from "effect/DateTime"
 import { eq } from "drizzle-orm"
 import { SessionTable } from "@opencode-ai/core/session/sql"
@@ -123,6 +124,7 @@ export const layer = Layer.effect(
     const sys = yield* SystemPrompt.Service
     const llm = yield* LLM.Service
     const skill = yield* Skill.Service
+    const ripgrep = yield* Ripgrep.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
@@ -174,6 +176,36 @@ export const layer = Layer.effect(
         { concurrency: "unbounded", discard: true },
       )
       return parts
+    })
+
+    const selectedSkillContent = Effect.fn("SessionPrompt.selectedSkillContent")(function* (info: Skill.Info) {
+      const dir = path.dirname(info.location)
+      const base = pathToFileURL(dir).href
+      const files = yield* ripgrep
+        .find({
+          cwd: dir,
+          pattern: "!**/SKILL.md",
+          hidden: true,
+          follow: false,
+          limit: 10,
+        })
+        .pipe(Effect.catch(() => Effect.succeed([] as { path: string }[])))
+
+      return [
+        `<skill_content name="${info.name}">`,
+        `# Skill: ${info.name}`,
+        "",
+        info.content.trim(),
+        "",
+        `Base directory for this skill: ${base}`,
+        "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",
+        "Note: file list is sampled.",
+        "",
+        "<skill_files>",
+        files.map((file) => `<file>${path.resolve(dir, file.path)}</file>`).join("\n"),
+        "</skill_files>",
+        "</skill_content>",
+      ].join("\n")
     })
 
     const title = Effect.fn("SessionPrompt.ensureTitle")(function* (input: {
@@ -986,7 +1018,7 @@ export const layer = Layer.effect(
               sessionID: input.sessionID,
               type: "text",
               synthetic: true,
-              text: `## Skill: ${found.name}\n\n${found.content.trim()}`,
+              text: yield* selectedSkillContent(found),
             },
           ]
         }
@@ -1606,6 +1638,7 @@ export const defaultLayer = Layer.suspend(() =>
         SystemPrompt.defaultLayer,
         LLM.defaultLayer,
         Skill.defaultLayer,
+        Ripgrep.defaultLayer,
         CrossSpawnSpawner.defaultLayer,
         RuntimeFlags.defaultLayer,
         EventV2Bridge.defaultLayer,
@@ -1736,6 +1769,7 @@ export const node = LayerNode.make(layer, [
   Truncate.node,
   Image.node,
   Skill.node,
+  Ripgrep.node,
   CrossSpawnSpawner.node,
   Instruction.node,
   SessionRunState.node,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -213,6 +213,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     Layer.provideMerge(deps),
   )
   return SessionPrompt.layer.pipe(
+    Layer.provide(Skill.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(Image.defaultLayer),
     Layer.provide(summary),
@@ -2056,6 +2057,51 @@ noLLMServer.instance(
       expect(text[0]?.startsWith("Called the Read tool with the following input:")).toBe(true)
       expect(text[1]?.includes("Read tool failed to read")).toBe(true)
       expect(text[2]).toBe("after-file")
+
+      yield* sessions.remove(session.id)
+    }),
+  { config: cfg },
+)
+
+noLLMServer.instance(
+  "resolves selected skill parts without replacing prompt text",
+  () =>
+    Effect.gen(function* () {
+      const { directory: dir } = yield* TestInstance
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      yield* writeText(
+        path.join(dir, ".opencode", "skill", "review", "SKILL.md"),
+        "---\nname: review\ndescription: Review implementation\n---\nReview the implementation carefully.\n",
+      )
+      yield* writeText(
+        path.join(dir, ".opencode", "skill", "write-a-prd", "SKILL.md"),
+        "---\nname: write-a-prd\ndescription: Write a PRD\n---\nWrite a focused PRD.\n",
+      )
+
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          { type: "text", text: "Use $review and $write-a-prd on this change" },
+          { type: "skill", name: "review", source: { value: "$review", start: 4, end: 11 } },
+          { type: "skill", name: "write-a-prd", source: { value: "$write-a-prd", start: 16, end: 28 } },
+          { type: "skill", name: "review", source: { value: "$review", start: 4, end: 11 } },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+
+      const skills = msg.parts.filter((part) => part.type === "skill").map((part) => part.name)
+      const text = msg.parts.filter((part) => part.type === "text").map((part) => part.text)
+
+      expect(skills).toEqual(["review", "write-a-prd"])
+      expect(text).toContain("Use $review and $write-a-prd on this change")
+      expect(text.filter((part) => part.includes("Review the implementation carefully."))).toHaveLength(1)
+      expect(text.filter((part) => part.includes("Write a focused PRD."))).toHaveLength(1)
 
       yield* sessions.remove(session.id)
     }),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -213,6 +213,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     Layer.provideMerge(deps),
   )
   return SessionPrompt.layer.pipe(
+    Layer.provide(Ripgrep.defaultLayer),
     Layer.provide(Skill.defaultLayer),
     Layer.provide(SessionRevert.defaultLayer),
     Layer.provide(Image.defaultLayer),
@@ -2072,10 +2073,13 @@ noLLMServer.instance(
       const sessions = yield* Session.Service
       const session = yield* sessions.create({})
 
+      const reviewDir = path.join(dir, ".opencode", "skill", "review")
       yield* writeText(
-        path.join(dir, ".opencode", "skill", "review", "SKILL.md"),
+        path.join(reviewDir, "SKILL.md"),
         "---\nname: review\ndescription: Review implementation\n---\nReview the implementation carefully.\n",
       )
+      const reviewScript = path.join(reviewDir, "scripts", "check.ts")
+      yield* writeText(reviewScript, "export const check = true\n")
       yield* writeText(
         path.join(dir, ".opencode", "skill", "write-a-prd", "SKILL.md"),
         "---\nname: write-a-prd\ndescription: Write a PRD\n---\nWrite a focused PRD.\n",
@@ -2102,6 +2106,8 @@ noLLMServer.instance(
       expect(text).toContain("Use $review and $write-a-prd on this change")
       expect(text.filter((part) => part.includes("Review the implementation carefully."))).toHaveLength(1)
       expect(text.filter((part) => part.includes("Write a focused PRD."))).toHaveLength(1)
+      expect(text.some((part) => part.includes(`Base directory for this skill: ${pathToFileURL(reviewDir).href}`))).toBe(true)
+      expect(text.some((part) => part.includes(`<file>${reviewScript}</file>`))).toBe(true)
 
       yield* sessions.remove(session.id)
     }),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2108,6 +2108,58 @@ noLLMServer.instance(
   { config: cfg },
 )
 
+noLLMServer.instance(
+  "does not inject denied selected skill content",
+  () =>
+    Effect.gen(function* () {
+      const { directory: dir } = yield* TestInstance
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({})
+
+      yield* writeText(
+        path.join(dir, ".opencode", "skill", "denied", "SKILL.md"),
+        "---\nname: denied\ndescription: Denied skill\n---\nDenied skill secret instructions.\n",
+      )
+
+      const msg = yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [
+          { type: "text", text: "Use $denied on this change" },
+          { type: "skill", name: "denied", source: { value: "$denied", start: 4, end: 11 } },
+        ],
+      })
+
+      if (msg.info.role !== "user") throw new Error("expected user message")
+
+      const skills = msg.parts.filter((part) => part.type === "skill").map((part) => part.name)
+      const text = msg.parts.filter((part) => part.type === "text").map((part) => part.text)
+
+      expect(skills).toEqual(["denied"])
+      expect(text).toContain("Use $denied on this change")
+      expect(text.some((part) => part.includes("Denied skill secret instructions."))).toBe(false)
+      expect(text.some((part) => part.includes("## Skill: denied"))).toBe(false)
+
+      yield* sessions.remove(session.id)
+    }),
+  {
+    config: {
+      ...cfg,
+      agent: {
+        build: {
+          permission: {
+            skill: {
+              denied: "deny",
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
 // Special characters in filenames
 
 noLLMServer.instance(

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -5,6 +5,7 @@ import type {
   FilePart,
   LspStatus,
   McpStatus,
+  SkillPart,
   Todo,
   Message,
   Part,
@@ -186,6 +187,7 @@ export type TuiPromptInfo = {
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">
+    | Omit<SkillPart, "id" | "messageID" | "sessionID">
     | (Omit<TextPart, "id" | "messageID" | "sessionID"> & {
         source?: {
           text: {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -219,6 +219,7 @@ import type {
   SessionUnshareResponses,
   SessionUpdateErrors,
   SessionUpdateResponses,
+  SkillPartInput,
   SubtaskPartInput,
   SyncHistoryListErrors,
   SyncHistoryListResponses,
@@ -3738,7 +3739,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
-      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -4091,7 +4092,7 @@ export class Session2 extends HeyApiClient {
       format?: OutputFormat
       system?: string
       variant?: string
-      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+      parts?: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -600,6 +600,19 @@ export type AgentPart = {
   }
 }
 
+export type SkillPart = {
+  id: string
+  sessionID: string
+  messageID: string
+  type: "skill"
+  name: string
+  source?: {
+    value: string
+    start: number
+    end: number
+  }
+}
+
 export type RetryPart = {
   id: string
   sessionID: string
@@ -633,6 +646,7 @@ export type Part =
   | SnapshotPart
   | PatchPart
   | AgentPart
+  | SkillPart
   | RetryPart
   | CompactionPart
 
@@ -2605,6 +2619,17 @@ export type FilePartInput = {
 export type AgentPartInput = {
   id?: string
   type: "agent"
+  name: string
+  source?: {
+    value: string
+    start: number
+    end: number
+  }
+}
+
+export type SkillPartInput = {
+  id?: string
+  type: "skill"
   name: string
   source?: {
     value: string
@@ -7877,7 +7902,7 @@ export type SessionPromptData = {
     format?: OutputFormat
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
   }
   path: {
     sessionID: string
@@ -8224,7 +8249,7 @@ export type SessionPromptAsyncData = {
     format?: OutputFormat
     system?: string
     variant?: string
-    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput>
+    parts: Array<TextPartInput | FilePartInput | AgentPartInput | SkillPartInput | SubtaskPartInput>
   }
   path: {
     sessionID: string

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -457,7 +457,7 @@ export function Prompt(props: PromptProps) {
               let virtualText = ""
               if (part.type === "file" && part.source?.text) {
                 virtualText = part.source.text.value
-              } else if (part.type === "agent" && part.source) {
+              } else if ((part.type === "agent" || part.type === "skill") && part.source) {
                 virtualText = part.source.value
               }
 
@@ -483,7 +483,7 @@ export function Prompt(props: PromptProps) {
                 }
               }
 
-              if (part.type === "agent" && part.source) {
+              if ((part.type === "agent" || part.type === "skill") && part.source) {
                 return {
                   ...part,
                   source: {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -28,7 +28,7 @@ import { useEvent } from "../../context/event"
 import { editorSelectionKey, useEditorContext, type EditorSelection } from "../../context/editor"
 import { normalizePromptContent, openEditor } from "../../editor"
 import { useExit } from "../../context/exit"
-import { promptOffsetWidth } from "../../prompt/display"
+import { displayCharAt, mentionTriggerIndex, promptOffsetWidth } from "../../prompt/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "../../prompt/history"
 import { computePromptTraits } from "../../prompt/traits"
@@ -203,6 +203,7 @@ export function Prompt(props: PromptProps) {
   })
   const editorContextLabelState = createMemo(() => editor.labelState())
   const [auto, setAuto] = createSignal<AutocompleteRef>()
+  const [skillTrigger, setSkillTrigger] = createSignal<{ start: number; end: number }>()
   const workspace = usePromptWorkspace(props.sessionID)
   const move = usePromptMove({ projectID: project.project, sessionID: () => props.sessionID })
   const [cursorVersion, setCursorVersion] = createSignal(0)
@@ -669,6 +670,11 @@ export function Prompt(props: PromptProps) {
         end = part.source.end
         virtualText = part.source.value
         styleId = agentStyleId
+      } else if (part.type === "skill" && part.source) {
+        start = part.source.start
+        end = part.source.end
+        virtualText = part.source.value
+        styleId = agentStyleId
       } else if (part.type === "text" && part.source?.text) {
         start = part.source.text.start
         end = part.source.text.end
@@ -708,6 +714,9 @@ export function Prompt(props: PromptProps) {
               if (part.type === "agent" && part.source) {
                 part.source.start = extmark.start
                 part.source.end = extmark.end
+              } else if (part.type === "skill" && part.source) {
+                part.source.start = extmark.start
+                part.source.end = extmark.end
               } else if (part.type === "file" && part.source?.text) {
                 part.source.text.start = extmark.start
                 part.source.text.end = extmark.end
@@ -725,6 +734,60 @@ export function Prompt(props: PromptProps) {
         draft.prompt.parts = newParts
       }),
     )
+  }
+
+  function insertSkill(skill: string) {
+    const trigger = skillTrigger()
+    if (!trigger) return
+    const charAfter = displayCharAt(input.plainText, trigger.end)
+    const virtualText = `$${skill}`
+    const insertText = virtualText + (charAfter === " " ? "" : " ")
+
+    input.cursorOffset = trigger.start
+    const startCursor = input.logicalCursor
+    input.cursorOffset = trigger.end
+    const endCursor = input.logicalCursor
+    input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
+    input.insertText(insertText)
+
+    const extmarkId = input.extmarks.create({
+      start: trigger.start,
+      end: trigger.start + promptOffsetWidth(virtualText),
+      virtual: true,
+      styleId: agentStyleId,
+      typeId: promptPartTypeId,
+    })
+
+    setStore(
+      produce((draft) => {
+        draft.prompt.input = input.plainText
+        const partIndex = draft.prompt.parts.length
+        draft.prompt.parts.push({
+          type: "skill",
+          name: skill,
+          source: {
+            value: virtualText,
+            start: trigger.start,
+            end: trigger.start + promptOffsetWidth(virtualText),
+          },
+        })
+        draft.extmarkToPartIndex.set(extmarkId, partIndex)
+      }),
+    )
+    setSkillTrigger(undefined)
+  }
+
+  function openSkillPicker(value: string) {
+    if (store.mode !== "normal") return
+    if (dialog.stack.length > 0) return
+    if (auto()?.visible) return
+    const offset = input.cursorOffset
+    const index = mentionTriggerIndex(value, offset, "$")
+    if (index === undefined) return
+    if (input.getTextRange(index, offset) !== "$") return
+
+    setSkillTrigger({ start: index, end: offset })
+    dialog.replace(() => <DialogSkill onSelect={insertSkill} />)
   }
 
   const stashCommands = createMemo(() =>
@@ -1029,6 +1092,13 @@ export function Prompt(props: PromptProps) {
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
+    const seenSkills = new Set<string>()
+    const sendingParts = nonTextParts.filter((part) => {
+      if (part.type !== "skill") return true
+      if (seenSkills.has(part.name)) return false
+      seenSkills.add(part.name)
+      return true
+    })
 
     // Capture mode before it gets reset
     const currentMode = store.mode
@@ -1099,7 +1169,7 @@ export function Prompt(props: PromptProps) {
                 type: "text",
                 text: inputText,
               },
-              ...nonTextParts,
+              ...sendingParts,
             ],
           },
           { throwOnError: true },
@@ -1372,6 +1442,7 @@ export function Prompt(props: PromptProps) {
                 const value = input.plainText
                 setStore("prompt", "input", value)
                 auto()?.onInput(value)
+                openSkillPicker(value)
                 syncExtmarksWithPromptParts()
                 setCursorVersion((value) => value + 1)
               }}

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -35,9 +35,9 @@ export function displayCharAt(value: string, offset: number) {
   }
 }
 
-export function mentionTriggerIndex(value: string, offset = promptOffsetWidth(value)) {
+export function mentionTriggerIndex(value: string, offset = promptOffsetWidth(value), trigger = "@") {
   const text = displaySlice(value, 0, offset)
-  const index = text.lastIndexOf("@")
+  const index = text.lastIndexOf(trigger)
   if (index === -1) return
 
   const before = index === 0 ? undefined : text[index - 1]

--- a/packages/tui/src/prompt/history.tsx
+++ b/packages/tui/src/prompt/history.tsx
@@ -1,7 +1,7 @@
 import path from "path"
 import { onMount } from "solid-js"
 import { createStore, produce, unwrap } from "solid-js/store"
-import type { AgentPart, FilePart, TextPart } from "@opencode-ai/sdk/v2"
+import type { AgentPart, FilePart, SkillPart, TextPart } from "@opencode-ai/sdk/v2"
 import { createSimpleContext } from "../context/helper"
 import { useTuiPaths } from "../context/runtime"
 import { appendText, readText, writeText } from "../util/persistence"
@@ -12,6 +12,7 @@ export type PromptInfo = {
   parts: (
     | Omit<FilePart, "id" | "messageID" | "sessionID">
     | Omit<AgentPart, "id" | "messageID" | "sessionID">
+    | Omit<SkillPart, "id" | "messageID" | "sessionID">
     | (Omit<TextPart, "id" | "messageID" | "sessionID"> & {
         source?: {
           text: {


### PR DESCRIPTION
### Issue for this PR

Closes #20982
Refs #15617
Refs #29217
Refs #25439

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a minimal TUI `$` skill picker flow.

When `$` is typed as its own token, opencode opens the existing skills picker. Selecting a skill inserts `$skill-name` into the current prompt instead of replacing the whole prompt, so multiple skills can be selected in one prompt.

Selected skills are sent as native `skill` prompt parts and resolved server-side through the skill service. This avoids routing skill invocation through slash-command execution.

### How did you verify your code works?

- `./packages/sdk/js/script/build.ts`
- `bun test --timeout 30000 test/session/prompt.test.ts -t "resolves selected skill parts"` from `packages/opencode`
- `bun --cwd packages/opencode test test/session/prompt.test.ts`
- `bun --cwd packages/opencode typecheck`
- `bun --cwd packages/tui typecheck`
- `bun --cwd packages/sdk/js typecheck`

### Screenshots / recordings

Not captured. This reuses the existing skills picker UI and only changes how `$` opens it and inserts the selected skill into the prompt.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
