### PR TITLE
fix(experimental llm pkg): forward topK to Converse via additionalModelRequestFields

### DIFF
--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -412,6 +412,9 @@ const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request:
             stopSequences: generation?.stop,
           },
     toolConfig,
+    // Converse's base inferenceConfig has no topK; Anthropic/Nova accept it
+    // as a model-specific field, so it goes through additionalModelRequestFields.
+    additionalModelRequestFields: generation?.topK === undefined ? undefined : { top_k: generation.topK },
   }
 })
 

--- a/packages/llm/test/provider/bedrock-converse.test.ts
+++ b/packages/llm/test/provider/bedrock-converse.test.ts
@@ -83,6 +83,26 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
+  it.effect("passes topK through additionalModelRequestFields as top_k", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(
+        LLM.updateRequest(baseRequest, { generation: { maxTokens: 64, temperature: 0, topK: 40 } }),
+      )
+
+      // Converse's inferenceConfig has no topK; Anthropic/Nova read it from
+      // additionalModelRequestFields as top_k.
+      expect(prepared.body.inferenceConfig).toEqual({ maxTokens: 64, temperature: 0 })
+      expect(prepared.body.additionalModelRequestFields).toEqual({ top_k: 40 })
+    }),
+  )
+
+  it.effect("omits additionalModelRequestFields when topK is unset", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(baseRequest)
+      expect(prepared.body.additionalModelRequestFields).toBeUndefined()
+    }),
+  )
+
   it.effect("lowers chronological system updates to wrapped user text in order", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(


### PR DESCRIPTION
### Issue for this PR

Closes #33003

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Bedrock Converse path silently drops the `topK` generation option. `fromRequest` in `packages/llm/src/protocols/bedrock-converse.ts` builds `inferenceConfig` from only maxTokens/temperature/topP/stopSequences, and never reads `generation.topK`.

The sibling Anthropic path already handles it (`anthropic-messages.ts`: `top_k: generation?.topK`), so the same model setting behaves differently depending on which protocol is used. The fix routes `topK` through `additionalModelRequestFields` as `top_k`. That is exactly where the AWS Converse API expects model-specific params that aren't part of the base `InferenceConfiguration` — the [Converse API reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) shows `{"additionalModelRequestFields": {"top_k": 200}}` for Anthropic models. The Converse body schema in this file already declares `additionalModelRequestFields`, so nothing new is introduced — this fills a gap in the existing mapping.

### How did you verify your code works?

From `packages/llm`:
- Added two tests in `test/provider/bedrock-converse.test.ts`: one asserting `topK` lands in `additionalModelRequestFields: { top_k }`, one asserting the field is omitted when `topK` is unset. Reverting the one-line fix makes the first test fail (`Expected { top_k: 40 }, received none`), confirming the test catches the bug.
- `bun test test/provider/bedrock-converse.test.ts` → 28 pass; `bun typecheck`, `oxlint`, `prettier --check` all clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_AI-assisted (Claude Code); changes, rationale, and tests reviewed by a human before submission._
