### PR TITLE
fix(acp): list sessions across projects

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -245,10 +245,12 @@ export function make(input: {
     const limit = 100
     const sessions = yield* request(
       () =>
-        input.sdk.session.list(
+        input.sdk.experimental.session.list(
           {
             ...(params.cwd ? { directory: params.cwd } : {}),
             roots: true,
+            ...(cursor !== undefined && Number.isFinite(cursor) ? { cursor } : {}),
+            limit: limit + 1,
           },
           { throwOnError: true },
         ),

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -160,6 +160,14 @@ describe("ACP service sessions", () => {
       title: `Session ${index + 1}`,
       time: { created: index + 1, updated: index + 1 },
     }))
+    const sessionListCalls: { directory?: string }[] = []
+    const experimentalSessionListCalls: { directory?: string; roots?: boolean; cursor?: number; limit?: number }[] = []
+    const listServerSessions = (input: { directory?: string; cursor?: number; limit?: number }) =>
+      sessions
+        .filter((session) => !input.directory || session.directory === input.directory)
+        .filter((session) => input.cursor === undefined || session.time.updated < input.cursor)
+        .toSorted((a, b) => b.time.updated - a.time.updated)
+        .slice(0, input.limit)
     const sdk = {
       config: {
         providers: () => Promise.resolve({ data: { providers: [provider], default: { test: modelID } } }),
@@ -188,10 +196,12 @@ describe("ACP service sessions", () => {
       session: {
         create: () => Promise.resolve({ data: { id: "ses_new" } }),
         get: () => Promise.resolve({ data: { id: "ses_loaded" } }),
-        list: (input: { directory?: string }) =>
-          Promise.resolve({
+        list: (input: { directory?: string }) => {
+          sessionListCalls.push(input)
+          return Promise.resolve({
             data: input.directory ? sessions.filter((session) => session.directory === input.directory) : sessions,
-          }),
+          })
+        },
         messages: () => Promise.resolve({ data: messages }),
         prompt: (input: unknown) => {
           prompts.push(input)
@@ -234,6 +244,14 @@ describe("ACP service sessions", () => {
           return Promise.resolve({ data: { id: `fork_${input.sessionID}` } })
         },
       },
+      experimental: {
+        session: {
+          list: (input: { directory?: string; cursor?: number; limit?: number }) => {
+            experimentalSessionListCalls.push(input)
+            return Promise.resolve({ data: listServerSessions(input) })
+          },
+        },
+      },
       mcp: {
         add: (input: { name?: string }) => {
           if (input.name) mcpAdds.push(input.name)
@@ -268,6 +286,8 @@ describe("ACP service sessions", () => {
       commands,
       summarizes,
       usageUpdates,
+      sessionListCalls,
+      experimentalSessionListCalls,
     }
   }
 
@@ -354,6 +374,15 @@ describe("ACP service sessions", () => {
         content: { type: "text", text: "hi there" },
       },
     ])
+  })
+
+  it("lists sessions through the global session endpoint", async () => {
+    const { service, sessionListCalls, experimentalSessionListCalls } = makeService()
+    const result = await Effect.runPromise(service.listSessions({}))
+
+    expect(result.sessions[0]?.sessionId).toBe("ses_102")
+    expect(sessionListCalls).toEqual([])
+    expect(experimentalSessionListCalls).toEqual([{ roots: true, limit: 101 }])
   })
 
   it("lists sessions sorted by updated time with cursor support", async () => {
@@ -1121,6 +1150,11 @@ describe("ACP service sessions", () => {
           create: () => Promise.resolve({ data: { id: session.sessionId } }),
           list: () => Promise.resolve({ data: [] }),
           prompt: () => Promise.reject({ name: "ProviderAuthError", data: { providerID: "test" } }),
+        },
+        experimental: {
+          session: {
+            list: () => Promise.resolve({ data: [] }),
+          },
         },
         mcp: {
           add: () => Promise.resolve({ data: {} }),


### PR DESCRIPTION
### Issue for this PR

Closes #33036
Closes #18575
Closes #16137

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ACP `session/list` treats `cwd` as an optional filter. When it is omitted, clients expect the first page of sessions known to the agent.

OpenCode previously routed ACP session discovery through the project-scoped `/session` endpoint, so registry-launched clients could see stale or empty history. This switches ACP discovery to the global session endpoint and keeps applying `cwd` only when the client provides it.

### How did you verify your code works?

- `bun test test/acp/service-session.test.ts`
- `bun typecheck`
- `bun run build --single`
- `python3 test_acp_final.py` from the Zed repo returned 100 OpenCode sessions and `nextCursor`
- pre-push hook ran `bun turbo typecheck`

### Screenshots / recordings

N/A; non-UI ACP behavior change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
