### PR TITLE
tweak: remove steering wrapper that can bust cache

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1304,24 +1304,6 @@ export const layer = Layer.effect(
             if (step === 1)
               yield* summary.summarize({ sessionID, messageID: lastUser.id }).pipe(Effect.ignore, Effect.forkIn(scope))
 
-            if (step > 1 && lastFinished) {
-              for (const m of msgs) {
-                if (m.info.role !== "user" || m.info.id <= lastFinished.id) continue
-                for (const p of m.parts) {
-                  if (p.type !== "text" || p.ignored || p.synthetic) continue
-                  if (!p.text.trim()) continue
-                  p.text = [
-                    "<system-reminder>",
-                    "The user sent the following message:",
-                    p.text,
-                    "",
-                    "Please address this message and continue with your tasks.",
-                    "</system-reminder>",
-                  ].join("\n")
-                }
-              }
-            }
-
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
             const [skills, env, instructions, modelMsgs] = yield* Effect.all([

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1346,7 +1346,7 @@ it.instance(
 
       const inputs = yield* llm.inputs
       expect(inputs).toHaveLength(2)
-      expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("second")
+      expect(inputs.at(-1)?.messages.at(-1)).toEqual({ role: "user", content: "second" })
     }),
   3_000,
 )

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1346,7 +1346,9 @@ it.instance(
 
       const inputs = yield* llm.inputs
       expect(inputs).toHaveLength(2)
-      expect(inputs.at(-1)?.messages.at(-1)).toEqual({ role: "user", content: "second" })
+      const messages = inputs.at(-1)?.messages
+      if (!Array.isArray(messages)) throw new Error("expected LLM messages")
+      expect(messages.at(-1)).toEqual({ role: "user", content: "second" })
     }),
   3_000,
 )


### PR DESCRIPTION
## Summary
- send prompts submitted during an active run as normal user messages
- remove the steering-only system reminder wrapper
- assert the next LLM input preserves the exact user message shape

## Testing
- `bun test test/session/prompt.test.ts --test-name-pattern "prompt submitted during an active run is included in the next LLM input"` in `packages/opencode`
- `bun test test/session-runner.test.ts --test-name-pattern "steers an active provider turn with newly recorded prompts"` in `packages/core`
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/core`