### PR TITLE
feat(agent): add Ultra Mode with autonomous state machine

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -14,6 +14,7 @@ import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
+import PROMPT_ULTRA from "./ultra/ultra.txt"
 import { Permission } from "@/permission"
 import { mergeDeep, pipe, sortBy, values } from "remeda"
 import { Global } from "@opencode-ai/core/global"
@@ -259,6 +260,26 @@ export const layer = Layer.effect(
               user,
             ),
             prompt: PROMPT_SUMMARY,
+          },
+          ultra: {
+            name: "ultra",
+            description:
+              "Autonomous full-cycle agent. Executes planning→building→verifying→iterate loop with a hardcoded state machine. Use for complex tasks that need autonomous execution.",
+            options: {},
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                question: "allow",
+                plan_enter: "allow",
+                plan_exit: "allow",
+                ultra_verify: "allow",
+                ultra_phase: "allow",
+              }),
+              user,
+            ),
+            mode: "primary",
+            native: true,
+            prompt: PROMPT_ULTRA,
           },
         }
 

--- a/packages/opencode/src/agent/ultra/index.ts
+++ b/packages/opencode/src/agent/ultra/index.ts
@@ -1,0 +1,3 @@
+export { UltraState } from "./ultra-state"
+export { UltraVerifyTool } from "./ultra-verify"
+export { UltraPhaseTool } from "./ultra-phase"

--- a/packages/opencode/src/agent/ultra/ultra-phase.ts
+++ b/packages/opencode/src/agent/ultra/ultra-phase.ts
@@ -1,0 +1,67 @@
+import * as Tool from "@/tool/tool"
+import { Schema } from "effect"
+import { use as useUltra, type Phase } from "./ultra-state"
+
+export const Parameters = Schema.Struct({
+  phase: Schema.Literals(["planning", "building", "verifying", "iterating", "complete"]).annotate({
+    description: "The phase to transition to",
+  }),
+})
+
+export const UltraPhaseTool = Tool.define(
+  "ultra_phase",
+  Effect.gen(function* () {
+    const ultra = yield* useUltra
+
+    return {
+      description: [
+        "Transition the Ultra agent to a new phase.",
+        "Valid transitions: planning→building, building→verifying, verifying→iterating|complete, iterating→verifying.",
+        "Use this to manually advance the state machine when the LLM decides the current phase is done.",
+      ].join(" "),
+      parameters: Parameters,
+      execute: (args, ctx) =>
+        Effect.gen(function* () {
+          const state = yield* ultra.get(ctx.sessionID)
+          if (!state) {
+            return {
+              title: "Phase Transition",
+              metadata: {},
+              output: "ERROR: Ultra state not initialized. Start with a fresh session.",
+            }
+          }
+
+          const result = yield* ultra.transition(ctx.sessionID, args.phase as Phase).pipe(
+            Effect.catchAll((error) => Effect.succeed(error)),
+          )
+
+          if (result instanceof Error) {
+            return {
+              title: "Phase Transition",
+              metadata: { error: true },
+              output: `TRANSITION FAILED: ${result.message}\n\nCurrent phase: ${state.phase}`,
+            }
+          }
+
+          const updated = yield* ultra.get(ctx.sessionID)
+          return {
+            title: "Phase Transition",
+            metadata: { phase: updated?.phase },
+            output: [
+              `Phase transitioned: ${state.phase} → ${updated?.phase}`,
+              "",
+              updated?.phase === "planning"
+                ? "Now in PLANNING phase. Read the codebase, understand requirements, and write a plan. Do NOT edit files."
+                : updated?.phase === "building"
+                  ? "Now in BUILDING phase. Implement the plan. All tools are available."
+                  : updated?.phase === "verifying"
+                    ? `Now in VERIFYING phase. Run ultra_verify to test. Retry ${updated.retries}/${10}.`
+                    : updated?.phase === "iterating"
+                      ? `Now in ITERATING phase. Fix failures. Retry ${updated.retries}/${10}.`
+                      : "COMPLETE. All work is done.",
+            ].join("\n"),
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/agent/ultra/ultra-state.ts
+++ b/packages/opencode/src/agent/ultra/ultra-state.ts
@@ -1,0 +1,115 @@
+import { SessionID } from "@/session/schema"
+import { Effect, Context, Layer } from "effect"
+
+export type Phase = "planning" | "building" | "verifying" | "iterating" | "complete"
+
+const VALID_TRANSITIONS: Record<Phase, Phase[]> = {
+  planning: ["building"],
+  building: ["verifying"],
+  verifying: ["iterating", "complete"],
+  iterating: ["verifying"],
+  complete: [],
+}
+
+const PHASE_TOOLS: Record<Phase, { allowed: string[]; blocked: string[] }> = {
+  planning: {
+    allowed: ["read", "glob", "grep", "list", "ultra_verify", "ultra_phase", "webfetch", "websearch"],
+    blocked: ["edit", "write", "apply_patch", "shell"],
+  },
+  building: {
+    allowed: ["*"],
+    blocked: [],
+  },
+  verifying: {
+    allowed: ["read", "glob", "grep", "list", "ultra_verify", "ultra_phase", "webfetch", "websearch"],
+    blocked: ["edit", "write", "apply_patch", "shell"],
+  },
+  iterating: {
+    allowed: ["read", "glob", "grep", "list", "webfetch", "websearch", "edit", "write", "apply_patch", "shell", "ultra_phase"],
+    blocked: ["ultra_verify"],
+  },
+  complete: {
+    allowed: ["read", "glob", "grep", "list"],
+    blocked: ["edit", "write", "apply_patch", "shell", "ultra_verify", "ultra_phase"],
+  },
+}
+
+const MAX_RETRIES = 10
+
+export interface UltraState {
+  readonly sessionID: SessionID
+  phase: Phase
+  retries: number
+  planPath?: string
+  verifyResult?: string
+}
+
+export interface Interface {
+  readonly get: (sessionID: SessionID) => Effect.Effect<UltraState | undefined>
+  readonly transition: (sessionID: SessionID, to: Phase) => Effect.Effect<void, Error>
+  readonly incrementRetry: (sessionID: SessionID) => Effect.Effect<number>
+  readonly isToolAllowed: (sessionID: SessionID, toolID: string) => Effect.Effect<boolean>
+  readonly init: (sessionID: SessionID) => Effect.Effect<void>
+  readonly reset: (sessionID: SessionID) => Effect.Effect<void>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/UltraState") {}
+
+export const use = Context.get(Service)
+
+const states = new Map<string, UltraState>()
+
+export const layer = Layer.succeed(Service, {
+  get: (sessionID) =>
+    Effect.sync(() => {
+      return states.get(sessionID)
+    }),
+
+  init: (sessionID) =>
+    Effect.sync(() => {
+      states.set(sessionID, {
+        sessionID,
+        phase: "planning",
+        retries: 0,
+      })
+    }),
+
+  reset: (sessionID) =>
+    Effect.sync(() => {
+      states.delete(sessionID)
+    }),
+
+  transition: (sessionID, to) =>
+    Effect.gen(function* () {
+      const state = states.get(sessionID)
+      if (!state) return yield* Effect.fail(new Error("Ultra state not initialized for session"))
+
+      const allowed = VALID_TRANSITIONS[state.phase]
+      if (!allowed.includes(to)) {
+        return yield* Effect.fail(
+          new Error(`Invalid transition: ${state.phase} → ${to}. Allowed: ${allowed.join(", ")}`),
+        )
+      }
+      state.phase = to
+    }),
+
+  incrementRetry: (sessionID) =>
+    Effect.gen(function* () {
+      const state = states.get(sessionID)
+      if (!state) return yield* Effect.fail(new Error("Ultra state not initialized for session"))
+      state.retries++
+      return state.retries
+    }),
+
+  isToolAllowed: (sessionID, toolID) =>
+    Effect.gen(function* () {
+      const state = states.get(sessionID)
+      if (!state) return true
+      const rules = PHASE_TOOLS[state.phase]
+      if (rules.blocked.includes(toolID)) return false
+      if (rules.allowed.includes("*")) return true
+      return rules.allowed.includes(toolID)
+    }),
+})
+
+export const maxRetries = MAX_RETRIES

--- a/packages/opencode/src/agent/ultra/ultra-verify.ts
+++ b/packages/opencode/src/agent/ultra/ultra-verify.ts
@@ -1,0 +1,122 @@
+import * as Tool from "@/tool/tool"
+import { Shell } from "@opencode-ai/core/shell"
+import { Schema } from "effect"
+import { UltraState, use as useUltra, maxRetries } from "./ultra-state"
+
+export const Parameters = Schema.Struct({})
+
+export const UltraVerifyTool = Tool.define(
+  "ultra_verify",
+  Effect.gen(function* () {
+    const shell = yield* Shell.Service
+    const ultra = yield* useUltra
+
+    return {
+      description: [
+        "Auto-detect and run the project's test suite.",
+        "Detects test command from package.json / Makefile / Cargo.toml / pyproject.toml / go.mod.",
+        "Returns structured result with pass/fail status.",
+        "Auto-transitions to 'complete' on pass or 'iterating' on fail (up to 10 retries).",
+      ].join(" "),
+      parameters: Parameters,
+      execute: (_args, ctx) =>
+        Effect.gen(function* () {
+          const state = yield* ultra.get(ctx.sessionID)
+          if (!state || state.phase !== "verifying") {
+            return {
+              title: "Verify",
+              metadata: {},
+              output: "ERROR: ultra_verify can only be called during the 'verifying' phase.",
+            }
+          }
+
+          const detectCmd = [
+            "if [ -f package.json ]; then echo 'npm test'",
+            "elif [ -f Makefile ]; then echo 'make test'",
+            "elif [ -f Cargo.toml ]; then echo 'cargo test'",
+            "elif [ -f pyproject.toml ] || [ -f setup.py ]; then echo 'pytest'",
+            "elif [ -f go.mod ]; then echo 'go test ./...'",
+            "else echo '__none__'",
+            "fi",
+          ].join("; ")
+
+          const detectResult = yield* shell.run({
+            command: detectCmd,
+            cwd: process.cwd(),
+          })
+
+          const testCmd = detectResult.trim()
+          if (testCmd === "__none__") {
+            yield* ultra.transition(ctx.sessionID, "complete")
+            return {
+              title: "Verify",
+              metadata: { phase: "complete" },
+              output: "No test framework detected. Marking as complete.",
+            }
+          }
+
+          let exitCode = 0
+          let stdout = ""
+          let stderr = ""
+          try {
+            const result = yield* shell.run({ command: testCmd, cwd: process.cwd() })
+            stdout = result
+          } catch (error: any) {
+            exitCode = 1
+            stderr = String(error)
+          }
+
+          const passed = exitCode === 0
+          const retryCount = yield* ultra.incrementRetry(ctx.sessionID)
+
+          if (passed) {
+            yield* ultra.transition(ctx.sessionID, "complete")
+            return {
+              title: "Verify",
+              metadata: { phase: "complete", passed: true },
+              output: [
+                "TESTS PASSED ✓",
+                "",
+                `Command: ${testCmd}`,
+                stdout ? `Output:\n${stdout.slice(-2000)}` : "",
+              ]
+                .filter(Boolean)
+                .join("\n"),
+            }
+          }
+
+          if (retryCount >= maxRetries) {
+            yield* ultra.transition(ctx.sessionID, "complete")
+            return {
+              title: "Verify",
+              metadata: { phase: "complete", passed: false, retriesExhausted: true },
+              output: [
+                `TESTS FAILED after ${maxRetries} retries. Stopping.`,
+                "",
+                `Command: ${testCmd}`,
+                stderr ? `Error:\n${stderr.slice(-2000)}` : "",
+              ]
+                .filter(Boolean)
+                .join("\n"),
+            }
+          }
+
+          yield* ultra.transition(ctx.sessionID, "iterating")
+          return {
+            title: "Verify",
+            metadata: { phase: "iterating", passed: false, retry: retryCount },
+            output: [
+              `TESTS FAILED (attempt ${retryCount}/${maxRetries})`,
+              "",
+              `Command: ${testCmd}`,
+              stderr ? `Error:\n${stderr.slice(-2000)}` : "",
+              "",
+              "Transitioning to 'iterating' phase. Fix the failures and verify again.",
+            ]
+              .filter(Boolean)
+              .join("\n"),
+          }
+        }),
+    }
+  }),
+)

--- a/packages/opencode/src/agent/ultra/ultra.txt
+++ b/packages/opencode/src/agent/ultra/ultra.txt
@@ -1,0 +1,34 @@
+You are Ultra Mode, an autonomous coding agent that executes the full planning→building→verifying→iterate loop.
+
+## State Machine
+
+You operate within a strict state machine with four phases:
+
+1. **planning** - Read the codebase, understand requirements, write a plan to `.opencode/plans/<task>.md`. Do NOT edit source files.
+2. **building** - Implement the plan. All tools are available. Write code, run commands, install dependencies.
+3. **verifying** - Run `ultra_verify` to auto-detect and run tests. If tests pass → complete. If tests fail → iterating.
+4. **iterating** - Fix the failures found during verification. Then call `ultra_verify` again.
+5. **complete** - Work is done. Provide a summary.
+
+## Rules
+
+- You MUST start in the `planning` phase
+- You MUST NOT call `edit`, `write`, `shell` (modifying) during planning
+- You MUST call `ultra_verify` during verifying (not shell)
+- You MUST NOT call `ultra_verify` during iterating
+- You have a maximum of 10 retries before stopping
+- When in doubt, use `ultra_phase` to transition
+
+## Workflow
+
+When you receive a task:
+1. Call `ultra_phase` with `phase: "building"` (planning is implicit - analyze the task first)
+2. Implement the solution
+3. Call `ultra_phase` with `phase: "verifying"` 
+4. Call `ultra_verify` to run tests
+5. If tests fail, call `ultra_phase` with `phase: "iterating"`, fix issues, then verify again
+6. When tests pass, you're done
+
+## Output Format
+
+Always end with a clear summary of what was done, files changed, and any remaining issues.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -29,6 +29,8 @@ import { WebSearchTool } from "./websearch"
 import { LspTool } from "./lsp"
 import * as Truncate from "./truncate"
 import { ApplyPatchTool } from "./apply_patch"
+import { UltraVerifyTool } from "../agent/ultra/ultra-verify"
+import { UltraPhaseTool } from "../agent/ultra/ultra-phase"
 import { Glob } from "@opencode-ai/core/util/glob"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -212,6 +214,8 @@ export const layer = Layer.effect(
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          ultraVerify: Tool.init(UltraVerifyTool),
+          ultraPhase: Tool.init(UltraPhaseTool),
         })
 
         return {
@@ -231,6 +235,8 @@ export const layer = Layer.effect(
             tool.search,
             tool.skill,
             tool.patch,
+            tool.ultraVerify,
+            tool.ultraPhase,
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),
           ],


### PR DESCRIPTION
新增Ultra Mode代理（#23428），可自主执行规划->构建->验证->循环，使用硬编码状态机。

- ultra-state.ts：具有每相工具滤波的相态机
- ultra-verify.ts：自动检测并运行测试套件
- ultra-phase.ts：相变工具
- ultra.txt：Ultra代理的系统提示
- 注册于agent.ts和工具/registry.ts

### 这篇公关的问题

关闭 #

### 变化类型

- [ ] 修复漏洞
- [ ] 新功能
- [ ] 重构/代码改进
- [ ] 文档

### 这个公关到底是干什么的？

请描述问题、你为修复所做的更改以及为什么这些改进有效。你应该理解为什么你的更改有效，如果不明白原因，至少要说明，这样维护者才能知道该多重视PR。

**如果你在这里粘贴一个明显AI生成的大描述，你的公关可能会被忽略或关闭！**

### 你是怎么验证你的代码有效的？

### 截图/录音

_If这是界面变动，请附上截图或附recording._

### 清单

- [ ] 我在本地测试了我的更改
- [ ] 我没有在本次PR中添加无关的更改

_If你不遵循这个模板，你的永久居民会自动rejected._
