### PR TITLE
fix(session): recover stale synthetic continuation models

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -397,6 +397,17 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             variant: msg.model?.variant ?? null,
           })
         },
+        sync(msg: { sessionID: string; agent: string; model: ModelKey }) {
+          const session = id()
+          if (!session) return
+          if (msg.sessionID !== session) return
+
+          setSaved("session", session, {
+            agent: msg.agent,
+            model: msg.model,
+            variant: msg.model?.variant ?? null,
+          })
+        },
       },
     }
     return result

--- a/packages/app/src/pages/session/session-model-helpers.test.ts
+++ b/packages/app/src/pages/session/session-model-helpers.test.ts
@@ -13,6 +13,29 @@ const message = (input?: { agent?: string; model?: UserMessage["model"] }) =>
   }) as UserMessage
 
 describe("syncSessionModel", () => {
+  test("syncs the last message when authoritative sync is available", () => {
+    const calls: unknown[] = []
+
+    syncSessionModel(
+      {
+        session: {
+          sync(value) {
+            calls.push(["sync", value])
+          },
+          restore(value) {
+            calls.push(["restore", value])
+          },
+          reset() {},
+        },
+      },
+      message({ model: { providerID: "anthropic", modelID: "claude-opus-4-8", variant: "max" } }),
+    )
+
+    expect(calls).toEqual([
+      ["sync", message({ model: { providerID: "anthropic", modelID: "claude-opus-4-8", variant: "max" } })],
+    ])
+  })
+
   test("restores the last message through session state", () => {
     const calls: unknown[] = []
 

--- a/packages/app/src/pages/session/session-model-helpers.ts
+++ b/packages/app/src/pages/session/session-model-helpers.ts
@@ -4,6 +4,7 @@ type Local = {
   session: {
     reset(): void
     restore(msg: UserMessage): void
+    sync?(msg: UserMessage): void
   }
 }
 
@@ -12,5 +13,9 @@ export const resetSessionModel = (local: Local) => {
 }
 
 export const syncSessionModel = (local: Local, msg: UserMessage) => {
+  if (local.session.sync) {
+    local.session.sync(msg)
+    return
+  }
   local.session.restore(msg)
 }

--- a/packages/app/src/pages/session/timeline/model.test.ts
+++ b/packages/app/src/pages/session/timeline/model.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, test } from "bun:test"
-import type { AssistantMessage, Message, UserMessage } from "@opencode-ai/sdk/v2"
-import { loadOlderTimeline, selectUserMessages, selectVisibleUserMessages } from "./model"
+import type { AssistantMessage, Message, Part, UserMessage } from "@opencode-ai/sdk/v2"
+import { isInternalUserMessage, loadOlderTimeline, selectUserMessages, selectVisibleUserMessages } from "./model"
 
 const user = (id: string) => ({ id, role: "user" }) as UserMessage
 const assistant = (id: string) => ({ id, role: "assistant" }) as AssistantMessage
+const textPart = (messageID: string, input: { synthetic?: boolean; text?: string } = {}) =>
+  ({
+    id: `prt_${messageID}_${input.synthetic ? "synthetic" : "real"}`,
+    sessionID: "ses",
+    messageID,
+    type: "text",
+    text: input.text ?? "continue",
+    synthetic: input.synthetic,
+  }) as Part
 
 describe("timeline model", () => {
   test("selects users and applies the revert boundary", () => {
@@ -13,6 +22,28 @@ describe("timeline model", () => {
     expect(users.map((message) => message.id)).toEqual(["msg_1", "msg_3", "msg_5"])
     expect(selectVisibleUserMessages(users, "msg_5").map((message) => message.id)).toEqual(["msg_1", "msg_3"])
     expect(selectVisibleUserMessages(users)).toBe(users)
+  })
+
+  test("hides synthetic-only internal continuation user messages", () => {
+    const real = user("msg_1")
+    const internal = user("msg_2")
+
+    expect(
+      selectVisibleUserMessages([real, internal], undefined, {
+        msg_1: [textPart("msg_1", { text: "real prompt" })],
+        msg_2: [textPart("msg_2", { synthetic: true, text: "continue\n<!-- OMO_INTERNAL_INITIATOR -->" })],
+      }),
+    ).toEqual([real])
+    expect(isInternalUserMessage(internal, { msg_2: [textPart("msg_2", { synthetic: true })] })).toBe(true)
+  })
+
+  test("keeps mixed real and synthetic user messages visible", () => {
+    const mixed = user("msg_1")
+    expect(
+      selectVisibleUserMessages([mixed], undefined, {
+        msg_1: [textPart("msg_1", { synthetic: true }), textPart("msg_1", { text: "real prompt" })],
+      }),
+    ).toEqual([mixed])
   })
 
   test("loads pages until a visible user turn is added", async () => {

--- a/packages/app/src/pages/session/timeline/model.ts
+++ b/packages/app/src/pages/session/timeline/model.ts
@@ -1,4 +1,4 @@
-import type { Message, UserMessage } from "@opencode-ai/sdk/v2"
+import type { Message, Part, UserMessage } from "@opencode-ai/sdk/v2"
 import { createMemo, createResource, onCleanup, untrack, type Accessor } from "solid-js"
 import { getSessionPrefetch, SESSION_PREFETCH_TTL } from "@/context/global-sync/session-prefetch"
 import { useSDK } from "@/context/sdk"
@@ -58,7 +58,7 @@ export function createTimelineModel(input: {
   const userMessages = createMemo(() => selectUserMessages(messages()), emptyUserMessages, { equals: same })
   const visibleUserMessages = createMemo(
     () => {
-      return selectVisibleUserMessages(userMessages(), input.revertMessageID())
+      return selectVisibleUserMessages(userMessages(), input.revertMessageID(), sync().data.part)
     },
     emptyUserMessages,
     { equals: same },
@@ -108,9 +108,21 @@ export function selectUserMessages(messages: Message[]) {
   return messages.filter((message): message is UserMessage => message.role === "user")
 }
 
-export function selectVisibleUserMessages(messages: UserMessage[], revertMessageID?: string) {
-  if (!revertMessageID) return messages
-  return messages.filter((message) => message.id < revertMessageID)
+export function isInternalUserMessage(message: UserMessage, partsByMessage: Record<string, Part[] | undefined> = {}) {
+  const parts = partsByMessage[message.id]
+  return !!parts?.length && parts.every((part) => "synthetic" in part && part.synthetic === true)
+}
+
+export function selectVisibleUserMessages(
+  messages: UserMessage[],
+  revertMessageID?: string,
+  partsByMessage: Record<string, Part[] | undefined> = {},
+) {
+  if (!revertMessageID && Object.keys(partsByMessage).length === 0) return messages
+  return messages.filter((message) => {
+    if (revertMessageID && message.id >= revertMessageID) return false
+    return !isInternalUserMessage(message, partsByMessage)
+  })
 }
 
 export async function loadOlderTimeline(input: {

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -31,6 +31,7 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import * as DateTime from "effect/DateTime"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ToolOutput, Usage, type LLMEvent } from "@opencode-ai/llm"
+import { ProviderError } from "@/provider/error"
 
 const DOOM_LOOP_THRESHOLD = 3
 export type Result = "compact" | "stop" | "continue"
@@ -978,6 +979,12 @@ export const layer = Layer.effect(
               Stream.takeUntil(() => ctx.needsCompaction),
               Stream.runDrain,
             )
+            const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
+              Effect.provideService(Database.Service, database),
+            )
+            if (parts.length === 0 && !ctx.assistantMessage.error && !ctx.needsCompaction) {
+              yield* Effect.fail(new ProviderError.ResponseStreamError("Provider stream ended without content"))
+            }
           }).pipe(
             Effect.onInterrupt(() =>
               Effect.gen(function* () {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -612,6 +612,42 @@ export const layer = Layer.effect(
       return yield* Effect.die(err)
     })
 
+    const modelFromSessionRow = (model: { id: string; providerID: string; variant?: string | null }) => ({
+      providerID: ProviderV2.ID.make(model.providerID),
+      modelID: ModelV2.ID.make(model.id),
+      ...(model.variant && model.variant !== "default" ? { variant: model.variant } : {}),
+    })
+
+    const sameModel = (left: SessionV1.User["model"], right: SessionV1.User["model"]) =>
+      left.providerID === right.providerID &&
+      left.modelID === right.modelID &&
+      (left.variant ?? "default") === (right.variant ?? "default")
+
+    const syntheticOnlyUser = (m: SessionV1.WithParts) =>
+      m.info.role === "user" && m.parts.length > 0 && m.parts.every((p) => "synthetic" in p && p.synthetic === true)
+
+    const recoverSyntheticPollutedModel = Effect.fnUntraced(function* (
+      sessionID: SessionID,
+      candidate: SessionV1.User["model"],
+    ) {
+      const latestUser = yield* sessions
+        .findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model)
+        .pipe(Effect.orDie)
+      if (
+        Option.isNone(latestUser) ||
+        latestUser.value.info.role !== "user" ||
+        !syntheticOnlyUser(latestUser.value) ||
+        !sameModel(candidate, latestUser.value.info.model)
+      ) {
+        return undefined
+      }
+      const latestRealUser = yield* sessions
+        .findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model && !syntheticOnlyUser(m))
+        .pipe(Effect.orDie)
+      if (Option.isSome(latestRealUser) && latestRealUser.value.info.role === "user") return latestRealUser.value.info.model
+      return undefined
+    })
+
     const currentModel = Effect.fnUntraced(function* (sessionID: SessionID) {
       const current = yield* db
         .select({ model: SessionTable.model })
@@ -619,17 +655,12 @@ export const layer = Layer.effect(
         .where(eq(SessionTable.id, sessionID))
         .get()
         .pipe(Effect.orDie)
-      if (current?.model) {
-        return {
-          providerID: ProviderV2.ID.make(current.model.providerID),
-          modelID: ModelV2.ID.make(current.model.id),
-          ...(current.model.variant && current.model.variant !== "default" ? { variant: current.model.variant } : {}),
-        }
-      }
-      const match = yield* sessions
-        .findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model)
+      const rowModel = current?.model ? modelFromSessionRow(current.model) : undefined
+      if (rowModel) return (yield* recoverSyntheticPollutedModel(sessionID, rowModel)) ?? rowModel
+      const latestRealUser = yield* sessions
+        .findMessage(sessionID, (m) => m.info.role === "user" && !!m.info.model && !syntheticOnlyUser(m))
         .pipe(Effect.orDie)
-      if (Option.isSome(match) && match.value.info.role === "user") return match.value.info.model
+      if (Option.isSome(latestRealUser) && latestRealUser.value.info.role === "user") return latestRealUser.value.info.model
       return yield* provider.defaultModel().pipe(Effect.orDie)
     })
 
@@ -650,7 +681,9 @@ export const layer = Layer.effect(
         .where(eq(SessionTable.id, input.sessionID))
         .get()
         .pipe(Effect.orDie)
-      const model = input.model ?? ag.model ?? (yield* currentModel(input.sessionID))
+      const model = input.model
+        ? ((yield* recoverSyntheticPollutedModel(input.sessionID, input.model)) ?? input.model)
+        : (ag.model ?? (yield* currentModel(input.sessionID)))
       const same = ag.model && model.providerID === ag.model.providerID && model.modelID === ag.model.modelID
       const full =
         !input.variant && ag.variant && same
@@ -1153,6 +1186,21 @@ export const layer = Layer.effect(
           const lastAssistantMsg = msgs.findLast(
             (msg) => msg.info.role === "assistant" && msg.info.id === lastAssistant?.id,
           )
+          if (
+            lastAssistant &&
+            lastAssistant.time.completed &&
+            !lastAssistant.finish &&
+            !lastAssistant.error &&
+            lastAssistantMsg?.parts.length === 0
+          ) {
+            // This is a stale/incomplete assistant row from an interrupted run.
+            // Do not convert it into MessageAbortedError or publish Session.Event.Error:
+            // OmO's fallback hook treats those as retry/fallback triggers, which can
+            // incorrectly switch the main session model during resume.
+            lastAssistant.finish = "stop"
+            yield* sessions.updateMessage(lastAssistant)
+            continue
+          }
           // Some providers return "stop" even when the assistant message contains
           // tool calls. Keep the loop running so tool results can be sent back to
           // the model, but ignore cleanup-marked interrupted orphans.
@@ -1254,14 +1302,22 @@ export const layer = Layer.effect(
           yield* sessions.updateMessage(msg)
 
           const finalizeInterruptedAssistant = Effect.gen(function* () {
-            if (msg.time.completed) return
-            msg.error ??= MessageV2.fromError(new DOMException("Aborted", "AbortError"), {
-              providerID: msg.providerID,
-              aborted: true,
-            })
-            msg.time.completed = Date.now()
+            if (msg.time.completed && (msg.finish || msg.error)) return
+            msg.finish ??= "stop"
+            msg.time.completed ??= Date.now()
             yield* sessions.updateMessage(msg)
           })
+
+          const finalizeFailedAssistant = (cause: Cause.Cause<unknown>) =>
+            Effect.gen(function* () {
+              if (Cause.hasInterruptsOnly(cause)) return
+              if (msg.finish || msg.error) return
+              msg.error = MessageV2.fromError(Cause.squash(cause), { providerID: msg.providerID })
+              msg.finish = "error"
+              msg.time.completed ??= Date.now()
+              yield* events.publish(Session.Event.Error, { sessionID, error: msg.error })
+              yield* sessions.updateMessage(msg)
+            })
 
           const handle = yield* processor
             .create({
@@ -1269,7 +1325,10 @@ export const layer = Layer.effect(
               sessionID,
               model,
             })
-            .pipe(Effect.onInterrupt(() => finalizeInterruptedAssistant))
+            .pipe(
+              Effect.onInterrupt(() => finalizeInterruptedAssistant),
+              Effect.catchCause((cause) => finalizeFailedAssistant(cause).pipe(Effect.andThen(Effect.failCause(cause)))),
+            )
 
           const outcome: "break" | "continue" = yield* Effect.gen(function* () {
             const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
@@ -1373,6 +1432,7 @@ export const layer = Layer.effect(
           }).pipe(
             Effect.ensuring(instruction.clear(handle.message.id)),
             Effect.onInterrupt(() => finalizeInterruptedAssistant),
+            Effect.catchCause((cause) => finalizeFailedAssistant(cause).pipe(Effect.andThen(Effect.failCause(cause)))),
           )
           if (outcome === "break") break
           continue

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -28,6 +28,19 @@ export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 
+function hasTransientText(value: string) {
+  const lower = value.toLowerCase()
+  return (
+    lower.includes("rate increased too quickly") ||
+    lower.includes("rate limit") ||
+    lower.includes("rate limited") ||
+    lower.includes("too many requests") ||
+    lower.includes("retry error") ||
+    lower.includes("you can retry your request") ||
+    lower.includes("an error occurred while processing your request")
+  )
+}
+
 function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
 }
@@ -70,9 +83,12 @@ export function retryable(error: Err, provider: string) {
   if (SessionV1.ContextOverflowError.isInstance(error)) return undefined
   if (SessionV1.APIError.isInstance(error)) {
     const status = error.data.statusCode
-    // 5xx errors are transient server failures and should always be retried,
-    // even when the provider SDK doesn't explicitly mark them as retryable.
-    if (!error.data.isRetryable && !(status !== undefined && status >= 500)) return undefined
+    const lower = `${error.data.message}\n${error.data.responseBody ?? ""}`.toLowerCase()
+    const transient = status === 429 || hasTransientText(lower)
+    // 5xx errors plus provider rate limits/transient retry advisories are
+    // transient failures and should be retried even when the provider SDK
+    // doesn't explicitly mark them as retryable.
+    if (!error.data.isRetryable && !(status !== undefined && status >= 500) && !transient) return undefined
     if (error.data.responseBody?.includes("FreeUsageLimitError")) {
       return {
         message: GO_UPSELL_MESSAGE,
@@ -125,12 +141,7 @@ export function retryable(error: Err, provider: string) {
   // Check for rate limit patterns in plain text error messages
   const msg = isRecord(error.data) ? error.data.message : undefined
   if (typeof msg === "string") {
-    const lower = msg.toLowerCase()
-    if (
-      lower.includes("rate increased too quickly") ||
-      lower.includes("rate limit") ||
-      lower.includes("too many requests")
-    ) {
+    if (hasTransientText(msg)) {
       return { message: msg }
     }
   }

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -227,6 +227,49 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "Service unavailable" })
   })
 
+  test("retries 429 rate limits even when isRetryable is false", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "Rate limited",
+        isRetryable: false,
+        statusCode: 429,
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "Rate limited" })
+  })
+
+  test("retries APIError text rate limits without status", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "Too many requests, please retry later",
+        isRetryable: false,
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "Too many requests, please retry later" })
+  })
+
+  test("retries OpenAI retry-advisory APIError even when isRetryable is false", () => {
+    const message =
+      "Retry Error: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx in your message."
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message,
+        isRetryable: false,
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message })
+  })
+
+  test("retries plain text retry-advisory errors", () => {
+    const message =
+      "Retry Error: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists."
+    const error = wrap(message)
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message })
+  })
+
   test("does not retry 4xx errors when isRetryable is false", () => {
     const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
       new SessionV1.APIError({


### PR DESCRIPTION
### Issue for this PR

Closes #33044

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents internal/synthetic continuation model state from becoming the durable session model used by later normal user turns.

This patch:

- excludes synthetic-only internal continuation user rows from Web timeline model selection
- adds an authoritative active-session model sync so stale local session model state is overwritten by the latest real user turn
- treats provider streams that end without content as retryable stream failures instead of successful blank turns
- classifies retry-advisory errors such as `Retry Error: ... You can retry your request ...` as retryable even when SDK metadata is incomplete
- closes interrupted blank assistant rows as stopped instead of emitting a fresh error event that can re-trigger fallback
- recovers stale explicit continuation models from the previous real user model when the UI sends stale or no explicit model

This intentionally does **not** include the OpenAI Responses tool-count cap; that is already covered by #32998.

Prepared with AI assistance.

### How did you verify your code works?

- `bun test --cwd packages/app --preload ./happydom.ts ./src/pages/session/timeline/model.test.ts ./src/pages/session/session-model-helpers.test.ts`
- `bun test --cwd packages/opencode test/session/retry.test.ts`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/opencode typecheck`
- pre-push hook: `bun turbo typecheck` (23/23 successful)

### Notes

`packages/opencode/test/session/processor-effect.test.ts` currently needs broader upstream harness work in this checkout for provider catalog setup, so this PR keeps the processor behavior minimal and verifies the retry classifier/session-model surfaces directly.



### Screenshots / recordings

N/A — session/model state and retry behavior changes only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
