### PR TITLE
fix(server): strip credentials from hosted UI fallback proxy

### DIFF
--- a/packages/opencode/src/server/proxy-util.ts
+++ b/packages/opencode/src/server/proxy-util.ts
@@ -14,6 +14,8 @@ const hop = new Set([
 function sanitize(out: Headers) {
   for (const key of hop) out.delete(key)
   out.delete("accept-encoding")
+  out.delete("authorization")
+  out.delete("cookie")
   out.delete("x-opencode-directory")
   out.delete("x-opencode-workspace")
 }

--- a/packages/opencode/test/server/proxy-util.test.ts
+++ b/packages/opencode/test/server/proxy-util.test.ts
@@ -65,12 +65,14 @@ describe("ProxyUtil", () => {
       expect(result.get("content-type")).toBe("application/json")
     })
 
-    test("strips opencode-specific headers", () => {
+    test("strips opencode-specific and credential headers", () => {
       const req = new Request("http://localhost", {
         headers: {
           "x-opencode-directory": "/home/user/project",
           "x-opencode-workspace": "ws_123",
           "accept-encoding": "gzip",
+          authorization: "Basic secret",
+          cookie: "session=secret",
           "x-custom": "keep",
         },
       })
@@ -78,6 +80,8 @@ describe("ProxyUtil", () => {
       expect(result.get("x-opencode-directory")).toBeNull()
       expect(result.get("x-opencode-workspace")).toBeNull()
       expect(result.get("accept-encoding")).toBeNull()
+      expect(result.get("authorization")).toBeNull()
+      expect(result.get("cookie")).toBeNull()
       expect(result.get("x-custom")).toBe("keep")
     })
 


### PR DESCRIPTION
### Issue for this PR

Closes #33046

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Strips credential-bearing request headers from the hosted UI fallback proxy path.

The proxy utility already removes hop-by-hop headers, including `proxy-authorization`. This update additionally strips `authorization` and `cookie` before forwarding.

### How did you verify your code works?

- `bun test --cwd packages/opencode test/server/proxy-util.test.ts` (13 passed)
- `bun run --cwd packages/opencode typecheck`
- pre-push: `bun turbo typecheck`

### Screenshots / recordings

N/A — server-side proxy header sanitization only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR