### PR TITLE
feat(opencode): autoload .env from global config directory for {env:}…

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -244,6 +244,8 @@ export const layer = Layer.effect(
     })
 
     const loadGlobal = Effect.fnUntraced(function* (env?: Record<string, string>) {
+      const envPath = path.join(Global.Path.config, ".env")
+      if (existsSync(envPath)) process.loadEnvFile(envPath)
       let result: Info = {}
       // Seed the default global config with the schema for editor completion, but avoid writing when the user
       // explicitly routes config through env-provided paths or content.

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -515,6 +515,21 @@ it.instance("handles environment variable substitution", () =>
   ),
 )
 
+it.instance("loads .env from global config directory for {env:} substitution", () =>
+  Effect.gen(function* () {
+    const dir = yield* tmpdirScoped()
+    yield* FSUtil.use.writeWithDirs(path.join(dir, ".env"), "MY_DOTENV_VAR=from-global-dotenv\n")
+    yield* writeConfigEffect(dir, {
+      $schema: "https://opencode.ai/config.json",
+      username: "{env:MY_DOTENV_VAR}",
+    })
+    yield* withGlobalConfigDir(dir, Effect.gen(function* () {
+      const config = yield* Config.use.get()
+      expect(config.username).toBe("from-global-dotenv")
+    }))
+  }).pipe(Effect.ensuring(Effect.sync(() => delete process.env.MY_DOTENV_VAR))),
+)
+
 it.instance("preserves env variables when adding $schema to config", () =>
   withProcessEnv(
     "PRESERVE_VAR",


### PR DESCRIPTION
… substitution

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [X ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode now auto-loads ~/.config/opencode/.env on startup via Node's built-in process.loadEnvFile. The vars are loaded into process.env before any config files are read, so {env:VAR} references in config files (e.g. MCP headers, provider API keys) resolve against the .env file.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
- Added a test (loads .env from global config directory for {env:} substitution) that creates a temp global config dir with an .env file and an opencode.json using {env:MY_DOTENV_VAR}, then asserts the substitution resolves correctly.
- Built the single binary with ./packages/opencode/script/build.ts --single — passed smoke test.
- Typecheck across all 29 packages passed via bun turbo typecheck.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ X] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
