### PR TITLE
fix(opencode): set finish and time.completed in halt error handler

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -950,6 +950,8 @@ export const layer = Layer.effect(
           }
         }
         ctx.assistantMessage.error = error
+        ctx.assistantMessage.finish = "error"
+        ctx.assistantMessage.time.completed = Date.now()
         yield* events.publish(Session.Event.Error, {
           sessionID: ctx.assistantMessage.sessionID,
           error: ctx.assistantMessage.error,


### PR DESCRIPTION
### Issue for this PR

Closes #33055

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the ACP server hits a model API error, the `halt` handler sets
`assistantMessage.error` but not `finish`. The `runLoop` exit condition
checks `lastAssistant?.finish` — without it the loop never breaks and
retries the failing call forever. This adds the two missing assignments:
`finish = "error"` and `time.completed = Date.now()`.

### How did you verify your code works?

Ran back-to-back ACP prompts against a rate-limited model. Before the
fix the process hangs indefinitely; after the fix each error returns
cleanly with a JSON-RPC error response.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
