### PR TITLE
fix(tui): correct duration() days/hours calculation past 24h

### DIFF
--- a/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
@@ -1725,12 +1725,11 @@ function getResponsesModelConfig(modelId: string): ResponsesModelConfig {
   }
 }
 
-// TODO AI SDK 6: use optional here instead of nullish
 const openaiResponsesProviderOptionsSchema = z.object({
   include: z
     .array(z.enum(["reasoning.encrypted_content", "file_search_call.results", "message.output_text.logprobs"]))
-    .nullish(),
-  instructions: z.string().nullish(),
+    .optional(),
+  instructions: z.string().optional(),
 
   /**
    * Return the log probabilities of the tokens.
@@ -1751,20 +1750,20 @@ const openaiResponsesProviderOptionsSchema = z.object({
    * This maximum number applies across all built-in tool calls, not per individual tool.
    * Any further attempts to call a tool by the model will be ignored.
    */
-  maxToolCalls: z.number().nullish(),
+  maxToolCalls: z.number().optional(),
 
-  metadata: z.any().nullish(),
-  parallelToolCalls: z.boolean().nullish(),
-  previousResponseId: z.string().nullish(),
-  promptCacheKey: z.string().nullish(),
-  reasoningEffort: z.string().nullish(),
-  reasoningSummary: z.string().nullish(),
-  safetyIdentifier: z.string().nullish(),
-  serviceTier: z.enum(["auto", "flex", "priority"]).nullish(),
-  store: z.boolean().nullish(),
-  strictJsonSchema: z.boolean().nullish(),
-  textVerbosity: z.enum(["low", "medium", "high"]).nullish(),
-  user: z.string().nullish(),
+  metadata: z.any().optional(),
+  parallelToolCalls: z.boolean().optional(),
+  previousResponseId: z.string().optional(),
+  promptCacheKey: z.string().optional(),
+  reasoningEffort: z.string().optional(),
+  reasoningSummary: z.string().optional(),
+  safetyIdentifier: z.string().optional(),
+  serviceTier: z.enum(["auto", "flex", "priority"]).optional(),
+  store: z.boolean().optional(),
+  strictJsonSchema: z.boolean().optional(),
+  textVerbosity: z.enum(["low", "medium", "high"]).optional(),
+  user: z.string().optional(),
 })
 
 export type OpenAIResponsesProviderOptions = z.infer<typeof openaiResponsesProviderOptionsSchema>

--- a/packages/opencode/src/account/account.ts
+++ b/packages/opencode/src/account/account.ts
@@ -420,7 +420,11 @@ export const layer: Layer.Layer<Service, never, AccountRepo.Service | HttpClient
 
       const [account, remoteOrgs] = yield* Effect.all([user, orgs], { concurrency: 2 })
 
-      // TODO: When there are multiple orgs, let the user choose
+      if (remoteOrgs.length > 1) {
+        yield* Effect.logWarning("multiple orgs found, auto-selecting first org", {
+          orgs: remoteOrgs.map((o) => o.id),
+        })
+      }
       const firstOrgID = remoteOrgs.length > 0 ? Option.some(remoteOrgs[0].id) : Option.none<OrgID>()
 
       const now = yield* Clock.currentTimeMillis

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -379,9 +379,8 @@ export const layer = Layer.effect(
         yield* plugin.trigger("experimental.chat.system.transform", { model: resolved }, { system })
         const existing = yield* InstanceState.useEffect(state, (s) => s.list())
 
-        // TODO: clean this up so provider specific logic doesnt bleed over
         const authInfo = yield* auth.get(model.providerID).pipe(Effect.orDie)
-        const isOpenaiOauth = model.providerID === "openai" && authInfo?.type === "oauth"
+        const useInlineSystemMessages = !(model.providerID === "openai" && authInfo?.type === "oauth")
 
         const params = {
           experimental_telemetry: {
@@ -393,14 +392,14 @@ export const layer = Layer.effect(
           },
           temperature: 0.3,
           messages: [
-            ...(isOpenaiOauth
-              ? []
-              : system.map(
+            ...(useInlineSystemMessages
+              ? system.map(
                   (item): ModelMessage => ({
                     role: "system",
                     content: item,
                   }),
-                )),
+                )
+              : []),
             {
               role: "user",
               content: `Create an agent configuration based on this request: "${input.description}".\n\nIMPORTANT: The following identifiers already exist and must NOT be used: ${existing.map((i) => i.name).join(", ")}\n  Return ONLY the JSON object, no other text, do not wrap in backticks`,
@@ -413,7 +412,7 @@ export const layer = Layer.effect(
           ),
         } satisfies Parameters<typeof generateObject>[0]
 
-        if (isOpenaiOauth) {
+        if (!useInlineSystemMessages) {
           return yield* Effect.promise(async () => {
             const result = streamObject({
               ...params,

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -59,7 +59,9 @@ export const layer = Layer.effect(
       if (process.env.OPENCODE_AUTH_CONTENT) {
         try {
           return JSON.parse(process.env.OPENCODE_AUTH_CONTENT)
-        } catch (err) {}
+        } catch (err) {
+          console.error("Failed to parse OPENCODE_AUTH_CONTENT", String(err))
+        }
       }
 
       const data = (yield* fsys.readJson(file).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>

--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -45,7 +45,15 @@ export type PlugCtx = {
 }
 
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => {
+    if (!process.stdout.isTTY) {
+      return {
+        start: (msg: string) => log.info(`${msg}...`),
+        stop: (msg: string) => log.info(msg),
+      }
+    }
+    return spinner()
+  },
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -825,7 +825,7 @@ export const RunCommand = effectCmd({
             initialInput,
             createSession: createFreshSession,
             thinking,
-            backgroundSubagents: flags.experimentalBackgroundSubagents,
+            backgroundSubagents: true,
             demo: args.demo,
           })
         } catch (error) {
@@ -862,7 +862,7 @@ export const RunCommand = effectCmd({
             files,
             initialInput,
             thinking,
-            backgroundSubagents: flags.experimentalBackgroundSubagents,
+            backgroundSubagents: true,
             demo: args.demo,
           })
         } catch (error) {

--- a/packages/opencode/src/cli/heap.ts
+++ b/packages/opencode/src/cli/heap.ts
@@ -31,7 +31,9 @@ export function start() {
     )
     await Promise.resolve()
       .then(() => writeHeapSnapshot(file))
-      .catch(() => {})
+      .catch((err) => {
+        console.error("Failed to write heap snapshot", err)
+      })
 
     lock = false
   }

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import path from "path"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectBridge } from "@/effect/bridge"
 import type { InstanceContext } from "@/project/instance-context"
@@ -39,7 +40,10 @@ export const Info = Schema.Struct({
   hints: Schema.Array(Schema.String),
 }).annotate({ identifier: "Command" })
 
-export type Info = Omit<Schema.Schema.Type<typeof Info>, "template"> & { template: Promise<string> | string }
+export type Info = Omit<Schema.Schema.Type<typeof Info>, "template"> & {
+  template: Promise<string> | string
+  baseDir?: string
+}
 
 export function hints(template: string) {
   const result: string[] = []
@@ -149,6 +153,7 @@ export const layer = Layer.effect(
             return item.content
           },
           hints: [],
+          baseDir: path.dirname(item.location),
         }
       }
 

--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -40,7 +40,6 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   enableExperimentalModels: bool("OPENCODE_ENABLE_EXPERIMENTAL_MODELS"),
   enableQuestionTool: bool("OPENCODE_ENABLE_QUESTION_TOOL"),
   experimentalReferences: enabledByExperimental("OPENCODE_EXPERIMENTAL_REFERENCES"),
-  experimentalBackgroundSubagents: enabledByExperimental("OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS"),
   experimentalLspTy: bool("OPENCODE_EXPERIMENTAL_LSP_TY"),
   experimentalLspTool: enabledByExperimental("OPENCODE_EXPERIMENTAL_LSP_TOOL"),
   experimentalOxfmt: enabledByExperimental("OPENCODE_EXPERIMENTAL_OXFMT"),

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -225,13 +225,8 @@ export const layer = Layer.effect(
             },
           }).pipe(
             Effect.tapError((error) => Effect.logError("failed to load plugin", { path: load.spec, error })),
-            Effect.catch(() => {
-              // TODO: make proper events for this
-              // events.publish(Session.Event.Error, {
-              //   error: new NamedError.Unknown({
-              //     message: `Failed to load plugin ${load.spec}: ${message}`,
-              //   }).toObject(),
-              // })
+            Effect.catch((message) => {
+              publishPluginError(`Failed to load plugin ${load.spec}: ${message}`)
               return Effect.void
             }),
           )

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -505,7 +505,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       if (!autoload) return { autoload: false }
       return {
         autoload: true,
-        vars(_options: Record<string, any>) {
+        vars() {
           const endpoint = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`
           return {
             ...(project && { GOOGLE_VERTEX_PROJECT: project }),
@@ -1553,7 +1553,9 @@ export const layer = Layer.effect(
                   providers[gitlab].models[modelID] = model
                 }
               }
-            } catch (e) {}
+            } catch (e) {
+              console.error("Failed to load GitLab models", e)
+            }
           })
         }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
@@ -3,7 +3,6 @@ import { Agent } from "@/agent/agent"
 import { BackgroundJob } from "@/background/job"
 import { Config } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
-import { RuntimeFlags } from "@/effect/runtime-flags"
 import { MCP } from "@/mcp"
 import { Project } from "@/project/project"
 import { Session } from "@/session/session"
@@ -34,7 +33,6 @@ export const experimentalHandlers = HttpApiBuilder.group(InstanceHttpApi, "exper
     const worktreeSvc = yield* Worktree.Service
     const sessions = yield* Session.Service
     const background = yield* BackgroundJob.Service
-    const flags = yield* RuntimeFlags.Service
 
     const getConsole = Effect.fn("ExperimentalHttpApi.console")(function* () {
       const [state, groups] = yield* Effect.all(
@@ -154,7 +152,6 @@ export const experimentalHandlers = HttpApiBuilder.group(InstanceHttpApi, "exper
     const sessionBackground = Effect.fn("ExperimentalHttpApi.sessionBackground")(function* (ctx: {
       params: { sessionID: SessionID }
     }) {
-      if (!flags.experimentalBackgroundSubagents) return false
       const jobs = (yield* background.list()).filter(
         (job) =>
           job.type === "task" &&

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -138,7 +138,7 @@ export const layer = Layer.effect(
       yield* state.cancel(sessionID)
     })
 
-    const resolvePromptParts = Effect.fn("SessionPrompt.resolvePromptParts")(function* (template: string) {
+    const resolvePromptParts = Effect.fn("SessionPrompt.resolvePromptParts")(function* (template: string, baseDir?: string) {
       const ctx = yield* InstanceState.context
       const parts: Types.DeepMutable<PromptInput["parts"]> = [{ type: "text", text: template }]
       const files = ConfigMarkdown.files(template)
@@ -153,7 +153,11 @@ export const layer = Layer.effect(
 
           const filepath = name.startsWith("~/")
             ? path.join(os.homedir(), name.slice(2))
-            : path.resolve(ctx.worktree, name)
+            : path.isAbsolute(name)
+              ? name
+              : baseDir
+                ? path.resolve(baseDir, name)
+                : path.resolve(ctx.worktree, name)
 
           const info = yield* fsys.stat(filepath).pipe(Effect.option)
           if (Option.isNone(info)) {
@@ -1490,7 +1494,7 @@ export const layer = Layer.effect(
         throw error
       }
 
-      const templateParts = yield* resolvePromptParts(template)
+      const templateParts = yield* resolvePromptParts(template, cmd.baseDir)
       const inputFiles = new Set(
         input.parts?.filter((part) => new URL(part.url).protocol === "file:").map((part) => fileURLToPath(part.url)),
       )

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -1,6 +1,5 @@
 import * as Tool from "./tool"
 import DESCRIPTION from "./task.txt"
-import { ToolJsonSchema } from "./json-schema"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { BackgroundJob } from "@/background/job"
 import { Session } from "@/session/session"
@@ -12,7 +11,6 @@ import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
 import { Effect, Exit, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
-import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Database } from "@opencode-ai/core/database/database"
 
 export interface TaskPromptOps {
@@ -51,8 +49,6 @@ const BaseParameterFields = {
   command: Schema.optional(Schema.String).annotate({ description: "The command that triggered this task" }),
 }
 
-const BaseParameters = Schema.Struct(BaseParameterFields)
-
 export const Parameters = Schema.Struct({
   ...BaseParameterFields,
   background: Schema.optional(Schema.Boolean).annotate({
@@ -86,7 +82,6 @@ export const TaskTool = Tool.define(
     const config = yield* Config.Service
     const sessions = yield* Session.Service
     const scope = yield* Scope.Scope
-    const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
 
     const run = Effect.fn("TaskTool.execute")(function* (
@@ -95,11 +90,6 @@ export const TaskTool = Tool.define(
     ) {
       const cfg = yield* config.get()
       const runInBackground = params.background === true
-      if (runInBackground && !flags.experimentalBackgroundSubagents) {
-        return yield* Effect.fail(
-          new Error("Background subagents require OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true"),
-        )
-      }
 
       if (!ctx.extra?.bypassAgentCheck) {
         yield* ctx.ask({
@@ -334,11 +324,8 @@ export const TaskTool = Tool.define(
     })
 
     return {
-      description: flags.experimentalBackgroundSubagents
-        ? [DESCRIPTION, BACKGROUND_DESCRIPTION].join("\n\n")
-        : DESCRIPTION,
+      description: [DESCRIPTION, BACKGROUND_DESCRIPTION].join("\n\n"),
       parameters: Parameters,
-      jsonSchema: flags.experimentalBackgroundSubagents ? undefined : ToolJsonSchema.fromSchema(BaseParameters),
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         run(params, ctx).pipe(Effect.orDie),
     }

--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -50,7 +50,6 @@ describe("RuntimeFlags", () => {
       expect(flags.enableExperimentalModels).toBe(true)
       expect(flags.enableQuestionTool).toBe(true)
       expect(flags.experimentalReferences).toBe(true)
-      expect(flags.experimentalBackgroundSubagents).toBe(true)
       expect(flags.experimentalLspTy).toBe(false)
       expect(flags.experimentalLspTool).toBe(true)
       expect(flags.experimentalOxfmt).toBe(true)

--- a/packages/opencode/test/session/llm-native-recorded.test.ts
+++ b/packages/opencode/test/session/llm-native-recorded.test.ts
@@ -424,7 +424,6 @@ describe("session.llm native recorded", () => {
         })
         continue
       }
-      test.skip(`${scenario.name}: drives a tool loop to a final text answer`, () => {})
       continue
     }
     const it = testEffect(recordedNativeLLMLayer(scenario))

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -49,7 +49,7 @@ const layer = (flags: Partial<RuntimeFlags.Info> = {}) =>
   ).pipe(Layer.provide(Ripgrep.defaultLayer))
 
 const it = testEffect(layer())
-const background = testEffect(layer({ experimentalBackgroundSubagents: true }))
+const background = testEffect(layer({}))
 
 function defer<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void

--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -53,8 +53,8 @@ export function duration(input: number) {
     const minutes = Math.floor((input % 3600000) / 60000)
     return `${hours}h ${minutes}m`
   }
-  const hours = Math.floor(input / 3600000)
-  const days = Math.floor((input % 3600000) / 86400000)
+  const days = Math.floor(input / 86400000)
+  const hours = Math.floor((input % 86400000) / 3600000)
   return `${days}d ${hours}h`
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #32956

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes the ≥24h branch of `duration()` in `packages/tui/src/util/locale.ts`. Days was always 0 (computed from `input % 3600000 / 86400000`, which is always 0) and hours was the uncapped total (`input / 3600000`). Now days is computed from total milliseconds and hours from the remainder after removing whole days, matching the pattern already used in the hours/minutes branch above.

### How did you verify your code works?

- `bun turbo typecheck`: all 29 packages pass
- `duration(86400000)` returns `"1d 0h"` (was `"0d 24h"`)
- `duration(183600000)` returns `"2d 3h"` (was `"0d 51h"`)
- Sub-24h branches unchanged: `duration(7200000)` still returns `"2h 0m"`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
