### PR TITLE
fix(core): ensure parent directory exists in writeIfUnchanged

### DIFF
--- a/packages/core/src/file-mutation.ts
+++ b/packages/core/src/file-mutation.ts
@@ -148,9 +148,15 @@ export const layer = Layer.effect(
           if (!sameBytes(current, input.expected)) {
             return yield* new StaleContentError({ path: input.target.canonical })
           }
-          yield* typeof input.content === "string"
-            ? fs.writeFileString(input.target.canonical, input.content)
-            : fs.writeFile(input.target.canonical, input.content)
+          const write =
+            typeof input.content === "string"
+              ? fs.writeFileString(input.target.canonical, input.content)
+              : fs.writeFile(input.target.canonical, input.content)
+          yield* write.pipe(
+            Effect.catchReason("PlatformError", "NotFound", () =>
+              fs.ensureDir(dirname(input.target.canonical)).pipe(Effect.andThen(write)),
+            ),
+          )
           return writeResult(input.target, true)
         }),
       ),


### PR DESCRIPTION
### Issue for this PR

Closes #33075

### Type of change

- [x] Bug fix

### What does this PR do?

`writeIfUnchanged` in `packages/core/src/file-mutation.ts` wrote without ensuring the parent directory exists, unlike `create` which catches `NotFound` and calls `fs.ensureDir(dirname(...))` before retrying. If the parent directory was deleted between the read and write steps (TOCTOU), the write failed with an unhandled ENOENT.

This PR extracts the write expression into a `write` const and adds the same `Effect.catchReason("PlatformError", "NotFound", ...)` + `ensureDir` + retry pattern already used by `create` (line 130-133).

### How did you verify your code works?

- `bun turbo typecheck`: all 29 packages pass
- The catch pattern is identical to `create` — only fires on `NotFound`, normal path unaffected

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
