### PR TITLE
fix(core): include last 2KB in sampledChecksum window

### DIFF
--- a/packages/core/src/util/encode.ts
+++ b/packages/core/src/util/encode.ts
@@ -39,7 +39,7 @@ export function sampledChecksum(content: string, limit = 500_000): string | unde
     Math.floor(content.length * 0.25),
     Math.floor(content.length * 0.5),
     Math.floor(content.length * 0.75),
-    content.length - size,
+    content.length,
   ]
   const hashes = points
     .map((point) => {


### PR DESCRIPTION
### Issue for this PR

Closes #33098

### Type of change

- [x] Bug fix

### What does this PR do?

`sampledChecksum()` in `packages/core/src/util/encode.ts` used `content.length - size` as the last sampling point. After centering and clamping, the last window covered `[content.length - 6144, content.length - 2048]` — the final ~2KB was never hashed. Since this function is used as a cache key for file viewers (`file.tsx`, `file-tabs.tsx`), edits to the end of large files (>500KB) went undetected and the UI showed stale content.

This PR changes the last point to `content.length` so the clamped window ends exactly at `content.length`, covering the final bytes.

### How did you verify your code works?

- `bun turbo typecheck`: all 29 packages pass
- Verified with a 600KB string: editing the last 100 bytes now changes the checksum (previously it did not)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
