### PR TITLE
fix(a11y): remove aria-hidden from streaming assistant content

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1112,7 +1112,6 @@ export function MessageTimeline(props: {
             <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
               <div
                 data-slot="session-turn-assistant-content"
-                aria-hidden={workingTurn(assistantPartRow().userMessageID)}
               >
                 {renderAssistantPartGroup(assistantPartRow, onSizeChange)}
               </div>


### PR DESCRIPTION
### Issue for this PR
## Summary

Fix an accessibility issue where screen readers could not access assistant content, tool calls, reasoning summaries, or progress updates while a response was being generated.

## Problem

The assistant content container was rendered with:

```tsx
aria-hidden={workingTurn(assistantPartRow().userMessageID)}
```

While a turn was generating, the content was removed from the accessibility tree.

As a result, screen reader users could hear the generic "Thinking..." status but could not access the actual tool activity, reasoning summaries, searches, or streamed assistant output that were visible on screen.

## Fix

Removed the conditional `aria-hidden` attribute from the assistant content container.

This allows screen readers to access the same information that sighted users can see during generation.

## Testing

* Reproduced using NVDA on Windows.
* Before the change, NVDA only exposed the thinking status.
* After the change, NVDA can access assistant content and generation progress while the response is being streamed.

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
