### PR TITLE
fix(opencode): use toLowerCase for Devstral model detection

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -218,7 +218,7 @@ function normalizeMessages(
   if (
     model.providerID === "mistral" ||
     model.api.id.toLowerCase().includes("mistral") ||
-    model.api.id.toLocaleLowerCase().includes("devstral")
+    model.api.id.toLowerCase().includes("devstral")
   ) {
     const scrub = (id: string) => {
       return id


### PR DESCRIPTION
### Issue for this PR

Closes #33108

### Type of change

- [x] Bug fix

### What does this PR do?

Changes `toLocaleLowerCase()` to `toLowerCase()` in the Devstral model detection check (`packages/opencode/src/provider/transform.ts:221`). The adjacent Mistral check on line 220 already uses `toLowerCase()`, and every other model-id check in this file does too. `toLocaleLowerCase()` is locale-sensitive — in Turkish locale it converts `I` to `ı` (dotless i), which would cause `includes("devstral")` to fail.

### How did you verify your code works?

- `bun turbo typecheck`: all 29 packages pass

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
