### PR TITLE
fix(app): todo dock reactivity to in-place todo updates

### DIFF
--- a/packages/app/src/pages/session/composer/session-todo-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-todo-dock.tsx
@@ -7,7 +7,7 @@ import { useSpring } from "@opencode-ai/ui/motion-spring"
 import { TextReveal } from "@opencode-ai/ui/text-reveal"
 import { TextStrikethrough } from "@opencode-ai/ui/text-strikethrough"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
-import { Index, createEffect, createMemo } from "solid-js"
+import { Index, createEffect, createMemo, For } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useLanguage } from "@/context/language"
 
@@ -210,40 +210,40 @@ function TodoList(props: { todos: Todo[] }) {
           setStore("stuck", e.currentTarget.scrollTop > 0)
         }}
       >
-        <Index each={props.todos}>
+        <For each={props.todos}>
           {(todo) => (
             <Checkbox
               readOnly
-              checked={todo().status === "completed"}
-              indeterminate={todo().status === "in_progress"}
-              data-in-progress={todo().status === "in_progress" ? "" : undefined}
-              data-state={todo().status}
-              icon={dot(todo().status)}
+              checked={todo.status === "completed"}
+              indeterminate={todo.status === "in_progress"}
+              data-in-progress={todo.status === "in_progress" ? "" : undefined}
+              data-state={todo.status}
+              icon={dot(todo.status)}
               style={{
                 "--checkbox-align": "flex-start",
                 "--checkbox-offset": "1px",
                 transition: "opacity 220ms var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1))",
-                opacity: todo().status === "pending" ? "0.94" : "1",
+                opacity: todo.status === "pending" ? "0.94" : "1",
               }}
             >
               <TextStrikethrough
-                active={todo().status === "completed" || todo().status === "cancelled"}
-                text={todo().content}
+                active={todo.status === "completed" || todo.status === "cancelled"}
+                text={todo.content}
                 class="text-14-regular min-w-0 break-words"
                 style={{
                   "line-height": "var(--line-height-normal)",
                   transition:
                     "color 220ms var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1)), opacity 220ms var(--tool-motion-ease, cubic-bezier(0.22, 1, 0.36, 1))",
                   color:
-                    todo().status === "completed" || todo().status === "cancelled"
+                    todo.status === "completed" || todo.status === "cancelled"
                       ? "var(--text-weak)"
                       : "var(--text-strong)",
-                  opacity: todo().status === "pending" ? "0.92" : "1",
+                  opacity: todo.status === "pending" ? "0.92" : "1",
                 }}
               />
             </Checkbox>
           )}
-        </Index>
+        </For>
       </div>
       <div
         class="pointer-events-none absolute top-0 left-0 right-0 h-4 transition-opacity duration-150"


### PR DESCRIPTION
### Issue for this PR

Closes #33063

### Type of change

- [x] Bug fix

### What does this PR do?

The `SessionTodoDock` rendered its todo list with Solid's `<Index>`, which only re-renders when the array length or item references change. The global todo store (`serverSync().data.session_todo[id]`) is updated via `reconcile(todos, { key: "id" })`, which preserves object references for matched IDs — so in-place status/content changes were invisible to `<Index>`.

When the `todowrite` tool flipped a todo's status from `pending` to `completed` or updated its content text, the dock's checkboxes stayed stale until a full page reload.

Switching `<Index>` to `<For>` diffs by value reference and re-runs the render prop when an item updates. `<For>` is the same primitive the TUI sidebar uses (`packages/tui/src/feature-plugins/sidebar/todo.tsx:26`), which works correctly today.

Single file change in `packages/app/src/pages/session/composer/session-todo-dock.tsx`:
- Import: add `For` to the `solid-js` import
- Inside `TodoList`: swap `<Index>` for `<For>` and update the render-prop signature from accessor `(todo) => todo()` to value `(todo) => todo`

The parent `SessionTodoDock` retains its `<Index each={progress()}>` for stable progress label tokens (unchanged).

### How did you verify your code works?

- `bun run typecheck` on the app package — no new errors introduced (25 pre-existing errors in unrelated files on `origin/dev` confirmed unchanged)
- `bun test` on the app package — 406 pass / 1 fail, identical to `origin/dev` baseline (the 1 failure is a missing `@pierre/trees` module in `pierre-tree.test.ts`, unrelated)
- Traced root cause through Solid source: `packages/app/node_modules/solid-js/dist/dev.js:1244-1286` (`indexArray`) shows `<Index>` only updates per-item signals when `items[i] !== newItems[i]`, which is false for items preserved by `reconcile({ key: "id" })`
- Confirmed TUI is unaffected: uses `<For each={list()}>` with direct value access (`item.status`, `item.content`)
- Confirmed bug exists on `origin/dev` (`009f3799c`) via `git show` of all affected files

### Screenshots / recordings

N/A — desktop-only render fix verifiable via DOM state, requires interactive session with todowrite tool calls.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR