### PR TITLE
feat(tui): add sidebar history and scroll-to-message support

### DIFF
--- a/packages/tui/src/context/scroll-to-message.ts
+++ b/packages/tui/src/context/scroll-to-message.ts
@@ -1,0 +1,9 @@
+let scrollTo: ((messageID: string) => void) | undefined
+
+export function setScrollToMessage(fn: ((messageID: string) => void) | undefined) {
+  scrollTo = fn
+}
+
+export function scrollToMessage(messageID: string) {
+  scrollTo?.(messageID)
+}

--- a/packages/tui/src/feature-plugins/builtins.ts
+++ b/packages/tui/src/feature-plugins/builtins.ts
@@ -6,6 +6,7 @@ import SidebarFiles from "./sidebar/files"
 import SidebarFooter from "./sidebar/footer"
 import SidebarLsp from "./sidebar/lsp"
 import SidebarMcp from "./sidebar/mcp"
+import SidebarHistory from "./sidebar/history"
 import SidebarTodo from "./sidebar/todo"
 import DiffViewer from "./system/diff-viewer"
 import Notifications from "./system/notifications"
@@ -27,6 +28,7 @@ export function createBuiltinPlugins(options: { experimentalEventSystem: boolean
     SidebarLsp,
     SidebarTodo,
     SidebarFiles,
+    SidebarHistory,
     SidebarFooter,
     Notifications,
     PluginManager,

--- a/packages/tui/src/feature-plugins/sidebar/history.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/history.tsx
@@ -1,0 +1,75 @@
+import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { BuiltinTuiPlugin } from "../builtins"
+import { createMemo, createSignal, For, Show } from "solid-js"
+import { scrollToMessage } from "../../context/scroll-to-message"
+import { Locale } from "../../util/locale"
+import type { Part, UserMessage } from "@opencode-ai/sdk/v2"
+
+const id = "internal:sidebar-history"
+
+function View(props: { api: TuiPluginApi; session_id: string }) {
+  const [open, setOpen] = createSignal(true)
+  const theme = () => props.api.theme.current
+
+  const items = createMemo(() => {
+    const msgs = props.api.state.session.messages(props.session_id)
+    return msgs
+      .filter((m): m is UserMessage => m.role === "user")
+      .map((m) => {
+        const parts = props.api.state.part(m.id)
+        const text = parts
+          .filter((p): p is Extract<Part, { type: "text" }> => p.type === "text" && !p.synthetic)
+          .map((p) => p.text)
+          .join("\n\n")
+        return { id: m.id, text }
+      })
+      .filter((item) => item.text.length > 0)
+      .reverse()
+  })
+
+  return (
+    <Show when={items().length > 0}>
+      <box>
+        <box flexDirection="row" gap={1} onMouseDown={() => items().length > 2 && setOpen((x) => !x)}>
+          <Show when={items().length > 2}>
+            <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
+          </Show>
+          <text fg={theme().text}>
+            <b>History</b>
+          </text>
+        </box>
+        <Show when={items().length <= 2 || open()}>
+          <scrollbox height={8} flexShrink={0}>
+            <For each={items()}>
+              {(entry) => (
+                <box onMouseUp={() => scrollToMessage(entry.id)}>
+                  <text fg={theme().textMuted} wrapMode="none" maxWidth={36}>
+                    {Locale.truncateMiddle(entry.text.split("\n")[0], 34)}
+                  </text>
+                </box>
+              )}
+            </For>
+          </scrollbox>
+        </Show>
+      </box>
+    </Show>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.slots.register({
+    order: 600,
+    slots: {
+      sidebar_content(_ctx, props) {
+        return <View api={api} session_id={props.session_id} />
+      },
+    },
+  })
+}
+
+const plugin: BuiltinTuiPlugin = {
+  id,
+  tui,
+}
+
+export default plugin

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -17,6 +17,7 @@ import {
 import { Dynamic } from "solid-js/web"
 import path from "node:path"
 import { mkdir, writeFile } from "node:fs/promises"
+import { setScrollToMessage } from "../../context/scroll-to-message"
 import { useRoute, useRouteData } from "../../context/route"
 import { useProject } from "../../context/project"
 import { useSync } from "../../context/sync"
@@ -1161,7 +1162,13 @@ export function Session() {
           <box flexGrow={1} minHeight={0} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
             <Show when={session()}>
               <scrollbox
-                ref={(r) => (scroll = r)}
+                ref={(r) => {
+                  scroll = r
+                  setScrollToMessage(r ? (messageID: string) => {
+                    const child = r.getChildren().find((c) => c.id === messageID)
+                    if (child) r.scrollBy(child.y - r.y - 1)
+                  } : undefined)
+                }}
                 viewportOptions={{
                   paddingRight: showScrollbar() ? 1 : 0,
                 }}


### PR DESCRIPTION
### Issue for this PR

Closes #32165

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a **History** sidebar panel in the session view that lists user messages and allows clicking to scroll to that message. Previously there was no way to navigate to a past user message from the sidebar.

Changes:
- New context module `scroll-to-message.ts` that stores a scroll-to function reference
- The session scrollbox now captures a `scrollToMessage` callback that scrolls to a child element by message ID
- New builtin sidebar plugin `history.tsx` that lists user messages (most recent first), collapsible when there are more than 2 entries
- Registered `SidebarHistory` in the builtin plugin list

### How did you verify your code works?

Manually tested in the TUI — history entries appear and clicking one scrolls the session view to the corresponding message.

### Screenshots / recordings

<img width="2742" height="1380" alt="image" src="https://github.com/user-attachments/assets/21040503-15b3-49f5-8070-28a9a4b437f7" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR