### PR TITLE
feat(app): add delete button for sessions in sidebar

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -76,6 +76,7 @@ import {
   latestRootSession,
   sortedRootSessions,
 } from "./layout/helpers"
+import { sessionTitle } from "@/utils/session-title"
 import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
@@ -988,6 +989,67 @@ export default function Layout(props: ParentProps) {
         navigate(`/${params.dir}/session`)
       }
     }
+  }
+
+  async function executeDeleteSession(session: Session) {
+    const [store] = serverSync().child(session.directory, { bootstrap: false })
+    const sessions = store.session ?? []
+    const index = sessions.findIndex((s) => s.id === session.id)
+    const nextSession = sessions[index + 1] ?? sessions[index - 1]
+
+    const result = await serverSDK()
+      .client.session.delete({ sessionID: session.id, directory: session.directory })
+      .then((x) => x.data)
+      .catch((err) => {
+        showToast({
+          title: language.t("session.delete.failed.title"),
+          description: errorMessage(err),
+        })
+        return false
+      })
+
+    if (!result) return
+
+    if (session.id === params.id) {
+      if (nextSession) {
+        navigate(`/${params.dir}/session/${nextSession.id}`)
+      } else {
+        navigate(`/${params.dir}/session`)
+      }
+    }
+  }
+
+  function confirmDeleteSession(session: Session) {
+    dialog.show(() => <DialogDeleteSession session={session} />)
+  }
+
+  function DialogDeleteSession(props: { session: Session }) {
+    const name = createMemo(() => sessionTitle(props.session.title))
+
+    const handleDelete = async () => {
+      await executeDeleteSession(props.session)
+      dialog.close()
+    }
+
+    return (
+      <Dialog title={language.t("session.delete.title")} fit>
+        <div class="flex flex-col gap-4 pl-6 pr-2.5 pb-3">
+          <div class="flex flex-col gap-1">
+            <span class="text-14-regular text-text-strong">
+              {language.t("session.delete.confirm", { name: name() })}
+            </span>
+          </div>
+          <div class="flex justify-end gap-2">
+            <Button variant="ghost" size="large" onClick={() => dialog.close()}>
+              {language.t("common.cancel")}
+            </Button>
+            <Button variant="primary" size="large" onClick={handleDelete}>
+              {language.t("session.delete.button")}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+    )
   }
 
   command.register("layout", () => {
@@ -1976,6 +2038,7 @@ export default function Layout(props: ParentProps) {
     clearHoverProjectSoon,
     prefetchSession,
     archiveSession,
+    confirmDeleteSession,
     workspaceName,
     renameWorkspace,
     editorOpen,
@@ -2022,6 +2085,7 @@ export default function Layout(props: ParentProps) {
       clearHoverProjectSoon,
       prefetchSession,
       archiveSession,
+      confirmDeleteSession,
     },
   }
 

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -84,6 +84,7 @@ export type SessionItemProps = {
   clearHoverProjectSoon: () => void
   prefetchSession: (session: Session, priority?: "high" | "low") => void
   archiveSession: (session: Session) => Promise<void>
+  confirmDeleteSession: (session: Session) => void
 }
 
 const SessionRow = (props: {
@@ -233,12 +234,12 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
 
           <Show when={!props.level}>
             <div
-              class="shrink-0 overflow-hidden transition-[width,opacity]"
+              class="shrink-0 overflow-hidden transition-[width,opacity] flex items-center gap-1"
               classList={{
-                "w-6 opacity-100 pointer-events-auto": !!props.mobile,
+                "w-[3.25rem] opacity-100 pointer-events-auto": !!props.mobile,
                 "w-0 opacity-0 pointer-events-none": !props.mobile,
-                "group-hover/session:w-6 group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
-                "group-focus-within/session:w-6 group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
+                "group-hover/session:w-[3.25rem] group-hover/session:opacity-100 group-hover/session:pointer-events-auto": true,
+                "group-focus-within/session:w-[3.25rem] group-focus-within/session:opacity-100 group-focus-within/session:pointer-events-auto": true,
               }}
             >
               <Tooltip value={language.t("common.archive")} placement="top">
@@ -251,6 +252,19 @@ export const SessionItem = (props: SessionItemProps): JSX.Element => {
                     event.preventDefault()
                     event.stopPropagation()
                     void props.archiveSession(props.session)
+                  }}
+                />
+              </Tooltip>
+              <Tooltip value={language.t("common.delete")} placement="top">
+                <IconButton
+                  icon="trash"
+                  variant="ghost"
+                  class="size-6 rounded-md"
+                  aria-label={language.t("common.delete")}
+                  onClick={(event) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    props.confirmDeleteSession(props.session)
                   }}
                 />
               </Tooltip>

--- a/packages/app/src/pages/layout/sidebar-workspace.tsx
+++ b/packages/app/src/pages/layout/sidebar-workspace.tsx
@@ -40,6 +40,7 @@ export type WorkspaceSidebarContext = {
   clearHoverProjectSoon: () => void
   prefetchSession: (session: Session, priority?: "high" | "low") => void
   archiveSession: (session: Session) => Promise<void>
+  confirmDeleteSession: (session: Session) => void
   workspaceName: (directory: string, projectId?: string, branch?: string) => string | undefined
   renameWorkspace: (directory: string, next: string, projectId?: string, branch?: string) => void
   editorOpen: (id: string) => boolean
@@ -269,6 +270,7 @@ const WorkspaceSessionList = (props: {
           clearHoverProjectSoon={props.ctx.clearHoverProjectSoon}
           prefetchSession={props.ctx.prefetchSession}
           archiveSession={props.ctx.archiveSession}
+          confirmDeleteSession={props.ctx.confirmDeleteSession}
         />
       )}
     </For>


### PR DESCRIPTION
Closes #33129

Add a delete (trash) icon button next to the existing archive button on root session rows in the project/session sidebar.

Clicking the trash icon opens a confirmation dialog. After confirming, the app calls the existing `client.session.delete` API to permanently remove the session. If the deleted session is currently active, the user is redirected to the next session or the new-session view.

### Changes
- `packages/app/src/pages/layout.tsx`: add `executeDeleteSession`, `confirmDeleteSession`, and `DialogDeleteSession`; wire into sidebar contexts.
- `packages/app/src/pages/layout/sidebar-items.tsx`: add trash `IconButton` next to archive button and expand hover width.
- `packages/app/src/pages/layout/sidebar-workspace.tsx`: pass `confirmDeleteSession` through workspace context.

### Verification
- [ ] `bun run --cwd packages/app typecheck`
- [ ] `bun lint`
- [ ] Manual test: hover session → click trash → confirm → session removed.