### PR TITLE
fix(core): tolerate orphan part projection from cascade-delete race

### DIFF
--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -366,7 +366,17 @@ export const layerWith = (options?: LayerOptions) =>
                         }),
                       { behavior: "immediate" },
                     )
-                    .pipe(Effect.orDie)
+                    .pipe(
+                      Effect.tapError((error) =>
+                        Effect.logError("durable event commit failed", {
+                          eventID: event.id,
+                          eventType: event.type,
+                          aggregateID,
+                          error,
+                        }),
+                      ),
+                      Effect.orDie,
+                    )
                   if (committed) {
                     yield* Effect.forEach(
                       synchronized.get(committed.aggregateID) ?? [],

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -191,22 +191,48 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
   })
 }
 
-function insertMessage(db: DatabaseService, event: SessionEvent.Event, message: SessionMessage.Message) {
-  if (event.seq === undefined) return Effect.die("Synchronized Session event is missing aggregate sequence")
-  const encoded = encodeMessage(message)
-  const { id, type, ...data } = encoded
+// True when the parent session row still exists. Every session-scoped child
+// table (message, session_message, session_input, ...) has a cascade FK to
+// session.id checked at COMMIT. A session removal commits in its own
+// transaction and cascade-deletes the session row; a later child-write event
+// from an in-flight turn would then fail that FK and crash the fiber via
+// Effect.orDie. Projections read committed state, so checking presence here is
+// correct regardless of why the row is missing, and is replay-safe.
+function sessionPresent(db: DatabaseService, sessionID: (typeof SessionTable.$inferSelect)["id"]) {
   return db
-    .insert(SessionMessageTable)
-    .values({
-      id: SessionMessage.ID.make(id),
-      session_id: event.data.sessionID,
-      type,
-      seq: event.seq,
-      time_created: DateTime.toEpochMillis(message.time.created),
-      data,
-    })
-    .run()
-    .pipe(Effect.orDie)
+    .select({ id: SessionTable.id })
+    .from(SessionTable)
+    .where(eq(SessionTable.id, sessionID))
+    .get()
+    .pipe(
+      Effect.orDie,
+      Effect.map((row) => row !== undefined),
+    )
+}
+
+function insertMessage(db: DatabaseService, event: SessionEvent.Event, message: SessionMessage.Message) {
+  return Effect.gen(function* () {
+    if (event.seq === undefined) return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
+    const encoded = encodeMessage(message)
+    const { id, type, ...data } = encoded
+    const sessionID = event.data.sessionID
+    if (!(yield* sessionPresent(db, sessionID))) {
+      yield* Effect.logWarning("skipping orphan session_message; parent session absent", { id, sessionID })
+      return
+    }
+    yield* db
+      .insert(SessionMessageTable)
+      .values({
+        id: SessionMessage.ID.make(id),
+        session_id: sessionID,
+        type,
+        seq: event.seq,
+        time_created: DateTime.toEpochMillis(message.time.created),
+        data,
+      })
+      .run()
+      .pipe(Effect.orDie)
+  })
 }
 
 export const layer = Layer.effectDiscard(
@@ -271,13 +297,7 @@ export const layer = Layer.effectDiscard(
         // late MessageUpdated from an in-flight turn is still in the commit
         // funnel. Skip the orphan write instead of failing the message ->
         // session FK at COMMIT (mirrors the orphan-part guard below).
-        const parent = yield* db
-          .select({ id: SessionTable.id })
-          .from(SessionTable)
-          .where(eq(SessionTable.id, sessionID))
-          .get()
-          .pipe(Effect.orDie)
-        if (!parent) {
+        if (!(yield* sessionPresent(db, sessionID))) {
           yield* Effect.logWarning("skipping orphan message; parent session absent", { id, sessionID })
           return
         }
@@ -391,6 +411,16 @@ export const layer = Layer.effectDiscard(
           .get()
           .pipe(Effect.orDie)
         if (existing) return yield* Effect.die(new PromptAlreadyProjected())
+        // session_input.session_id is a cascade FK to session.id. If the session
+        // was removed while this prompt was in flight, skip rather than crash on
+        // the FK at COMMIT (mirrors the message/part orphan guards).
+        if (!(yield* sessionPresent(db, event.data.sessionID))) {
+          yield* Effect.logWarning("skipping orphan prompt; parent session absent", {
+            messageID,
+            sessionID: event.data.sessionID,
+          })
+          return
+        }
         yield* run(db, event)
         if (event.seq === undefined)
           return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
@@ -408,6 +438,15 @@ export const layer = Layer.effectDiscard(
       Effect.gen(function* () {
         if (event.seq === undefined)
           return yield* Effect.die("Synchronized Session event is missing aggregate sequence")
+        // session_input.session_id is a cascade FK to session.id; skip the
+        // admitted insert if the session was removed mid-flight.
+        if (!(yield* sessionPresent(db, event.data.sessionID))) {
+          yield* Effect.logWarning("skipping orphan admitted prompt; parent session absent", {
+            messageID: event.data.messageID,
+            sessionID: event.data.sessionID,
+          })
+          return
+        }
         yield* SessionInput.projectAdmitted(db, {
           admittedSeq: event.seq,
           id: event.data.messageID,

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -318,6 +318,16 @@ export const layer = Layer.effectDiscard(
         const sessionID = event.data.part.sessionID
         const data = partData(event.data.part)
         const row = yield* db.select().from(PartTable).where(eq(PartTable.id, id)).get().pipe(Effect.orDie)
+        const parent = yield* db
+          .select({ id: MessageTable.id })
+          .from(MessageTable)
+          .where(eq(MessageTable.id, messageID))
+          .get()
+          .pipe(Effect.orDie)
+        if (!parent) {
+          yield* Effect.logWarning("skipping orphan part; parent message absent", { id, messageID, sessionID })
+          return
+        }
         yield* db
           .insert(PartTable)
           .values({ id, message_id: messageID, session_id: sessionID, time_created: event.data.time, data })

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -267,6 +267,20 @@ export const layer = Layer.effectDiscard(
         const id = event.data.info.id
         const sessionID = event.data.info.sessionID
         const data = messageData(event.data.info)
+        // A session removal can cascade-delete the parent session row while a
+        // late MessageUpdated from an in-flight turn is still in the commit
+        // funnel. Skip the orphan write instead of failing the message ->
+        // session FK at COMMIT (mirrors the orphan-part guard below).
+        const parent = yield* db
+          .select({ id: SessionTable.id })
+          .from(SessionTable)
+          .where(eq(SessionTable.id, sessionID))
+          .get()
+          .pipe(Effect.orDie)
+        if (!parent) {
+          yield* Effect.logWarning("skipping orphan message; parent session absent", { id, sessionID })
+          return
+        }
         yield* db
           .insert(MessageTable)
           .values({ id, session_id: sessionID, time_created, data })

--- a/packages/core/src/session/todo.ts
+++ b/packages/core/src/session/todo.ts
@@ -5,7 +5,7 @@ import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
 import { EventV2 } from "../event"
 import { SessionSchema } from "./schema"
-import { TodoTable } from "./sql"
+import { SessionTable, TodoTable } from "./sql"
 
 export const Info = Schema.Struct({
   content: Schema.String.annotate({ description: "Brief description of the task" }),
@@ -46,11 +46,23 @@ export const layer = Layer.effect(
       readonly sessionID: SessionSchema.ID
       readonly todos: ReadonlyArray<Info>
     }) {
-      yield* db
+      const wrote = yield* db
         .transaction((tx) =>
           Effect.gen(function* () {
+            // todo.session_id is a cascade FK to session.id. If the session was
+            // removed concurrently, the INSERT below would fail the FK at COMMIT
+            // and crash via orDie. Skip when the parent session is gone.
+            const session = yield* tx
+              .select({ id: SessionTable.id })
+              .from(SessionTable)
+              .where(eq(SessionTable.id, input.sessionID))
+              .get()
+            if (!session) {
+              yield* Effect.logWarning("skipping todo update; parent session absent", { sessionID: input.sessionID })
+              return false
+            }
             yield* tx.delete(TodoTable).where(eq(TodoTable.session_id, input.sessionID)).run()
-            if (input.todos.length === 0) return
+            if (input.todos.length === 0) return true
             yield* tx
               .insert(TodoTable)
               .values(
@@ -63,9 +75,11 @@ export const layer = Layer.effect(
                 })),
               )
               .run()
+            return true
           }),
         )
         .pipe(Effect.orDie)
+      if (!wrote) return
       yield* events.publish(Event.Updated, input)
     })
 

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -18,7 +18,14 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionInput } from "@opencode-ai/core/session/input"
 import { SessionStore } from "@opencode-ai/core/session/store"
-import { SessionInputTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
+import {
+  MessageTable,
+  PartTable,
+  SessionInputTable,
+  SessionMessageTable,
+  SessionTable,
+} from "@opencode-ai/core/session/sql"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { testEffect } from "./lib/effect"
 
 const database = Database.layerFromPath(":memory:")
@@ -613,6 +620,68 @@ describe("SessionProjector", () => {
           time: { created },
         }),
       ])
+    }),
+  )
+})
+
+describe("SessionProjector orphan-part tolerance", () => {
+  const it = testEffect(Layer.mergeAll(database, events, projector))
+  const sessionID = SessionV2.ID.make("ses_orphan_test")
+  const messageID = SessionV1.MessageID.make("msg_orphan")
+  const partID = SessionV1.PartID.make("prt_orphan")
+
+  it.effect("does not throw and does not insert part when parent message is gone", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "orphan-test",
+          directory: "/project",
+          title: "orphan test",
+          version: "test",
+        })
+        .run()
+        .pipe(Effect.orDie)
+
+      // Insert a message row directly, then delete it to simulate cascade-delete
+      yield* db
+        .insert(MessageTable)
+        .values({ id: messageID, session_id: sessionID, time_created: 0, data: {} as never })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db.delete(MessageTable).where(eq(MessageTable.id, messageID)).run().pipe(Effect.orDie)
+
+      const evts = yield* EventV2.Service
+
+      // Late PartUpdated arrives after the parent was deleted
+      const exit = yield* evts
+        .publish(SessionV1.Event.PartUpdated, {
+          sessionID,
+          time: 0,
+          part: {
+            id: partID,
+            sessionID,
+            messageID,
+            type: "text",
+            text: "late orphan part",
+          } as SessionV1.TextPart,
+        })
+        .pipe(Effect.exit)
+
+      // Must not defect
+      expect(exit._tag).toBe("Success")
+
+      // Part row must NOT exist in PartTable
+      const row = yield* db.select().from(PartTable).where(eq(PartTable.id, partID)).get().pipe(Effect.orDie)
+      expect(row).toBeUndefined()
     }),
   )
 })

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -740,3 +740,89 @@ describe("SessionProjector orphan-message tolerance", () => {
     }),
   )
 })
+
+describe("SessionProjector orphan session-scoped writes", () => {
+  const it = testEffect(Layer.mergeAll(database, events, projector))
+  const model = { id: ModelV2.ID.make("model"), providerID: ProviderV2.ID.make("provider") }
+  const created = DateTime.makeUnsafe(0)
+
+  const seedAndDeleteSession = (id: SessionV2.ID) =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .onConflictDoNothing()
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id,
+          project_id: Project.ID.global,
+          slug: "orphan-scoped",
+          directory: "/project",
+          title: "orphan scoped",
+          version: "test",
+        })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db.delete(SessionTable).where(eq(SessionTable.id, id)).run().pipe(Effect.orDie)
+    })
+
+  it.effect("skips session_message append when parent session is gone", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionV2.ID.make("ses_orphan_smsg")
+      yield* seedAndDeleteSession(sessionID)
+      const { db } = yield* Database.Service
+      const evts = yield* EventV2.Service
+      const id = SessionMessage.ID.make("msg_orphan_append")
+
+      // Step.Started appends an assistant session_message via insertMessage.
+      const exit = yield* evts
+        .publish(SessionEvent.Step.Started, {
+          sessionID,
+          assistantMessageID: id,
+          timestamp: created,
+          agent: "build",
+          model,
+        })
+        .pipe(Effect.exit)
+
+      expect(exit._tag).toBe("Success")
+      const row = yield* db
+        .select()
+        .from(SessionMessageTable)
+        .where(eq(SessionMessageTable.id, id))
+        .get()
+        .pipe(Effect.orDie)
+      expect(row).toBeUndefined()
+    }),
+  )
+
+  it.effect("skips session_input admit when parent session is gone", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionV2.ID.make("ses_orphan_sinput")
+      yield* seedAndDeleteSession(sessionID)
+      const { db } = yield* Database.Service
+      const evts = yield* EventV2.Service
+      const id = SessionMessage.ID.make("msg_orphan_admit")
+
+      const exit = yield* SessionInput.admit(db, evts, {
+        id,
+        sessionID,
+        prompt: new Prompt({ text: "orphan admit" }),
+        delivery: "steer",
+      }).pipe(Effect.exit)
+
+      expect(exit._tag).toBe("Success")
+      const row = yield* db
+        .select()
+        .from(SessionInputTable)
+        .where(eq(SessionInputTable.id, id))
+        .get()
+        .pipe(Effect.orDie)
+      expect(row).toBeUndefined()
+    }),
+  )
+})

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -685,3 +685,58 @@ describe("SessionProjector orphan-part tolerance", () => {
     }),
   )
 })
+
+describe("SessionProjector orphan-message tolerance", () => {
+  const it = testEffect(Layer.mergeAll(database, events, projector))
+  const sessionID = SessionV2.ID.make("ses_orphan_msg_test")
+  const messageID = SessionV1.MessageID.make("msg_orphan_session")
+
+  it.effect("does not throw and does not insert message when parent session is gone", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+        .pipe(Effect.orDie)
+      // Create a session row, then delete it to simulate a removal cascade.
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "orphan-msg-test",
+          directory: "/project",
+          title: "orphan msg test",
+          version: "test",
+        })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db.delete(SessionTable).where(eq(SessionTable.id, sessionID)).run().pipe(Effect.orDie)
+
+      const evts = yield* EventV2.Service
+
+      // Late MessageUpdated arrives after the parent session was deleted.
+      const exit = yield* evts
+        .publish(SessionV1.Event.MessageUpdated, {
+          sessionID,
+          info: {
+            id: messageID,
+            sessionID,
+            role: "user",
+            time: { created: 0 },
+            agent: "orchestrator",
+            model: { providerID: ProviderV2.ID.make("homelab"), modelID: ModelV2.ID.make("test/model") },
+          } as SessionV1.User,
+        })
+        .pipe(Effect.exit)
+
+      // Must not defect.
+      expect(exit._tag).toBe("Success")
+
+      // Message row must NOT exist in MessageTable.
+      const row = yield* db.select().from(MessageTable).where(eq(MessageTable.id, messageID)).get().pipe(Effect.orDie)
+      expect(row).toBeUndefined()
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31990

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Occasionally the app crashes while projecting session events into SQLite, dumping a raw stack to the TUI with no log line. The failing query is an INSERT/UPSERT into a session-scoped table (`part`, `message`, `session_message`, `session_input`, ...) during a turn, failing with a foreign-key `ConstraintError`.

**Root cause — a cascade-delete commit race.** Session events are each committed in their own `BEGIN IMMEDIATE` transaction (`event.ts`), so they are not atomic with each other, and SQLite checks FKs at COMMIT. Writes are serialized (single-writer), so this is purely commit-ordering between concurrently-scheduled fibers: a session/message **removal** commits and cascade-deletes a parent row, then a **later** child-write event from a still-running turn commits and fails its FK. `Effect.orDie` turns the `ConstraintError` into a defect and the turn fiber crashes. The window stays open because session removal does not interrupt/await the in-flight turn.

This PR closes the whole class by skipping (and warning) an orphan child write when its parent row is already gone — mirroring the FK's own cascade intent. It fabricates nothing, skips the associated usage accounting (correct, since nothing is persisted), and is replay-safe (events apply in `seq` order, so the removal -> late-write sequence deterministically hits the skip).

Every child table with a cascade FK to a concurrently-removable parent:

| Child -> parent FK | Write site | Status |
| --- | --- | --- |
| `part.message_id -> message` | `PartUpdated` projection | guarded |
| `message.session_id -> session` | `MessageUpdated` projection | guarded |
| `session_message.session_id -> session` | `insertMessage` (chokepoint for all append events + `Promoted`) | guarded |
| `session_input.session_id -> session` | `Prompted` + `Admitted` projections | guarded |
| `todo.session_id -> session` | `SessionTodo.update` (command path) | guarded |
| `session_context_epoch.session_id -> session` | runner `initialize` | already safe (SELECTs session in-txn, dies before insert) |
| `event.aggregate_id -> event_sequence` | commit funnel | safe (parent inserted in same txn) |
| `session.project_id -> project` | `Created` projection | `onConflictDoNothing`; cross-aggregate, project delete cascades sessions anyway |

Changes:
- `event.ts`: log `eventID`/`eventType`/`aggregateID` via `Effect.tapError` before `Effect.orDie` at the durable-commit funnel, so DB commit failures are visible in logs instead of only as a raw TUI stack. Crash behaviour is unchanged (typed `SqlError` in the error channel, not a defect).
- `session/projector.ts`: add a shared `sessionPresent` helper; guard the `PartUpdated`, `MessageUpdated`, `insertMessage` (covers every append event), `Prompted`, and `Admitted` paths.
- `session/todo.ts`: parity guard for the command-path todo insert.

This makes the orphan benign and logged. It does not stop the source from emitting the stray child event; quiescing the turn on session removal (interrupt + drain before publishing `Deleted`) is a sensible follow-up that would shrink the window at the source — but it can't replace these guards (replay and crash-recovery re-drive events independent of the live runner).

### How did you verify your code works?

- Added tests in `packages/core/test/session-projector.test.ts` covering each guarded edge: a late `PartUpdated` after `MessageRemoved`; a `MessageUpdated` for a removed session; a `Step.Started` append (session_message) for a removed session; and an `admit` (session_input) for a removed session. Each asserts no defect and no row written.
- `bun typecheck` clean in `packages/core`.
- `bun test test/session-projector.test.ts` -> 14 pass / 0 fail; todo tests 3 pass / 0 fail.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR