### PR TITLE
test(core): simplify search layer wiring

### DIFF
--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -2,12 +2,13 @@ import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
-const it = testEffect(Ripgrep.defaultLayer)
+const it = testEffect(LayerNode.buildLayer(Ripgrep.node))
 
 const withTmp = <A, E, R>(f: (directory: AbsolutePath) => Effect.Effect<A, E, R>) =>
   Effect.acquireRelease(


### PR DESCRIPTION
## Summary
- build the filesystem search test environment from the canonical `Ripgrep.node`
- remove direct test provisioning of `Ripgrep.defaultLayer`

## Testing
- `bun test test/filesystem/search.test.ts` (from `packages/core`)
- `bun typecheck` (from `packages/core`)