### PR TITLE
test(core): simplify process layer wiring

### DIFF
--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -5,10 +5,11 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 import { Effect, Exit, Fiber, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AppProcess } from "@opencode-ai/core/process"
 import { testEffect } from "../lib/effect"
 
-const it = testEffect(AppProcess.defaultLayer)
+const it = testEffect(LayerNode.buildLayer(AppProcess.node))
 
 const NODE = process.execPath
 const cmd = (...args: string[]) => ChildProcess.make(NODE, args)


### PR DESCRIPTION
## Summary
- build the AppProcess test layer from the canonical LayerNode graph
- remove direct default-layer wiring from the process tests

## Testing
- `bun test test/process/process.test.ts`
- `bun typecheck`