### PR TITLE
test(core): simplify git layer wiring

### DIFF
--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -4,12 +4,13 @@ import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
 import { Git } from "@opencode-ai/core/git"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { branch, commit, gitRemote } from "./fixture/git"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(Git.defaultLayer)
+const it = testEffect(LayerNode.buildLayer(Git.node))
 
 describe("Git", () => {
   it.live("clones a remote and reads checkout metadata", () =>


### PR DESCRIPTION
## Summary

- build the Git test layer from the canonical `Git.node` dependency graph
- remove direct `Git.defaultLayer` test provisioning

## Testing

- `bun test test/git.test.ts`
- `bun typecheck`