### PR TITLE
test(core): simplify ripgrep layer wiring

### DIFF
--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -2,12 +2,13 @@ import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { RelativePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(Ripgrep.defaultLayer)
+const it = testEffect(LayerNode.buildLayer(Ripgrep.node))
 
 describe("Ripgrep", () => {
   it.live("keeps ignored files out of catch-all find results", () =>


### PR DESCRIPTION
## Summary

- build the Ripgrep test layer from the canonical LayerNode graph
- remove direct reliance on the legacy default layer wiring

## Testing

- `bun test test/ripgrep.test.ts`
- `bun typecheck` (from `packages/core`)
- pre-push repository typecheck (`23 successful`)