### PR TITLE
test(opencode): simplify git layer wiring

### DIFF
--- a/packages/opencode/test/git/git.test.ts
+++ b/packages/opencode/test/git/git.test.ts
@@ -3,12 +3,13 @@ import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Git } from "../../src/git"
 import { tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const weird = process.platform === "win32" ? "space file.txt" : "tab\tfile.txt"
-const it = testEffect(Git.defaultLayer)
+const it = testEffect(LayerNode.buildLayer(Git.node))
 
 const scopedTmpdir = (options?: Parameters<typeof tmpdir>[0]) =>
   Effect.acquireRelease(


### PR DESCRIPTION
## Summary

- build the Git test environment from the canonical `Git.node` dependency graph
- remove direct test wiring to `Git.defaultLayer`

## Testing

- `bun test test/git/git.test.ts`
- `bun typecheck`