### PR TITLE
fix(core): retry transient SQLite lock-timeouts on durable event commits

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -26,7 +26,7 @@ export const layer = Layer.effect(
 
     yield* db.run("PRAGMA journal_mode = WAL")
     yield* db.run("PRAGMA synchronous = NORMAL")
-    yield* db.run("PRAGMA busy_timeout = 5000")
+    yield* db.run("PRAGMA busy_timeout = 10000")
     yield* db.run("PRAGMA cache_size = -64000")
     yield* db.run("PRAGMA foreign_keys = ON")
     yield* db.run("PRAGMA wal_checkpoint(PASSIVE)")

--- a/packages/core/src/database/sqlite.bun.ts
+++ b/packages/core/src/database/sqlite.bun.ts
@@ -161,6 +161,7 @@ const nativeLayer = (config: Config) =>
         create: config.create ?? true,
       })
       yield* Effect.addFinalizer(() => Effect.sync(() => native.close()))
+      native.run("PRAGMA busy_timeout = 10000;")
       if (config.disableWAL !== true) native.run("PRAGMA journal_mode = WAL;")
       return native
     }),

--- a/packages/core/src/database/sqlite.node.ts
+++ b/packages/core/src/database/sqlite.node.ts
@@ -156,6 +156,7 @@ const nativeLayer = (config: Config) =>
         open: true,
       })
       yield* Effect.addFinalizer(() => Effect.sync(() => native.close()))
+      if (config.readonly !== true) native.exec("PRAGMA busy_timeout = 10000;")
       if (config.disableWAL !== true && config.readonly !== true) native.exec("PRAGMA journal_mode = WAL;")
       return native
     }),

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -366,7 +366,17 @@ export const layerWith = (options?: LayerOptions) =>
                         }),
                       { behavior: "immediate" },
                     )
-                    .pipe(Effect.orDie)
+                    .pipe(
+                      Effect.tapError((error) =>
+                        Effect.logError("durable event commit failed", {
+                          eventID: event.id,
+                          eventType: event.type,
+                          aggregateID,
+                          error,
+                        }),
+                      ),
+                      Effect.orDie,
+                    )
                   if (committed) {
                     yield* Effect.forEach(
                       synchronized.get(committed.aggregateID) ?? [],

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -1,6 +1,6 @@
 export * as EventV2 from "./event"
 
-import { Cause, Context, Effect, Layer, Option, PubSub, Schema, Stream } from "effect"
+import { Cause, Context, Effect, Layer, Option, PubSub, Schedule, Schema, Stream } from "effect"
 import { and, asc, eq, gt } from "drizzle-orm"
 import { Database } from "./database/database"
 import { EventSequenceTable, EventTable } from "./event/sql"
@@ -9,6 +9,7 @@ import { externalID, type ExternalID, NonNegativeInt, withStatics } from "./sche
 import { Identifier } from "./util/identifier"
 import { LayerNode } from "./effect/layer-node"
 import { isDeepStrictEqual } from "node:util"
+import { SqlError } from "effect/unstable/sql/SqlError"
 
 export const ID = Schema.String.check(Schema.isStartsWith("evt_")).pipe(
   Schema.brand("Event.ID"),
@@ -48,6 +49,15 @@ export type Payload<D extends Definition = Definition> = {
   readonly metadata?: Record<string, unknown>
   /** Internal replay marker for projectors that own non-replicated operational state. */
   readonly replay?: boolean
+}
+
+const sqliteLockRetrySchedule = Schedule.exponential("40 millis").pipe(Schedule.jittered, Schedule.take(8))
+
+// NOTE: gate on the reason tag, not error.isRetryable. In effect@4.0.0-beta.66 the
+// SqlError isRetryable flags are inverted (LockTimeoutError=false, ConstraintError=true),
+// so isRetryable would crash on locks and retry FK violations forever. Revisit on effect bump.
+export function isLockTimeoutSqlError(error: unknown) {
+  return error instanceof SqlError && error.reason._tag === "LockTimeoutError"
 }
 
 export type Projector<D extends Definition = Definition> = (event: Payload<D>) => Effect.Effect<void>
@@ -367,6 +377,10 @@ export const layerWith = (options?: LayerOptions) =>
                       { behavior: "immediate" },
                     )
                     .pipe(
+                      Effect.retry({
+                        while: isLockTimeoutSqlError,
+                        schedule: sqliteLockRetrySchedule,
+                      }),
                       Effect.tapError((error) =>
                         Effect.logError("durable event commit failed", {
                           eventID: event.id,

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -318,6 +318,16 @@ export const layer = Layer.effectDiscard(
         const sessionID = event.data.part.sessionID
         const data = partData(event.data.part)
         const row = yield* db.select().from(PartTable).where(eq(PartTable.id, id)).get().pipe(Effect.orDie)
+        const parent = yield* db
+          .select({ id: MessageTable.id })
+          .from(MessageTable)
+          .where(eq(MessageTable.id, messageID))
+          .get()
+          .pipe(Effect.orDie)
+        if (!parent) {
+          yield* Effect.logWarning("skipping orphan part; parent message absent", { id, messageID, sessionID })
+          return
+        }
         yield* db
           .insert(PartTable)
           .values({ id, message_id: messageID, session_id: sessionID, time_created: event.data.time, data })

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -8,6 +8,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import { V2Schema } from "@opencode-ai/core/v2-schema"
 import { eq } from "drizzle-orm"
+import { ConstraintError, LockTimeoutError, SqlError } from "effect/unstable/sql/SqlError"
 import { location } from "./fixture/location"
 import { testEffect } from "./lib/effect"
 
@@ -139,6 +140,21 @@ describe("EventV2", () => {
   it.effect("stores definitions in the exported registry", () =>
     Effect.sync(() => {
       expect(EventV2.registry.get(Message.type)).toBe(Message)
+    }),
+  )
+
+  it.effect("retries only SQLite lock timeouts", () =>
+    Effect.sync(() => {
+      expect(
+        EventV2.isLockTimeoutSqlError(
+          new SqlError({ reason: new LockTimeoutError({ cause: new Error("locked") }) }),
+        ),
+      ).toBeTrue()
+      expect(
+        EventV2.isLockTimeoutSqlError(
+          new SqlError({ reason: new ConstraintError({ cause: new Error("constraint") }) }),
+        ),
+      ).toBeFalse()
     }),
   )
 

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -18,7 +18,14 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionInput } from "@opencode-ai/core/session/input"
 import { SessionStore } from "@opencode-ai/core/session/store"
-import { SessionInputTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
+import {
+  MessageTable,
+  PartTable,
+  SessionInputTable,
+  SessionMessageTable,
+  SessionTable,
+} from "@opencode-ai/core/session/sql"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { testEffect } from "./lib/effect"
 
 const database = Database.layerFromPath(":memory:")
@@ -613,6 +620,68 @@ describe("SessionProjector", () => {
           time: { created },
         }),
       ])
+    }),
+  )
+})
+
+describe("SessionProjector orphan-part tolerance", () => {
+  const it = testEffect(Layer.mergeAll(database, events, projector))
+  const sessionID = SessionV2.ID.make("ses_orphan_test")
+  const messageID = SessionV1.MessageID.make("msg_orphan")
+  const partID = SessionV1.PartID.make("prt_orphan")
+
+  it.effect("does not throw and does not insert part when parent message is gone", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      yield* db
+        .insert(ProjectTable)
+        .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "orphan-test",
+          directory: "/project",
+          title: "orphan test",
+          version: "test",
+        })
+        .run()
+        .pipe(Effect.orDie)
+
+      // Insert a message row directly, then delete it to simulate cascade-delete
+      yield* db
+        .insert(MessageTable)
+        .values({ id: messageID, session_id: sessionID, time_created: 0, data: {} as never })
+        .run()
+        .pipe(Effect.orDie)
+      yield* db.delete(MessageTable).where(eq(MessageTable.id, messageID)).run().pipe(Effect.orDie)
+
+      const evts = yield* EventV2.Service
+
+      // Late PartUpdated arrives after the parent was deleted
+      const exit = yield* evts
+        .publish(SessionV1.Event.PartUpdated, {
+          sessionID,
+          time: 0,
+          part: {
+            id: partID,
+            sessionID,
+            messageID,
+            type: "text",
+            text: "late orphan part",
+          } as SessionV1.TextPart,
+        })
+        .pipe(Effect.exit)
+
+      // Must not defect
+      expect(exit._tag).toBe("Success")
+
+      // Part row must NOT exist in PartTable
+      const row = yield* db.select().from(PartTable).where(eq(PartTable.id, partID)).get().pipe(Effect.orDie)
+      expect(row).toBeUndefined()
     }),
   )
 })


### PR DESCRIPTION
> **Stacked on #33134.** The retry sits directly on the commit-funnel `tapError` + `orDie` introduced by #33134, so this branch includes that commit. Once #33134 merges into `dev`, this PR shows only the lock-retry change. Review/merge #33134 first.

### Issue for this PR

Related to #21215 and #19521.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When several opencode processes share one SQLite database, durable event commits (`BEGIN IMMEDIATE`) can exhaust `busy_timeout` and fail with a `LockTimeoutError` ("database is locked"). That error flows through the event commit funnel's `Effect.orDie`, which turns it into a defect that crashes the prompt fiber and halts the TUI mid-turn.

Note on #21215: its premise was `busy_timeout=0`. That has since been addressed — `busy_timeout=5000` is set in the pragma block (`database.ts`, added in 7f571d36e). The remaining failure is genuine exhaustion of that 5s wait under heavy concurrent write contention, so a transient lock still crashes the fiber. High-frequency durable writes on the concurrent path (e.g. per-turn interrupt frames) make it easy to hit.

This treats a transient lock as retryable instead of fatal:

- `event.ts`: wrap the durable-commit transaction in a bounded `Effect.retry` gated to `LockTimeoutError` (exponential backoff + jitter, ~8 attempts) before the existing `tapError` + `orDie`. Retrying the whole `BEGIN IMMEDIATE` block is safe: rollback undoes all in-transaction writes, `seq` is recomputed from a fresh in-txn SELECT each attempt, and the pubsub notify happens outside the transaction, so no event is double-emitted. The gate keys on `reason._tag === "LockTimeoutError"`, not `error.isRetryable`, because in `effect@4.0.0-beta.66` those flags are inverted (LockTimeoutError reports not-retryable, ConstraintError reports retryable); a comment pins this to the version.
- `database.ts`: bump `PRAGMA busy_timeout` 5000 -> 10000.
- `sqlite.node.ts` / `sqlite.bun.ts`: set `PRAGMA busy_timeout = 10000` on every native connection (before WAL) so all connections get the wait, not only the ones configured via the higher-level layer.

`busy_timeout` is the in-SQLite wait; the retry is the graceful outer fallback when even that wait is exceeded. They are complementary.

This makes a transient lock benign and logged instead of fatal. It does not change the underlying write volume; reducing durable writes on the concurrent path and pruning the append-only event log are sensible follow-ups.

### How did you verify your code works?

- Added a classifier test in \`packages/core/test/event.test.ts\` asserting \`LockTimeoutError\` is treated as retryable and \`ConstraintError\` is not.
- \`bun typecheck\` clean in \`packages/core\`.
- \`bun test test/event.test.ts\` -> 47 pass / 0 fail.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR