### PR TITLE
feat: Allow editing project settings for non-git projects

### DIFF
--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -97,6 +97,7 @@ export function DialogEditProject(props: { project: LocalProject; server: Server
         icon: { color: store.color || undefined, override: store.iconOverride || undefined },
         commands: { start: start || undefined },
       })
+      serverSync().project.icon(props.project.worktree, store.iconOverride || undefined)
       dialog.close()
     },
   }))

--- a/packages/app/src/context/layout-helpers.ts
+++ b/packages/app/src/context/layout-helpers.ts
@@ -1,4 +1,34 @@
 import type { Accessor } from "solid-js"
+import type { Project } from "@opencode-ai/sdk/v2"
+import type { ProjectMeta } from "./global-sync/types"
+
+/**
+ * Merge per-workspace overrides from localStorage on top of the database
+ * metadata for a project.
+ *
+ * `meta` (the `projectMeta` cache: name/color/commands/icon) is only populated
+ * for projects that resolve to the shared "global" id (non-git directories),
+ * where every directory shares a single database row and needs its own local
+ * overrides to be distinguishable. `iconOverride` (the per-workspace `icon`
+ * cache) lets subdirectories of the same git repo carry individual icons.
+ *
+ * Icon precedence is database < projectMeta < per-workspace icon cache.
+ */
+export function mergeProjectOverrides<T extends { worktree: string; expanded: boolean }>(input: {
+  metadata: Partial<Project> | undefined
+  meta: ProjectMeta | undefined
+  iconOverride: string | undefined
+  project: T
+}): Partial<Project> & T {
+  const { metadata, meta, iconOverride, project } = input
+  const base = { ...metadata, ...meta, ...project }
+
+  const override = iconOverride ?? meta?.icon?.override
+  if (meta?.icon || override) {
+    base.icon = { ...metadata?.icon, ...meta?.icon, ...(override ? { override } : {}) }
+  }
+  return base
+}
 
 export function ensureSessionKey(key: string, touch: (key: string) => void, seed: (key: string) => void) {
   touch(key)

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout-helpers"
+import {
+  createSessionKeyReader,
+  ensureSessionKey,
+  mergeProjectOverrides,
+  pruneSessionKeys,
+} from "./layout-helpers"
 
 describe("layout session-key helpers", () => {
   test("couples touch and scroll seed in order", () => {
@@ -65,5 +70,64 @@ describe("pruneSessionKeys", () => {
     })
 
     expect(drop).toEqual([])
+  })
+})
+
+describe("mergeProjectOverrides", () => {
+  const project = { worktree: "/Users/me/proj/Assets", expanded: false }
+
+  test("surfaces projectMeta name/color/commands for a global project", () => {
+    const result = mergeProjectOverrides({
+      metadata: { id: "global", worktree: "/" },
+      meta: {
+        name: "My Assets",
+        icon: { color: "mint" },
+        commands: { start: "echo hi" },
+      },
+      iconOverride: undefined,
+      project,
+    })
+
+    expect(result.name).toBe("My Assets")
+    expect(result.icon?.color).toBe("mint")
+    expect(result.commands?.start).toBe("echo hi")
+    // the opened directory wins over the shared global worktree
+    expect(result.worktree).toBe("/Users/me/proj/Assets")
+  })
+
+  test("projectMeta icon override takes precedence over database icon", () => {
+    const result = mergeProjectOverrides({
+      metadata: { id: "global", icon: { url: "data:image/png;base64,db" } },
+      meta: { icon: { override: "data:image/png;base64,local" } },
+      iconOverride: undefined,
+      project,
+    })
+
+    expect(result.icon?.override).toBe("data:image/png;base64,local")
+    // database fields that aren't overridden are preserved
+    expect(result.icon?.url).toBe("data:image/png;base64,db")
+  })
+
+  test("per-workspace icon cache wins over projectMeta override", () => {
+    const result = mergeProjectOverrides({
+      metadata: { id: "p1" },
+      meta: { icon: { override: "stale" } },
+      iconOverride: "fresh",
+      project,
+    })
+
+    expect(result.icon?.override).toBe("fresh")
+  })
+
+  test("preserves database metadata when no overrides exist", () => {
+    const result = mergeProjectOverrides({
+      metadata: { id: "p1", name: "Repo", icon: { color: "pink" } },
+      meta: undefined,
+      iconOverride: undefined,
+      project,
+    })
+
+    expect(result.name).toBe("Repo")
+    expect(result.icon?.color).toBe("pink")
   })
 })

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import {
-  createSessionKeyReader,
-  ensureSessionKey,
-  mergeProjectOverrides,
-  pruneSessionKeys,
-} from "./layout-helpers"
+import { createSessionKeyReader, ensureSessionKey, mergeProjectOverrides, pruneSessionKeys } from "./layout-helpers"
 
 describe("layout session-key helpers", () => {
   test("couples touch and scroll seed in order", () => {

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -15,7 +15,7 @@ import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 import { createPathHelpers } from "./file/path"
 import type { ProjectAvatarVariant } from "@opencode-ai/ui/v2/project-avatar-v2"
 import { migrateLegacySessionStateKeys, ServerScope, SessionStateKey } from "@/utils/server-scope"
-import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout-helpers"
+import { createSessionKeyReader, ensureSessionKey, mergeProjectOverrides, pruneSessionKeys } from "./layout-helpers"
 
 export { createSessionKeyReader, ensureSessionKey, pruneSessionKeys }
 
@@ -415,14 +415,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         ? serverSync().data.project.find((x) => x.id === projectID)
         : serverSync().data.project.find((x) => x.worktree === project.worktree)
 
-      // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
-      // Without this, different subdirectories of the same git repo would share the same
-      // icon from the database instead of using their individual overrides.
-      const base = { ...metadata, ...project }
-      if (childStore.icon) {
-        return { ...base, icon: { ...base.icon, override: childStore.icon } }
-      }
-      return base
+      return mergeProjectOverrides({
+        metadata,
+        meta: childStore.projectMeta,
+        iconOverride: childStore.icon,
+        project,
+      })
     }
 
     const roots = createMemo(() => {


### PR DESCRIPTION
### Issue for this PR
Closes #33165 
### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Currently, OpenCode Desktop only allows editing of project settings if the folder is a git repo.
This change allows the changing of project settings info without the folder being a git repo. This is good for projects that use alternate VCS, like UnityVCS/PlasticSCM. Allows you to update project settings for generic folders.

Full disclaimer, I am not all too familiar with electron and bun so I had Claude assist, so here's how I understand it:
The way project settings are implemented now is that the storage relies on the git repo's ID to restore the information, since generic folders (and other VCS) don't provide this, there's nothing to save and continues to use the directory to fill-out the data.
What changed here is that project settings for non-git folders will utilize a cache system which has existed before but was never used to map these folders. 

### How did you verify your code works?
Testing the app directly, there's also a new layout test which pass individually, and when all tests are ran.
### Screenshots / recordings

Darkest window is the current version, the other one has my changes.

https://github.com/user-attachments/assets/1c01dda9-2230-4e5a-9f94-4c348ec4ff6a

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._