### PR TITLE
test(core): simplify command layer wiring

### DIFF
--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -2,6 +2,7 @@ export * as CommandV2 from "./command"
 
 import { Context, Effect, Layer, Schema } from "effect"
 import { castDraft, type Draft } from "immer"
+import { LayerNode } from "./effect/layer-node"
 import { ModelV2 } from "./model"
 import { State } from "./state"
 
@@ -68,3 +69,4 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer
+export const node = LayerNode.make(layer, [])

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -1,10 +1,11 @@
 import fs from "fs/promises"
 import path from "path"
 import { describe, expect } from "bun:test"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import { CommandV2 } from "@opencode-ai/core/command"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigCommandPlugin } from "@opencode-ai/core/config/plugin/command"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -12,7 +13,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
-const it = testEffect(Layer.mergeAll(CommandV2.locationLayer, FSUtil.defaultLayer))
+const it = testEffect(LayerNode.buildLayer(LayerNode.group([CommandV2.node, FSUtil.node])))
 const decode = Schema.decodeUnknownSync(Config.Info)
 
 describe("ConfigCommandPlugin.Plugin", () => {


### PR DESCRIPTION
## Summary
- add the canonical LayerNode for the command service
- build the command config test environment from the command and filesystem node graph

## Testing
- bun test test/config/command.test.ts
- bun typecheck