### PR TITLE
test(core): simplify agent config layer wiring

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -7,6 +7,7 @@ import { PermissionSchema } from "./permission/schema"
 import { ProviderV2 } from "./provider"
 import { PositiveInt } from "./schema"
 import { State } from "./state"
+import { LayerNode } from "./effect/layer-node"
 
 export const ID = Schema.String.pipe(Schema.brand("AgentV2.ID"))
 export type ID = typeof ID.Type
@@ -140,3 +141,4 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer
+export const node = LayerNode.make(layer, [])

--- a/packages/core/test/config/agent.test.ts
+++ b/packages/core/test/config/agent.test.ts
@@ -1,17 +1,18 @@
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigAgentPlugin } from "@opencode-ai/core/config/plugin/agent"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { PermissionV2 } from "@opencode-ai/core/permission"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
-const it = testEffect(Layer.mergeAll(AgentV2.locationLayer, FSUtil.defaultLayer))
+const it = testEffect(LayerNode.buildLayer(LayerNode.group([AgentV2.node, FSUtil.node])))
 const decode = Schema.decodeUnknownSync(Config.Info)
 
 describe("ConfigAgentPlugin.Plugin", () => {


### PR DESCRIPTION
## Summary
- add the canonical zero-dependency LayerNode for AgentV2
- build the agent config test environment from grouped canonical nodes
- remove direct defaultLayer and locationLayer wiring from the target test

## Testing
- `bun test test/config/agent.test.ts` (from `packages/core`)
- `bun typecheck` (from `packages/core`)