### PR TITLE
test(core): simplify project layer wiring

### DIFF
--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -2,30 +2,19 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { Database } from "@opencode-ai/core/database/database"
-import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Git } from "@opencode-ai/core/git"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Hash } from "@opencode-ai/core/util/hash"
-import { ProjectDirectories } from "@opencode-ai/core/project/directories"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const databaseLayer = Database.layerFromPath(":memory:")
-const directoriesLayer = ProjectDirectories.layer.pipe(Layer.provide(databaseLayer))
 const it = testEffect(
-  Layer.mergeAll(
-    ProjectV2.layer.pipe(
-      Layer.provide(FSUtil.defaultLayer),
-      Layer.provide(Git.defaultLayer),
-      Layer.provide(directoriesLayer),
-      Layer.provide(databaseLayer),
-    ),
-    databaseLayer,
-    directoriesLayer,
-  ),
+  LayerNode.buildLayer(ProjectV2.node, {
+    replacements: [LayerNode.replace(Database.node, Database.layerFromPath(":memory:"))],
+  }),
 )
 
 function remoteID(remote: string) {


### PR DESCRIPTION
## Summary
- build the ProjectV2 test environment from its canonical LayerNode graph
- replace the database node with an in-memory test database
- remove manual default-layer provisioning and merging

## Testing
- `bun test test/project.test.ts` (from `packages/core`)
- `bun typecheck` (from `packages/core`)