### PR TITLE
test(core): simplify cross-spawn layer wiring

### DIFF
--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -6,9 +6,10 @@ import { Effect, Exit, Stream } from "effect"
 import type * as PlatformError from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { testEffect } from "../lib/effect"
 
-const live = CrossSpawnSpawner.defaultLayer
+const live = LayerNode.buildLayer(CrossSpawnSpawner.node)
 const fx = testEffect(live)
 
 function js(code: string, opts?: ChildProcess.CommandOptions) {


### PR DESCRIPTION
## Summary
- build the cross-spawn spawner test environment from the canonical LayerNode graph
- keep provisioning scoped to the spawner node and its strict filesystem and path dependencies

## Testing
- `bun test test/effect/cross-spawn-spawner.test.ts`
- `bun typecheck`