### PR TITLE
test(core): simplify integration layer wiring

### DIFF
--- a/packages/core/src/credential.ts
+++ b/packages/core/src/credential.ts
@@ -7,6 +7,7 @@ import { IntegrationSchema } from "./integration/schema"
 import { NonNegativeInt, withStatics } from "./schema"
 import { Identifier } from "./util/identifier"
 import { CredentialTable } from "./credential/sql"
+import { LayerNode } from "./effect/layer-node"
 
 export const ID = Schema.String.pipe(
   Schema.brand("Credential.ID"),
@@ -150,3 +151,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -9,6 +9,7 @@ import { State } from "./state"
 import { Identifier } from "./util/identifier"
 import { EventV2 } from "./event"
 import { IntegrationConnection } from "./integration/connection"
+import { LayerNode } from "./effect/layer-node"
 
 export const ID = IntegrationSchema.ID
 export type ID = IntegrationSchema.ID
@@ -567,3 +568,5 @@ export const locationLayer = Layer.effect(
     })
   }),
 )
+
+export const node = LayerNode.make(locationLayer, [Credential.node, EventV2.node])

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -4,17 +4,21 @@ import * as TestClock from "effect/testing/TestClock"
 import { Integration } from "@opencode-ai/core/integration"
 import { Credential } from "@opencode-ai/core/credential"
 import { EventV2 } from "@opencode-ai/core/event"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { it } from "./lib/effect"
 
-const layer = Integration.locationLayer.pipe(
-  Layer.provide(EventV2.defaultLayer),
-  Layer.provide(
-    Layer.mock(Credential.Service)({
-      create: () => Effect.die("unexpected credential creation"),
-      list: () => Effect.succeed([]),
-    }),
-  ),
-)
+const root = LayerNode.group([Integration.node, EventV2.node])
+const layer = LayerNode.buildLayer(root, {
+  replacements: [
+    LayerNode.replace(
+      Credential.node,
+      Layer.mock(Credential.Service)({
+        create: () => Effect.die("unexpected credential creation"),
+        list: () => Effect.succeed([]),
+      }),
+    ),
+  ],
+})
 
 function connectionLayer(
   created: Array<{
@@ -23,24 +27,26 @@ function connectionLayer(
     value: Credential.Info
   }>,
 ) {
-  return Integration.locationLayer.pipe(
-    Layer.provideMerge(EventV2.defaultLayer),
-    Layer.provide(
-      Layer.mock(Credential.Service)({
-        create: (input) =>
-          Effect.sync(() => {
-            created.push(input)
-            return new Credential.Stored({
-              id: Credential.ID.create(),
-              integrationID: input.integrationID,
-              label: input.label ?? "default",
-              value: input.value,
-            })
-          }),
-        list: () => Effect.succeed([]),
-      }),
-    ),
-  )
+  return LayerNode.buildLayer(root, {
+    replacements: [
+      LayerNode.replace(
+        Credential.node,
+        Layer.mock(Credential.Service)({
+          create: (input) =>
+            Effect.sync(() => {
+              created.push(input)
+              return new Credential.Stored({
+                id: Credential.ID.create(),
+                integrationID: input.integrationID,
+                label: input.label ?? "default",
+                value: input.value,
+              })
+            }),
+          list: () => Effect.succeed([]),
+        }),
+      ),
+    ],
+  })
 }
 
 describe("Integration", () => {
@@ -357,14 +363,16 @@ describe("Integration", () => {
         value: new Credential.Key({ type: "key", key: "b" }),
       },
     ]
-    const projectionLayer = Integration.locationLayer.pipe(
-      Layer.provide(EventV2.defaultLayer),
-      Layer.provide(
-        Layer.mock(Credential.Service)({
-          list: () => Effect.succeed(rows.map((row) => new Credential.Stored(row))),
-        }),
-      ),
-    )
+    const projectionLayer = LayerNode.buildLayer(root, {
+      replacements: [
+        LayerNode.replace(
+          Credential.node,
+          Layer.mock(Credential.Service)({
+            list: () => Effect.succeed(rows.map((row) => new Credential.Stored(row))),
+          }),
+        ),
+      ],
+    })
     return Effect.acquireUseRelease(
       Effect.sync(() => {
         const previous = process.env.INTEGRATION_TEST_ACME_KEY


### PR DESCRIPTION
## Summary
- add canonical LayerNode nodes for Credential and Integration
- build integration test environments from a grouped graph with credential replacements

## Testing
- `bun test test/integration.test.ts` (packages/core)
- `bun typecheck` (packages/core)