### PR TITLE
fix(tui): reduce noisy MCP autocomplete matches

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -359,9 +359,8 @@ export function Autocomplete(props: {
     const width = props.anchor().width - 4
 
     for (const res of Object.values(sync.data.mcp_resource)) {
-      const text = `${res.name} (${res.uri})`
       options.push({
-        display: Locale.truncateMiddle(text, width),
+        display: Locale.truncateMiddle(res.name, width),
         // Match the name only; matching the URI caused unrelated fuzzy hits.
         value: res.name,
         description: res.description,
@@ -497,6 +496,7 @@ export function Autocomplete(props: {
           ...(store.visible === "/" ? ["description" as const] : []),
           (obj) => obj.aliases?.join(" ") ?? "",
         ],
+        threshold: store.visible === "@" ? 0.5 : 0,
         limit: 10,
         scoreFn: (objResults) => {
           const displayResult = objResults[0]


### PR DESCRIPTION
## Summary
- hide MCP resource URIs from autocomplete labels
- filter weak non-file fuzzy matches in `@` autocomplete with a score threshold
- leave filesystem and slash-command matching unchanged

## Testing
- `bun typecheck` in `packages/tui`
- repository pre-push typecheck (23 packages)