### PR TITLE
test(core): simplify config layer wiring

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -24,6 +24,7 @@ import { ConfigToolOutput } from "./config/tool-output"
 import { ConfigWatcher } from "./config/watcher"
 import { ConfigV1 } from "./v1/config/config"
 import { ConfigMigrateV1 } from "./v1/config/migrate"
+import { LayerNode } from "./effect/layer-node"
 
 export class Info extends Schema.Class<Info>("Config.Info")({
   $schema: Schema.optional(Schema.String).annotate({
@@ -218,3 +219,5 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer.pipe(Layer.provideMerge(Policy.locationLayer))
+export const node = (location: LayerNode.Node<Location.Service>, policy = Policy.node(location)) =>
+  LayerNode.make(layer, [FSUtil.node, Global.node, location, policy])

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -3,6 +3,7 @@ export * as Policy from "./policy"
 import { Context, Effect as EffectRuntime, Layer, Schema } from "effect"
 import { Wildcard } from "./util/wildcard"
 import { Location } from "./location"
+import { LayerNode } from "./effect/layer-node"
 
 export const Effect = Schema.Literals(["allow", "deny"]).annotate({ identifier: "Policy.Effect" })
 export type Effect = typeof Effect.Type
@@ -44,3 +45,4 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer
+export const node = (location: LayerNode.Node<Location.Service>) => LayerNode.make(layer, [location])

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -5,9 +5,9 @@ import { Effect, Layer, Schema } from "effect"
 import { FastCheck } from "effect/testing"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigProvider } from "@opencode-ai/core/config/provider"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { ConfigMigrateV1 } from "@opencode-ai/core/v1/config/migrate"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
-import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
 import { Location } from "@opencode-ai/core/location"
 import { Policy } from "@opencode-ai/core/policy"
@@ -25,21 +25,24 @@ function testLayer(
   projectDirectory = directory,
   vcs?: Project.Vcs,
 ) {
-  return Config.locationLayer.pipe(
-    Layer.provide(FSUtil.defaultLayer),
-    Layer.provide(Global.layerWith({ config: globalDirectory })),
-    Layer.provide(
-      Layer.succeed(
-        Location.Service,
-        Location.Service.of(
-          location(
-            { directory: AbsolutePath.make(directory) },
-            { projectDirectory: AbsolutePath.make(projectDirectory), vcs },
-          ),
+  const locationNode = LayerNode.make(
+    Layer.succeed(
+      Location.Service,
+      Location.Service.of(
+        location(
+          { directory: AbsolutePath.make(directory) },
+          { projectDirectory: AbsolutePath.make(projectDirectory), vcs },
         ),
       ),
     ),
+    [],
   )
+  const policyNode = Policy.node(locationNode)
+  return LayerNode.buildLayer(LayerNode.group([Config.node(locationNode, policyNode), policyNode, locationNode]), {
+    replacements: [
+      LayerNode.replace(Global.node, Global.layerWith({ config: globalDirectory })),
+    ],
+  })
 }
 
 const provider = {


### PR DESCRIPTION
## Summary
- expose canonical LayerNode builders for config and policy
- build the config test environment from grouped nodes and a global replacement
- remove defaultLayer wrapper provisioning from the config test

## Testing
- `bun test test/config/config.test.ts`
- `bun typecheck`