### PR TITLE
test(core): simplify location mutation layer wiring

### DIFF
--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -2,6 +2,7 @@ export * as LocationMutation from "./location-mutation"
 
 import path from "path"
 import { Context, Effect, Layer, Schema } from "effect"
+import { LayerNode } from "./effect/layer-node"
 import { FSUtil } from "./fs-util"
 import { Location } from "./location"
 
@@ -153,3 +154,5 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer
+
+export const node = (location: LayerNode.Node<Location.Service>) => LayerNode.make(layer, [FSUtil.node, location])

--- a/packages/core/test/location-mutation.test.ts
+++ b/packages/core/test/location-mutation.test.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises"
 import path from "path"
 import { describe, expect, test } from "bun:test"
 import { Effect, Layer, Schema } from "effect"
-import { FSUtil } from "@opencode-ai/core/fs-util"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Location } from "@opencode-ai/core/location"
 import { LocationMutation } from "@opencode-ai/core/location-mutation"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -11,16 +11,11 @@ import { location } from "./fixture/location"
 import { it } from "./lib/effect"
 
 function provide(directory: string) {
-  return Effect.provide(
-    LocationMutation.layer.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          FSUtil.defaultLayer,
-          Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
-        ),
-      ),
-    ),
+  const activeLocation = LayerNode.make(
+    Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
+    [],
   )
+  return Effect.provide(LayerNode.buildLayer(LocationMutation.node(activeLocation)))
 }
 
 function withTmp<A, E, R>(f: (directory: string) => Effect.Effect<A, E, R>) {


### PR DESCRIPTION
## Summary
- add the canonical LayerNode graph for location mutation with explicit filesystem and active-location dependencies
- build the location mutation test layer from that graph instead of wrapping `defaultLayer` manually

## Testing
- `bun test test/location-mutation.test.ts`
- `bun typecheck`