### PR TITLE
test(core): simplify models layer wiring

### DIFF
--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -6,6 +6,8 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { EventV2 } from "@opencode-ai/core/event"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { httpClient } from "@opencode-ai/core/effect/layer-node-platform"
 import { it } from "./lib/effect"
 import { readFile, rm, writeFile, utimes, mkdir } from "fs/promises"
 import path from "path"
@@ -90,10 +92,11 @@ const buildLayer = (state: Ref.Ref<MockState>) =>
   // Layer.fresh is required: ModelsDev.layer is a module-level Layer constant,
   // and Effect.provide uses a process-global MemoMap by default — without fresh,
   // every test would reuse the cachedInvalidateWithTTL state from the first run.
-  Layer.fresh(ModelsDev.layer).pipe(
-    Layer.provide(Layer.succeed(HttpClient.HttpClient, makeMockClient(state))),
-    Layer.provide(FSUtil.defaultLayer),
-    Layer.provide(EventV2.defaultLayer),
+  LayerNode.buildLayer(
+    LayerNode.group([LayerNode.make(Layer.fresh(ModelsDev.layer), [FSUtil.node, EventV2.node, httpClient])]),
+    {
+      replacements: [LayerNode.replace(httpClient, Layer.succeed(HttpClient.HttpClient, makeMockClient(state)))],
+    },
   )
 
 const writeCacheText = (text: string, mtimeMs?: number) =>


### PR DESCRIPTION
## Summary
- build the models test environment from canonical LayerNode dependencies
- replace the HTTP client node with the stateful test client while preserving fresh ModelsDev state

## Testing
- bun test test/models.test.ts
- bun typecheck