### PR TITLE
test(core): simplify move session layer wiring

### DIFF
--- a/packages/core/src/control-plane/move-session.ts
+++ b/packages/core/src/control-plane/move-session.ts
@@ -2,6 +2,7 @@ export * as MoveSession from "./move-session"
 
 import { Context, DateTime, Effect, Layer, Schema } from "effect"
 import { EventV2 } from "../event"
+import { LayerNode } from "../effect/layer-node"
 import { Git } from "../git"
 import { Location } from "../location"
 import { ProjectV2 } from "../project"
@@ -128,3 +129,4 @@ export const defaultLayer = layer.pipe(
   Layer.provide(SessionExecution.noopLayer),
   Layer.provide(SessionV2.defaultLayer),
 )
+export const node = LayerNode.make(layer, [Git.node, EventV2.node, ProjectV2.node, SessionV2.node])

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -3,6 +3,7 @@ export * from "./session/schema"
 
 import { Cause, DateTime, Effect, Layer, Schema, Context, Stream } from "effect"
 import { and, asc, desc, eq, gt, like, lt, or, type SQL } from "drizzle-orm"
+import { LayerNode } from "./effect/layer-node"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
 import { ModelV2 } from "./model"
@@ -434,3 +435,11 @@ export const defaultLayer = layer.pipe(
   Layer.provide(ProjectV2.defaultLayer),
   Layer.orDie,
 )
+export const node = LayerNode.make(layer.pipe(Layer.orDie), [
+  Database.node,
+  EventV2.node,
+  ProjectV2.node,
+  SessionExecution.noopNode,
+  SessionProjector.node,
+  SessionStore.node,
+])

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -1,6 +1,7 @@
 export * as SessionExecution from "./execution"
 
 import { Context, Effect, Layer } from "effect"
+import { LayerNode } from "../effect/layer-node"
 import { SessionRunner } from "./runner/index"
 import { SessionSchema } from "./schema"
 
@@ -21,3 +22,4 @@ export const noopLayer = Layer.succeed(
   Service,
   Service.of({ resume: () => Effect.void, wake: () => Effect.void, interrupt: () => Effect.void }),
 )
+export const noopNode = LayerNode.make(noopLayer, [])

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -3,6 +3,7 @@ export * as SessionStore from "./store"
 import { eq } from "drizzle-orm"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
+import { LayerNode } from "../effect/layer-node"
 import { SessionHistory } from "./history"
 import { MessageDecodeError } from "./error"
 import { SessionMessage } from "./message"
@@ -60,3 +61,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/core/test/move-session.test.ts
+++ b/packages/core/test/move-session.test.ts
@@ -3,52 +3,22 @@ import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
 import { eq } from "drizzle-orm"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
 import { Database } from "@opencode-ai/core/database/database"
-import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Git } from "@opencode-ai/core/git"
-import { EventV2 } from "@opencode-ai/core/event"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
-import { ProjectDirectories } from "@opencode-ai/core/project/directories"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
-import { SessionExecution } from "@opencode-ai/core/session/execution"
-import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionTable } from "@opencode-ai/core/session/sql"
-import { SessionStore } from "@opencode-ai/core/session/store"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const database = Database.layerFromPath(":memory:")
-const events = EventV2.layer.pipe(Layer.provide(database))
-const directories = ProjectDirectories.layer.pipe(Layer.provide(database), Layer.provide(events))
-const projector = SessionProjector.layer.pipe(Layer.provide(database), Layer.provide(events))
-const project = Project.layer.pipe(
-  Layer.provide(database),
-  Layer.provide(FSUtil.defaultLayer),
-  Layer.provide(Git.defaultLayer),
-  Layer.provide(directories),
-)
-const store = SessionStore.layer.pipe(Layer.provide(database))
-const sessions = SessionV2.layer.pipe(
-  Layer.provide(database),
-  Layer.provide(events),
-  Layer.provide(project),
-  Layer.provide(store),
-  Layer.provide(SessionExecution.noopLayer),
-)
-const layer = MoveSession.layer.pipe(
-  Layer.provide(database),
-  Layer.provide(FSUtil.defaultLayer),
-  Layer.provide(Git.defaultLayer),
-  Layer.provide(events),
-  Layer.provide(project),
-  Layer.provide(sessions),
-)
 const it = testEffect(
-  Layer.mergeAll(layer, database, events, directories, project, projector, store, SessionExecution.noopLayer, sessions),
+  LayerNode.buildLayer(LayerNode.group([MoveSession.node, Database.node, Project.node]), {
+    replacements: [LayerNode.replace(Database.node, Database.layerFromPath(":memory:"))],
+  }),
 )
 
 function abs(input: string) {


### PR DESCRIPTION
## Summary
- build the move-session test environment from the canonical LayerNode graph
- add the necessary canonical nodes for move-session and session dependencies
- replace the database node with an in-memory test database and remove manual layer wrappers

## Testing
- `bun test test/move-session.test.ts` (from `packages/core`)
- `bun typecheck` (from `packages/core`)