### PR TITLE
test(core): simplify location filesystem layer wiring

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -8,6 +8,7 @@ import { Location } from "./location"
 import { PositiveInt, RelativePath } from "./schema"
 import { FileSystemSearch } from "./filesystem/search"
 import { Entry, Match } from "./filesystem/schema"
+import { LayerNode } from "./effect/layer-node"
 export { Entry, Match, Submatch } from "./filesystem/schema"
 
 export const ReadInput = Schema.Struct({
@@ -126,3 +127,6 @@ const baseLayer = Layer.effect(
 export const layer = baseLayer.pipe(Layer.provide(FileSystemSearch.defaultLayer), Layer.provide(FSUtil.defaultLayer))
 
 export const locationLayer = layer
+
+export const node = (location: LayerNode.Node<Location.Service>) =>
+  LayerNode.make(baseLayer, [FSUtil.node, FileSystemSearch.node(location), location])

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -10,6 +10,7 @@ import { Location } from "../location"
 import { Ripgrep } from "../ripgrep"
 import { RelativePath } from "../schema"
 import { Flag } from "../flag/flag"
+import { LayerNode } from "../effect/layer-node"
 
 export interface Interface {
   readonly find: (input: FileSystem.FindInput) => Effect.Effect<FileSystem.Entry[]>
@@ -235,3 +236,6 @@ export const fffLayer = Layer.effect(
 export const defaultLayer = Layer.unwrap(
   Effect.sync(() => (Flag.OPENCODE_DISABLE_FFF || !Fff.available() ? ripgrepLayer : fffLayer)),
 )
+
+export const node = (location: LayerNode.Node<Location.Service>) =>
+  LayerNode.make(defaultLayer, [FSUtil.node, Ripgrep.node, location])

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -2,27 +2,21 @@ import fs from "fs/promises"
 import path from "path"
 import { describe, expect } from "bun:test"
 import { Effect, Exit, Layer } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FileSystem } from "@opencode-ai/core/filesystem"
-import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Location } from "@opencode-ai/core/location"
-import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { location } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
 import { it } from "./lib/effect"
 
-const provide = (directory: string) =>
-  Effect.provide(
-    FileSystem.layer.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          FSUtil.defaultLayer,
-          Ripgrep.defaultLayer,
-          Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
-        ),
-      ),
-    ),
+const provide = (directory: string) => {
+  const activeLocation = LayerNode.make(
+    Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
+    [],
   )
+  return Effect.provide(LayerNode.buildLayer(FileSystem.node(activeLocation)))
+}
 
 const withTmp = <A, E, R>(f: (directory: string) => Effect.Effect<A, E, R>) =>
   Effect.acquireRelease(


### PR DESCRIPTION
## Summary
- add canonical LayerNode graph nodes for location filesystem and search services
- build the location filesystem test environment from the graph instead of nested defaultLayer provisioning

## Testing
- `bun test test/location-filesystem.test.ts` (packages/core)
- `bun typecheck` (packages/core)