### PR TITLE
test(core): simplify location layer wiring

### DIFF
--- a/packages/core/src/credential.ts
+++ b/packages/core/src/credential.ts
@@ -7,6 +7,7 @@ import { IntegrationSchema } from "./integration/schema"
 import { NonNegativeInt, withStatics } from "./schema"
 import { Identifier } from "./util/identifier"
 import { CredentialTable } from "./credential/sql"
+import { LayerNode } from "./effect/layer-node"
 
 export const ID = Schema.String.pipe(
   Schema.brand("Credential.ID"),
@@ -150,3 +151,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/core/src/tool/application-tools.ts
+++ b/packages/core/src/tool/application-tools.ts
@@ -4,6 +4,7 @@ import { Context, Effect, Layer, Scope } from "effect"
 import { enableMapSet } from "immer"
 import { State } from "../state"
 import { Tool } from "./tool"
+import { LayerNode } from "../effect/layer-node"
 
 type Data = {
   readonly entries: Map<string, Entry>
@@ -56,3 +57,5 @@ export const layer = Layer.effect(
     })
   }),
 )
+
+export const node = LayerNode.make(layer, [])

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -4,6 +4,7 @@ import { describe, expect } from "bun:test"
 import { Effect, Equal, Hash, Layer, Schema } from "effect"
 import { Tool } from "@opencode-ai/core/public"
 import { Catalog } from "@opencode-ai/core/catalog"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 import { Location } from "@opencode-ai/core/location"
 import { PluginBoot } from "@opencode-ai/core/plugin/boot"
@@ -24,26 +25,20 @@ import { Reference } from "../src/reference"
 import { ToolRegistry } from "../src/tool/registry"
 import { ApplicationTools } from "../src/tool/application-tools"
 
-const applicationTools = ApplicationTools.layer
+const locationServices = LayerNode.make(LocationServiceMap.layer, [
+  ApplicationTools.node,
+  Project.node,
+  EventV2.node,
+  Credential.node,
+  Npm.node,
+  ModelsDev.node,
+  FSUtil.node,
+  Global.node,
+])
 const it = testEffect(
-  Layer.merge(
-    Layer.mergeAll(applicationTools, Database.defaultLayer, EventV2.defaultLayer),
-    LocationServiceMap.layer.pipe(
-      Layer.provide(applicationTools),
-      Layer.provide(
-        Layer.mergeAll(
-          Project.defaultLayer,
-          EventV2.defaultLayer,
-          Credential.defaultLayer,
-          Credential.layer.pipe(Layer.provide(Database.layerFromPath(":memory:").pipe(Layer.fresh))),
-          Npm.defaultLayer,
-          ModelsDev.defaultLayer,
-          FSUtil.defaultLayer,
-          Global.defaultLayer,
-        ),
-      ),
-    ),
-  ),
+  LayerNode.buildLayer(LayerNode.group([ApplicationTools.node, Database.node, EventV2.node, locationServices]), {
+    replacements: [LayerNode.replace(Database.node, Database.layerFromPath(":memory:").pipe(Layer.fresh))],
+  }),
 )
 
 describe("LocationServiceMap", () => {


### PR DESCRIPTION
## Summary
- replace manual location test environment wiring with a canonical LayerNode graph
- add canonical nodes for Credential and ApplicationTools
- replace the graph database node with a fresh in-memory database for the test

## Testing
- `bun test test/location-layer.test.ts` (packages/core)
- `bun typecheck` (packages/core)