### PR TITLE
test(core): simplify project copy layer wiring

### DIFF
--- a/packages/core/test/project-copy.test.ts
+++ b/packages/core/test/project-copy.test.ts
@@ -3,30 +3,23 @@ import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
 import { eq } from "drizzle-orm"
-import { Effect, Fiber, Layer, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import { AbsolutePath } from "@opencode-ai/core/schema"
-import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Git } from "@opencode-ai/core/git"
 import { Database } from "@opencode-ai/core/database/database"
 import { EventV2 } from "@opencode-ai/core/event"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectDirectoryTable, ProjectTable } from "@opencode-ai/core/project/sql"
 import { ProjectCopy } from "@opencode-ai/core/project/copy"
-import { ProjectDirectories } from "@opencode-ai/core/project/directories"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const databaseLayer = Database.layerFromPath(":memory:")
-const eventLayer = EventV2.layer.pipe(Layer.provide(databaseLayer))
-const directoriesLayer = ProjectDirectories.layer.pipe(Layer.provide(databaseLayer))
-const copyLayer = ProjectCopy.layer.pipe(
-  Layer.provide(databaseLayer),
-  Layer.provide(directoriesLayer),
-  Layer.provide(eventLayer),
-  Layer.provide(FSUtil.defaultLayer),
-  Layer.provide(Git.defaultLayer),
+const it = testEffect(
+  LayerNode.buildLayer(LayerNode.group([ProjectCopy.node, Database.node, EventV2.node]), {
+    replacements: [LayerNode.replace(Database.node, Database.layerFromPath(":memory:"))],
+  }),
 )
-const it = testEffect(Layer.mergeAll(copyLayer, databaseLayer, eventLayer, directoriesLayer))
 
 function abs(input: string) {
   return AbsolutePath.make(input)


### PR DESCRIPTION
## Summary
- build the project copy test environment from the canonical LayerNode graph
- replace the database node with the in-memory test database layer
- remove manual defaultLayer wrappers and redundant layer wiring

## Testing
- `bun test test/project-copy.test.ts`
- `bun typecheck`