### PR TITLE
test(core): simplify session prompt layer wiring

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -29,6 +29,7 @@ import { logFailure } from "./session/logging"
 import { MessageDecodeError } from "./session/error"
 import { SessionEvent } from "./session/event"
 import { SessionInput } from "./session/input"
+import { LayerNode } from "./effect/layer-node"
 
 // get project -> project.locations
 //
@@ -424,6 +425,15 @@ export const layer = Layer.effect(
     return result
   }),
 )
+
+export const node = LayerNode.make(layer, [
+  SessionExecution.node,
+  SessionStore.node,
+  SessionProjector.node,
+  EventV2.node,
+  Database.node,
+  ProjectV2.node,
+])
 
 export const defaultLayer = layer.pipe(
   Layer.provide(SessionExecution.noopLayer),

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -3,6 +3,7 @@ export * as SessionExecution from "./execution"
 import { Context, Effect, Layer } from "effect"
 import { SessionRunner } from "./runner/index"
 import { SessionSchema } from "./schema"
+import { LayerNode } from "../effect/layer-node"
 
 export interface Interface {
   /** Explicitly drain one Session, making at least one provider attempt. */
@@ -21,3 +22,5 @@ export const noopLayer = Layer.succeed(
   Service,
   Service.of({ resume: () => Effect.void, wake: () => Effect.void, interrupt: () => Effect.void }),
 )
+
+export const node = LayerNode.make(noopLayer, [])

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -9,6 +9,7 @@ import { SessionMessage } from "./message"
 import { SessionSchema } from "./schema"
 import { SessionMessageTable, SessionTable } from "./sql"
 import { fromRow } from "./info"
+import { LayerNode } from "../effect/layer-node"
 
 export interface Interface {
   readonly get: (sessionID: SessionSchema.ID) => Effect.Effect<SessionSchema.Info | undefined>
@@ -58,5 +59,7 @@ export const layer = Layer.effect(
     })
   }),
 )
+
+export const node = LayerNode.make(layer, [Database.node])
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -15,13 +15,10 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionInput } from "@opencode-ai/core/session/input"
 import { SessionInputTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
-import { SessionStore } from "@opencode-ai/core/session/store"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { testEffect } from "./lib/effect"
 
 const database = Database.layerFromPath(":memory:")
-const events = EventV2.layer.pipe(Layer.provide(database))
-const projector = SessionProjector.layer.pipe(Layer.provide(events), Layer.provide(database))
-const store = SessionStore.layer.pipe(Layer.provide(database))
 const executionCalls: SessionV2.ID[] = []
 const interruptCalls: SessionV2.ID[] = []
 const interruptSeqs: Array<number | undefined> = []
@@ -46,14 +43,12 @@ const execution = Layer.succeed(
       }),
   }),
 )
-const sessions = SessionV2.layer.pipe(
-  Layer.provide(events),
-  Layer.provide(database),
-  Layer.provide(store),
-  Layer.provide(Project.defaultLayer),
-  Layer.provide(execution),
+const root = LayerNode.group([SessionV2.node, SessionProjector.node, EventV2.node, Database.node])
+const it = testEffect(
+  LayerNode.buildLayer(root, {
+    replacements: [LayerNode.replace(Database.node, database), LayerNode.replace(SessionExecution.node, execution)],
+  }),
 )
-const it = testEffect(Layer.mergeAll(database, events, projector, store, execution, sessions))
 const sessionID = SessionV2.ID.make("ses_prompt_test")
 const messageID = SessionMessage.ID.create()
 


### PR DESCRIPTION
## Summary
- add canonical LayerNode source nodes for SessionV2, SessionStore, and SessionExecution
- build the session prompt test environment from a grouped graph with database and execution replacements
- remove manual defaultLayer provisioning and merged wrapper layers

## Testing
- `bun test test/session-prompt.test.ts`
- `bun typecheck`