### PR TITLE
test(core): simplify repository cache layer wiring

### DIFF
--- a/packages/core/src/repository-cache.ts
+++ b/packages/core/src/repository-cache.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { Context, Effect, Layer, Schema } from "effect"
+import { LayerNode } from "./effect/layer-node"
 import { FSUtil } from "./fs-util"
 import { Git } from "./git"
 import { Global } from "./global"
@@ -258,6 +259,7 @@ export const defaultLayer: Layer.Layer<Service> = layer.pipe(
   Layer.provide(Git.defaultLayer),
   Layer.provide(Global.defaultLayer),
 )
+export const node = LayerNode.make(layer, [FSUtil.node, Git.node, EffectFlock.node, Global.node])
 
 function statusForRepository(input: { reuse: boolean; refresh?: boolean; branchMatches?: boolean }) {
   if (!input.reuse) return "cloned" as const

--- a/packages/core/test/repository-cache.test.ts
+++ b/packages/core/test/repository-cache.test.ts
@@ -3,12 +3,10 @@ import fs from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
 import { Effect, Layer } from "effect"
-import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Git } from "@opencode-ai/core/git"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Global } from "@opencode-ai/core/global"
 import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
-import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 import { git, gitRemote } from "./fixture/git"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
@@ -89,15 +87,14 @@ describe("RepositoryCache", () => {
 })
 
 function cacheLayer(root: string) {
-  const dependencies = Layer.mergeAll(
-    Global.layerWith({ state: path.join(root, "state"), repos: path.join(root, "repos") }),
-    FSUtil.defaultLayer,
-  )
-  return RepositoryCache.layer.pipe(
-    Layer.provide(EffectFlock.layer.pipe(Layer.provide(dependencies))),
-    Layer.provide(Git.defaultLayer),
-    Layer.provide(dependencies),
-  )
+  return LayerNode.buildLayer(RepositoryCache.node, {
+    replacements: [
+      LayerNode.replace(
+        Global.node,
+        Global.layerWith({ state: path.join(root, "state"), repos: path.join(root, "repos") }),
+      ),
+    ],
+  })
 }
 
 function withRemote<A, E, R>(body: (fixture: Awaited<ReturnType<typeof gitRemote>>) => Effect.Effect<A, E, R>) {


### PR DESCRIPTION
## Summary
- add the canonical LayerNode definition for RepositoryCache
- build the repository cache test layer from the node graph with a scoped Global replacement
- remove manual defaultLayer provisioning wrappers from the target test

## Testing
- `bun test test/repository-cache.test.ts` (packages/core)
- `bun typecheck` (packages/core)