### PR TITLE
test(core): simplify permission layer wiring

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -7,6 +7,7 @@ import { PermissionSchema } from "./permission/schema"
 import { ProviderV2 } from "./provider"
 import { PositiveInt } from "./schema"
 import { State } from "./state"
+import { LayerNode } from "./effect/layer-node"
 
 export const ID = Schema.String.pipe(Schema.brand("AgentV2.ID"))
 export type ID = typeof ID.Type
@@ -140,3 +141,4 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer
+export const node = LayerNode.make(layer, [])

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -11,6 +11,7 @@ import { Identifier } from "./util/identifier"
 import { Wildcard } from "./util/wildcard"
 import { PermissionSchema } from "./permission/schema"
 import { PermissionSaved } from "./permission/saved"
+import { LayerNode } from "./effect/layer-node"
 
 export { Effect, Rule, Ruleset } from "./permission/schema"
 type Effect = PermissionSchema.Effect
@@ -327,3 +328,5 @@ export const layer = Layer.effect(
 )
 
 export const locationLayer = layer.pipe(Layer.provideMerge(AgentV2.locationLayer))
+export const node = (location: LayerNode.Node<Location.Service>) =>
+  LayerNode.make(layer, [EventV2.node, location, AgentV2.node, SessionStore.node, PermissionSaved.node])

--- a/packages/core/src/permission/saved.ts
+++ b/packages/core/src/permission/saved.ts
@@ -7,6 +7,7 @@ import { ProjectV2 } from "../project"
 import { withStatics } from "../schema"
 import { Identifier } from "../util/identifier"
 import { PermissionTable } from "./sql"
+import { LayerNode } from "../effect/layer-node"
 
 export const ID = Schema.String.pipe(
   Schema.brand("PermissionSaved.ID"),
@@ -85,3 +86,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -9,6 +9,7 @@ import { SessionMessage } from "./message"
 import { SessionSchema } from "./schema"
 import { SessionMessageTable, SessionTable } from "./sql"
 import { fromRow } from "./info"
+import { LayerNode } from "../effect/layer-node"
 
 export interface Interface {
   readonly get: (sessionID: SessionSchema.ID) => Effect.Effect<SessionSchema.Info | undefined>
@@ -60,3 +61,4 @@ export const layer = Layer.effect(
 )
 
 export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
+export const node = LayerNode.make(layer, [Database.node])

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { Deferred, Effect, Fiber, Layer } from "effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
 import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Location } from "@opencode-ai/core/location"
 import { PermissionV2 } from "@opencode-ai/core/permission"
@@ -12,35 +13,26 @@ import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { SessionTable } from "@opencode-ai/core/session/sql"
-import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { eq } from "drizzle-orm"
 import { location } from "./fixture/location"
 import { testEffect } from "./lib/effect"
 
 const database = Database.layerFromPath(":memory:")
-const current = Layer.succeed(
-  Location.Service,
-  Location.Service.of(location({ directory: AbsolutePath.make("/project") })),
+const current = LayerNode.make(
+  Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make("/project") }))),
+  [],
 )
-const events = EventV2.layer.pipe(Layer.provide(database))
-const store = SessionStore.layer.pipe(Layer.provide(database))
-const sessions = SessionV2.layer.pipe(
-  Layer.provide(events),
-  Layer.provide(database),
-  Layer.provide(store),
-  Layer.provide(Project.defaultLayer),
-  Layer.provide(SessionExecution.noopLayer),
-)
-const saved = PermissionSaved.layer.pipe(Layer.provide(database))
-const layer = PermissionV2.locationLayer.pipe(
-  Layer.provideMerge(database),
-  Layer.provideMerge(store),
-  Layer.provideMerge(events),
-  Layer.provideMerge(current),
-  Layer.provideMerge(sessions),
-  Layer.provideMerge(SessionExecution.noopLayer),
-  Layer.provideMerge(saved),
+const layer = LayerNode.buildLayer(
+  LayerNode.group([
+    PermissionV2.node(current),
+    Database.node,
+    EventV2.node,
+    AgentV2.node,
+    SessionStore.node,
+    PermissionSaved.node,
+  ]),
+  { replacements: [LayerNode.replace(Database.node, database)] },
 )
 const it = testEffect(layer)
 


### PR DESCRIPTION
## Summary

- model permission test dependencies with canonical LayerNode nodes
- replace the shared database node with an in-memory test layer
- remove unnecessary SessionV2 and defaultLayer provisioning

## Testing

- `bun test test/permission.test.ts` (packages/core)
- `bun typecheck` (packages/core)