### PR TITLE
fix: tolerate unrecognized config keys instead of failing all session loading

### DIFF
--- a/packages/opencode/src/config/parse.ts
+++ b/packages/opencode/src/config/parse.ts
@@ -39,17 +39,10 @@ export function schema<S extends EffectSchema.Decoder<unknown, never>>(
 ): DeepMutable<S["Type"]> {
   const extra = topLevelExtraKeys(schema, data)
   if (extra.length) {
-    throw new InvalidError({
-      path: source,
-      issues: [
-        {
-          code: "unrecognized_keys",
-          keys: extra,
-          path: [],
-          message: `Unrecognized key${extra.length === 1 ? "" : "s"}: ${extra.join(", ")}`,
-        },
-      ],
-    })
+    console.warn(`Config "${source}": ignoring unrecognized keys: ${extra.join(", ")}`)
+    data = Object.fromEntries(
+      Object.entries(data as Record<string, unknown>).filter(([key]) => !extra.includes(key)),
+    )
   }
 
   const decoded = EffectSchema.decodeUnknownExit(schema)(data, { errors: "all", propertyOrder: "original" })


### PR DESCRIPTION
### Issue for this PR

Closes #33196

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode.json` / `opencode.jsonc` root-level fields not in the Config schema (e.g., `"files": {}`) currently throw `ConfigInvalidError` and block all session loading. This is fragile — a stray key can crash the entire app.

Instead of throwing `InvalidError` via `topLevelExtraKeys()`, the fix logs `console.warn()` for each unrecognized key and strips them from data before Effect Schema validation. Valid config still applies normally.

### How did you verify your code works?

- Tested locally with a config file containing the `"files"` key from the debug archive — no more crash, warning printed to console
- Verified valid keys (e.g., `"sessions"`, `"models"`) still work correctly after the change

### Screenshots / recordings

N/A — this is a backend/config change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR