### PR TITLE
Set native theme source in setTitlebar function

### DIFF
--- a/packages/desktop/src/main/windows.ts
+++ b/packages/desktop/src/main/windows.ts
@@ -89,6 +89,7 @@ function overlay(theme: Partial<TitlebarTheme> = {}, zoom = 1) {
 
 export function setTitlebar(win: BrowserWindow, theme: Partial<TitlebarTheme> = {}) {
   titlebarThemes.set(win, theme)
+  nativeTheme.themeSource = theme.mode ?? tone()
   updateTitlebar(win)
 }
 


### PR DESCRIPTION
Synchronize the native theme in setTitlebar()

### Issue for this PR
If `nativeTheme.themeSource` is not set and the user's system theme differs from the app's theme, inconsistent display of the system menu will occur.

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### Checklist

- [X] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR
