### PR TITLE
feat(app): persist web sidebar project state

### DIFF
--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -5,6 +5,7 @@ import {
   createServerProjects,
   migrateCanonicalLocalServerState,
   nextServerAfterRemoval,
+  resolveSidebarHydration,
   resolveServerList,
   ServerConnection,
 } from "./server"
@@ -93,6 +94,50 @@ test("active server removal falls back across built-in and persisted servers", (
       ServerConnection.Key.make("sidecar"),
     ),
   ).toBe(ServerConnection.Key.make("sidecar"))
+})
+
+describe("resolveSidebarHydration", () => {
+  const local = {
+    projects: [{ worktree: "/local", expanded: true }],
+    lastProject: "/local",
+  }
+
+  test("ignores a server response when the sidebar changed while it was loading", () => {
+    expect(
+      resolveSidebarHydration({
+        startedRevision: 2,
+        currentRevision: 3,
+        local,
+        remote: { projects: [{ worktree: "/remote", expanded: true }] },
+      }),
+    ).toEqual({ type: "ignore" })
+  })
+
+  test("seeds an empty server from existing browser state", () => {
+    expect(
+      resolveSidebarHydration({
+        startedRevision: 2,
+        currentRevision: 2,
+        local,
+        remote: { projects: [] },
+      }),
+    ).toEqual({ type: "save", state: local })
+  })
+
+  test("hydrates a fresh browser from populated server state", () => {
+    const remote = {
+      projects: [{ worktree: "/remote", expanded: false }],
+      lastProject: "/remote",
+    }
+    expect(
+      resolveSidebarHydration({
+        startedRevision: 0,
+        currentRevision: 0,
+        local: { projects: [] },
+        remote,
+      }),
+    ).toEqual({ type: "load", state: remote })
+  })
 })
 
 describe("createServerProjects", () => {

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -100,18 +100,47 @@ describe("createServerProjects", () => {
     createRoot((dispose) => {
       const [scope] = createSignal(ServerScope.local)
       const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
-      const active = createServerProjects({ scope, store, setStore })
-      const remote = createServerProjects({ scope: () => "https://debian.example" as ServerScope, store, setStore })
+      const changes: Array<{
+        scope: ServerScope
+        projects: Array<{ worktree: string; expanded: boolean }>
+        lastProject?: string
+      }> = []
+      const onChange = (
+        scope: ServerScope,
+        state: { projects: Array<{ worktree: string; expanded: boolean }>; lastProject?: string },
+      ) => {
+        changes.push({ scope, projects: [...state.projects], lastProject: state.lastProject })
+      }
+      const active = createServerProjects({ scope, store, setStore, onChange })
+      const remote = createServerProjects({
+        scope: () => "https://debian.example" as ServerScope,
+        store,
+        setStore,
+        onChange,
+      })
 
       remote.open("/repo")
       expect(remote.list()).toEqual([{ worktree: "/repo", expanded: true }])
       expect(active.list()).toEqual([])
 
-      const adopted = createServerProjects({ scope: () => "https://debian.example" as ServerScope, store, setStore })
+      const adopted = createServerProjects({
+        scope: () => "https://debian.example" as ServerScope,
+        store,
+        setStore,
+        onChange,
+      })
       expect(adopted.list()).toEqual([{ worktree: "/repo", expanded: true }])
 
       adopted.close("/repo")
       expect(remote.list()).toEqual([])
+      expect(changes).toEqual([
+        {
+          scope: "https://debian.example" as ServerScope,
+          projects: [{ worktree: "/repo", expanded: true }],
+          lastProject: undefined,
+        },
+        { scope: "https://debian.example" as ServerScope, projects: [], lastProject: undefined },
+      ])
       dispose()
     })
   })

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -264,6 +264,19 @@ export function nextServerAfterRemoval(
   return next ? ServerConnection.key(next) : fallback
 }
 
+export function resolveSidebarHydration(input: {
+  startedRevision: number
+  currentRevision: number
+  local: { projects: StoredProject[]; lastProject?: string }
+  remote: { projects: StoredProject[]; lastProject?: string }
+}) {
+  if (input.startedRevision !== input.currentRevision) return { type: "ignore" as const }
+  if (input.remote.projects.length === 0 && input.local.projects.length > 0) {
+    return { type: "save" as const, state: input.local }
+  }
+  return { type: "load" as const, state: input.remote }
+}
+
 function sidebarProjectPersistence(input: { conn: ServerConnection.Any | undefined; scope: ServerScope }) {
   if (!input.conn || input.conn.type !== "http") return
   const client = createSdkForServer({ server: input.conn.http, throwOnError: true }).project
@@ -340,9 +353,11 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
     )
 
     const scope = (key = state.active) => ServerScope.fromServerKey(key, props.canonicalLocalServer)
-    const saveSidebar = (targetScope: ServerScope, state: { projects: StoredProject[]; lastProject?: string }) => {
+    const sidebarRevision = new Map<ServerScope, number>()
+    const saveSidebar = (targetScope: ServerScope, sidebar: { projects: StoredProject[]; lastProject?: string }) => {
+      sidebarRevision.set(targetScope, (sidebarRevision.get(targetScope) ?? 0) + 1)
       const conn = allServers().find((server) => scope(ServerConnection.key(server)) === targetScope)
-      return sidebarProjectPersistence({ conn, scope: targetScope })?.save(state)
+      return sidebarProjectPersistence({ conn, scope: targetScope })?.save(sidebar)
     }
 
     const projects = createServerProjects({ scope, store, setStore, onChange: saveSidebar })
@@ -366,13 +381,29 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
           const persistence = sidebarProjectPersistence({ conn, scope: scope(ServerConnection.key(conn)) })
           if (!persistence) return
           const key = ServerConnection.key(conn)
+          const targetScope = scope(key)
+          const startedRevision = sidebarRevision.get(targetScope) ?? 0
           persistence
             .load()
-            .then((state) => {
-              if (!state) return
+            .then((remote) => {
+              if (!remote) return
               if (ServerConnection.key(current() ?? conn) !== key) return
-              setStore("projects", scope(key), state.projects)
-              if (state.lastProject) setStore("lastProject", scope(key), state.lastProject)
+              const result = resolveSidebarHydration({
+                startedRevision,
+                currentRevision: sidebarRevision.get(targetScope) ?? 0,
+                local: {
+                  projects: store.projects[targetScope] ?? [],
+                  lastProject: store.lastProject[targetScope],
+                },
+                remote,
+              })
+              if (result.type === "ignore") return
+              if (result.type === "save") {
+                saveSidebar(targetScope, result.state)
+                return
+              }
+              setStore("projects", targetScope, result.state.projects)
+              if (result.state.lastProject) setStore("lastProject", targetScope, result.state.lastProject)
             })
             .catch(() => undefined)
         },

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -1,9 +1,10 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
-import { type Accessor, batch, createMemo } from "solid-js"
+import { type Accessor, batch, createEffect, createMemo, on } from "solid-js"
 import { createStore, type SetStoreFunction, type Store } from "solid-js/store"
 import { Persist, persisted } from "@/utils/persist"
 import { pathKey } from "@/utils/path-key"
 import { ServerScope } from "@/utils/server-scope"
+import { createSdkForServer } from "@/utils/server"
 
 type StoredProject = { worktree: string; expanded: boolean }
 type StoredServer = string | ServerConnection.HttpBase | ServerConnection.Http
@@ -80,16 +81,20 @@ export function createServerProjects<T extends ServerProjectState>(input: {
   scope: Accessor<ServerScope>
   store: Store<T>
   setStore: SetStoreFunction<T>
+  onChange?: (scope: ServerScope, state: { projects: StoredProject[]; lastProject?: string }) => void
 }) {
   const setStore = input.setStore as unknown as SetStoreFunction<ServerProjectState>
   const current = () => input.store.projects[input.scope()] ?? []
   const currentClosed = () => input.store.recentlyClosed?.[input.scope()] ?? []
+  const changed = () =>
+    input.onChange?.(input.scope(), { projects: current(), lastProject: input.store.lastProject[input.scope()] })
   const remove = (directory: string) => {
     setStore(
       "projects",
       input.scope(),
       current().filter((project) => project.worktree !== directory),
     )
+    changed()
   }
   return {
     list: current,
@@ -108,6 +113,7 @@ export function createServerProjects<T extends ServerProjectState>(input: {
       }
       if (current().some((project) => project.worktree === directory)) return
       setStore("projects", scope, [{ worktree: directory, expanded: true }, ...current()])
+      changed()
     },
     // User-initiated close: removes the project and records it in recently closed.
     // Internal, non-user removals (e.g. sandbox/worktree normalization) should use remove().
@@ -122,11 +128,15 @@ export function createServerProjects<T extends ServerProjectState>(input: {
     },
     expand(directory: string) {
       const index = current().findIndex((project) => project.worktree === directory)
-      if (index !== -1) setStore("projects", input.scope(), index, "expanded", true)
+      if (index === -1) return
+      setStore("projects", input.scope(), index, "expanded", true)
+      changed()
     },
     collapse(directory: string) {
       const index = current().findIndex((project) => project.worktree === directory)
-      if (index !== -1) setStore("projects", input.scope(), index, "expanded", false)
+      if (index === -1) return
+      setStore("projects", input.scope(), index, "expanded", false)
+      changed()
     },
     move(directory: string, toIndex: number) {
       const fromIndex = current().findIndex((project) => project.worktree === directory)
@@ -135,12 +145,14 @@ export function createServerProjects<T extends ServerProjectState>(input: {
       const [item] = next.splice(fromIndex, 1)
       next.splice(toIndex, 0, item)
       setStore("projects", input.scope(), next)
+      changed()
     },
     last() {
       return input.store.lastProject[input.scope()]
     },
     touch(directory: string) {
       setStore("lastProject", input.scope(), directory)
+      changed()
     },
   }
 }
@@ -252,6 +264,16 @@ export function nextServerAfterRemoval(
   return next ? ServerConnection.key(next) : fallback
 }
 
+function sidebarProjectPersistence(input: { conn: ServerConnection.Any | undefined; scope: ServerScope }) {
+  if (!input.conn || input.conn.type !== "http") return
+  const client = createSdkForServer({ server: input.conn.http, throwOnError: true }).project
+  return {
+    load: () => client.sidebar().then((response) => response.data),
+    save: (state: { projects: StoredProject[]; lastProject?: string }) =>
+      client.updateSidebar({ projectSidebarState: state }).catch(() => undefined),
+  }
+}
+
 export const { use: useServer, provider: ServerProvider } = createSimpleContext({
   name: "Server",
   gate: true,
@@ -318,12 +340,17 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
     )
 
     const scope = (key = state.active) => ServerScope.fromServerKey(key, props.canonicalLocalServer)
-    const projects = createServerProjects({ scope, store, setStore })
+    const saveSidebar = (targetScope: ServerScope, state: { projects: StoredProject[]; lastProject?: string }) => {
+      const conn = allServers().find((server) => scope(ServerConnection.key(server)) === targetScope)
+      return sidebarProjectPersistence({ conn, scope: targetScope })?.save(state)
+    }
+
+    const projects = createServerProjects({ scope, store, setStore, onChange: saveSidebar })
     const projectStores = new Map<ServerConnection.Key, ReturnType<typeof createServerProjects>>()
     const projectsForServer = (key: ServerConnection.Key) => {
       const existing = projectStores.get(key)
       if (existing) return existing
-      const next = createServerProjects({ scope: () => scope(key), store, setStore })
+      const next = createServerProjects({ scope: () => scope(key), store, setStore, onChange: saveSidebar })
       projectStores.set(key, next)
       return next
     }
@@ -331,6 +358,27 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
       () => allServers().find((s) => ServerConnection.key(s) === state.active) ?? allServers()[0],
     )
     const isLocal = createMemo(() => ServerConnection.local(current()))
+    createEffect(
+      on(
+        () => current(),
+        (conn) => {
+          if (!conn) return
+          const persistence = sidebarProjectPersistence({ conn, scope: scope(ServerConnection.key(conn)) })
+          if (!persistence) return
+          const key = ServerConnection.key(conn)
+          persistence
+            .load()
+            .then((state) => {
+              if (!state) return
+              if (ServerConnection.key(current() ?? conn) !== key) return
+              setStore("projects", scope(key), state.projects)
+              if (state.lastProject) setStore("lastProject", scope(key), state.lastProject)
+            })
+            .catch(() => undefined)
+        },
+        { defer: false },
+      ),
+    )
 
     return {
       ready: isReady,

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
@@ -14,6 +14,14 @@ const UpdatePayload = Schema.Struct({
   icon: Schema.optional(Project.Info.fields.icon),
   commands: Schema.optional(Project.Info.fields.commands),
 })
+const SidebarProject = Schema.Struct({
+  worktree: Schema.String,
+  expanded: Schema.Boolean,
+}).annotate({ identifier: "ProjectSidebarProject" })
+export const SidebarState = Schema.Struct({
+  projects: Schema.Array(SidebarProject),
+  lastProject: Schema.optional(Schema.String),
+}).annotate({ identifier: "ProjectSidebarState" })
 
 export const ProjectApi = HttpApi.make("project")
   .add(
@@ -37,6 +45,28 @@ export const ProjectApi = HttpApi.make("project")
             identifier: "project.current",
             summary: "Get current project",
             description: "Retrieve the currently active project that OpenCode is working with.",
+          }),
+        ),
+
+        HttpApiEndpoint.get("sidebar", `${root}/sidebar`, {
+          query: WorkspaceRoutingQuery,
+          success: described(SidebarState, "Persisted web sidebar project state"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "project.sidebar",
+            summary: "Get web sidebar projects",
+            description: "Get the server-persisted web sidebar project list for this OpenCode server.",
+          }),
+        ),
+        HttpApiEndpoint.put("updateSidebar", `${root}/sidebar`, {
+          query: WorkspaceRoutingQuery,
+          payload: SidebarState,
+          success: described(SidebarState, "Persisted web sidebar project state"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "project.updateSidebar",
+            summary: "Update web sidebar projects",
+            description: "Persist the web sidebar project list on the OpenCode server so it is shared across browsers.",
           }),
         ),
         HttpApiEndpoint.post("initGit", `${root}/git/init`, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
@@ -1,16 +1,21 @@
 import * as InstanceState from "@/effect/instance-state"
 import { Project } from "@/project/project"
 import { ProjectV2 } from "@opencode-ai/core/project"
-import { Effect } from "effect"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Global } from "@opencode-ai/core/global"
+import path from "path"
+import { Effect, Schema } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { ProjectNotFoundError } from "../errors"
 import { markInstanceForReload } from "../lifecycle"
+import { SidebarState } from "../groups/project"
 
 export const projectHandlers = HttpApiBuilder.group(InstanceHttpApi, "project", (handlers) =>
   Effect.gen(function* () {
     const svc = yield* Project.Service
     const project = yield* ProjectV2.Service
+    const fs = yield* FSUtil.Service
 
     const list = Effect.fn("ProjectHttpApi.list")(function* () {
       return yield* svc.list()
@@ -18,6 +23,23 @@ export const projectHandlers = HttpApiBuilder.group(InstanceHttpApi, "project", 
 
     const current = Effect.fn("ProjectHttpApi.current")(function* () {
       return (yield* InstanceState.context).project
+    })
+
+    const sidebarFile = path.join(Global.Path.state, "web-projects.json")
+    const emptySidebar = { projects: [] }
+
+    const sidebar = Effect.fn("ProjectHttpApi.sidebar")(function* () {
+      return yield* fs.readJson(sidebarFile).pipe(
+        Effect.flatMap(Schema.decodeUnknownEffect(SidebarState)),
+        Effect.catch(() => Effect.succeed(emptySidebar)),
+      )
+    })
+
+    const updateSidebar = Effect.fn("ProjectHttpApi.updateSidebar")(function* (ctx: {
+      payload: typeof SidebarState.Type
+    }) {
+      yield* fs.writeWithDirs(sidebarFile, JSON.stringify(ctx.payload, null, 2)).pipe(Effect.orDie)
+      return ctx.payload
     })
 
     const initGit = Effect.fn("ProjectHttpApi.initGit")(function* () {
@@ -56,6 +78,8 @@ export const projectHandlers = HttpApiBuilder.group(InstanceHttpApi, "project", 
     return handlers
       .handle("list", list)
       .handle("current", current)
+      .handle("sidebar", sidebar)
+      .handle("updateSidebar", updateSidebar)
       .handle("initGit", initGit)
       .handle("update", update)
       .handle("directories", directories)

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -171,6 +171,34 @@ const scenarios: Scenario[] = [
     },
     "status",
   ),
+  http.protected.get("/project/sidebar", "project.sidebar").json(
+    200,
+    (body) => {
+      object(body)
+      array(body.projects)
+    },
+    "status",
+  ),
+  http.protected
+    .put("/project/sidebar", "project.updateSidebar")
+    .mutating()
+    .at((ctx) => ({
+      path: "/project/sidebar",
+      headers: ctx.headers(),
+      body: { projects: [{ worktree: ctx.directory, expanded: true }], lastProject: ctx.directory },
+    }))
+    .json(
+      200,
+      (body, ctx) => {
+        object(body)
+        array(body.projects)
+        const project = body.projects[0]
+        check(isRecord(project), "sidebar update should return a project object")
+        check(project.worktree === ctx.directory, "sidebar update should return persisted project")
+        check(body.lastProject === ctx.directory, "sidebar update should return persisted last project")
+      },
+      "status",
+    ),
   http.protected
     .patch("/project/{projectID}", "project.update")
     .mutating()

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -140,8 +140,13 @@ import type {
   ProjectInitGitResponses,
   ProjectListErrors,
   ProjectListResponses,
+  ProjectSidebarErrors,
+  ProjectSidebarResponses,
+  ProjectSidebarState,
   ProjectUpdateErrors,
   ProjectUpdateResponses,
+  ProjectUpdateSidebarErrors,
+  ProjectUpdateSidebarResponses,
   PromptInput,
   ProviderAuthErrors,
   ProviderAuthResponses,
@@ -2585,6 +2590,77 @@ export class Project extends HeyApiClient {
       url: "/project/current",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Get web sidebar projects
+   *
+   * Get the server-persisted web sidebar project list for this OpenCode server.
+   */
+  public sidebar<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<ProjectSidebarResponses, ProjectSidebarErrors, ThrowOnError>({
+      url: "/project/sidebar",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Update web sidebar projects
+   *
+   * Persist the web sidebar project list on the OpenCode server so it is shared across browsers.
+   */
+  public updateSidebar<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      projectSidebarState?: ProjectSidebarState
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { key: "projectSidebarState", map: "body" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).put<
+      ProjectUpdateSidebarResponses,
+      ProjectUpdateSidebarErrors,
+      ThrowOnError
+    >({
+      url: "/project/sidebar",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2428,6 +2428,16 @@ export type Project = {
   sandboxes: Array<string>
 }
 
+export type ProjectSidebarProject = {
+  worktree: string
+  expanded: boolean
+}
+
+export type ProjectSidebarState = {
+  projects: Array<ProjectSidebarProject>
+  lastProject?: string
+}
+
 export type ProjectNotFoundError = {
   _tag: "ProjectNotFoundError"
   projectID: string
@@ -8753,6 +8763,62 @@ export type ProjectCurrentResponses = {
 }
 
 export type ProjectCurrentResponse = ProjectCurrentResponses[keyof ProjectCurrentResponses]
+
+export type ProjectSidebarData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/sidebar"
+}
+
+export type ProjectSidebarErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ProjectSidebarError = ProjectSidebarErrors[keyof ProjectSidebarErrors]
+
+export type ProjectSidebarResponses = {
+  /**
+   * Persisted web sidebar project state
+   */
+  200: ProjectSidebarState
+}
+
+export type ProjectSidebarResponse = ProjectSidebarResponses[keyof ProjectSidebarResponses]
+
+export type ProjectUpdateSidebarData = {
+  body?: ProjectSidebarState
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/project/sidebar"
+}
+
+export type ProjectUpdateSidebarErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type ProjectUpdateSidebarError = ProjectUpdateSidebarErrors[keyof ProjectUpdateSidebarErrors]
+
+export type ProjectUpdateSidebarResponses = {
+  /**
+   * Persisted web sidebar project state
+   */
+  200: ProjectSidebarState
+}
+
+export type ProjectUpdateSidebarResponse = ProjectUpdateSidebarResponses[keyof ProjectUpdateSidebarResponses]
 
 export type ProjectInitGitData = {
   body?: never


### PR DESCRIPTION
### Issue for this PR

Closes #23934
Closes #28340

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Persists the Web project sidebar on the OpenCode server for HTTP-backed clients. Fresh browsers connected to the same server hydrate the same project list, ordering, expansion state, and last project instead of depending only on browser storage.

It adds project-sidebar GET/PUT routes, stores the state under the server state directory, hydrates and updates the Web client through the generated SDK, and covers the routes in the HTTP API exerciser.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/context/server.test.ts` in `packages/app`
- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/opencode`
- `bun run script/httpapi-exercise.ts --mode coverage --fail-on-missing --fail-on-skip`
- `bun run script/httpapi-exercise.ts --mode auth --fail-on-missing --fail-on-skip`
- `bun run script/httpapi-exercise.ts --mode effect --fail-on-missing --fail-on-skip`
- `./packages/sdk/js/script/build.ts`
- `bun run build` in `packages/app`
- `./packages/opencode/script/build.ts --single`
- Pre-push hook: `bun turbo typecheck`
- Manual fresh-browser verification against one server through a different origin: projects and existing sessions appeared and opened successfully

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
