### PR TITLE
fix(snapshot): preserve subdirectory path handling

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -120,7 +120,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               "-z",
             ],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -136,7 +136,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
             ],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -147,7 +147,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           const result = yield* git(
             [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
             {
-              cwd: state.directory,
+              cwd: state.worktree,
               stdin: feed(files),
             },
           )
@@ -238,7 +238,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               git([...quote, ...args(["diff-files", "--name-only", "-z", "--", "."])], {
                 cwd: state.directory,
               }),
-              git([...quote, ...args(["ls-files", "--others", "--exclude-standard", "-z", "--", "."])], {
+              git([...quote, ...args(["ls-files", "--full-name", "--others", "--exclude-standard", "-z", "--", "."])], {
                 cwd: state.directory,
               }),
             ],
@@ -277,7 +277,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             (yield* Effect.all(
               allow.map((item) =>
                 fs
-                  .stat(path.join(state.directory, item))
+                  .stat(path.join(state.worktree, item))
                   .pipe(Effect.catch(() => Effect.void))
                   .pipe(
                     Effect.map((stat) => {

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -448,6 +448,47 @@ it.live(
   }),
 )
 
+it.live(
+  "tracks scoped changes when instance directory is a git subdirectory",
+  Effect.gen(function* () {
+    const dir = yield* scopedGitTmpdir()
+    const subdir = path.join(dir, "src")
+    yield* mkdirp(subdir)
+    yield* write(`${dir}/root.txt`, "root initial")
+    yield* write(`${subdir}/date.txt`, "subdir initial")
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${dir}/root.txt`, "root changed")
+      yield* write(`${subdir}/date.txt`, "subdir changed")
+      const patch = yield* snapshot.patch(before!)
+      expect(patch.files).toContain(fwd(dir, "src", "date.txt"))
+      expect(patch.files).not.toContain(fwd(dir, "root.txt"))
+    }).pipe(provideInstance(subdir))
+  }),
+)
+
+it.live(
+  "subdirectory snapshots respect worktree-root ignore rules",
+  Effect.gen(function* () {
+    const dir = yield* scopedGitTmpdir()
+    const subdir = path.join(dir, "src")
+    yield* mkdirp(subdir)
+    yield* write(`${dir}/.gitignore`, "src/ignored.txt\n")
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${subdir}/ignored.txt`, "ignored")
+      yield* write(`${subdir}/visible.txt`, "visible")
+      const patch = yield* snapshot.patch(before!)
+      expect(patch.files).toContain(fwd(dir, "src", "visible.txt"))
+      expect(patch.files).not.toContain(fwd(dir, "src", "ignored.txt"))
+    }).pipe(provideInstance(subdir))
+  }),
+)
+
 it.instance(
   "gitignore changes",
   withTrackedSnapshot(({ tmp, snapshot, before }) =>


### PR DESCRIPTION
### Issue for this PR

Closes #27688

Related: #32935. This PR keeps the snapshot file listing scoped to the launch directory while fixing the pathspec consumers, instead of moving the listing commands to the worktree root.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When opencode is launched from a git subdirectory, snapshot candidate paths can be consumed from the wrong cwd. For tracked files, git can report worktree-relative paths such as `src/date.txt`; feeding those pathspecs to `git add` from `repo/src` makes git look for `repo/src/src/date.txt` and snapshot tracking fails.

This fixes the path handling without broadening snapshot scope:

- keeps `diff-files` and `ls-files --others` scoped to `state.directory`, so a `repo/src` instance does not snapshot unrelated `repo/root.txt` changes
- adds `--full-name` to `ls-files --others` so untracked files are also worktree-relative
- runs `ignore`, `drop`, and `stage` from `state.worktree`, where those pathspecs resolve correctly
- checks large-file size using `state.worktree` because the candidate paths are worktree-relative

The extra `--full-name` matters because from a subdirectory, `git diff-files --name-only -- .` can return `src/date.txt`, while `git ls-files --others -- .` can return `date.txt` unless full-name output is requested.

### How did you verify your code works?

From `packages/opencode`:

- `bun test test/snapshot/snapshot.test.ts`
- `bun test test/session/revert-compact.test.ts`
- `bun test test/session/snapshot-tool-race.test.ts`
- `bun run typecheck`

From the repo root / during push:

- `git diff --check`
- `PATH=/tmp/opencode-bun-1.3.14:$PATH git push -u fork snapshot-subdir` ran the pre-push hook successfully, including root `bun turbo typecheck`

Manual checks:

- reproduced the original `src/src` / `pathspec` failure before the fix
- confirmed the committed-file repro no longer logs the snapshot pathspec warning
- confirmed an untracked file created under `repo/src` is reported correctly after adding `--full-name`

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR