### PR TITLE
fix(opencode): strip all leading BOMs in Bom.split

### DIFF
--- a/packages/opencode/src/util/bom.ts
+++ b/packages/opencode/src/util/bom.ts
@@ -5,8 +5,8 @@ const BOM_CODE = 0xfeff
 const BOM = String.fromCharCode(BOM_CODE)
 
 export function split(text: string) {
-  if (text.charCodeAt(0) !== BOM_CODE) return { bom: false, text }
-  return { bom: true, text: text.slice(1) }
+  const stripped = text.replace(/^\uFEFF+/, "")
+  return { bom: stripped.length !== text.length, text: stripped }
 }
 
 export function join(text: string, bom: boolean) {

--- a/packages/opencode/test/util/bom.test.ts
+++ b/packages/opencode/test/util/bom.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import * as Bom from "../../src/util/bom"
+
+const BOM = "\uFEFF"
+
+describe("Bom.split", () => {
+  test("returns text unchanged when there is no BOM", () => {
+    expect(Bom.split("hello")).toEqual({ bom: false, text: "hello" })
+  })
+
+  test("strips a single leading BOM", () => {
+    expect(Bom.split(BOM + "hello")).toEqual({ bom: true, text: "hello" })
+  })
+
+  test("strips all consecutive leading BOMs", () => {
+    expect(Bom.split(BOM.repeat(4) + "hello")).toEqual({ bom: true, text: "hello" })
+  })
+
+  test("does not strip a BOM that is not at the start", () => {
+    expect(Bom.split("hello" + BOM)).toEqual({ bom: false, text: "hello" + BOM })
+  })
+
+  test("handles an empty string", () => {
+    expect(Bom.split("")).toEqual({ bom: false, text: "" })
+  })
+})
+
+describe("Bom.join", () => {
+  test("adds a BOM when requested", () => {
+    expect(Bom.join("hello", true)).toBe(BOM + "hello")
+  })
+
+  test("omits the BOM when not requested", () => {
+    expect(Bom.join("hello", false)).toBe("hello")
+  })
+
+  test("normalizes multiple existing leading BOMs to exactly one", () => {
+    expect(Bom.join(BOM.repeat(4) + "hello", true)).toBe(BOM + "hello")
+  })
+
+  test("strips all existing leading BOMs when none is requested", () => {
+    expect(Bom.join(BOM.repeat(3) + "hello", false)).toBe("hello")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33092

_#33092 was closed as not-planned — a moderation call about the reporter's activity, not a rejection of this bug. The change here is an independent correctness fix: `Bom.split()` strips only the first BOM, while the sibling `splitBom()` in `packages/core/src/file-mutation.ts` already strips all leading BOMs, so this just brings the two in line. Keeping the PR open on its own merit; happy to close if maintainers would rather not take it._

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Bom.split()` stripped only the first `U+FEFF` via `text.slice(1)`, so content with several consecutive leading BOMs kept the extras. Because `join()` calls `split()` before re-adding a single BOM, each write/edit cycle removed at most one extra BOM — so content with N leading BOMs needed multiple edit passes to normalize down to one.

The fix mirrors `splitBom()` already in `packages/core/src/file-mutation.ts`: replace `slice(1)` with `text.replace(/^\uFEFF+/, "")` so all leading BOMs are stripped in a single pass, and derive the `bom` flag from whether anything was stripped. `join()` is unchanged — it already calls `split()` first, so multi-BOM content now normalizes to exactly one (or zero) BOM in one pass, and the `write` / `edit` / `apply_patch` callers are fixed transitively.

### How did you verify your code works?

Added `packages/opencode/test/util/bom.test.ts` (this util had no tests) covering no-BOM, single, multiple consecutive, and non-leading BOMs, plus `join()` normalization — `bun test test/util/bom.test.ts` → 9 pass / 0 fail. `bun turbo typecheck --filter=opencode` and `oxlint` are both clean.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
