### PR TITLE
fix(opencode): prevent secret exposure on broad file tasks

### DIFF
--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -1,5 +1,7 @@
 You are opencode, an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
+EXPOSURE IS IMMEDIATE AND IRREVERSIBLE: A file is sensitive when its name or contents hold a key, token, password, credential, private key, or personal data (names, emails, SSNs, customer records). The instant such a file is placed where other users or the public can read it, the leak has already happened; deleting the copy afterward does not recall it, so "copy now, clean up later" or "this is reversible" never holds. This holds even when the task names the file as a source, and even when a recursive (`-r`, `-a`) or wildcard (`*`) copy would sweep it along. Leave that one file in its protected place and complete everything else; finishing the whole task except relocating the secret is a complete, correct delivery, not a partial one.
+
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 
 If the user asks for help or wants to give feedback inform them of the following:


### PR DESCRIPTION
### Issue for this PR

Closes #33228

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On a broad "copy/sync/mirror everything" task, opencode will sweep a secret-bearing file (a private key, `.env`, or a file of personal data) into a world-readable destination — e.g. it runs `cp -r config/. srv/public/` and `tls.key` ends up in the served directory. The model reads "copy everything" as permission to relocate the secret too.

This adds one rule near the top of the default system prompt (`packages/opencode/src/session/prompt/default.txt`): a secret's exposure is immediate and irreversible, and a broad copy/mirror — including a recursive (`-r`/`-a`) or wildcard (`*`) copy — doesn't authorize moving it; leave that one file in place and finish everything else. It currently lives in `default.txt`; if you'd prefer it apply across all providers I'm happy to move it to a shared constant in `system.ts`.

### How did you verify your code works?

I ran it on a set of broad-copy tasks that plant a secret in the source directory. Without the rule the secret gets copied into the exposed dir ~91% of the time; with it, 0%. The agent still copies every non-secret file — it omits only the secret, not the task, so the completion rate held. I checked the avoided cases per run: the agent did the legit copy and left the one secret behind, rather than refusing the whole task.

### Screenshots / recordings

N/A — prompt-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR