### PR TITLE
docs: fix outdated TUI source path in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Replace `<platform>` with your platform (e.g., `darwin-arm64`, `linux-x64`).
 
 - Core pieces:
   - `packages/opencode`: OpenCode core business logic & server.
-  - `packages/opencode/src/cli/cmd/tui/`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)
+  - `packages/tui`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)
   - `packages/app`: The shared web UI components, written in SolidJS
   - `packages/desktop`: The native desktop app, built with Electron (wraps `packages/app`)
   - `packages/plugin`: Source for `@opencode-ai/plugin`


### PR DESCRIPTION
### Issue for this PR

Closes #33230

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

CONTRIBUTING.md (Developing OpenCode → "Core pieces") lists the TUI code at `packages/opencode/src/cli/cmd/tui/`, but that directory doesn't exist. The actual SolidJS/opentui TUI is the `@opencode-ai/tui` package in `packages/tui`; `packages/opencode/src/cli/cmd/tui.ts` is only the command launcher. This one-line change points new contributors to the right place — the wrong path tripped me up while setting the project up.

### How did you verify your code works?

- `packages/opencode/src/cli/cmd/tui` does not exist on `dev`.
- `packages/tui/package.json` is `@opencode-ai/tui` (SolidJS, depends on `@opentui/*`), confirming that is where the TUI code lives.
- Documentation-only change; no code paths are affected.

### Screenshots / recordings

N/A — documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
