### PR TITLE
fix(core): clear share_url on unshare in session projector (#32912)

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -55,7 +55,7 @@ function sessionRow(info: SessionV1.SessionInfo): typeof SessionTable.$inferInse
     agent: info.agent,
     model: info.model,
     version: info.version,
-    share_url: info.share?.url,
+    share_url: info.share?.url ?? null,
     summary_additions: info.summary?.additions,
     summary_deletions: info.summary?.deletions,
     summary_files: info.summary?.files,

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -246,3 +246,27 @@ describe("Session", () => {
     }),
   )
 })
+
+describe("session.setShare", () => {
+  it.instance("clears the share url on unshare and keeps it cleared after later patches", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const created = yield* Effect.acquireRelease(session.create({ title: "shared" }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+
+      yield* session.setShare({ sessionID: created.id, share: { url: "https://opencode.ai/s/abc123" } })
+      const shared = yield* session.get(created.id)
+      expect(shared.share?.url).toBe("https://opencode.ai/s/abc123")
+
+      yield* session.setShare({ sessionID: created.id, share: undefined })
+      const unshared = yield* session.get(created.id)
+      expect(unshared.share).toBeUndefined()
+
+      // a later unrelated patch must not bring back a stale share url from the persisted row
+      yield* session.setTitle({ sessionID: created.id, title: "after unshare" })
+      const afterPatch = yield* session.get(created.id)
+      expect(afterPatch.share).toBeUndefined()
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #32912

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After `/unshare`, the share link reappears in the TUI. The root cause is in the session projector, not the TUI: `sessionRow()` in `packages/core/src/session/projector.ts` builds `share_url: info.share?.url`, which is `undefined` once a session is unshared. Drizzle **skips `undefined` fields on UPDATE**, so the `share_url` column keeps its old value. `Session.get()` reads it straight back from the DB, and the next `patch()` (from `touch` / `setTitle` / `setSummary`) reloads `current.share` from that stale row and re-publishes a `session.updated` event carrying the old URL — so the link comes back in the UI.

The fix coalesces to `null` (`share_url: info.share?.url ?? null`), matching the sibling `revert: info.revert ?? null` a few lines below, so the UPDATE emits `SET share_url = NULL` and the share is cleared from the row. The TUI command and the server unshare handler were already correct.

### How did you verify your code works?

Added a `Session.setShare` regression test in `packages/opencode/test/session/session.test.ts`: share → unshare → an unrelated later patch (`setTitle`), asserting `get().share` stays `undefined`. It fails before the fix (the persisted row still holds the stale `share_url`, so the get immediately after unshare returns it) and passes after. The full `session.test.ts` suite is green (8 pass), and `bun turbo typecheck` for `@opencode-ai/core` + `opencode` and `oxlint` on the changed files are clean.

### Screenshots / recordings

N/A — internal state/persistence fix; the only visible effect is the share link correctly disappearing after `/unshare`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
