### PR TITLE
fix(tui): hide read tool arguments

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2164,7 +2164,7 @@ function Read(props: ToolProps) {
         spinner={isRunning()}
         part={props.part}
       >
-        Read {pathFormatter.format(stringValue(props.input.filePath))} {input(props.input, ["filePath"])}
+        Read {pathFormatter.format(stringValue(props.input.filePath))}
       </InlineTool>
       <For each={loaded()}>
         {(filepath) => (


### PR DESCRIPTION
## Summary
- show only the formatted file path for Read tool calls
- omit supplementary inputs such as offset and limit

## Testing
- `bun typecheck` in `packages/tui`
- repository pre-push typecheck (23 packages)