### PR TITLE
Add opencode-rtl to ecosystem plugin list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -37,6 +37,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                       |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events                |
+| [opencode-rtl](https://github.com/razavioo/opencode-rtl)                                          | Automatic RTL text detection, bidi isolation, and alignment for Persian/Arabic/Hebrew workflows    |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |


### PR DESCRIPTION
Adds [opencode-rtl](https://github.com/razavioo/opencode-rtl) to the Plugins table in the ecosystem page — an npm plugin for automatic RTL text detection, bidi isolation, and alignment for Persian/Arabic/Hebrew workflows.