### PR TITLE
fix(core): handle missing read paths

### DIFF
--- a/packages/core/src/tool/read.ts
+++ b/packages/core/src/tool/read.ts
@@ -57,8 +57,8 @@ export const layer = Layer.effectDiscard(
               const selected = path.isAbsolute(input.path) ? path.dirname(absolute) : location.directory
               if (!path.isAbsolute(input.path) && !FSUtil.contains(location.directory, absolute))
                 return yield* Effect.die(new Error("Path escapes the allowed read root"))
-              const real = yield* fs.realPath(absolute).pipe(Effect.orDie)
-              const root = yield* fs.realPath(selected).pipe(Effect.orDie)
+              const real = yield* fs.realPath(absolute)
+              const root = yield* fs.realPath(selected)
               if (!FSUtil.contains(root, real))
                 return yield* Effect.die(new Error("Path escapes the allowed read root"))
               const resource = path.relative(root, real).replaceAll("\\", "/") || "."

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -18,6 +18,7 @@ import { testEffect } from "./lib/effect"
 import { toolIdentity, executeTool, settleTool, toolDefinitions } from "./lib/tool"
 
 const assertions: PermissionV2.AssertInput[] = []
+const missingPath = "__missing_read_target__.txt"
 const readCalls: {
   input: AbsolutePath
   page: ReadToolFileSystem.PageInput
@@ -70,7 +71,14 @@ const config = Layer.succeed(Config.Service, Config.Service.of({ entries: () => 
 const image = Image.layer.pipe(Layer.provide(config))
 const testFileSystem = Layer.effect(
   FSUtil.Service,
-  FSUtil.Service.use((fs) => Effect.succeed(FSUtil.Service.of({ ...fs, realPath: (path) => Effect.succeed(path) }))),
+  FSUtil.Service.use((fs) =>
+    Effect.succeed(
+      FSUtil.Service.of({
+        ...fs,
+        realPath: (path) => (path.endsWith(missingPath) ? fs.realPath(path) : Effect.succeed(path)),
+      }),
+    ),
+  ),
 ).pipe(Layer.provide(FSUtil.defaultLayer))
 const infrastructure = Layer.mergeAll(
   testFileSystem,
@@ -449,6 +457,22 @@ describe("ReadTool", () => {
           call: { type: "tool-call", id: "call-read", name: "read", input: { path: "README.md" } },
         }),
       ).toEqual({ type: "error", value: "Unable to read README.md" })
+      expect(readCalls).toEqual([])
+    }),
+  )
+
+  it.effect("returns missing paths as model-visible tool failures", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+
+      expect(
+        yield* executeTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: { type: "tool-call", id: "call-missing-path", name: "read", input: { path: missingPath } },
+        }),
+      ).toEqual({ type: "error", value: `Unable to read ${missingPath}` })
+      expect(assertions).toEqual([])
       expect(readCalls).toEqual([])
     }),
   )

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect } from "bun:test"
-import { Effect, Exit, Layer } from "effect"
+import { Effect, Exit, Layer, PlatformError } from "effect"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigAttachments } from "@opencode-ai/core/config/attachments"
 import { FileSystem } from "@opencode-ai/core/filesystem"
@@ -19,6 +19,7 @@ import { toolIdentity, executeTool, settleTool, toolDefinitions } from "./lib/to
 
 const assertions: PermissionV2.AssertInput[] = []
 const missingPath = "__missing_read_target__.txt"
+const missingAbsolutePath = `${process.cwd()}/${missingPath}`
 const readCalls: {
   input: AbsolutePath
   page: ReadToolFileSystem.PageInput
@@ -75,7 +76,17 @@ const testFileSystem = Layer.effect(
     Effect.succeed(
       FSUtil.Service.of({
         ...fs,
-        realPath: (path) => (path.endsWith(missingPath) ? fs.realPath(path) : Effect.succeed(path)),
+        realPath: (path) =>
+          path === missingAbsolutePath
+            ? Effect.fail(
+                PlatformError.systemError({
+                  _tag: "NotFound",
+                  module: "FileSystem",
+                  method: "realPath",
+                  pathOrDescriptor: path,
+                }),
+              )
+            : Effect.succeed(path),
       }),
     ),
   ),


### PR DESCRIPTION
## Summary

- keep `realPath` failures in the read tool error channel
- return missing paths as model-visible tool failures instead of terminating the session drain
- verify missing targets do not reach permission checks or file inspection

## Test plan

- `bun run test test/tool-read.test.ts` from `packages/core` (17 passed)
- `bun typecheck` from `packages/core`
- pre-push `bun turbo typecheck` (23 packages passed)

## Additional validation

The full Core suite was attempted, but the run encountered an unrelated shared-test database failure (`SQLiteError: table session_context_epoch already exists`) across 308 tests. The focused test and all typechecks pass.