### PR TITLE
fix(tui): improve worker rpc errors handling

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -13,6 +13,8 @@ import type { EventSource } from "@opencode-ai/tui/context/sdk"
 import { writeHeapSnapshot } from "v8"
 import { validateSession } from "../tui/validate-session"
 import { win32InstallCtrlCGuard } from "@opencode-ai/tui/terminal-win32"
+import { Global } from "@opencode-ai/core/global"
+import { appendFileSync } from "fs"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -22,6 +24,15 @@ type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
 
 type WorkerFile = string | URL
 type WorkerManager = ReturnType<typeof createWorkerManager>
+
+function workerDebug(event: string, data: Record<string, unknown> = {}) {
+  try {
+    appendFileSync(
+      path.join(Global.Path.log, "tui-worker-debug.log"),
+      JSON.stringify({ time: new Date().toISOString(), pid: process.pid, event, ...data }) + "\n",
+    )
+  } catch {}
+}
 
 function createWorkerFetch(worker: WorkerManager): typeof fetch {
   const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -54,9 +65,12 @@ function createEventSource(worker: WorkerManager): EventSource {
 function createWorkerManager(file: WorkerFile) {
   const listeners = new Map<string, Set<(data: unknown) => void>>()
   let stopped = false
+  let generation = 0
   let state = start()
 
   function start() {
+    generation += 1
+    workerDebug("start", { generation, file: String(file) })
     const worker = new Worker(file)
     const client = Rpc.client<typeof rpc>(worker)
     let workerError: string | undefined
@@ -64,6 +78,7 @@ function createWorkerManager(file: WorkerFile) {
       const error = "error" in event ? event.error : undefined
       const message = "message" in event && typeof event.message === "string" ? event.message : undefined
       workerError = error instanceof Error ? error.message : (message ?? "worker error")
+      workerDebug("error", { generation, error: workerError })
     })
     for (const [event, handlers] of listeners) {
       for (const handler of handlers) client.on(event, handler)
@@ -73,6 +88,7 @@ function createWorkerManager(file: WorkerFile) {
 
   function restart(error: unknown) {
     if (stopped) throw error
+    workerDebug("restart", { generation, error: errorMessage(error) })
     const previous = state
     state = start()
     previous.worker.terminate()
@@ -83,15 +99,23 @@ function createWorkerManager(file: WorkerFile) {
       method: Method,
       input: Parameters<(typeof rpc)[Method]>[0],
     ): Promise<ReturnType<(typeof rpc)[Method]>> {
+      workerDebug("call", { generation, method: String(method) })
       return state.client.call(method, input).catch((error) => {
         const detail = state.error()
         if (!isWorkerTerminated(error)) {
+          workerDebug("call_failed", { generation, method: String(method), error: errorMessage(error), detail })
           if (detail) throw new Error(`TUI worker failed: ${detail}`)
           throw error
         }
         restart(error)
         return state.client.call(method, input).catch((retryError) => {
           const nextDetail = state.error()
+          workerDebug("retry_failed", {
+            generation,
+            method: String(method),
+            error: errorMessage(retryError),
+            detail: nextDetail,
+          })
           if (nextDetail) throw new Error(`TUI worker failed: ${nextDetail}`)
           throw retryError
         })
@@ -115,6 +139,7 @@ function createWorkerManager(file: WorkerFile) {
     async stop() {
       if (stopped) return
       stopped = true
+      workerDebug("stop", { generation })
       await withTimeout(state.client.call("shutdown", undefined), 5000).catch(() => {})
       state.worker.terminate()
     },

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -135,12 +135,9 @@ export const TuiThreadCommand = cmd({
       const worker = new Worker(file)
       let workerError: string | undefined
       worker.addEventListener("error", (event) => {
-        workerError =
-          event instanceof ErrorEvent && event.error instanceof Error
-            ? event.error.message
-            : event instanceof ErrorEvent
-              ? event.message
-              : "worker error"
+        const error = "error" in event ? event.error : undefined
+        const message = "message" in event && typeof event.message === "string" ? event.message : undefined
+        workerError = error instanceof Error ? error.message : (message ?? "worker error")
       })
       const client = Rpc.client<typeof rpc>(worker)
       const reload = () => {

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -18,8 +18,6 @@ declare global {
   const OPENCODE_WORKER_PATH: string
 }
 
-type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
-
 type WorkerFile = string | URL
 type WorkerManager = ReturnType<typeof createWorkerManager>
 

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -20,22 +20,19 @@ declare global {
 
 type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
 
-function createWorkerFetch(client: RpcClient, workerError: () => string | undefined): typeof fetch {
+type WorkerFile = string | URL
+type WorkerManager = ReturnType<typeof createWorkerManager>
+
+function createWorkerFetch(worker: WorkerManager): typeof fetch {
   const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const request = new Request(input, init)
     const body = request.body ? await request.text() : undefined
-    const result = await client
-      .call("fetch", {
-        url: request.url,
-        method: request.method,
-        headers: Object.fromEntries(request.headers.entries()),
-        body,
-      })
-      .catch((error) => {
-        const detail = workerError()
-        if (detail) throw new Error(`TUI worker failed: ${detail}`)
-        throw error
-      })
+    const result = await worker.call("fetch", {
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      body,
+    })
     return new Response(result.body, {
       status: result.status,
       headers: result.headers,
@@ -44,14 +41,88 @@ function createWorkerFetch(client: RpcClient, workerError: () => string | undefi
   return fn as typeof fetch
 }
 
-function createEventSource(client: RpcClient): EventSource {
+function createEventSource(worker: WorkerManager): EventSource {
   return {
     subscribe: async (handler) => {
-      return client.on<GlobalEvent>("global.event", (e) => {
+      return worker.on<GlobalEvent>("global.event", (e) => {
         handler(e)
       })
     },
   }
+}
+
+function createWorkerManager(file: WorkerFile) {
+  const listeners = new Map<string, Set<(data: unknown) => void>>()
+  let stopped = false
+  let state = start()
+
+  function start() {
+    const worker = new Worker(file)
+    const client = Rpc.client<typeof rpc>(worker)
+    let workerError: string | undefined
+    worker.addEventListener("error", (event) => {
+      const error = "error" in event ? event.error : undefined
+      const message = "message" in event && typeof event.message === "string" ? event.message : undefined
+      workerError = error instanceof Error ? error.message : (message ?? "worker error")
+    })
+    for (const [event, handlers] of listeners) {
+      for (const handler of handlers) client.on(event, handler)
+    }
+    return { worker, client, error: () => workerError }
+  }
+
+  function restart(error: unknown) {
+    if (stopped) throw error
+    const previous = state
+    state = start()
+    previous.worker.terminate()
+  }
+
+  return {
+    call<Method extends keyof typeof rpc>(
+      method: Method,
+      input: Parameters<(typeof rpc)[Method]>[0],
+    ): Promise<ReturnType<(typeof rpc)[Method]>> {
+      return state.client.call(method, input).catch((error) => {
+        const detail = state.error()
+        if (!isWorkerTerminated(error)) {
+          if (detail) throw new Error(`TUI worker failed: ${detail}`)
+          throw error
+        }
+        restart(error)
+        return state.client.call(method, input).catch((retryError) => {
+          const nextDetail = state.error()
+          if (nextDetail) throw new Error(`TUI worker failed: ${nextDetail}`)
+          throw retryError
+        })
+      })
+    },
+    on<Data>(event: string, handler: (data: Data) => void) {
+      let handlers = listeners.get(event)
+      if (!handlers) {
+        handlers = new Set()
+        listeners.set(event, handlers)
+      }
+      const wrapped = (data: unknown) => {
+        if (listeners.get(event)?.has(wrapped)) handler(data as Data)
+      }
+      handlers.add(wrapped)
+      state.client.on(event, wrapped)
+      return () => {
+        handlers!.delete(wrapped)
+      }
+    },
+    async stop() {
+      if (stopped) return
+      stopped = true
+      await withTimeout(state.client.call("shutdown", undefined), 5000).catch(() => {})
+      state.worker.terminate()
+    },
+  }
+}
+
+function isWorkerTerminated(error: unknown) {
+  return error instanceof Error && error.message.includes("Worker has been terminated")
 }
 
 async function target() {
@@ -132,16 +203,9 @@ export const TuiThreadCommand = cmd({
       }
       const cwd = Filesystem.resolve(process.cwd())
 
-      const worker = new Worker(file)
-      let workerError: string | undefined
-      worker.addEventListener("error", (event) => {
-        const error = "error" in event ? event.error : undefined
-        const message = "message" in event && typeof event.message === "string" ? event.message : undefined
-        workerError = error instanceof Error ? error.message : (message ?? "worker error")
-      })
-      const client = Rpc.client<typeof rpc>(worker)
+      const worker = createWorkerManager(file)
       const reload = () => {
-        client.call("reload", undefined).catch(() => {})
+        worker.call("reload", undefined).catch(() => {})
       }
       process.on("SIGUSR2", reload)
 
@@ -150,8 +214,7 @@ export const TuiThreadCommand = cmd({
         if (stopped) return
         stopped = true
         process.off("SIGUSR2", reload)
-        await withTimeout(client.call("shutdown", undefined), 5000).catch(() => {})
-        worker.terminate()
+        await worker.stop()
       }
 
       const prompt = await input(args.prompt)
@@ -168,14 +231,14 @@ export const TuiThreadCommand = cmd({
 
       const transport = external
         ? {
-            url: (await client.call("server", network)).url,
+            url: (await worker.call("server", network)).url,
             fetch: undefined,
             events: undefined,
           }
         : {
             url: "http://opencode.internal",
-            fetch: createWorkerFetch(client, () => workerError),
-            events: createEventSource(client),
+            fetch: createWorkerFetch(worker),
+            events: createEventSource(worker),
           }
 
       try {
@@ -204,7 +267,7 @@ export const TuiThreadCommand = cmd({
             url: transport.url,
             async onSnapshot() {
               const tui = writeHeapSnapshot("tui.heapsnapshot")
-              const server = await client.call("snapshot", undefined)
+              const server = await worker.call("snapshot", undefined)
               return [tui, server]
             },
             config,

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -280,7 +280,7 @@ export const TuiThreadCommand = cmd({
       }
 
       setTimeout(() => {
-        client.call("checkUpgrade", { directory: cwd }).catch(() => {})
+        worker.call("checkUpgrade", { directory: cwd }).catch(() => {})
       }, 1000).unref?.()
 
       try {

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -20,16 +20,22 @@ declare global {
 
 type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
 
-function createWorkerFetch(client: RpcClient): typeof fetch {
+function createWorkerFetch(client: RpcClient, workerError: () => string | undefined): typeof fetch {
   const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const request = new Request(input, init)
     const body = request.body ? await request.text() : undefined
-    const result = await client.call("fetch", {
-      url: request.url,
-      method: request.method,
-      headers: Object.fromEntries(request.headers.entries()),
-      body,
-    })
+    const result = await client
+      .call("fetch", {
+        url: request.url,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        body,
+      })
+      .catch((error) => {
+        const detail = workerError()
+        if (detail) throw new Error(`TUI worker failed: ${detail}`)
+        throw error
+      })
     return new Response(result.body, {
       status: result.status,
       headers: result.headers,
@@ -127,6 +133,15 @@ export const TuiThreadCommand = cmd({
       const cwd = Filesystem.resolve(process.cwd())
 
       const worker = new Worker(file)
+      let workerError: string | undefined
+      worker.addEventListener("error", (event) => {
+        workerError =
+          event instanceof ErrorEvent && event.error instanceof Error
+            ? event.error.message
+            : event instanceof ErrorEvent
+              ? event.message
+              : "worker error"
+      })
       const client = Rpc.client<typeof rpc>(worker)
       const reload = () => {
         client.call("reload", undefined).catch(() => {})
@@ -162,7 +177,7 @@ export const TuiThreadCommand = cmd({
           }
         : {
             url: "http://opencode.internal",
-            fetch: createWorkerFetch(client),
+            fetch: createWorkerFetch(client, () => workerError),
             events: createEventSource(client),
           }
 

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -13,8 +13,6 @@ import type { EventSource } from "@opencode-ai/tui/context/sdk"
 import { writeHeapSnapshot } from "v8"
 import { validateSession } from "../tui/validate-session"
 import { win32InstallCtrlCGuard } from "@opencode-ai/tui/terminal-win32"
-import { Global } from "@opencode-ai/core/global"
-import { appendFileSync } from "fs"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -24,15 +22,6 @@ type RpcClient = ReturnType<typeof Rpc.client<typeof rpc>>
 
 type WorkerFile = string | URL
 type WorkerManager = ReturnType<typeof createWorkerManager>
-
-function workerDebug(event: string, data: Record<string, unknown> = {}) {
-  try {
-    appendFileSync(
-      path.join(Global.Path.log, "tui-worker-debug.log"),
-      JSON.stringify({ time: new Date().toISOString(), pid: process.pid, event, ...data }) + "\n",
-    )
-  } catch {}
-}
 
 function createWorkerFetch(worker: WorkerManager): typeof fetch {
   const fn = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
@@ -70,7 +59,6 @@ function createWorkerManager(file: WorkerFile) {
 
   function start() {
     generation += 1
-    workerDebug("start", { generation, file: String(file) })
     const worker = new Worker(file)
     const client = Rpc.client<typeof rpc>(worker)
     let workerError: string | undefined
@@ -78,7 +66,6 @@ function createWorkerManager(file: WorkerFile) {
       const error = "error" in event ? event.error : undefined
       const message = "message" in event && typeof event.message === "string" ? event.message : undefined
       workerError = error instanceof Error ? error.message : (message ?? "worker error")
-      workerDebug("error", { generation, error: workerError })
     })
     for (const [event, handlers] of listeners) {
       for (const handler of handlers) client.on(event, handler)
@@ -88,7 +75,6 @@ function createWorkerManager(file: WorkerFile) {
 
   function restart(error: unknown) {
     if (stopped) throw error
-    workerDebug("restart", { generation, error: errorMessage(error) })
     const previous = state
     state = start()
     previous.worker.terminate()
@@ -99,23 +85,15 @@ function createWorkerManager(file: WorkerFile) {
       method: Method,
       input: Parameters<(typeof rpc)[Method]>[0],
     ): Promise<ReturnType<(typeof rpc)[Method]>> {
-      workerDebug("call", { generation, method: String(method) })
       return state.client.call(method, input).catch((error) => {
         const detail = state.error()
         if (!isWorkerTerminated(error)) {
-          workerDebug("call_failed", { generation, method: String(method), error: errorMessage(error), detail })
           if (detail) throw new Error(`TUI worker failed: ${detail}`)
           throw error
         }
         restart(error)
         return state.client.call(method, input).catch((retryError) => {
           const nextDetail = state.error()
-          workerDebug("retry_failed", {
-            generation,
-            method: String(method),
-            error: errorMessage(retryError),
-            detail: nextDetail,
-          })
           if (nextDetail) throw new Error(`TUI worker failed: ${nextDetail}`)
           throw retryError
         })
@@ -139,7 +117,6 @@ function createWorkerManager(file: WorkerFile) {
     async stop() {
       if (stopped) return
       stopped = true
-      workerDebug("stop", { generation })
       await withTimeout(state.client.call("shutdown", undefined), 5000).catch(() => {})
       state.worker.terminate()
     },

--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -10,53 +10,8 @@ import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
-import { Global } from "@opencode-ai/core/global"
-import { appendFileSync } from "fs"
-import path from "path"
 
 Heap.start()
-
-function workerDebug(event: string, data: Record<string, unknown> = {}) {
-  try {
-    appendFileSync(
-      path.join(Global.Path.log, "tui-worker-debug.log"),
-      JSON.stringify({ time: new Date().toISOString(), pid: process.pid, scope: "worker", event, ...data }) + "\n",
-    )
-  } catch {}
-}
-
-function errorInfo(error: unknown) {
-  if (error instanceof Error) return { name: error.name, message: error.message, stack: error.stack }
-  return { message: String(error) }
-}
-
-function safeURL(value: string) {
-  try {
-    const url = new URL(value)
-    return `${url.origin}${url.pathname}`
-  } catch {
-    return value.split("?")[0]
-  }
-}
-
-process.on("uncaughtException", (error) => {
-  workerDebug("uncaught_exception", errorInfo(error))
-})
-
-process.on("unhandledRejection", (error) => {
-  workerDebug("unhandled_rejection", errorInfo(error))
-})
-
-if ("addEventListener" in globalThis) {
-  globalThis.addEventListener("error", (event) => {
-    const error = "error" in event ? event.error : undefined
-    workerDebug("global_error", errorInfo(error ?? event))
-  })
-  globalThis.addEventListener("unhandledrejection", (event) => {
-    const reason = "reason" in event ? event.reason : undefined
-    workerDebug("global_unhandled_rejection", errorInfo(reason ?? event))
-  })
-}
 
 // Subscribe to global events and forward them via RPC
 GlobalBus.on("event", (event) => {
@@ -67,7 +22,6 @@ let server: Awaited<ReturnType<typeof Server.listen>> | undefined
 
 export const rpc = {
   async fetch(input: { url: string; method: string; headers: Record<string, string>; body?: string }) {
-    workerDebug("fetch_start", { method: input.method, url: safeURL(input.url) })
     const headers = { ...input.headers }
     const auth = ServerAuth.header()
     if (auth && !headers["authorization"] && !headers["Authorization"]) {
@@ -80,7 +34,6 @@ export const rpc = {
     })
     const response = await Server.Default().app.fetch(request)
     const body = await response.text()
-    workerDebug("fetch_done", { method: input.method, url: safeURL(input.url), status: response.status })
     return {
       status: response.status,
       headers: Object.fromEntries(response.headers.entries()),
@@ -88,24 +41,19 @@ export const rpc = {
     }
   },
   snapshot() {
-    workerDebug("snapshot")
     const result = writeHeapSnapshot("server.heapsnapshot")
     return result
   },
   async server(input: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
-    workerDebug("server_start", { port: input.port, hostname: input.hostname, mdns: input.mdns })
     if (server) await server.stop(true)
     server = await Server.listen(input)
-    workerDebug("server_done", { url: server.url.toString() })
     return { url: server.url.toString() }
   },
   async checkUpgrade(input: { directory: string }) {
-    workerDebug("check_upgrade", { directory: input.directory })
     await InstanceRuntime.load({ directory: input.directory })
     await upgrade().catch(() => {})
   },
   async reload() {
-    workerDebug("reload")
     await AppRuntime.runPromise(
       Effect.gen(function* () {
         const cfg = yield* Config.Service
@@ -115,7 +63,6 @@ export const rpc = {
     )
   },
   async shutdown() {
-    workerDebug("shutdown")
     await InstanceRuntime.disposeAllInstances()
     if (server) await server.stop(true)
   },

--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -10,8 +10,53 @@ import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
+import { Global } from "@opencode-ai/core/global"
+import { appendFileSync } from "fs"
+import path from "path"
 
 Heap.start()
+
+function workerDebug(event: string, data: Record<string, unknown> = {}) {
+  try {
+    appendFileSync(
+      path.join(Global.Path.log, "tui-worker-debug.log"),
+      JSON.stringify({ time: new Date().toISOString(), pid: process.pid, scope: "worker", event, ...data }) + "\n",
+    )
+  } catch {}
+}
+
+function errorInfo(error: unknown) {
+  if (error instanceof Error) return { name: error.name, message: error.message, stack: error.stack }
+  return { message: String(error) }
+}
+
+function safeURL(value: string) {
+  try {
+    const url = new URL(value)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return value.split("?")[0]
+  }
+}
+
+process.on("uncaughtException", (error) => {
+  workerDebug("uncaught_exception", errorInfo(error))
+})
+
+process.on("unhandledRejection", (error) => {
+  workerDebug("unhandled_rejection", errorInfo(error))
+})
+
+if ("addEventListener" in globalThis) {
+  globalThis.addEventListener("error", (event) => {
+    const error = "error" in event ? event.error : undefined
+    workerDebug("global_error", errorInfo(error ?? event))
+  })
+  globalThis.addEventListener("unhandledrejection", (event) => {
+    const reason = "reason" in event ? event.reason : undefined
+    workerDebug("global_unhandled_rejection", errorInfo(reason ?? event))
+  })
+}
 
 // Subscribe to global events and forward them via RPC
 GlobalBus.on("event", (event) => {
@@ -22,6 +67,7 @@ let server: Awaited<ReturnType<typeof Server.listen>> | undefined
 
 export const rpc = {
   async fetch(input: { url: string; method: string; headers: Record<string, string>; body?: string }) {
+    workerDebug("fetch_start", { method: input.method, url: safeURL(input.url) })
     const headers = { ...input.headers }
     const auth = ServerAuth.header()
     if (auth && !headers["authorization"] && !headers["Authorization"]) {
@@ -34,6 +80,7 @@ export const rpc = {
     })
     const response = await Server.Default().app.fetch(request)
     const body = await response.text()
+    workerDebug("fetch_done", { method: input.method, url: safeURL(input.url), status: response.status })
     return {
       status: response.status,
       headers: Object.fromEntries(response.headers.entries()),
@@ -41,19 +88,24 @@ export const rpc = {
     }
   },
   snapshot() {
+    workerDebug("snapshot")
     const result = writeHeapSnapshot("server.heapsnapshot")
     return result
   },
   async server(input: { port: number; hostname: string; mdns?: boolean; cors?: string[] }) {
+    workerDebug("server_start", { port: input.port, hostname: input.hostname, mdns: input.mdns })
     if (server) await server.stop(true)
     server = await Server.listen(input)
+    workerDebug("server_done", { url: server.url.toString() })
     return { url: server.url.toString() }
   },
   async checkUpgrade(input: { directory: string }) {
+    workerDebug("check_upgrade", { directory: input.directory })
     await InstanceRuntime.load({ directory: input.directory })
     await upgrade().catch(() => {})
   },
   async reload() {
+    workerDebug("reload")
     await AppRuntime.runPromise(
       Effect.gen(function* () {
         const cfg = yield* Config.Service
@@ -63,6 +115,7 @@ export const rpc = {
     )
   },
   async shutdown() {
+    workerDebug("shutdown")
     await InstanceRuntime.disposeAllInstances()
     if (server) await server.stop(true)
   },

--- a/packages/opencode/src/util/rpc.ts
+++ b/packages/opencode/src/util/rpc.ts
@@ -2,12 +2,23 @@ type Definition = {
   [method: string]: (input: any) => any
 }
 
+type RpcError = {
+  name?: string
+  message: string
+  stack?: string
+}
+
 export function listen(rpc: Definition) {
   onmessage = async (evt) => {
     const parsed = JSON.parse(evt.data)
-    if (parsed.type === "rpc.request") {
-      const result = await rpc[parsed.method](parsed.input)
-      postMessage(JSON.stringify({ type: "rpc.result", result, id: parsed.id }))
+    if (parsed.type !== "rpc.request") return
+
+    try {
+      const fn = rpc[parsed.method]
+      if (!fn) throw new Error(`Unknown RPC method: ${parsed.method}`)
+      postMessage(JSON.stringify({ type: "rpc.result", result: await fn(parsed.input), id: parsed.id }))
+    } catch (error) {
+      postMessage(JSON.stringify({ type: "rpc.error", error: serializeError(error), id: parsed.id }))
     }
   }
 }
@@ -20,15 +31,22 @@ export function client<T extends Definition>(target: {
   postMessage: (data: string) => void | null
   onmessage: ((this: Worker, ev: MessageEvent<any>) => any) | null
 }) {
-  const pending = new Map<number, (result: any) => void>()
+  const pending = new Map<number, { resolve: (result: any) => void; reject: (error: Error) => void }>()
   const listeners = new Map<string, Set<(data: any) => void>>()
   let id = 0
   target.onmessage = async (evt) => {
     const parsed = JSON.parse(evt.data)
     if (parsed.type === "rpc.result") {
-      const resolve = pending.get(parsed.id)
-      if (resolve) {
-        resolve(parsed.result)
+      const request = pending.get(parsed.id)
+      if (request) {
+        request.resolve(parsed.result)
+        pending.delete(parsed.id)
+      }
+    }
+    if (parsed.type === "rpc.error") {
+      const request = pending.get(parsed.id)
+      if (request) {
+        request.reject(deserializeError(parsed.error))
         pending.delete(parsed.id)
       }
     }
@@ -44,9 +62,14 @@ export function client<T extends Definition>(target: {
   return {
     call<Method extends keyof T>(method: Method, input: Parameters<T[Method]>[0]): Promise<ReturnType<T[Method]>> {
       const requestId = id++
-      return new Promise((resolve) => {
-        pending.set(requestId, resolve)
-        target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
+      return new Promise((resolve, reject) => {
+        pending.set(requestId, { resolve, reject })
+        try {
+          target.postMessage(JSON.stringify({ type: "rpc.request", method, input, id: requestId }))
+        } catch (error) {
+          pending.delete(requestId)
+          reject(error instanceof Error ? error : new Error(String(error)))
+        }
       })
     },
     on<Data>(event: string, handler: (data: Data) => void) {
@@ -61,6 +84,18 @@ export function client<T extends Definition>(target: {
       }
     },
   }
+}
+
+function serializeError(error: unknown): RpcError {
+  if (error instanceof Error) return { name: error.name, message: error.message, stack: error.stack }
+  return { message: String(error) }
+}
+
+function deserializeError(error: RpcError) {
+  const result = new Error(error.message)
+  result.name = error.name ?? "Error"
+  result.stack = error.stack
+  return result
 }
 
 export * as Rpc from "./rpc"


### PR DESCRIPTION
### Issue for this PR

Closes #33269

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI backend runs in a Bun worker. If an RPC handler in that worker threw, the error was not sent back to the caller. Instead, the exception could terminate the worker, and the next prompt would fail with a generic `Worker has been terminated` error.

This changes the worker RPC layer to catch handler errors and return them as RPC errors. The client now rejects the matching pending call with the original error instead of leaving the failure to kill the worker or surface later as a worker termination.

The TUI command now also manages the worker lifecycle through a small wrapper. If a call fails because the worker was terminated, it starts a new worker, reattaches existing event subscriptions, and retries the call once. If the worker reports a concrete failure reason, that reason is surfaced as `TUI worker failed: <reason>`.

This works because request failures are now handled at the RPC boundary, where each request already has an ID and a matching pending promise. That lets the worker return a structured error for the specific request instead of allowing the exception to escape the message handler.

### How did you verify your code works?

- Ran `bun run typecheck` from `packages/opencode`.
- Confirmed the temporary worker debug logging used during diagnosis was removed.
- Verified the RPC client now resolves successful responses, rejects RPC error responses, and does not leave pending calls behind after failures.

### Screenshots / recordings
<img width="936" height="601" alt="Screenshot 2026-06-21 at 10 44 30" src="https://github.com/user-attachments/assets/9a434c63-faf4-4849-8174-424ab9dafd40" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR