### PR TITLE
fix(cli): increment ports from default

### DIFF
--- a/packages/cli/src/commands/handlers/serve.ts
+++ b/packages/cli/src/commands/handlers/serve.ts
@@ -27,9 +27,11 @@ export default Runtime.handler(
 
 function listen(hostname: string, port: Option.Option<number>, password: string) {
   if (Option.isSome(port)) return bind(hostname, port.value, password)
-  // Preserve the familiar default when available, but let the OS choose a free
-  // port when another local server already owns 4096.
-  return bind(hostname, 4096, password).pipe(Effect.catch(() => bind(hostname, 0, password)))
+  const next = (port: number): ReturnType<typeof bind> =>
+    bind(hostname, port, password).pipe(
+      Effect.catch((error) => (port === 65_535 ? Effect.fail(error) : next(port + 1))),
+    )
+  return next(4096)
 }
 
 function bind(hostname: string, port: number, password: string) {


### PR DESCRIPTION
## Summary
- probe ports sequentially from 4096 when no port is specified
- preserve fail-fast behavior for an explicit `--port`
- stop probing at the maximum valid port

## Testing
- `bun typecheck` in `packages/cli`
- repository pre-push `bun turbo typecheck`