### PR TITLE
fix(app): prevent web client freeze from delta event bursts and SSE reconnect loops

### DIFF
--- a/packages/app/src/context/directory-sync.ts
+++ b/packages/app/src/context/directory-sync.ts
@@ -187,8 +187,8 @@ export const createDirSyncContext = (
     return serverSync.child(directory)
   }
   const absolute = (path: string) => (current()[0].path.directory + "/" + path).replace("//", "/")
-  const initialMessagePageSize = 80
-  const historyMessagePageSize = 200
+  const initialMessagePageSize = 20
+  const historyMessagePageSize = 40
   const inflight = new Map<string, Promise<void>>()
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()

--- a/packages/app/src/context/server-sdk.tsx
+++ b/packages/app/src/context/server-sdk.tsx
@@ -81,10 +81,10 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
   type Queued = QueuedServerEvent
   const FLUSH_FRAME_MS = 16
   const STREAM_YIELD_MS = 8
+  const FLUSH_MAX_EVENTS = 100
   const RECONNECT_DELAY_MS = 250
 
   let queue: Queued[] = []
-  let buffer: Queued[] = []
   const coalesced = new Map<string, number>()
   const staleDeltas = new Set<string>()
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -105,11 +105,10 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
 
     if (queue.length === 0) return
 
-    const events = queue
+    const events = queue.length > FLUSH_MAX_EVENTS ? queue.slice(0, FLUSH_MAX_EVENTS) : queue
+    const remaining = queue.length > FLUSH_MAX_EVENTS ? queue.slice(FLUSH_MAX_EVENTS) : []
     const skip = staleDeltas.size > 0 ? new Set(staleDeltas) : undefined
-    queue = buffer
-    buffer = events
-    queue.length = 0
+    queue = remaining
     coalesced.clear()
     staleDeltas.clear()
 
@@ -118,8 +117,6 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
     batch(() => {
       output.forEach((event) => emitter.emit(event.directory, event.payload))
     })
-
-    buffer.length = 0
   }
 
   const schedule = () => {

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -368,24 +368,30 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
     return promise
   }
 
+  let lastReconnectFlushAt = 0
+  const RECONNECT_COOLDOWN_MS = 60000
+
   const unsub = serverSDK.event.listen((e) => {
     const directory = e.name
     const key = directoryKey(directory)
     const event = e.details
     const recent = bootingRoot || Date.now() - bootedAt < 1500
+    const reconnectOnCooldown = Date.now() - lastReconnectFlushAt < RECONNECT_COOLDOWN_MS
+    const skipReconnect = bootedAt > 0 && (recent || reconnectOnCooldown)
 
     if (directory === "global") {
       applyGlobalEvent({
         event,
         project: globalStore.project,
         refresh: () => {
-          if (recent) return
+          if (skipReconnect) return
           bootstrap.refetch()
         },
         setGlobalProject: setProjects,
       })
       if (event.type === "server.connected" || event.type === "global.disposed") {
-        if (recent) return
+        if (skipReconnect) return
+        lastReconnectFlushAt = Date.now()
         for (const directory of Object.keys(children.children)) {
           queue.push(directory)
         }

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -645,9 +645,9 @@ export default function Layout(props: ParentProps) {
     running: number
   }
 
-  const prefetchChunk = 200
-  const prefetchConcurrency = 2
-  const prefetchPendingLimit = 10
+  const prefetchChunk = 20
+  const prefetchConcurrency = 1
+  const prefetchPendingLimit = 5
   const span = 4
   const prefetchToken = { value: 0 }
   const prefetchQueues = new Map<string, PrefetchQueue>()

--- a/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/gen/core/serverSentEvents.gen.ts
@@ -77,12 +77,29 @@ export const createSseClient = <TData = unknown>({
 }: ServerSentEventsOptions): ServerSentEventsResult<TData> => {
   let lastEventId: string | undefined
 
-  const sleep = sseSleepFn ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)))
-
   const createStream = async function* () {
     let retryDelay: number = sseDefaultRetryDelay ?? 3000
     let attempt = 0
     const signal = options.signal ?? new AbortController().signal
+
+    const sleep = sseSleepFn
+      ? sseSleepFn
+      : (ms: number) =>
+          new Promise<void>((resolve, reject) => {
+            if (signal.aborted) {
+              reject(new DOMException("Aborted", "AbortError"))
+              return
+            }
+            const timer = setTimeout(() => {
+              signal.removeEventListener("abort", onAbort)
+              resolve()
+            }, ms)
+            const onAbort = () => {
+              clearTimeout(timer)
+              reject(new DOMException("Aborted", "AbortError"))
+            }
+            signal.addEventListener("abort", onAbort, { once: true })
+          })
 
     while (true) {
       if (signal.aborted) break
@@ -192,6 +209,8 @@ export const createSseClient = <TData = unknown>({
       } catch (error) {
         // connection failed or aborted; retry after delay
         onSseError?.(error)
+
+        if (signal.aborted) break
 
         if (sseMaxRetryAttempts !== undefined && attempt >= sseMaxRetryAttempts) {
           break // stop after firing error

--- a/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
+++ b/packages/sdk/js/src/v2/gen/core/serverSentEvents.gen.ts
@@ -90,12 +90,29 @@ export const createSseClient = <TData = unknown>({
 }: ServerSentEventsOptions): ServerSentEventsResult<TData> => {
   let lastEventId: string | undefined
 
-  const sleep = sseSleepFn ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)))
-
   const createStream = async function* () {
     let retryDelay: number = sseDefaultRetryDelay ?? 3000
     let attempt = 0
     const signal = options.signal ?? new AbortController().signal
+
+    const sleep = sseSleepFn
+      ? sseSleepFn
+      : (ms: number) =>
+          new Promise<void>((resolve, reject) => {
+            if (signal.aborted) {
+              reject(new DOMException("Aborted", "AbortError"))
+              return
+            }
+            const timer = setTimeout(() => {
+              signal.removeEventListener("abort", onAbort)
+              resolve()
+            }, ms)
+            const onAbort = () => {
+              clearTimeout(timer)
+              reject(new DOMException("Aborted", "AbortError"))
+            }
+            signal.addEventListener("abort", onAbort, { once: true })
+          })
 
     while (true) {
       if (signal.aborted) break
@@ -221,6 +238,8 @@ export const createSseClient = <TData = unknown>({
       } catch (error) {
         // connection failed or aborted; retry after delay
         onSseError?.(error)
+
+        if (signal.aborted) break
 
         if (sseMaxRetryAttempts !== undefined && attempt >= sseMaxRetryAttempts) {
           break // stop after firing error


### PR DESCRIPTION
### Issue for this PR

Closes #13947

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The web client freezes when loading sessions with large message histories. The browser main thread gets blocked by four related issues:

1. **SSE retry sleep blocks on abort** — The SDK's `createSseClient` sleeps for the full exponential backoff (1-30s) without checking the abort signal. When the reconnection loop in `server-sdk.tsx` aborts the current attempt (heartbeat timeout, visibility change, network error), the `for await` loop is stuck waiting for the sleep to finish before it can check `signal.aborted`. Fixed by moving the sleep function inside `createStream` where the abort signal is in scope, and making it reject immediately when the signal fires.

2. **Uncapped delta event flush** — `message.part.delta` events are coalesced per flush cycle, but there was no cap on how many events get processed in a single batch. A session with thousands of messages produces hundreds of delta events per cycle, all processed synchronously in a `batch()` call. Added `FLUSH_MAX_EVENTS = 100` to cap the flush, with remaining events deferred to the next frame.

3. **No reconnect cooldown** — Every SSE reconnect triggers a full re-bootstrap against the session store. In a loop this causes cascading refetches. Added a 60-second cooldown after each re-bootstrap flush so subsequent reconnect events skip the expensive refetch.

4. **Page sizes too large for big databases** — Prefetching 200 messages with concurrency 2, and loading 80 messages per initial page, creates excessive data transfer and rendering load. Reduced prefetch chunk to 20, concurrency to 1, initial page to 20, and history page to 40.

These were tested against a 3.5GB session database with 308 sessions and individual sessions containing 4,000+ messages.

### How did you verify your code works?

- Verified SSE sleep correctly rejects on abort signal by testing with aborted AbortController
- Confirmed flush cap limits batch size to 100 events with burst delta test
- Tested reconnect cooldown prevents cascading re-bootstraps by simulating rapid reconnects
- Page size reductions verified against a 3.5GB session database with 308 sessions
- TypeScript type checking passes across all packages

### Screenshots / recordings

_No UI changes — this is a performance/reliability fix._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR