### PR TITLE
fix(tui): render skill load errors inline

### DIFF
--- a/packages/tui/src/component/dialog-skill.tsx
+++ b/packages/tui/src/component/dialog-skill.tsx
@@ -1,7 +1,10 @@
+import { TextAttributes } from "@opentui/core"
 import { DialogSelect, type DialogSelectOption } from "../ui/dialog-select"
-import { createResource, createMemo } from "solid-js"
+import { createResource, createMemo, createSignal } from "solid-js"
 import { useDialog } from "../ui/dialog"
 import { useSDK } from "../context/sdk"
+import { useTheme } from "../context/theme"
+import { errorMessage } from "../util/error"
 
 export type DialogSkillProps = {
   onSelect: (skill: string) => void
@@ -10,14 +13,27 @@ export type DialogSkillProps = {
 export function DialogSkill(props: DialogSkillProps) {
   const dialog = useDialog()
   const sdk = useSDK()
+  const { theme } = useTheme()
   dialog.setSize("large")
 
-  const [skills] = createResource(async () => {
-    const result = await sdk.client.app.skills()
-    return result.data ?? []
-  })
+  const [loadError, setLoadError] = createSignal<unknown>()
+
+  const [skills] = createResource(() =>
+    sdk.client.app
+      .skills({}, { throwOnError: true })
+      .then((result) => result.data ?? [])
+      // Catch so the rejected resource never reaches the memo below: reading
+      // skills() in an errored state re-throws and tears down the dialog.
+      .catch((error) => {
+        setLoadError(error)
+        return undefined
+      }),
+  )
+
+  const showError = createMemo(() => Boolean(loadError()))
 
   const options = createMemo<DialogSelectOption<string>[]>(() => {
+    if (showError()) return []
     const list = skills() ?? []
     const maxWidth = Math.max(0, ...list.map((s) => s.name.length))
     return list.map((skill) => ({
@@ -32,5 +48,23 @@ export function DialogSkill(props: DialogSkillProps) {
     }))
   })
 
-  return <DialogSelect title="Skills" placeholder="Search skills..." options={options()} />
+  return (
+    <DialogSelect
+      title="Skills"
+      placeholder="Search skills..."
+      options={options()}
+      renderFilter={!showError()}
+      locked={showError()}
+      emptyView={
+        showError() ? (
+          <box paddingLeft={4} paddingRight={4}>
+            <text fg={theme.error} attributes={TextAttributes.BOLD}>
+              Could not load skills
+            </text>
+            <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
+          </box>
+        ) : undefined
+      }
+    />
+  )
 }


### PR DESCRIPTION
## Problem

The `/skills` dialog (`DialogSkill`) loaded skills via `app.skills()` without surfacing failures: it returned `result.data ?? []`, so an error response silently rendered an empty list (indistinguishable from "no skills"), and a rejected request would put the resource in an errored state that re-throws when read in the `options` memo.

Same failure class addressed for the move dialog (#32241) and the console org dialog (#33040).

## Fix

Switch the fetch to `throwOnError: true` and funnel both failure modes (error responses and rejections) into a `loadError` signal via `.then().catch()`, then render an inline error inside the dialog instead of a silent empty list / crash. Reuses the `emptyView` slot on `DialogSelect`:

- `renderFilter={false}`, `locked`, and `options={[]}` in the error state
- red bold "Could not load skills" title + muted error message
- `esc` dismisses; same dialog shell

Single-shot load (no source signal / refetch): success renders the list, failure renders the inline error.

## Testing

- `bun typecheck` and `bun prettier --check` pass from `packages/tui`.
- Verified with termctrl using a forced failure: compact inline error in the "Skills" shell, filter hidden, `esc` dismisses cleanly, no crash.