### PR TITLE
feat: add untrimmed patch metadata for edit tools

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -62,12 +62,14 @@ export const ApplyPatchTool = Tool.define(
         type: "add" | "update" | "delete" | "move"
         movePath?: string
         diff: string
+        patch: string
         additions: number
         deletions: number
         bom: boolean
       }> = []
 
       let totalDiff = ""
+      let totalPatch = ""
 
       for (const hunk of hunks) {
         const filePath = path.resolve(instance.directory, hunk.path)
@@ -79,7 +81,8 @@ export const ApplyPatchTool = Tool.define(
             const newContent =
               hunk.contents.length === 0 || hunk.contents.endsWith("\n") ? hunk.contents : `${hunk.contents}\n`
             const next = Bom.split(newContent)
-            const diff = trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, next.text))
+            const patch = createTwoFilesPatch(filePath, filePath, oldContent, next.text)
+            const diff = trimDiff(patch)
 
             let additions = 0
             let deletions = 0
@@ -94,12 +97,14 @@ export const ApplyPatchTool = Tool.define(
               newContent: next.text,
               type: "add",
               diff,
+              patch,
               additions,
               deletions,
               bom: next.bom,
             })
 
             totalDiff += diff + "\n"
+            totalPatch += patch + "\n"
             break
           }
 
@@ -130,7 +135,8 @@ export const ApplyPatchTool = Tool.define(
               return yield* Effect.fail(new Error(`apply_patch verification failed: ${error}`))
             }
 
-            const diff = trimDiff(createTwoFilesPatch(filePath, filePath, oldContent, newContent))
+            const patch = createTwoFilesPatch(filePath, filePath, oldContent, newContent)
+            const diff = trimDiff(patch)
 
             let additions = 0
             let deletions = 0
@@ -149,12 +155,14 @@ export const ApplyPatchTool = Tool.define(
               type: hunk.move_path ? "move" : "update",
               movePath,
               diff,
+              patch,
               additions,
               deletions,
               bom,
             })
 
             totalDiff += diff + "\n"
+            totalPatch += patch + "\n"
             break
           }
 
@@ -169,7 +177,8 @@ export const ApplyPatchTool = Tool.define(
               ),
             )
             const contentToDelete = source.text
-            const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
+            const deletePatch = createTwoFilesPatch(filePath, filePath, contentToDelete, "")
+            const deleteDiff = trimDiff(deletePatch)
 
             const deletions = contentToDelete.split("\n").length
 
@@ -179,12 +188,14 @@ export const ApplyPatchTool = Tool.define(
               newContent: "",
               type: "delete",
               diff: deleteDiff,
+              patch: deletePatch,
               additions: 0,
               deletions,
               bom: source.bom,
             })
 
             totalDiff += deleteDiff + "\n"
+            totalPatch += deletePatch + "\n"
             break
           }
         }
@@ -210,6 +221,7 @@ export const ApplyPatchTool = Tool.define(
         metadata: {
           filepath: relativePaths.join(", "),
           diff: totalDiff,
+          patch: totalPatch,
           files,
         },
       })
@@ -296,6 +308,7 @@ export const ApplyPatchTool = Tool.define(
         title: output,
         metadata: {
           diff: totalDiff,
+          patch: totalPatch,
           files,
           diagnostics,
         },

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -83,6 +83,7 @@ export const EditTool = Tool.define(
           yield* assertExternalDirectoryEffect(ctx, filePath)
 
           let diff = ""
+          let patch = ""
           let contentOld = ""
           let contentNew = ""
           yield* lock(filePath).withPermits(1)(
@@ -98,7 +99,8 @@ export const EditTool = Tool.define(
                 const desiredBom = next.bom
                 contentOld = ""
                 contentNew = next.text
-                diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
+                patch = createTwoFilesPatch(filePath, filePath, contentOld, contentNew)
+                diff = trimDiff(patch)
                 yield* ctx.ask({
                   permission: "edit",
                   patterns: [path.relative(instance.worktree, filePath)],
@@ -106,6 +108,7 @@ export const EditTool = Tool.define(
                   metadata: {
                     filepath: filePath,
                     diff,
+                    patch,
                   },
                 })
                 yield* afs.writeWithDirs(filePath, Bom.join(contentNew, desiredBom))
@@ -134,14 +137,13 @@ export const EditTool = Tool.define(
               const desiredBom = source.bom || next.bom
               contentNew = next.text
 
-              diff = trimDiff(
-                createTwoFilesPatch(
-                  filePath,
-                  filePath,
-                  normalizeLineEndings(contentOld),
-                  normalizeLineEndings(contentNew),
-                ),
+              patch = createTwoFilesPatch(
+                filePath,
+                filePath,
+                normalizeLineEndings(contentOld),
+                normalizeLineEndings(contentNew),
               )
+              diff = trimDiff(patch)
               yield* ctx.ask({
                 permission: "edit",
                 patterns: [path.relative(instance.worktree, filePath)],
@@ -149,6 +151,7 @@ export const EditTool = Tool.define(
                 metadata: {
                   filepath: filePath,
                   diff,
+                  patch,
                 },
               })
 
@@ -161,14 +164,13 @@ export const EditTool = Tool.define(
                 file: filePath,
                 event: "change",
               })
-              diff = trimDiff(
-                createTwoFilesPatch(
-                  filePath,
-                  filePath,
-                  normalizeLineEndings(contentOld),
-                  normalizeLineEndings(contentNew),
-                ),
+              patch = createTwoFilesPatch(
+                filePath,
+                filePath,
+                normalizeLineEndings(contentOld),
+                normalizeLineEndings(contentNew),
               )
+              diff = trimDiff(patch)
             }).pipe(Effect.orDie),
           )
 
@@ -188,6 +190,7 @@ export const EditTool = Tool.define(
           yield* ctx.metadata({
             metadata: {
               diff,
+              patch,
               filediff,
               diagnostics: {},
             },
@@ -204,6 +207,7 @@ export const EditTool = Tool.define(
             metadata: {
               diagnostics,
               diff,
+              patch,
               filediff,
             },
             title: `${path.relative(instance.worktree, filePath)}`,

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -97,6 +97,7 @@ export const WriteTool = Tool.define(
               diagnostics,
               filepath,
               exists: exists,
+              diff,
               patch,
             },
             output,

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -50,7 +50,8 @@ export const WriteTool = Tool.define(
           const contentOld = source.text
           const contentNew = next.text
 
-          const diff = trimDiff(createTwoFilesPatch(filepath, filepath, contentOld, contentNew))
+          const patch = createTwoFilesPatch(filepath, filepath, contentOld, contentNew)
+          const diff = trimDiff(patch)
           yield* ctx.ask({
             permission: "edit",
             patterns: [path.relative(instance.worktree, filepath)],
@@ -58,6 +59,7 @@ export const WriteTool = Tool.define(
             metadata: {
               filepath,
               diff,
+              patch,
             },
           })
 
@@ -95,6 +97,7 @@ export const WriteTool = Tool.define(
               diagnostics,
               filepath,
               exists: exists,
+              patch,
             },
             output,
           }

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -40,6 +40,7 @@ type AskInput = {
   always: string[]
   metadata: {
     diff: string
+    patch: string
     filepath: string
     files: Array<{
       filePath: string
@@ -201,6 +202,30 @@ describe("tool.apply_patch freeform", () => {
       yield* execute({ patchText }, ctx)
 
       expect(yield* readText(target)).toBe("line1\nchanged2\nline3\nchanged4\n")
+    }),
+  )
+
+  it.instance("adds untrimmed patch metadata while preserving trimmed diff", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx, calls } = makeCtx()
+      const target = path.join(test.directory, "indented.txt")
+      yield* writeText(target, "  old\n")
+
+      const patchText = "*** Begin Patch\n*** Update File: indented.txt\n@@\n-  old\n+  new\n*** End Patch"
+
+      const result = yield* execute({ patchText }, ctx)
+
+      expect(result.metadata.diff).toContain("-old")
+      expect(result.metadata.diff).not.toContain("-  old")
+      expect(result.metadata.patch).toContain("-  old")
+      expect(result.metadata.patch).toContain("+  new")
+      expect(calls[0]?.metadata.diff).toContain("-old")
+      expect(calls[0]?.metadata.diff).not.toContain("-  old")
+      expect(calls[0]?.metadata.patch).toContain("-  old")
+      expect(calls[0]?.metadata.patch).toContain("+  new")
+      expect(calls[0]?.metadata.files[0]?.patch).toContain("-old")
+      expect(calls[0]?.metadata.files[0]?.patch).not.toContain("-  old")
     }),
   )
 

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -26,6 +26,8 @@ const ctx = {
   ask: () => Effect.void,
 }
 
+type AskInput = Parameters<Tool.Context["ask"]>[0]
+
 afterEach(async () => {
   await disposeAllInstances()
 })
@@ -156,6 +158,35 @@ describe("tool.edit", () => {
 
         expect(result.output).toContain("Edit applied successfully")
         expect(yield* load(filepath)).toBe("new content here")
+      }),
+    )
+
+    it.instance("adds untrimmed patch metadata while preserving trimmed diff", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "existing.txt")
+        yield* put(filepath, "  old content\n")
+        const asks: AskInput[] = []
+
+        const result = yield* run(
+          { filePath: filepath, oldString: "old content", newString: "new content" },
+          {
+            ...ctx,
+            ask: (input) =>
+              Effect.sync(() => {
+                asks.push(input)
+              }),
+          },
+        )
+
+        expect(result.metadata.diff).toContain("-old content")
+        expect(result.metadata.diff).not.toContain("-  old content")
+        expect(result.metadata.patch).toContain("-  old content")
+        expect(result.metadata.patch).toContain("+  new content")
+        expect(asks[0]?.metadata.diff).toContain("-old content")
+        expect(asks[0]?.metadata.diff).not.toContain("-  old content")
+        expect(asks[0]?.metadata.patch).toContain("-  old content")
+        expect(asks[0]?.metadata.patch).toContain("+  new content")
       }),
     )
 

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -188,6 +188,8 @@ describe("tool.write", () => {
           },
         )
 
+        expect(result.metadata.diff).toContain("-old")
+        expect(result.metadata.diff).not.toContain("-  old")
         expect(result.metadata.patch).toContain("-  old")
         expect(result.metadata.patch).toContain("+  new")
         expect(asks[0]?.metadata.diff).toContain("-old")

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -26,6 +26,8 @@ const ctx = {
   ask: () => Effect.void,
 }
 
+type AskInput = Parameters<Tool.Context["ask"]>[0]
+
 afterEach(async () => {
   await disposeAllInstances()
 })
@@ -165,6 +167,33 @@ describe("tool.write", () => {
 
         expect(result.metadata).toHaveProperty("filepath", filepath)
         expect(result.metadata).toHaveProperty("exists", true)
+      }),
+    )
+
+    it.instance("adds untrimmed patch permission metadata while preserving trimmed diff", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "file.txt")
+        yield* Effect.promise(() => fs.writeFile(filepath, "  old\n", "utf-8"))
+        const asks: AskInput[] = []
+
+        const result = yield* run(
+          { filePath: filepath, content: "  new\n" },
+          {
+            ...ctx,
+            ask: (input) =>
+              Effect.sync(() => {
+                asks.push(input)
+              }),
+          },
+        )
+
+        expect(result.metadata.patch).toContain("-  old")
+        expect(result.metadata.patch).toContain("+  new")
+        expect(asks[0]?.metadata.diff).toContain("-old")
+        expect(asks[0]?.metadata.diff).not.toContain("-  old")
+        expect(asks[0]?.metadata.patch).toContain("-  old")
+        expect(asks[0]?.metadata.patch).toContain("+  new")
       }),
     )
   })


### PR DESCRIPTION
### Issue for this PR

Closes #31625

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `metadata.patch` for edit-related tools so integrations can read the untrimmed `createTwoFilesPatch(...)` output while existing `metadata.diff` remains display-trimmed.

This covers `edit`, `write`, and `apply_patch`. For `apply_patch`, the existing per-file `files[].patch` remains unchanged as the trimmed display patch; the new untrimmed patch is added at top-level `metadata.patch`.

### How did you verify your code works?

- `npx -y bun@1.3.14 test test/tool/edit.test.ts test/tool/write.test.ts test/tool/apply_patch.test.ts --timeout 30000` from `packages/opencode`: 74 pass, 0 fail, 172 expect() calls
- `npx -y bun@1.3.14 typecheck` from `packages/opencode`: exit 0
- `npx -y bun@1.3.14 typecheck` from repo root: exit 0, 23 successful / 23 total

### Screenshots / recordings

Not applicable; this is metadata/API behavior with test coverage.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
