### PR TITLE
fix(llm): forward frequencyPenalty, presencePenalty, seed to Gemini

### DIFF
--- a/packages/llm/src/protocols/gemini.ts
+++ b/packages/llm/src/protocols/gemini.ts
@@ -101,6 +101,9 @@ const GeminiGenerationConfig = Schema.Struct({
   temperature: Schema.optional(Schema.Number),
   topP: Schema.optional(Schema.Number),
   topK: Schema.optional(Schema.Number),
+  frequencyPenalty: Schema.optional(Schema.Number),
+  presencePenalty: Schema.optional(Schema.Number),
+  seed: Schema.optional(Schema.Number),
   stopSequences: optionalArray(Schema.String),
   thinkingConfig: Schema.optional(GeminiThinkingConfig),
 })
@@ -308,6 +311,9 @@ const fromRequest = Effect.fn("Gemini.fromRequest")(function* (request: LLMReque
     temperature: generation?.temperature,
     topP: generation?.topP,
     topK: generation?.topK,
+    frequencyPenalty: generation?.frequencyPenalty,
+    presencePenalty: generation?.presencePenalty,
+    seed: generation?.seed,
     stopSequences: generation?.stop,
     thinkingConfig: thinkingConfig(request),
   }

--- a/packages/llm/test/provider/gemini.test.ts
+++ b/packages/llm/test/provider/gemini.test.ts
@@ -36,6 +36,24 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("forwards frequencyPenalty, presencePenalty, and seed to generationConfig", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<Gemini.GeminiBody>(
+        LLM.request({
+          model,
+          prompt: "Say hello.",
+          generation: { frequencyPenalty: 0.5, presencePenalty: 0.25, seed: 7 },
+        }),
+      )
+
+      expect(prepared.body.generationConfig).toMatchObject({
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.25,
+        seed: 7,
+      })
+    }),
+  )
+
   it.effect("lowers chronological system updates to wrapped user text in order", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<Gemini.GeminiBody>(


### PR DESCRIPTION
### Issue for this PR

Closes #33325

### Type of change

- [x] Bug fix

### What does this PR do?

`GenerationOptions` defines `frequencyPenalty`, `presencePenalty`, and `seed` as user-settable generation parameters, and the OpenAI-chat protocol forwards all three. The Gemini protocol dropped them: `GeminiGenerationConfig` only declared `maxOutputTokens / temperature / topP / topK / stopSequences / thinkingConfig`, and the request builder forwarded only those.

Gemini's `generateContent` `generationConfig` supports all three, so values a user set were honored on OpenAI but silently ignored on Gemini. This PR adds the three fields to `GeminiGenerationConfig` and forwards them in the request builder, gated by the existing all-undefined guard so unset requests are unchanged.

### How did you verify your code works?

- Added a test asserting `frequencyPenalty` / `presencePenalty` / `seed` appear in the prepared `generationConfig` when set.
- `bun test test/provider/gemini.test.ts` — 20 pass (existing "prepares Gemini target" test confirms the unset case still omits them).
- `bun typecheck` (packages/llm) — clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR