### PR TITLE
fix(mcp): preserve server additionalProperties in convertTool

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -44,7 +44,7 @@ export function convertTool(mcpTool: MCPToolDef, client: Client, timeout?: numbe
     ...(mcpTool.inputSchema as JSONSchema7),
     type: "object",
     properties: (mcpTool.inputSchema.properties ?? {}) as JSONSchema7["properties"],
-    additionalProperties: false,
+    additionalProperties: (mcpTool.inputSchema as JSONSchema7).additionalProperties ?? false,
   }
 
   return dynamicTool({

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import type { Tool as MCPToolDef } from "@modelcontextprotocol/sdk/types.js"
+import type { Schema } from "ai"
+import { convertTool } from "../../src/mcp/catalog"
+
+const mockClient = {} as any
+
+function makeMCPTool(inputSchema: Record<string, unknown>): MCPToolDef {
+  return {
+    name: "test_tool",
+    inputSchema: inputSchema as MCPToolDef["inputSchema"],
+  }
+}
+
+function getJsonSchema(tool: ReturnType<typeof convertTool>): Record<string, unknown> {
+  return (tool.inputSchema as Schema<unknown>).jsonSchema as Record<string, unknown>
+}
+
+describe("convertTool additionalProperties", () => {
+  test("defaults to false when server omits additionalProperties", () => {
+    const mcpTool = makeMCPTool({
+      type: "object",
+      properties: { name: { type: "string" } },
+    })
+
+    const tool = convertTool(mcpTool, mockClient)
+    const schema = getJsonSchema(tool)
+
+    expect(schema.additionalProperties).toBe(false)
+  })
+
+  test("preserves additionalProperties: true from server schema", () => {
+    const mcpTool = makeMCPTool({
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: true,
+    })
+
+    const tool = convertTool(mcpTool, mockClient)
+    const schema = getJsonSchema(tool)
+
+    expect(schema.additionalProperties).toBe(true)
+  })
+
+  test("preserves additionalProperties object sub-schema from server", () => {
+    const subSchema = { type: "string" as const }
+    const mcpTool = makeMCPTool({
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: subSchema,
+    })
+
+    const tool = convertTool(mcpTool, mockClient)
+    const schema = getJsonSchema(tool)
+
+    expect(schema.additionalProperties).toEqual(subSchema)
+  })
+
+  test("preserves explicit additionalProperties: false from server", () => {
+    const mcpTool = makeMCPTool({
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: false,
+    })
+
+    const tool = convertTool(mcpTool, mockClient)
+    const schema = getJsonSchema(tool)
+
+    expect(schema.additionalProperties).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33322

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `catalog.ts` `convertTool`, `additionalProperties` is hardcoded to `false` after spreading the MCP server's input schema. This discards whatever the server declared — breaking tools that use `additionalProperties: true` or an object sub-schema.

The fix preserves the server's original value and only defaults to `false` when the server omits it:

```diff
- additionalProperties: false,
+ additionalProperties: (mcpTool.inputSchema as JSONSchema7).additionalProperties ?? false,
```

### How did you verify your code works?

Added unit tests in `test/mcp/catalog.test.ts` covering all four cases: server omits additionalProperties (defaults to false), server sets true, server sets an object sub-schema, and server explicitly sets false. All 64 MCP tests pass.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
