### PR TITLE
fix(cli): add missing trailing newline to stderr output

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -39,7 +39,7 @@ function show(out: string) {
     process.stderr.write(text + EOL)
     return
   }
-  process.stderr.write(out)
+  process.stderr.write(out.endsWith(EOL) ? out : out + EOL)
 }
 
 const cli = yargs(args)


### PR DESCRIPTION
### Issue for this PR

Fixes #33370 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Just adding a missing newline if it's not there. Yes the fix was done by the AI, and we can argue if it's the right place.
It could also be the missing newline in the actual "session" command, but assuming `opencode` is widely coded with AI (would be too ironic otherwise) the fix seems fair in a sake of "autoprotection".

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

```
packages/opencode$ dist/opencode-linux-x64/bin/opencode session
```

### Screenshots / recordings

Here's the screenshot of "after the fix" command and then "before the fix" command:

<img width="1502" height="684" alt="image" src="https://github.com/user-attachments/assets/215bf26e-ffb6-4795-b113-1022ced24022" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
