### PR TITLE
fix(tui): use cross-platform path splitting for local plugin names in status dialog

### DIFF
--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -20,7 +20,7 @@ export function DialogStatus() {
       const value = typeof item === "string" ? item : item[0]
       if (value.startsWith("file://")) {
         const path = fileURLToPath(value)
-        const parts = path.split("/")
+        const parts = path.replace(/\\/g, "/").split("/")
         const filename = parts.pop() || path
         if (!filename.includes(".")) return { name: filename }
         const basename = filename.split(".")[0]


### PR DESCRIPTION
### Issue for this PR

Closes #33373 
Closes #16559 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, `fileURLToPath()` returns paths with `\` separators,
but the Status dialog display logic in `packages/tui/src/component/dialog-status.tsx`
only splits on `/`. The entire path is kept as a single string, and
`.split(".")[0]` truncates at the `.config` dot, showing `C:\Users\licat\`
instead of the plugin directory name.

This PR adds `.replace(/\\/g, "/")` before the split call to normalize
Windows backslashes, so the path component extraction works on all platforms.

### How did you verify your code works?

- `bun typecheck` passes in `packages/tui/`
- Manually tested on Windows: added a local plugin path to `opencode.json`,
  opened the Status dialog, confirmed the plugin name displays its directory
  basename instead of a truncated path
- Unix paths (no backslashes) are unchanged — no regression

### Screenshots / recordings

| Before          | After                |
| --------------- | -------------------- |
| C:\Users\licat\ | opencode-lazy-loader |

Before:
<img width="526" height="252" alt="修改前" src="https://github.com/user-attachments/assets/8aef336f-ae92-4a89-80f3-4b1d3647203e" />

After:
<img width="414" height="224" alt="修改后" src="https://github.com/user-attachments/assets/c003218a-cbfc-401f-9401-843f99516d35" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
