### PR TITLE
fix(opencode): preserve request logger context

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -281,7 +281,7 @@ export function createRoutes(
     ]),
     Layer.provide(LayerNode.buildLayer(app)),
     Layer.provide(Layer.succeed(CorsConfig)(corsOptions)),
-    Layer.provide(Observability.layer),
+    Layer.provideMerge(Observability.layer),
   )
 }
 


### PR DESCRIPTION
## Summary
- retain the observability logger FiberRef patch in the HTTP route layer output
- prevent request error logs from falling back to Effect's default stdout logger
- keep `opencode run --format json` stdout as pure NDJSON while preserving file and `--print-logs` stderr logging

## Root cause
`HttpRouter.toWebHandler` starts request fibers from the built route context. `createRoutes` used `Layer.provide(Observability.layer)`, which applied observability while constructing the layer but discarded its FiberRef patch from the context later used by request fibers. Those fibers therefore used Effect's default pretty stdout logger.

## Verification
- `bun run test -- test/cli/run/run-process.test.ts` (13 pass)
- `bun run test -- test/server/httpapi-instance.test.ts` (7 pass)
- `bunx prettier --write packages/opencode/src/server/routes/instance/httpapi/server.ts`
- `bunx oxlint packages/opencode/src/server/routes/instance/httpapi/server.ts`
- `bun typecheck` from `packages/opencode`
- push hook full workspace typecheck (23 packages)