### PR TITLE
test(opencode): synchronize shell cancellation

### DIFF
--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1711,11 +1711,17 @@ unixNoLLMServer(
     withSh(() =>
       Effect.gen(function* () {
         const { prompt, run, chat } = yield* boot()
+        const { directory: dir } = yield* TestInstance
+        const afs = yield* FSUtil.Service
+        const ready = path.join(dir, ".shell-ready")
 
         const sh = yield* prompt
-          .shell({ sessionID: chat.id, agent: "build", command: "sleep 30" })
+          .shell({ sessionID: chat.id, agent: "build", command: ": > '.shell-ready'; sleep 30" })
           .pipe(Effect.forkChild)
-        yield* waitForBusy(chat.id)
+        yield* pollWithTimeout(
+          afs.existsSafe(ready).pipe(Effect.map((exists) => (exists ? (true as const) : undefined))),
+          "shell never created readiness marker",
+        )
 
         yield* prompt.cancel(chat.id)
 


### PR DESCRIPTION
## Summary
- wait for a fixture-local marker written by the spawned shell before cancelling
- preserve the cancellation status, runner, fiber, and aborted-output assertions

## Root cause
`waitForBusy` only observed the runner entering its shell transition. That transition publishes readiness before `/bin/sh` is selected and spawned, so cancellation could race shell initialization under load. The test now waits for the shell command itself to create `.shell-ready` before cancelling.

## Verification
- `bun run test -- test/session/prompt.test.ts --test-name-pattern "cancel interrupts shell and resolves cleanly" --rerun-each 50`
- `bun run test -- test/session/prompt.test.ts`
- `bunx prettier --check packages/opencode/test/session/prompt.test.ts`
- `bunx oxlint packages/opencode/test/session/prompt.test.ts` (0 errors; 13 pre-existing warnings)
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`