### PR TITLE
test(opencode): synchronize websocket retry failures

### DIFF
--- a/packages/opencode/test/plugin/openai-ws.test.ts
+++ b/packages/opencode/test/plugin/openai-ws.test.ts
@@ -559,21 +559,28 @@ describe("plugin.openai.ws-pool", () => {
   })
 
   test("retries failed websocket streams before using HTTP fallback", async () => {
+    const attempts: Array<(socket: WebSocket) => void> = []
     await using server = await createWebSocketServer((socket) => {
       socket.once("message", () => {
         socket.send(JSON.stringify({ type: "response.output_text.delta", delta: "started" }))
+        attempts.shift()?.(socket)
       })
     })
     const fetch = OpenAIWebSocketPool.createWebSocketFetch({
       url: server.url,
-      idleTimeout: 20,
       streamRetries: 1,
     })
 
+    const firstAttempt = new Promise<WebSocket>((resolve) => attempts.push(resolve))
     const first = await fetch(server.url, streamRequest())
-    expect((await readTextError(first.text())).message).toContain("idle timeout waiting for websocket")
+    const firstSocket = await firstAttempt
+    firstSocket.terminate()
+    expect((await readTextError(first.text())).message).toContain("WebSocket closed before response.completed")
+    const secondAttempt = new Promise<WebSocket>((resolve) => attempts.push(resolve))
     const second = await fetch(server.url, streamRequest())
-    expect((await readTextError(second.text())).message).toContain("idle timeout waiting for websocket")
+    const secondSocket = await secondAttempt
+    secondSocket.terminate()
+    expect((await readTextError(second.text())).message).toContain("WebSocket closed before response.completed")
     const third = await fetch(server.url, streamRequest())
 
     expect(await third.text()).toBe("http")


### PR DESCRIPTION
## Summary

- replace the 20 ms idle-timeout trigger with per-attempt websocket gates
- terminate each socket only after the client has processed its first stream event
- preserve coverage that two failed websocket streams consume the retry budget before HTTP fallback

## Root cause

Under full-suite scheduler pressure, the 20 ms idle timer could fire before the fake server's initial delta was processed. The second pre-event failure then correctly returned HTTP fallback, while the test incorrectly expected another rejected websocket body.

## Verification

- exact test repeated 100 times
- exact test repeated 400 times across four concurrent processes
- full `openai-ws.test.ts`
- Prettier
- file-scoped oxlint (0 errors; existing warnings only)
- `packages/opencode` typecheck
- full pre-push workspace typecheck