### PR TITLE
fix(core): distinguish WebFetch URL errors from network errors

### DIFF
--- a/packages/core/src/tool/webfetch.ts
+++ b/packages/core/src/tool/webfetch.ts
@@ -1,7 +1,7 @@
 export * as WebFetchTool from "./webfetch"
 
 import { ToolFailure } from "@opencode-ai/llm"
-import { Duration, Effect, Layer, Schema } from "effect"
+import { Data, Duration, Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { Parser } from "htmlparser2"
 import TurndownService from "turndown"
@@ -9,6 +9,11 @@ import { PermissionV2 } from "../permission"
 import { collectBoundedResponseBody } from "./http-body"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
+
+export class InvalidUrlError extends Data.TaggedError("WebFetch.InvalidUrl")<{
+  readonly url: string
+  readonly reason: string
+}> {}
 
 export const name = "webfetch"
 export const MAX_RESPONSE_BYTES = 5 * 1024 * 1024
@@ -22,7 +27,16 @@ Use a more targeted tool when one is available. This tool is read-only. Large te
 const Timeout = Schema.Number.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(MAX_TIMEOUT_SECONDS))
 
 export const Input = Schema.Struct({
-  url: Schema.String.annotate({ description: "The HTTP or HTTPS URL to fetch content from" }),
+  url: Schema.String.check(
+    Schema.makeFilter((s) => {
+      try {
+        new URL(s)
+        return true
+      } catch {
+        return "Invalid URL"
+      }
+    }),
+  ).annotate({ description: "The HTTP or HTTPS URL to fetch content from" }),
   format: Schema.Literals(["text", "markdown", "html"])
     .annotate({ description: "The format to return the content in. Defaults to markdown." })
     .pipe(Schema.withDecodingDefault(Effect.succeed("markdown" as const))),
@@ -79,10 +93,6 @@ const isCloudflareChallenge = (error: unknown) => {
 const request = (url: string, format: Format, userAgent = browserUserAgent) =>
   HttpClientRequest.get(url).pipe(HttpClientRequest.setHeaders(headers(format, userAgent)))
 
-const assertHttpUrl = (url: URL) => {
-  if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("URL must use http:// or https://")
-}
-
 const execute = (http: HttpClient.HttpClient, url: string, format: Format, userAgent = browserUserAgent) =>
   http.execute(request(url, format, userAgent)).pipe(Effect.flatMap(HttpClientResponse.filterStatusOk))
 
@@ -127,9 +137,16 @@ export const layer = Layer.effectDiscard(
           toModelOutput: ({ output }) => [{ type: "text", text: output.output }],
           execute: (input, context) =>
             Effect.gen(function* () {
-              yield* Effect.try({
-                try: () => assertHttpUrl(new URL(input.url)),
-                catch: (error) => error,
+              yield* Effect.gen(function* () {
+                const url = new URL(input.url)
+                if (url.protocol !== "http:" && url.protocol !== "https:") {
+                  return yield* Effect.fail(
+                    new InvalidUrlError({
+                      url: input.url,
+                      reason: "URL must use http:// or https://",
+                    }),
+                  )
+                }
               })
 
               yield* permission.assert({
@@ -170,7 +187,13 @@ export const layer = Layer.effectDiscard(
                 format: input.format,
                 output,
               }
-            }).pipe(Effect.mapError(() => new ToolFailure({ message: `Unable to fetch ${input.url}` }))),
+            }).pipe(
+              Effect.mapError((error) =>
+                error instanceof InvalidUrlError
+                  ? new ToolFailure({ message: `Invalid URL ${error.url}: ${error.reason}` })
+                  : new ToolFailure({ message: `Unable to fetch ${input.url}` }),
+              ),
+            ),
         }),
       })
       .pipe(Effect.orDie)

--- a/packages/core/test/tool-webfetch.test.ts
+++ b/packages/core/test/tool-webfetch.test.ts
@@ -147,7 +147,35 @@ describe("WebFetchTool registration", () => {
 
       expect(yield* executeTool(registry, call({ url: "file:///etc/passwd", format: "text" }))).toEqual({
         type: "error",
-        value: "Unable to fetch file:///etc/passwd",
+        value: "Invalid URL file:///etc/passwd: URL must use http:// or https://",
+      })
+      expect(assertions).toEqual([])
+      expect(requests).toEqual([])
+    }),
+  )
+
+  it.effect("rejects malformed URLs at schema decode without permission or transport", () =>
+    Effect.gen(function* () {
+      reset()
+      const registry = yield* ToolRegistry.Service
+
+      expect(yield* executeTool(registry, call({ url: "not-a-url", format: "text" }))).toEqual({
+        type: "error",
+        value: 'Invalid tool input: Invalid URL\n  at ["url"]',
+      })
+      expect(assertions).toEqual([])
+      expect(requests).toEqual([])
+    }),
+  )
+
+  it.effect("rejects non-HTTP schemes with a typed error before permission or transport", () =>
+    Effect.gen(function* () {
+      reset()
+      const registry = yield* ToolRegistry.Service
+
+      expect(yield* executeTool(registry, call({ url: "ftp://example.com", format: "text" }))).toEqual({
+        type: "error",
+        value: "Invalid URL ftp://example.com: URL must use http:// or https://",
       })
       expect(assertions).toEqual([])
       expect(requests).toEqual([])


### PR DESCRIPTION
### Issue for this PR

Closes #33073

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

WebFetch's URL validation collapses every failure (malformed URL, wrong scheme, transport failure, timeout, response too large, MIME rejection, HTML conversion crash) into the same `"Unable to fetch <url>"` message. The model cannot tell whether it sent a bad URL or hit an unreachable host. The reporter's "Expected behavior" asks for a clear distinction between format errors and network errors.

This PR introduces two-layer URL validation, matching Claude Code's WebFetch shape:

1. **Schema-level parseability check** via `Schema.makeFilter` on the `url` field rejects inputs that `new URL()` cannot parse. These surface through the standard tool-input channel as `Invalid tool input: Invalid URL\n  at ["url"]` (the same path every other tool's schema rejection takes via `Tool.make`'s built-in `Schema.decodeUnknown` step in `packages/core/src/tool/tool.ts:82`).

2. **Tool-layer scheme check** (kept from the original `assertHttpUrl`) rejects non-http/https schemes with a typed `InvalidUrlError`. These surface as `Invalid URL <url>: URL must use http:// or https://`, carrying the reason into the message so the model knows why the request was rejected.

Network, timeout, body-size, MIME, and HTML-conversion failures keep the generic `Unable to fetch <url>` message so existing tests and downstream consumers do not break.

#### Implementation notes

- Replaces `Effect.try({ catch: (error) => error })` at the validation site with `Effect.gen` + `Effect.fail(InvalidUrlError)` so the tagged error reaches the boundary mapper without erasure through `unknown → E`. (`Effect.try`'s catch returns its value as the failure type, but the surrounding `Effect.mapError(() => …)` was discarding it.)
- Removes the now-unused `assertHttpUrl` helper (line 81-83 of the old file) — the same check is inlined in the new `Effect.gen`.
- The second `Effect.try({ catch: (error) => error })` site added by PR #33259 for HTML-to-Markdown conversion (lines 162-165) has the same generic-message anti-pattern but does not cause user-visible failures today. Left alone in this PR; flagged in the solution doc as a follow-up.

#### Why two layers (and not just Schema-level)

Claude Code uses a JSON-schema `format: "url"` constraint to reject unparseable URLs before the tool runs, and a separate tool-layer check for the http/https scheme. Two layers produce two distinct error categories — exactly the "format vs. network" distinction the bug report asks for. The tool-layer scheme check is also strictly stricter than Claude Code's (Claude Code leaks `file://` to the network and returns a confusing socket error — cross-checked 2026-06-22).

### How did you verify your code works?

```bash
$ cd packages/core && bun test ./test/tool-webfetch.test.ts
14 pass, 0 fail, 35 expect() calls  [814ms]

$ bun typecheck
Tasks: 23 successful, 23 total  (FULL TURBO)

$ bun test
# 1028 pass across 132 files. The 3 unrelated failures
# (ProjectCopy/Worktree, Watcher/.git, LocationServiceMap timeouts)
# are pre-existing — none touch webfetch.
```

Manual verification: invoked `webfetch` with `not-a-url`, `ftp://example.com`, `file:///etc/passwd`, and an unreachable host via the live tool:

| Input | Output |
|---|---|
| `not-a-url` | `Invalid tool input: Invalid URL\n  at ["url"]` (no permission, no network) |
| `ftp://example.com` | `Invalid URL ftp://example.com: URL must use http:// or https://` (no permission, no network) |
| `file:///etc/passwd` | `Invalid URL file:///etc/passwd: URL must use http:// or https://` (no permission, no network) |
| unreachable host | `Unable to fetch <url>` (permission + network, as before) |

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

#### Notes for the reviewer

- **Security posture unchanged**: this fix only changes the *message* for the `file://` rejection (from `Unable to fetch file:///etc/passwd` to `Invalid URL file:///etc/passwd: URL must use http:// or https://`). The rejection itself, the absence of permission/network calls, and the read-tool-only path for local files are all preserved unchanged (verified against `packages/opencode/src/tool/read.ts:241-260` and `packages/core/src/location-mutation.ts:37`).
- **Cross-check**: Claude Code's WebFetch was probed with the same inputs on 2026-06-22 to validate the design. Findings recorded in `DEVS/fixes/SOLUTION-33073.md` ("Cross-check: Claude Code WebFetch" and "Security context: local file access" sections).