### PR TITLE
feat(run): forward child session events to NDJSON stream

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -680,6 +680,9 @@ export const RunCommand = effectCmd({
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
           let error: string | undefined
+          // Track child session IDs spawned by the task tool so their events
+          // can be forwarded to the parent NDJSON stream.
+          const childSessionIDs = new Set<string>()
 
           for await (const event of events.stream) {
             if (
@@ -695,9 +698,33 @@ export const RunCommand = effectCmd({
               toggles.set("start", true)
             }
 
+            // Forward streaming token deltas from child sessions.
+            if (event.type === "message.part.delta") {
+              if (childSessionIDs.has(event.properties.sessionID)) {
+                emit("subtask_delta", {
+                  childSessionID: event.properties.sessionID,
+                  partID: event.properties.partID,
+                  delta: event.properties.delta,
+                })
+              }
+            }
+
             if (event.type === "message.part.updated") {
               const part = event.properties.part
-              if (part.sessionID !== sessionID) continue
+
+              // Register child session ID when a task tool starts running.
+              if (part.type === "tool" && part.tool === "task" && part.state.status === "running") {
+                const meta = (part.state as { metadata?: { sessionId?: string } }).metadata
+                if (meta?.sessionId) childSessionIDs.add(meta.sessionId)
+              }
+
+              // Forward completed/updated parts from child sessions.
+              if (part.sessionID !== sessionID) {
+                if (childSessionIDs.has(part.sessionID)) {
+                  emit("subtask_event", { childSessionID: part.sessionID, part })
+                }
+                continue
+              }
 
               if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
                 if (emit("tool_use", { part })) continue


### PR DESCRIPTION
## Problem

When using `opencode run --format json` with agents that invoke the `task` tool (subagents), the parent NDJSON stream receives no events from child sessions during execution — only the final `tool_use` event with `status: completed` after the subagent finishes.

This makes `opencode run` unsuitable as a headless runtime for multi-agent platforms that need real-time observability into subagent execution: tool calls, text tokens, step events.

We investigated every alternative before opening this PR:
- **stdout during task execution**: `task` tool only emits `completed` — no intermediate events reach the parent stream
- **stderr**: opencode swallows child process stderr
- **SQLite polling**: text parts are written atomically at transaction commit — the `data` field is empty for the entire duration of subagent execution
- **`opencode serve` + `/event` SSE**: works, but requires a persistent process per session — not viable for stateless, ephemeral worker architectures

Related issue: #33397

## Root Cause

In `cli/cmd/run.ts`, the event loop has a single filter that drops every event whose `sessionID` doesn't match the root session:

```typescript
if (part.sessionID !== sessionID) continue  // drops all child session events
```

Child session events (`message.part.delta` for streaming tokens, `message.part.updated` for completed parts) are published on the bus correctly — they're just silently discarded here.

The child `sessionID` is already available: `task.ts` stores it in `ctx.metadata({ metadata: { sessionId: session.id } })`, which surfaces as `part.state.metadata.sessionId` in the `tool_use` event when the task starts.

## Solution

A minimal, additive change to `run.ts` — no changes to `task.ts`, the bus, or any other file:

**1.** Declare a `childSessionIDs` set at the top of `loop()`.

**2.** When a `task` tool part transitions to `running`, register its child `sessionId` from `part.state.metadata`.

**3.** For `message.part.delta` events from a known child session, emit `subtask_delta`.

**4.** For `message.part.updated` events from a known child session, emit `subtask_event` instead of discarding.

## New NDJSON event types (--format json only)

```jsonl
{"type":"subtask_delta","sessionID":"ses_parent","childSessionID":"ses_child","partID":"prt_1","delta":"Analyzing"}
{"type":"subtask_delta","sessionID":"ses_parent","childSessionID":"ses_child","partID":"prt_1","delta":" the code"}
{"type":"subtask_event","sessionID":"ses_parent","childSessionID":"ses_child","part":{"type":"tool","tool":"bash",...}}
{"type":"subtask_event","sessionID":"ses_parent","childSessionID":"ses_child","part":{"type":"text","text":"Done.",...}}
```

## Properties

- **Fully additive**: existing event types and default (non-json) output are completely unchanged.
- **No new dependencies**: uses only data already present in the event stream.
- **Scoped**: only events from sessions explicitly spawned by the `task` tool are forwarded. Unrelated sessions are unaffected.
- **One file changed**: `packages/opencode/src/cli/cmd/run.ts`, +28 lines.

## Testing

Validated against a squad workflow: master agent + 3 subagents (planner → executor → reviewer) coordinated via a custom pipeline MCP. With this patch, each subagent's tool calls and text output appear in the parent NDJSON stream in real time as `subtask_delta` and `subtask_event`.