### PR TITLE
feat(run): forward child session events to NDJSON stream

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -680,6 +680,9 @@ export const RunCommand = effectCmd({
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
           let error: string | undefined
+          // Track child session IDs spawned by the task tool so their events
+          // can be forwarded to the parent NDJSON stream.
+          const childSessionIDs = new Set<string>()
 
           for await (const event of events.stream) {
             if (
@@ -695,9 +698,33 @@ export const RunCommand = effectCmd({
               toggles.set("start", true)
             }
 
+            // Forward streaming token deltas from child sessions.
+            if (event.type === "message.part.delta") {
+              if (childSessionIDs.has(event.properties.sessionID)) {
+                emit("subtask_delta", {
+                  childSessionID: event.properties.sessionID,
+                  partID: event.properties.partID,
+                  delta: event.properties.delta,
+                })
+              }
+            }
+
             if (event.type === "message.part.updated") {
               const part = event.properties.part
-              if (part.sessionID !== sessionID) continue
+
+              // Register child session ID when a task tool starts running.
+              if (part.type === "tool" && part.tool === "task" && part.state.status === "running") {
+                const meta = (part.state as { metadata?: { sessionId?: string } }).metadata
+                if (meta?.sessionId) childSessionIDs.add(meta.sessionId)
+              }
+
+              // Forward completed/updated parts from child sessions.
+              if (part.sessionID !== sessionID) {
+                if (childSessionIDs.has(part.sessionID)) {
+                  emit("subtask_event", { childSessionID: part.sessionID, part })
+                }
+                continue
+              }
 
               if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
                 if (emit("tool_use", { part })) continue


### PR DESCRIPTION
### Issue for this PR

Closes #33397

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --format json` filters out all events from child sessions (subagents spawned by the `task` tool), so there is no way to observe what a subagent is doing while it runs — only the final result arrives after it completes.

The fix tracks child session IDs as task tool parts transition to `running` (the ID is already in `part.state.metadata.sessionId`) and forwards two new event types to the parent NDJSON stream:

- `subtask_delta` — a streaming token delta from a child session
- `subtask_event` — a completed/updated part from a child session

Change is additive: one file touched (`cli/cmd/run.ts`, +28 lines), no existing event types or default output affected.

### How did you verify your code works?

Ran a multi-agent squad workflow (master + 3 subagents: planner → executor → reviewer) coordinated via a custom pipeline MCP. Without the patch, only the final `tool_use completed` event arrives. With the patch, each subagent's tool calls and text appear as `subtask_delta` / `subtask_event` in real time.

### Screenshots / recordings

_N/A — CLI-only change, no UI._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR