### PR TITLE
fix(provider): scope AI Gateway token to workers-ai models

### DIFF
--- a/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
+++ b/packages/core/src/plugin/provider/cloudflare-ai-gateway.ts
@@ -25,9 +25,12 @@ export const CloudflareAIGatewayPlugin = define({
           apiKey: config.apiKey,
           options: gatewayOptions(evt.options, metadata),
         } as any)
-        const unified = createUnified({ apiKey: config.apiKey })
         evt.sdk = {
           languageModel(modelID: string) {
+            // Only Workers AI sub-requests are authenticated by the Cloudflare token (the upstream
+            // is Cloudflare itself); third-party providers must not receive it as their Authorization
+            // header, so they rely on the gateway's stored/BYOK keys instead.
+            const unified = createUnified(modelID.startsWith("workers-ai/") ? { apiKey: config.apiKey } : {})
             return gateway(unified(modelID))
           },
         }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -816,12 +816,14 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         apiKey: apiToken,
         ...(Object.values(opts).some((v) => v !== undefined) ? { options: opts } : {}),
       })
-      const unified = createUnified({ apiKey: apiToken })
-
       return {
         autoload: true,
         async getModel(_sdk: any, modelID: string, _options?: Record<string, any>) {
-          // Model IDs use Unified API format: provider/model (e.g., "anthropic/claude-sonnet-4-5")
+          // Model IDs use Unified API format: provider/model (e.g., "anthropic/claude-sonnet-4-5").
+          // Only Workers AI sub-requests are authenticated by the Cloudflare token (the upstream
+          // is Cloudflare itself); third-party providers must not receive it as their Authorization
+          // header, so they rely on the gateway's stored/BYOK keys instead.
+          const unified = createUnified(modelID.startsWith("workers-ai/") ? { apiKey: apiToken } : {})
           return aigateway(unified(modelID))
         },
         options: {},

--- a/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
+++ b/packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts
@@ -16,7 +16,7 @@ import type * as Provider from "@/provider/provider"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 
-type Captured = { url: string; outerBody: unknown }
+type Captured = { url: string; outerBody: unknown; headers: Record<string, string> }
 type ProviderOptions = Record<string, Record<string, JSONValue>>
 
 const realFetch = globalThis.fetch
@@ -32,7 +32,11 @@ beforeEach(() => {
     const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
     if (url.startsWith("https://gateway.ai.cloudflare.com/")) {
       const bodyText = typeof init?.body === "string" ? init.body : ""
-      captured = { url, outerBody: bodyText ? JSON.parse(bodyText) : null }
+      captured = {
+        url,
+        outerBody: bodyText ? JSON.parse(bodyText) : null,
+        headers: Object.fromEntries(new Headers(init?.headers).entries()),
+      }
       return new Response(
         JSON.stringify({
           id: "chatcmpl-test",
@@ -88,9 +92,19 @@ function extractUpstreamQuery(body: unknown): Record<string, unknown> | undefine
   return isRecord(query) ? query : undefined
 }
 
-async function callThroughGateway(apiId: string, providerOptions: ProviderOptions) {
-  const aigateway = createAiGateway({ accountId: "test", gateway: "test", apiKey: "test" })
-  const unified = createUnified()
+// Each step descriptor also carries the `headers` forwarded to the upstream provider.
+function extractUpstreamHeaders(body: unknown): Record<string, unknown> | undefined {
+  if (!Array.isArray(body) || body.length === 0) return undefined
+  const first = body[0]
+  if (!isRecord(first)) return undefined
+  const headers = first.headers
+  return isRecord(headers) ? headers : undefined
+}
+
+async function callThroughGateway(apiId: string, providerOptions: ProviderOptions, gatewayToken = "test") {
+  const aigateway = createAiGateway({ accountId: "test", gateway: "test", apiKey: gatewayToken })
+  // Mirrors the runtime: only workers-ai sub-requests get the Cloudflare token as their apiKey.
+  const unified = createUnified(apiId.startsWith("workers-ai/") ? { apiKey: gatewayToken } : {})
   await generateText({ model: aigateway(unified(apiId)), prompt: "hi", providerOptions })
   return extractUpstreamQuery(captured?.outerBody)
 }
@@ -128,5 +142,19 @@ describe("cf-ai-gateway end-to-end (regression: #24432)", () => {
       "cloudflare-ai-gateway": { reasoningEffort: "high" },
     })
     expect(upstream?.reasoning_effort).toBeUndefined()
+  })
+
+  test("third-party models do NOT forward the Cloudflare token upstream (regression: #32052)", async () => {
+    await callThroughGateway("openai/gpt-5.4", {}, "cf-gateway-secret")
+
+    expect(captured?.headers["cf-aig-authorization"]).toBe("Bearer cf-gateway-secret")
+    expect(JSON.stringify(captured?.outerBody)).not.toContain("cf-gateway-secret")
+  })
+
+  test("workers-ai models DO forward the Cloudflare token upstream (regression: #32051)", async () => {
+    await callThroughGateway("workers-ai/@cf/google/gemma-4-26b-a4b-it", {}, "cf-gateway-secret")
+
+    expect(captured?.headers["cf-aig-authorization"]).toBe("Bearer cf-gateway-secret")
+    expect(extractUpstreamHeaders(captured?.outerBody)?.["authorization"]).toBe("Bearer cf-gateway-secret")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #32051

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#32052 fixed #32051 (Workers AI models 401'd through the gateway) by passing `apiKey` to `createUnified`. This was an overcorrection. The Cloudflare API token used for AI Gateway was then passed as the upstream `Authorization` header on requests to third party models (OpenAI, Anthropic), causing it to 401 with Invalid API Key.

We should not pass the Cloudflare API token upstream, instead these models should use the credentials the user has stored in the AI Gateway (or Cloudflare's Unified Billing).

This makes token forwarding model-aware — the Cloudflare token is only attached for first-party `workers-ai/` models (where the upstream *is* Cloudflare), and omitted for everything else:

```ts
createUnified(modelID.startsWith("workers-ai/") ? { apiKey } : {})
```

Applied in both the v1 provider path (provider.ts) and the v2 plugin path (core/.../cloudflare-ai-gateway.ts).
How did you verify your code works?
Added two tests in packages/opencode/test/provider/cf-ai-gateway-e2e.test.ts that capture the real upstream headers and assert both directions:
- No leak (#32052) — third-party models do not forward the Cloudflare token as the upstream Authorization header.
- Workers AI auth (#32051) — workers-ai/ models do forward the token.

```
cd packages/opencode
bun test test/provider/cf-ai-gateway-e2e.test.ts   # 5 pass
bun typecheck                                       # clean
Live end-to-end against a real AI Gateway:
export CLOUDFLARE_ACCOUNT_ID=<account-id>
export CLOUDFLARE_GATEWAY_ID=<gateway-id>
export CLOUDFLARE_API_TOKEN=<gateway-token>

# Workers AI path (token is forwarded)
echo "Reply with exactly: PONG" | \
  bun run dev run --model "cloudflare-ai-gateway/workers-ai/@cf/meta/llama-3.3-70b-instruct-fp8-fast"

# Third-party path (token must NOT be forwarded)
echo "Reply with exactly: PONG" | \
  bun run dev run --model "cloudflare-ai-gateway/openai/gpt-4o-mini"
```

### Screenshots / recordings
N/A — no UI changes.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR