### PR TITLE
fix(session): restore session summary from per-turn diffs (#30877)

### DIFF
--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -130,7 +130,10 @@ export const layer = Layer.effect(
       // Each touched file appears once (last turn wins).
       const byFile = new Map<string, Snapshot.FileDiff>()
       for (const msg of all) {
-        for (const d of msg.info.summary?.diffs ?? []) {
+        if (msg.info.role !== "user") continue
+        const diffs = msg.info.summary?.diffs
+        if (!diffs) continue
+        for (const d of diffs) {
           byFile.set(d.file ?? `__nofile_${byFile.size}`, d)
         }
       }

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -103,16 +103,14 @@ export const layer = Layer.effect(
       sessionID: SessionID
       messageID: MessageID
     }) {
-      yield* sessions.setSummary({
-        sessionID: input.sessionID,
-        summary: {
-          additions: 0,
-          deletions: 0,
-          files: 0,
-        },
-      })
-      yield* events.publish(Session.Event.Diff, { sessionID: input.sessionID, diff: [] })
-      if ((yield* config.get()).snapshot === false) return
+      if ((yield* config.get()).snapshot === false) {
+        yield* sessions.setSummary({
+          sessionID: input.sessionID,
+          summary: { additions: 0, deletions: 0, files: 0 },
+        })
+        yield* events.publish(Session.Event.Diff, { sessionID: input.sessionID, diff: [] })
+        return
+      }
       const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
       if (!all.length) return
 
@@ -124,6 +122,29 @@ export const layer = Layer.effect(
       const msgDiffs = yield* computeDiff({ messages })
       target.info.summary = { ...target.info.summary, diffs: msgDiffs }
       yield* sessions.updateMessage(target.info)
+
+      // Re-aggregate the session-level summary from the cheap per-message
+      // turn diffs (already computed above and on prior turns). This restores
+      // the "Modified Files" sidebar, which reads session.summary, without
+      // the expensive full-session snapshot diff that #30127 removed.
+      // Each touched file appears once (last turn wins).
+      const byFile = new Map<string, Snapshot.FileDiff>()
+      for (const msg of all) {
+        for (const d of msg.info.summary?.diffs ?? []) {
+          byFile.set(d.file ?? `__nofile_${byFile.size}`, d)
+        }
+      }
+      const aggregate = [...byFile.values()]
+      yield* sessions.setSummary({
+        sessionID: input.sessionID,
+        summary: {
+          additions: aggregate.reduce((sum, x) => sum + x.additions, 0),
+          deletions: aggregate.reduce((sum, x) => sum + x.deletions, 0),
+          files: aggregate.length,
+          diffs: aggregate,
+        },
+      })
+      yield* events.publish(Session.Event.Diff, { sessionID: input.sessionID, diff: aggregate })
     })
 
     const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {


### PR DESCRIPTION
### Issue for this PR

Closes #30877

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#30127 zeroed `session.summary` (`files: 0, additions: 0, deletions: 0`, empty diff event) to fix a performance issue with full-session snapshot diffs. Per-message turn diffs (`session.diff({ messageID })`) were kept, but the TUI sidebar reads the session-level aggregate — which is now always empty. This is why "Modified Files" has been blank since v1.16.0.

This PR re-aggregates `session.summary` from the per-message turn diffs that #30127 preserved. After the existing per-turn `computeDiff` runs and stores its result on the message, we sum all messages' `info.summary.diffs` into the session-level summary. Each touched file appears once (last turn wins).

This does not reintroduce the expensive full-session snapshot diff — it only reads already-computed per-message metadata.

One file changed: `packages/opencode/src/session/summary.ts`, the `summarize` function.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — clean, no errors in `summary.ts`
- Built a standalone binary from this branch and ran it in a test repo:
  - Edited a file, then inspected the session DB
  - Before patch: `summary_files=0, summary_diffs=(empty)`
  - After patch: `summary_files=1, summary_additions=1, summary_deletions=1, summary_diffs=[{file:"sample.txt",...}]`
- A second user confirmed the fix works by running the built binary against their TUI — "Modified Files" sidebar populated correctly after edits.

### Screenshots / recordings

Restores existing sidebar behavior, no visual design change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR