### PR TITLE
feat(tui): enable scrollbar by default with Ctrl+Alt+S toggle

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -78,7 +78,7 @@ export const Definitions = {
   theme_switch_mode: keybind("none", "Switch between light and dark theme mode"),
   theme_mode_lock: keybind("none", "Lock or unlock theme mode"),
   sidebar_toggle: keybind("<leader>b", "Toggle sidebar"),
-  scrollbar_toggle: keybind("none", "Toggle session scrollbar"),
+  scrollbar_toggle: keybind("ctrl+alt+s", "Toggle session scrollbar"),
   status_view: keybind("<leader>s", "View status"),
 
   session_export: keybind("<leader>x", "Export session to editor"),

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -250,7 +250,7 @@ export function Session() {
   const [timestamps, setTimestamps] = kv.signal<"hide" | "show">("timestamps", "hide")
   const [showDetails, setShowDetails] = kv.signal("tool_details_visibility", true)
   const [showAssistantMetadata, _setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
-  const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
+  const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", true)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)


### PR DESCRIPTION
## Summary

Fixes #33411 — makes the session scrollbar **visible by default** and adds a **keyboard shortcut** (`Ctrl+Alt+S`) to toggle it.

Currently, the scrollbar is hidden with no default keybinding, making long conversation navigation painful. The `@opentui/core` `<scrollbox>` component already has full scrollbar rendering support — it was just never turned on.

## Changes

### 1. Enable scrollbar by default

**`packages/tui/src/routes/session/index.tsx`** — Changed the `scrollbar_visible` persistent signal default from `false` to `true`:

```diff
- const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
+ const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", true)
```

### 2. Add default keybinding

**`packages/tui/src/config/keybind.ts`** — Assigned `Ctrl+Alt+S` to toggle the scrollbar:

```diff
- scrollbar_toggle: keybind("none", "Toggle session scrollbar"),
+ scrollbar_toggle: keybind("ctrl+alt+s", "Toggle session scrollbar"),
```

## Why `Ctrl+Alt+S`?

- `Ctrl+B` is taken by `session_background`
- `<leader>S` is taken by `status_view`
- `Ctrl+S` conflicts with terminal XON/XOFF flow control on many terminals
- `Ctrl+Alt+S` is unassigned, ergonomic (both hands on home row), and mnemonic (**S**crollbar)

## Impact

This is a **low-risk, high-impact** UX improvement. The rendering infrastructure (`verticalScrollbarOptions` on `<scrollbox>`) was already fully implemented — only the visibility flag and default keybinding were missing. No new dependencies or architectural changes are needed.

The scrollbar uses the existing theme-aware styling:
- Track: `backgroundColor: theme.backgroundElement`
- Thumb: `foregroundColor: theme.border`
- Proper padding reservation when visible (`viewportOptions.paddingRight: showScrollbar() ? 1 : 0`)
