### PR TITLE
refactor(core): own todo event schema

### DIFF
--- a/packages/core/src/session/todo.ts
+++ b/packages/core/src/session/todo.ts
@@ -13,7 +13,7 @@ export const Info = Schema.Struct({
     description: "Current status of the task: pending, in_progress, completed, cancelled",
   }),
   priority: Schema.String.annotate({ description: "Priority level of the task: high, medium, low" }),
-}).annotate({ identifier: "SessionTodo.Info" })
+}).annotate({ identifier: "Todo" })
 export type Info = typeof Info.Type
 
 export const Event = {

--- a/packages/opencode/src/session/todo.ts
+++ b/packages/opencode/src/session/todo.ts
@@ -1,31 +1,16 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionID } from "./schema"
-import { Effect, Layer, Context, Schema } from "effect"
+import { Effect, Layer, Context } from "effect"
 import { Database } from "@opencode-ai/core/database/database"
 import { eq } from "drizzle-orm"
 import { asc } from "drizzle-orm"
 import { TodoTable } from "@opencode-ai/core/session/sql"
+import { SessionTodo } from "@opencode-ai/core/session/todo"
 import { EventV2Bridge } from "@/event-v2-bridge"
-import { EventV2 } from "@opencode-ai/core/event"
 
-export const Info = Schema.Struct({
-  content: Schema.String.annotate({ description: "Brief description of the task" }),
-  status: Schema.String.annotate({
-    description: "Current status of the task: pending, in_progress, completed, cancelled",
-  }),
-  priority: Schema.String.annotate({ description: "Priority level of the task: high, medium, low" }),
-}).annotate({ identifier: "Todo" })
-export type Info = Schema.Schema.Type<typeof Info>
-
-export const Event = {
-  Updated: EventV2.define({
-    type: "todo.updated",
-    schema: {
-      sessionID: SessionID,
-      todos: Schema.Array(Info),
-    },
-  }),
-}
+export const Info = SessionTodo.Info
+export type Info = typeof Info.Type
+export const Event = SessionTodo.Event
 
 export interface Interface {
   readonly update: (input: { sessionID: SessionID; todos: Info[] }) => Effect.Effect<void>


### PR DESCRIPTION
## Summary

- make Core the single owner of the shared `Todo` schema and `todo.updated` event definition
- reuse those definitions from the existing OpenCode todo service
- preserve the current event payload, route behavior, and generated API output

## Why

Core and OpenCode independently registered equivalent `todo.updated` definitions in the global EventV2 registry. Reusing the Core definition removes import-order ownership and future schema-drift risk without migrating either service.

## Verification

- `bun run test test/session-todo.test.ts`
- Core typecheck
- OpenCode typecheck
- full generation produced no generated artifact changes
- pre-push workspace typecheck (23/23 tasks)