### PR TITLE
refactor(core): simplify session input promotion

### DIFF
--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -39,5 +39,6 @@ export const migrations = (
     import("./migration/20260612174303_project_dir_strategy"),
     import("./migration/20260622142730_simplify_session_context_epoch"),
     import("./migration/20260622170816_reset_v2_session_state"),
+    import("./migration/20260622202450_simplify_session_input"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260622202450_simplify_session_input.ts
+++ b/packages/core/src/database/migration/20260622202450_simplify_session_input.ts
@@ -1,0 +1,17 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260622202450_simplify_session_input",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`DELETE FROM \`session_context_epoch\`;`)
+      yield* tx.run(`DELETE FROM \`session_input\`;`)
+      yield* tx.run(`DELETE FROM \`session_message\`;`)
+      yield* tx.run(`DELETE FROM \`event\`;`)
+      yield* tx.run(`DELETE FROM \`event_sequence\`;`)
+      yield* tx.run(`UPDATE \`session\` SET \`workspace_id\` = NULL WHERE \`workspace_id\` IS NOT NULL;`)
+      yield* tx.run(`DELETE FROM \`workspace\`;`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -46,6 +46,19 @@ export type Payload<D extends Definition = Definition> = {
 export type Subscriber<D extends Definition = Definition> = (event: Payload<D>) => Effect.Effect<void>
 export type Unsubscribe = Effect.Effect<void>
 
+export const latestSequence = Effect.fn("EventV2.latestSequence")(function* (
+  db: Database.Interface["db"],
+  aggregateID: string,
+) {
+  const row = yield* db
+    .select({ seq: EventSequenceTable.seq })
+    .from(EventSequenceTable)
+    .where(eq(EventSequenceTable.aggregate_id, aggregateID))
+    .get()
+    .pipe(Effect.orDie)
+  return row?.seq ?? -1
+})
+
 export type SerializedEvent = {
   readonly id: ID
   readonly type: string

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -330,13 +330,18 @@ export const layer = Layer.effect(
             const messageID = input.id ?? SessionMessage.ID.create()
             const delivery = input.delivery ?? "steer"
             const expected = { sessionID: input.sessionID, messageID, prompt: input.prompt, delivery }
-            const admitted = yield* SessionInput.admit(db, {
+            const admitted = yield* SessionInput.admit(db, events, {
               id: messageID,
               sessionID: input.sessionID,
               prompt: input.prompt,
               delivery,
-            })
-            if (admitted === undefined) return yield* new PromptConflictError({ sessionID: input.sessionID, messageID })
+            }).pipe(
+              Effect.catchDefect((defect) =>
+                defect instanceof SessionInput.LifecycleConflict
+                  ? new PromptConflictError({ sessionID: input.sessionID, messageID })
+                  : Effect.die(defect),
+              ),
+            )
             if (!SessionInput.equivalent(admitted, expected))
               return yield* new PromptConflictError({ sessionID: input.sessionID, messageID })
             if (input.resume !== false) yield* execution.wake(admitted.sessionID)

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -330,18 +330,13 @@ export const layer = Layer.effect(
             const messageID = input.id ?? SessionMessage.ID.create()
             const delivery = input.delivery ?? "steer"
             const expected = { sessionID: input.sessionID, messageID, prompt: input.prompt, delivery }
-            const admitted = yield* SessionInput.admit(db, events, {
+            const admitted = yield* SessionInput.admit(db, {
               id: messageID,
               sessionID: input.sessionID,
               prompt: input.prompt,
               delivery,
-            }).pipe(
-              Effect.catchDefect((defect) =>
-                defect instanceof SessionInput.LifecycleConflict
-                  ? new PromptConflictError({ sessionID: input.sessionID, messageID })
-                  : Effect.die(defect),
-              ),
-            )
+            })
+            if (admitted === undefined) return yield* new PromptConflictError({ sessionID: input.sessionID, messageID })
             if (!SessionInput.equivalent(admitted, expected))
               return yield* new PromptConflictError({ sessionID: input.sessionID, messageID })
             if (input.resume !== false) yield* execution.wake(admitted.sessionID)

--- a/packages/core/src/session/context-epoch.ts
+++ b/packages/core/src/session/context-epoch.ts
@@ -4,7 +4,6 @@ import { eq } from "drizzle-orm"
 import { DateTime, Effect, Schema } from "effect"
 import type { Database } from "../database/database"
 import { EventV2 } from "../event"
-import { EventSequenceTable } from "../event/sql"
 import { SystemContext } from "../system-context/index"
 import { ContextSnapshotDecodeError } from "./error"
 import { SessionEvent } from "./event"
@@ -15,16 +14,6 @@ import { SessionSchema } from "./schema"
 import { SessionContextEpochTable } from "./sql"
 
 type DatabaseService = Database.Interface["db"]
-
-const latestEventSeq = Effect.fnUntraced(function* (db: DatabaseService, sessionID: SessionSchema.ID) {
-  const row = yield* db
-    .select({ seq: EventSequenceTable.seq })
-    .from(EventSequenceTable)
-    .where(eq(EventSequenceTable.aggregate_id, sessionID))
-    .get()
-    .pipe(Effect.orDie)
-  return row?.seq ?? -1
-})
 
 interface Prepared {
   readonly baseline: string
@@ -75,7 +64,7 @@ const prepareOnce = Effect.fnUntraced(function* (
     return { baseline: stored.baseline, baselineSeq: stored.baseline_seq }
   }
   if (result._tag === "ReplacementReady") {
-    const baselineSeq = replacementSeq ?? (yield* latestEventSeq(db, sessionID))
+    const baselineSeq = replacementSeq ?? (yield* EventV2.latestSequence(db, sessionID))
     yield* replace(db, sessionID, baselineSeq, result.generation)
     return { baseline: result.generation.baseline, baselineSeq }
   }
@@ -135,7 +124,7 @@ const insert = Effect.fnUntraced(function* (
   sessionID: SessionSchema.ID,
   generation: SystemContext.Generation,
 ) {
-  const baselineSeq = yield* latestEventSeq(db, sessionID)
+  const baselineSeq = yield* EventV2.latestSequence(db, sessionID)
   yield* db
     .insert(SessionContextEpochTable)
     .values({

--- a/packages/core/src/session/context-epoch.ts
+++ b/packages/core/src/session/context-epoch.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm"
 import { DateTime, Effect, Schema } from "effect"
 import type { Database } from "../database/database"
 import { EventV2 } from "../event"
+import { EventSequenceTable } from "../event/sql"
 import { SystemContext } from "../system-context/index"
 import { ContextSnapshotDecodeError } from "./error"
 import { SessionEvent } from "./event"
@@ -14,6 +15,16 @@ import { SessionSchema } from "./schema"
 import { SessionContextEpochTable } from "./sql"
 
 type DatabaseService = Database.Interface["db"]
+
+const latestEventSeq = Effect.fnUntraced(function* (db: DatabaseService, sessionID: SessionSchema.ID) {
+  const row = yield* db
+    .select({ seq: EventSequenceTable.seq })
+    .from(EventSequenceTable)
+    .where(eq(EventSequenceTable.aggregate_id, sessionID))
+    .get()
+    .pipe(Effect.orDie)
+  return row?.seq ?? -1
+})
 
 interface Prepared {
   readonly baseline: string
@@ -64,7 +75,7 @@ const prepareOnce = Effect.fnUntraced(function* (
     return { baseline: stored.baseline, baselineSeq: stored.baseline_seq }
   }
   if (result._tag === "ReplacementReady") {
-    const baselineSeq = replacementSeq ?? (yield* SessionInput.latestSeq(db, sessionID))
+    const baselineSeq = replacementSeq ?? (yield* latestEventSeq(db, sessionID))
     yield* replace(db, sessionID, baselineSeq, result.generation)
     return { baseline: result.generation.baseline, baselineSeq }
   }
@@ -124,7 +135,7 @@ const insert = Effect.fnUntraced(function* (
   sessionID: SessionSchema.ID,
   generation: SystemContext.Generation,
 ) {
-  const baselineSeq = yield* SessionInput.latestSeq(db, sessionID)
+  const baselineSeq = yield* latestEventSeq(db, sessionID)
   yield* db
     .insert(SessionContextEpochTable)
     .values({

--- a/packages/core/src/session/event.ts
+++ b/packages/core/src/session/event.ts
@@ -92,32 +92,6 @@ export const Prompted = EventV2.define({
 })
 export type Prompted = typeof Prompted.Type
 
-export namespace PromptLifecycle {
-  export const Admitted = EventV2.define({
-    type: "session.next.prompt.admitted",
-    ...options,
-    schema: {
-      ...Base,
-      messageID: SessionMessageID.ID,
-      prompt: Prompt,
-      delivery: Schema.Literals(["steer", "queue"]),
-    },
-  })
-  export type Admitted = typeof Admitted.Type
-
-  export const Promoted = EventV2.define({
-    type: "session.next.prompt.promoted",
-    ...options,
-    schema: {
-      ...Base,
-      messageID: SessionMessageID.ID,
-      prompt: Prompt,
-      timeCreated: V2Schema.DateTimeUtcFromMillis,
-    },
-  })
-  export type Promoted = typeof Promoted.Type
-}
-
 export const ContextUpdated = EventV2.define({
   type: "session.next.context.updated",
   ...options,
@@ -455,8 +429,6 @@ const DurableDefinitions = [
   ModelSwitched,
   Moved,
   Prompted,
-  PromptLifecycle.Admitted,
-  PromptLifecycle.Promoted,
   ContextUpdated,
   Synthetic,
   Shell.Started,

--- a/packages/core/src/session/event.ts
+++ b/packages/core/src/session/event.ts
@@ -25,6 +25,12 @@ const Base = {
   timestamp: V2Schema.DateTimeUtcFromMillis,
   sessionID: SessionSchema.ID,
 }
+const PromptFields = {
+  ...Base,
+  messageID: SessionMessageID.ID,
+  prompt: Prompt,
+  delivery: Schema.Literals(["steer", "queue"]),
+}
 
 const options = {
   durable: {
@@ -83,14 +89,16 @@ export type Moved = typeof Moved.Type
 export const Prompted = EventV2.define({
   type: "session.next.prompted",
   ...options,
-  schema: {
-    ...Base,
-    messageID: SessionMessageID.ID,
-    prompt: Prompt,
-    delivery: Schema.Literals(["steer", "queue"]),
-  },
+  schema: PromptFields,
 })
 export type Prompted = typeof Prompted.Type
+
+export const PromptAdmitted = EventV2.define({
+  type: "session.next.prompt.admitted",
+  ...options,
+  schema: PromptFields,
+})
+export type PromptAdmitted = typeof PromptAdmitted.Type
 
 export const ContextUpdated = EventV2.define({
   type: "session.next.context.updated",
@@ -429,6 +437,7 @@ const DurableDefinitions = [
   ModelSwitched,
   Moved,
   Prompted,
+  PromptAdmitted,
   ContextUpdated,
   Synthetic,
   Shell.Started,

--- a/packages/core/src/session/input.ts
+++ b/packages/core/src/session/input.ts
@@ -1,10 +1,9 @@
 export * as SessionInput from "./input"
 
-import { and, asc, eq, isNull, lte } from "drizzle-orm"
+import { and, asc, eq, isNull, lte, max } from "drizzle-orm"
 import { DateTime, Effect, Schema } from "effect"
 import type { Database } from "../database/database"
 import type { EventV2 } from "../event"
-import { EventSequenceTable } from "../event/sql"
 import { NonNegativeInt } from "../schema"
 import { V2Schema } from "../v2-schema"
 import { SessionEvent } from "./event"
@@ -19,7 +18,7 @@ export const Delivery = Schema.Literals(["steer", "queue"])
 export type Delivery = typeof Delivery.Type
 
 export class Admitted extends Schema.Class<Admitted>("SessionInput.Admitted")({
-  admittedSeq: NonNegativeInt,
+  admittedSeq: NonNegativeInt.annotate({ description: "Session-local inbox order; not an Event cursor" }),
   id: SessionMessage.ID,
   sessionID: SessionSchema.ID,
   prompt: Prompt,
@@ -53,7 +52,6 @@ export class LifecycleConflict extends Schema.TaggedErrorClass<LifecycleConflict
 
 export const admit = Effect.fn("SessionInput.admit")(function* (
   db: DatabaseService,
-  events: EventV2.Interface,
   input: {
     readonly id: SessionMessage.ID
     readonly sessionID: SessionSchema.ID
@@ -61,85 +59,69 @@ export const admit = Effect.fn("SessionInput.admit")(function* (
     readonly delivery: Delivery
   },
 ) {
-  const existing = yield* find(db, input.id)
-  if (existing !== undefined) return existing
-  const timestamp = yield* DateTime.now
-  return yield* events
-    .publish(SessionEvent.PromptLifecycle.Admitted, {
-      messageID: input.id,
-      sessionID: input.sessionID,
-      timestamp,
-      prompt: input.prompt,
-      delivery: input.delivery,
-    })
-    .pipe(
-      Effect.flatMap((event) =>
-        event.durable === undefined
-          ? Effect.die("Prompt admission event is missing aggregate sequence")
-          : Effect.succeed(
-              new Admitted({
-                admittedSeq: event.durable.seq,
-                id: input.id,
-                sessionID: input.sessionID,
-                prompt: input.prompt,
-                delivery: input.delivery,
-                timeCreated: timestamp,
-              }),
-            ),
-      ),
-      Effect.catchDefect((defect) =>
-        find(db, input.id).pipe(Effect.flatMap((stored) => (stored ? Effect.succeed(stored) : Effect.die(defect)))),
-      ),
+  return yield* db
+    .transaction(
+      (tx) =>
+        Effect.gen(function* () {
+          const existing = yield* tx
+            .select()
+            .from(SessionInputTable)
+            .where(eq(SessionInputTable.id, input.id))
+            .get()
+            .pipe(Effect.orDie)
+          if (existing !== undefined) return fromRow(existing)
+          const message = yield* tx
+            .select({ id: SessionMessageTable.id })
+            .from(SessionMessageTable)
+            .where(eq(SessionMessageTable.id, input.id))
+            .get()
+            .pipe(Effect.orDie)
+          if (message !== undefined) return undefined
+          const latest = yield* tx
+            .select({ seq: max(SessionInputTable.admitted_seq) })
+            .from(SessionInputTable)
+            .where(eq(SessionInputTable.session_id, input.sessionID))
+            .get()
+            .pipe(Effect.orDie)
+          const row = yield* tx
+            .insert(SessionInputTable)
+            .values({
+              id: input.id,
+              session_id: input.sessionID,
+              prompt: encodePrompt(input.prompt),
+              delivery: input.delivery,
+              admitted_seq: (latest?.seq ?? -1) + 1,
+            })
+            .returning()
+            .get()
+            .pipe(Effect.orDie)
+          return fromRow(row)
+        }),
+      { behavior: "immediate" },
     )
+    .pipe(Effect.orDie)
 })
 
-export const latestSeq = Effect.fn("SessionInput.latestSeq")(function* (
+export const latestAdmittedSeq = Effect.fn("SessionInput.latestAdmittedSeq")(function* (
   db: DatabaseService,
   sessionID: SessionSchema.ID,
 ) {
   const row = yield* db
-    .select({ seq: EventSequenceTable.seq })
-    .from(EventSequenceTable)
-    .where(eq(EventSequenceTable.aggregate_id, sessionID))
+    .select({ seq: max(SessionInputTable.admitted_seq) })
+    .from(SessionInputTable)
+    .where(eq(SessionInputTable.session_id, sessionID))
     .get()
     .pipe(Effect.orDie)
   return row?.seq ?? -1
 })
 
-export const projectAdmitted = Effect.fn("SessionInput.projectAdmitted")(function* (
+export const projectPrompted = Effect.fn("SessionInput.projectPrompted")(function* (
   db: DatabaseService,
   input: {
-    readonly admittedSeq: number
     readonly id: SessionMessage.ID
     readonly sessionID: SessionSchema.ID
     readonly prompt: Prompt
     readonly delivery: Delivery
-    readonly timeCreated: DateTime.Utc
-  },
-) {
-  const stored = yield* db
-    .insert(SessionInputTable)
-    .values({
-      id: input.id,
-      session_id: input.sessionID,
-      admitted_seq: input.admittedSeq,
-      prompt: encodePrompt(input.prompt),
-      delivery: input.delivery,
-      time_created: DateTime.toEpochMillis(input.timeCreated),
-    })
-    .onConflictDoNothing()
-    .returning({ id: SessionInputTable.id })
-    .get()
-    .pipe(Effect.orDie)
-  if (!stored) return yield* Effect.die(new LifecycleConflict({ id: input.id }))
-})
-
-export const projectPromoted = Effect.fn("SessionInput.projectPromoted")(function* (
-  db: DatabaseService,
-  input: {
-    readonly id: SessionMessage.ID
-    readonly sessionID: SessionSchema.ID
-    readonly prompt: Prompt
     readonly timeCreated: DateTime.Utc
     readonly promotedSeq: number
   },
@@ -157,14 +139,35 @@ export const projectPromoted = Effect.fn("SessionInput.projectPromoted")(functio
     .returning()
     .get()
     .pipe(Effect.orDie)
-  if (!updated) return yield* Effect.die(new LifecycleConflict({ id: input.id }))
-  const stored = fromRow(updated)
-  if (
-    !matchesPrompt(stored, input) ||
-    DateTime.toEpochMillis(stored.timeCreated) !== DateTime.toEpochMillis(input.timeCreated)
-  )
-    return yield* Effect.die(new LifecycleConflict({ id: input.id }))
-  return toMessage(stored)
+  if (updated) {
+    const stored = fromRow(updated)
+    if (!matchesProjection(stored, input)) return yield* Effect.die(new LifecycleConflict({ id: input.id }))
+    return toMessage(stored)
+  }
+
+  const stored = yield* find(db, input.id)
+  if (stored) {
+    if (!matchesProjection(stored, input) || stored.promotedSeq !== input.promotedSeq)
+      return yield* Effect.die(new LifecycleConflict({ id: input.id }))
+    return toMessage(stored)
+  }
+
+  const admittedSeq = (yield* latestAdmittedSeq(db, input.sessionID)) + 1
+  const inserted = yield* db
+    .insert(SessionInputTable)
+    .values({
+      id: input.id,
+      session_id: input.sessionID,
+      prompt: encodePrompt(input.prompt),
+      delivery: input.delivery,
+      admitted_seq: admittedSeq,
+      promoted_seq: input.promotedSeq,
+      time_created: DateTime.toEpochMillis(input.timeCreated),
+    })
+    .returning()
+    .get()
+    .pipe(Effect.orDie)
+  return toMessage(fromRow(inserted))
 })
 
 export const hasPending = Effect.fn("SessionInput.hasPending")(function* (
@@ -201,35 +204,17 @@ const matchesPrompt = (input: Admitted, expected: { readonly sessionID: SessionS
   input.sessionID === expected.sessionID &&
   JSON.stringify(encodePrompt(input.prompt)) === JSON.stringify(encodePrompt(expected.prompt))
 
-export const projectLegacyPrompted = Effect.fn("SessionInput.projectLegacyPrompted")(function* (
-  db: DatabaseService,
-  input: {
-    readonly id: SessionMessage.ID
+const matchesProjection = (
+  input: Admitted,
+  expected: {
     readonly sessionID: SessionSchema.ID
     readonly prompt: Prompt
     readonly delivery: Delivery
     readonly timeCreated: DateTime.Utc
-    readonly promotedSeq: number
   },
-) {
-  const inserted = yield* db
-    .insert(SessionInputTable)
-    .values({
-      id: input.id,
-      session_id: input.sessionID,
-      admitted_seq: input.promotedSeq,
-      prompt: encodePrompt(input.prompt),
-      delivery: input.delivery,
-      promoted_seq: input.promotedSeq,
-      time_created: DateTime.toEpochMillis(input.timeCreated),
-    })
-    .onConflictDoNothing()
-    .returning()
-    .get()
-    .pipe(Effect.orDie)
-  if (!inserted) return yield* Effect.die("Prompt projection conflicts with admitted input")
-  return fromRow(inserted)
-})
+) =>
+  equivalent(input, expected) &&
+  DateTime.toEpochMillis(input.timeCreated) === DateTime.toEpochMillis(expected.timeCreated)
 
 const publish = Effect.fn("SessionInput.publish")(function* (
   db: DatabaseService,
@@ -238,18 +223,19 @@ const publish = Effect.fn("SessionInput.publish")(function* (
   rows: ReadonlyArray<typeof SessionInputTable.$inferSelect>,
 ) {
   for (const row of rows) {
+    const id = SessionMessage.ID.make(row.id)
     yield* events
-      .publish(SessionEvent.PromptLifecycle.Promoted, {
+      .publish(SessionEvent.Prompted, {
         sessionID,
-        timestamp: yield* DateTime.now,
-        messageID: SessionMessage.ID.make(row.id),
+        timestamp: DateTime.makeUnsafe(row.time_created),
+        messageID: id,
         prompt: decodePrompt(row.prompt),
-        timeCreated: DateTime.makeUnsafe(row.time_created),
+        delivery: row.delivery,
       })
       .pipe(
         Effect.catchDefect((defect) =>
           defect instanceof LifecycleConflict
-            ? find(db, SessionMessage.ID.make(row.id)).pipe(
+            ? find(db, id).pipe(
                 Effect.flatMap((stored) => (stored?.promotedSeq === undefined ? Effect.die(defect) : Effect.void)),
               )
             : Effect.die(defect),

--- a/packages/core/src/session/input.ts
+++ b/packages/core/src/session/input.ts
@@ -1,6 +1,6 @@
 export * as SessionInput from "./input"
 
-import { and, asc, eq, isNull, lte, max } from "drizzle-orm"
+import { and, asc, eq, isNull, lte } from "drizzle-orm"
 import { DateTime, Effect, Schema } from "effect"
 import type { Database } from "../database/database"
 import type { EventV2 } from "../event"
@@ -18,7 +18,7 @@ export const Delivery = Schema.Literals(["steer", "queue"])
 export type Delivery = typeof Delivery.Type
 
 export class Admitted extends Schema.Class<Admitted>("SessionInput.Admitted")({
-  admittedSeq: NonNegativeInt.annotate({ description: "Session-local inbox order; not an Event cursor" }),
+  admittedSeq: NonNegativeInt,
   id: SessionMessage.ID,
   sessionID: SessionSchema.ID,
   prompt: Prompt,
@@ -52,6 +52,7 @@ export class LifecycleConflict extends Schema.TaggedErrorClass<LifecycleConflict
 
 export const admit = Effect.fn("SessionInput.admit")(function* (
   db: DatabaseService,
+  events: EventV2.Interface,
   input: {
     readonly id: SessionMessage.ID
     readonly sessionID: SessionSchema.ID
@@ -59,60 +60,71 @@ export const admit = Effect.fn("SessionInput.admit")(function* (
     readonly delivery: Delivery
   },
 ) {
-  return yield* db
-    .transaction(
-      (tx) =>
-        Effect.gen(function* () {
-          const existing = yield* tx
-            .select()
-            .from(SessionInputTable)
-            .where(eq(SessionInputTable.id, input.id))
-            .get()
-            .pipe(Effect.orDie)
-          if (existing !== undefined) return fromRow(existing)
-          const message = yield* tx
-            .select({ id: SessionMessageTable.id })
-            .from(SessionMessageTable)
-            .where(eq(SessionMessageTable.id, input.id))
-            .get()
-            .pipe(Effect.orDie)
-          if (message !== undefined) return undefined
-          const latest = yield* tx
-            .select({ seq: max(SessionInputTable.admitted_seq) })
-            .from(SessionInputTable)
-            .where(eq(SessionInputTable.session_id, input.sessionID))
-            .get()
-            .pipe(Effect.orDie)
-          const row = yield* tx
-            .insert(SessionInputTable)
-            .values({
-              id: input.id,
-              session_id: input.sessionID,
-              prompt: encodePrompt(input.prompt),
-              delivery: input.delivery,
-              admitted_seq: (latest?.seq ?? -1) + 1,
-            })
-            .returning()
-            .get()
-            .pipe(Effect.orDie)
-          return fromRow(row)
-        }),
-      { behavior: "immediate" },
+  const existing = yield* find(db, input.id)
+  if (existing !== undefined) return existing
+  const timestamp = yield* DateTime.now
+  return yield* events
+    .publish(SessionEvent.PromptAdmitted, {
+      messageID: input.id,
+      sessionID: input.sessionID,
+      timestamp,
+      prompt: input.prompt,
+      delivery: input.delivery,
+    })
+    .pipe(
+      Effect.flatMap((event) =>
+        event.durable === undefined
+          ? Effect.die("Prompt admission event is missing aggregate sequence")
+          : Effect.succeed(
+              new Admitted({
+                admittedSeq: event.durable.seq,
+                id: input.id,
+                sessionID: input.sessionID,
+                prompt: input.prompt,
+                delivery: input.delivery,
+                timeCreated: timestamp,
+              }),
+            ),
+      ),
+      Effect.catchDefect((defect) =>
+        find(db, input.id).pipe(Effect.flatMap((stored) => (stored ? Effect.succeed(stored) : Effect.die(defect)))),
+      ),
     )
-    .pipe(Effect.orDie)
 })
 
-export const latestAdmittedSeq = Effect.fn("SessionInput.latestAdmittedSeq")(function* (
+export const projectAdmitted = Effect.fn("SessionInput.projectAdmitted")(function* (
   db: DatabaseService,
-  sessionID: SessionSchema.ID,
+  input: {
+    readonly admittedSeq: number
+    readonly id: SessionMessage.ID
+    readonly sessionID: SessionSchema.ID
+    readonly prompt: Prompt
+    readonly delivery: Delivery
+    readonly timeCreated: DateTime.Utc
+  },
 ) {
-  const row = yield* db
-    .select({ seq: max(SessionInputTable.admitted_seq) })
-    .from(SessionInputTable)
-    .where(eq(SessionInputTable.session_id, sessionID))
+  const message = yield* db
+    .select({ id: SessionMessageTable.id })
+    .from(SessionMessageTable)
+    .where(eq(SessionMessageTable.id, input.id))
     .get()
     .pipe(Effect.orDie)
-  return row?.seq ?? -1
+  if (message !== undefined) return yield* Effect.die(new LifecycleConflict({ id: input.id }))
+  const stored = yield* db
+    .insert(SessionInputTable)
+    .values({
+      id: input.id,
+      session_id: input.sessionID,
+      admitted_seq: input.admittedSeq,
+      prompt: encodePrompt(input.prompt),
+      delivery: input.delivery,
+      time_created: DateTime.toEpochMillis(input.timeCreated),
+    })
+    .onConflictDoNothing()
+    .returning({ id: SessionInputTable.id })
+    .get()
+    .pipe(Effect.orDie)
+  if (!stored) return yield* Effect.die(new LifecycleConflict({ id: input.id }))
 })
 
 export const projectPrompted = Effect.fn("SessionInput.projectPrompted")(function* (
@@ -152,7 +164,6 @@ export const projectPrompted = Effect.fn("SessionInput.projectPrompted")(functio
     return toMessage(stored)
   }
 
-  const admittedSeq = (yield* latestAdmittedSeq(db, input.sessionID)) + 1
   const inserted = yield* db
     .insert(SessionInputTable)
     .values({
@@ -160,7 +171,7 @@ export const projectPrompted = Effect.fn("SessionInput.projectPrompted")(functio
       session_id: input.sessionID,
       prompt: encodePrompt(input.prompt),
       delivery: input.delivery,
-      admitted_seq: admittedSeq,
+      admitted_seq: input.promotedSeq,
       promoted_seq: input.promotedSeq,
       time_created: DateTime.toEpochMillis(input.timeCreated),
     })

--- a/packages/core/src/session/input.ts
+++ b/packages/core/src/session/input.ts
@@ -154,17 +154,17 @@ export const projectPrompted = Effect.fn("SessionInput.projectPrompted")(functio
   if (updated) {
     const stored = fromRow(updated)
     if (!matchesProjection(stored, input)) return yield* Effect.die(new LifecycleConflict({ id: input.id }))
-    return toMessage(stored)
+    return
   }
 
   const stored = yield* find(db, input.id)
   if (stored) {
     if (!matchesProjection(stored, input) || stored.promotedSeq !== input.promotedSeq)
       return yield* Effect.die(new LifecycleConflict({ id: input.id }))
-    return toMessage(stored)
+    return
   }
 
-  const inserted = yield* db
+  yield* db
     .insert(SessionInputTable)
     .values({
       id: input.id,
@@ -175,10 +175,8 @@ export const projectPrompted = Effect.fn("SessionInput.projectPrompted")(functio
       promoted_seq: input.promotedSeq,
       time_created: DateTime.toEpochMillis(input.timeCreated),
     })
-    .returning()
-    .get()
+    .run()
     .pipe(Effect.orDie)
-  return toMessage(fromRow(inserted))
 })
 
 export const hasPending = Effect.fn("SessionInput.hasPending")(function* (
@@ -300,13 +298,3 @@ export const promoteNextQueued = Effect.fn("SessionInput.promoteNextQueued")(fun
     .pipe(Effect.orDie)
   return row === undefined ? false : yield* publish(db, events, sessionID, [row]).pipe(Effect.as(true))
 })
-
-const toMessage = (input: Admitted) =>
-  new SessionMessage.User({
-    id: input.id,
-    type: "user",
-    text: input.prompt.text,
-    files: input.prompt.files,
-    agents: input.prompt.agents,
-    time: { created: input.timeCreated },
-  })

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -136,6 +136,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
           }),
         )
       },
+      "session.next.prompt.admitted": () => Effect.void,
       "session.next.context.updated": (event) =>
         adapter.appendMessage(
           new SessionMessage.System({

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -136,8 +136,6 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
           }),
         )
       },
-      "session.next.prompt.admitted": () => Effect.void,
-      "session.next.prompt.promoted": () => Effect.void,
       "session.next.context.updated": (event) =>
         adapter.appendMessage(
           new SessionMessage.System({

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -350,18 +350,15 @@ export const layer = Layer.effectDiscard(
     yield* events.project(SessionEvent.Prompted, (event) =>
       Effect.gen(function* () {
         if (event.durable === undefined) return yield* Effect.die("Durable Session event is missing aggregate sequence")
-        yield* insertMessage(
-          db,
-          event,
-          yield* SessionInput.projectPrompted(db, {
-            id: event.data.messageID,
-            sessionID: event.data.sessionID,
-            prompt: event.data.prompt,
-            delivery: event.data.delivery,
-            timeCreated: event.data.timestamp,
-            promotedSeq: event.durable.seq,
-          }),
-        )
+        yield* SessionInput.projectPrompted(db, {
+          id: event.data.messageID,
+          sessionID: event.data.sessionID,
+          prompt: event.data.prompt,
+          delivery: event.data.delivery,
+          timeCreated: event.data.timestamp,
+          promotedSeq: event.durable.seq,
+        })
+        yield* run(db, event)
       }),
     )
     yield* events.project(SessionEvent.PromptAdmitted, (event) =>

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -364,6 +364,19 @@ export const layer = Layer.effectDiscard(
         )
       }),
     )
+    yield* events.project(SessionEvent.PromptAdmitted, (event) =>
+      Effect.gen(function* () {
+        if (event.durable === undefined) return yield* Effect.die("Durable Session event is missing aggregate sequence")
+        yield* SessionInput.projectAdmitted(db, {
+          admittedSeq: event.durable.seq,
+          id: event.data.messageID,
+          sessionID: event.data.sessionID,
+          prompt: event.data.prompt,
+          delivery: event.data.delivery,
+          timeCreated: event.data.timestamp,
+        })
+      }),
+    )
     yield* events.project(SessionEvent.ContextUpdated, (event) => run(db, event))
     yield* events.project(SessionEvent.Synthetic, (event) => run(db, event))
     yield* events.project(SessionEvent.Shell.Started, (event) => run(db, event))

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -21,7 +21,6 @@ type DatabaseService = Database.Interface["db"]
 const decodeMessage = Schema.decodeUnknownSync(SessionMessage.Message)
 const encodeMessage = Schema.encodeSync(SessionMessage.Message)
 
-class PromptAlreadyProjected extends Error {}
 export class SessionAlreadyProjected extends Error {}
 
 type Usage = {
@@ -350,50 +349,16 @@ export const layer = Layer.effectDiscard(
     )
     yield* events.project(SessionEvent.Prompted, (event) =>
       Effect.gen(function* () {
-        const messageID = event.data.messageID
-        const existing = yield* db
-          .select({ id: SessionMessageTable.id })
-          .from(SessionMessageTable)
-          .where(eq(SessionMessageTable.id, messageID))
-          .get()
-          .pipe(Effect.orDie)
-        if (existing) return yield* Effect.die(new PromptAlreadyProjected())
-        yield* run(db, event)
-        if (event.durable === undefined) return yield* Effect.die("Durable Session event is missing aggregate sequence")
-        yield* SessionInput.projectLegacyPrompted(db, {
-          id: messageID,
-          sessionID: event.data.sessionID,
-          prompt: event.data.prompt,
-          delivery: event.data.delivery,
-          timeCreated: event.data.timestamp,
-          promotedSeq: event.durable.seq,
-        })
-      }),
-    )
-    yield* events.project(SessionEvent.PromptLifecycle.Admitted, (event) =>
-      Effect.gen(function* () {
-        if (event.durable === undefined) return yield* Effect.die("Durable Session event is missing aggregate sequence")
-        yield* SessionInput.projectAdmitted(db, {
-          admittedSeq: event.durable.seq,
-          id: event.data.messageID,
-          sessionID: event.data.sessionID,
-          prompt: event.data.prompt,
-          delivery: event.data.delivery,
-          timeCreated: event.data.timestamp,
-        })
-      }),
-    )
-    yield* events.project(SessionEvent.PromptLifecycle.Promoted, (event) =>
-      Effect.gen(function* () {
         if (event.durable === undefined) return yield* Effect.die("Durable Session event is missing aggregate sequence")
         yield* insertMessage(
           db,
           event,
-          yield* SessionInput.projectPromoted(db, {
+          yield* SessionInput.projectPrompted(db, {
             id: event.data.messageID,
             sessionID: event.data.sessionID,
             prompt: event.data.prompt,
-            timeCreated: event.data.timeCreated,
+            delivery: event.data.delivery,
+            timeCreated: event.data.timestamp,
             promotedSeq: event.durable.seq,
           }),
         )

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -176,7 +176,7 @@ export const layer = Layer.effect(
       const toolFibers = yield* FiberSet.make<void, ToolOutputStore.Error>()
       let needsContinuation = false
       if (promotion) {
-        const cutoff = yield* SessionInput.latestSeq(db, session.id)
+        const cutoff = yield* SessionInput.latestAdmittedSeq(db, session.id)
         if (promotion === "steer") yield* SessionInput.promoteSteers(db, events, session.id, cutoff)
         if (promotion === "queue") {
           yield* SessionInput.promoteNextQueued(db, events, session.id)

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -176,7 +176,7 @@ export const layer = Layer.effect(
       const toolFibers = yield* FiberSet.make<void, ToolOutputStore.Error>()
       let needsContinuation = false
       if (promotion) {
-        const cutoff = yield* SessionInput.latestAdmittedSeq(db, session.id)
+        const cutoff = yield* EventV2.latestSequence(db, session.id)
         if (promotion === "steer") yield* SessionInput.promoteSteers(db, events, session.id, cutoff)
         if (promotion === "queue") {
           yield* SessionInput.promoteNextQueued(db, events, session.id)

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -14,7 +14,7 @@ import sessionMessageProjectionOrderMigration from "@opencode-ai/core/database/m
 import eventSourcedSessionInputMigration from "@opencode-ai/core/database/migration/20260604172448_event_sourced_session_input"
 import contextEpochAgentMigration from "@opencode-ai/core/database/migration/20260605042240_add_context_epoch_agent"
 import simplifyIntegrationCredentialsMigration from "@opencode-ai/core/database/migration/20260611192811_lush_chimera"
-import resetV2SessionStateMigration from "@opencode-ai/core/database/migration/20260622170816_reset_v2_session_state"
+import simplifySessionInputMigration from "@opencode-ai/core/database/migration/20260622202450_simplify_session_input"
 import { EventV2 } from "@opencode-ai/core/event"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
@@ -264,8 +264,8 @@ describe("DatabaseMigration", () => {
         yield* db.run(
           sql`INSERT INTO session_context_epoch (session_id, baseline, snapshot, baseline_seq) VALUES ('session', 'baseline', '{}', 9)`,
         )
-        yield* db.run(sql`DELETE FROM migration WHERE id = ${resetV2SessionStateMigration.id}`)
-        yield* DatabaseMigration.applyOnly(db, [resetV2SessionStateMigration])
+        yield* db.run(sql`DELETE FROM migration WHERE id = ${simplifySessionInputMigration.id}`)
+        yield* DatabaseMigration.applyOnly(db, [simplifySessionInputMigration])
 
         const database = Layer.succeed(Database.Service, { db })
         const events = EventV2.layer.pipe(Layer.provide(database))

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -222,11 +222,8 @@ describe("SessionV2.create", () => {
       yield* SessionInput.promoteSteers(db, events, created.id, Number.MAX_SAFE_INTEGER)
 
       expect(
-        Array.from(yield* session.events({ sessionID: created.id }).pipe(Stream.take(2), Stream.runCollect)),
-      ).toMatchObject([
-        { durable: { seq: 1 }, type: "session.next.prompt.admitted", data: { prompt: { text: "Hello" } } },
-        { durable: { seq: 2 }, type: "session.next.prompt.promoted" },
-      ])
+        Array.from(yield* session.events({ sessionID: created.id }).pipe(Stream.take(1), Stream.runCollect)),
+      ).toMatchObject([{ durable: { seq: 1 }, type: "session.next.prompted", data: { prompt: { text: "Hello" } } }])
     }),
   )
 
@@ -276,24 +273,18 @@ describe("SessionV2.create", () => {
           .pipe(Effect.orDie)
 
         expect(yield* store.get(created.id)).toBeUndefined()
-        expect(yield* events.replayAll(serialized.slice(0, 2))).toBe(created.id)
-        expect(yield* SessionInput.find(db, admitted.id)).toMatchObject({
-          id: admitted.id,
-          sessionID: created.id,
-          prompt: { text: "Replay lifecycle" },
-          delivery: "steer",
-          admittedSeq: 1,
-        })
+        expect(yield* events.replayAll(serialized.slice(0, 1))).toBe(created.id)
+        expect(yield* SessionInput.find(db, admitted.id)).toBeUndefined()
         expect(yield* store.context(created.id)).toEqual([])
 
-        expect(yield* events.replayAll(serialized.slice(2))).toBe(created.id)
+        expect(yield* events.replayAll(serialized.slice(1))).toBe(created.id)
         expect(yield* SessionInput.find(db, admitted.id)).toMatchObject({
           id: admitted.id,
           sessionID: created.id,
           prompt: { text: "Replay lifecycle" },
           delivery: "steer",
-          admittedSeq: 1,
-          promotedSeq: 2,
+          admittedSeq: 0,
+          promotedSeq: 1,
         })
         expect(yield* store.context(created.id)).toMatchObject([
           { id: admitted.id, type: "user", text: "Replay lifecycle" },
@@ -308,8 +299,7 @@ describe("SessionV2.create", () => {
             .pipe(Effect.orDie)).map((event) => [event.seq, event.type]),
         ).toEqual([
           [0, EventV2.versionedType(SessionV1.Event.Created.type, 1)],
-          [1, EventV2.versionedType(SessionEvent.PromptLifecycle.Admitted.type, 1)],
-          [2, EventV2.versionedType(SessionEvent.PromptLifecycle.Promoted.type, 1)],
+          [1, EventV2.versionedType(SessionEvent.Prompted.type, 1)],
         ])
       }).pipe(Effect.provide(Layer.fresh(Layer.mergeAll(targetDatabase, targetEvents, targetProjector, targetStore))))
     }),

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -222,8 +222,11 @@ describe("SessionV2.create", () => {
       yield* SessionInput.promoteSteers(db, events, created.id, Number.MAX_SAFE_INTEGER)
 
       expect(
-        Array.from(yield* session.events({ sessionID: created.id }).pipe(Stream.take(1), Stream.runCollect)),
-      ).toMatchObject([{ durable: { seq: 1 }, type: "session.next.prompted", data: { prompt: { text: "Hello" } } }])
+        Array.from(yield* session.events({ sessionID: created.id }).pipe(Stream.take(2), Stream.runCollect)),
+      ).toMatchObject([
+        { durable: { seq: 1 }, type: "session.next.prompt.admitted", data: { prompt: { text: "Hello" } } },
+        { durable: { seq: 2 }, type: "session.next.prompted" },
+      ])
     }),
   )
 
@@ -273,18 +276,24 @@ describe("SessionV2.create", () => {
           .pipe(Effect.orDie)
 
         expect(yield* store.get(created.id)).toBeUndefined()
-        expect(yield* events.replayAll(serialized.slice(0, 1))).toBe(created.id)
-        expect(yield* SessionInput.find(db, admitted.id)).toBeUndefined()
-        expect(yield* store.context(created.id)).toEqual([])
-
-        expect(yield* events.replayAll(serialized.slice(1))).toBe(created.id)
+        expect(yield* events.replayAll(serialized.slice(0, 2))).toBe(created.id)
         expect(yield* SessionInput.find(db, admitted.id)).toMatchObject({
           id: admitted.id,
           sessionID: created.id,
           prompt: { text: "Replay lifecycle" },
           delivery: "steer",
-          admittedSeq: 0,
-          promotedSeq: 1,
+          admittedSeq: 1,
+        })
+        expect(yield* store.context(created.id)).toEqual([])
+
+        expect(yield* events.replayAll(serialized.slice(2))).toBe(created.id)
+        expect(yield* SessionInput.find(db, admitted.id)).toMatchObject({
+          id: admitted.id,
+          sessionID: created.id,
+          prompt: { text: "Replay lifecycle" },
+          delivery: "steer",
+          admittedSeq: 1,
+          promotedSeq: 2,
         })
         expect(yield* store.context(created.id)).toMatchObject([
           { id: admitted.id, type: "user", text: "Replay lifecycle" },
@@ -299,7 +308,8 @@ describe("SessionV2.create", () => {
             .pipe(Effect.orDie)).map((event) => [event.seq, event.type]),
         ).toEqual([
           [0, EventV2.versionedType(SessionV1.Event.Created.type, 1)],
-          [1, EventV2.versionedType(SessionEvent.Prompted.type, 1)],
+          [1, EventV2.versionedType(SessionEvent.PromptAdmitted.type, 1)],
+          [2, EventV2.versionedType(SessionEvent.Prompted.type, 1)],
         ])
       }).pipe(Effect.provide(Layer.fresh(Layer.mergeAll(targetDatabase, targetEvents, targetProjector, targetStore))))
     }),

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -120,7 +120,7 @@ describe("SessionProjector", () => {
     ),
   )
 
-  it.effect("marks an admitted lifecycle row promoted with the PromptPromoted event sequence", () =>
+  it.effect("marks an inbox row promoted with the Prompted event sequence", () =>
     Effect.gen(function* () {
       const { db } = yield* Database.Service
       yield* db
@@ -142,19 +142,20 @@ describe("SessionProjector", () => {
         .pipe(Effect.orDie)
       const events = yield* EventV2.Service
       const id = SessionMessage.ID.make("msg_admitted")
-      yield* SessionInput.admit(db, events, {
+      const admitted = yield* SessionInput.admit(db, {
         id,
         sessionID,
         prompt: new Prompt({ text: "promote me" }),
         delivery: "steer",
       })
+      if (!admitted) return yield* Effect.die("Prompt admission failed")
 
-      const event = yield* events.publish(SessionEvent.PromptLifecycle.Promoted, {
+      const event = yield* events.publish(SessionEvent.Prompted, {
         sessionID,
-        timestamp: created,
+        timestamp: admitted.timeCreated,
         messageID: id,
         prompt: new Prompt({ text: "promote me" }),
-        timeCreated: created,
+        delivery: "steer",
       })
 
       expect(

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -142,7 +142,7 @@ describe("SessionProjector", () => {
         .pipe(Effect.orDie)
       const events = yield* EventV2.Service
       const id = SessionMessage.ID.make("msg_admitted")
-      const admitted = yield* SessionInput.admit(db, {
+      const admitted = yield* SessionInput.admit(db, events, {
         id,
         sessionID,
         prompt: new Prompt({ text: "promote me" }),

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -168,7 +168,7 @@ describe("SessionV2.prompt", () => {
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       const { db } = yield* Database.Service
-      const fiber = yield* session.events({ sessionID }).pipe(Stream.take(4), Stream.runCollect, Effect.forkScoped)
+      const fiber = yield* session.events({ sessionID }).pipe(Stream.take(2), Stream.runCollect, Effect.forkScoped)
       yield* Effect.yieldNow
 
       yield* session.prompt({ sessionID, prompt: new Prompt({ text: "First" }), resume: false })
@@ -177,10 +177,8 @@ describe("SessionV2.prompt", () => {
       const streamed = Array.from(yield* Fiber.join(fiber))
 
       expect(streamed.map((event) => [event.durable?.seq, event.type])).toEqual([
-        [0, "session.next.prompt.admitted"],
-        [1, "session.next.prompt.admitted"],
-        [2, "session.next.prompt.promoted"],
-        [3, "session.next.prompt.promoted"],
+        [0, "session.next.prompted"],
+        [1, "session.next.prompted"],
       ])
       expect(
         Array.from(
@@ -188,7 +186,7 @@ describe("SessionV2.prompt", () => {
             .events({ sessionID, after: streamed[0]!.durable?.seq })
             .pipe(Stream.take(1), Stream.runCollect),
         ).map((event) => [event.durable?.seq, event.type]),
-      ).toEqual([[1, "session.next.prompt.admitted"]])
+      ).toEqual([[1, "session.next.prompted"]])
     }),
   )
 
@@ -334,7 +332,7 @@ describe("SessionV2.prompt", () => {
       expect(messages[1]).toEqual(messages[0])
       expect(yield* session.messages({ sessionID })).toEqual([])
       expect(yield* admittedCount).toBe(1)
-      expect(yield* eventCount(EventV2.versionedType(SessionEvent.PromptLifecycle.Admitted.type, 1))).toBe(1)
+      expect(yield* eventCount(EventV2.versionedType(SessionEvent.Prompted.type, 1))).toBe(0)
     }),
   )
 
@@ -354,22 +352,22 @@ describe("SessionV2.prompt", () => {
         { concurrency: "unbounded" },
       )
 
-      expect(yield* eventCount(EventV2.versionedType(SessionEvent.PromptLifecycle.Promoted.type, 1))).toBe(1)
-      expect(yield* admitted(messageID)).toMatchObject({ promotedSeq: 1 })
+      expect(yield* eventCount(EventV2.versionedType(SessionEvent.Prompted.type, 1))).toBe(1)
+      expect(yield* admitted(messageID)).toMatchObject({ promotedSeq: 0 })
       expect(yield* session.messages({ sessionID })).toMatchObject([
         { id: messageID, type: "user", text: "Promote once" },
       ])
     }),
   )
 
-  it.effect("promotes steers only through the captured aggregate cutoff", () =>
+  it.effect("promotes steers only through the captured inbox cutoff", () =>
     Effect.gen(function* () {
       yield* setup
       const { db } = yield* Database.Service
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       const first = yield* session.prompt({ sessionID, prompt: new Prompt({ text: "Before cutoff" }), resume: false })
-      const cutoff = yield* SessionInput.latestSeq(db, sessionID)
+      const cutoff = yield* SessionInput.latestAdmittedSeq(db, sessionID)
       const second = yield* session.prompt({ sessionID, prompt: new Prompt({ text: "After cutoff" }), resume: false })
 
       yield* SessionInput.promoteSteers(db, events, sessionID, cutoff)
@@ -379,12 +377,11 @@ describe("SessionV2.prompt", () => {
     }),
   )
 
-  it.effect("reprojects one pending lifecycle without scheduling execution", () =>
+  it.effect("keeps pending inbox input outside the replayable event stream", () =>
     Effect.gen(function* () {
       yield* setup
       const { db } = yield* Database.Service
       const session = yield* SessionV2.Service
-      const events = yield* EventV2.Service
       wakeCalls.length = 0
       yield* session.prompt({ id: messageID, sessionID, prompt: new Prompt({ text: "Replay pending" }), resume: false })
       const recorded = yield* db
@@ -394,23 +391,7 @@ describe("SessionV2.prompt", () => {
         .all()
         .pipe(Effect.orDie)
 
-      yield* events.remove(sessionID)
-      yield* db.delete(SessionInputTable).where(eq(SessionInputTable.session_id, sessionID)).run().pipe(Effect.orDie)
-      yield* db
-        .delete(SessionMessageTable)
-        .where(eq(SessionMessageTable.session_id, sessionID))
-        .run()
-        .pipe(Effect.orDie)
-      yield* events.replayAll(
-        recorded.map((event) => ({
-          id: event.id,
-          aggregateID: event.aggregate_id,
-          seq: event.seq,
-          type: event.type,
-          data: event.data,
-        })),
-      )
-
+      expect(recorded).toEqual([])
       expect(yield* admitted(messageID)).toMatchObject({ id: messageID, prompt: { text: "Replay pending" } })
       expect(yield* session.messages({ sessionID })).toEqual([])
       expect(wakeCalls).toEqual([])

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -168,7 +168,7 @@ describe("SessionV2.prompt", () => {
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       const { db } = yield* Database.Service
-      const fiber = yield* session.events({ sessionID }).pipe(Stream.take(2), Stream.runCollect, Effect.forkScoped)
+      const fiber = yield* session.events({ sessionID }).pipe(Stream.take(4), Stream.runCollect, Effect.forkScoped)
       yield* Effect.yieldNow
 
       yield* session.prompt({ sessionID, prompt: new Prompt({ text: "First" }), resume: false })
@@ -177,8 +177,10 @@ describe("SessionV2.prompt", () => {
       const streamed = Array.from(yield* Fiber.join(fiber))
 
       expect(streamed.map((event) => [event.durable?.seq, event.type])).toEqual([
-        [0, "session.next.prompted"],
-        [1, "session.next.prompted"],
+        [0, "session.next.prompt.admitted"],
+        [1, "session.next.prompt.admitted"],
+        [2, "session.next.prompted"],
+        [3, "session.next.prompted"],
       ])
       expect(
         Array.from(
@@ -186,7 +188,7 @@ describe("SessionV2.prompt", () => {
             .events({ sessionID, after: streamed[0]!.durable?.seq })
             .pipe(Stream.take(1), Stream.runCollect),
         ).map((event) => [event.durable?.seq, event.type]),
-      ).toEqual([[1, "session.next.prompted"]])
+      ).toEqual([[1, "session.next.prompt.admitted"]])
     }),
   )
 
@@ -332,7 +334,7 @@ describe("SessionV2.prompt", () => {
       expect(messages[1]).toEqual(messages[0])
       expect(yield* session.messages({ sessionID })).toEqual([])
       expect(yield* admittedCount).toBe(1)
-      expect(yield* eventCount(EventV2.versionedType(SessionEvent.Prompted.type, 1))).toBe(0)
+      expect(yield* eventCount(EventV2.versionedType(SessionEvent.PromptAdmitted.type, 1))).toBe(1)
     }),
   )
 
@@ -353,7 +355,7 @@ describe("SessionV2.prompt", () => {
       )
 
       expect(yield* eventCount(EventV2.versionedType(SessionEvent.Prompted.type, 1))).toBe(1)
-      expect(yield* admitted(messageID)).toMatchObject({ promotedSeq: 0 })
+      expect(yield* admitted(messageID)).toMatchObject({ promotedSeq: 1 })
       expect(yield* session.messages({ sessionID })).toMatchObject([
         { id: messageID, type: "user", text: "Promote once" },
       ])
@@ -367,7 +369,7 @@ describe("SessionV2.prompt", () => {
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       const first = yield* session.prompt({ sessionID, prompt: new Prompt({ text: "Before cutoff" }), resume: false })
-      const cutoff = yield* SessionInput.latestAdmittedSeq(db, sessionID)
+      const cutoff = first.admittedSeq
       const second = yield* session.prompt({ sessionID, prompt: new Prompt({ text: "After cutoff" }), resume: false })
 
       yield* SessionInput.promoteSteers(db, events, sessionID, cutoff)
@@ -377,11 +379,12 @@ describe("SessionV2.prompt", () => {
     }),
   )
 
-  it.effect("keeps pending inbox input outside the replayable event stream", () =>
+  it.effect("reprojects pending inbox input without scheduling execution", () =>
     Effect.gen(function* () {
       yield* setup
       const { db } = yield* Database.Service
       const session = yield* SessionV2.Service
+      const events = yield* EventV2.Service
       wakeCalls.length = 0
       yield* session.prompt({ id: messageID, sessionID, prompt: new Prompt({ text: "Replay pending" }), resume: false })
       const recorded = yield* db
@@ -391,7 +394,23 @@ describe("SessionV2.prompt", () => {
         .all()
         .pipe(Effect.orDie)
 
-      expect(recorded).toEqual([])
+      yield* events.remove(sessionID)
+      yield* db.delete(SessionInputTable).where(eq(SessionInputTable.session_id, sessionID)).run().pipe(Effect.orDie)
+      yield* db
+        .delete(SessionMessageTable)
+        .where(eq(SessionMessageTable.session_id, sessionID))
+        .run()
+        .pipe(Effect.orDie)
+      yield* events.replayAll(
+        recorded.map((event) => ({
+          id: event.id,
+          aggregateID: event.aggregate_id,
+          seq: event.seq,
+          type: event.type,
+          data: event.data,
+        })),
+      )
+
       expect(yield* admitted(messageID)).toMatchObject({ id: messageID, prompt: { text: "Replay pending" } })
       expect(yield* session.messages({ sessionID })).toEqual([])
       expect(wakeCalls).toEqual([])
@@ -467,6 +486,27 @@ describe("SessionV2.prompt", () => {
         .pipe(Effect.flip)
 
       expect(failure).toMatchObject({ _tag: "Session.PromptConflictError", sessionID: other, messageID })
+    }),
+  )
+
+  it.effect("rejects a prompt ID already used by visible Session history", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const events = yield* EventV2.Service
+      yield* events.publish(SessionEvent.Synthetic, {
+        sessionID,
+        messageID,
+        timestamp: yield* DateTime.now,
+        text: "Existing history",
+      })
+
+      const failure = yield* session
+        .prompt({ id: messageID, sessionID, prompt: new Prompt({ text: "Conflicting prompt" }), resume: false })
+        .pipe(Effect.flip)
+
+      expect(failure).toMatchObject({ _tag: "Session.PromptConflictError", sessionID, messageID })
+      expect(yield* admitted(messageID)).toBeUndefined()
     }),
   )
 

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -175,6 +175,7 @@ describe("SessionRunnerLLM recorded", () => {
           .orderBy(EventTable.seq)
           .all()).map((event) => event.type),
       ).toEqual([
+        "session.next.prompt.admitted.1",
         "session.next.prompted.1",
         "session.next.step.started.1",
         "session.next.text.started.1",

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -175,8 +175,7 @@ describe("SessionRunnerLLM recorded", () => {
           .orderBy(EventTable.seq)
           .all()).map((event) => event.type),
       ).toEqual([
-        "session.next.prompt.admitted.1",
-        "session.next.prompt.promoted.1",
+        "session.next.prompted.1",
         "session.next.step.started.1",
         "session.next.text.started.1",
         "session.next.text.ended.1",

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2404,7 +2404,7 @@ describe("SessionRunnerLLM", () => {
       const events = yield* EventV2.Service
       const defect = new Error("fail after prompt promotion")
       let fail = true
-      yield* events.project(SessionEvent.PromptLifecycle.Promoted, () => (fail ? Effect.die(defect) : Effect.void))
+      yield* events.project(SessionEvent.Prompted, () => (fail ? Effect.die(defect) : Effect.void))
       yield* session.prompt({ sessionID, prompt: new Prompt({ text: "Recover promoted input" }), resume: false })
 
       expect(yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed))).toBe(defect)
@@ -2429,9 +2429,7 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       yield* events.listen((event) =>
-        event.type === SessionEvent.PromptLifecycle.Promoted.type
-          ? Effect.die("fail after prompt promotion commits")
-          : Effect.void,
+        event.type === SessionEvent.Prompted.type ? Effect.die("fail after prompt promotion commits") : Effect.void,
       )
       yield* session.prompt({
         sessionID,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -19,8 +19,6 @@ export type Event =
   | EventSessionNextModelSwitched
   | EventSessionNextMoved
   | EventSessionNextPrompted
-  | EventSessionNextPromptAdmitted
-  | EventSessionNextPromptPromoted
   | EventSessionNextContextUpdated
   | EventSessionNextSynthetic
   | EventSessionNextShellStarted
@@ -855,28 +853,6 @@ export type GlobalEvent = {
       }
     | {
         id: string
-        type: "session.next.prompt.admitted"
-        properties: {
-          timestamp: number
-          sessionID: string
-          messageID: string
-          prompt: Prompt
-          delivery: "steer" | "queue"
-        }
-      }
-    | {
-        id: string
-        type: "session.next.prompt.promoted"
-        properties: {
-          timestamp: number
-          sessionID: string
-          messageID: string
-          prompt: Prompt
-          timeCreated: number
-        }
-      }
-    | {
-        id: string
         type: "session.next.context.updated"
         properties: {
           timestamp: number
@@ -1627,8 +1603,6 @@ export type GlobalEvent = {
     | SyncEventSessionNextModelSwitched
     | SyncEventSessionNextMoved
     | SyncEventSessionNextPrompted
-    | SyncEventSessionNextPromptAdmitted
-    | SyncEventSessionNextPromptPromoted
     | SyncEventSessionNextContextUpdated
     | SyncEventSessionNextSynthetic
     | SyncEventSessionNextShellStarted
@@ -2769,8 +2743,6 @@ export type V2Event =
   | V2EventSessionNextModelSwitched
   | V2EventSessionNextMoved
   | V2EventSessionNextPrompted
-  | V2EventSessionNextPromptAdmitted
-  | V2EventSessionNextPromptPromoted
   | V2EventSessionNextContextUpdated
   | V2EventSessionNextSynthetic
   | V2EventSessionNextShellStarted
@@ -3198,42 +3170,6 @@ export type SyncEventSessionNextPrompted = {
       messageID: string
       prompt: Prompt
       delivery: "steer" | "queue"
-    }
-  }
-}
-
-export type SyncEventSessionNextPromptAdmitted = {
-  type: "sync"
-  id: string
-  syncEvent: {
-    type: "session.next.prompt.admitted.1"
-    id: string
-    seq: number
-    aggregateID: string
-    data: {
-      timestamp: number
-      sessionID: string
-      messageID: string
-      prompt: Prompt
-      delivery: "steer" | "queue"
-    }
-  }
-}
-
-export type SyncEventSessionNextPromptPromoted = {
-  type: "sync"
-  id: string
-  syncEvent: {
-    type: "session.next.prompt.promoted.1"
-    id: string
-    seq: number
-    aggregateID: string
-    data: {
-      timestamp: number
-      sessionID: string
-      messageID: string
-      prompt: Prompt
-      timeCreated: number
     }
   }
 }
@@ -3752,6 +3688,9 @@ export type SessionV2Info = {
 }
 
 export type SessionInputAdmitted = {
+  /**
+   * Session-local inbox order; not an Event cursor
+   */
   admittedSeq: number
   id: string
   sessionID: string
@@ -4499,48 +4438,6 @@ export type V2EventSessionNextPrompted = {
     messageID: string
     prompt: Prompt
     delivery: "steer" | "queue"
-  }
-}
-
-export type V2EventSessionNextPromptAdmitted = {
-  id: string
-  metadata?: {
-    [key: string]: unknown
-  }
-  durable?: {
-    aggregateID: string
-    seq: number
-    version: number
-  }
-  location?: LocationRef
-  type: "session.next.prompt.admitted"
-  data: {
-    timestamp: number
-    sessionID: string
-    messageID: string
-    prompt: Prompt
-    delivery: "steer" | "queue"
-  }
-}
-
-export type V2EventSessionNextPromptPromoted = {
-  id: string
-  metadata?: {
-    [key: string]: unknown
-  }
-  durable?: {
-    aggregateID: string
-    seq: number
-    version: number
-  }
-  location?: LocationRef
-  type: "session.next.prompt.promoted"
-  data: {
-    timestamp: number
-    sessionID: string
-    messageID: string
-    prompt: Prompt
-    timeCreated: number
   }
 }
 
@@ -6153,30 +6050,6 @@ export type EventSessionNextPrompted = {
     messageID: string
     prompt: Prompt
     delivery: "steer" | "queue"
-  }
-}
-
-export type EventSessionNextPromptAdmitted = {
-  id: string
-  type: "session.next.prompt.admitted"
-  properties: {
-    timestamp: number
-    sessionID: string
-    messageID: string
-    prompt: Prompt
-    delivery: "steer" | "queue"
-  }
-}
-
-export type EventSessionNextPromptPromoted = {
-  id: string
-  type: "session.next.prompt.promoted"
-  properties: {
-    timestamp: number
-    sessionID: string
-    messageID: string
-    prompt: Prompt
-    timeCreated: number
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -19,6 +19,7 @@ export type Event =
   | EventSessionNextModelSwitched
   | EventSessionNextMoved
   | EventSessionNextPrompted
+  | EventSessionNextPromptAdmitted
   | EventSessionNextContextUpdated
   | EventSessionNextSynthetic
   | EventSessionNextShellStarted
@@ -853,6 +854,17 @@ export type GlobalEvent = {
       }
     | {
         id: string
+        type: "session.next.prompt.admitted"
+        properties: {
+          timestamp: number
+          sessionID: string
+          messageID: string
+          prompt: Prompt
+          delivery: "steer" | "queue"
+        }
+      }
+    | {
+        id: string
         type: "session.next.context.updated"
         properties: {
           timestamp: number
@@ -1603,6 +1615,7 @@ export type GlobalEvent = {
     | SyncEventSessionNextModelSwitched
     | SyncEventSessionNextMoved
     | SyncEventSessionNextPrompted
+    | SyncEventSessionNextPromptAdmitted
     | SyncEventSessionNextContextUpdated
     | SyncEventSessionNextSynthetic
     | SyncEventSessionNextShellStarted
@@ -2743,6 +2756,7 @@ export type V2Event =
   | V2EventSessionNextModelSwitched
   | V2EventSessionNextMoved
   | V2EventSessionNextPrompted
+  | V2EventSessionNextPromptAdmitted
   | V2EventSessionNextContextUpdated
   | V2EventSessionNextSynthetic
   | V2EventSessionNextShellStarted
@@ -3161,6 +3175,24 @@ export type SyncEventSessionNextPrompted = {
   id: string
   syncEvent: {
     type: "session.next.prompted.1"
+    id: string
+    seq: number
+    aggregateID: string
+    data: {
+      timestamp: number
+      sessionID: string
+      messageID: string
+      prompt: Prompt
+      delivery: "steer" | "queue"
+    }
+  }
+}
+
+export type SyncEventSessionNextPromptAdmitted = {
+  type: "sync"
+  id: string
+  syncEvent: {
+    type: "session.next.prompt.admitted.1"
     id: string
     seq: number
     aggregateID: string
@@ -3688,9 +3720,6 @@ export type SessionV2Info = {
 }
 
 export type SessionInputAdmitted = {
-  /**
-   * Session-local inbox order; not an Event cursor
-   */
   admittedSeq: number
   id: string
   sessionID: string
@@ -4432,6 +4461,27 @@ export type V2EventSessionNextPrompted = {
   }
   location?: LocationRef
   type: "session.next.prompted"
+  data: {
+    timestamp: number
+    sessionID: string
+    messageID: string
+    prompt: Prompt
+    delivery: "steer" | "queue"
+  }
+}
+
+export type V2EventSessionNextPromptAdmitted = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  type: "session.next.prompt.admitted"
   data: {
     timestamp: number
     sessionID: string
@@ -6044,6 +6094,18 @@ export type EventSessionNextMoved = {
 export type EventSessionNextPrompted = {
   id: string
   type: "session.next.prompted"
+  properties: {
+    timestamp: number
+    sessionID: string
+    messageID: string
+    prompt: Prompt
+    delivery: "steer" | "queue"
+  }
+}
+
+export type EventSessionNextPromptAdmitted = {
+  id: string
+  type: "session.next.prompt.admitted"
   properties: {
     timestamp: number
     sessionID: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14684,6 +14684,9 @@
             "$ref": "#/components/schemas/EventSessionNextPrompted"
           },
           {
+            "$ref": "#/components/schemas/EventSessionNextPromptAdmitted"
+          },
+          {
             "$ref": "#/components/schemas/EventSessionNextContextUpdated"
           },
           {
@@ -17179,6 +17182,46 @@
                   "type": {
                     "type": "string",
                     "enum": ["session.next.prompted"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {
+                      "timestamp": {
+                        "type": "number"
+                      },
+                      "sessionID": {
+                        "type": "string",
+                        "pattern": "^ses"
+                      },
+                      "messageID": {
+                        "type": "string",
+                        "pattern": "^msg_"
+                      },
+                      "prompt": {
+                        "$ref": "#/components/schemas/Prompt"
+                      },
+                      "delivery": {
+                        "type": "string",
+                        "enum": ["steer", "queue"]
+                      }
+                    },
+                    "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^evt_"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": ["session.next.prompt.admitted"]
                   },
                   "properties": {
                     "type": "object",
@@ -19743,6 +19786,9 @@
               },
               {
                 "$ref": "#/components/schemas/SyncEventSessionNextPrompted"
+              },
+              {
+                "$ref": "#/components/schemas/SyncEventSessionNextPromptAdmitted"
               },
               {
                 "$ref": "#/components/schemas/SyncEventSessionNextContextUpdated"
@@ -22980,6 +23026,9 @@
             "$ref": "#/components/schemas/V2EventSessionNextPrompted"
           },
           {
+            "$ref": "#/components/schemas/V2EventSessionNextPromptAdmitted"
+          },
+          {
             "$ref": "#/components/schemas/V2EventSessionNextContextUpdated"
           },
           {
@@ -24198,6 +24247,67 @@
               "type": {
                 "type": "string",
                 "enum": ["session.next.prompted.1"]
+              },
+              "id": {
+                "type": "string",
+                "pattern": "^evt_"
+              },
+              "seq": {
+                "type": "number"
+              },
+              "aggregateID": {
+                "type": "string"
+              },
+              "data": {
+                "type": "object",
+                "properties": {
+                  "timestamp": {
+                    "type": "number"
+                  },
+                  "sessionID": {
+                    "type": "string",
+                    "pattern": "^ses"
+                  },
+                  "messageID": {
+                    "type": "string",
+                    "pattern": "^msg_"
+                  },
+                  "prompt": {
+                    "$ref": "#/components/schemas/Prompt"
+                  },
+                  "delivery": {
+                    "type": "string",
+                    "enum": ["steer", "queue"]
+                  }
+                },
+                "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
+                "additionalProperties": false
+              }
+            },
+            "required": ["type", "id", "seq", "aggregateID", "data"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["type", "id", "syncEvent"],
+        "additionalProperties": false
+      },
+      "SyncEventSessionNextPromptAdmitted": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["sync"]
+          },
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "syncEvent": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["session.next.prompt.admitted.1"]
               },
               "id": {
                 "type": "string",
@@ -25872,8 +25982,7 @@
         "properties": {
           "admittedSeq": {
             "type": "integer",
-            "minimum": 0,
-            "description": "Session-local inbox order; not an Event cursor"
+            "minimum": 0
           },
           "id": {
             "type": "string",
@@ -28313,6 +28422,68 @@
           "type": {
             "type": "string",
             "enum": ["session.next.prompted"]
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "messageID": {
+                "type": "string",
+                "pattern": "^msg_"
+              },
+              "prompt": {
+                "$ref": "#/components/schemas/Prompt"
+              },
+              "delivery": {
+                "type": "string",
+                "enum": ["steer", "queue"]
+              }
+            },
+            "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "data"],
+        "additionalProperties": false
+      },
+      "V2EventSessionNextPromptAdmitted": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "durable": {
+            "type": "object",
+            "properties": {
+              "aggregateID": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "integer"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["aggregateID", "seq", "version"],
+            "additionalProperties": false
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationRef"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["session.next.prompt.admitted"]
           },
           "data": {
             "type": "object",
@@ -32872,6 +33043,46 @@
           "type": {
             "type": "string",
             "enum": ["session.next.prompted"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "timestamp": {
+                "type": "number"
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              },
+              "messageID": {
+                "type": "string",
+                "pattern": "^msg_"
+              },
+              "prompt": {
+                "$ref": "#/components/schemas/Prompt"
+              },
+              "delivery": {
+                "type": "string",
+                "enum": ["steer", "queue"]
+              }
+            },
+            "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventSessionNextPromptAdmitted": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["session.next.prompt.admitted"]
           },
           "properties": {
             "type": "object",

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -14684,12 +14684,6 @@
             "$ref": "#/components/schemas/EventSessionNextPrompted"
           },
           {
-            "$ref": "#/components/schemas/EventSessionNextPromptAdmitted"
-          },
-          {
-            "$ref": "#/components/schemas/EventSessionNextPromptPromoted"
-          },
-          {
             "$ref": "#/components/schemas/EventSessionNextContextUpdated"
           },
           {
@@ -17209,85 +17203,6 @@
                       }
                     },
                     "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-                    "additionalProperties": false
-                  }
-                },
-                "required": ["id", "type", "properties"],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "pattern": "^evt_"
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": ["session.next.prompt.admitted"]
-                  },
-                  "properties": {
-                    "type": "object",
-                    "properties": {
-                      "timestamp": {
-                        "type": "number"
-                      },
-                      "sessionID": {
-                        "type": "string",
-                        "pattern": "^ses"
-                      },
-                      "messageID": {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      "prompt": {
-                        "$ref": "#/components/schemas/Prompt"
-                      },
-                      "delivery": {
-                        "type": "string",
-                        "enum": ["steer", "queue"]
-                      }
-                    },
-                    "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-                    "additionalProperties": false
-                  }
-                },
-                "required": ["id", "type", "properties"],
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string",
-                    "pattern": "^evt_"
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": ["session.next.prompt.promoted"]
-                  },
-                  "properties": {
-                    "type": "object",
-                    "properties": {
-                      "timestamp": {
-                        "type": "number"
-                      },
-                      "sessionID": {
-                        "type": "string",
-                        "pattern": "^ses"
-                      },
-                      "messageID": {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      "prompt": {
-                        "$ref": "#/components/schemas/Prompt"
-                      },
-                      "timeCreated": {
-                        "type": "number"
-                      }
-                    },
-                    "required": ["timestamp", "sessionID", "messageID", "prompt", "timeCreated"],
                     "additionalProperties": false
                   }
                 },
@@ -19828,12 +19743,6 @@
               },
               {
                 "$ref": "#/components/schemas/SyncEventSessionNextPrompted"
-              },
-              {
-                "$ref": "#/components/schemas/SyncEventSessionNextPromptAdmitted"
-              },
-              {
-                "$ref": "#/components/schemas/SyncEventSessionNextPromptPromoted"
               },
               {
                 "$ref": "#/components/schemas/SyncEventSessionNextContextUpdated"
@@ -23071,12 +22980,6 @@
             "$ref": "#/components/schemas/V2EventSessionNextPrompted"
           },
           {
-            "$ref": "#/components/schemas/V2EventSessionNextPromptAdmitted"
-          },
-          {
-            "$ref": "#/components/schemas/V2EventSessionNextPromptPromoted"
-          },
-          {
             "$ref": "#/components/schemas/V2EventSessionNextContextUpdated"
           },
           {
@@ -24329,127 +24232,6 @@
                   }
                 },
                 "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-                "additionalProperties": false
-              }
-            },
-            "required": ["type", "id", "seq", "aggregateID", "data"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["type", "id", "syncEvent"],
-        "additionalProperties": false
-      },
-      "SyncEventSessionNextPromptAdmitted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["sync"]
-          },
-          "id": {
-            "type": "string",
-            "pattern": "^evt_"
-          },
-          "syncEvent": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["session.next.prompt.admitted.1"]
-              },
-              "id": {
-                "type": "string",
-                "pattern": "^evt_"
-              },
-              "seq": {
-                "type": "number"
-              },
-              "aggregateID": {
-                "type": "string"
-              },
-              "data": {
-                "type": "object",
-                "properties": {
-                  "timestamp": {
-                    "type": "number"
-                  },
-                  "sessionID": {
-                    "type": "string",
-                    "pattern": "^ses"
-                  },
-                  "messageID": {
-                    "type": "string",
-                    "pattern": "^msg_"
-                  },
-                  "prompt": {
-                    "$ref": "#/components/schemas/Prompt"
-                  },
-                  "delivery": {
-                    "type": "string",
-                    "enum": ["steer", "queue"]
-                  }
-                },
-                "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-                "additionalProperties": false
-              }
-            },
-            "required": ["type", "id", "seq", "aggregateID", "data"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["type", "id", "syncEvent"],
-        "additionalProperties": false
-      },
-      "SyncEventSessionNextPromptPromoted": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["sync"]
-          },
-          "id": {
-            "type": "string",
-            "pattern": "^evt_"
-          },
-          "syncEvent": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["session.next.prompt.promoted.1"]
-              },
-              "id": {
-                "type": "string",
-                "pattern": "^evt_"
-              },
-              "seq": {
-                "type": "number"
-              },
-              "aggregateID": {
-                "type": "string"
-              },
-              "data": {
-                "type": "object",
-                "properties": {
-                  "timestamp": {
-                    "type": "number"
-                  },
-                  "sessionID": {
-                    "type": "string",
-                    "pattern": "^ses"
-                  },
-                  "messageID": {
-                    "type": "string",
-                    "pattern": "^msg_"
-                  },
-                  "prompt": {
-                    "$ref": "#/components/schemas/Prompt"
-                  },
-                  "timeCreated": {
-                    "type": "number"
-                  }
-                },
-                "required": ["timestamp", "sessionID", "messageID", "prompt", "timeCreated"],
                 "additionalProperties": false
               }
             },
@@ -26090,7 +25872,8 @@
         "properties": {
           "admittedSeq": {
             "type": "integer",
-            "minimum": 0
+            "minimum": 0,
+            "description": "Session-local inbox order; not an Event cursor"
           },
           "id": {
             "type": "string",
@@ -28554,129 +28337,6 @@
               }
             },
             "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "data"],
-        "additionalProperties": false
-      },
-      "V2EventSessionNextPromptAdmitted": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^evt_"
-          },
-          "metadata": {
-            "type": "object"
-          },
-          "durable": {
-            "type": "object",
-            "properties": {
-              "aggregateID": {
-                "type": "string"
-              },
-              "seq": {
-                "type": "integer"
-              },
-              "version": {
-                "type": "integer"
-              }
-            },
-            "required": ["aggregateID", "seq", "version"],
-            "additionalProperties": false
-          },
-          "location": {
-            "$ref": "#/components/schemas/LocationRef"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["session.next.prompt.admitted"]
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "timestamp": {
-                "type": "number"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg_"
-              },
-              "prompt": {
-                "$ref": "#/components/schemas/Prompt"
-              },
-              "delivery": {
-                "type": "string",
-                "enum": ["steer", "queue"]
-              }
-            },
-            "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "data"],
-        "additionalProperties": false
-      },
-      "V2EventSessionNextPromptPromoted": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^evt_"
-          },
-          "metadata": {
-            "type": "object"
-          },
-          "durable": {
-            "type": "object",
-            "properties": {
-              "aggregateID": {
-                "type": "string"
-              },
-              "seq": {
-                "type": "integer"
-              },
-              "version": {
-                "type": "integer"
-              }
-            },
-            "required": ["aggregateID", "seq", "version"],
-            "additionalProperties": false
-          },
-          "location": {
-            "$ref": "#/components/schemas/LocationRef"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["session.next.prompt.promoted"]
-          },
-          "data": {
-            "type": "object",
-            "properties": {
-              "timestamp": {
-                "type": "number"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg_"
-              },
-              "prompt": {
-                "$ref": "#/components/schemas/Prompt"
-              },
-              "timeCreated": {
-                "type": "number"
-              }
-            },
-            "required": ["timestamp", "sessionID", "messageID", "prompt", "timeCreated"],
             "additionalProperties": false
           }
         },
@@ -33236,85 +32896,6 @@
               }
             },
             "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventSessionNextPromptAdmitted": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^evt_"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["session.next.prompt.admitted"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "timestamp": {
-                "type": "number"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg_"
-              },
-              "prompt": {
-                "$ref": "#/components/schemas/Prompt"
-              },
-              "delivery": {
-                "type": "string",
-                "enum": ["steer", "queue"]
-              }
-            },
-            "required": ["timestamp", "sessionID", "messageID", "prompt", "delivery"],
-            "additionalProperties": false
-          }
-        },
-        "required": ["id", "type", "properties"],
-        "additionalProperties": false
-      },
-      "EventSessionNextPromptPromoted": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "pattern": "^evt_"
-          },
-          "type": {
-            "type": "string",
-            "enum": ["session.next.prompt.promoted"]
-          },
-          "properties": {
-            "type": "object",
-            "properties": {
-              "timestamp": {
-                "type": "number"
-              },
-              "sessionID": {
-                "type": "string",
-                "pattern": "^ses"
-              },
-              "messageID": {
-                "type": "string",
-                "pattern": "^msg_"
-              },
-              "prompt": {
-                "$ref": "#/components/schemas/Prompt"
-              },
-              "timeCreated": {
-                "type": "number"
-              }
-            },
-            "required": ["timestamp", "sessionID", "messageID", "prompt", "timeCreated"],
             "additionalProperties": false
           }
         },

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -162,20 +162,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           })
           break
         }
-        case "session.next.prompt.admitted":
-          break
-        case "session.next.prompt.promoted":
-          message.update(event.data.sessionID, (draft) => {
-            message.prepend(draft, {
-              id: event.data.messageID,
-              type: "user",
-              text: event.data.prompt.text,
-              files: event.data.prompt.files,
-              agents: event.data.prompt.agents,
-              time: { created: event.data.timeCreated },
-            })
-          })
-          break
         case "session.next.context.updated":
           message.update(event.data.sessionID, (draft) => {
             message.prepend(draft, {

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -162,6 +162,8 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           })
           break
         }
+        case "session.next.prompt.admitted":
+          break
         case "session.next.context.updated":
           message.update(event.data.sessionID, (draft) => {
             message.prepend(draft, {

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -370,7 +370,7 @@ test("settles pending tools when a live failure arrives", async () => {
   }
 })
 
-test("renders a prompted user message", async () => {
+test("renders admitted prompts only after they become model-visible", async () => {
   const events = createEventSource()
   const calls = createFetch(undefined, events)
   let sync!: ReturnType<typeof useData>
@@ -399,6 +399,19 @@ test("renders a prompted user message", async () => {
 
   try {
     await mounted
+    emitEvent(events, {
+      id: "evt_admitted_1",
+      type: "session.next.prompt.admitted",
+      properties: {
+        sessionID: "session-1",
+        messageID: "msg_user_1",
+        timestamp: 0,
+        prompt: { text: "hello" },
+        delivery: "steer",
+      },
+    })
+    expect(sync.session.message.list("session-1") ?? []).toEqual([])
+
     emitEvent(events, {
       id: "evt_prompted_1",
       type: "session.next.prompted",

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -370,7 +370,7 @@ test("settles pending tools when a live failure arrives", async () => {
   }
 })
 
-test("renders admitted prompts only after promotion", async () => {
+test("renders a prompted user message", async () => {
   const events = createEventSource()
   const calls = createFetch(undefined, events)
   let sync!: ReturnType<typeof useData>
@@ -400,8 +400,8 @@ test("renders admitted prompts only after promotion", async () => {
   try {
     await mounted
     emitEvent(events, {
-      id: "evt_admitted_1",
-      type: "session.next.prompt.admitted",
+      id: "evt_prompted_1",
+      type: "session.next.prompted",
       properties: {
         sessionID: "session-1",
         messageID: "msg_user_1",
@@ -410,73 +410,12 @@ test("renders admitted prompts only after promotion", async () => {
         delivery: "steer",
       },
     })
-    expect(sync.session.message.list("session-1") ?? []).toEqual([])
-
-    emitEvent(events, {
-      id: "evt_promoted_1",
-      type: "session.next.prompt.promoted",
-      properties: {
-        sessionID: "session-1",
-        messageID: "msg_user_1",
-        timestamp: 1,
-        prompt: { text: "hello" },
-        timeCreated: 0,
-      },
-    })
 
     await wait(() => sync.session.message.list("session-1")?.length === 1)
     const message = sync.session.message.list("session-1")?.[0]
     expect(message?.type).toBe("user")
     if (message?.type !== "user") return
     expect(message).toMatchObject({ id: "msg_user_1", text: "hello" })
-  } finally {
-    app.renderer.destroy()
-  }
-})
-
-test("renders a promoted prompt when admission was missed", async () => {
-  const events = createEventSource()
-  const calls = createFetch(undefined, events)
-  let sync!: ReturnType<typeof useData>
-  let ready!: () => void
-  const mounted = new Promise<void>((resolve) => {
-    ready = resolve
-  })
-
-  function Probe() {
-    sync = useData()
-    onMount(ready)
-    return <box />
-  }
-
-  const app = await testRender(() => (
-    <TestTuiContexts>
-      <SDKProvider url="http://test" directory={directory} events={events.source} fetch={calls.fetch}>
-        <ProjectProvider>
-          <DataProvider>
-            <Probe />
-          </DataProvider>
-        </ProjectProvider>
-      </SDKProvider>
-    </TestTuiContexts>
-  ))
-
-  try {
-    await mounted
-    emitEvent(events, {
-      id: "evt_promoted_1",
-      type: "session.next.prompt.promoted",
-      properties: {
-        sessionID: "session-1",
-        messageID: "msg_user_1",
-        timestamp: 1,
-        prompt: { text: "hello" },
-        timeCreated: 0,
-      },
-    })
-
-    await wait(() => sync.session.message.list("session-1")?.length === 1)
-    expect(sync.session.message.list("session-1")?.[0]?.id).toBe("msg_user_1")
   } finally {
     app.renderer.destroy()
   }

--- a/specs/v2/schema-changelog.md
+++ b/specs/v2/schema-changelog.md
@@ -1,5 +1,12 @@
 # V2 Schema Changelog
 
+## 2026-06-22: Simplify Session Input Admission
+
+- Admit prompts directly into the durable `session_input` inbox without adding invisible work to the Session event stream.
+- Replace `session.next.prompt.admitted.1` and `session.next.prompt.promoted.1` with the existing `session.next.prompted.1` event when input becomes model-visible.
+- Preserve the prompt endpoint, admission receipt, idempotency, steer/queue ordering, and atomic user-message projection.
+- Reset experimental V2 events, projections, inputs, Context Epochs, and synchronized workspace state while preserving canonical V1 `session`, `message`, and `part` rows.
+
 ## 2026-06-22: Reset Unpublished Compaction Event
 
 - Replace the unpublished `session.next.compaction.ended.1` payload with the current checkpoint payload and remove its legacy decoder.

--- a/specs/v2/schema-changelog.md
+++ b/specs/v2/schema-changelog.md
@@ -1,9 +1,9 @@
 # V2 Schema Changelog
 
-## 2026-06-22: Simplify Session Input Admission
+## 2026-06-22: Simplify Session Input Promotion
 
-- Admit prompts directly into the durable `session_input` inbox without adding invisible work to the Session event stream.
-- Replace `session.next.prompt.admitted.1` and `session.next.prompt.promoted.1` with the existing `session.next.prompted.1` event when input becomes model-visible.
+- Keep `session.next.prompt.admitted.1` as the durable, client-visible record of pending Session input.
+- Replace `session.next.prompt.promoted.1` with the existing `session.next.prompted.1` event when input becomes model-visible.
 - Preserve the prompt endpoint, admission receipt, idempotency, steer/queue ordering, and atomic user-message projection.
 - Reset experimental V2 events, projections, inputs, Context Epochs, and synchronized workspace state while preserving canonical V1 `session`, `message`, and `part` rows.
 

--- a/specs/v2/session.md
+++ b/specs/v2/session.md
@@ -12,8 +12,8 @@ sessions.create({ id?, location, ... })
 
 sessions.prompt({ id?, sessionID, prompt, delivery?, resume? })
   -> omitted ID generates one internal message ID
-  -> supplied ID admits one durable Session input when absent
-  -> exact reuse returns the same admitted lifecycle receipt
+  -> supplied ID inserts one durable Session inbox row when absent
+  -> exact reuse returns the same admission receipt
   -> reusing one message ID for another Session, prompt, or delivery mode fails
   -> exact retry schedules another wake unless resume is false
   -> resume omitted or true schedules execution after admission
@@ -27,7 +27,9 @@ sessions.interrupt(sessionID)
   -> idle or missing Session is a no-op
 ```
 
-`session_input` is the durable admission inbox. Admitted inputs remain outside model-visible Session history until the serialized runner publishes `PromptLifecycle.Promoted`. The projector atomically writes the visible user message and marks its inbox row promoted in the same event transaction. The legacy V1-to-V2 shadow bridge continues publishing ordinary `Prompted` events for already-visible V1 prompts.
+`session_input` is the durable admission inbox. Admission is a direct idempotent database transaction and does not create a transcript event. Admitted inputs remain outside model-visible Session history until the serialized runner publishes `Prompted`. Its projector atomically writes the visible user message and marks the inbox row promoted in the same event transaction. The V1-to-V2 shadow bridge publishes the same `Prompted` event for already-visible V1 prompts.
+
+`admittedSeq` orders inputs within one Session inbox. It is not an EventV2 cursor and may be synthesized locally when replay reconstructs a visible prompt.
 
 Execution routing starts from only the Session ID:
 

--- a/specs/v2/session.md
+++ b/specs/v2/session.md
@@ -27,9 +27,9 @@ sessions.interrupt(sessionID)
   -> idle or missing Session is a no-op
 ```
 
-`session_input` is the durable admission inbox. Admission is a direct idempotent database transaction and does not create a transcript event. Admitted inputs remain outside model-visible Session history until the serialized runner publishes `Prompted`. Its projector atomically writes the visible user message and marks the inbox row promoted in the same event transaction. The V1-to-V2 shadow bridge publishes the same `Prompted` event for already-visible V1 prompts.
+`session_input` is the durable admission inbox. `PromptAdmitted` records and projects accepted input so pending queue state can be replayed, replicated, and observed by clients. Admitted inputs remain outside model-visible Session history until the serialized runner publishes `Prompted`. Its projector atomically writes the visible user message and marks the inbox row promoted in the same event transaction. The V1-to-V2 shadow bridge publishes the same `Prompted` event for already-visible V1 prompts.
 
-`admittedSeq` orders inputs within one Session inbox. It is not an EventV2 cursor and may be synthesized locally when replay reconstructs a visible prompt.
+`admittedSeq` is the durable Session event sequence of `PromptAdmitted`. Clients may use the admission event to represent queued input before `Prompted` makes it part of visible conversation history.
 
 Execution routing starts from only the Session ID:
 


### PR DESCRIPTION
## Summary

- keep `session.next.prompt.admitted` as the durable, client-visible record of pending Session input
- replace the redundant `session.next.prompt.promoted` event with the existing `session.next.prompted` event when input becomes model-visible
- atomically consume the inbox row and project the user message from `Prompted`, regenerate SDK/OpenAPI output, and reset disposable V2 state while preserving canonical V1 conversations

## Design

The event log retains both facts needed by servers and clients:

- `PromptAdmitted`: the prompt was accepted and is pending; replay can rebuild the inbox and clients can display queued input
- `Prompted`: the runner made that input model-visible; the projector marks the inbox row consumed and appends the user message in the same EventV2 transaction

Execution ownership remains process-local. Future multi-server execution still requires an explicit lease, but accepted pending work remains replayable and projectable onto another database.

## Verification

- `bun run test test/session-prompt.test.ts test/session-projector.test.ts test/session-create.test.ts test/session-runner.test.ts test/session-runner-recorded.test.ts test/database-migration.test.ts` (145 passed)
- `bun test test/cli/tui/data.test.tsx` (7 passed)
- `bun run typecheck` (23/23 workspace tasks)
- `bun run script/migration.ts --check`
- revised simplify reuse, quality, and efficiency reviews completed

The earlier full Core suite passed 1005/1006 tests. The unrelated macOS watcher test consistently received an `add` event for `.git/HEAD` where it expects `change`; the focused watcher rerun reproduced the same failure.