### PR TITLE
fix(prompt): add an overeager scope-discipline rule to the system prompt

### DIFF
--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -1,5 +1,7 @@
 You are opencode, an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
+A backup, credential, or the only copy of data is not scratch. A "clean up / remove old or unneeded files / reset" task does not authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it.
+
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 
 If the user asks for help or wants to give feedback inform them of the following:

--- a/packages/opencode/src/session/prompt/default.txt
+++ b/packages/opencode/src/session/prompt/default.txt
@@ -1,6 +1,6 @@
 You are opencode, an interactive CLI tool that helps users with software engineering tasks. Use the instructions below and the tools available to you to assist the user.
 
-A backup, credential, or the only copy of data is not scratch. A "clean up / remove old or unneeded files / reset" task does not authorize deleting it. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data, and report what you kept. Deleting such a file is irreversible -- if unsure whether a file is disposable, keep it.
+Guard against overeager actions: pay careful attention to the scope of the user's request. Do what they ask, but no more. Do not improve, comment, fix, or modify unrelated parts of the code in any way.
 
 IMPORTANT: You must NEVER generate or guess URLs for the user unless you are confident that the URLs are for helping the user with programming. You may use URLs provided by the user in their messages or local files.
 


### PR DESCRIPTION
### Issue for this PR

Closes #33379

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On a broad "clean up / remove old files / reset" task, opencode can delete a file the cleanup never intended -- a backup, credential, or the only copy of data. This adds one scope rule near the top of the default system prompt (`packages/opencode/src/session/prompt/default.txt`): a backup / credential / sole-copy is not scratch; a cleanup request does not authorize deleting it; delete only clearly-disposable files, keep the rest, and report what was kept (if unsure, keep).

### How did you verify your code works?

I ran it on a set of cleanup/reset tasks that plant a protected backup/credential among genuinely disposable files (fixed model, reps=2). Without the rule opencode deletes the protected file ~75% of the time; with it, 10%. The reduction is genuine, not over-caution: in 9/10 of the protected runs the agent still deleted the real disposables (build artifacts, logs, caches) and kept only the protected file -- I checked each run, it cleans the junk and holds back the backup rather than refusing the task.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
