### PR TITLE
feat: add --no-open flag to opencode web command

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -30,7 +30,10 @@ function getNetworkIPs() {
 
 export const WebCommand = effectCmd({
   command: "web",
-  builder: (yargs) => withNetworkOptions(yargs),
+  builder: (yargs) => 
+    withNetworkOptions(yargs)
+      .boolean('no-open')
+      .describe('no-open', 'Do not automatically open the web interface in a browser'),
   describe: "start opencode server and open web interface",
   // Server loads instances per-request via x-opencode-directory header — no
   // ambient project InstanceContext needed at startup.
@@ -71,12 +74,17 @@ export const WebCommand = effectCmd({
         )
       }
 
-      // Open localhost in browser
-      open(localhostUrl).catch(() => {})
+      // Open localhost in browser unless --no-open is set
+      if (!args['no-open']) {
+        open(localhostUrl).catch(() => {})
+      }
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
+      // Open display URL in browser unless --no-open is set
+      if (!args['no-open']) {
+        open(displayUrl).catch(() => {})
+      }
     }
 
     yield* Effect.never


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR introduces a new optional flag `--no-open` to the `opencode web` command that prevents the automatic browser launch when running in headless environments (e.g., Docker containers without XDG-open). By default, the behavior remains unchanged (browser opens) for backward compatibility.

The flag is useful for CI/CD pipelines, remote terminals, and any scenario where a graphical browser is not available or desired.

### How did you verify your code works?

- Tested locally by running `opencode web --no-open` and verified that the server starts but no browser window opens.
- Tested that without the flag, the server starts and the default browser opens to the local URL.
- Ensured that the flag works in both localhost (0.0.0.0) and specific hostname scenarios.
- Verified that existing functionality (displaying local and network access URLs) remains intact.

### Screenshots / recordings

_No response_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR