### PR TITLE
Add opencode-trigger-panel to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -75,6 +75,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 
 ---
 
+| [opencode-trigger-panel](https://github.com/yangjh0829/opencode-trigger-panel) | TUI sidebar panel for visual keyword-trigger skill configuration |
+
 ## Agents
 
 | Name                                                              | Description                                                  |


### PR DESCRIPTION
Add [opencode-trigger-panel](https://github.com/yangjh0829/opencode-trigger-panel) to Project ecosystem - a TUI sidebar panel for visual keyword-trigger skill configuration.