### PR TITLE
fix(session): sync model switch to server immediately

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -307,6 +307,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!options?.recent) return
           models.recent.push(item)
         })
+
+        const sessionID = id()
+        if (sessionID && item) {
+          ;(sdk().client.session as any).switchModel({
+            sessionID,
+            model: { providerID: item.providerID, id: item.modelID },
+          })
+        }
       },
       visible(item: ModelKey) {
         return models.visible(item)

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -67,6 +67,11 @@ export const SummarizePayload = Schema.Struct({
   modelID: ModelV2.ID,
   auto: Schema.optional(Schema.Boolean),
 })
+export const SwitchModelPayload = Schema.Struct({
+  id: ModelV2.ID,
+  providerID: ProviderV2.ID,
+  variant: Schema.optional(ModelV2.VariantID),
+})
 export const PromptPayload = Schema.Struct(Struct.omit(SessionPrompt.PromptInput.fields, ["sessionID"]))
 export const CommandPayload = Schema.Struct(Struct.omit(SessionPrompt.CommandInput.fields, ["sessionID"]))
 export const ShellPayload = Schema.Struct(Struct.omit(SessionPrompt.ShellInput.fields, ["sessionID"]))
@@ -87,6 +92,7 @@ export const SessionPaths = {
   create: root,
   remove: `${root}/:sessionID`,
   update: `${root}/:sessionID`,
+  switchModel: `${root}/:sessionID/model`,
   fork: `${root}/:sessionID/fork`,
   abort: `${root}/:sessionID/abort`,
   share: `${root}/:sessionID/share`,
@@ -235,6 +241,19 @@ export const SessionApi = HttpApi.make("session")
             identifier: "session.update",
             summary: "Update session",
             description: "Update properties of an existing session, such as title or other metadata.",
+          }),
+        ),
+        HttpApiEndpoint.post("switchModel", SessionPaths.switchModel, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          payload: SwitchModelPayload,
+          success: described(HttpApiSchema.NoContent, "Model switched"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.switchModel",
+            summary: "Switch session model",
+            description: "Switch the model used by subsequent session activity.",
           }),
         ),
         HttpApiEndpoint.post("fork", SessionPaths.fork, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -13,6 +13,7 @@ import { SessionRevert } from "@/session/revert"
 import { SessionRunState } from "@/session/run-state"
 import { SessionStatus } from "@/session/status"
 import { SessionSummary } from "@/session/summary"
+import { ModelV2 } from "@opencode-ai/core/model"
 import { Todo } from "@/session/todo"
 import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
@@ -33,6 +34,7 @@ import {
   RevertPayload,
   ShellPayload,
   SummarizePayload,
+  SwitchModelPayload,
   UpdatePayload,
 } from "../groups/session"
 import { PermissionNotFoundError } from "../errors"
@@ -199,6 +201,15 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         yield* session.setArchived({ sessionID: ctx.params.sessionID, time: ctx.payload.time.archived })
       }
       return yield* requireSession(ctx.params.sessionID)
+    })
+
+    const switchModel = Effect.fn("SessionHttpApi.switchModel")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof SwitchModelPayload.Type
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      yield* session.switchModel({ sessionID: ctx.params.sessionID, model: ctx.payload })
+      return HttpApiSchema.NoContent.make()
     })
 
     const fork = Effect.fn("SessionHttpApi.fork")(function* (ctx: {
@@ -420,6 +431,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handleRaw("create", createRaw)
       .handle("remove", remove)
       .handle("update", update)
+      .handle("switchModel", switchModel)
       .handleRaw("fork", forkRaw)
       .handle("abort", abort)
       .handle("init", init)

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -12,6 +12,8 @@ import { Database } from "@opencode-ai/core/database/database"
 import { makeRuntime } from "@opencode-ai/core/effect/runtime"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { EventV2 } from "@opencode-ai/core/event"
+import { SessionEvent } from "@opencode-ai/core/session/event"
+import { SessionMessageID } from "@opencode-ai/core/session/message-id"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 
@@ -40,7 +42,7 @@ import { SessionID, MessageID, PartID } from "./schema"
 import type { Provider } from "@/provider/provider"
 import { Permission } from "@/permission"
 import { Global } from "@opencode-ai/core/global"
-import { Effect, Layer, Option, Context, Schema, Types } from "effect"
+import { DateTime, Effect, Layer, Option, Context, Schema, Types } from "effect"
 import { NonNegativeInt, optionalOmitUndefined } from "@opencode-ai/core/schema"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -486,6 +488,7 @@ export interface Interface {
   readonly setSummary: (input: { sessionID: SessionID; summary: Info["summary"] }) => Effect.Effect<void>
   readonly setShare: (input: { sessionID: SessionID; share: Info["share"] }) => Effect.Effect<void>
   readonly setWorkspace: (input: { sessionID: SessionID; workspaceID: Info["workspaceID"] }) => Effect.Effect<void>
+  readonly switchModel: (input: { sessionID: SessionID; model: ModelV2.Ref }) => Effect.Effect<void>
   readonly diff: (sessionID: SessionID) => Effect.Effect<Snapshot.FileDiff[]>
   readonly messages: (input: { sessionID: SessionID; limit?: number }) => Effect.Effect<SessionV1.WithParts[], NotFound>
   readonly children: (parentID: SessionID) => Effect.Effect<Info[]>
@@ -849,6 +852,18 @@ export const layer: Layer.Layer<
       )
     })
 
+    const switchModel = Effect.fn("Session.switchModel")(function* (input: {
+      sessionID: SessionID
+      model: ModelV2.Ref
+    }) {
+      yield* events.publish(SessionEvent.ModelSwitched, {
+        sessionID: input.sessionID,
+        messageID: SessionMessageID.ID.create(),
+        timestamp: DateTime.makeUnsafe(Date.now()),
+        model: input.model,
+      })
+    })
+
     const diff = Effect.fn("Session.diff")(function* (sessionID: SessionID) {
       void sessionID
       return [] as Snapshot.FileDiff[]
@@ -948,6 +963,7 @@ export const layer: Layer.Layer<
       setSummary,
       setShare,
       setWorkspace,
+      switchModel,
       diff,
       messages,
       children,

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -838,6 +838,29 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "switchModel endpoint updates session model and returns 204",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory, "content-type": "application/json" }
+        const session = yield* createSession({ title: "model-switch" })
+
+        const response = yield* request(pathFor(SessionPaths.switchModel, { sessionID: session.id }), {
+          method: "POST",
+          headers,
+          body: JSON.stringify({
+            id: ModelV2.ID.make("vision-model"),
+            providerID: ProviderV2.ID.make("vision-provider"),
+            variant: ModelV2.VariantID.make("default"),
+          }),
+        })
+
+        expect(response.status).toBe(204)
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "uses project-scoped path and directory precedence",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #33199

### Type of change

- [x] Bug fix

### What does this PR do?

**Root cause:** When the user switched models in the UI, `local.model.set()` only updated the local persisted store. The server's `SessionTable.model` was only updated when a prompt arrived with a different `model:` field in the payload. The session runner resolved models using `SessionTable.model`, causing image/vision capability checks to use the stale model between the UI switch and the next message.

**Fix:** Added `POST /api/session/{sessionID}/model` endpoint that publishes a `ModelSwitched` event. When the user changes models in the UI, the app now immediately calls `client.session.switchModel()` to sync the change to the server. The projector (already wired in `core/src/session.ts`) handles persisting the new model to `SessionTable.model`.

Files changed:
- `packages/app/src/context/local.tsx` — calls `switchModel()` after `model.set()`
- `packages/opencode/src/server/routes/instance/httpapi/groups/session.ts` — new endpoint + `SwitchModelPayload` schema
- `packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts` — handler calling `session.switchModel()`
- `packages/opencode/src/session/session.ts` — added `switchModel` to `Interface` and implemented via `events.publish(SessionEvent.ModelSwitched, ...)`

### How did you verify your code works?

- `bun test test/server/httpapi-session.test.ts` — 19/19 pass including new test "switchModel endpoint updates session model and returns 204"
- `bun test test/session-projector.test.ts` — 7/7 pass
- `cd packages/opencode && bun typecheck` — clean

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
