### PR TITLE
fix(ui): line number click and hover utility not opening comment editor

### DIFF
--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -405,7 +405,7 @@ export function FileTabContent(props: { tab: string }) {
           cacheKey: cacheKey(),
         }}
         enableLineSelection
-        enableHoverUtility
+        enableGutterUtility
         selectedLines={activeSelection()}
         commentedLines={commentedLines()}
         onRendered={() => {
@@ -413,7 +413,7 @@ export function FileTabContent(props: { tab: string }) {
         }}
         annotations={commentsUi.annotations()}
         renderAnnotation={commentsUi.renderAnnotation}
-        renderHoverUtility={commentsUi.renderHoverUtility}
+        renderGutterUtility={commentsUi.renderHoverUtility}
         onLineSelected={(range: SelectedLineRange | null) => {
           commentsUi.onLineSelected(range)
         }}

--- a/packages/ui/src/components/file.tsx
+++ b/packages/ui/src/components/file.tsx
@@ -65,6 +65,8 @@ type SharedProps<T> = {
   classList?: ComponentProps<"div">["classList"]
   media?: FileMediaOptions
   search?: FileSearchControl
+  enableGutterUtility?: boolean
+  renderGutterUtility?: (getHoveredRow: () => any) => HTMLElement | null | undefined
 }
 
 export type FileSearchHandle = {
@@ -211,13 +213,9 @@ function useFileViewer(config: ViewerConfig) {
     if (event.button !== 0) return
 
     const hit = config.lineFromMouseEvent(event)
-    if (hit.numberColumn) {
-      bridge.begin(true, hit.line)
-      return
-    }
     if (hit.line === undefined) return
 
-    bridge.begin(false, hit.line)
+    bridge.begin(hit.numberColumn, hit.line)
     dragStart = hit.line
     dragEnd = hit.line
     dragMoved = false
@@ -249,7 +247,7 @@ function useFileViewer(config: ViewerConfig) {
 
   const handleMouseUp = () => {
     if (!config.enableLineSelection()) return
-    if (bridge.finish() === "numbers") return
+    bridge.finish()
     if (dragStart === undefined) return
 
     if (!dragMoved) {

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -620,13 +620,13 @@ export const SessionReview = (props: SessionReviewProps) => {
                                       props.onDiffRendered?.()
                                     }}
                                     enableLineSelection={props.onLineComment != null}
-                                    enableHoverUtility={props.onLineComment != null}
+                                    enableGutterUtility={props.onLineComment != null}
                                     onLineSelected={handleLineSelected}
                                     onLineSelectionEnd={handleLineSelectionEnd}
                                     onLineNumberSelectionEnd={commentsUi.onLineNumberSelectionEnd}
                                     annotations={commentsUi.annotations()}
                                     renderAnnotation={commentsUi.renderAnnotation}
-                                    renderHoverUtility={props.onLineComment ? commentsUi.renderHoverUtility : undefined}
+                                    renderGutterUtility={props.onLineComment ? commentsUi.renderHoverUtility : undefined}
                                     selectedLines={selectedLines()}
                                     commentedLines={commentedLines()}
                                     media={{

--- a/packages/ui/src/pierre/selection-bridge.ts
+++ b/packages/ui/src/pierre/selection-bridge.ts
@@ -115,12 +115,12 @@ export function createLineNumberSelectionBridge() {
     },
     finish() {
       const current = mode
-      pending = current === "numbers" && moved
+      pending = current === "numbers"
       clear()
       return current
     },
-    consume(range: SelectedLineRange | null) {
-      const result = pending && !isSingleLineSelection(range)
+    consume(_range: SelectedLineRange | null) {
+      const result = pending
       pending = false
       return result
     },


### PR DESCRIPTION
### Issue for this PR

Closes #32835

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two fixes for the review panel comment feature:

1. Clicking a line number now opens the comment editor. Previously `handleMouseUp`
   returned early for number column clicks, skipping all selection callbacks.
   Fix: route number column clicks through the same selection flow as text clicks,
   and relax `consume()` to accept single-line selections from the gutter.

2. The hover "+" button now renders. The props were named `enableHoverUtility` /
   `renderHoverUtility` but pierre expects `enableGutterUtility` / `renderGutterUtility`.
   Fix: rename props to match pierre's option names and add them to `SharedProps`.

### How did you verify your code works?

1. Started API server with `bun dev serve` and web app with `bun run --cwd packages/app dev`
2. Opened a session with diffs, expanded a file in the Review panel
3. Clicked a line number → comment draft editor opens
4. Hovered over a line number → "+" button appears and opens draft on click

### Screenshots / recordings

https://github.com/user-attachments/assets/baeb5a9c-d6e5-4ab1-bbd5-9e62a2a12ea8

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
