### PR TITLE
fix(read): don't leak external directory listings in not-found suggestions

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -7,6 +7,7 @@ import { LSP } from "@/lsp/lsp"
 import DESCRIPTION from "./read.txt"
 import { InstanceState } from "@/effect/instance-state"
 import { assertExternalDirectoryEffect } from "./external-directory"
+import { containsPath, type InstanceContext } from "../project/instance-context"
 import { Instruction } from "../session/instruction"
 import { isPdfAttachment, sniffAttachmentMime } from "@/util/media"
 
@@ -73,9 +74,20 @@ export const ReadTool = Tool.define<
     const lsp = yield* LSP.Service
     const scope = yield* Scope.Scope
 
-    const miss = Effect.fn("ReadTool.miss")(function* (filepath: string) {
+    const miss = Effect.fn("ReadTool.miss")(function* (filepath: string, instance: InstanceContext) {
       const dir = path.dirname(filepath)
       const base = path.basename(filepath)
+
+      // SECURITY: "did you mean?" suggestions list sibling entries of the parent
+      // directory. Only do this when the parent directory is inside the project
+      // boundary (worktree/working dir). For paths outside the boundary, return a
+      // plain not-found error so we never leak names of files/dirs that exist in
+      // an external directory — even if a single-file external_directory read was
+      // permitted, enumerating that directory is a separate, broader disclosure.
+      if (!containsPath(dir, instance)) {
+        return yield* Effect.fail(new Error(`File not found: ${filepath}`))
+      }
+
       const items = yield* fs.readDirectory(dir).pipe(
         Effect.map((items) =>
           items
@@ -259,7 +271,7 @@ export const ReadTool = Tool.define<
         metadata: {},
       })
 
-      if (!stat) return yield* miss(filepath)
+      if (!stat) return yield* miss(filepath, instance)
 
       if (stat.type === "Directory") {
         const items = yield* list(filepath)

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -256,6 +256,61 @@ describe("tool.read external_directory permission", () => {
   )
 })
 
+describe("tool.read not-found suggestions", () => {
+  // Wrap FSUtil so we can observe which directories the "did you mean?" path enumerates.
+  const spyReadDirectory = Effect.fn("ReadToolTest.spyReadDirectory")(function* (calls: string[]) {
+    const fs = yield* FSUtil.Service
+    return FSUtil.Service.of({
+      ...fs,
+      readDirectory: (...args: Parameters<typeof fs.readDirectory>) => {
+        calls.push(args[0])
+        return fs.readDirectory(...args)
+      },
+    })
+  })
+
+  it.live("suggests sibling files for a not-found path inside the worktree", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      yield* put(path.join(dir, "src", "config.ts"), "export const x = 1")
+
+      const calls: string[] = []
+      const service = yield* spyReadDirectory(calls)
+      const err = yield* fail(dir, { filePath: path.join(dir, "src", "confg.ts") }).pipe(
+        Effect.provideService(FSUtil.Service, service),
+      )
+
+      expect(err.message).toContain("File not found")
+      expect(err.message).toContain("Did you mean one of these?")
+      expect(err.message).toContain(path.join(dir, "src", "config.ts"))
+      // The parent dir is inside the worktree, so enumerating it is allowed.
+      expect(calls).toContain(full(path.join(dir, "src")))
+    }),
+  )
+
+  it.live("does not leak sibling listings for a not-found path outside the worktree", () =>
+    Effect.gen(function* () {
+      const outer = yield* tmpdirScoped()
+      const dir = yield* tmpdirScoped({ git: true })
+      // A real, existing sibling that MUST NOT appear in the error message.
+      yield* put(path.join(outer, "secret.txt"), "secret data")
+
+      const calls: string[] = []
+      const service = yield* spyReadDirectory(calls)
+      const err = yield* fail(dir, { filePath: path.join(outer, "secrets.txt") }).pipe(
+        Effect.provideService(FSUtil.Service, service),
+      )
+
+      // Plain not-found error, no "did you mean?" disclosure.
+      expect(err.message).toContain("File not found")
+      expect(err.message).not.toContain("Did you mean one of these?")
+      expect(err.message).not.toContain("secret.txt")
+      // The external directory was never enumerated.
+      expect(calls).not.toContain(full(outer))
+    }),
+  )
+})
+
 describe("tool.read env file permissions", () => {
   const cases: [string, boolean][] = [
     [".env", true],


### PR DESCRIPTION
### Issue for this PR

Closes #33274

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a read targets a path that doesn't exist, the Read tool builds a "Did you mean…?" suggestion by listing the parent directory's entries (the `miss` helper in `tool/read.ts`). Unlike the actual read path — which gates access to paths outside the project via `assertExternalDirectoryEffect` — `miss` called `fs.readDirectory(dirname(filepath))` unconditionally. So reading a non-existent path *outside* the worktree returned an error listing the real sibling files in that external directory, disclosing names from outside the project boundary.

The fix gates the suggestion on the same project-boundary predicate the read path already relies on — `containsPath(dir, instance)` from `project/instance-context` (the helper `assertExternalDirectoryEffect` is built on). When the parent directory is outside the worktree/working dir, `miss` returns a plain `File not found` with no listing; inside the boundary, suggestions behave exactly as before. I gate on `containsPath` specifically (not the broader external-directory grant) because permitting a single-file `external_directory` read shouldn't also authorize enumerating that directory's other entries — that's a separate, wider disclosure.

### How did you verify your code works?

Added two cases to `test/tool/read.test.ts`: (1) a missing file *inside* a git-backed worktree still returns the "Did you mean…" suggestion and `readDirectory` is called on its directory; (2) a missing file in an *external* directory returns a plain not-found, includes no suggestion, leaks no sibling name, and `readDirectory` is never called on the external dir (asserted via an FS spy). I traced the imports/types against `instance-context.ts` (`containsPath`/`InstanceContext`). I rely on CI to run the full suite — my isolated worktree can't cleanly resolve the `@opencode-ai/core` workspace alias for a local `bun test`.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
