### PR TITLE
fix(app): reject stale timeline range indexes

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -73,7 +73,7 @@ import { makeTimer } from "@solid-primitives/timer"
 import { scheduleConnectedMeasure } from "./measure"
 import { createTimelineProjection } from "./projection"
 import { MessageComment, SummaryDiff, TimelineRow, TimelineRowMap } from "./rows"
-import { mapVirtualItems } from "./virtual-items"
+import { filterVirtualIndexes } from "./virtual-items"
 
 const emptyMessages: MessageType[] = []
 const emptyParts: PartType[] = []
@@ -453,7 +453,10 @@ export function MessageTimeline(props: {
       const id = activeMessageID()
       const active = id ? (messageLastRowIndex().get(id) ?? -1) : -1
       const indexes = defaultRangeExtractor({ ...range, overscan: renderOverscan() })
-      return [...new Set([...resizePinnedIndexes, ...indexes, ...(active < 0 ? [] : [active])])].sort((a, b) => a - b)
+      return filterVirtualIndexes(
+        [...new Set([...resizePinnedIndexes, ...indexes, ...(active < 0 ? [] : [active])])].sort((a, b) => a - b),
+        range.count,
+      )
     },
   })
   const resizeItem = virtualizer.resizeItem
@@ -481,8 +484,10 @@ export function MessageTimeline(props: {
   }
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) =>
     item.end <= instance.getLogicalScrollOffset()
-  const virtualItemByKey = createMemo(() => mapVirtualItems(virtualizer.getVirtualItems()))
-  const virtualRowKeys = createMemo(() => [...virtualItemByKey().keys()].map((key) => key as string))
+  const virtualItemByKey = createMemo(
+    () => new Map(virtualizer.getVirtualItems().map((item) => [item.key, item] as const)),
+  )
+  const virtualRowKeys = createMemo(() => virtualizer.getVirtualItems().map((item) => item.key as string))
   createEffect(() => {
     props.setRevealMessage?.((id) => {
       const index = messageRowIndex().get(id)

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -73,6 +73,7 @@ import { makeTimer } from "@solid-primitives/timer"
 import { scheduleConnectedMeasure } from "./measure"
 import { createTimelineProjection } from "./projection"
 import { MessageComment, SummaryDiff, TimelineRow, TimelineRowMap } from "./rows"
+import { mapVirtualItems } from "./virtual-items"
 
 const emptyMessages: MessageType[] = []
 const emptyParts: PartType[] = []
@@ -480,10 +481,8 @@ export function MessageTimeline(props: {
   }
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) =>
     item.end <= instance.getLogicalScrollOffset()
-  const virtualItemByKey = createMemo(
-    () => new Map(virtualizer.getVirtualItems().map((item) => [item.key, item] as const)),
-  )
-  const virtualRowKeys = createMemo(() => virtualizer.getVirtualItems().map((item) => item.key as string))
+  const virtualItemByKey = createMemo(() => mapVirtualItems(virtualizer.getVirtualItems()))
+  const virtualRowKeys = createMemo(() => [...virtualItemByKey().keys()].map((key) => key as string))
   createEffect(() => {
     props.setRevealMessage?.((id) => {
       const index = messageRowIndex().get(id)

--- a/packages/app/src/pages/session/timeline/virtual-items.test.ts
+++ b/packages/app/src/pages/session/timeline/virtual-items.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "bun:test"
+import type { VirtualItem } from "@tanstack/solid-virtual"
+import { mapVirtualItems } from "./virtual-items"
+
+test("maps virtual items when the virtualizer returns a sparse array", () => {
+  const item = { key: "row-1" } as VirtualItem
+  const items = new Array<VirtualItem>(2)
+  items[1] = item
+
+  expect([...mapVirtualItems(items)]).toEqual([["row-1", item]])
+})

--- a/packages/app/src/pages/session/timeline/virtual-items.test.ts
+++ b/packages/app/src/pages/session/timeline/virtual-items.test.ts
@@ -1,11 +1,6 @@
 import { expect, test } from "bun:test"
-import type { VirtualItem } from "@tanstack/solid-virtual"
-import { mapVirtualItems } from "./virtual-items"
+import { filterVirtualIndexes } from "./virtual-items"
 
-test("maps virtual items when the virtualizer returns a sparse array", () => {
-  const item = { key: "row-1" } as VirtualItem
-  const items = new Array<VirtualItem>(2)
-  items[1] = item
-
-  expect([...mapVirtualItems(items)]).toEqual([["row-1", item]])
+test("removes pinned indexes left behind after the timeline shrinks", () => {
+  expect(filterVirtualIndexes([0, 2, 4, 8], 5)).toEqual([0, 2, 4])
 })

--- a/packages/app/src/pages/session/timeline/virtual-items.test.ts
+++ b/packages/app/src/pages/session/timeline/virtual-items.test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from "bun:test"
-import { filterVirtualIndexes } from "./virtual-items"
-
-test("removes pinned indexes left behind after the timeline shrinks", () => {
-  expect(filterVirtualIndexes([0, 2, 4, 8], 5)).toEqual([0, 2, 4])
-})

--- a/packages/app/src/pages/session/timeline/virtual-items.ts
+++ b/packages/app/src/pages/session/timeline/virtual-items.ts
@@ -1,5 +1,3 @@
-import type { VirtualItem } from "@tanstack/solid-virtual"
-
-export function mapVirtualItems(items: VirtualItem[]) {
-  return new Map(items.flatMap((item) => [[item.key, item] as const]))
+export function filterVirtualIndexes(indexes: number[], count: number) {
+  return indexes.filter((index) => index >= 0 && index < count)
 }

--- a/packages/app/src/pages/session/timeline/virtual-items.ts
+++ b/packages/app/src/pages/session/timeline/virtual-items.ts
@@ -1,0 +1,5 @@
+import type { VirtualItem } from "@tanstack/solid-virtual"
+
+export function mapVirtualItems(items: VirtualItem[]) {
+  return new Map(items.flatMap((item) => [[item.key, item] as const]))
+}

--- a/packages/app/test-browser/solid-virtual.test.ts
+++ b/packages/app/test-browser/solid-virtual.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test"
-import { createVirtualizer } from "@tanstack/solid-virtual"
+import { createVirtualizer, defaultRangeExtractor } from "@tanstack/solid-virtual"
 import { createRoot, createSignal } from "solid-js"
+import { filterVirtualIndexes } from "@/pages/session/timeline/virtual-items"
 
 test("reactive count updates preserve measured row sizes", () => {
   createRoot((dispose) => {
@@ -41,6 +42,29 @@ test("logical scroll offset includes pending measurement adjustments", () => {
 
     expect(virtualizer.scrollOffset).toBe(100)
     expect(virtualizer.getLogicalScrollOffset()).toBe(140)
+    dispose()
+  })
+})
+
+test("stale pinned indexes do not produce missing virtual items after count shrinks", () => {
+  createRoot((dispose) => {
+    const [count, setCount] = createSignal(2)
+    const pinned = [1]
+    const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({
+      get count() {
+        return count()
+      },
+      getScrollElement: () => null,
+      estimateSize: () => 60,
+      initialRect: { width: 800, height: 600 },
+      rangeExtractor: (range) =>
+        filterVirtualIndexes([...new Set([...defaultRangeExtractor(range), ...pinned])], range.count),
+    })
+
+    expect(virtualizer.getVirtualItems().map((item) => item.index)).toEqual([0, 1])
+    setCount(1)
+    expect(virtualizer.getVirtualItems().map((item) => item.index)).toEqual([0])
+    expect(() => new Map(virtualizer.getVirtualItems().map((item) => [item.key, item]))).not.toThrow()
     dispose()
   })
 })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1242,7 +1242,7 @@ it.instance(
       }
     }),
   { git: true },
-  3_000,
+  10_000,
 )
 
 // Queue semantics
@@ -1669,7 +1669,7 @@ it.instance(
       expect(yield* llm.calls).toBe(1)
     }),
   { git: true },
-  3_000,
+  10_000,
 )
 
 unix(


### PR DESCRIPTION
## Summary

- constrain the custom timeline `rangeExtractor` to indexes in `[0, range.count)`
- prevent stale resize-pinned indexes from becoming missing TanStack virtual items after the timeline shrinks
- reproduce the full count-shrink and `new Map(...)` crash path with the installed patched Solid adapter
- give two existing live-clock queued prompt tests enough time for real HTTP, Git, and subprocess work

## Deterministic root cause

Large row resizes capture visible DOM indexes in `resizePinnedIndexes` and retain them for two animation frames. The timeline projection can shrink before those frames expire. The custom range extractor previously merged the stale pinned indexes without validating them against the new `range.count`.

TanStack Virtual trusts custom range extractors. `getVirtualItems()` indexes directly into the current measurement array, so an out-of-range index adds `undefined`. The Solid adapter reconciles that value into its keyed store, leaving a sparse array. The timeline then preserves the hole through `.map(...)`, and `new Map(...)` throws `TypeError: Iterator value undefined is not an entry object`.

The browser-condition regression uses the real adapter:

1. Start with count 2 and pinned index 1.
2. Shrink count to 1 while index 1 remains pinned.
3. Assert `getVirtualItems()` contains only index 0.
4. Assert the production `new Map(items.map(...))` conversion does not throw.

With `filterVirtualIndexes` changed to return its input unchanged, this test deterministically fails at step 4 with `TypeError`.

The fix rejects invalid indexes at the custom range producer rather than masking missing items at the `Map` consumer.

## CI timeout stabilization

The first CI run also exposed two unrelated `packages/opencode/test/session/prompt.test.ts` tests whose 3-second limits were below their observed live-clock runtimes. Both use `it.instance`, which runs with the live Effect clock, plus real temporary Git repositories, HTTP, and subprocess work; the shell case also executes `sleep 0.2`.

Using the pinned Bun 1.3.14 locally, both failed 5/5 at 3 seconds and completed cleanly at 10 seconds. Their timeout limits are raised to 10 seconds without changing test behavior.

## Verification

- `bun install --frozen-lockfile`
- `bun run test:virtualizer`: 3 passed
- focused timeline unit tests: 7 passed
- pinned Bun 1.3.14 queued prompt tests: 2 passed
- `bun typecheck` from `packages/app`
- repository push-hook typecheck: 23 tasks passed
- `git diff --check upstream/dev...HEAD`