### PR TITLE
fix: project edit dialog does not persist name and icon changes for local projects

### DIFF
--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -116,10 +116,18 @@ function createServerCtx(
       ? sync.data.project.find((x) => x.id === projectID)
       : sync.data.project.find((x) => x.worktree === project.worktree)
 
-    // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
+    // Preserve local project overrides from per-workspace localStorage cache (childStore.projectMeta).
     // Without this, different subdirectories of the same git repo would share the same
-    // icon from the database instead of using their individual overrides.
+    // name and icon from the database instead of using their individual overrides.
     const base = { ...metadata, ...project }
+    if (childStore.projectMeta?.name) {
+      base.name = childStore.projectMeta.name
+    }
+    // Apply icon override from projectMeta (written by projectMeta() for local projects)
+    if (childStore.projectMeta?.icon?.override) {
+      return { ...base, icon: { ...base.icon, override: childStore.projectMeta.icon.override } }
+    }
+    // Fallback: legacy icon override from projectIcon() (written for server projects)
     if (childStore.icon) {
       return { ...base, icon: { ...base.icon, override: childStore.icon } }
     }


### PR DESCRIPTION
## Description

Fixes #32164

When editing a project's name or icon via the Edit dialog (right-click ? Edit) in the Desktop app for **local projects** (without a SQLite project ID), the name and icon are saved to the per-workspace persisted store via serverSync().project.meta(), but the enrich() function in global.tsx never reads them back.

Two issues in enrich():
1. **Name**: childStore.projectMeta?.name was never checked - only childStore.icon was applied
2. **Icon**: For local projects, icon is saved via projectMeta() into childStore.projectMeta.icon.override, but enrich() only checked the legacy childStore.icon field (written by projectIcon(), which is only called for server projects)

## Changes

- packages/app/src/context/global.tsx: 
  - Added check for childStore.projectMeta?.name to apply local project name overrides
  - Added check for childStore.projectMeta?.icon?.override to apply local project icon overrides (with fallback to legacy childStore.icon)