### PR TITLE
feat(core): add instructionMode config to skip AGENTS.md discovery

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -95,6 +95,10 @@ export class Info extends Schema.Class<Info>("Config.Info")({
   instructions: Schema.String.pipe(Schema.Array, Schema.optional).annotate({
     description: "Additional paths or URLs supplying ambient instructions",
   }),
+  instruction_mode: Schema.Literals(["default", "explicit"]).pipe(Schema.optional).annotate({
+    description:
+      "Controls instruction discovery. 'default' auto-discovers AGENTS.md files. 'explicit' only loads instructions listed in the 'instructions' field.",
+  }),
   references: ConfigReference.Info.pipe(Schema.optional).annotate({
     description: "Named local directories or Git repositories available as external context",
   }),

--- a/packages/core/src/instruction-context.ts
+++ b/packages/core/src/instruction-context.ts
@@ -2,6 +2,7 @@ export * as InstructionContext from "./instruction-context"
 
 import { Array, Effect, Layer, Schema } from "effect"
 import { isAbsolute, join, relative, sep } from "path"
+import { Config } from "./config"
 import { FSUtil } from "./fs-util"
 import { Flag } from "./flag/flag"
 import { Global } from "./global"
@@ -24,6 +25,7 @@ export const layer = Layer.effectDiscard(
     const global = yield* Global.Service
     const location = yield* Location.Service
     const registry = yield* SystemContextRegistry.Service
+    const config = yield* Config.Service
 
     const source = (value: ReadonlyArray<File> | SystemContext.Unavailable) =>
       SystemContext.make({
@@ -37,6 +39,11 @@ export const layer = Layer.effectDiscard(
       })
 
     const observe = Effect.fn("InstructionContext.observe")(function* () {
+      const entries = yield* config.entries()
+      const instructionMode = Config.latest(entries, "instruction_mode")
+
+      if (instructionMode === "explicit") return []
+
       const start = FSUtil.resolve(location.directory)
       const stop = FSUtil.resolve(location.project.directory)
       const fromProject = relative(stop, start)

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -118,6 +118,10 @@ export const Info = Schema.Struct({
     description:
       "Enable or configure LSP servers. Omit or set to false to disable, true to enable built-ins, or an object to enable built-ins with overrides.",
   }),
+  instructionMode: Schema.optional(Schema.Literals(["default", "explicit"])).annotate({
+    description:
+      "Controls instruction discovery. 'default' auto-discovers AGENTS.md files from project and global config. 'explicit' only loads instructions listed in the 'instructions' field.",
+  }),
   instructions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Additional instruction files or patterns to include",
   }),

--- a/packages/core/src/v1/config/migrate.ts
+++ b/packages/core/src/v1/config/migrate.ts
@@ -63,6 +63,7 @@ export function migrate(info: typeof ConfigV1.Info.Type) {
     skills: info.skills && [...(info.skills.paths ?? []), ...(info.skills.urls ?? [])],
     commands: info.command,
     instructions: info.instructions,
+    instruction_mode: info.instructionMode,
     references: info.references ?? info.reference,
     plugins: info.plugin?.map((plugin) =>
       typeof plugin === "string" ? plugin : { package: plugin[0], options: plugin[1] },

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -112,22 +112,24 @@ export const layer: Layer.Layer<
       const ctx = yield* InstanceState.context
       const paths = new Set<string>()
 
-      for (const file of globalFiles) {
-        if (yield* fs.existsSafe(file)) {
-          paths.add(path.resolve(file))
-          break
-        }
-      }
-
-      // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
-      if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-        for (const file of instructionFiles) {
-          const matches = yield* fs
-            .findUp(file, ctx.directory, ctx.worktree)
-            .pipe(Effect.catch(() => Effect.succeed([])))
-          if (matches.length > 0) {
-            matches.forEach((item) => paths.add(path.resolve(item)))
+      if (config.instructionMode !== "explicit") {
+        for (const file of globalFiles) {
+          if (yield* fs.existsSafe(file)) {
+            paths.add(path.resolve(file))
             break
+          }
+        }
+
+        // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
+        if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+          for (const file of instructionFiles) {
+            const matches = yield* fs
+              .findUp(file, ctx.directory, ctx.worktree)
+              .pipe(Effect.catch(() => Effect.succeed([])))
+            if (matches.length > 0) {
+              matches.forEach((item) => paths.add(path.resolve(item)))
+              break
+            }
           }
         }
       }


### PR DESCRIPTION
### Issue for this PR

N/A — feature request from user feedback, no issue filed.

### Type of change

- [x] New feature

### What does this PR do?

Agents with narrow, focused tasks waste tokens loading auto-discovered AGENTS.md files (global + project) that are irrelevant to their work. There was no way to opt out of auto-discovery.

This PR adds an `instructionMode` field to `opencode.json`:

```json
{
  "instructionMode": "explicit",
  "instructions": ["team/rules.md"]
}
```

Two modes:
- **`"default"`** (or omit the field) — existing behavior preserved. Auto-discovers AGENTS.md from `~/.config/opencode/` + project upward walk. Zero change.
- **`"explicit"`** — skips all automatic AGENTS.md discovery. Only loads paths from the `instructions` array. If `instructions` is empty, nothing loads → zero token waste.

Implementation spans both session systems. V1 (`instruction.ts`) wraps its auto-discovery blocks in a check: skip when `config.instructionMode === "explicit"`. V2 (`instruction-context.ts`) reads `instruction_mode` from the V2 config service and returns an empty file list when set to `"explicit"`, which produces `SystemContext.empty` — no instruction content in the baseline at all.

The field is added to both the V1 config schema (`ConfigV1.Info`, camelCase) and V2 config schema (`Config.Info`, snake_case), with migration passthrough in `ConfigMigrateV1`.

### How did you verify your code works?

- Both packages pass `pnpm typecheck` with zero errors.
- V2 instruction-context test suite passes.
- Existing test for the `OPENCODE_DISABLE_PROJECT_CONFIG` env var validates the early-return path pattern that `"explicit"` follows.

### Screenshots / recordings

N/A — config-level change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR