### PR TITLE
fix(opencode): handle snapshot paths from subdirectories

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -82,8 +82,9 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
         const args = (cmd: string[]) => ["--git-dir", state.gitdir, "--work-tree", state.worktree, ...cmd]
 
-        const feed = (list: string[]) => list.join("\0") + "\0"
-        const feedSpec = (list: string[]) => feed(list.map((item) => `:(top,literal)${item}`))
+        const encodeNulTerminatedPaths = (files: string[]) => files.join("\0") + "\0"
+        const encodeTopLevelLiteralPathspecs = (files: string[]) =>
+          encodeNulTerminatedPaths(files.map((file) => `:(top,literal)${file}`))
 
         const git = Effect.fnUntraced(
           function* (cmd: string[], opts?: { cwd?: string; env?: Record<string, string>; stdin?: string }) {
@@ -108,7 +109,8 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
         const ignore = Effect.fnUntraced(function* (files: string[]) {
           if (!files.length) return new Set<string>()
-          const input = files.map((item) => (item.startsWith(":") ? `./${item}` : item))
+          // check-ignore treats a leading colon as pathspec magic but accepts and echoes a protective ./ prefix.
+          const checkIgnorePaths = files.map((item) => (item.startsWith(":") ? `./${item}` : item))
           const check = yield* git(
             [
               ...quote,
@@ -123,7 +125,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             ],
             {
               cwd: state.worktree,
-              stdin: feed(input),
+              stdin: encodeNulTerminatedPaths(checkIgnorePaths),
             },
           )
           if (check.code !== 0 && check.code !== 1) return new Set<string>()
@@ -144,7 +146,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             ],
             {
               cwd: state.worktree,
-              stdin: feedSpec(files),
+              stdin: encodeTopLevelLiteralPathspecs(files),
             },
           )
         })
@@ -155,7 +157,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
             {
               cwd: state.worktree,
-              stdin: feedSpec(files),
+              stdin: encodeTopLevelLiteralPathspecs(files),
             },
           )
           if (result.code === 0) return

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -83,6 +83,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
         const args = (cmd: string[]) => ["--git-dir", state.gitdir, "--work-tree", state.worktree, ...cmd]
 
         const feed = (list: string[]) => list.join("\0") + "\0"
+        const feedSpec = (list: string[]) => feed(list.map((item) => `:(top,literal)${item}`))
 
         const git = Effect.fnUntraced(
           function* (cmd: string[], opts?: { cwd?: string; env?: Record<string, string>; stdin?: string }) {
@@ -107,6 +108,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
         const ignore = Effect.fnUntraced(function* (files: string[]) {
           if (!files.length) return new Set<string>()
+          const input = files.map((item) => (item.startsWith(":") ? `./${item}` : item))
           const check = yield* git(
             [
               ...quote,
@@ -120,12 +122,17 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               "-z",
             ],
             {
-              cwd: state.directory,
-              stdin: feed(files),
+              cwd: state.worktree,
+              stdin: feed(input),
             },
           )
           if (check.code !== 0 && check.code !== 1) return new Set<string>()
-          return new Set(check.text.split("\0").filter(Boolean))
+          return new Set(
+            check.text
+              .split("\0")
+              .filter(Boolean)
+              .map((item) => (item.startsWith("./:") ? item.slice(2) : item)),
+          )
         })
 
         const drop = Effect.fnUntraced(function* (files: string[]) {
@@ -136,8 +143,8 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               ...args(["rm", "--cached", "-f", "--ignore-unmatch", "--pathspec-from-file=-", "--pathspec-file-nul"]),
             ],
             {
-              cwd: state.directory,
-              stdin: feed(files),
+              cwd: state.worktree,
+              stdin: feedSpec(files),
             },
           )
         })
@@ -147,8 +154,8 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           const result = yield* git(
             [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
             {
-              cwd: state.directory,
-              stdin: feed(files),
+              cwd: state.worktree,
+              stdin: feedSpec(files),
             },
           )
           if (result.code === 0) return
@@ -238,7 +245,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               git([...quote, ...args(["diff-files", "--name-only", "-z", "--", "."])], {
                 cwd: state.directory,
               }),
-              git([...quote, ...args(["ls-files", "--others", "--exclude-standard", "-z", "--", "."])], {
+              git([...quote, ...args(["ls-files", "--full-name", "--others", "--exclude-standard", "-z", "--", "."])], {
                 cwd: state.directory,
               }),
             ],
@@ -277,7 +284,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
             (yield* Effect.all(
               allow.map((item) =>
                 fs
-                  .stat(path.join(state.directory, item))
+                  .stat(path.join(state.worktree, item))
                   .pipe(Effect.catch(() => Effect.void))
                   .pipe(
                     Effect.map((stat) => {

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -16,7 +16,8 @@ import {
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(Snapshot.defaultLayer, FSUtil.defaultLayer, testInstanceStoreLayer))
-const literalPathIt = process.platform === "win32" ? it.live.skip : it.live
+// Windows forbids both * and : in directory names.
+const nonWindowsIt = process.platform === "win32" ? it.live.skip : it.live
 
 // Git always outputs /-separated paths internally. Snapshot.patch() joins them
 // with path.join (which produces \ on Windows) then normalizes back to /.
@@ -455,7 +456,9 @@ it.live(
     const dir = yield* scopedGitTmpdir()
     const frontend = path.join(dir, "frontend")
     yield* write(`${frontend}/tracked.txt`, "initial")
+    yield* write(`${frontend}/deleted.txt`, "initial")
     yield* write(`${dir}/backend/tracked.txt`, "initial")
+    yield* write(`${dir}/backend/deleted.txt`, "initial")
     yield* exec(dir, ["git", "add", "."])
     yield* exec(dir, ["git", "commit", "-m", "init"])
     yield* Effect.gen(function* () {
@@ -464,18 +467,23 @@ it.live(
       expect(before).toBeTruthy()
       yield* write(`${frontend}/tracked.txt`, "changed")
       yield* write(`${frontend}/untracked.txt`, "new")
+      yield* rm(`${frontend}/deleted.txt`)
       yield* write(`${dir}/backend/tracked.txt`, "changed")
+      yield* rm(`${dir}/backend/deleted.txt`)
       const patch = yield* snapshot.patch(before!)
       const diff = yield* snapshot.diff(before!)
       expect(patch.files).toContain(fwd(frontend, "tracked.txt"))
       expect(patch.files).toContain(fwd(frontend, "untracked.txt"))
+      expect(patch.files).toContain(fwd(frontend, "deleted.txt"))
       expect(patch.files).not.toContain(fwd(dir, "backend", "tracked.txt"))
+      expect(patch.files).not.toContain(fwd(dir, "backend", "deleted.txt"))
       expect(diff).not.toContain("backend/tracked.txt")
+      expect(diff).not.toContain("backend/deleted.txt")
     }).pipe(provideInstance(frontend))
   }),
 )
 
-literalPathIt(
+nonWindowsIt(
   "subdirectory snapshots treat wildcard characters literally",
   Effect.gen(function* () {
     const dir = yield* scopedGitTmpdir()
@@ -499,12 +507,14 @@ literalPathIt(
       expect(patch.files).toContain(fwd(subdir, ".gitignore"))
       expect(patch.files).not.toContain(fwd(subdir, "later-ignored.txt"))
       expect(patch.files).not.toContain(fwd(dir, "srca", "file.txt"))
+      expect(diff).toContain("src*/later-ignored.txt")
+      expect(diff).toContain("deleted file mode")
       expect(diff).not.toContain("srca/file.txt")
     }).pipe(provideInstance(subdir))
   }),
 )
 
-literalPathIt(
+nonWindowsIt(
   "subdirectory snapshots treat leading colons literally",
   Effect.gen(function* () {
     const dir = yield* scopedGitTmpdir()
@@ -521,9 +531,12 @@ literalPathIt(
       yield* write(`${subdir}/later-ignored.txt`, "changed")
       yield* write(`${subdir}/.gitignore`, "later-ignored.txt\n")
       const patch = yield* snapshot.patch(before!)
+      const diff = yield* snapshot.diff(before!)
       expect(patch.files).toContain(fwd(subdir, "kept.txt"))
       expect(patch.files).toContain(fwd(subdir, ".gitignore"))
       expect(patch.files).not.toContain(fwd(subdir, "later-ignored.txt"))
+      expect(diff).toContain(":src/later-ignored.txt")
+      expect(diff).toContain("deleted file mode")
     }).pipe(provideInstance(subdir))
   }),
 )

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -448,6 +448,85 @@ it.live(
   }),
 )
 
+it.live(
+  "subdirectory snapshots include scoped changes only",
+  Effect.gen(function* () {
+    const dir = yield* scopedGitTmpdir()
+    const frontend = path.join(dir, "frontend")
+    yield* write(`${frontend}/tracked.txt`, "initial")
+    yield* write(`${dir}/backend/tracked.txt`, "initial")
+    yield* exec(dir, ["git", "add", "."])
+    yield* exec(dir, ["git", "commit", "-m", "init"])
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${frontend}/tracked.txt`, "changed")
+      yield* write(`${frontend}/untracked.txt`, "new")
+      yield* write(`${dir}/backend/tracked.txt`, "changed")
+      const patch = yield* snapshot.patch(before!)
+      const diff = yield* snapshot.diff(before!)
+      expect(patch.files).toContain(fwd(frontend, "tracked.txt"))
+      expect(patch.files).toContain(fwd(frontend, "untracked.txt"))
+      expect(patch.files).not.toContain(fwd(dir, "backend", "tracked.txt"))
+      expect(diff).not.toContain("backend/tracked.txt")
+    }).pipe(provideInstance(frontend))
+  }),
+)
+
+it.live(
+  "subdirectory snapshots treat wildcard characters literally",
+  Effect.gen(function* () {
+    const dir = yield* scopedGitTmpdir()
+    const subdir = path.join(dir, "src*")
+    yield* write(`${subdir}/file.txt`, "initial")
+    yield* write(`${subdir}/later-ignored.txt`, "initial")
+    yield* write(`${dir}/srca/file.txt`, "initial")
+    yield* exec(dir, ["git", "add", "."])
+    yield* exec(dir, ["git", "commit", "-m", "init"])
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${subdir}/file.txt`, "changed")
+      yield* write(`${subdir}/later-ignored.txt`, "changed")
+      yield* write(`${subdir}/.gitignore`, "later-ignored.txt\n")
+      yield* write(`${dir}/srca/file.txt`, "changed")
+      const patch = yield* snapshot.patch(before!)
+      const diff = yield* snapshot.diff(before!)
+      expect(patch.files).toContain(fwd(subdir, "file.txt"))
+      expect(patch.files).toContain(fwd(subdir, ".gitignore"))
+      expect(patch.files).not.toContain(fwd(subdir, "later-ignored.txt"))
+      expect(patch.files).not.toContain(fwd(dir, "srca", "file.txt"))
+      expect(diff).not.toContain("srca/file.txt")
+    }).pipe(provideInstance(subdir))
+  }),
+)
+
+it.live(
+  "subdirectory snapshots treat leading colons literally",
+  Effect.gen(function* () {
+    const dir = yield* scopedGitTmpdir()
+    const subdir = path.join(dir, ":src")
+    yield* write(`${subdir}/kept.txt`, "initial")
+    yield* write(`${subdir}/later-ignored.txt`, "initial")
+    yield* exec(dir, ["git", "add", "."])
+    yield* exec(dir, ["git", "commit", "-m", "init"])
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${subdir}/kept.txt`, "changed")
+      yield* write(`${subdir}/later-ignored.txt`, "changed")
+      yield* write(`${subdir}/.gitignore`, "later-ignored.txt\n")
+      const patch = yield* snapshot.patch(before!)
+      expect(patch.files).toContain(fwd(subdir, "kept.txt"))
+      expect(patch.files).toContain(fwd(subdir, ".gitignore"))
+      expect(patch.files).not.toContain(fwd(subdir, "later-ignored.txt"))
+    }).pipe(provideInstance(subdir))
+  }),
+)
+
 it.instance(
   "gitignore changes",
   withTrackedSnapshot(({ tmp, snapshot, before }) =>

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -16,6 +16,7 @@ import {
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.mergeAll(Snapshot.defaultLayer, FSUtil.defaultLayer, testInstanceStoreLayer))
+const literalPathIt = process.platform === "win32" ? it.live.skip : it.live
 
 // Git always outputs /-separated paths internally. Snapshot.patch() joins them
 // with path.join (which produces \ on Windows) then normalizes back to /.
@@ -474,7 +475,7 @@ it.live(
   }),
 )
 
-it.live(
+literalPathIt(
   "subdirectory snapshots treat wildcard characters literally",
   Effect.gen(function* () {
     const dir = yield* scopedGitTmpdir()
@@ -503,7 +504,7 @@ it.live(
   }),
 )
 
-it.live(
+literalPathIt(
   "subdirectory snapshots treat leading colons literally",
   Effect.gen(function* () {
     const dir = yield* scopedGitTmpdir()


### PR DESCRIPTION
Closes #27688.

## Summary

- keep snapshot candidate discovery scoped to the instance directory
- consume worktree-relative identities from the Git worktree root
- encode `git add` and `git rm` inputs as literal top-level pathspecs
- preserve leading-colon paths through `git check-ignore --stdin`
- add regressions for nested scope, sibling exclusion, `src*`, `:src`, and ignored-file removal

## Why

Git discovery commands run from the launch directory to decide which files belong to the instance, but they return worktree-relative identities. Commands that consume those identities must therefore run from the worktree root. Literal top-level pathspec encoding prevents wildcard and leading-colon filenames from being interpreted as Git pathspec syntax.

## Verification

- `bun run test -- test/snapshot/snapshot.test.ts` (55 passed, 1 existing skip on macOS/Linux)
- Windows runs the portable nested-scope regression; `src*` and `:src` fixtures are skipped because those names are invalid on Windows filesystems
- `bun run test -- test/session/revert-compact.test.ts test/session/snapshot-tool-race.test.ts` (8 passed)
- `bun typecheck` from `packages/opencode`
- repository push hook typecheck (23 packages)
- `bunx prettier --check packages/opencode/src/snapshot/index.ts packages/opencode/test/snapshot/snapshot.test.ts`
- file-scoped oxlint (0 errors; 8 pre-existing warnings on untouched lines)
- `git diff --check`

This keeps the scoped architecture from #33211 by @Aqu1bp and adds the literal path handling demonstrated in Simon Klee's earlier commit 4a608b202669d57ead254dece8d951ca51a6dd15, without including its separate restore changes. #32935 takes the broader whole-worktree discovery approach and is superseded by this fix.