### PR TITLE
fix(tui): support clipboard image paste on Windows via FileDrop format

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -51,12 +51,38 @@ export async function read() {
   }
 
   if (platform() === "win32" || release().includes("WSL")) {
-    const script =
-      "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $ms = New-Object System.IO.MemoryStream; $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray()) }"
-    const image = await command("powershell.exe", ["-NonInteractive", "-NoProfile", "-command", script]).catch(() =>
+    // GetImage()/ContainsImage() return null/false for FileDrop clipboard content
+    // (images copied via Win+Shift+S → Ctrl+C or most Windows screenshot tools).
+    // Probe GetDataObject() first: FileDrop yields a file path we can read directly;
+    // fall back to Bitmap format for raw in-memory images (e.g. Ctrl+C in Paint).
+    const script = [
+      "Add-Type -AssemblyName System.Windows.Forms",
+      "$obj = [System.Windows.Forms.Clipboard]::GetDataObject()",
+      "if ($obj -and $obj.GetDataPresent([System.Windows.Forms.DataFormats]::FileDrop)) {",
+      "  $files = $obj.GetData([System.Windows.Forms.DataFormats]::FileDrop)",
+      "  if ($files -and $files.Length -gt 0) { $files[0] }",
+      "} elseif ($obj -and $obj.GetDataPresent([System.Windows.Forms.DataFormats]::Bitmap)) {",
+      "  $img = [System.Windows.Forms.Clipboard]::GetImage()",
+      "  if ($img) { $ms = New-Object System.IO.MemoryStream; $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); 'data:image/png;base64,' + [System.Convert]::ToBase64String($ms.ToArray()) }",
+      "}",
+    ].join("; ")
+    const result = await command("powershell.exe", ["-NonInteractive", "-NoProfile", "-command", script]).catch(() =>
       Buffer.alloc(0),
     )
-    if (image.length) return { data: image.toString().trim(), mime: "image/png" }
+    const output = result.toString("utf8").trim()
+    if (output.startsWith("data:image/png;base64,")) {
+      return { data: output.slice("data:image/png;base64,".length), mime: "image/png" }
+    }
+    if (
+      output.length > 0 &&
+      !output.includes(" ") &&
+      /\.(png|jpe?g|webp|gif|bmp)$/i.test(output)
+    ) {
+      try {
+        const fileData = await readFile(output)
+        return { data: fileData.toString("base64"), mime: `image/${path.extname(output).slice(1).toLowerCase()}` }
+      } catch {}
+    }
   }
 
   if (platform() === "linux") {


### PR DESCRIPTION
### Issue for this PR

Closes #31737
Closes #19502

### Type of change

- [x] Bug fix

### What does this PR do?

**Problem:** On Windows, screenshots copied with Win+Shift+S or Ctrl+C are stored in the clipboard as FileDrop (file references), not as Bitmap data. The current `clipboard.read()` calls `GetImage()` and `ContainsImage()` from `System.Windows.Forms.Clipboard`, which return `null`/`false` for FileDrop content. As a result, pasting a screenshot into the TUI prompt produces no `[Image 1]` — the image is silently ignored.

**Root cause:** Windows screenshot tools (Snipping Tool, Win+Shift+S, Print Screen) write a temporary PNG file path into the clipboard under the `FileDrop` format, not raw pixel data under `Bitmap`. The existing code only checks `Bitmap`.

**Fix:** Use `GetDataObject().GetDataPresent(FileDrop)` to detect file-reference images first. If present, read `GetData(FileDrop)` to get the file path, then read the file bytes and convert to base64. Fall back to `Bitmap` format (raw in-memory images, e.g. Ctrl+C in Paint or direct bitmap copies) when FileDrop is not present.

The change is confined to `packages/tui/src/clipboard.ts` — no new dependencies, no changes to the paste dispatch flow.

### How did you verify your code works?

Tested on Windows 11 with Windows Terminal:
- Win+Shift+S → Ctrl+C → Ctrl+V in TUI → `[Image 1]` appears correctly
- Ctrl+C in Paint (raw Bitmap) → Ctrl+V in TUI → `[Image 1]` appears correctly  
- Text paste still works normally
- No regression on macOS/Linux paths (guarded by `platform() === "win32"` check)

### Screenshots / recordings

_Terminal session before fix: no `[Image 1]` on paste. After fix: `[Image 1]` appears immediately._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR