### PR TITLE
fix(tui): make move session command bindable

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -83,6 +83,7 @@ export const Definitions = {
 
   session_export: keybind("<leader>x", "Export session to editor"),
   session_copy: keybind("none", "Copy session transcript"),
+  session_move: keybind("none", "Move session"),
   session_new: keybind("<leader>n", "Create a new session"),
   session_list: keybind("<leader>l", "List all sessions"),
   session_timeline: keybind("<leader>g", "Show session timeline"),
@@ -287,6 +288,7 @@ export const CommandMap = {
   status_view: "opencode.status",
   session_export: "session.export",
   session_copy: "session.copy",
+  session_move: "session.move",
   session_new: "session.new",
   session_list: "session.list",
   session_timeline: "session.timeline",

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -80,6 +80,12 @@ test("resolves overrides without mutating input", () => {
   expect(input.keybinds).toEqual({ session_list: "ctrl+l" })
 })
 
+test("resolves a session move keybind", () => {
+  const config = resolve({ keybinds: { session_move: "ctrl+o" } }, { terminalSuspend: true })
+
+  expect(config.keybinds.get("session.move")).toMatchObject([{ key: "ctrl+o" }])
+})
+
 test("disables suspend and assigns ctrl+z to undo when unsupported", () => {
   const config = resolve({}, { terminalSuspend: false })
 

--- a/packages/web/src/content/docs/keybinds.mdx
+++ b/packages/web/src/content/docs/keybinds.mdx
@@ -34,6 +34,7 @@ OpenCode has a list of keybinds that you can customize through `tui.json`.
 
     "session_export": "<leader>x",
     "session_copy": "none",
+    "session_move": "none",
     "session_new": "<leader>n",
     "session_list": "<leader>l",
     "session_timeline": "<leader>g",


### PR DESCRIPTION
Add the session_move TUI keybind and map it to the existing session.move command. Keep it unbound by default and document the new configuration option.

Closes #33239