### PR TITLE
fix: refresh worktree agents after startup scripts

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -57,6 +57,7 @@ import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { SessionRouteKey, SessionStateKey } from "@/utils/server-scope"
+import { useQueryClient } from "@tanstack/solid-query"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -116,6 +117,7 @@ export default function LegacyLayout(props: ParentProps) {
 
   const params = useParams()
   const serverSync = useServerSync()
+  const queryClient = useQueryClient()
   const layout = useLayout()
   const layoutReady = createMemo(() => layout.ready())
   const platform = usePlatform()
@@ -399,6 +401,13 @@ export default function LegacyLayout(props: ParentProps) {
         if (e.details?.type === "worktree.ready") {
           setBusy(e.name, false)
           WorktreeState.ready(serverSDK().scope, e.name)
+          void queryClient
+            .fetchQuery(serverSync().queryOptions.agents(pathKey(e.name)))
+            .then((agents) => {
+              const [, setChildStore] = serverSync().child(e.name, { bootstrap: false })
+              setChildStore("agent", agents)
+            })
+            .catch(() => undefined)
           return
         }
 

--- a/packages/opencode/src/worktree/index.ts
+++ b/packages/opencode/src/worktree/index.ts
@@ -263,7 +263,9 @@ export const layer: Layer.Layer<
         return
       }
 
-      const booted = yield* store.load({ directory: info.directory }).pipe(
+      yield* runStartScripts(info.directory, { projectID, extra })
+
+      const booted = yield* store.reload({ directory: info.directory }).pipe(
         Effect.as(true),
         Effect.catch((error) =>
           Effect.gen(function* () {
@@ -290,8 +292,6 @@ export const layer: Layer.Layer<
           properties: { name: info.name, ...(info.branch ? { branch: info.branch } : {}) },
         },
       })
-
-      yield* runStartScripts(info.directory, { projectID, extra })
     })
 
     const createFromInfo = Effect.fn("Worktree.createFromInfo")(function* (info: Info, startCommand?: string) {

--- a/packages/opencode/test/server/worktree-endpoint-repro.test.ts
+++ b/packages/opencode/test/server/worktree-endpoint-repro.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect } from "bun:test"
 import { Effect, Layer, Queue } from "effect"
+import fs from "node:fs/promises"
+import path from "node:path"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { GlobalBus, type GlobalEvent } from "@/bus/global"
 import { Worktree } from "@/worktree"
 import { Server } from "../../src/server/server"
 import { ExperimentalPaths } from "../../src/server/routes/instance/httpapi/groups/experimental"
+import { InstancePaths } from "../../src/server/routes/instance/httpapi/groups/instance"
 import { WorkspacePaths } from "../../src/server/routes/instance/httpapi/groups/workspace"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
@@ -301,6 +304,68 @@ describe("worktree endpoint reproduction", () => {
         })
 
         expect(Date.now() - started).toBeLessThan(1_500)
+      }),
+    { git: true },
+  )
+
+  worktreeTest(
+    "worktree ready reloads agents created by project start command after early agent load",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const server = yield* serverScoped()
+        yield* setProjectStartCommand({
+          server,
+          directory: test.directory,
+          command:
+            'while [ ! -f .opencode-agent-ready ]; do sleep 0.1; done; mkdir -p .opencode/agents && printf -- "---\\ndescription: Script reviewer\\nmode: subagent\\n---\\nReview script output\\n" > .opencode/agents/script-reviewer.md',
+        })
+
+        yield* Effect.acquireUseRelease(
+          Effect.gen(function* () {
+            const waitReady = yield* readyWatcher()
+            const response = yield* withRequestTimeout(
+              request(server, `${ExperimentalPaths.worktree}?directory=${encodeURIComponent(test.directory)}`, {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({ name: "agent-startup" }),
+              }),
+              "worktree create with agent startup",
+            )
+            expect(response.status).toBe(200)
+            const body = yield* json<CreatedWorktree>(response)
+            return { directory: body.directory, ready: waitReady(body.directory) }
+          }),
+          ({ directory, ready }) =>
+            Effect.gen(function* () {
+              const earlyResponse = yield* request(
+                server,
+                `${InstancePaths.agent}?directory=${encodeURIComponent(directory)}`,
+              )
+              expect(earlyResponse.status).toBe(200)
+              const early = yield* json<{ name: string }[]>(earlyResponse)
+              expect(early.map((agent) => agent.name)).not.toContain("script-reviewer")
+
+              yield* Effect.promise(() => fs.writeFile(path.join(directory, ".opencode-agent-ready"), "ready"))
+
+              yield* ready
+
+              const loadedResponse = yield* request(
+                server,
+                `${InstancePaths.agent}?directory=${encodeURIComponent(directory)}`,
+              )
+              expect(loadedResponse.status).toBe(200)
+              const loaded = yield* json<{ name: string }[]>(loadedResponse)
+              expect(loaded.map((agent) => agent.name)).toContain("script-reviewer")
+            }),
+          ({ directory, ready }) =>
+            removeCreatedWorktree({
+              server,
+              rootDirectory: test.directory,
+              worktreeDirectory: directory,
+              ready,
+            }).pipe(Effect.orDie),
+        )
       }),
     { git: true },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #33501

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Worktree startup scripts can create or symlink project agents after the Web server has already loaded the new worktree instance. This PR runs startup scripts before the ready-time instance reload, then emits `worktree.ready` only after the reloaded instance can discover those agents. The Web app also refreshes the agents query when `worktree.ready` arrives so the `@` mention list does not keep an early cached response.

### How did you verify your code works?

- `bun test test/server/worktree-endpoint-repro.test.ts --timeout 30000`
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/app`
- pre-push hook ran `bun turbo typecheck`

### Screenshots / recordings

N/A. This is a worktree/server cache bug fix with regression coverage.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR