### PR TITLE
fix(opencode): scope --continue to the current worktree directory

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -1014,6 +1014,9 @@ function listByProject(
           : or(...conds)!,
       )
     }
+    if (input.path === "" && input.directory) {
+      conditions.push(eq(SessionTable.directory, input.directory))
+    }
   } else if (input.scope !== "project") {
     if (input.directory) {
       conditions.push(eq(SessionTable.directory, input.directory))

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect } from "bun:test"
+import { $ } from "bun"
 import { Effect, Layer } from "effect"
 import { Database } from "@opencode-ai/core/database/database"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
@@ -233,6 +234,39 @@ describe("session.list", () => {
         )).map((session) => session.id)
         expect(pathIDs).toContain(current.id)
         expect(pathIDs).not.toContain(sibling.id)
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "filters root worktree sessions by directory when path is empty",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        // Two root-level git worktrees of the same repo. Each worktree root maps to an
+        // empty project-relative path (""), so both root sessions share a project_id and
+        // path === "" — directory is the only thing that distinguishes them. Regression
+        // for #25963, where `--continue` could resume another worktree's root session.
+        const featureDir = path.join(test.directory, "..", path.basename(test.directory) + "-feature")
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(() => $`git worktree remove --force ${featureDir}`.cwd(test.directory).quiet().nothrow()).pipe(
+            Effect.ignore,
+          ),
+        )
+        yield* Effect.promise(() => $`git worktree add ${featureDir} -b feature`.cwd(test.directory).quiet())
+
+        const mainSession = yield* withSession({ title: "main-root" })
+        const featureSession = yield* withSession({ title: "feature-root" }).pipe(provideInstance(featureDir))
+
+        expect(mainSession.projectID).toBe(featureSession.projectID)
+        expect(mainSession.path).toBe("")
+        expect(featureSession.path).toBe("")
+
+        const ids = (yield* SessionNs.Service.use((session) =>
+          session.list({ directory: featureDir, path: "" }),
+        )).map((session) => session.id)
+        expect(ids).toContain(featureSession.id)
+        expect(ids).not.toContain(mainSession.id)
       }),
     { git: true },
   )

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -149,10 +149,11 @@ export const {
       hydratingSessions.get(sessionID)?.parts.add(partID)
     }
 
-    function sessionListQuery(): { scope?: "project"; path?: string } {
+    function sessionListQuery(): { directory?: string; scope?: "project"; path?: string } {
       if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
       if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
       return {
+        directory: project.data.instance.path.directory,
         path: path
           .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)
           .replaceAll("\\", "/"),


### PR DESCRIPTION
### Issue for this PR

Closes #25963

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Fixes the bug where `opencode --continue` would continue the wrong session if you were using worktrees**

Root-level git worktrees of the same repo all share an empty project-relative path (""), so `listByProject` filtered root sessions by `project_id` alone and `--continue` could resume another worktree's most recently updated session.

This fix sends the current absolute directory with the TUI session list query and, when the project-relative path is empty, filters sessions by that directory. It also adds a regression test with two real git worktrees asserting the feature worktree's list excludes the main worktree's root session.

### How did you verify your code works?

- Integration tests (included in PR)

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
