### PR TITLE
test(core): avoid models cache recovery race

### DIFF
--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -157,15 +157,12 @@ describe("ModelsDev Service", () => {
     Effect.gen(function* () {
       yield* writeCacheText("{")
       const state = yield* Ref.make({ ...initialState, body: JSON.stringify(fixture2) })
+      const context = yield* Layer.build(buildLayer(state))
       const result = yield* Effect.acquireUseRelease(
         Effect.sync(() => {
           Flag.OPENCODE_DISABLE_MODELS_FETCH = false
         }),
-        () =>
-          provided(
-            state,
-            ModelsDev.Service.use((s) => s.get()),
-          ),
+        () => ModelsDev.Service.use((s) => s.get()).pipe(Effect.provide(context)),
         () =>
           Effect.sync(() => {
             Flag.OPENCODE_DISABLE_MODELS_FETCH = true


### PR DESCRIPTION
## Summary
- build the ModelsDev test layer while automatic model fetching is disabled
- enable fetching only for the explicit corrupted-cache recovery call
- prevent the eager refresh fiber from racing with `get()` and issuing a second request

This addresses the Windows unit failure in https://github.com/anomalyco/opencode/actions/runs/28038263453/job/82997394532.

## Testing
- `bun test test/models.test.ts --test-name-pattern "recovers from a corrupted cache" --rerun-each 100`
- `bun test test/models.test.ts`
- `bun typecheck`