### PR TITLE
fix(app): use correct server sdk for titlebar session lookup

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -524,10 +524,16 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                           }
 
                           const [session] = createResource(
-                            () => tab.sessionId,
-                            (sessionID) =>
-                              serverSdk()
-                                .client.session.get({ sessionID })
+                            () => {
+                              const id = tab.sessionId
+                              const conn = server.list.find((s) => ServerConnection.key(s) === tab.server)
+                              if (!conn) return null
+                              const { sdk } = global.createServerCtx(conn)
+                              return { id, sdk }
+                            },
+                            ({ id, sdk }) =>
+                              sdk.client.session
+                                .get({ sessionID: id })
                                 .then((x) => x.data)
                                 .catch(() => undefined),
                           )


### PR DESCRIPTION
Fixes the titlebar session resource to use the correct per-server SDK instead of the global `serverSdk()`. This ensures the session lookup is routed to the right server connection when multiple servers are configured.