### PR TITLE
feat(tui): show tokens per second in message footer

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1484,6 +1484,13 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     return props.message.time.completed - user.time.created
   })
 
+  const tokensPerSecond = createMemo(() => {
+    const dur = duration()
+    if (!dur || dur < 100) return 0
+    const output = props.message.tokens?.output ?? 0
+    return output / (dur / 1000)
+  })
+
   const childShortcut = useCommandShortcut("session.child.first")
   const backgroundShortcut = useCommandShortcut("session.background")
 
@@ -1561,6 +1568,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               <span style={{ fg: theme.textMuted }}> · {model()}</span>
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
+              </Show>
+              <Show when={tokensPerSecond() > 0}>
+                <span style={{ fg: theme.textMuted }}> · {tokensPerSecond().toFixed(1)} t/s</span>
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>


### PR DESCRIPTION
## Qué agrega

Muestra **tokens por segundo** en el footer de cada mensaje del asistente en la TUI, junto al modelo y la duración.

Ejemplo:
`
▣ build · qwen3-30b-a3b-2507 · 3.2s · 42.5 t/s
`

## Cambios

- packages/tui/src/routes/session/index.tsx: agrega 	okensPerSecond memo calculado a partir de props.message.tokens.output y duration()
- Solo se muestra cuando hay output tokens y la respuesta tomó al menos 100ms

## Cómo probar

1. Clonar el fork y hacer checkout de 	okens-per-second-2
2. 
pm install && npm run build en packages/tui y packages/opencode
3. Instalar el nuevo binary
4. Usar opencode normalmente — el dato aparece en el footer del último mensaje