### PR TITLE
docs: add opencode-git-trailers plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-git-trailers](https://github.com/lannuttia/opencode-git-trailers)                        | Automatically add standardized git trailers to AI-assisted commits for compliance and audit trails |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-git-trailers` to the ecosystem docs plugin list in `packages/web/src/content/docs/ecosystem.mdx`.

`opencode-git-trailers` automatically adds standardized git trailers to AI-assisted commits for compliance, audit trails, and attribution. The plugin creates temporary git commit-msg hooks that append configured trailers using git interpret-trailers, with support for variable interpolation (model, provider, timestamp, etc.) and graceful hook chaining.

Project links:
- GitHub: https://github.com/lannuttia/opencode-git-trailers
- npm: https://www.npmjs.com/package/opencode-git-trailers

### How did you verify your code works?

- Confirmed the docs entry was added to the `Plugins` table in `packages/web/src/content/docs/ecosystem.mdx`
- Verified the link target and description text match the plugin's published GitHub repo and npm package
- Confirmed this PR only adds the new ecosystem entry with no unrelated changes

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR