### PR TITLE
docs(ecosystem): add OpenTab to projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [OpenTab](https://github.com/hamidi-dev/opentab)                                           | TUI to browse your AI coding spend across OpenCode and more      |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — community ecosystem listing.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds OpenTab to the Projects table in the ecosystem docs. OpenTab is a
terminal UI that reads OpenCode's SQLite database read-only and browses your
AI coding spend by month / day / project / session / model, including the
recursive subagent tree. One row added, aligned to the existing columns.

### How did you verify your code works?

Diff is a single added line; confirmed the new row aligns with the existing
Projects table columns. Repo: https://github.com/hamidi-dev/opentab

### Screenshots / recordings

N/A — single-row addition to a markdown table, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
