### PR TITLE
docs: add agentcairn to the ecosystem (local-first memory plugin)

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [agentcairn](https://github.com/ccf/agentcairn/tree/main/integrations/opencode) | Local-first memory: your agent's memory as plain Markdown in an Obsidian vault you own — recall-at-start + capture-at-end, shared across Claude Code, Cursor & Hermes |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — small docs addition (one row in the ecosystem Plugins table).

### Type of change

- [x] Documentation

### What does this PR do?

Adds one row to the Plugins table in `ecosystem.mdx` for **agentcairn** — an OpenCode plugin that gives the agent local-first memory: recall-at-start + capture-at-end, stored as plain Markdown in an Obsidian vault you own. Installed with `cairn install opencode`.

### How did you verify your code works?

Tested on OpenCode 1.17.5: the MCP `recall`/`remember` tools and the ambient plugin hooks (`system.transform`, `session.idle`) both work, and the install command wires up the MCP server + slash commands + plugin. The added table row matches the format of the existing rows and renders correctly.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR