### PR TITLE
fix(avatar,project): fix project icon reactivity and global project icon sync

### DIFF
--- a/packages/app/src/components/dialog-edit-project.tsx
+++ b/packages/app/src/components/dialog-edit-project.tsx
@@ -97,6 +97,7 @@ export function DialogEditProject(props: { project: LocalProject; server: Server
         icon: { color: store.color || undefined, override: store.iconOverride || undefined },
         commands: { start: start || undefined },
       })
+      serverSync().project.icon(props.project.worktree, store.iconOverride || undefined)
       dialog.close()
     },
   }))

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -30,24 +30,23 @@ export function Avatar(props: AvatarProps) {
     "classList",
     "style",
   ])
-  const src = split.src // did this so i can zero it out to test fallback
   return (
     <div
       {...rest}
       data-component="avatar"
       data-size={split.size || "normal"}
-      data-has-image={src ? "" : undefined}
+      data-has-image={split.src ? "" : undefined}
       classList={{
         ...split.classList,
         [split.class ?? ""]: !!split.class,
       }}
       style={{
         ...(typeof split.style === "object" ? split.style : {}),
-        ...(!src && split.background ? { "--avatar-bg": split.background } : {}),
-        ...(!src && split.foreground ? { "--avatar-fg": split.foreground } : {}),
+        ...(!split.src && split.background ? { "--avatar-bg": split.background } : {}),
+        ...(!split.src && split.foreground ? { "--avatar-fg": split.foreground } : {}),
       }}
     >
-      <Show when={src} fallback={first(split.fallback)}>
+      <Show when={split.src} fallback={first(split.fallback)}>
         {(src) => <img src={src()} draggable={false} data-slot="avatar-image" />}
       </Show>
     </div>

--- a/packages/ui/src/v2/components/project-avatar-v2.tsx
+++ b/packages/ui/src/v2/components/project-avatar-v2.tsx
@@ -35,7 +35,6 @@ export interface ProjectAvatarProps extends ComponentProps<"div"> {
 
 export function ProjectAvatar(props: ProjectAvatarProps) {
   const [split, rest] = splitProps(props, ["fallback", "src", "variant", "unread", "class", "classList", "style"])
-  const src = split.src
   return (
     <div
       {...rest}
@@ -50,9 +49,9 @@ export function ProjectAvatar(props: ProjectAvatarProps) {
       <div
         data-slot="project-avatar-surface"
         data-variant={split.variant ?? "gray"}
-        data-has-image={src ? "" : undefined}
+        data-has-image={split.src ? "" : undefined}
       >
-        <Show when={src} fallback={first(split.fallback)}>
+        <Show when={split.src} fallback={first(split.fallback)}>
           {(value) => <img src={value()} draggable={false} data-slot="project-avatar-image" />}
         </Show>
       </div>


### PR DESCRIPTION
## Summary

Fixes multiple issues where custom project icons would save to the database but not render in the UI.

## Changes

### 1. Fix SolidJS reactivity in Avatar components

Removed static `src` variable capture in both `Avatar` and `ProjectAvatar` components. In SolidJS, accessing a prop once outside of a reactive context breaks reactivity. When the project icon was updated after saving, these components never re-rendered because `src` was read once and never tracked.

**Before:**
srcis not found
now not found
static not found

**After:**
split.src

### 2. Fix global project icon sync

For non-git projects (saved as "global"), the `dialog-edit-project` component was calling `serverSync().project.meta()` but not `serverSync().project.icon()`. The latter is required to update the local icon cache that the UI reads from. Without this, global projects would save the icon to the database but the UI would continue showing the old icon.

**Added:**


## Related Issues

- Fixes #27882 - Project profile image not displayed after upload
- Fixes #29807 - Desktop: custom project icons save but never render
- Fixes #30199 - Desktop app: Project icon not saved after clicking Save
- Fixes #32708 - Custom project icon upload not applying after save
- Fixes #32164 - Project edit dialog does not persist name or icon changes

## Testing

1. Open a project directory that is NOT a git repository
2. Open the project edit dialog
3. Upload a custom image
4. Click Save
5. Verify the icon renders immediately in the project list
6. Restart the app
7. Verify the icon persists after restart