### PR TITLE
fix(tui): sort model picker by release date

### DIFF
--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -118,7 +118,10 @@ export function DialogModel(props: { providerID?: string }) {
 
     if (needle) {
       return [
-        ...fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
+        ...sortModelOptions(
+          fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
+          false,
+        ),
         ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
       ]
     }
@@ -188,6 +191,7 @@ export function sortModelOptions<T extends { footer?: string; releaseDate: strin
   return sortBy(
     options,
     (option) => option.footer !== "Free",
+    [(option) => option.releaseDate, "desc"],
     (option) => option.title,
   )
 }

--- a/packages/tui/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/model-options.test.ts
@@ -15,16 +15,18 @@ describe("sortModelOptions", () => {
     expect(sorted.map((model) => model.title)).toEqual(["GPT 5.4", "GPT 5.2", "GPT 5.1"])
   })
 
-  test("preserves free-first alphabetical ordering for the regular picker", () => {
+  test("orders regular model choices free-first and then newest-first", () => {
     const sorted = sortModelOptions(
       [
-        { title: "Beta", releaseDate: "2026-01-01" },
-        { title: "Alpha", releaseDate: "2025-01-01", footer: "Free" },
-        { title: "Gamma", releaseDate: "2024-01-01", footer: "Free" },
+        { title: "GLM 5", releaseDate: "2025-07-28" },
+        { title: "GLM 5.1", releaseDate: "2025-12-09" },
+        { title: "GLM 5.2", releaseDate: "2026-02-16" },
+        { title: "Free old", releaseDate: "2024-01-01", footer: "Free" },
+        { title: "Free new", releaseDate: "2025-01-01", footer: "Free" },
       ],
       false,
     )
 
-    expect(sorted.map((model) => model.title)).toEqual(["Alpha", "Gamma", "Beta"])
+    expect(sorted.map((model) => model.title)).toEqual(["Free new", "Free old", "GLM 5.2", "GLM 5.1", "GLM 5"])
   })
 })


### PR DESCRIPTION
## Summary
- preserve favorites, recents, and free-model priority in the main model picker
- order remaining models newest-first by release date
- apply the same ordering after fuzzy search so model families show newest versions first

## Tests
- `bun test test/cli/cmd/tui/model-options.test.ts`
- `bun typecheck`