### PR TITLE
fix(core): simplify opencode connection flow

### DIFF
--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -85,26 +85,16 @@ function oauth(http: HttpClient.HttpClient) {
     method: {
       id: methodID,
       type: "oauth",
-      label: "Sign in with OpenCode",
-      prompts: [
-        {
-          type: "text",
-          key: "server",
-          message: "OpenCode server",
-          placeholder: defaultServer,
-        },
-      ],
+      label: "OpenCode Console account",
     },
-    authorize: (inputs) =>
+    authorize: () =>
       Effect.gen(function* () {
-        const url = new URL(inputs.server || defaultServer)
-        const server = `${url.origin}${url.pathname.replace(/\/+$/, "")}`
-        const device = yield* post(http, `${server}/auth/device/code`, { client_id: clientID }, Device)
+        const device = yield* post(http, `${defaultServer}/auth/device/code`, { client_id: clientID }, Device)
         return {
           mode: "auto" as const,
-          url: `${server}${device.verification_uri_complete}`,
+          url: `${defaultServer}${device.verification_uri_complete}`,
           instructions: `Enter code: ${device.user_code}`,
-          callback: poll(http, server, device.device_code, Duration.seconds(device.interval)),
+          callback: poll(http, defaultServer, device.device_code, Duration.seconds(device.interval)),
         }
       }),
     refresh: (credential) =>
@@ -157,7 +147,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
         integration.name = "OpenCode"
       })
       draft.method.update(oauth(http))
-      draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key" } })
+      draft.method.update({ integrationID: "opencode", method: { type: "key", label: "Service account" } })
     })
 
     yield* load()
@@ -302,7 +292,7 @@ function credential(http: HttpClient.HttpClient, server: string, token: typeof T
       ],
       { concurrency: 2 },
     )
-    const org = orgs.toSorted((a, b) => a.id.localeCompare(b.id))[0]
+    const org = orgs.toSorted((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id))[0]
     return new Credential.OAuth({
       type: "oauth" as const,
       methodID,

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -147,7 +147,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
         integration.name = "OpenCode"
       })
       draft.method.update(oauth(http))
-      draft.method.update({ integrationID: "opencode", method: { type: "key", label: "Service account" } })
+      draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key (service account)" } })
     })
 
     yield* load()

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -49,24 +49,16 @@ function withEnv<A, E, R>(vars: Record<string, string | undefined>, effect: () =
 const cost = (input: number, output = 0) => [{ input, output, cache: { read: 0, write: 0 } }]
 
 describe("OpencodePlugin", () => {
-  it.effect("registers OAuth and API key methods", () =>
+  it.effect("registers account and service account methods", () =>
     Effect.gen(function* () {
       yield* addPlugin()
       expect((yield* (yield* Integration.Service).get(Integration.ID.make("opencode")))?.methods).toEqual([
         {
           id: Integration.MethodID.make("device"),
           type: "oauth",
-          label: "Sign in with OpenCode",
-          prompts: [
-            {
-              type: "text",
-              key: "server",
-              message: "OpenCode server",
-              placeholder: "https://console.opencode.ai",
-            },
-          ],
+          label: "OpenCode Console account",
         },
-        { type: "key", label: "API key" },
+        { type: "key", label: "Service account" },
       ])
     }),
   )

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -58,7 +58,7 @@ describe("OpencodePlugin", () => {
           type: "oauth",
           label: "OpenCode Console account",
         },
-        { type: "key", label: "Service account" },
+        { type: "key", label: "API key (service account)" },
       ])
     }),
   )


### PR DESCRIPTION
## Summary
- use the OpenCode Console URL directly instead of prompting for a server
- select the first organization alphabetically for the OAuth connection
- rename the OAuth method to `OpenCode Console account`
- label API-key authentication as `API key (service account)`

## Testing
- workspace `bun turbo typecheck` pre-push hook
- `bun test test/plugin/provider-opencode.test.ts` in `packages/core`