### PR TITLE
feat(core): map providers to integrations

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -73,7 +73,7 @@ export const layer = Layer.effect(
       if (provider.disabled) return false
       if (typeof provider.request.body.apiKey === "string") return true
       if (integration?.connections.length) return true
-      return !integration
+      return provider.integrationID === undefined && !integration
     }
 
     const projectModel = (model: ModelV2.Info, provider: ProviderV2.Info) => {
@@ -184,7 +184,7 @@ export const layer = Layer.effect(
         available: Effect.fn("CatalogV2.provider.available")(function* () {
           const active = new Map((yield* integrations.list()).map((integration) => [integration.id, integration]))
           return (yield* result.provider.all()).filter((provider) =>
-            available(provider, active.get(Integration.ID.make(provider.id))),
+            available(provider, active.get(provider.integrationID ?? Integration.ID.make(provider.id))),
           )
         }),
       },

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -128,6 +128,11 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
           Object.assign(provider.request.body, withoutCredentials(item.options))
         })
 
+        const modelIDs = new Set(Object.keys(item.models ?? {}))
+        for (const model of catalog.provider.get(providerID)?.models.values() ?? []) {
+          if (!modelIDs.has(model.id)) catalog.model.remove(providerID, model.id)
+        }
+
         for (const [modelID, config] of Object.entries(item.models ?? {})) {
           catalog.model.update(providerID, modelID, (model) => {
             if (config.family !== undefined) model.family = config.family

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -169,7 +169,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
           if (item.api !== undefined) provider.api = { ...item.api }
           if (item.request !== undefined) {
             Object.assign(provider.request.headers, item.request.headers)
-            Object.assign(provider.request.body, item.request.body)
+            Object.assign(provider.request.body, withoutApiKey(item.request.body))
           }
         })
         const providerApi = catalog.provider.get(providerID)?.provider.api
@@ -191,7 +191,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
             if (config.request !== undefined) {
               ModelRequest.assign(model.request, {
                 headers: config.request.headers,
-                ...ModelRequest.normalizeAiSdkOptions(packageName, config.request.body ?? {}),
+                ...ModelRequest.normalizeAiSdkOptions(packageName, withoutApiKey(config.request.body)),
               })
               if (config.request.variant !== undefined) model.request.variant = config.request.variant
             }
@@ -204,7 +204,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
                 }
                 ModelRequest.assign(existing, {
                   headers: variant.headers,
-                  ...ModelRequest.normalizeAiSdkOptions(packageName, variant.body ?? {}),
+                  ...ModelRequest.normalizeAiSdkOptions(packageName, withoutApiKey(variant.body)),
                 })
               }
             }
@@ -267,6 +267,10 @@ function fetchProviders(http: HttpClient.HttpClient, value: CredentialValue) {
         )
       }),
     )
+}
+
+function withoutApiKey(body: Readonly<Record<string, unknown>> | undefined) {
+  return Object.fromEntries(Object.entries(body ?? {}).filter(([key]) => key !== "apiKey"))
 }
 
 function poll(http: HttpClient.HttpClient, server: string, deviceCode: string, interval: Duration.Duration) {

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -14,52 +14,60 @@ import { ProviderV2 } from "../../provider"
 const defaultServer = "https://console.opencode.ai"
 const clientID = "opencode-cli"
 const methodID = Integration.MethodID.make("device")
-const RemoteRequest = Schema.Struct({
-  headers: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
-  body: Schema.Record(Schema.String, Schema.Any).pipe(Schema.optional),
-})
-const RemoteModelApi = Schema.Union([
-  Schema.Struct({ id: ModelV2.ID.pipe(Schema.optional), ...ProviderV2.AISDK.fields }),
-  Schema.Struct({ id: ModelV2.ID.pipe(Schema.optional), ...ProviderV2.Native.fields }),
-  Schema.Struct({ id: ModelV2.ID }),
-])
+const RemoteOptions = Schema.StructWithRest(
+  Schema.Struct({
+    apiKey: Schema.Any.pipe(Schema.optional),
+    headers: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
+  }),
+  [Schema.Record(Schema.String, Schema.Any)],
+)
 const RemoteCost = Schema.Struct({
-  tier: Schema.Struct({ type: Schema.Literal("context"), size: Schema.Int }).pipe(Schema.optional),
   input: Schema.Finite,
   output: Schema.Finite,
-  cache: Schema.Struct({
-    read: Schema.Finite.pipe(Schema.optional),
-    write: Schema.Finite.pipe(Schema.optional),
+  cache_read: Schema.Finite.pipe(Schema.optional),
+  cache_write: Schema.Finite.pipe(Schema.optional),
+  context_over_200k: Schema.Struct({
+    input: Schema.Finite,
+    output: Schema.Finite,
+    cache_read: Schema.Finite.pipe(Schema.optional),
+    cache_write: Schema.Finite.pipe(Schema.optional),
   }).pipe(Schema.optional),
 })
 const RemoteModel = Schema.Struct({
-  family: ModelV2.Family.pipe(Schema.optional),
+  id: ModelV2.ID.pipe(Schema.optional),
+  family: Schema.String.pipe(Schema.optional),
   name: Schema.String.pipe(Schema.optional),
-  api: RemoteModelApi.pipe(Schema.optional),
-  capabilities: ModelV2.Capabilities.pipe(Schema.optional),
-  request: Schema.Struct({ ...RemoteRequest.fields, variant: Schema.String.pipe(Schema.optional) }).pipe(
-    Schema.optional,
-  ),
-  variants: Schema.Struct({
-    id: ModelV2.VariantID,
-    ...RemoteRequest.fields,
-  }).pipe(Schema.Array, Schema.optional),
-  cost: Schema.Union([RemoteCost, Schema.Array(RemoteCost)]).pipe(Schema.optional),
+  release_date: Schema.String.pipe(Schema.optional),
+  tool_call: Schema.Boolean.pipe(Schema.optional),
+  modalities: Schema.Struct({
+    input: Schema.Array(Schema.String).pipe(Schema.optional),
+    output: Schema.Array(Schema.String).pipe(Schema.optional),
+  }).pipe(Schema.optional),
+  provider: Schema.Struct({
+    npm: Schema.String.pipe(Schema.optional),
+    api: Schema.String.pipe(Schema.optional),
+  }).pipe(Schema.optional),
+  options: RemoteOptions.pipe(Schema.optional),
+  headers: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
+  variants: Schema.Record(Schema.String, RemoteOptions).pipe(Schema.optional),
+  cost: RemoteCost.pipe(Schema.optional),
   disabled: Schema.Boolean.pipe(Schema.optional),
   limit: Schema.Struct({
-    context: Schema.Int.pipe(Schema.optional),
+    context: Schema.Int,
     input: Schema.Int.pipe(Schema.optional),
-    output: Schema.Int.pipe(Schema.optional),
+    output: Schema.Int,
   }).pipe(Schema.optional),
 })
 const RemoteProvider = Schema.Struct({
   name: Schema.String.pipe(Schema.optional),
-  api: ProviderV2.Api.pipe(Schema.optional),
-  request: RemoteRequest.pipe(Schema.optional),
+  npm: Schema.String.pipe(Schema.optional),
+  api: Schema.String.pipe(Schema.optional),
+  env: Schema.Array(Schema.String).pipe(Schema.optional),
+  options: RemoteOptions.pipe(Schema.optional),
   models: Schema.Record(Schema.String, RemoteModel).pipe(Schema.optional),
 })
 const RemoteConfig = Schema.Struct({
-  providers: Schema.Record(Schema.String, RemoteProvider),
+  provider: Schema.Record(Schema.String, RemoteProvider),
 })
 const RemoteResponse = Schema.Struct({ config: RemoteConfig })
 const Device = Schema.Struct({
@@ -135,7 +143,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
     const events = yield* EventV2.Service
     const http = yield* HttpClient.HttpClient
     let connected = false
-    let providers: typeof RemoteConfig.Type.providers | undefined
+    let providers: typeof RemoteConfig.Type.provider | undefined
 
     const load = Effect.fn("OpencodePlugin.load")(function* () {
       const connection = yield* ctx.integration.connection.active("opencode")
@@ -166,58 +174,52 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
         catalog.provider.update(providerID, (provider) => {
           provider.integrationID = Integration.ID.make("opencode")
           if (item.name !== undefined) provider.name = item.name
-          if (item.api !== undefined) provider.api = { ...item.api }
-          if (item.request !== undefined) {
-            Object.assign(provider.request.headers, item.request.headers)
-            Object.assign(provider.request.body, withoutCredentials(item.request.body))
-          }
+          provider.api = item.npm
+            ? { type: "aisdk", package: item.npm, url: item.api }
+            : { type: "native", url: item.api, settings: {} }
+          Object.assign(provider.request.headers, item.options?.headers)
+          Object.assign(provider.request.body, withoutCredentials(item.options))
         })
-        const providerApi = catalog.provider.get(providerID)?.provider.api
-        const providerPackage = providerApi?.type === "aisdk" ? providerApi.package : undefined
 
         for (const [modelID, config] of Object.entries(item.models ?? {})) {
           catalog.model.update(providerID, modelID, (model) => {
             if (config.family !== undefined) model.family = config.family
             if (config.name !== undefined) model.name = config.name
-            if (config.api !== undefined) model.api = { ...model.api, ...config.api }
-            const packageName = model.api.type === "aisdk" ? model.api.package : providerPackage
-            if (config.capabilities !== undefined) {
-              model.capabilities = {
-                tools: config.capabilities.tools,
-                input: [...config.capabilities.input],
-                output: [...config.capabilities.output],
-              }
+            if (config.id !== undefined) model.api.id = config.id
+            if (config.provider !== undefined) {
+              model.api = config.provider.npm
+                ? {
+                    id: model.api.id,
+                    type: "aisdk",
+                    package: config.provider.npm,
+                    url: config.provider.api,
+                  }
+                : { id: model.api.id, type: "native", url: config.provider.api, settings: {} }
             }
-            if (config.request !== undefined) {
-              ModelRequest.assign(model.request, {
-                headers: config.request.headers,
-                ...ModelRequest.normalizeAiSdkOptions(packageName, withoutCredentials(config.request.body)),
-              })
-              if (config.request.variant !== undefined) model.request.variant = config.request.variant
-            }
+            if (config.tool_call !== undefined) model.capabilities.tools = config.tool_call
+            if (config.modalities?.input !== undefined) model.capabilities.input = [...config.modalities.input]
+            if (config.modalities?.output !== undefined) model.capabilities.output = [...config.modalities.output]
+            const packageName = config.provider?.npm ?? item.npm
+            ModelRequest.assign(model.request, {
+              headers: config.headers,
+              ...ModelRequest.normalizeAiSdkOptions(packageName, withoutCredentials(config.options)),
+            })
             if (config.variants !== undefined) {
-              for (const variant of config.variants) {
-                let existing = model.variants.find((item) => item.id === variant.id)
-                if (!existing) {
-                  existing = { id: variant.id, headers: {}, body: {}, generation: {}, options: {} }
-                  model.variants.push(existing)
-                }
-                ModelRequest.assign(existing, {
-                  headers: variant.headers,
-                  ...ModelRequest.normalizeAiSdkOptions(packageName, withoutCredentials(variant.body)),
-                })
-              }
-            }
-            if (config.cost !== undefined) {
-              model.cost = (Array.isArray(config.cost) ? config.cost : [config.cost]).map((cost) => ({
-                tier: cost.tier && { ...cost.tier },
-                input: cost.input,
-                output: cost.output,
-                cache: { read: cost.cache?.read ?? 0, write: cost.cache?.write ?? 0 },
+              model.variants = Object.entries(config.variants).map(([id, options]) => ({
+                id: ModelV2.VariantID.make(id),
+                headers: { ...(options.headers ?? {}) },
+                ...ModelRequest.normalizeAiSdkOptions(packageName, withoutCredentials(options)),
               }))
             }
-            if (config.disabled !== undefined) model.enabled = !config.disabled
-            if (config.limit !== undefined) model.limit = { ...model.limit, ...config.limit }
+            if (config.release_date !== undefined) {
+              const released = Date.parse(config.release_date)
+              model.time.released = Number.isFinite(released) ? released : 0
+            }
+            if (config.cost !== undefined) {
+              model.cost = remoteCost(config.cost)
+            }
+            model.enabled = !config.disabled
+            if (config.limit !== undefined) model.limit = { ...config.limit }
           })
         }
       }
@@ -263,14 +265,35 @@ function fetchProviders(http: HttpClient.HttpClient, value: CredentialValue) {
         if (response.status === 404) return Effect.succeed(undefined)
         return HttpClientResponse.filterStatusOk(response).pipe(
           Effect.flatMap(HttpClientResponse.schemaBodyJson(RemoteResponse)),
-          Effect.map((remote) => remote.config.providers),
+          Effect.map((remote) => remote.config.provider),
         )
       }),
     )
 }
 
 function withoutCredentials(body: Readonly<Record<string, unknown>> | undefined) {
-  return Object.fromEntries(Object.entries(body ?? {}).filter(([key]) => key !== "apiKey" && key !== "env"))
+  return Object.fromEntries(Object.entries(body ?? {}).filter(([key]) => key !== "apiKey" && key !== "headers"))
+}
+
+function remoteCost(input: typeof RemoteCost.Type) {
+  const base = {
+    input: input.input,
+    output: input.output,
+    cache: { read: input.cache_read ?? 0, write: input.cache_write ?? 0 },
+  }
+  if (!input.context_over_200k) return [base]
+  return [
+    base,
+    {
+      tier: { type: "context" as const, size: 200_000 },
+      input: input.context_over_200k.input,
+      output: input.context_over_200k.output,
+      cache: {
+        read: input.context_over_200k.cache_read ?? 0,
+        write: input.context_over_200k.cache_write ?? 0,
+      },
+    },
+  ]
 }
 
 function poll(http: HttpClient.HttpClient, server: string, deviceCode: string, interval: Duration.Duration) {

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -10,66 +10,13 @@ import { Integration } from "../../integration"
 import { ModelV2 } from "../../model"
 import { ModelRequest } from "../../model-request"
 import { ProviderV2 } from "../../provider"
+import { ConfigProviderV1 } from "../../v1/config/provider"
+import { ConfigV1 } from "../../v1/config/config"
 
 const defaultServer = "https://console.opencode.ai"
 const clientID = "opencode-cli"
 const methodID = Integration.MethodID.make("device")
-const RemoteOptions = Schema.StructWithRest(
-  Schema.Struct({
-    apiKey: Schema.Any.pipe(Schema.optional),
-    headers: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
-  }),
-  [Schema.Record(Schema.String, Schema.Any)],
-)
-const RemoteCost = Schema.Struct({
-  input: Schema.Finite,
-  output: Schema.Finite,
-  cache_read: Schema.Finite.pipe(Schema.optional),
-  cache_write: Schema.Finite.pipe(Schema.optional),
-  context_over_200k: Schema.Struct({
-    input: Schema.Finite,
-    output: Schema.Finite,
-    cache_read: Schema.Finite.pipe(Schema.optional),
-    cache_write: Schema.Finite.pipe(Schema.optional),
-  }).pipe(Schema.optional),
-})
-const RemoteModel = Schema.Struct({
-  id: ModelV2.ID.pipe(Schema.optional),
-  family: Schema.String.pipe(Schema.optional),
-  name: Schema.String.pipe(Schema.optional),
-  release_date: Schema.String.pipe(Schema.optional),
-  tool_call: Schema.Boolean.pipe(Schema.optional),
-  modalities: Schema.Struct({
-    input: Schema.Array(Schema.String).pipe(Schema.optional),
-    output: Schema.Array(Schema.String).pipe(Schema.optional),
-  }).pipe(Schema.optional),
-  provider: Schema.Struct({
-    npm: Schema.String.pipe(Schema.optional),
-    api: Schema.String.pipe(Schema.optional),
-  }).pipe(Schema.optional),
-  options: RemoteOptions.pipe(Schema.optional),
-  headers: Schema.Record(Schema.String, Schema.String).pipe(Schema.optional),
-  variants: Schema.Record(Schema.String, RemoteOptions).pipe(Schema.optional),
-  cost: RemoteCost.pipe(Schema.optional),
-  disabled: Schema.Boolean.pipe(Schema.optional),
-  limit: Schema.Struct({
-    context: Schema.Int,
-    input: Schema.Int.pipe(Schema.optional),
-    output: Schema.Int,
-  }).pipe(Schema.optional),
-})
-const RemoteProvider = Schema.Struct({
-  name: Schema.String.pipe(Schema.optional),
-  npm: Schema.String.pipe(Schema.optional),
-  api: Schema.String.pipe(Schema.optional),
-  env: Schema.Array(Schema.String).pipe(Schema.optional),
-  options: RemoteOptions.pipe(Schema.optional),
-  models: Schema.Record(Schema.String, RemoteModel).pipe(Schema.optional),
-})
-const RemoteConfig = Schema.Struct({
-  provider: Schema.Record(Schema.String, RemoteProvider),
-})
-const RemoteResponse = Schema.Struct({ config: RemoteConfig })
+const RemoteResponse = Schema.Struct({ config: ConfigV1.Info })
 const Device = Schema.Struct({
   device_code: Schema.String,
   user_code: Schema.String,
@@ -143,7 +90,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
     const events = yield* EventV2.Service
     const http = yield* HttpClient.HttpClient
     let connected = false
-    let providers: typeof RemoteConfig.Type.provider | undefined
+    let providers: typeof ConfigV1.Info.Type.provider | undefined
 
     const load = Effect.fn("OpencodePlugin.load")(function* () {
       const connection = yield* ctx.integration.connection.active("opencode")
@@ -218,7 +165,11 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
             if (config.cost !== undefined) {
               model.cost = remoteCost(config.cost)
             }
-            model.enabled = !config.disabled
+            model.status = config.status ?? "active"
+            model.enabled =
+              config.status !== "deprecated" &&
+              (item.whitelist === undefined || item.whitelist.includes(modelID)) &&
+              !item.blacklist?.includes(modelID)
             if (config.limit !== undefined) model.limit = { ...config.limit }
           })
         }
@@ -275,7 +226,7 @@ function withoutCredentials(body: Readonly<Record<string, unknown>> | undefined)
   return Object.fromEntries(Object.entries(body ?? {}).filter(([key]) => key !== "apiKey" && key !== "headers"))
 }
 
-function remoteCost(input: typeof RemoteCost.Type) {
+function remoteCost(input: NonNullable<(typeof ConfigProviderV1.Model.Type)["cost"]>) {
   const base = {
     input: input.input,
     output: input.output,

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -164,6 +164,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
     yield* ctx.catalog.transform((catalog) => {
       for (const [providerID, item] of Object.entries(providers ?? {})) {
         catalog.provider.update(providerID, (provider) => {
+          provider.integrationID = Integration.ID.make("opencode")
           if (item.name !== undefined) provider.name = item.name
           if (item.api !== undefined) provider.api = { ...item.api }
           if (item.request !== undefined) {

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -169,7 +169,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
           if (item.api !== undefined) provider.api = { ...item.api }
           if (item.request !== undefined) {
             Object.assign(provider.request.headers, item.request.headers)
-            Object.assign(provider.request.body, withoutApiKey(item.request.body))
+            Object.assign(provider.request.body, withoutCredentials(item.request.body))
           }
         })
         const providerApi = catalog.provider.get(providerID)?.provider.api
@@ -191,7 +191,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
             if (config.request !== undefined) {
               ModelRequest.assign(model.request, {
                 headers: config.request.headers,
-                ...ModelRequest.normalizeAiSdkOptions(packageName, withoutApiKey(config.request.body)),
+                ...ModelRequest.normalizeAiSdkOptions(packageName, withoutCredentials(config.request.body)),
               })
               if (config.request.variant !== undefined) model.request.variant = config.request.variant
             }
@@ -204,7 +204,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
                 }
                 ModelRequest.assign(existing, {
                   headers: variant.headers,
-                  ...ModelRequest.normalizeAiSdkOptions(packageName, withoutApiKey(variant.body)),
+                  ...ModelRequest.normalizeAiSdkOptions(packageName, withoutCredentials(variant.body)),
                 })
               }
             }
@@ -269,8 +269,8 @@ function fetchProviders(http: HttpClient.HttpClient, value: CredentialValue) {
     )
 }
 
-function withoutApiKey(body: Readonly<Record<string, unknown>> | undefined) {
-  return Object.fromEntries(Object.entries(body ?? {}).filter(([key]) => key !== "apiKey"))
+function withoutCredentials(body: Readonly<Record<string, unknown>> | undefined) {
+  return Object.fromEntries(Object.entries(body ?? {}).filter(([key]) => key !== "apiKey" && key !== "env"))
 }
 
 function poll(http: HttpClient.HttpClient, server: string, deviceCode: string, interval: Duration.Duration) {

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -166,10 +166,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
               model.cost = remoteCost(config.cost)
             }
             model.status = config.status ?? "active"
-            model.enabled =
-              config.status !== "deprecated" &&
-              (item.whitelist === undefined || item.whitelist.includes(modelID)) &&
-              !item.blacklist?.includes(modelID)
+            model.enabled = config.status !== "deprecated"
             if (config.limit !== undefined) model.limit = { ...config.limit }
           })
         }

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -1,6 +1,7 @@
 export * as ProviderV2 from "./provider"
 
 import { withStatics } from "./schema"
+import { IntegrationSchema } from "./integration/schema"
 import { Schema, Types } from "effect"
 
 export const ID = Schema.String.pipe(
@@ -49,6 +50,7 @@ export type Request = typeof Request.Type
 
 export class Info extends Schema.Class<Info>("ProviderV2.Info")({
   id: ID,
+  integrationID: IntegrationSchema.ID.pipe(Schema.optional),
   name: Schema.String,
   disabled: Schema.Boolean.pipe(Schema.optional),
   api: Api,

--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -10,7 +10,6 @@ import { produce } from "immer"
 import { Catalog } from "../../catalog"
 import { Credential } from "../../credential"
 import { Integration } from "../../integration"
-import { IntegrationConnection } from "../../integration/connection"
 import { ModelV2 } from "../../model"
 import { ModelRequest } from "../../model-request"
 import { ProviderV2 } from "../../provider"
@@ -65,7 +64,12 @@ export class UnsupportedApiError extends Schema.TaggedErrorClass<UnsupportedApiE
   }
 }
 
-export type Error = ModelNotSelectedError | ModelUnavailableError | VariantUnavailableError | UnsupportedApiError
+export type Error =
+  | ModelNotSelectedError
+  | ModelUnavailableError
+  | VariantUnavailableError
+  | UnsupportedApiError
+  | Integration.AuthorizationError
 
 export interface Interface {
   readonly resolve: (session: SessionSchema.Info) => Effect.Effect<Model, Error>
@@ -76,12 +80,11 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/v2
 /** Test or embedding seam for supplying a model resolver directly. */
 export const layerWith = (resolve: Interface["resolve"]) => Layer.succeed(Service, Service.of({ resolve }))
 
-const apiKey = (model: ModelV2.Info, connection?: IntegrationConnection.Info, credential?: Credential.Info) => {
-  if (credential?.value.type === "key") return Auth.value(credential.value.key)
-  if (credential?.value.type === "oauth") return Auth.value(credential.value.access)
+const apiKey = (model: ModelV2.Info, credential?: Credential.Value) => {
+  if (credential?.type === "key") return Auth.value(credential.key)
+  if (credential?.type === "oauth") return Auth.value(credential.access)
   const value = model.request.body.apiKey ?? model.api.settings?.apiKey
   if (typeof value === "string") return Auth.value(value)
-  return connection?.type === "env" ? Auth.config(connection.name) : undefined
 }
 
 const withDefaults = (model: ModelV2.Info, route: AnyRoute) => {
@@ -130,16 +133,15 @@ const apiName = (model: ModelV2.Info) =>
 
 export const fromCatalogModel = (
   model: ModelV2.Info,
-  connection?: IntegrationConnection.Info,
-  credential?: Credential.Info,
+  credential?: Credential.Value,
 ): Effect.Effect<Model, UnsupportedApiError> => {
   const resolved =
-    credential?.value.metadata === undefined
+    credential?.metadata === undefined
       ? model
       : produce(model, (draft) => {
-          Object.assign(draft.request.body, credential.value.metadata)
+          Object.assign(draft.request.body, credential.metadata)
         })
-  const key = apiKey(resolved, connection, credential)
+  const key = apiKey(resolved, credential)
   if (resolved.api.type === "aisdk" && resolved.api.package === "@ai-sdk/openai") {
     return Effect.succeed(
       withDefaults(resolved, OpenAIResponses.route)
@@ -173,11 +175,10 @@ export const fromCatalogModel = (
 export const resolve = (
   session: SessionSchema.Info,
   model: ModelV2.Info,
-  connection?: IntegrationConnection.Info,
-  credential?: Credential.Info,
+  credential?: Credential.Value,
 ) =>
   withVariant(model, session.model?.variant).pipe(
-    Effect.flatMap((model) => fromCatalogModel(model, connection, credential)),
+    Effect.flatMap((model) => fromCatalogModel(model, credential)),
   )
 
 export const supported = (model: ModelV2.Info) =>
@@ -191,7 +192,6 @@ export const locationLayer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const catalog = yield* Catalog.Service
-    const credentials = yield* Credential.Service
     const integrations = yield* Integration.Service
     return Service.of({
       resolve: Effect.fn("SessionRunnerModel.resolve")(function* (session) {
@@ -210,12 +210,14 @@ export const locationLayer = Layer.effect(
             modelID: session.model.id,
           })
         if (!selected) return yield* new ModelNotSelectedError({ sessionID: session.id })
-        const connection = yield* integrations.connection.active(Integration.ID.make(selected.providerID))
+        const provider = yield* catalog.provider.get(selected.providerID)
+        const connection = yield* integrations.connection.active(
+          provider?.integrationID ?? Integration.ID.make(selected.providerID),
+        )
         return yield* resolve(
           session,
           selected,
-          connection,
-          connection?.type === "credential" ? yield* credentials.get(connection.id) : undefined,
+          connection ? yield* integrations.connection.resolve(connection) : undefined,
         )
       }),
     })

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -76,6 +76,35 @@ describe("CatalogV2", () => {
     }).pipe(Effect.provide(layer))
   })
 
+  it.effect("derives availability from a provider's integration", () => {
+    const integrationID = Integration.ID.make("gateway")
+    const providerID = ProviderV2.ID.make("remote")
+    const layer = Catalog.locationLayer.pipe(
+      Layer.fresh,
+      Layer.provideMerge(EventV2.defaultLayer),
+      Layer.provideMerge(locationLayer),
+      Layer.provideMerge(Credential.defaultLayer.pipe(Layer.fresh)),
+    )
+
+    return Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      yield* (yield* Integration.Service).transform((editor) => editor.update(integrationID, () => {}))
+      yield* catalog.transform((editor) =>
+        editor.provider.update(providerID, (provider) => {
+          provider.integrationID = integrationID
+        }),
+      )
+      expect(yield* catalog.provider.available()).toEqual([])
+
+      yield* (yield* Credential.Service).create({
+        integrationID,
+        value: new Credential.Key({ type: "key", key: "secret" }),
+      })
+
+      expect((yield* catalog.provider.available()).map((provider) => provider.id)).toEqual([providerID])
+    }).pipe(Effect.provide(layer))
+  })
+
   it.effect("projects environment connections without a catalog plugin", () =>
     Effect.acquireUseRelease(
       Effect.sync(() => {

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -86,8 +86,13 @@ describe("OpencodePlugin", () => {
                   providers: {
                     remote: {
                       name: "Remote",
+                      request: { body: { apiKey: "centralized-secret", custom: "value" } },
                       models: {
-                        model: { name: "Remote Model" },
+                        model: {
+                          name: "Remote Model",
+                          request: { body: { apiKey: "model-secret", temperature: 0.5 } },
+                          variants: [{ id: "high", body: { apiKey: "variant-secret", temperature: 0.2 } }],
+                        },
                       },
                     },
                   },
@@ -115,10 +120,13 @@ describe("OpencodePlugin", () => {
           expect(yield* catalog.provider.get(ProviderV2.ID.make("remote"))).toMatchObject({
             name: "Remote",
             integrationID: "opencode",
+            request: { body: { custom: "value" } },
           })
-          expect((yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("model")))?.name).toBe(
-            "Remote Model",
-          )
+          expect(yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("model"))).toMatchObject({
+            name: "Remote Model",
+            request: { body: { custom: "value" }, generation: { temperature: 0.5 } },
+            variants: [{ id: "high", body: {}, generation: { temperature: 0.2 } }],
+          })
           expect(authorization).toContain("Bearer secret")
         }),
       ({ server }) => Effect.promise(() => server.stop(true)),

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -96,6 +96,7 @@ describe("OpencodePlugin", () => {
                         headers: { "x-org-id": "org" },
                         custom: "value",
                       },
+                      blacklist: ["disabled"],
                       models: {
                         model: {
                           name: "Remote Model",
@@ -108,6 +109,7 @@ describe("OpencodePlugin", () => {
                           cost: { input: 1, output: 2, cache_read: 0.1 },
                           limit: { context: 1000, output: 100 },
                         },
+                        disabled: { name: "Disabled" },
                       },
                     },
                   },
@@ -164,6 +166,9 @@ describe("OpencodePlugin", () => {
               options: {},
             },
           ])
+          expect(
+            required(yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("disabled"))).enabled,
+          ).toBe(false)
           expect(authorization).toContain("Bearer secret")
         }),
       ({ server }) => Effect.promise(() => server.stop(true)),

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -112,7 +112,10 @@ describe("OpencodePlugin", () => {
           yield* addPlugin()
 
           const catalog = yield* Catalog.Service
-          expect((yield* catalog.provider.get(ProviderV2.ID.make("remote")))?.name).toBe("Remote")
+          expect(yield* catalog.provider.get(ProviderV2.ID.make("remote"))).toMatchObject({
+            name: "Remote",
+            integrationID: "opencode",
+          })
           expect((yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("model")))?.name).toBe(
             "Remote Model",
           )

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -86,12 +86,21 @@ describe("OpencodePlugin", () => {
                   providers: {
                     remote: {
                       name: "Remote",
-                      request: { body: { apiKey: "centralized-secret", custom: "value" } },
+                      request: {
+                        body: { apiKey: "centralized-secret", env: ["REMOTE_API_KEY"], custom: "value" },
+                      },
                       models: {
                         model: {
                           name: "Remote Model",
-                          request: { body: { apiKey: "model-secret", temperature: 0.5 } },
-                          variants: [{ id: "high", body: { apiKey: "variant-secret", temperature: 0.2 } }],
+                          request: {
+                            body: { apiKey: "model-secret", env: ["MODEL_API_KEY"], temperature: 0.5 },
+                          },
+                          variants: [
+                            {
+                              id: "high",
+                              body: { apiKey: "variant-secret", env: ["VARIANT_API_KEY"], temperature: 0.2 },
+                            },
+                          ],
                         },
                       },
                     },

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -81,26 +81,32 @@ describe("OpencodePlugin", () => {
             port: 0,
             fetch: (request) => {
               authorization.push(request.headers.get("authorization"))
+              const origin = new URL(request.url).origin
               return Response.json({
                 config: {
-                  providers: {
+                  enterprise: { url: origin },
+                  provider: {
                     remote: {
                       name: "Remote",
-                      request: {
-                        body: { apiKey: "centralized-secret", env: ["REMOTE_API_KEY"], custom: "value" },
+                      npm: "@ai-sdk/openai-compatible",
+                      api: `${origin}/v1`,
+                      env: ["REMOTE_API_KEY"],
+                      options: {
+                        apiKey: "{env:REMOTE_API_KEY}",
+                        headers: { "x-org-id": "org" },
+                        custom: "value",
                       },
                       models: {
                         model: {
                           name: "Remote Model",
-                          request: {
-                            body: { apiKey: "model-secret", env: ["MODEL_API_KEY"], temperature: 0.5 },
-                          },
-                          variants: [
-                            {
-                              id: "high",
-                              body: { apiKey: "variant-secret", env: ["VARIANT_API_KEY"], temperature: 0.2 },
-                            },
-                          ],
+                          family: "remote",
+                          release_date: "2026-01-02",
+                          tool_call: true,
+                          modalities: { input: ["text", "image"], output: ["text"] },
+                          options: { apiKey: "model-secret", temperature: 0.5 },
+                          variants: { high: { apiKey: "variant-secret", temperature: 0.2 } },
+                          cost: { input: 1, output: 2, cache_read: 0.1 },
+                          limit: { context: 1000, output: 100 },
                         },
                       },
                     },
@@ -126,16 +132,38 @@ describe("OpencodePlugin", () => {
           yield* addPlugin()
 
           const catalog = yield* Catalog.Service
-          expect(yield* catalog.provider.get(ProviderV2.ID.make("remote"))).toMatchObject({
+          const provider = required(yield* catalog.provider.get(ProviderV2.ID.make("remote")))
+          expect(provider).toMatchObject({
             name: "Remote",
             integrationID: "opencode",
-            request: { body: { custom: "value" } },
+            api: {
+              type: "aisdk",
+              package: "@ai-sdk/openai-compatible",
+              url: `${server.url.origin}/v1`,
+            },
           })
-          expect(yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("model"))).toMatchObject({
+          expect(provider.request).toEqual({ headers: { "x-org-id": "org" }, body: { custom: "value" } })
+          expect(yield* (yield* Integration.Service).get(Integration.ID.make("remote"))).toBeUndefined()
+
+          const model = required(yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("model")))
+          expect(model).toMatchObject({
             name: "Remote Model",
-            request: { body: { custom: "value" }, generation: { temperature: 0.5 } },
-            variants: [{ id: "high", body: {}, generation: { temperature: 0.2 } }],
+            family: "remote",
+            capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+            cost: [{ input: 1, output: 2, cache: { read: 0.1, write: 0 } }],
+            limit: { context: 1000, output: 100 },
           })
+          expect(model.request).toMatchObject({ body: { custom: "value" }, generation: { temperature: 0.5 } })
+          expect(model.request.body).toEqual({ custom: "value" })
+          expect(model.variants).toEqual([
+            {
+              id: ModelV2.VariantID.make("high"),
+              headers: {},
+              body: {},
+              generation: { temperature: 0.2 },
+              options: {},
+            },
+          ])
           expect(authorization).toContain("Bearer secret")
         }),
       ({ server }) => Effect.promise(() => server.stop(true)),

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -121,6 +121,11 @@ describe("OpencodePlugin", () => {
       ({ authorization, server }) =>
         Effect.gen(function* () {
           const credentials = yield* Credential.Service
+          const catalog = yield* Catalog.Service
+          yield* catalog.transform((draft) => {
+            draft.provider.update(ProviderV2.ID.make("remote"), () => {})
+            draft.model.update(ProviderV2.ID.make("remote"), ModelV2.ID.make("stale"), () => {})
+          })
           yield* credentials.create({
             integrationID: Integration.ID.make("opencode"),
             value: new Credential.Key({
@@ -132,7 +137,6 @@ describe("OpencodePlugin", () => {
 
           yield* addPlugin()
 
-          const catalog = yield* Catalog.Service
           const provider = required(yield* catalog.provider.get(ProviderV2.ID.make("remote")))
           expect(provider).toMatchObject({
             name: "Remote",
@@ -168,6 +172,7 @@ describe("OpencodePlugin", () => {
           expect(
             required(yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("disabled"))).enabled,
           ).toBe(false)
+          expect(yield* catalog.model.get(ProviderV2.ID.make("remote"), ModelV2.ID.make("stale"))).toBeUndefined()
           expect(authorization).toContain("Bearer secret")
         }),
       ({ server }) => Effect.promise(() => server.stop(true)),

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -96,7 +96,6 @@ describe("OpencodePlugin", () => {
                         headers: { "x-org-id": "org" },
                         custom: "value",
                       },
-                      blacklist: ["disabled"],
                       models: {
                         model: {
                           name: "Remote Model",
@@ -109,7 +108,7 @@ describe("OpencodePlugin", () => {
                           cost: { input: 1, output: 2, cache_read: 0.1 },
                           limit: { context: 1000, output: 100 },
                         },
-                        disabled: { name: "Disabled" },
+                        disabled: { name: "Disabled", status: "deprecated" },
                       },
                     },
                   },

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect } from "bun:test"
 import { LLM } from "@opencode-ai/llm"
 import { LLMClient } from "@opencode-ai/llm/route"
-import { ConfigProvider, DateTime, Effect } from "effect"
+import { DateTime, Effect } from "effect"
 import { Headers } from "effect/unstable/http"
 import { Credential } from "@opencode-ai/core/credential"
-import { Integration } from "@opencode-ai/core/integration"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ProjectV2 } from "@opencode-ai/core/project"
@@ -262,27 +261,23 @@ describe("SessionRunnerModel", () => {
     }),
   )
 
-  it.effect("preserves environment-backed bearer auth", () =>
+  it.effect("uses resolved credentials for bearer auth", () =>
     Effect.gen(function* () {
       const resolved = yield* SessionRunnerModel.fromCatalogModel(
         new ModelV2.Info({
           ...model({ type: "aisdk", package: "@ai-sdk/openai", url: "https://openai.example/v1" }),
           request: { headers: {}, body: {}, generation: {}, options: {} },
         }),
-        { type: "env", name: "TEST_PROVIDER_API_KEY" },
+        new Credential.Key({ type: "key", key: "secret" }),
       )
       const request = LLM.request({ model: resolved, prompt: "Hello" })
-      const headers = yield* resolved.route.auth
-        .apply({
-          request,
-          method: "POST",
-          url: "https://openai.example/v1/responses",
-          body: "{}",
-          headers: Headers.empty,
-        })
-        .pipe(
-          Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: { TEST_PROVIDER_API_KEY: "secret" } }))),
-        )
+      const headers = yield* resolved.route.auth.apply({
+        request,
+        method: "POST",
+        url: "https://openai.example/v1/responses",
+        body: "{}",
+        headers: Headers.empty,
+      })
 
       expect(headers.authorization).toBe("Bearer secret")
     }),
@@ -290,18 +285,12 @@ describe("SessionRunnerModel", () => {
 
   it.effect("prefers stored credentials over configured auth", () =>
     Effect.gen(function* () {
-      const credential = new Credential.Info({
-        id: Credential.ID.create(),
-        integrationID: Integration.ID.make("test-provider"),
-        label: "Work",
-        value: new Credential.Key({ type: "key", key: "stored-secret", metadata: { tenant: "work" } }),
-      })
+      const credential = new Credential.Key({ type: "key", key: "stored-secret", metadata: { tenant: "work" } })
       const resolved = yield* SessionRunnerModel.fromCatalogModel(
         new ModelV2.Info({
           ...model({ type: "aisdk", package: "@ai-sdk/openai", url: "https://openai.example/v1" }),
           request: { headers: {}, body: { apiKey: "configured-secret" }, generation: {}, options: {} },
         }),
-        { type: "credential", id: credential.id, label: credential.label },
         credential,
       )
       const headers = yield* resolved.route.auth.apply({

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4082,6 +4082,7 @@ export type ModelV2Info = {
 
 export type ProviderV2Info = {
   id: string
+  integrationID?: string
   name: string
   disabled?: boolean
   api:


### PR DESCRIPTION
## Summary
- add an optional integration ID to provider metadata
- resolve catalog availability and LLM credentials through the mapped integration
- map OpenCode remote providers to the OpenCode integration and regenerate SDK types

## Testing
- `bun test --only-failures` in `packages/core`
- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/plugin`
- `bun typecheck` in `packages/sdk/js`
- repository-wide typecheck push hook