### PR TITLE
fix(ui): keep permission dock buttons in view on long requests

### DIFF
--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -711,7 +711,7 @@
   flex-direction: column;
   gap: 0;
   min-height: 0;
-  max-height: 100dvh;
+  max-height: min(40dvh, calc(100dvh - var(--sticky-accordion-top, 0px)));
 
   [data-slot="permission-body"] {
     display: flex;
@@ -735,6 +735,13 @@
 
   [data-slot="permission-row"][data-variant="header"] {
     align-items: center;
+  }
+
+  [data-slot="permission-row"]:has(> [data-slot="permission-patterns"]) {
+    flex: 1;
+    min-height: 0;
+    grid-template-rows: minmax(0, 1fr);
+    align-items: stretch;
   }
 
   [data-slot="permission-icon"] {
@@ -783,8 +790,11 @@
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    overscroll-behavior: contain;
     scrollbar-width: none;
     -ms-overflow-style: none;
+    -webkit-mask-image: linear-gradient(to bottom, #000 calc(100% - 24px), transparent 100%);
+    mask-image: linear-gradient(to bottom, #000 calc(100% - 24px), transparent 100%);
 
     &::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
### Issue for this PR

Closes #28979 #33575 #29515
Re-opening of #29004

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A long `permission.patterns` could push the permission dock past its slot under the session header. The page's `overflow: hidden` then clipped the action buttons off-screen.

The fix:

1. Cap the permission dock to `40dvh` while still accounting for the sticky session header, so the panel stays compact and the action buttons remain visible.
2. Constrain the row that contains permission patterns so the existing `overflow-y: auto` can actually create an internal scroll area instead of letting long patterns grow the dock.
3. `overscroll-behavior: contain` + bottom-only `mask-image` to prevent the scroll from bubbling to the page, and a 24px fade at the bottom edge signals more content below.

### How did you verify your code works?

Reproduced the bug with a Playwright fixture that injects a `PermissionV1.Request` with 40 long `bash` patterns into a mock-server-backed session (uses the `mockOpenCodeServer` pattern from `packages/app/e2e/utils/mock-server.ts`). See the verification script in the comment below.

### Screenshots / recordings

The content body is scrollable.

<img width="100%" alt="PixPin_2026-06-23_20-28-01" src="https://github.com/user-attachments/assets/2e03582d-da6b-4de5-a919-8423d606fd6d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
