### PR TITLE
fix(tui): restore file mention mime

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -261,7 +261,7 @@ export function Autocomplete(props: {
       filename,
       part: {
         type: "file" as const,
-        mime: item.mime,
+        mime: "text/plain",
         filename,
         url: urlObj.href,
         source: {


### PR DESCRIPTION
## Summary
- restore filesystem autocomplete mentions to `text/plain`
- keep the session-scoped path resolution introduced in #33458
- prevent source files such as `.ts` from being sent as unsupported binary media

## Testing
- `bun typecheck` in `packages/tui`
- `bun test` in `packages/tui` (176 passed, 1 skipped; 8 existing sync fixture failures due to missing `ExitProvider`, as documented in #33458)