### PR TITLE
fix(app): mount shortcuts per titlebar tab

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -482,6 +482,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                       <For each={tabsStore}>
                         {(tab, i) => {
                           let ref!: HTMLDivElement
+                          useTabShortcut(i, () => tabs.select(tab))
 
                           const divider = () =>
                             i() !== 0 && (
@@ -492,7 +493,6 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                             return (
                               <>
                                 {divider()}
-                                <TabShortcut index={i()} onSelect={() => tabs.select(tab)} />
                                 <DraftTabItem
                                   ref={ref}
                                   href={tabHref(tab)}
@@ -528,25 +528,22 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                               {divider()}
                               <Show when={session()}>
                                 {(session) => (
-                                  <>
-                                    <TabShortcut index={i()} onSelect={() => tabs.select(tab)} />
-                                    <TabNavItem
-                                      ref={ref}
-                                      href={tabHref(tab)}
-                                      server={tab.server}
-                                      sessionId={tab.sessionId}
-                                      session={session()}
-                                      onNavigate={() => {
-                                        tabs.select(tab)
+                                  <TabNavItem
+                                    ref={ref}
+                                    href={tabHref(tab)}
+                                    server={tab.server}
+                                    sessionId={tab.sessionId}
+                                    session={session()}
+                                    onNavigate={() => {
+                                      tabs.select(tab)
 
-                                        ref.scrollIntoView({ behavior: "instant" })
-                                      }}
-                                      onClose={() => tabsStoreActions.removeTab(i())}
-                                      active={currentTab() === tab}
-                                      activeServer={tab.server === server.key}
-                                      forceTruncate={tabsAreOverflowing()}
-                                    />
-                                  </>
+                                      ref.scrollIntoView({ behavior: "instant" })
+                                    }}
+                                    onClose={() => tabsStoreActions.removeTab(i())}
+                                    active={currentTab() === tab}
+                                    activeServer={tab.server === server.key}
+                                    forceTruncate={tabsAreOverflowing()}
+                                  />
                                 )}
                               </Show>
                             </>
@@ -823,11 +820,11 @@ function TitlebarUpdateIconButton(props: { state: TitlebarUpdatePillState }) {
   )
 }
 
-function TabShortcut(props: { index: number; onSelect: () => void }) {
+function useTabShortcut(index: () => number, onSelect: () => void) {
   const command = useCommand()
 
   command.register(() => {
-    const number = props.index + 1
+    const number = index() + 1
     if (number > 9) return []
 
     return [
@@ -837,12 +834,10 @@ function TabShortcut(props: { index: number; onSelect: () => void }) {
         title: "",
         keybind: `mod+${number}`,
         hidden: true,
-        onSelect: () => props.onSelect(),
+        onSelect,
       },
     ]
   })
-
-  return null
 }
 
 function TabNavItem(props: {

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -419,22 +419,6 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                     if (next) tabs.select(next)
                   },
                 },
-                ...Array.from({ length: 9 }, (_, i) => {
-                  const index = i
-                  const number = index + 1
-                  return {
-                    id: `tab.${number}`,
-                    category: "tab",
-                    title: "",
-                    keybind: `mod+${number}`,
-                    disabled: layout.projects.list().length <= index,
-                    hidden: true,
-                    onSelect: () => {
-                      const tab = tabsStore[index]
-                      if (tab) tabs.select(tab)
-                    },
-                  }
-                }),
               ].filter((v) => v !== undefined)
             })
 
@@ -508,6 +492,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                             return (
                               <>
                                 {divider()}
+                                <TabShortcut index={i()} onSelect={() => tabs.select(tab)} />
                                 <DraftTabItem
                                   ref={ref}
                                   href={tabHref(tab)}
@@ -543,22 +528,25 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                               {divider()}
                               <Show when={session()}>
                                 {(session) => (
-                                  <TabNavItem
-                                    ref={ref}
-                                    href={tabHref(tab)}
-                                    server={tab.server}
-                                    sessionId={tab.sessionId}
-                                    session={session()}
-                                    onNavigate={() => {
-                                      tabs.select(tab)
+                                  <>
+                                    <TabShortcut index={i()} onSelect={() => tabs.select(tab)} />
+                                    <TabNavItem
+                                      ref={ref}
+                                      href={tabHref(tab)}
+                                      server={tab.server}
+                                      sessionId={tab.sessionId}
+                                      session={session()}
+                                      onNavigate={() => {
+                                        tabs.select(tab)
 
-                                      ref.scrollIntoView({ behavior: "instant" })
-                                    }}
-                                    onClose={() => tabsStoreActions.removeTab(i())}
-                                    active={currentTab() === tab}
-                                    activeServer={tab.server === server.key}
-                                    forceTruncate={tabsAreOverflowing()}
-                                  />
+                                        ref.scrollIntoView({ behavior: "instant" })
+                                      }}
+                                      onClose={() => tabsStoreActions.removeTab(i())}
+                                      active={currentTab() === tab}
+                                      activeServer={tab.server === server.key}
+                                      forceTruncate={tabsAreOverflowing()}
+                                    />
+                                  </>
                                 )}
                               </Show>
                             </>
@@ -833,6 +821,28 @@ function TitlebarUpdateIconButton(props: { state: TitlebarUpdatePillState }) {
       </button>
     </div>
   )
+}
+
+function TabShortcut(props: { index: number; onSelect: () => void }) {
+  const command = useCommand()
+
+  command.register(() => {
+    const number = props.index + 1
+    if (number > 9) return []
+
+    return [
+      {
+        id: `tab.${number}`,
+        category: "tab",
+        title: "",
+        keybind: `mod+${number}`,
+        hidden: true,
+        onSelect: () => props.onSelect(),
+      },
+    ]
+  })
+
+  return null
 }
 
 function TabNavItem(props: {


### PR DESCRIPTION
## Summary

- mount one numeric shortcut registration per rendered titlebar tab
- derive `mod+1` through `mod+9` from each tab's reactive list index
- avoid registering shortcuts for absent tabs or tabs beyond the ninth position

## Validation

- `bun typecheck` in `packages/app`
- focused command and titlebar unit tests (13 passed)
- repository pre-push typecheck (23 packages passed)