### PR TITLE
fix(app): clear viewed session notifications

### DIFF
--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -1,18 +1,25 @@
 import { createEffect, Suspense, type ParentProps } from "solid-js"
-import { useNavigate } from "@solidjs/router"
+import { useNavigate, useParams } from "@solidjs/router"
 import { DebugBar } from "@/components/debug-bar"
 import { HelpButton } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { useNotification } from "@/context/notification"
 import { usePlatform } from "@/context/platform"
 import { setNavigate } from "@/utils/notification-click"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
+  const notification = useNotification()
   const navigate = useNavigate()
+  const params = useParams<{ id?: string }>()
   setNavigate(navigate)
 
   createEffect(() => setV2Toast(true))
+  createEffect(() => {
+    if (!notification.ready() || !params.id) return
+    notification.session.markViewed(params.id)
+  })
 
   const update: TitlebarUpdate = {
     version: () => {


### PR DESCRIPTION
## Summary

- mark existing session notifications viewed when the new layout opens a session route
- wait for persisted notification state before clearing unread indexes
- restore the route-entry behavior provided by the legacy layout

## Testing

- `bun typecheck` from `packages/app`
- `bun test --preload ./happydom.ts ./src/utils/session-route.test.ts ./src/utils/notification-click.test.ts`
- pre-push repository typecheck (23 packages)