### PR TITLE
fix(skill): emit base directory as filesystem path, not file:// URL

### DIFF
--- a/packages/core/src/tool/skill.ts
+++ b/packages/core/src/tool/skill.ts
@@ -1,7 +1,6 @@
 export * as SkillTool from "./skill"
 
 import path from "path"
-import { pathToFileURL } from "url"
 import { ToolFailure } from "@opencode-ai/llm"
 import { Effect, Layer, Schema } from "effect"
 import { FSUtil } from "../fs-util"
@@ -39,7 +38,7 @@ export const toModelOutput = (skill: SkillV2.Info, files: ReadonlyArray<string>)
     "",
     skill.content.trim(),
     "",
-    `Base directory for this skill: ${pathToFileURL(directory).href}`,
+    `Base directory for this skill: ${directory}`,
     "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",
     "Note: file list is sampled.",
     "",

--- a/packages/core/test/tool-skill.test.ts
+++ b/packages/core/test/tool-skill.test.ts
@@ -23,7 +23,7 @@ describe("SkillTool", () => {
     ).pipe(
       Effect.flatMap((tmp) =>
         Effect.gen(function* () {
-          const directory = path.join(tmp.path, "effect#v1")
+          const directory = path.join(tmp.path, "effect")
           const location = path.join(directory, "SKILL.md")
           const reference = path.join(directory, "reference.md")
           yield* Effect.promise(() => fs.mkdir(directory, { recursive: true }))

--- a/packages/core/test/tool-skill.test.ts
+++ b/packages/core/test/tool-skill.test.ts
@@ -1,6 +1,5 @@
 import fs from "fs/promises"
 import path from "path"
-import { pathToFileURL } from "url"
 import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -24,7 +23,7 @@ describe("SkillTool", () => {
     ).pipe(
       Effect.flatMap((tmp) =>
         Effect.gen(function* () {
-          const directory = path.join(tmp.path, "effect")
+          const directory = path.join(tmp.path, "effect#v1")
           const location = path.join(directory, "SKILL.md")
           const reference = path.join(directory, "reference.md")
           yield* Effect.promise(() => fs.mkdir(directory, { recursive: true }))
@@ -90,7 +89,7 @@ describe("SkillTool", () => {
               value: SkillTool.toModelOutput(info, [reference]),
             })
             expect(SkillTool.toModelOutput(info, [reference])).toContain(
-              `Base directory for this skill: ${pathToFileURL(directory).href}`,
+              `Base directory for this skill: ${directory}`,
             )
             expect(
               yield* settleTool(registry, {

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -1,5 +1,4 @@
 import path from "path"
-import { pathToFileURL } from "url"
 import { Effect, Schema } from "effect"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Skill } from "../skill"
@@ -33,7 +32,7 @@ export const SkillTool = Tool.define(
           })
 
           const dir = path.dirname(info.location)
-          const base = pathToFileURL(dir).href
+          const base = dir
           const files = yield* ripgrep.find({
             cwd: dir,
             pattern: "!**/SKILL.md",

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -4,7 +4,6 @@ import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Cause, Effect, Exit, Layer } from "effect"
 import { afterEach, describe, expect } from "bun:test"
 import path from "path"
-import { pathToFileURL } from "url"
 import type { Permission } from "../../src/permission"
 import type { Tool } from "@/tool/tool"
 import { SkillTool } from "../../src/tool/skill"
@@ -90,7 +89,7 @@ Use this skill.
       expect(requests[0].always).toContain("tool-skill")
       expect(result.metadata.dir).toBe(skill)
       expect(result.output).toContain(`<skill_content name="tool-skill">`)
-      expect(result.output).toContain(`Base directory for this skill: ${pathToFileURL(skill).href}`)
+      expect(result.output).toContain(`Base directory for this skill: ${skill}`)
       expect(result.output).toContain(`<file>${file}</file>`)
     }),
   )

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -34,7 +34,7 @@ describe("tool.skill", () => {
   it.instance("execute returns skill content block with files", () =>
     Effect.gen(function* () {
       const dir = (yield* TestInstance).directory
-      const skill = path.join(dir, ".opencode", "skill", "tool-skill#v1")
+      const skill = path.join(dir, ".opencode", "skill", "tool-skill")
       yield* Effect.promise(() =>
         Bun.write(
           path.join(skill, "SKILL.md"),

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -34,7 +34,7 @@ describe("tool.skill", () => {
   it.instance("execute returns skill content block with files", () =>
     Effect.gen(function* () {
       const dir = (yield* TestInstance).directory
-      const skill = path.join(dir, ".opencode", "skill", "tool-skill")
+      const skill = path.join(dir, ".opencode", "skill", "tool-skill#v1")
       yield* Effect.promise(() =>
         Bun.write(
           path.join(skill, "SKILL.md"),


### PR DESCRIPTION
### Issue for this PR

Closes #18370

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `skill` tool emitted the skill's base directory as a `file://` URL via `pathToFileURL(dir).href`. When the skill path contained characters that get URL-encoded — most notably `#` from git-tagged plugin cache dirs (e.g. `...git#v1.3.0` → `...git%23v1.3.0`) — the LLM derived a read-tool path with `%23` but the filesystem has `#`, so `read` returned "File not found" and the skill's reference files appeared missing.

Emit `dir` directly instead. The `<file>` entries on the next line already use `path.resolve(dir, file.path)` (plain paths), so the base now matches and the LLM gets a path it can pass straight to `read`.

This also fixes the `file:///` prefix issue reported by ACP editors in #23885.

### How did you verify your code works?

- `bun test packages/opencode/test/tool/skill.test.ts` — both tests pass (updated the base-directory assertion to expect a plain path).
- Reproduced the original bug with my own plugin (`writing-humanizer@git+https://...#v1.3.0`): confirmed `read` fails on a `%23` path but succeeds on the `#` path. After this change the base directory no longer contains `%23`.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
