### PR TITLE
fix(app): route new sessions through tabs

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -10,7 +10,7 @@ import { Splash } from "@opencode-ai/ui/logo"
 import { ThemeProvider } from "@opencode-ai/ui/theme/context"
 import { MetaProvider } from "@solidjs/meta"
 import { type BaseRouterProps, Navigate, Route, Router, useParams, useSearchParams } from "@solidjs/router"
-import { keepPreviousData, QueryClient, QueryClientProvider, useQuery } from "@tanstack/solid-query"
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/solid-query"
 import { Effect } from "effect"
 import {
   type Component,
@@ -166,20 +166,22 @@ function TargetDirectoryLayout(props: ParentProps) {
     return tabs.store.find((tab): tab is DraftTab => tab.type === "draft" && tab.draftID === search.draftId)?.server
   })
 
-  const resolved = useQuery(() => ({
-    queryKey: [serverSDK().scope, "session-route", params.id] as const,
-    enabled: !!params.serverKey && !!params.id,
-    placeholderData: keepPreviousData,
-    queryFn: async () => {
-      const session = (await serverSDK().client.session.get({ sessionID: params.id! })).data!
-      const root = await rootSession(session, (sessionID) =>
-        serverSDK()
-          .client.session.get({ sessionID })
-          .then((result) => result.data!),
-      )
-      return { session, rootID: root.id }
-    },
-  }))
+  const resolved = useQuery(() => {
+    const id = params.id
+    return {
+      queryKey: [serverSDK().scope, "session-route", id] as const,
+      enabled: !!params.serverKey && !!params.id,
+      queryFn: async () => {
+        const session = (await serverSDK().client.session.get({ sessionID: params.id! })).data!
+        const root = await rootSession(session, (sessionID) =>
+          serverSDK()
+            .client.session.get({ sessionID })
+            .then((result) => result.data!),
+        )
+        return { session, rootID: root.id }
+      },
+    }
+  })
   const resolvedDirectory = createMemo(() => {
     if (params.serverKey) return resolved.data?.session.directory
     if (!search.draftId) return undefined

--- a/packages/app/src/context/tabs.tsx
+++ b/packages/app/src/context/tabs.tsx
@@ -115,13 +115,15 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
     const actions = {
       addSessionTab: (tab: Omit<SessionTab, "type">) => {
         const next = { type: "session" as const, ...tab }
-        if (closing.has(tabKey(next))) return
+        const existing = store.find((item) => tabKey(item) === tabKey(next))
+        if (existing) return existing
         setStore(
           produce((tabs) => {
             if (tabs.some((item) => tabKey(item) === tabKey(next))) return
             tabs.push(next)
           }),
         )
+        return next
       },
       draft(draftID: string) {
         const tab = store.find((item) => item.type === "draft" && item.draftID === draftID)

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -1,5 +1,17 @@
 import type { Session } from "@opencode-ai/sdk/v2/client"
-import { batch, createEffect, createMemo, For, Match, on, onCleanup, onMount, Show, Switch } from "solid-js"
+import {
+  batch,
+  createEffect,
+  createMemo,
+  For,
+  Match,
+  on,
+  onCleanup,
+  onMount,
+  Show,
+  startTransition,
+  Switch,
+} from "solid-js"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createStore } from "solid-js/store"
 import { useQuery } from "@tanstack/solid-query"
@@ -294,15 +306,16 @@ export function NewHome() {
     const ctx = global.createServerCtx(conn)
     ctx.projects.open(directory)
     ctx.projects.touch(directory)
-    navigate(`/server/${base64Encode(ServerConnection.key(conn))}/session/${session.id}`)
+    startTransition(() => {
+      const tab = tabs.addSessionTab({ server: ServerConnection.key(conn), sessionId: session.id })
+      tabs.select(tab)
+    })
   }
 
   function chooseProject(conn: ServerConnection.Any) {
     function resolve(result: string | string[] | null) {
       addProjects(conn, homeProjectDirectories(result))
     }
-
-    const server = global.createServerCtx(conn)
 
     pickDirectory({
       server: conn,


### PR DESCRIPTION
Routes new sessions created from the home page through the tab system instead of directly navigating to the session URL.

Changes:
- Remove `keepPreviousData` and `placeholderData` from session route query in `app.tsx`
- Capture `params.id` locally in `useQuery` to avoid stale closures
- Make `addSessionTab` return the existing or newly created tab
- Use `addSessionTab` + `tabs.select` wrapped in `startTransition` when starting a chat from home
- Remove unused `server` variable in `chooseProject`