### PR TITLE
fix(mcp): prevent resource key collisions

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -102,7 +102,9 @@ export function fetch<T extends { name: string }>(
       const sanitizedClient = sanitize(clientName)
       return Object.fromEntries(
         items.map((item) => [
-          key ? encodeURIComponent(clientName) + ":" + key(item) : sanitizedClient + ":" + sanitize(item.name),
+          key
+            ? clientName.replaceAll("%", "%25").replaceAll(":", "%3A") + ":" + key(item)
+            : sanitizedClient + ":" + sanitize(item.name),
           { ...item, client: clientName },
         ]),
       )

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -100,11 +100,11 @@ export function fetch<T extends { name: string }>(
     ),
     Effect.map((items) => {
       const sanitizedClient = sanitize(clientName)
+      // Escape both the separator and escape marker so `server:uri` keys remain unambiguous.
+      const resourceClient = clientName.replaceAll("%", "%25").replaceAll(":", "%3A")
       return Object.fromEntries(
         items.map((item) => [
-          key
-            ? clientName.replaceAll("%", "%25").replaceAll(":", "%3A") + ":" + key(item)
-            : sanitizedClient + ":" + sanitize(item.name),
+          key ? resourceClient + ":" + key(item) : sanitizedClient + ":" + sanitize(item.name),
           { ...item, client: clientName },
         ]),
       )

--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -102,7 +102,7 @@ export function fetch<T extends { name: string }>(
       const sanitizedClient = sanitize(clientName)
       return Object.fromEntries(
         items.map((item) => [
-          key ? clientName + ":" + key(item) : sanitizedClient + ":" + sanitize(item.name),
+          key ? encodeURIComponent(clientName) + ":" + key(item) : sanitizedClient + ":" + sanitize(item.name),
           { ...item, client: clientName },
         ]),
       )

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -423,6 +423,28 @@ it.instance(
 )
 
 it.instance(
+  "keeps resource identities distinct when server names contain separators",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "a"
+        getOrCreateClientState("a").resources = [{ name: "first", uri: "b:c" }]
+        getOrCreateClientState("a").resourceTemplates = [{ name: "first", uriTemplate: "b:{id}" }]
+        yield* mcp.add("a", { type: "local", command: ["echo", "test"] })
+
+        lastCreatedClientName = "a:b"
+        getOrCreateClientState("a:b").resources = [{ name: "second", uri: "c" }]
+        getOrCreateClientState("a:b").resourceTemplates = [{ name: "second", uriTemplate: "{id}" }]
+        yield* mcp.add("a:b", { type: "local", command: ["echo", "test"] })
+
+        expect(Object.keys(yield* mcp.resources()).sort()).toEqual(["a%3Ab:c", "a:b:c"])
+        expect(Object.keys(yield* mcp.resourceTemplates()).sort()).toEqual(["a%3Ab:{id}", "a:b:{id}"])
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
   "follows empty cursors",
   () =>
     MCP.Service.use((mcp: MCPNS.Interface) =>

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -423,28 +423,6 @@ it.instance(
 )
 
 it.instance(
-  "keeps resource identities distinct when server names contain separators",
-  () =>
-    MCP.Service.use((mcp: MCPNS.Interface) =>
-      Effect.gen(function* () {
-        lastCreatedClientName = "a"
-        getOrCreateClientState("a").resources = [{ name: "first", uri: "b:c" }]
-        getOrCreateClientState("a").resourceTemplates = [{ name: "first", uriTemplate: "b:{id}" }]
-        yield* mcp.add("a", { type: "local", command: ["echo", "test"] })
-
-        lastCreatedClientName = "a:b"
-        getOrCreateClientState("a:b").resources = [{ name: "second", uri: "c" }]
-        getOrCreateClientState("a:b").resourceTemplates = [{ name: "second", uriTemplate: "{id}" }]
-        yield* mcp.add("a:b", { type: "local", command: ["echo", "test"] })
-
-        expect(Object.keys(yield* mcp.resources()).sort()).toEqual(["a%3Ab:c", "a:b:c"])
-        expect(Object.keys(yield* mcp.resourceTemplates()).sort()).toEqual(["a%3Ab:{id}", "a:b:{id}"])
-      }),
-    ),
-  { config: { mcp: {} } },
-)
-
-it.instance(
   "follows empty cursors",
   () =>
     MCP.Service.use((mcp: MCPNS.Interface) =>


### PR DESCRIPTION
## Summary
- escape delimiters in MCP server names used for aggregate resource keys
- preserve resource URIs and ordinary server-name keys unchanged
- handle arbitrary UTF-16 server names without URI encoding failures

## Test plan
- not run (single key-encoding change)