### PR TITLE
feat(core): add pinFirstUserTurn compaction option for prefix cache stability

### DIFF
--- a/packages/core/src/config/compaction.ts
+++ b/packages/core/src/config/compaction.ts
@@ -12,4 +12,5 @@ export class Info extends Schema.Class<Info>("ConfigV2.Compaction")({
   prune: Schema.Boolean.pipe(Schema.optional),
   keep: Keep.pipe(Schema.optional),
   buffer: NonNegativeInt.pipe(Schema.optional),
+  pinFirstUserTurn: Schema.Boolean.pipe(Schema.optional),
 }) {}

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -59,6 +59,7 @@ type Settings = {
   readonly auto: boolean
   readonly buffer: number
   readonly tokens: number
+  readonly pinFirstUserTurn: boolean
 }
 
 type Dependencies = {
@@ -125,25 +126,42 @@ const settings = (documents: readonly Config.Entry[]) => {
       auto: current.auto ?? result.auto,
       buffer: current.buffer ?? result.buffer,
       tokens: current.keep?.tokens ?? result.tokens,
+      pinFirstUserTurn: current.pinFirstUserTurn ?? result.pinFirstUserTurn,
     }),
-    { auto: true, buffer: DEFAULT_BUFFER, tokens: DEFAULT_KEEP_TOKENS },
+    { auto: true, buffer: DEFAULT_BUFFER, tokens: DEFAULT_KEEP_TOKENS, pinFirstUserTurn: false },
   )
 }
 
 const select = (
   entries: readonly Entry[],
   tokens: number,
+  pinFirstUserTurn?: boolean,
 ): { readonly head: string; readonly recent: string } | undefined => {
   const conversation = entries
     .filter((entry) => entry.message.type !== "compaction")
     .map((entry) => serialize(entry.message))
     .filter(Boolean)
   if (conversation.length === 0) return
+  let firstUserIdx = -1
+  if (pinFirstUserTurn) {
+    let convIdx = 0
+    for (const entry of entries) {
+      if (entry.message.type === "compaction") continue
+      const text = serialize(entry.message)
+      if (!text) continue
+      if (entry.message.type === "user") {
+        firstUserIdx = convIdx
+        break
+      }
+      convIdx++
+    }
+  }
   let total = 0
   let split = conversation.length
   let splitPrefix = ""
   let splitSuffix = ""
   for (let index = conversation.length - 1; index >= 0; index--) {
+    if (pinFirstUserTurn && index < firstUserIdx) break
     const next = total + Token.estimate(conversation[index])
     if (next > tokens) {
       const remaining = Math.max(0, tokens - total) * 4
@@ -178,7 +196,7 @@ export const make = (dependencies: Dependencies) => {
     const context = input.model.route.defaults.limits?.context
     if (context === undefined || context <= 0) return false
     const output = input.request.generation?.maxTokens ?? input.model.route.defaults.limits?.output ?? 0
-    const selected = select(input.entries, config.tokens)
+    const selected = select(input.entries, config.tokens, config.pinFirstUserTurn)
     const previousSummary = input.entries.find((entry) => entry.message.type === "compaction")?.message
     if (!selected || (selected.head.length === 0 && previousSummary?.type !== "compaction")) return false
     const summaryPrompt = buildPrompt({

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -161,6 +161,10 @@ export const Info = Schema.Struct({
       reserved: Schema.optional(NonNegativeInt).annotate({
         description: "Token buffer for compaction. Leaves enough window to avoid overflow during compaction.",
       }),
+      pin_first_user_turn: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Preserve the first user message verbatim during compaction, keeping the prompt prefix stable for cache (default: false)",
+      }),
     }),
   ),
   experimental: Schema.optional(

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -205,7 +205,11 @@ export const layer = Layer.effect(
       const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model })
       const all = turns(input.messages)
       if (!all.length) return { head: input.messages, tail_start_id: undefined }
-      const recent = all.slice(-limit)
+      let recent = all.slice(-limit)
+      const pinFirst = input.cfg.compaction?.pin_first_user_turn === true
+      if (pinFirst && all.length > 0 && !recent.some((t) => t.id === all[0].id)) {
+        recent = [all[0], ...recent]
+      }
       const sizes = yield* Effect.forEach(
         recent,
         (turn) =>


### PR DESCRIPTION
### Issue for this PR

N/A — incremental improvement, no issue filed.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `pinFirstUserTurn` compaction option. When enabled, the first user message is kept verbatim during compaction instead of being summarized. This keeps the prompt prefix stable across turns, which helps providers with prefix caching (DeepSeek, OpenAI, etc.) reuse cached computation.

The change is tiny (~30 lines, 4 files) and defaults to false, so existing users are unaffected.

Related: #31867 improves DeepSeek cache from the system prompt side (date injection), this one improves it from the compaction side (first user turn protection). They complement each other.

### How did you verify your code works?

Reviewed the logic manually:

- V2 select(): the backwards walk now stops before the first user message index when `pinFirstUserTurn` is set, ensuring it lands in `recent` instead of `head`. The index calculation properly accounts for compaction messages being filtered out and serialized messages that evaluate to empty being skipped.
- V1 select(): the first user turn is prepended to the recent turns list when not already included by `tail_turns`.
- Both paths: default `false` means no change to current behavior.

I haven't been able to run tests — building requires downloading platform-specific Bun dependencies which timed out in my environment. Happy to run them if a maintainer can suggest a simpler test path.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
