### PR TITLE
fix(copilot): support max reasoning effort for claude-sonnet-4.6

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -220,19 +220,27 @@ export async function get(
       return item && usable(item) ? ([[item.id, item]] as const) : []
     }),
   )
+  // Secondary lookup index: normalize version separators so catalog keys like
+  // "claude-sonnet-4-6" (hyphen) match API IDs like "claude-sonnet-4.6" (dot).
+  const remoteByNormalized = new Map(
+    [...remote].map(([id, item]) => [id.replace(/\./g, "-"), item] as const),
+  )
 
   // prune existing models whose api.id isn't in the endpoint response
+  const matched = new Set<string>()
   for (const [key, model] of Object.entries(result)) {
-    const m = remote.get(model.api.id)
+    const m = remote.get(model.api.id) ?? remoteByNormalized.get(model.api.id.replace(/\./g, "-"))
     if (!m) {
       delete result[key]
       continue
     }
+    matched.add(m.id)
     result[key] = build(key, m, baseURL, model)
   }
 
   // add new endpoint models not already keyed in result
   for (const [id, m] of remote) {
+    if (matched.has(id)) continue
     if (id in result) continue
     result[id] = build(id, m, baseURL)
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -523,6 +523,9 @@ const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
 const OPENAI_GPT5_CHAT_EFFORTS = ["medium"]
 const OPENAI_GPT5_CODEX_XHIGH_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_CODEX_3_PLUS_EFFORTS = ["none", ...OPENAI_GPT5_CODEX_XHIGH_EFFORTS]
+// Copilot API returns reasoning_effort: ["low","medium","high","max"] for claude-sonnet-4.6.
+// reasoning_summary=auto and include are accepted by /chat/completions for claude models.
+const COPILOT_CLAUDE_EFFORTS = [...WIDELY_SUPPORTED_EFFORTS, "max"]
 
 // OpenAI rolled out the `none` reasoning_effort tier on this date (Responses API).
 // Models released before it 400 on `reasoning_effort: "none"`, so we only expose
@@ -822,7 +825,16 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
         return {}
       }
       if (model.id.includes("claude")) {
-        return Object.fromEntries(WIDELY_SUPPORTED_EFFORTS.map((effort) => [effort, { reasoningEffort: effort }]))
+        return Object.fromEntries(
+          COPILOT_CLAUDE_EFFORTS.map((effort) => [
+            effort,
+            {
+              reasoningEffort: effort,
+              reasoningSummary: "auto",
+              include: INCLUDE_ENCRYPTED_REASONING,
+            },
+          ]),
+        )
       }
       const copilotEfforts = iife(() => {
         if (id.includes("5.1-codex-max") || id.includes("5.2") || id.includes("5.3"))
@@ -901,8 +913,8 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
           if (model.api.id.includes("opus-4.7")) {
             efforts = ["medium"]
           }
-          // Efforts currently supported are: low, medium, high
-          efforts = efforts.filter((v) => v !== "max" && v !== "xhigh")
+          // xhigh is not surfaced by the Copilot API; max is explicitly supported
+          efforts = efforts.filter((v) => v !== "xhigh")
         }
         return Object.fromEntries(
           efforts.map((effort) => [


### PR DESCRIPTION
### Issue for this PR

Closes #33607

### Type of change

- [x] Bug fix

### What does this PR do?

**Bug 1: max reasoning effort not available for claude-sonnet-4.6**

The Copilot API returns `reasoning_effort: ["low", "medium", "high", "max"]` for claude-sonnet-4.6. Two places in `transform.ts` blocked max from reaching the user:

1. `@ai-sdk/anthropic` + github-copilot fallback path filtered it out with `efforts.filter(v => v !== "max" && v !== "xhigh")`. Comment said "Efforts currently supported: low, medium, high" — outdated.
2. `@ai-sdk/github-copilot` claude fallback path used `WIDELY_SUPPORTED_EFFORTS` (no max).

Fix: remove the max filter (keep xhigh filtered, not in Copilot API); add max to the claude efforts list; extract `COPILOT_CLAUDE_EFFORTS` constant.

**Bug 2: model key mismatch drops catalog metadata on every refresh**

Static catalog keys `claude-sonnet-4-6` (hyphen). Copilot API returns `claude-sonnet-4.6` (dot). `remote.get(model.api.id)` fails the lookup, so the catalog entry is pruned and replaced with a new entry (no `prev`) on every refresh, discarding catalog metadata and breaking saved model preferences.

Fix: build a secondary normalized map keying API IDs with dots replaced by hyphens, track matched IDs to avoid duplicates.

### How did you verify your code works?

- Live API calls confirmed `output_config.effort=max` accepted by `/v1/messages`, produces more thinking tokens than `effort=low`
- Live API call confirmed `reasoning_effort=max` accepted by `/chat/completions` for claude models
- 279 existing tests pass

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR