### PR TITLE
fix(opencode): resolve plugin dependency in local builds

### DIFF
--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -91,6 +91,7 @@ for (const item of targets) {
       OPENCODE_CLI_NAME: `'${binary}'`,
       OPENCODE_MODELS_DEV: modelsData,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
+      OPENCODE_LOCAL_BUILD: String(Script.local),
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "undefined",
       // FFF_LIBC selects the fff native lib variant: "musl" or "gnu".
       FFF_LIBC: item.os === "linux" ? `'${item.abi ?? "gnu"}'` : "undefined",

--- a/packages/core/src/installation/version.ts
+++ b/packages/core/src/installation/version.ts
@@ -1,8 +1,10 @@
 declare global {
   const OPENCODE_VERSION: string
   const OPENCODE_CHANNEL: string
+  const OPENCODE_LOCAL_BUILD: boolean
 }
 
 export const InstallationVersion = typeof OPENCODE_VERSION === "string" ? OPENCODE_VERSION : "local"
 export const InstallationChannel = typeof OPENCODE_CHANNEL === "string" ? OPENCODE_CHANNEL : "local"
-export const InstallationLocal = InstallationChannel === "local"
+export const InstallationLocal =
+  (typeof OPENCODE_LOCAL_BUILD === "boolean" && OPENCODE_LOCAL_BUILD) || InstallationChannel === "local"

--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -22,6 +22,7 @@ await Bun.build({
   define: {
     OPENCODE_MODELS_DEV: generated.modelsData,
     OPENCODE_CHANNEL: `'${Script.channel}'`,
+    OPENCODE_LOCAL_BUILD: String(Script.local),
   },
   files: {
     "opencode-web-ui.gen.ts": "",

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -193,6 +193,7 @@ for (const item of targets) {
       OTUI_TREE_SITTER_WORKER_PATH: bunfsRoot + workerRelativePath,
       OPENCODE_WORKER_PATH: workerPath,
       OPENCODE_CHANNEL: `'${Script.channel}'`,
+      OPENCODE_LOCAL_BUILD: String(Script.local),
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
       ...(item.os === "linux" ? { "process.env.OPENTUI_LIBC": JSON.stringify(item.abi ?? "glibc") } : {}),
     },

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -30,6 +30,7 @@ const CHANNEL = await (async () => {
   return await $`git branch --show-current`.text().then((x) => x.trim())
 })()
 const IS_PREVIEW = CHANNEL !== "latest"
+const IS_LOCAL = !env.OPENCODE_BUMP && !env.OPENCODE_VERSION && !env.OPENCODE_RELEASE && !process.env.CI
 
 const VERSION = await (async () => {
   if (env.OPENCODE_VERSION) return env.OPENCODE_VERSION
@@ -66,6 +67,9 @@ export const Script = {
   },
   get preview() {
     return IS_PREVIEW
+  },
+  get local() {
+    return IS_LOCAL
   },
   get release(): boolean {
     return !!env.OPENCODE_RELEASE


### PR DESCRIPTION
Ran into an issue were my --single dev build of opencode would consistently fail with

```
ResolveMessage: Cannot find module '@opencode-ai/plugin' from '/home/simon/src/wt/oc-remove-animation/.opencode/tool/github-triage.ts'
    at ToolRegistry.state (/$bunfs/root/chunk-rzse67en.js:52:3914)
    at ToolRegistry.state (definition) (/$bunfs/root/chunk-qyz31cry.js:479:689)
    at ToolRegistry.all (/$bunfs/root/chunk-qyz31cry.js:481:62)
    at ToolRegistry.all (definition) (/$bunfs/root/chunk-qyz31cry.js:479:2689)
    at ToolRegistry.tools (/$bunfs/root/chunk-zktxrx90.js:1000:1786)
    at ToolRegistry.tools (definition) (/$bunfs/root/chunk-qyz31cry.js:481:12)
    at SessionTools.resolve (/$bunfs/root/chunk-zktxrx90.js:1019:3558)
    at SessionTools.resolve (definition) (/$bunfs/root/chunk-zktxrx90.js:1000:964)
    at SessionPrompt.run (/$bunfs/root/chunk-zktxrx90.js:1019:5630)
    at SessionPrompt.run (definition) (/$bunfs/root/chunk-zktxrx90.js:1019:903) 
```

The local compiled binaries looked like unpublished preview releases. The build then created version `0.0.0-dev-202606240737`, and at runtime tried to install: `@opencode-ai/plugin@<opencode version>`. 

This looked more like a latent thing than a recent regression. The changeset has a bit more changes to avoid changing the db name as well. 
