### PR TITLE
fix(core): break agent loop on permission rejection with feedback

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -16,6 +16,7 @@ import { EventV2 } from "../../event"
 import { Location } from "../../location"
 import { ModelV2 } from "../../model"
 import { ProviderV2 } from "../../provider"
+import { PermissionV2 } from "../../permission"
 import { QuestionV2 } from "../../question"
 import { SystemContext } from "../../system-context/index"
 import { SystemContextRegistry } from "../../system-context/registry"
@@ -136,9 +137,15 @@ export const layer = Layer.effect(
     const awaitToolFibers = (fibers: FiberSet.FiberSet<void, ToolOutputStore.Error>) =>
       Effect.raceFirst(FiberSet.join(fibers), FiberSet.awaitEmpty(fibers))
 
-    // Match V1: dismissing a question halts the loop instead of becoming model-facing tool output.
-    const isQuestionRejected = (cause: Cause.Cause<unknown>) =>
-      cause.reasons.some((reason) => Cause.isDieReason(reason) && reason.defect instanceof QuestionV2.RejectedError)
+    // Match V1: dismissing a question or permission prompt halts the loop instead of becoming model-facing tool output.
+    const isHalted = (cause: Cause.Cause<unknown>) =>
+      cause.reasons.some(
+        (reason) =>
+          Cause.isDieReason(reason) &&
+          (reason.defect instanceof QuestionV2.RejectedError ||
+            reason.defect instanceof PermissionV2.RejectedError ||
+            reason.defect instanceof PermissionV2.CorrectedError),
+      )
 
     type TurnTransition =
       // Automatic compaction completed; rebuild the request from compacted history.
@@ -283,7 +290,7 @@ export const layer = Layer.effect(
           }
           if (stream._tag === "Failure" && Cause.hasInterrupts(stream.cause)) yield* FiberSet.clear(toolFibers)
           const settled = yield* restore(awaitToolFibers(toolFibers)).pipe(Effect.exit)
-          if (settled._tag === "Failure" && isQuestionRejected(settled.cause)) {
+          if (settled._tag === "Failure" && isHalted(settled.cause)) {
             yield* FiberSet.clear(toolFibers)
             yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))
             return yield* Effect.interrupt

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -238,7 +238,11 @@ export const layer = Layer.effect(
             time: { start: match.part.state.time.start, end: Date.now() },
           },
         })
-        if (error instanceof PermissionV1.RejectedError || error instanceof Question.RejectedError) {
+        if (
+          error instanceof PermissionV1.RejectedError ||
+          error instanceof PermissionV1.CorrectedError ||
+          error instanceof Question.RejectedError
+        ) {
           ctx.blocked = ctx.shouldBreak
         }
         yield* settleToolCall(toolCallID)


### PR DESCRIPTION
### Issue for this PR

Closes #28793

### Type of change

- [x] Bug fix

### What does this PR do?

When a user rejects a tool call **with a feedback message**, the permission system throws `CorrectedError` (carrying the user's reason in `.feedback`). This is a separate class from `RejectedError` (plain rejection, no message).

The loop-break checks in both the V1 processor and V2 session runner only caught `RejectedError` and `Question.RejectedError`, missing `CorrectedError` entirely. So `ctx.blocked` was never set, the agent loop kept running, and the parent re-delegated the same command indefinitely — infinite loop.

**Changes:**
- `packages/opencode/src/session/processor.ts` — added `PermissionV1.CorrectedError` to the `instanceof` check so the V1 loop breaks on rejection-with-feedback.
- `packages/core/src/session/runner/llm.ts` — extended the V2 halt check (renamed `isQuestionRejected` → `isHalted`) to also match `PermissionV2.RejectedError` and `PermissionV2.CorrectedError`.

`CorrectedError.message` already includes the feedback text, so `errorMessage()` picks it up and the reason reaches the model as part of the tool-error result. The missing piece was the loop-break itself.

### How did you verify your code works?

- `bun typecheck` passes for both `packages/core` and `packages/opencode`.
- Configured a primary agent with `bash: "deny"` and a subagent with bash access. Rejected a delegated bash command with a reason in the permission prompt. The agent loop now halts immediately instead of retrying indefinitely.

### Screenshots / recordings

_N/A — logic change, no UI impact._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
