### PR TITLE
fix(app): share synced session data

### DIFF
--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -7,7 +7,6 @@ import { useServerSync } from "./server-sync"
 import { usePlatform } from "@/context/platform"
 import { useLanguage } from "@/context/language"
 import { useSettings } from "@/context/settings"
-import { Binary } from "@opencode-ai/core/util/binary"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { decode64 } from "@/utils/base64"
 import { EventSessionError } from "@opencode-ai/sdk/v2"
@@ -208,12 +207,12 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
 
     const lookup = async (directory: string, sessionID?: string) => {
       if (!sessionID) return undefined
-      const [syncStore] = serverSync().child(directory, { bootstrap: false })
-      const match = Binary.search(syncStore.session, sessionID, (s) => s.id)
-      if (match.found) return syncStore.session[match.index]
-      return serverSDK()
-        .client.session.get({ directory, sessionID })
-        .then((x) => x.data)
+      const sync = serverSync().createDirSyncContext(directory)
+      const session = sync.session.get(sessionID)
+      if (session) return session
+      return sync.session
+        .sync(sessionID)
+        .then(() => sync.session.get(sessionID))
         .catch(() => undefined)
     }
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1299,15 +1299,15 @@ export default function LegacyLayout(props: ParentProps) {
     }
     const openSession = async (target: { directory: string; id: string }) => {
       if (!canOpen(target.directory)) return false
-      const [data] = serverSync().child(target.directory, { bootstrap: false })
-      if (data.session.some((item) => item.id === target.id)) {
+      const sync = serverSync().createDirSyncContext(target.directory)
+      if (sync.session.get(target.id)) {
         setStore("lastProjectSession", root, { directory: target.directory, id: target.id, at: Date.now() })
         navigateWithSidebarReset(`/${base64Encode(target.directory)}/session/${target.id}`)
         return true
       }
-      const resolved = await serverSDK()
-        .client.session.get({ sessionID: target.id })
-        .then((x) => x.data)
+      const resolved = await sync.session
+        .sync(target.id)
+        .then(() => sync.session.get(target.id))
         .catch(() => undefined)
       if (!resolved?.directory) return false
       if (!canOpen(resolved.directory)) return false


### PR DESCRIPTION
## Summary

- load notification sessions through the directory sync context
- reuse synchronized session data when restoring project navigation
- keep direct API access only where directory sync is unavailable or being initialized

## Testing

- `bun typecheck` in `packages/app`
- `bun test --only-failures --preload ./happydom.ts ./src/context/layout.test.ts ./src/context/layout-scroll.test.ts ./src/utils/notification-click.test.ts`
- repository-wide `bun turbo typecheck` push hook
- `bunx playwright test --config e2e/performance/playwright.config.ts e2e/performance/timeline/first-navigation-benchmark.spec.ts` attempted before and after; both runs failed before metrics because the existing smoke fixture did not render the expected `Uncommitted changes inquiry` session title