### PR TITLE
fix(app): clear followup queue on session revert, add remove button to queued messages

### DIFF
--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -640,6 +640,7 @@ export const dict = {
   "session.followupDock.summary.other": "{{count}} queued messages",
   "session.followupDock.sendNow": "Send now",
   "session.followupDock.edit": "Edit",
+  "session.followupDock.remove": "Remove",
   "session.followupDock.collapse": "Collapse queued messages",
   "session.followupDock.expand": "Expand queued messages",
   "session.revertDock.summary.one": "{{count}} rolled back message",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -749,6 +749,10 @@ export default function Page() {
     setActiveMessage,
     focusInput,
     review: reviewTab,
+    clearFollowupQueue: () => {
+      const id = params.id
+      if (id) clearFollowupQueue(id)
+    },
   })
 
   const openReviewFile = createOpenReviewFile({
@@ -1338,6 +1342,13 @@ export default function Page() {
           .catch(() => {})
       : Promise.resolve()
 
+  const clearFollowupQueue = (sessionID: string) => {
+    setFollowup("items", sessionID, [])
+    setFollowup("failed", sessionID, undefined)
+    setFollowup("paused", sessionID, undefined)
+    setFollowup("edit", sessionID, undefined)
+  }
+
   const revertMutation = useMutation(() => ({
     mutationFn: async (input: { sessionID: string; messageID: string }) => {
       const prev = prompt.current().slice()
@@ -1346,6 +1357,7 @@ export default function Page() {
       batch(() => {
         roll(input.sessionID, { messageID: input.messageID })
         prompt.set(value)
+        clearFollowupQueue(input.sessionID)
       })
       await halt(input.sessionID)
         .then(() => sdk().client.session.revert(input))
@@ -1392,6 +1404,7 @@ export default function Page() {
       await task
         .then((result) => {
           if (result.data) merge(result.data)
+          clearFollowupQueue(sessionID)
         })
         .catch((err) => {
           batch(() => {
@@ -1546,6 +1559,12 @@ export default function Page() {
               },
               onSend: (id) => {
                 void sendFollowup(params.id!, id, { manual: true })
+              },
+              onRemove: (id) => {
+                const sessionID = params.id
+                if (!sessionID) return
+                setFollowup("items", sessionID, (items) => (items ?? []).filter((entry) => entry.id !== id))
+                setFollowup("failed", sessionID, (value) => (value === id ? undefined : value))
               },
               onEdit: editFollowup,
               onEditLoaded: clearFollowupEdit,

--- a/packages/app/src/pages/session/composer/session-composer-region.tsx
+++ b/packages/app/src/pages/session/composer/session-composer-region.tsx
@@ -49,6 +49,7 @@ export function SessionComposerRegion(props: {
     onQueue: (draft: FollowupDraft) => void
     onAbort: () => void
     onSend: (id: string) => void
+    onRemove: (id: string) => void
     onEdit: (id: string) => void
     onEditLoaded: () => void
   }
@@ -331,6 +332,7 @@ export function SessionComposerRegion(props: {
                   items={props.followup!.items}
                   sending={props.followup!.sending}
                   onSend={props.followup!.onSend}
+                  onRemove={props.followup!.onRemove}
                   onEdit={props.followup!.onEdit}
                 />
               </Show>

--- a/packages/app/src/pages/session/composer/session-followup-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-followup-dock.tsx
@@ -9,6 +9,7 @@ export function SessionFollowupDock(props: {
   items: { id: string; text: string }[]
   sending?: string
   onSend: (id: string) => void
+  onRemove: (id: string) => void
   onEdit: (id: string) => void
 }) {
   const language = useLanguage()
@@ -98,6 +99,15 @@ export function SessionFollowupDock(props: {
                   onClick={() => props.onEdit(item.id)}
                 >
                   {language.t("session.followupDock.edit")}
+                </Button>
+                <Button
+                  size="small"
+                  variant="ghost"
+                  class="shrink-0 text-text-weak hover:text-danger-base"
+                  disabled={!!props.sending}
+                  onClick={() => props.onRemove(item.id)}
+                >
+                  {language.t("session.followupDock.remove")}
                 </Button>
               </div>
             )}

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -26,6 +26,7 @@ export type SessionCommandContext = {
   setActiveMessage: (message: UserMessage | undefined) => void
   focusInput: () => void
   review?: () => boolean
+  clearFollowupQueue: () => void
 }
 
 const withCategory = (category: string) => {
@@ -297,6 +298,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     if (!message) return
 
     await sdk().client.session.revert({ sessionID, messageID: message.id })
+    actions.clearFollowupQueue()
     const parts = sync().data.part[message.id]
     if (parts) {
       const restored = extractPromptFromParts(parts, { directory: sdk().directory })
@@ -317,6 +319,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     const next = userMessages().find((x) => x.id > revertMessageID)
     if (!next) {
       await sdk().client.session.unrevert({ sessionID })
+      actions.clearFollowupQueue()
       prompt.reset()
       const last = findLast(userMessages(), (x) => x.id >= revertMessageID)
       setActiveMessage(last)
@@ -324,6 +327,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     }
 
     await sdk().client.session.revert({ sessionID, messageID: next.id })
+    actions.clearFollowupQueue()
     const prev = findLast(userMessages(), (x) => x.id < next.id)
     setActiveMessage(prev)
   }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -95,6 +95,10 @@ export class Info extends Schema.Class<Info>("Config.Info")({
   instructions: Schema.String.pipe(Schema.Array, Schema.optional).annotate({
     description: "Additional paths or URLs supplying ambient instructions",
   }),
+  instruction_mode: Schema.Literals(["default", "explicit"]).pipe(Schema.optional).annotate({
+    description:
+      "Controls instruction discovery. 'default' auto-discovers AGENTS.md files. 'explicit' only loads instructions listed in the 'instructions' field.",
+  }),
   references: ConfigReference.Info.pipe(Schema.optional).annotate({
     description: "Named local directories or Git repositories available as external context",
   }),

--- a/packages/core/src/instruction-context.ts
+++ b/packages/core/src/instruction-context.ts
@@ -2,6 +2,7 @@ export * as InstructionContext from "./instruction-context"
 
 import { Array, Effect, Layer, Schema } from "effect"
 import { isAbsolute, join, relative, sep } from "path"
+import { Config } from "./config"
 import { FSUtil } from "./fs-util"
 import { Flag } from "./flag/flag"
 import { Global } from "./global"
@@ -24,6 +25,7 @@ export const layer = Layer.effectDiscard(
     const global = yield* Global.Service
     const location = yield* Location.Service
     const registry = yield* SystemContextRegistry.Service
+    const config = yield* Config.Service
 
     const source = (value: ReadonlyArray<File> | SystemContext.Unavailable) =>
       SystemContext.make({
@@ -37,6 +39,11 @@ export const layer = Layer.effectDiscard(
       })
 
     const observe = Effect.fn("InstructionContext.observe")(function* () {
+      const entries = yield* config.entries()
+      const instructionMode = Config.latest(entries, "instruction_mode")
+
+      if (instructionMode === "explicit") return []
+
       const start = FSUtil.resolve(location.directory)
       const stop = FSUtil.resolve(location.project.directory)
       const fromProject = relative(stop, start)

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -118,6 +118,10 @@ export const Info = Schema.Struct({
     description:
       "Enable or configure LSP servers. Omit or set to false to disable, true to enable built-ins, or an object to enable built-ins with overrides.",
   }),
+  instructionMode: Schema.optional(Schema.Literals(["default", "explicit"])).annotate({
+    description:
+      "Controls instruction discovery. 'default' auto-discovers AGENTS.md files from project and global config. 'explicit' only loads instructions listed in the 'instructions' field.",
+  }),
   instructions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Additional instruction files or patterns to include",
   }),

--- a/packages/core/src/v1/config/migrate.ts
+++ b/packages/core/src/v1/config/migrate.ts
@@ -63,6 +63,7 @@ export function migrate(info: typeof ConfigV1.Info.Type) {
     skills: info.skills && [...(info.skills.paths ?? []), ...(info.skills.urls ?? [])],
     commands: info.command,
     instructions: info.instructions,
+    instruction_mode: info.instructionMode,
     references: info.references ?? info.reference,
     plugins: info.plugin?.map((plugin) =>
       typeof plugin === "string" ? plugin : { package: plugin[0], options: plugin[1] },

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -112,22 +112,24 @@ export const layer: Layer.Layer<
       const ctx = yield* InstanceState.context
       const paths = new Set<string>()
 
-      for (const file of globalFiles) {
-        if (yield* fs.existsSafe(file)) {
-          paths.add(path.resolve(file))
-          break
-        }
-      }
-
-      // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
-      if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
-        for (const file of instructionFiles) {
-          const matches = yield* fs
-            .findUp(file, ctx.directory, ctx.worktree)
-            .pipe(Effect.catch(() => Effect.succeed([])))
-          if (matches.length > 0) {
-            matches.forEach((item) => paths.add(path.resolve(item)))
+      if (config.instructionMode !== "explicit") {
+        for (const file of globalFiles) {
+          if (yield* fs.existsSafe(file)) {
+            paths.add(path.resolve(file))
             break
+          }
+        }
+
+        // The first project-level match wins so we don't stack AGENTS.md/CLAUDE.md from every ancestor.
+        if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
+          for (const file of instructionFiles) {
+            const matches = yield* fs
+              .findUp(file, ctx.directory, ctx.worktree)
+              .pipe(Effect.catch(() => Effect.succeed([])))
+            if (matches.length > 0) {
+              matches.forEach((item) => paths.add(path.resolve(item)))
+              break
+            }
           }
         }
       }


### PR DESCRIPTION
Queued messages in the followup dock stayed after session revert/undo because the followup queue was never cleared when revert happened. Also added a 'Remove' button to each queued message so users can individually cancel a queued message without editing it.