### PR TITLE
feat(app): add open session deep links

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -79,6 +79,7 @@ import {
 import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
+  collectOpenSessionDeepLinks,
   deepLinkEvent,
   drainPendingDeepLinks,
 } from "./layout/deep-links"
@@ -1378,6 +1379,11 @@ export default function LegacyLayout(props: ParentProps) {
       }
       const href = link.prompt ? `/${slug}/session?prompt=${encodeURIComponent(link.prompt)}` : `/${slug}/session`
       navigateWithSidebarReset(href)
+    }
+
+    for (const link of collectOpenSessionDeepLinks(urls)) {
+      void openProject(link.directory, false)
+      navigateWithSidebarReset(`/${base64Encode(link.directory)}/session/${link.session}`)
     }
   }
 

--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -30,11 +30,25 @@ export const parseNewSessionDeepLink = (input: string) => {
   return { directory, prompt }
 }
 
+export const parseOpenSessionDeepLink = (input: string) => {
+  const url = parseUrl(input)
+  if (!url) return
+  if (url.hostname !== "open-session") return
+  const directory = url.searchParams.get("directory")
+  if (!directory) return
+  const session = url.searchParams.get("session")
+  if (!session) return
+  return { directory, session }
+}
+
 export const collectOpenProjectDeepLinks = (urls: string[]) =>
   urls.map(parseDeepLink).filter((directory): directory is string => !!directory)
 
 export const collectNewSessionDeepLinks = (urls: string[]) =>
   urls.map(parseNewSessionDeepLink).filter((link): link is { directory: string; prompt?: string } => !!link)
+
+export const collectOpenSessionDeepLinks = (urls: string[]) =>
+  urls.map(parseOpenSessionDeepLink).filter((link): link is { directory: string; session: string } => !!link)
 
 type OpenCodeWindow = Window & {
   __OPENCODE__?: {

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test"
 import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
+  collectOpenSessionDeepLinks,
   drainPendingDeepLinks,
   parseDeepLink,
   parseNewSessionDeepLink,
+  parseOpenSessionDeepLink,
 } from "./deep-links"
 import { type Session } from "@opencode-ai/sdk/v2/client"
 import {
@@ -96,6 +98,27 @@ describe("layout deep links", () => {
       "opencode://new-session?directory=/c&prompt=ship%20it",
     ])
     expect(result).toEqual([{ directory: "/a" }, { directory: "/c", prompt: "ship it" }])
+  })
+
+  test("parses open-session deep links", () => {
+    expect(parseOpenSessionDeepLink("opencode://open-session?directory=/tmp/demo&session=ses_123")).toEqual({
+      directory: "/tmp/demo",
+      session: "ses_123",
+    })
+    expect(parseOpenSessionDeepLink("opencode://open-session?directory=/tmp/demo")).toBeUndefined()
+    expect(parseOpenSessionDeepLink("opencode://open-session?session=ses_123")).toBeUndefined()
+  })
+
+  test("collects only valid open-session deep links", () => {
+    const result = collectOpenSessionDeepLinks([
+      "opencode://open-session?directory=/a&session=ses_a",
+      "opencode://open-project?directory=/b",
+      "opencode://open-session?directory=/c&session=ses_c",
+    ])
+    expect(result).toEqual([
+      { directory: "/a", session: "ses_a" },
+      { directory: "/c", session: "ses_c" },
+    ])
   })
 
   test("drains global deep links once", () => {


### PR DESCRIPTION
## Context

Automation and launcher workflows need a stable way to open OpenCode Desktop directly on the right existing session. Today deep links can open a project or start a new session, but tools that already know the session ID still have to fall back to browser routes or manual CLI handoff.

## What changed

Adds support for `opencode://open-session?directory=<dir>&session=<id>` in the app deep-link parser. When Desktop receives this URL on a local server, it opens the project context and navigates directly to the requested session. Parser coverage now includes valid and invalid `open-session` links.