### PR TITLE
chore(github-copilot): restore stream chunk type safety

### DIFF
--- a/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
@@ -58,7 +58,7 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
   readonly modelId: OpenAICompatibleChatModelId
   private readonly config: OpenAICompatibleChatConfig
   private readonly failedResponseHandler: ResponseHandler<APICallError>
-  private readonly chunkSchema // type inferred via constructor
+  private readonly chunkSchema: z.ZodType<OpenAICompatibleChatChunk | { error: { message: string } }>
 
   constructor(modelId: OpenAICompatibleChatModelId, config: OpenAICompatibleChatConfig) {
     this.modelId = modelId
@@ -378,12 +378,11 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
     return {
       stream: response.pipeThrough(
-        new TransformStream<ParseResult<z.infer<typeof this.chunkSchema>>, LanguageModelV3StreamPart>({
+        new TransformStream<ParseResult<OpenAICompatibleChatChunk | { error: { message: string } }>, LanguageModelV3StreamPart>({
           start(controller) {
             controller.enqueue({ type: "stream-start", warnings })
           },
 
-          // TODO we lost type safety on Chunk, most likely due to the error schema. MUST FIX
           transform(chunk, controller) {
             // Emit raw chunk if requested (before anything else)
             if (options.includeRawChunks) {
@@ -775,41 +774,44 @@ const OpenAICompatibleChatResponseSchema = z.object({
   usage: openaiCompatibleTokenUsageSchema,
 })
 
+const openAICompatibleChatChunkSchema = z.object({
+  id: z.string().nullish(),
+  created: z.number().nullish(),
+  model: z.string().nullish(),
+  choices: z.array(
+    z.object({
+      delta: z
+        .object({
+          role: z.enum(["assistant"]).nullish(),
+          content: z.string().nullish(),
+          // Copilot-specific reasoning fields
+          reasoning_text: z.string().nullish(),
+          reasoning_opaque: z.string().nullish(),
+          tool_calls: z
+            .array(
+              z.object({
+                index: z.number(),
+                id: z.string().nullish(),
+                function: z.object({
+                  name: z.string().nullish(),
+                  arguments: z.string().nullish(),
+                }),
+              }),
+            )
+            .nullish(),
+        })
+        .nullish(),
+      finish_reason: z.string().nullish(),
+    }),
+  ),
+  usage: openaiCompatibleTokenUsageSchema,
+})
+
+type OpenAICompatibleChatChunk = z.infer<typeof openAICompatibleChatChunkSchema>
+
 // limited version of the schema, focussed on what is needed for the implementation
 // this approach limits breakages when the API changes and increases efficiency
-const createOpenAICompatibleChatChunkSchema = <ERROR_SCHEMA extends z.core.$ZodType>(errorSchema: ERROR_SCHEMA) =>
-  z.union([
-    z.object({
-      id: z.string().nullish(),
-      created: z.number().nullish(),
-      model: z.string().nullish(),
-      choices: z.array(
-        z.object({
-          delta: z
-            .object({
-              role: z.enum(["assistant"]).nullish(),
-              content: z.string().nullish(),
-              // Copilot-specific reasoning fields
-              reasoning_text: z.string().nullish(),
-              reasoning_opaque: z.string().nullish(),
-              tool_calls: z
-                .array(
-                  z.object({
-                    index: z.number(),
-                    id: z.string().nullish(),
-                    function: z.object({
-                      name: z.string().nullish(),
-                      arguments: z.string().nullish(),
-                    }),
-                  }),
-                )
-                .nullish(),
-            })
-            .nullish(),
-          finish_reason: z.string().nullish(),
-        }),
-      ),
-      usage: openaiCompatibleTokenUsageSchema,
-    }),
-    errorSchema,
-  ])
+const createOpenAICompatibleChatChunkSchema = (errorSchema: z.ZodType) =>
+  z.union([openAICompatibleChatChunkSchema, errorSchema]) as z.ZodType<
+    OpenAICompatibleChatChunk | { error: { message: string } }
+  >


### PR DESCRIPTION
### Issue for this PR

Closes #33093

### Type of change

- [x] Bug fix

### What does this PR do?

Restores TypeScript type safety on the chunk stream transform callback in `OpenAICompatibleChatLanguageModel.doStream()`.

`ProviderErrorStructure<any>` passes `ZodType<any>` as the error schema to the generic `createOpenAICompatibleChatChunkSchema`. The generic infers `any`, so `z.union([successSchema, ZodType<any>])` collapses output to `any`. This propagates through `z.infer<typeof chunkSchema>` to the TransformStream's `ParseResult<any>`, leaving all `chunk.value` accesses (choices, usage, delta, etc.) untyped.

Fix: extract the success chunk schema into a named const, derive a concrete type, and use a non-generic version of the chunk schema builder with an explicit cast. This preserves runtime validation (error schema still participates in the union) while giving TypeScript a proper type for narrowing.

### How did you verify your code works?

- `bun typecheck` — zero new errors
- `bun test --filter copilot-chat-model` — 11/11 pass
- Runtime behavior unchanged: error schema still validates error chunks in the union

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
