### PR TITLE
fix(opencode): resolve MCP prompts with real arguments, not $N placeholders

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -1,6 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceState } from "@/effect/instance-state"
-import { EffectBridge } from "@/effect/bridge"
 import type { InstanceContext } from "@/project/instance-context"
 import { SessionID, MessageID } from "@/session/schema"
 import { Effect, Layer, Context, Schema } from "effect"
@@ -11,8 +10,15 @@ import { EventV2 } from "@opencode-ai/core/event"
 import PROMPT_INITIALIZE from "./template/initialize.txt"
 import PROMPT_REVIEW from "./template/review.txt"
 
+type McpPromptInfo = {
+  client: string
+  name: string
+  arguments: string[]
+}
+
 type State = {
   commands: Record<string, Info>
+  mcpPrompts: Record<string, McpPromptInfo>
 }
 
 export const Event = {
@@ -59,6 +65,7 @@ export const Default = {
 export interface Interface {
   readonly get: (name: string) => Effect.Effect<Info | undefined>
   readonly list: () => Effect.Effect<Info[]>
+  readonly template: (name: string, args: string[]) => Effect.Effect<string>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Command") {}
@@ -72,8 +79,8 @@ export const layer = Layer.effect(
 
     const init = Effect.fn("Command.state")(function* (ctx: InstanceContext) {
       const cfg = yield* config.get()
-      const bridge = yield* EffectBridge.make()
       const commands: Record<string, Info> = {}
+      const mcpPrompts: Record<string, McpPromptInfo> = {}
 
       commands[Default.INIT] = {
         name: Default.INIT,
@@ -111,32 +118,20 @@ export const layer = Layer.effect(
       }
 
       for (const [name, prompt] of Object.entries(yield* mcp.prompts())) {
+        const argNames = prompt.arguments?.map((argument) => argument.name) ?? []
         commands[name] = {
           name,
           source: "mcp",
           description: prompt.description,
+          // Resolved at invocation time (SessionPrompt.command) by calling
+          // getPrompt with the user-provided arguments. Doing it here would send
+          // literal $N placeholders to prompts/get, failing type validation.
           get template() {
-            return bridge.promise(
-              mcp
-                .getPrompt(
-                  prompt.client,
-                  prompt.name,
-                  prompt.arguments
-                    ? Object.fromEntries(prompt.arguments.map((argument, i) => [argument.name, `$${i + 1}`]))
-                    : {},
-                )
-                .pipe(
-                  Effect.map(
-                    (template) =>
-                      template?.messages
-                        .map((message) => (message.content.type === "text" ? message.content.text : ""))
-                        .join("\n") || "",
-                  ),
-                ),
-            )
+            return ""
           },
-          hints: prompt.arguments?.map((_, i) => `$${i + 1}`) ?? [],
+          hints: argNames.map((_, i) => `$${i + 1}`),
         }
+        mcpPrompts[name] = { client: prompt.client, name: prompt.name, arguments: argNames }
       }
 
       for (const item of yield* skill.all()) {
@@ -154,6 +149,7 @@ export const layer = Layer.effect(
 
       return {
         commands,
+        mcpPrompts,
       }
     })
 
@@ -169,7 +165,25 @@ export const layer = Layer.effect(
       return Object.values(s.commands)
     })
 
-    return Service.of({ get, list })
+    const template = Effect.fn("Command.template")(function* (name: string, args: string[]) {
+      const s = yield* InstanceState.get(state)
+      const mcpPrompt = s.mcpPrompts[name]
+      if (mcpPrompt) {
+        const argumentsMap = Object.fromEntries(
+          mcpPrompt.arguments.slice(0, args.length).map((argName, i) => [argName, args[i]] as const),
+        )
+        const result = yield* mcp.getPrompt(mcpPrompt.client, mcpPrompt.name, argumentsMap)
+        return (
+          result?.messages
+            .map((message) => (message.content.type === "text" ? message.content.text : ""))
+            .join("\n") ?? ""
+        )
+      }
+      const cmd = s.commands[name]
+      return cmd ? yield* Effect.promise(async () => cmd.template) : ""
+    })
+
+    return Service.of({ get, list, template })
   }),
 )
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1467,7 +1467,8 @@ export const layer = Layer.effect(
 
       const raw = input.arguments.match(argsRegex) ?? []
       const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
-      const templateCommand = yield* Effect.promise(async () => cmd.template)
+
+      const templateCommand = yield* commands.template(input.command, args)
 
       const placeholders = templateCommand.match(placeholderRegex) ?? []
       let last = 0
@@ -1486,7 +1487,7 @@ export const layer = Layer.effect(
       const usesArgumentsPlaceholder = templateCommand.includes("$ARGUMENTS")
       let template = withArgs.replaceAll("$ARGUMENTS", input.arguments)
 
-      if (placeholders.length === 0 && !usesArgumentsPlaceholder && input.arguments.trim()) {
+      if (placeholders.length === 0 && !usesArgumentsPlaceholder && input.arguments.trim() && cmd.source !== "mcp") {
         template = template + "\n\n" + input.arguments
       }
 


### PR DESCRIPTION
### Issue for this PR

Closes #33564

### Type of change

- [x] Bug fix

### What does this PR do?

MCP prompt commands sent literal `$1`/`$2` strings as argument values to `prompts/get` when registering commands. Servers that validate argument types (e.g. `precision: int`) rejected them, logging `failed to getPrompt` at startup and leaving the command with an empty template.

Since `listPrompts` argument metadata has no type info, a type-correct placeholder can't be synthesized. Instead, resolve MCP prompt templates at invocation: store prompt metadata in `Command.state` and add `Command.template(name, args)`, which calls `getPrompt` with the user's real positional arguments (servers coerce numeric strings). Non-MCP commands are unchanged.

### How did you verify your code works?

- oxlint clean on both changed files
- types verified against the codebase (`noUncheckedIndexedAccess` is off, so `args[i]` is `string`)
- repro: a typed-arg MCP prompt (e.g. `precision: int`) no longer logs `$2`/`$1` conversion errors at startup; invoking it with real args renders the prompt server-side

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR