### PR TITLE
fix(opencode): deny bash in plan mode

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -173,6 +173,7 @@ export const layer = Layer.effect(
                   [path.join(".opencode", "plans", "*.md")]: "allow",
                   [path.relative(ctx.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
                 },
+                bash: "deny",
               }),
               user,
             ),


### PR DESCRIPTION
### Issue for this PR

Closes #33526

### Type of change

- [x] Bug fix

### What does this PR do?

Plan mode is supposed to be read-only. `plan-mode.txt` states the agent "MUST NOT ... run any non-readonly tools (including changing configs or making commits)". But the `plan` agent's permission only denies `edit` and `task.general`; it inherits `defaults` (`"*": "allow"`) for everything else, so `bash` stays allowed. That lets the model run write commands like `git add` / `git commit` directly while planning — the behavior reported in #33526.

This adds `bash: "deny"` to the `plan` agent's permission. Exploration still works because it goes through the `explore` subagent, which carries its own `bash: "allow"`. The plan agent keeps its read-only tools (`read`, `grep`, `glob`, `list`, `webfetch`, `websearch`), plan-file editing, `question`, `plan_exit`, and `task` (subagents).

### How did you verify your code works?

- `bun typecheck` in `packages/opencode` passes.
- Confirmed `bash` is the permission key the shell tool uses (`packages/opencode/src/tool/shell/id.ts`, kept as `"bash"` for compatibility) and that permission resolution uses last-match (`evaluate` via `findLast` over the merged ruleset), so the plan agent's `bash: "deny"` — declared after `defaults` — wins over `defaults`'s `"*": "allow"`.
- Behaviorally, the plan agent can no longer execute `bash`; the `explore` subagent it dispatches still can, and the default `build` agent is unaffected.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR