### PR TITLE
fix(session): handle type validation errors gracefully

### DIFF
--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -262,6 +262,13 @@ export function toLLMEvents(
       })
 
     case "error":
+      if (event.error instanceof Error && event.error.name === "AI_TypeValidationError") {
+        return Effect.succeed([
+          LLMEvent.providerError({
+            message: `Provider returned an invalid response format: ${errorMessage(event.error)}`,
+          }),
+        ])
+      }
       return Effect.fail(event.error)
 
     case "abort":

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -671,7 +671,9 @@ export const layer = Layer.effect(
           }
 
           case "provider-error":
-            throw new Error(value.message)
+            if (value.retryable === true) throw new Error(value.message)
+            yield* halt(new Error(value.message))
+            return
 
           case "step-start":
             if (!ctx.snapshot) ctx.snapshot = yield* snapshot.track()


### PR DESCRIPTION
### Issue for this PR

Closes #31324

### Type of change

- [x] Bug fix

### What does this PR do?

When the AI SDK receives a non-standard response chunk (e.g. from MCP-related tool calls), it emits a `TypeValidationError` (`name: "AI_TypeValidationError"`). The previous code called `Effect.fail(event.error)` which crashed the stream, leaving the assistant message in a broken state.

Two changes:

1. **`ai-sdk.ts`**: `TypeValidationError` errors are now converted to `LLMEvent.providerError` events instead of failing the stream. Other error types (e.g. `APICallError`) still use `Effect.fail` so retry/classification logic is unaffected.

2. **`processor.ts`**: The `provider-error` handler now checks the `retryable` flag. Retryable errors still throw to trigger the retry policy. Non-retryable errors call `halt()` which flushes partial fragments, sets the error on the assistant message, publishes the error event, and sets session status to idle — the same graceful shutdown path used for other terminal errors.

### How did you verify your code works?

- `bun typecheck` — passes
- `bun test test/session/` — 362 pass, 0 fail
- All 15 `processor-effect.test.ts` tests pass (including retry, context-overflow, and error-classification tests)
- All 26 `llm.test.ts` tests pass

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR