### PR TITLE
tui: fix multi-day duration formatting

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -53,8 +53,8 @@ export function duration(input: number) {
     const minutes = Math.floor((input % 3600000) / 60000)
     return `${hours}h ${minutes}m`
   }
-  const hours = Math.floor(input / 3600000)
-  const days = Math.floor((input % 3600000) / 86400000)
+  const days = Math.floor(input / 86400000)
+  const hours = Math.floor((input % 86400000) / 3600000)
   return `${days}d ${hours}h`
 }
 


### PR DESCRIPTION
Report elapsed days and remaining hours instead of showing zero days and
the total duration as hours.

Close #32957
Close #32956
