### PR TITLE
docs(cli): document missing env flags

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -679,6 +679,7 @@ OpenCode can be configured using environment variables.
 | Variable                              | Type    | Description                                       |
 | ------------------------------------- | ------- | ------------------------------------------------- |
 | `OPENCODE_AUTO_SHARE`                 | boolean | Automatically share sessions                      |
+| `OPENCODE_PURE`                       | boolean | Run without external plugins                      |
 | `OPENCODE_GIT_BASH_PATH`              | string  | Path to Git Bash executable on Windows            |
 | `OPENCODE_CONFIG`                     | string  | Path to config file                               |
 | `OPENCODE_TUI_CONFIG`                 | string  | Path to TUI config file                           |
@@ -689,6 +690,8 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_DISABLE_TERMINAL_TITLE`     | boolean | Disable automatic terminal title updates          |
 | `OPENCODE_PERMISSION`                 | string  | Inlined json permissions config                   |
 | `OPENCODE_DISABLE_DEFAULT_PLUGINS`    | boolean | Disable default plugins                           |
+| `OPENCODE_DISABLE_EMBEDDED_WEB_UI`    | boolean | Disable serving the embedded web UI               |
+| `OPENCODE_DISABLE_EXTERNAL_SKILLS`    | boolean | Disable loading external skills                   |
 | `OPENCODE_DISABLE_LSP_DOWNLOAD`       | boolean | Disable automatic LSP server downloads            |
 | `OPENCODE_ENABLE_EXPERIMENTAL_MODELS` | boolean | Enable experimental models                        |
 | `OPENCODE_DISABLE_AUTOCOMPACT`        | boolean | Disable automatic context compaction              |
@@ -700,6 +703,8 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
 | `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
 | `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
+| `OPENCODE_ENABLE_PARALLEL`            | boolean | Enable Parallel web search tools                  |
+| `OPENCODE_ENABLE_QUESTION_TOOL`       | boolean | Enable the question tool for non-default clients  |
 | `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
 | `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
 | `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |
@@ -724,9 +729,11 @@ These environment variables enable experimental features that may change or be r
 | `OPENCODE_EXPERIMENTAL_EXA`                     | boolean | Enable experimental Exa features        |
 | `OPENCODE_EXPERIMENTAL_LSP_TY`                  | boolean | Enable TY LSP for python files          |
 | `OPENCODE_EXPERIMENTAL_PLAN_MODE`               | boolean | Enable plan mode                        |
+| `OPENCODE_EXPERIMENTAL_REFERENCES`              | boolean | Enable project references               |
 | `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS`    | boolean | Enable background subagent tasks        |
 | `OPENCODE_EXPERIMENTAL_EVENT_SYSTEM`            | boolean | Enable experimental event system        |
 | `OPENCODE_EXPERIMENTAL_NATIVE_LLM`              | boolean | Enable native LLM request path          |
 | `OPENCODE_EXPERIMENTAL_PARALLEL`                | boolean | Enable parallel web search execution    |
 | `OPENCODE_EXPERIMENTAL_SCOUT`                   | boolean | Enable Scout subagent                   |
+| `OPENCODE_EXPERIMENTAL_WEBSOCKETS`              | boolean | Enable WebSocket auth transport         |
 | `OPENCODE_EXPERIMENTAL_WORKSPACES`              | boolean | Enable workspace support                |


### PR DESCRIPTION
### Issue for this PR

Refs #27707

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the RuntimeFlags environment variables that were missing from the English CLI docs environment variable table.

I compared `packages/opencode/src/effect/runtime-flags.ts` against `packages/web/src/content/docs/cli.mdx` and added the documented rows for the currently missing flags.

### How did you verify your code works?

From the repo root:

- `git diff --check`
- Ran a Node script comparing `OPENCODE_*` names in `runtime-flags.ts` against `packages/web/src/content/docs/cli.mdx`; it reports: `All 30 runtime flags are documented in packages/web/src/content/docs/cli.mdx`.

Attempted from `packages/web`:

- `bun run build` could not start locally because the existing install is missing the optional `@cloudflare/workerd-windows-64` package required by workerd.

### Screenshots / recordings

N/A - documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
