### PR TITLE
fix(cli): exit on broken pipes

### DIFF
--- a/packages/opencode/src/cli/broken-pipe.ts
+++ b/packages/opencode/src/cli/broken-pipe.ts
@@ -1,0 +1,35 @@
+type Exit = (code?: number | string | null | undefined) => never | void
+
+type ErrorLike = {
+  code?: unknown
+  errno?: unknown
+  cause?: unknown
+}
+
+export function isBrokenPipeError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+
+  const candidate = error as ErrorLike
+  if (candidate.code === "EPIPE" || candidate.errno === "EPIPE") return true
+  return isBrokenPipeError(candidate.cause)
+}
+
+export function exitOnBrokenPipe(error: unknown, exit: Exit = process.exit) {
+  if (!isBrokenPipeError(error)) return false
+  exit(1)
+  return true
+}
+
+export function installBrokenPipeHandler(exit: Exit = process.exit) {
+  const onError = (error: Error) => {
+    if (!exitOnBrokenPipe(error, exit)) throw error
+  }
+
+  process.stdout.on("error", onError)
+  process.stderr.on("error", onError)
+
+  return () => {
+    process.stdout.off("error", onError)
+    process.stderr.off("error", onError)
+  }
+}

--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -10,12 +10,19 @@ import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
+import { exitOnBrokenPipe, installBrokenPipeHandler } from "@/cli/broken-pipe"
 
 Heap.start()
 
-const onUnhandledRejection = (_error: unknown) => {}
+const uninstallBrokenPipeHandler = installBrokenPipeHandler()
 
-const onUncaughtException = (_error: Error) => {}
+const onUnhandledRejection = (error: unknown) => {
+  exitOnBrokenPipe(error)
+}
+
+const onUncaughtException = (error: Error) => {
+  exitOnBrokenPipe(error)
+}
 
 process.on("unhandledRejection", onUnhandledRejection)
 process.on("uncaughtException", onUncaughtException)
@@ -74,6 +81,7 @@ export const rpc = {
     if (server) await server.stop(true)
     process.off("unhandledRejection", onUnhandledRejection)
     process.off("uncaughtException", onUncaughtException)
+    uninstallBrokenPipeHandler()
   },
 }
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -29,8 +29,10 @@ import { DbCommand } from "./cli/cmd/db"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
+import { installBrokenPipeHandler } from "./cli/broken-pipe"
 
 const args = hideBin(process.argv)
+installBrokenPipeHandler()
 
 function show(out: string) {
   const text = out.trimStart()

--- a/packages/opencode/test/cli/broken-pipe.test.ts
+++ b/packages/opencode/test/cli/broken-pipe.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { exitOnBrokenPipe, isBrokenPipeError } from "../../src/cli/broken-pipe"
+
+describe("broken pipe handling", () => {
+  test("detects EPIPE errors", () => {
+    expect(isBrokenPipeError(Object.assign(new Error("broken pipe"), { code: "EPIPE" }))).toBe(true)
+    expect(isBrokenPipeError(Object.assign(new Error("broken pipe"), { errno: "EPIPE" }))).toBe(true)
+    expect(isBrokenPipeError(new Error("other"))).toBe(false)
+  })
+
+  test("detects EPIPE errors nested in causes", () => {
+    const cause = Object.assign(new Error("broken pipe"), { code: "EPIPE" })
+    expect(isBrokenPipeError(new Error("write failed", { cause }))).toBe(true)
+  })
+
+  test("exits only for broken pipe errors", () => {
+    const codes: unknown[] = []
+    const exit = (code?: number | string | null | undefined) => {
+      codes.push(code)
+    }
+
+    expect(exitOnBrokenPipe(new Error("other"), exit)).toBe(false)
+    expect(codes).toEqual([])
+
+    expect(exitOnBrokenPipe(Object.assign(new Error("broken pipe"), { code: "EPIPE" }), exit)).toBe(true)
+    expect(codes).toEqual([1])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33653

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode can keep running after stdout or stderr is closed by a parent process. When that broken pipe surfaces as an `EPIPE` stream error, the process should stop instead of continuing to retry writes.

This PR adds a small broken-pipe helper, installs it in the main CLI entrypoint for commands such as `opencode run --format json`, and reuses the same detection in the TUI worker handlers. The handler exits only for `EPIPE` errors; non-EPIPE stream errors are rethrown by the main stream listener so normal failures are not silently swallowed.

### How did you verify your code works?

- `bun test test/cli/broken-pipe.test.ts` from `packages/opencode`
- `bun test test/cli/run/run-process.test.ts` from `packages/opencode`
- `bun run typecheck` from `packages/opencode`
- `git diff --check` from the repo root

### Screenshots / recordings

Not applicable; this is CLI subprocess error handling.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
