### PR TITLE
fix(plugin): skip mismatched detected plugins

### DIFF
--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -290,6 +290,8 @@ export function readV1Plugin(
   if (tui !== undefined && typeof tui !== "function") {
     throw new TypeError(`Plugin ${spec} has invalid tui export`)
   }
+  if (mode === "detect" && kind === "server" && server === undefined) return
+  if (mode === "detect" && kind === "tui" && tui === undefined) return
   if (server !== undefined && tui !== undefined) {
     throw new TypeError(`Plugin ${spec} must default export either server() or tui(), not both`)
   }

--- a/packages/opencode/test/plugin/shared.test.ts
+++ b/packages/opencode/test/plugin/shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { parsePluginSpecifier } from "../../src/plugin/shared"
+import { parsePluginSpecifier, readV1Plugin } from "../../src/plugin/shared"
 
 describe("parsePluginSpecifier", () => {
   test("parses standard npm package without version", () => {
@@ -84,5 +84,23 @@ describe("parsePluginSpecifier", () => {
       pkg: "@opencode/acme",
       version: "latest",
     })
+  })
+})
+
+describe("readV1Plugin", () => {
+  test("skips plugins without the requested entrypoint in detect mode", () => {
+    const tuiOnly = { id: "demo.tui", tui: async () => {} }
+    const serverOnly = { id: "demo.server", server: async () => {} }
+
+    expect(readV1Plugin({ default: tuiOnly }, "demo-tui", "server", "detect")).toBeUndefined()
+    expect(readV1Plugin({ default: serverOnly }, "demo-server", "tui", "detect")).toBeUndefined()
+  })
+
+  test("still rejects missing entrypoints in strict mode", () => {
+    const tuiOnly = { id: "demo.tui", tui: async () => {} }
+
+    expect(() => readV1Plugin({ default: tuiOnly }, "demo-tui", "server")).toThrow(
+      "Plugin demo-tui must default export an object with server()",
+    )
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31610

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`readV1Plugin(..., "detect")` currently skips non-plugin modules, but it still throws when a plugin has only the opposite entrypoint. That makes a TUI-only plugin noisy when the server plugin loader probes it with `kind = "server"`.

This PR keeps strict mode unchanged, and keeps invalid present entrypoints as errors, but in detect mode returns `undefined` when the requested entrypoint is absent. That lets the caller skip mismatched plugins instead of logging a misleading load error.

### How did you verify your code works?

- `bun test test/plugin/shared.test.ts` from `packages/opencode`
- `bun run typecheck` from `packages/opencode`
- `git diff --check` from the repo root

### Screenshots / recordings

Not applicable; this is plugin loader behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
