### PR TITLE
fix(ui): guard session review diffs

### DIFF
--- a/packages/ui/src/components/session-review-diffs.ts
+++ b/packages/ui/src/components/session-review-diffs.ts
@@ -1,0 +1,26 @@
+import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
+import type { PreloadMultiFileDiffResult } from "@pierre/diffs/ssr"
+
+export type ReviewDiff = ((SnapshotFileDiff & { file: string }) | VcsFileDiff) & {
+  preloaded?: PreloadMultiFileDiffResult<any>
+}
+
+function diff(value: unknown): value is ReviewDiff {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  if (!("file" in value) || typeof value.file !== "string") return false
+  if (!("additions" in value) || typeof value.additions !== "number") return false
+  if (!("deletions" in value) || typeof value.deletions !== "number") return false
+  if ("patch" in value && value.patch !== undefined && typeof value.patch !== "string") return false
+  if ("before" in value && value.before !== undefined && typeof value.before !== "string") return false
+  if ("after" in value && value.after !== undefined && typeof value.after !== "string") return false
+  if (!("status" in value) || value.status === undefined) return true
+  return value.status === "added" || value.status === "deleted" || value.status === "modified"
+}
+
+export function listReviewDiffs(value: unknown): ReviewDiff[] {
+  if (Array.isArray(value) && value.every(diff)) return value
+  if (Array.isArray(value)) return value.filter(diff)
+  if (diff(value)) return [value]
+  if (!value || typeof value !== "object") return []
+  return Object.values(value).filter(diff)
+}

--- a/packages/ui/src/components/session-review.test.ts
+++ b/packages/ui/src/components/session-review.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import type { SnapshotFileDiff } from "@opencode-ai/sdk/v2"
+import { listReviewDiffs } from "./session-review-diffs"
+
+const diff = {
+  file: "src/app.ts",
+  patch: "@@ -1 +1 @@\n-old\n+new\n",
+  additions: 1,
+  deletions: 1,
+  status: "modified",
+} satisfies SnapshotFileDiff
+
+describe("listReviewDiffs", () => {
+  test("keeps valid arrays", () => {
+    expect(listReviewDiffs([diff])).toEqual([diff])
+  })
+
+  test("normalizes single and keyed diff payloads", () => {
+    expect(listReviewDiffs(diff)).toEqual([diff])
+    expect(listReviewDiffs({ app: diff })).toEqual([diff])
+  })
+
+  test("drops non-diff payloads", () => {
+    expect(listReviewDiffs(null)).toEqual([])
+    expect(listReviewDiffs({ diffs: "not an array" })).toEqual([])
+  })
+})

--- a/packages/ui/src/components/session-review.tsx
+++ b/packages/ui/src/components/session-review.tsx
@@ -15,7 +15,7 @@ import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
 import { checksum } from "@opencode-ai/core/util/encode"
 import { createEffect, createMemo, For, Match, onCleanup, Show, Switch, untrack, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
-import { type FileContent, type SnapshotFileDiff, type VcsFileDiff } from "@opencode-ai/sdk/v2"
+import { type FileContent } from "@opencode-ai/sdk/v2"
 import { PreloadMultiFileDiffResult } from "@pierre/diffs/ssr"
 import { type SelectedLineRange } from "@pierre/diffs"
 import { Dynamic } from "solid-js/web"
@@ -24,6 +24,7 @@ import { cloneSelectedLineRange, previewSelectedLines } from "../pierre/selectio
 import { createLineCommentController } from "./line-comment-annotations"
 import type { LineCommentEditorProps } from "./line-comment"
 import { normalize, text, type ViewDiff } from "./session-diff"
+import { listReviewDiffs } from "./session-review-diffs"
 
 const MAX_DIFF_CHANGED_LINES = 500
 const REVIEW_MOUNT_MARGIN = 300
@@ -62,33 +63,7 @@ export type SessionReviewCommentActions = {
 
 export type SessionReviewFocus = { file: string; id: string }
 
-type RawReviewDiff = (SnapshotFileDiff | VcsFileDiff) & {
-  preloaded?: PreloadMultiFileDiffResult<any>
-}
-type ReviewDiff = ((SnapshotFileDiff & { file: string }) | VcsFileDiff) & {
-  preloaded?: PreloadMultiFileDiffResult<any>
-}
 type Item = ViewDiff & { preloaded?: PreloadMultiFileDiffResult<any> }
-
-function diff(value: unknown): value is ReviewDiff {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false
-  if (!("file" in value) || typeof value.file !== "string") return false
-  if (!("additions" in value) || typeof value.additions !== "number") return false
-  if (!("deletions" in value) || typeof value.deletions !== "number") return false
-  if ("patch" in value && value.patch !== undefined && typeof value.patch !== "string") return false
-  if ("before" in value && value.before !== undefined && typeof value.before !== "string") return false
-  if ("after" in value && value.after !== undefined && typeof value.after !== "string") return false
-  if (!("status" in value) || value.status === undefined) return true
-  return value.status === "added" || value.status === "deleted" || value.status === "modified"
-}
-
-function list(value: unknown): ReviewDiff[] {
-  if (Array.isArray(value) && value.every(diff)) return value
-  if (Array.isArray(value)) return value.filter(diff)
-  if (diff(value)) return [value]
-  if (!value || typeof value !== "object") return []
-  return Object.values(value).filter(diff)
-}
 
 export interface SessionReviewProps {
   title?: JSX.Element
@@ -113,7 +88,7 @@ export interface SessionReviewProps {
   classList?: Record<string, boolean | undefined>
   classes?: { root?: string; header?: string; container?: string }
   actions?: JSX.Element
-  diffs: RawReviewDiff[]
+  diffs: unknown
   onViewFile?: (file: string) => void
   readFile?: (path: string) => Promise<FileContent | undefined>
   lineCommentMention?: LineCommentEditorProps["mention"]
@@ -182,10 +157,11 @@ export const SessionReview = (props: SessionReviewProps) => {
   const opened = () => store.opened
 
   const open = () => props.open ?? store.open
+  const reviewDiffs = createMemo(() => listReviewDiffs(props.diffs))
   const itemsMap = createMemo(() =>
-    Object.fromEntries(list(props.diffs).map((diff) => [diff.file, { ...normalize(diff), preloaded: diff.preloaded }])),
+    Object.fromEntries(reviewDiffs().map((diff) => [diff.file, { ...normalize(diff), preloaded: diff.preloaded }])),
   )
-  const files = createMemo(() => props.diffs.map((diff) => diff.file!))
+  const files = createMemo(() => reviewDiffs().map((diff) => diff.file))
   const grouped = createMemo(() => {
     const next = new Map<string, SessionReviewComment[]>()
     for (const comment of props.comments ?? []) {


### PR DESCRIPTION
### Issue for this PR

Closes #19268

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionReview` already had a local normalizer for diff-like payloads, but one path still called `props.diffs.map(...)` directly. If a stale or malformed session payload supplied `summary.diffs` as an object, null, or another non-array value, the review UI could crash before the normalizer helped.

This PR moves the review diff normalizer into a small pure module, uses it for both the diff map and file list, and widens the component prop to accept unknown runtime payloads defensively.

### How did you verify your code works?

- `bun test src/components/session-review.test.ts` from `packages/ui`
- `bun run typecheck` from `packages/ui`
- `bun run typecheck` from `packages/app`
- `git diff --check` from the repo root

### Screenshots / recordings

Not included; this is a defensive crash fix for malformed diff data.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
