### PR TITLE
fix(context): use input window for usage percent

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.boot.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.boot.ts
@@ -85,6 +85,14 @@ function runTuiConfig(config: Config | undefined): RunTuiConfig {
   }
 }
 
+function contextLimit(limit: { input?: number; context?: number } | undefined) {
+  const input = limit?.input
+  if (typeof input === "number" && input > 0) return input
+
+  const context = limit?.context
+  if (typeof context === "number" && context > 0) return context
+}
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -112,10 +120,8 @@ const layer = Layer.effect(
       const limits = Object.fromEntries(
         providers.flatMap((provider) =>
           Object.entries(provider.models ?? {}).flatMap(([modelID, info]) => {
-            const limit = info?.limit?.context
-            if (typeof limit !== "number" || limit <= 0) {
-              return []
-            }
+            const limit = contextLimit(info?.limit)
+            if (!limit) return []
 
             return [[`${provider.id}/${modelID}`, limit] as const]
           }),

--- a/packages/opencode/test/cli/run/runtime.boot.test.ts
+++ b/packages/opencode/test/cli/run/runtime.boot.test.ts
@@ -5,7 +5,13 @@ import { TuiConfig } from "@/config/tui"
 import { resolveDiffStyle, resolveModelInfo, resolveRunTuiConfig } from "@/cli/cmd/run/runtime.boot"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 
-function model(id: string, providerID: string, context: number, variants?: Record<string, Record<string, never>>) {
+function model(
+  id: string,
+  providerID: string,
+  context: number,
+  variants?: Record<string, Record<string, never>>,
+  input?: number,
+) {
   return {
     id,
     providerID,
@@ -46,6 +52,7 @@ function model(id: string, providerID: string, context: number, variants?: Recor
     },
     limit: {
       context,
+      ...(input === undefined ? {} : { input }),
       output: 8192,
     },
     status: "active" as const,
@@ -277,6 +284,43 @@ describe("run runtime boot", () => {
       limits: {
         "openai/gpt-5": 128000,
         "anthropic/sonnet": 200000,
+      },
+    })
+  })
+
+  test("uses input window for split-window model limits", async () => {
+    const sdk = new OpencodeClient()
+    const configured = {
+      providers: [
+        {
+          id: "openai",
+          name: "OpenAI",
+          source: "api" as const,
+          env: [],
+          options: {},
+          models: {
+            "gpt-5.5": model("gpt-5.5", "openai", 400_000, undefined, 272_000),
+            "gpt-4.1": model("gpt-4.1", "openai", 128_000),
+          },
+        },
+      ],
+      default: {},
+    }
+    spyOn(sdk.config, "providers").mockImplementation(() =>
+      Promise.resolve({
+        data: configured,
+        error: undefined,
+        request: new Request("https://opencode.test"),
+        response: new Response(),
+      }),
+    )
+
+    await expect(resolveModelInfo(sdk, "/workspace", { providerID: "openai", modelID: "gpt-5.5" })).resolves.toEqual({
+      providers: configured.providers,
+      variants: [],
+      limits: {
+        "openai/gpt-5.5": 272_000,
+        "openai/gpt-4.1": 128_000,
       },
     })
   })

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -56,6 +56,7 @@ import { useTuiConfig } from "../../config"
 import { usePromptWorkspace } from "./workspace"
 import { usePromptMove } from "./move"
 import { readLocalAttachment } from "./local-attachment"
+import { contextPercent } from "../../util/model"
 
 export type PromptProps = {
   sessionID?: string
@@ -268,10 +269,10 @@ export function Prompt(props: PromptProps) {
     if (tokens <= 0) return
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+    const pct = contextPercent(tokens, model)
     const cost = session?.cost ?? 0
     return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
+      context: pct === undefined ? Locale.number(tokens) : `${Locale.number(tokens)} (${pct}%)`,
       cost: cost > 0 ? money.format(cost) : undefined,
     }
   })

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
 import { createMemo } from "solid-js"
+import { contextPercent } from "../../util/model"
 
 const id = "internal:sidebar-context"
 
@@ -30,7 +31,7 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
     const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     return {
       tokens,
-      percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,
+      percent: contextPercent(tokens, model) ?? null,
     }
   })
 

--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "../../context/theme"
 import { SplitBorder } from "../../ui/border"
 import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import { Locale } from "../../util/locale"
+import { contextPercent } from "../../util/model"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 
@@ -40,7 +41,7 @@ export function SubagentFooter() {
     if (tokens <= 0) return
 
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
-    const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
+    const pct = contextPercent(tokens, model)
     const cost = session()?.cost ?? 0
 
     const money = new Intl.NumberFormat("en-US", {
@@ -49,7 +50,7 @@ export function SubagentFooter() {
     })
 
     return {
-      context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
+      context: pct === undefined ? Locale.number(tokens) : `${Locale.number(tokens)} (${pct}%)`,
       cost: cost > 0 ? money.format(cost) : undefined,
     }
   })

--- a/packages/tui/src/util/model.ts
+++ b/packages/tui/src/util/model.ts
@@ -1,4 +1,4 @@
-import type { Provider } from "@opencode-ai/sdk/v2"
+import type { Model, Provider } from "@opencode-ai/sdk/v2"
 
 export function parse(value: string) {
   const [providerID, ...modelID] = value.split("/")
@@ -25,4 +25,17 @@ export function name(
   modelID: string,
 ) {
   return get(list, providerID, modelID)?.name ?? modelID
+}
+
+export function contextLimit(model: Pick<Model, "limit"> | undefined) {
+  const input = model?.limit.input
+  if (typeof input === "number" && input > 0) return input
+
+  const context = model?.limit.context
+  if (typeof context === "number" && context > 0) return context
+}
+
+export function contextPercent(tokens: number, model: Pick<Model, "limit"> | undefined) {
+  const limit = contextLimit(model)
+  return limit ? Math.round((tokens / limit) * 100) : undefined
 }

--- a/packages/tui/test/util/model.test.ts
+++ b/packages/tui/test/util/model.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "bun:test"
-import { parse } from "../../src/util/model"
+import { contextLimit, contextPercent, parse } from "../../src/util/model"
 
 describe("util.model", () => {
   test("splits provider from a nested model identifier", () => {
     expect(parse("provider/org/model")).toEqual({ providerID: "provider", modelID: "org/model" })
     expect(parse("invalid")).toEqual({ providerID: "invalid", modelID: "" })
+  })
+
+  test("uses the input limit when present for context display", () => {
+    const splitWindow = { limit: { context: 400_000, input: 272_000, output: 128_000 } }
+    const sharedWindow = { limit: { context: 200_000, output: 8_192 } }
+
+    expect(contextLimit(splitWindow)).toBe(272_000)
+    expect(contextPercent(270_000, splitWindow)).toBe(99)
+    expect(contextLimit(sharedWindow)).toBe(200_000)
+    expect(contextPercent(100_000, sharedWindow)).toBe(50)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #32119

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Context usage displays were dividing by `model.limit.context`. For split-window models, `limit.context` includes both input and output windows, while prompt-fill pressure should use the input window when `model.limit.input` is present.

This PR adds a TUI helper that prefers a positive `limit.input` and falls back to `limit.context`, then uses it in the prompt footer, sidebar context plugin, and subagent footer. It also makes the direct `opencode run` footer limit map use the same effective context limit.

### How did you verify your code works?

- `bun test test/util/model.test.ts` from `packages/tui`
- `bun test test/cli/run/runtime.boot.test.ts` from `packages/opencode`
- `bun run typecheck` from `packages/tui`
- `bun run typecheck` from `packages/opencode`
- `git diff --check` from the repo root

### Screenshots / recordings

Not included; this is display denominator logic covered by unit tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
