### PR TITLE
fix(session): classify context overflow from generic errors before unknown fallback

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -34,6 +34,7 @@ import { MessageTable, PartTable, SessionTable } from "@opencode-ai/core/session
 import { ProviderError } from "@/provider/error"
 import { iife } from "@/util/iife"
 import { errorMessage } from "@/util/error"
+import { isContextOverflow } from "@opencode-ai/llm"
 import { isMedia } from "@/util/media"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
@@ -713,8 +714,16 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
-    case e instanceof Error:
-      return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
+    case e instanceof Error: {
+      const msg = errorMessage(e)
+      if (isContextOverflow(msg)) {
+        return new ContextOverflowError(
+          { message: msg, responseBody: msg },
+          { cause: e },
+        ).toObject()
+      }
+      return new NamedError.Unknown({ message: msg }, { cause: e }).toObject()
+    }
     default:
       try {
         const parsed = ProviderError.parseStreamError(e)

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1487,6 +1487,28 @@ describe("session.message-v2.fromError", () => {
     expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(true)
   })
 
+  test("detects context overflow from generic Error messages", () => {
+    const cases = [
+      "prompt is too long: 213462 tokens > 200000 maximum",
+      "Your input exceeds the context window of this model",
+      "The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)",
+      "Please reduce the length of the messages or completion",
+      "This model's maximum context length is 8192 tokens",
+    ]
+
+    cases.forEach((message) => {
+      const error = new Error(message)
+      const result = MessageV2.fromError(error, { providerID })
+      expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(true)
+    })
+  })
+
+  test("does not classify generic non-overflow Error as context overflow", () => {
+    const result = MessageV2.fromError(new Error("Network connection lost."), { providerID })
+    expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(false)
+    expect(result.name).toBe("UnknownError")
+  })
+
   test("does not classify 429 no body as context overflow", () => {
     const result = MessageV2.fromError(
       new APICallError({


### PR DESCRIPTION
### Issue for this PR

Closes #33376

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a provider returns a context-length error wrapped in a generic `Error` (not an `APICallError`), `fromError()` in `message-v2.ts` classifies it as `UnknownError` instead of `ContextOverflowError`. This means the processor never triggers auto-compaction — the session dies with "Network connection lost." and no recovery is possible.

The root cause is the `case e instanceof Error:` branch in `fromError()` — it returns `NamedError.Unknown` without checking whether the error message indicates context overflow. The `default` branch does call `ProviderError.parseStreamError()` which can detect overflow, but generic `Error` instances never reach it.

This PR adds an `isContextOverflow(msg)` check before the unknown fallback. `isContextOverflow` already exists in `@opencode-ai/llm` with 18+ patterns covering messages from OpenAI, Anthropic, Bedrock, and others — so any provider whose overflow error lands as a plain `Error` now gets correctly classified, and the processor sets `needsCompaction = true` instead of killing the session.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` — passes
- `bun test test/session/message-v2.test.ts --test-name-pattern "fromError"` — 12/12 pass
- Added two new tests:
  - "detects context overflow from generic Error messages" — 5 real-world overflow strings all classify as `ContextOverflowError`
  - "does not classify generic non-overflow Error as context overflow" — `"Network connection lost."` still classifies as `UnknownError`

### Screenshots / recordings

N/A — logic change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
