### PR TITLE
fix(app): navigate to selected directory instead of project root when opening sandbox

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1348,7 +1348,7 @@ export default function LegacyLayout(props: ParentProps) {
       return
     }
 
-    navigateWithSidebarReset(`/${base64Encode(root)}/session`)
+    navigateWithSidebarReset(`/${base64Encode(directory)}/session`)
   }
 
   function navigateToSession(session: Session | undefined) {


### PR DESCRIPTION
### Description

When a user opens a directory that belongs to an existing project as a sandbox (e.g., a copied repo with the same git root hash), the app navigates to the project's primary worktree instead of the user-selected directory.

This happens because `navigateToProject` always navigates to `root` (the project's worktree from `projectRoot()`) rather than the `directory` parameter that was passed in.

### Root Cause

- Two separate git repos (e.g. `MCP-FRAMEWORKS` and `MCP-FRAMEWORKS_copy`) share the same git root hash
- `ProjectV2.resolve` generates the same project ID for both
- `Project.fromDirectory` preserves the existing worktree and adds the new directory as a sandbox
- `projectRoot()` returns the project worktree, not the sandbox path
- `navigateToProject` used the worktree as the final navigation target

### Fix

Changed the final navigation fallback in `navigateToProject` from `root` (project worktree) to `directory` (the user's actual selected directory). Existing session navigation already correctly uses `target.directory`, so only the fallback (when no existing session is found) was affected.

### Verification

- `bun turbo typecheck` passes on all 24 packages
