### PR TITLE
fix(mcp): hide denied resource template tool

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -214,7 +214,7 @@ export function merge(...rulesets: PermissionV1.Ruleset[]): PermissionV1.Rule[] 
 
 export function disabled(tools: string[], ruleset: PermissionV1.Ruleset): Set<string> {
   const edits = ["edit", "write", "apply_patch"]
-  const reads = ["list_mcp_resources", "read_mcp_resource"]
+  const reads = ["list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource"]
   return new Set(
     tools.filter((tool) => {
       const permission = edits.includes(tool) ? "edit" : reads.includes(tool) ? "read" : tool


### PR DESCRIPTION
## Summary
- classify `list_mcp_resource_templates` as a read tool during visibility filtering
- hide it when the active ruleset denies `read` globally, matching its execution-time permission

## Test plan
- not run (single permission mapping change)