### PR TITLE
fix(lsp): match extensionless filenames in extensions config

### DIFF
--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -212,7 +212,7 @@ export const layer = Layer.effect(
       if (!containsPath(file, ctx)) return [] as LSPClient.Info[]
       const s = yield* InstanceState.get(state)
       const clients = yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = path.parse(file).ext || path.basename(file)
         const result: LSPClient.Info[] = []
         let updated = 0
 
@@ -331,7 +331,7 @@ export const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const s = yield* InstanceState.get(state)
       return yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = path.parse(file).ext || path.basename(file)
         for (const server of Object.values(s.servers)) {
           if (server.extensions.length && !server.extensions.includes(extension)) continue
           const root = await server.root(file, ctx)


### PR DESCRIPTION
### Issue for this PR

Closes #33372

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

LSP servers configured with an extensionless filename in `extensions` (e.g. `wscript`, `Makefile`, `Dockerfile`) never activate.

The match logic was:

```ts
const extension = path.parse(file).ext || file
```

For a file with no extension, `path.parse(file).ext` is `""`, so `extension` falls back to the full absolute path. `server.extensions.includes("wscript")` then never matches, because the value being compared is `/home/user/project/wscript`, not `wscript`.

The fix falls back to the basename instead:

```ts
const extension = path.parse(file).ext || path.basename(file)
```

Now an extensionless file compares as `wscript` / `Dockerfile`, which matches the configured entry. Files that do have an extension are unchanged — `.ext` is truthy so the fallback never runs.

The same `.ext || file` pattern existed in two places in `lsp.ts` (`getClients` and `hasClients`); both are changed. This also fixes the built-in `DockerfileLS` server, which declares `extensions: [".dockerfile", "Dockerfile"]` but never started for a bare `Dockerfile`.

### How did you verify your code works?

Confirmed the path behavior directly with Node:

- `path.parse("/home/user/project/wscript").ext` → `""`, so old code yielded the full path `/home/user/project/wscript` (no match); new code yields `wscript` (matches a configured `"wscript"`).
- `path.parse("/a/b/foo.py").ext` → `.py`, fallback not taken, behavior unchanged.
- `Dockerfile` → `Dockerfile`.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
