### PR TITLE
feat(provider): add BlueClaw provider

### DIFF
--- a/packages/llm/src/providers/blueclaw.ts
+++ b/packages/llm/src/providers/blueclaw.ts
@@ -1,0 +1,58 @@
+import { AuthOptions, type ProviderAuthOption } from "../route/auth-options"
+import type { RouteDefaultsInput } from "../route/client"
+import { ProviderID, type ModelID } from "../schema"
+import * as OpenAICompatibleChat from "../protocols/openai-compatible-chat"
+import * as OpenAIResponses from "../protocols/openai-responses"
+
+export const id = ProviderID.make("blueclaw")
+
+export type ModelOptions = RouteDefaultsInput &
+  ProviderAuthOption<"optional"> & {
+    readonly baseURL?: string
+  }
+
+export const routes = [OpenAIResponses.route, OpenAICompatibleChat.route]
+
+const DEFAULT_BASE_URL = "https://openai.blueclaw.network/v1"
+
+const auth = (options: ProviderAuthOption<"optional">) =>
+  AuthOptions.bearer(options, "BLUECLAW_API_KEY")
+
+const configuredResponsesRoute = (input: ModelOptions) => {
+  const { apiKey: _, auth: _auth, baseURL, ...rest } = input
+  return OpenAIResponses.route.with({
+    ...rest,
+    provider: id,
+    endpoint: { baseURL: baseURL ?? DEFAULT_BASE_URL },
+    auth: auth(input),
+  })
+}
+
+const configuredChatRoute = (input: ModelOptions) => {
+  const { apiKey: _, auth: _auth, baseURL, ...rest } = input
+  return OpenAICompatibleChat.route.with({
+    ...rest,
+    provider: id,
+    endpoint: { baseURL: baseURL ?? DEFAULT_BASE_URL },
+    auth: auth(input),
+  })
+}
+
+export const configure = (input: ModelOptions = {}) => {
+  const responsesRoute = configuredResponsesRoute(input)
+  const chatRoute = configuredChatRoute(input)
+  const responses = (modelID: string | ModelID) => responsesRoute.model({ id: modelID })
+  const chat = (modelID: string | ModelID) => chatRoute.model({ id: modelID })
+  return {
+    id,
+    model: responses,
+    responses,
+    chat,
+    configure,
+  }
+}
+
+export const provider = configure()
+export const model = provider.model
+export const responses = provider.responses
+export const chat = provider.chat

--- a/packages/llm/src/providers/index.ts
+++ b/packages/llm/src/providers/index.ts
@@ -1,6 +1,7 @@
 export * as Anthropic from "./anthropic"
 export * as AmazonBedrock from "./amazon-bedrock"
 export * as Azure from "./azure"
+export * as BlueClaw from "./blueclaw"
 export * as Cloudflare from "./cloudflare"
 export { CloudflareAIGateway, CloudflareWorkersAI } from "./cloudflare"
 export * as GitHubCopilot from "./github-copilot"

--- a/packages/llm/src/providers/openai-compatible-profile.ts
+++ b/packages/llm/src/providers/openai-compatible-profile.ts
@@ -5,6 +5,7 @@ export interface OpenAICompatibleProfile {
 
 export const profiles = {
   baseten: { provider: "baseten", baseURL: "https://inference.baseten.co/v1" },
+  blueclaw: { provider: "blueclaw", baseURL: "https://openai.blueclaw.network/v1" },
   cerebras: { provider: "cerebras", baseURL: "https://api.cerebras.ai/v1" },
   deepinfra: { provider: "deepinfra", baseURL: "https://api.deepinfra.com/v1/openai" },
   deepseek: { provider: "deepseek", baseURL: "https://api.deepseek.com/v1" },


### PR DESCRIPTION
## Summary

Adds BlueClaw as a first-class provider in the provider picker.

BlueClaw exposes an OpenAI-compatible API and supports:
- Chat completions
- Streaming
- Tool calling
- Reasoning models

Default endpoint: `https://openai.blueclaw.network/v1`
Auth env var: `BLUECLAW_API_KEY` (Bearer token)

## Motivation

BlueClaw provides access to AI models through a unified OpenAI-compatible API. This integration allows OpenCode users to select BlueClaw directly from the provider picker without custom `opencode.json` configuration.

## Changes

- `packages/llm/src/providers/blueclaw.ts` — New provider definition (~55 lines, follows existing xAI pattern)
- `packages/llm/src/providers/index.ts` — Register BlueClaw export (+1 line)
- `packages/llm/src/providers/openai-compatible-profile.ts` — Add profile entry (+1 line)

## Testing

- [x] Uses existing OpenAI-compatible infrastructure (no new dependencies)
- [x] Follows established provider pattern (xAI template)
- [x] Bearer token auth via `BLUECLAW_API_KEY`