### PR TITLE
fix(tui): expand pasted text placeholders literally

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -424,12 +424,7 @@ export function Prompt(props: PromptProps) {
           dialog.clear()
 
           // replace summarized text parts with the actual text
-          const text = store.prompt.parts
-            .filter((p) => p.type === "text")
-            .reduce((acc, p) => {
-              if (!p.source) return acc
-              return acc.replace(p.source.text.value, p.text)
-            }, store.prompt.input)
+          const text = expandPastedTextPlaceholders(store.prompt.input, store.prompt.parts)
 
           const nonTextParts = store.prompt.parts.filter((p) => p.type !== "text")
 

--- a/packages/tui/src/prompt/part.ts
+++ b/packages/tui/src/prompt/part.ts
@@ -8,7 +8,7 @@ export function stripPromptPartIDs<Part extends { id: string; messageID: string;
 export function expandPastedTextPlaceholders(text: string, parts: readonly unknown[]) {
   return parts.reduce<string>((result, part) => {
     if (!isPastedTextPart(part)) return result
-    return result.replace(part.source.text.value, part.text)
+    return result.replace(part.source.text.value, () => part.text)
   }, text)
 }
 

--- a/packages/tui/test/prompt/part.test.ts
+++ b/packages/tui/test/prompt/part.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test"
-import { expandTrackedPastedText, stripPromptPartIDs } from "../../src/prompt/part"
+import { expandPastedTextPlaceholders, expandTrackedPastedText, stripPromptPartIDs } from "../../src/prompt/part"
+
+function pastedTextPart(marker: string, text: string) {
+  return { type: "text" as const, text, source: { text: { value: marker } } }
+}
 
 describe("prompt part", () => {
   test("strips persisted IDs from reused parts", () => {
@@ -49,5 +53,34 @@ describe("prompt part", () => {
         },
       ]),
     ).toBe(`keep ${marker} then alpha\nbeta\ngamma tail`)
+  })
+
+  test("expands placeholders with dollar sequences literally", () => {
+    const marker = "[Pasted ~1 lines]"
+    for (const pasted of ["const cost = ${price}$$", "echo $&foo", "a $` b", "x $' y", "price $1 each"]) {
+      expect(expandPastedTextPlaceholders(`see ${marker} here`, [pastedTextPart(marker, pasted)])).toBe(
+        `see ${pasted} here`,
+      )
+    }
+  })
+
+  test("expands repeated same-line-count placeholders in order", () => {
+    const marker = "[Pasted ~2 lines]"
+    expect(
+      expandPastedTextPlaceholders(`${marker} and ${marker}`, [
+        pastedTextPart(marker, "first"),
+        pastedTextPart(marker, "second"),
+      ]),
+    ).toBe("first and second")
+  })
+
+  test("leaves non pasted-text parts untouched", () => {
+    const marker = "[Pasted ~1 lines]"
+    expect(
+      expandPastedTextPlaceholders(`see ${marker} here`, [
+        { type: "file", url: "data:," },
+        pastedTextPart(marker, "$$$"),
+      ]),
+    ).toBe("see $$$ here")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #33699

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`expandPastedTextPlaceholders` re-inflates a `[Pasted ~N lines]` placeholder with `result.replace(marker, part.text)`. When the second argument is a string, `replace` treats `$` sequences in it as patterns, so pasted text containing `$$`, `$&`, `` $` ``, or `$'` came back changed. `$&` was the worst case: it re-inserted the placeholder string itself into the user's code.

Passing a function instead (`() => part.text`) inserts the text verbatim.

The "open editor" command had its own copy of the old loop, so I pointed it at the same helper. The submit path was already safe (it uses the range-based `expandTrackedPastedText`).

### How did you verify your code works?

Added tests in `packages/tui/test/prompt/part.test.ts` for `$$`, `$&`, `` $` ``, `$'`, a repeated placeholder, and a non-pasted part. They fail on the old code and pass with the fix. The tui test suite has no new failures and `tsgo --noEmit` is clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
