### PR TITLE
fix: restore dev CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -325,6 +325,7 @@ jobs:
         run: bun run build
         working-directory: packages/desktop
         env:
+          NODE_OPTIONS: --max-old-space-size=4096
           OPENCODE_CHANNEL: ${{ (github.ref_name == 'beta' && 'beta') || 'prod' }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -99,6 +99,8 @@ void mock.module("@modelcontextprotocol/sdk/client/index.js", () => ({
       return serverCapabilities
     }
 
+    getInstructions() {}
+
     async listTools() {
       listToolsCalls++
       return { tools: [{ name: "test_tool", inputSchema: { type: "object", properties: {} } }] }


### PR DESCRIPTION
## Summary
- update the MCP OAuth client test double for server instructions
- increase the desktop release build heap to avoid renderer build OOMs

## Testing
- `bun test test/mcp/oauth-auto-connect.test.ts`
- `bun typecheck` in `packages/opencode`
- `NODE_OPTIONS=--max-old-space-size=4096 bun run build` in `packages/desktop`
- `git diff --check`