### PR TITLE
feat(tui): add /session-id and /session-info slash commands

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -528,6 +528,48 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Copy session ID",
+        desc: "Copy the current session ID to clipboard",
+        name: "session.copy-id",
+        category: "Session",
+        slashName: "session-id",
+        enabled: Boolean(props.sessionID),
+        run: async () => {
+          if (!props.sessionID || !clipboard.write) return
+          await clipboard.write(props.sessionID)
+          toast.show({
+            variant: "success",
+            message: `Copied: ${props.sessionID}`,
+            duration: 3000,
+          })
+          dialog.clear()
+        },
+      },
+      {
+        title: "Copy session info",
+        desc: "Copy project path, session title, and session ID to clipboard",
+        name: "session.copy-info",
+        category: "Session",
+        slashName: "session-info",
+        enabled: Boolean(props.sessionID),
+        run: async () => {
+          if (!props.sessionID || !clipboard.write) return
+          const dir =
+            (project.instance.path().worktree === "/" ? undefined : project.instance.path().worktree) ||
+            project.instance.directory() ||
+            ""
+          const session = sync.session.get(props.sessionID)
+          const title = session?.title ?? ""
+          await clipboard.write(`Project ${dir}; Session ${title}; ID ${props.sessionID}`)
+          toast.show({
+            variant: "success",
+            message: "Copied project, session title, and ID to clipboard",
+            duration: 3000,
+          })
+          dialog.clear()
+        },
+      },
+      {
         title: "Warp",
         desc: "Change the workspace for the session",
         name: "workspace.set",


### PR DESCRIPTION
## Summary

Adds two native TUI slash commands that copy session information to the system clipboard with a toast confirmation — no LLM round-trip.

| Command | What it copies |
|---------|----------------|
| `/session-id` | The current session ID (e.g. `ses_abc123`) |
| `/session-info` | `Project <dir>; Session <title>; ID <session-id>` |

Both commands appear in the slash command palette under the **Session** category and are only enabled when a session is active (`props.sessionID` exists).

Supersedes #11938 (closed by automated PR cleanup after 1 month + <2 reactions — not a technical rejection). That PR covered only `/session-id`; this PR adds `/session-info` as a superset that also includes the project directory and session title.

## Motivation

Session IDs are needed for handoff workflows, cross-session references, and manual `session_read` / `session_search` lookups. Currently there is no way to copy the session ID without mouse-selecting from the status bar or running `session_list` and scanning output.

`/session-info` is the broader version — copying project path + session title + ID in one operation is useful for pasting context into bug reports, PR descriptions, or team chat.

## Implementation

- Uses the existing `useClipboard()` context (`clipboard.write()`) — cross-platform, no `xclip` dependency
- Uses the existing `toast.show()` for success feedback
- Only 42 lines added — two command palette entries in `packages/tui/src/component/prompt/index.tsx`
- Both commands are disabled (greyed out) when no session is active
- No plugin, no `command.execute.before` hook, no throw-based abort — pure TUI command palette entries

## Related

- Supersedes #11938 (closed by automated cleanup)
- Original feature request: #11937 (auto-closed with the PR)
- #18559 — adds `output.cancelled` to `command.execute.before` for plugin-based cancellation (complementary; would allow plugins to cleanly abort without throwing)
- #15206 — CLI `opencode session <id>` info request (different scope)

## Testing

- `bunx tsc --noEmit` passes (0 errors in modified file; pre-existing errors in `dialog-move-session.tsx` are unrelated)
- Pre-push CI hook: 25/25 packages typecheck successfully

Manual testing:
1. Open any session in TUI
2. Type `/session-id` — session ID is copied to clipboard + toast confirms
3. Type `/session-info` — project path, session title, and session ID are copied + toast confirms
4. Both commands are greyed out when no session is active

## Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR