### PR TITLE
fix(opencode): evict idle per-directory instances to bound serve memory

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -5,6 +5,11 @@ export function truthy(key: string) {
   return value === "true" || value === "1"
 }
 
+export function number(key: string, fallback = 0) {
+  const value = Number(process.env[key])
+  return Number.isFinite(value) ? value : fallback
+}
+
 const copy = process.env["OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"]
 const fff = process.env["OPENCODE_DISABLE_FFF"]
 
@@ -74,5 +79,16 @@ export const Flag = {
   },
   get OPENCODE_CLIENT() {
     return process.env["OPENCODE_CLIENT"] ?? "cli"
+  },
+
+  // Idle per-directory instance eviction for long-running `serve` (opt-in; 0 = disabled).
+  get OPENCODE_INSTANCE_IDLE_TTL_MS() {
+    return number("OPENCODE_INSTANCE_IDLE_TTL_MS")
+  },
+  get OPENCODE_INSTANCE_MAX() {
+    return number("OPENCODE_INSTANCE_MAX")
+  },
+  get OPENCODE_INSTANCE_SWEEP_MS() {
+    return number("OPENCODE_INSTANCE_SWEEP_MS")
   },
 }

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -5,6 +5,7 @@ import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance as runDisposers } from "@/effect/instance-registry"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
 import { type InstanceContext } from "./instance-context"
 import { InstanceBootstrap } from "./bootstrap-service"
@@ -24,6 +25,10 @@ export interface Interface {
   readonly disposeDirectory: (directory: string) => Effect.Effect<void>
   readonly disposeAll: () => Effect.Effect<void>
   readonly provide: <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>
+  /** Mark an instance as in-use (pins it against idle eviction) and refresh its lastUsed. */
+  readonly acquire: (directory: string) => Effect.Effect<void>
+  /** Release an in-use mark and refresh lastUsed. Pair with acquire via ensuring. */
+  readonly release: (directory: string) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/InstanceStore") {}
@@ -32,7 +37,23 @@ export const use = serviceUse(Service)
 
 interface Entry {
   readonly deferred: Deferred.Deferred<InstanceContext>
+  /** Epoch ms of the last time this instance was loaded/acquired/released. */
+  lastUsed: number
+  /** Count of in-flight requests holding this instance (pins it against eviction). */
+  active: number
 }
+
+// Idle-instance eviction (opt-in). Without it, the per-directory instance cache grows
+// unbounded for long-running `serve` processes that see many distinct directories (e.g.
+// one directory per session): every instance keeps file watchers, LSP/MCP subprocesses,
+// plugins and bus subscriptions alive forever. Resolved from Flag inside the layer so the
+// defaults stay 0 (disabled) and tests can set the env at runtime.
+//   OPENCODE_INSTANCE_IDLE_TTL_MS  dispose instances idle (active==0) longer than this
+//   OPENCODE_INSTANCE_MAX          LRU cap on live instances (idle ones evicted oldest-first)
+//   OPENCODE_INSTANCE_SWEEP_MS     sweep interval (defaults to a third of the TTL)
+const sweepInterval = (idleTtlMs: number) =>
+  Flag.OPENCODE_INSTANCE_SWEEP_MS ||
+  Math.max(1000, Math.min(idleTtlMs > 0 ? Math.floor(idleTtlMs / 3) : 15000, 30000))
 
 export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Service> = Layer.effect(
   Service,
@@ -110,9 +131,12 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const existing = cache.get(directory)
-          if (existing) return yield* restore(Deferred.await(existing.deferred))
+          if (existing) {
+            existing.lastUsed = Date.now()
+            return yield* restore(Deferred.await(existing.deferred))
+          }
 
-          const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>() }
+          const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>(), lastUsed: Date.now(), active: 0 }
           cache.set(directory, entry)
           yield* Effect.gen(function* () {
             yield* Effect.logInfo("creating instance", { directory: directory })
@@ -128,7 +152,7 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const previous = cache.get(directory)
-          const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>() }
+          const entry: Entry = { deferred: Deferred.makeUnsafe<InstanceContext>(), lastUsed: Date.now(), active: 0 }
           cache.set(directory, entry)
           yield* Effect.gen(function* () {
             yield* Effect.logInfo("reloading instance", { directory: directory })
@@ -186,6 +210,71 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
       return yield* cachedDisposeAll
     })
 
+    const acquire = (input: string) =>
+      Effect.sync(() => {
+        const entry = cache.get(FSUtil.resolve(input))
+        if (entry) {
+          entry.active++
+          entry.lastUsed = Date.now()
+        }
+      })
+
+    const release = (input: string) =>
+      Effect.sync(() => {
+        const entry = cache.get(FSUtil.resolve(input))
+        if (entry) {
+          entry.active = Math.max(0, entry.active - 1)
+          entry.lastUsed = Date.now()
+        }
+      })
+
+    // Dispose one cached entry from the sweeper (mirrors disposeDirectory but for a known entry).
+    const evictEntry = Effect.fnUntraced(function* (directory: string, entry: Entry) {
+      const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)
+      if (Exit.isFailure(exit)) {
+        yield* removeEntry(directory, entry)
+        return
+      }
+      yield* disposeEntry(directory, entry, exit.value).pipe(Effect.asVoid)
+    })
+
+    const idleTtlMs = Flag.OPENCODE_INSTANCE_IDLE_TTL_MS
+    const maxInstances = Flag.OPENCODE_INSTANCE_MAX
+
+    const sweepOnce = Effect.fnUntraced(function* () {
+      const now = Date.now()
+      if (idleTtlMs > 0) {
+        for (const [directory, entry] of [...cache.entries()]) {
+          if (entry.active > 0) continue
+          if (now - entry.lastUsed < idleTtlMs) continue
+          yield* Effect.logInfo("evicting idle instance", { directory, idleMs: now - entry.lastUsed })
+          yield* evictEntry(directory, entry)
+        }
+      }
+      if (maxInstances > 0 && cache.size > maxInstances) {
+        const victims = [...cache.entries()]
+          .filter(([, entry]) => entry.active <= 0)
+          .sort((a, b) => a[1].lastUsed - b[1].lastUsed)
+          .slice(0, cache.size - maxInstances)
+        for (const [directory, entry] of victims) {
+          yield* Effect.logInfo("evicting LRU instance over cap", { directory, size: cache.size, max: maxInstances })
+          yield* evictEntry(directory, entry)
+        }
+      }
+    })
+
+    if (idleTtlMs > 0 || maxInstances > 0) {
+      const sweepMs = sweepInterval(idleTtlMs)
+      yield* Effect.logInfo("instance eviction enabled", { idleTtlMs, maxInstances, sweepMs })
+      yield* sweepOnce()
+        .pipe(
+          Effect.catchCause((cause) => Effect.logWarning("instance sweep failed", { cause })),
+          Effect.delay(Duration.millis(sweepMs)),
+          Effect.forever,
+        )
+        .pipe(Effect.forkIn(scope, { startImmediately: true }))
+    }
+
     const provide = <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
       load(input).pipe(Effect.flatMap((ctx) => effect.pipe(Effect.provideService(InstanceRef, ctx))))
 
@@ -198,6 +287,8 @@ export const layer: Layer.Layer<Service, never, Project.Service | InstanceBootst
       disposeDirectory,
       disposeAll,
       provide,
+      acquire,
+      release,
     })
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -26,10 +26,15 @@ function provideInstanceContext<E>(
 ): Effect.Effect<HttpServerResponse.HttpServerResponse, E, WorkspaceRouteContext> {
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
-    const ctx = yield* store.load({ directory: decode(route.directory) })
+    const directory = decode(route.directory)
+    const ctx = yield* store.load({ directory })
+    // Pin the instance for the duration of the request so the idle-eviction sweeper
+    // never disposes an instance with in-flight work; release refreshes lastUsed.
+    yield* store.acquire(directory)
     return yield* effect.pipe(
       Effect.provideService(InstanceRef, ctx),
       Effect.provideService(WorkspaceRef, route.workspaceID),
+      Effect.ensuring(store.release(directory)),
     )
   })
 }

--- a/packages/opencode/test/project/instance-eviction.test.ts
+++ b/packages/opencode/test/project/instance-eviction.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, describe, expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Duration, Effect, Layer } from "effect"
+import { registerDisposer } from "../../src/effect/instance-registry"
+import { InstanceBootstrap } from "../../src/project/bootstrap-service"
+import { InstanceStore } from "../../src/project/instance-store"
+import { tmpdirScoped } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+// Eviction reads OPENCODE_INSTANCE_* from Flag when the layer is built. Set it in
+// beforeAll so it is in effect before each per-test layer build, and clear it after
+// so other test files keep the default (disabled) behavior.
+const TTL = 100
+beforeAll(() => {
+  process.env["OPENCODE_INSTANCE_IDLE_TTL_MS"] = String(TTL)
+  process.env["OPENCODE_INSTANCE_SWEEP_MS"] = "20"
+})
+afterAll(() => {
+  delete process.env["OPENCODE_INSTANCE_IDLE_TTL_MS"]
+  delete process.env["OPENCODE_INSTANCE_SWEEP_MS"]
+})
+
+const noopBootstrap = Layer.succeed(
+  InstanceBootstrap.Service,
+  InstanceBootstrap.Service.of({ run: Effect.void }),
+)
+
+const it = testEffect(
+  Layer.mergeAll(InstanceStore.defaultLayer, CrossSpawnSpawner.defaultLayer).pipe(Layer.provide(noopBootstrap)),
+)
+
+const registerDisposerScoped = (disposer: (directory: string) => Promise<void>) =>
+  Effect.acquireRelease(
+    Effect.sync(() => registerDisposer(disposer)),
+    (off) => Effect.sync(off),
+  )
+
+describe("InstanceStore eviction", () => {
+  it.live("evicts an instance left idle past the TTL", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const disposed: Array<string> = []
+      yield* registerDisposerScoped(async (directory) => {
+        disposed.push(directory)
+      })
+
+      yield* store.load({ directory: dir })
+      expect(disposed).toEqual([])
+
+      yield* Effect.sleep(Duration.millis(TTL * 6))
+      expect(disposed).toContain(dir)
+    }),
+  )
+
+  it.live("does not evict an instance while it is acquired (in use)", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const disposed: Array<string> = []
+      yield* registerDisposerScoped(async (directory) => {
+        disposed.push(directory)
+      })
+
+      yield* store.load({ directory: dir })
+      yield* store.acquire(dir)
+
+      yield* Effect.sleep(Duration.millis(TTL * 6))
+      expect(disposed).toEqual([]) // pinned by active counter
+
+      yield* store.release(dir)
+      yield* Effect.sleep(Duration.millis(TTL * 6))
+      expect(disposed).toContain(dir) // freed, now evictable
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33720
Related to #33213

### Type of change

- [x] Bug fix

### What does this PR do?

`serve` caches one `InstanceStore` entry per directory (`x-opencode-directory`) and never frees it — no TTL/LRU/idle eviction. A server that sees many distinct directories (e.g. one directory per session) accumulates an instance each, with its own file watchers, LSP/MCP subprocesses, plugins and bus subscriptions, so RSS climbs until OOM.

Adds **opt-in** eviction:

- entries track `lastUsed` + an `active` in-flight counter;
- a sweeper disposes idle entries (`active==0`) older than `OPENCODE_INSTANCE_IDLE_TTL_MS`, and/or trims LRU ones above `OPENCODE_INSTANCE_MAX`;
- the request middleware acquires/releases (via `ensuring`), so an in-flight request is never evicted mid-turn;
- eviction frees only runtime resources — the session lives in the DB and re-loads on the next request.

With neither env var set the sweeper never starts; behavior is unchanged.

### How did you verify your code works?

- Unit tests (`test/project/instance-eviction.test.ts`): an idle instance is evicted after the TTL; an acquired one is not until released. Existing instance tests pass and `bun typecheck` is clean.
- Mock OpenAI-compatible provider (no real LLM), 60 sequential sessions, one directory each, ~1s apart, RSS sampled from /proc: **off -> 506->1338 MB and climbing, 0 disposed; on (TTL 4s, max 4) -> ~700 MB flat, 59/60 disposed**.
- Evicted a session's instance, then re-prompted that session — it re-booted and continued with full history.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
