### PR TITLE
fix(opencode): restrict local mcp environment

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -117,12 +117,74 @@ type ResourceInfo = Awaited<ReturnType<MCPClient["listResources"]>>["resources"]
 type ResourceTemplateInfo = Awaited<ReturnType<MCPClient["listResourceTemplates"]>>["resourceTemplates"][number]
 type McpEntry = NonNullable<ConfigV1.Info["mcp"]>[string]
 
+const LOCAL_MCP_INHERITED_ENV = [
+  "APPDATA",
+  "COMSPEC",
+  "HOME",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "LANG",
+  "LANGUAGE",
+  "LC_ADDRESS",
+  "LC_ALL",
+  "LC_COLLATE",
+  "LC_CTYPE",
+  "LC_IDENTIFICATION",
+  "LC_MEASUREMENT",
+  "LC_MESSAGES",
+  "LC_MONETARY",
+  "LC_NAME",
+  "LC_NUMERIC",
+  "LC_PAPER",
+  "LC_TELEPHONE",
+  "LC_TIME",
+  "LOCALAPPDATA",
+  "LOGNAME",
+  "PATH",
+  "PATHEXT",
+  "PROCESSOR_ARCHITECTURE",
+  "PROGRAMDATA",
+  "PROGRAMFILES",
+  "PROGRAMFILES(X86)",
+  "SHELL",
+  "SYSTEMDRIVE",
+  "SYSTEMROOT",
+  "TEMP",
+  "TERM",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "USERNAME",
+  "USERPROFILE",
+  "WINDIR",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+  "XDG_STATE_HOME",
+] as const
+
 function isMcpConfigured(entry: McpEntry): entry is ConfigMCPV1.Info {
   return typeof entry === "object" && entry !== null && "type" in entry
 }
 
 function remoteURL(value: string) {
   if (URL.canParse(value)) return new URL(value)
+}
+
+function localMcpEnvironment(command: string, environment?: Record<string, string>) {
+  const inherited = Object.fromEntries(
+    LOCAL_MCP_INHERITED_ENV.flatMap((key) => {
+      const value = process.env[key]
+      if (value === undefined || value.startsWith("()")) return []
+      return [[key, value] as const]
+    }),
+  )
+  return {
+    ...inherited,
+    ...(command === "opencode" ? { BUN_BE_BUN: "1" } : {}),
+    ...environment,
+  }
 }
 
 interface CreateResult {
@@ -338,11 +400,7 @@ export const layer = Layer.effect(
         command: cmd,
         args,
         cwd,
-        env: {
-          ...process.env,
-          ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
-          ...mcp.environment,
-        },
+        env: localMcpEnvironment(cmd, mcp.environment),
       })
 
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -180,9 +180,15 @@ function localMcpEnvironment(command: string, environment?: Record<string, strin
       return [[key, value] as const]
     }),
   )
-  return {
+  const defaults = {
     ...inherited,
     ...(command === "opencode" ? { BUN_BE_BUN: "1" } : {}),
+  }
+  if (process.platform !== "win32" || !environment) return { ...defaults, ...environment }
+
+  const configured = new Set(Object.keys(environment).map((key) => key.toUpperCase()))
+  return {
+    ...Object.fromEntries(Object.entries(defaults).filter(([key]) => !configured.has(key.toUpperCase()))),
     ...environment,
   }
 }

--- a/packages/opencode/test/fixture/mcp-environment.js
+++ b/packages/opencode/test/fixture/mcp-environment.js
@@ -1,11 +1,12 @@
 import readline from "node:readline"
+import { writeFile } from "node:fs/promises"
 
-await Bun.write(process.env.MCP_ENV_OUTPUT!, JSON.stringify(process.env))
+await writeFile(process.env.MCP_ENV_OUTPUT, JSON.stringify(process.env))
 
 const lines = readline.createInterface({ input: process.stdin })
 lines.on("close", () => process.exit(0))
 lines.on("line", (line) => {
-  const request = JSON.parse(line) as { id?: number; method: string; params?: { protocolVersion?: string } }
+  const request = JSON.parse(line)
   if (request.method !== "initialize") return
   process.stdout.write(
     `${JSON.stringify({

--- a/packages/opencode/test/fixture/mcp-environment.ts
+++ b/packages/opencode/test/fixture/mcp-environment.ts
@@ -1,0 +1,21 @@
+import readline from "node:readline"
+
+await Bun.write(process.env.MCP_ENV_OUTPUT!, JSON.stringify(process.env))
+
+const lines = readline.createInterface({ input: process.stdin })
+lines.on("close", () => process.exit(0))
+lines.on("line", (line) => {
+  const request = JSON.parse(line) as { id?: number; method: string; params?: { protocolVersion?: string } }
+  if (request.method !== "initialize") return
+  process.stdout.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        protocolVersion: request.params?.protocolVersion,
+        capabilities: {},
+        serverInfo: { name: "environment-test", version: "1" },
+      },
+    })}\n`,
+  )
+})

--- a/packages/opencode/test/mcp/environment.test.ts
+++ b/packages/opencode/test/mcp/environment.test.ts
@@ -1,0 +1,62 @@
+import path from "node:path"
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { MCP } from "../../src/mcp/index"
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(MCP.defaultLayer)
+
+it.instance(
+  "local subprocess receives only baseline and configured environment",
+  () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const values = {
+        APPDATA: path.join(test.directory, "appdata"),
+        LC_TIME: "C",
+        OPENCODE_MCP_PARENT_SECRET: "parent-secret",
+        PATHEXT: ".EXE;.CMD",
+        SYSTEMROOT: path.join(test.directory, "windows"),
+        TMPDIR: test.directory,
+      }
+      const previous = Object.fromEntries(Object.keys(values).map((key) => [key, process.env[key]]))
+      Object.assign(process.env, values)
+
+      yield* MCP.Service.use((mcp) =>
+        Effect.gen(function* () {
+          const output = path.join(test.directory, "environment.json")
+          const result = yield* mcp.add("environment", {
+            type: "local",
+            command: [process.execPath, path.join(import.meta.dir, "../fixture/mcp-environment.ts")],
+            environment: {
+              MCP_ENV_OUTPUT: output,
+              MCP_EXPLICIT_TOKEN: "configured-token",
+            },
+          })
+
+          expect(result.status.environment).toEqual({ status: "connected" })
+          const env = (yield* Effect.promise(() => Bun.file(output).json())) as Record<string, string>
+          expect(env.OPENCODE_MCP_PARENT_SECRET).toBeUndefined()
+          expect(env.MCP_EXPLICIT_TOKEN).toBe("configured-token")
+          expect(env.PATH).toBe(process.env.PATH!)
+          expect(env.HOME).toBe(process.env.HOME!)
+          expect(env.TMPDIR).toBe(values.TMPDIR)
+          expect(env.LC_TIME).toBe(values.LC_TIME)
+          expect(env.APPDATA).toBe(values.APPDATA)
+          expect(env.PATHEXT).toBe(values.PATHEXT)
+          expect(env.SYSTEMROOT).toBe(values.SYSTEMROOT)
+        }).pipe(Effect.ensuring(mcp.disconnect("environment").pipe(Effect.ignore))),
+      ).pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            Object.entries(previous).forEach(([key, value]) => {
+              if (value === undefined) delete process.env[key]
+              else process.env[key] = value
+            })
+          }),
+        ),
+      )
+    }),
+  { config: { mcp: {} } },
+)

--- a/packages/opencode/test/mcp/environment.test.ts
+++ b/packages/opencode/test/mcp/environment.test.ts
@@ -6,54 +6,60 @@ import { TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(MCP.defaultLayer)
+const inherited = [
+  "APPDATA",
+  "HOME",
+  "LANG",
+  "LOCALAPPDATA",
+  "PATH",
+  "PATHEXT",
+  "SYSTEMROOT",
+  "TEMP",
+  "TMPDIR",
+  "USERPROFILE",
+] as const
 
 it.instance(
   "local subprocess receives only baseline and configured environment",
   () =>
     Effect.gen(function* () {
       const test = yield* TestInstance
-      const values = {
-        APPDATA: path.join(test.directory, "appdata"),
-        LC_TIME: "C",
-        OPENCODE_MCP_PARENT_SECRET: "parent-secret",
-        PATHEXT: ".EXE;.CMD",
-        SYSTEMROOT: path.join(test.directory, "windows"),
-        TMPDIR: test.directory,
-      }
-      const previous = Object.fromEntries(Object.keys(values).map((key) => [key, process.env[key]]))
-      Object.assign(process.env, values)
+      const previous = process.env.OPENCODE_MCP_PARENT_SECRET
+      process.env.OPENCODE_MCP_PARENT_SECRET = "parent-secret"
 
       yield* MCP.Service.use((mcp) =>
         Effect.gen(function* () {
           const output = path.join(test.directory, "environment.json")
           const result = yield* mcp.add("environment", {
             type: "local",
-            command: [process.execPath, path.join(import.meta.dir, "../fixture/mcp-environment.ts")],
+            command: [process.execPath, path.join(import.meta.dir, "../fixture/mcp-environment.js")],
             environment: {
               MCP_ENV_OUTPUT: output,
               MCP_EXPLICIT_TOKEN: "configured-token",
+              ...(process.platform === "win32" ? { Path: path.dirname(process.execPath) } : {}),
             },
           })
 
+          if (!("environment" in result.status)) throw new Error("Expected MCP status map")
           expect(result.status.environment).toEqual({ status: "connected" })
           const env = (yield* Effect.promise(() => Bun.file(output).json())) as Record<string, string>
           expect(env.OPENCODE_MCP_PARENT_SECRET).toBeUndefined()
           expect(env.MCP_EXPLICIT_TOKEN).toBe("configured-token")
-          expect(env.PATH).toBe(process.env.PATH!)
-          expect(env.HOME).toBe(process.env.HOME!)
-          expect(env.TMPDIR).toBe(values.TMPDIR)
-          expect(env.LC_TIME).toBe(values.LC_TIME)
-          expect(env.APPDATA).toBe(values.APPDATA)
-          expect(env.PATHEXT).toBe(values.PATHEXT)
-          expect(env.SYSTEMROOT).toBe(values.SYSTEMROOT)
+          inherited.forEach((key) => {
+            if (process.platform === "win32" && key === "PATH") return
+            if (process.env[key] !== undefined) expect(env[key]).toBe(process.env[key])
+          })
+          if (process.platform === "win32") {
+            expect(Object.entries(env).find(([key]) => key.toUpperCase() === "PATH")?.[1]).toBe(
+              path.dirname(process.execPath),
+            )
+          }
         }).pipe(Effect.ensuring(mcp.disconnect("environment").pipe(Effect.ignore))),
       ).pipe(
         Effect.ensuring(
           Effect.sync(() => {
-            Object.entries(previous).forEach(([key, value]) => {
-              if (value === undefined) delete process.env[key]
-              else process.env[key] = value
-            })
+            if (previous === undefined) delete process.env.OPENCODE_MCP_PARENT_SECRET
+            else process.env.OPENCODE_MCP_PARENT_SECRET = previous
           }),
         ),
       )


### PR DESCRIPTION
### Issue

Fixes #31778.

Alternative to #32450, with regression coverage through a real stdio MCP subprocess rather than mocked transport options.

### What changed

Local MCP subprocesses no longer receive the complete OpenCode parent environment. They inherit an explicit operational baseline for executable lookup, home/user and XDG directories, temporary directories, shell/terminal and locale behavior, and required Windows process/runtime paths. The MCP server's configured `environment` is then applied last, so intentional credentials and overrides continue to work. Windows environment names are handled case-insensitively when applying configured overrides.

The existing `BUN_BE_BUN=1` compatibility behavior for the `opencode` command is preserved. Shell-function exports are excluded from inherited baseline values, following MCP SDK behavior.

This avoids implicitly exposing unrelated provider tokens such as `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`. MCP servers that intentionally need credentials must declare them in their per-server `environment` configuration.

### Compatibility rationale

The baseline follows the MCP SDK's safe inherited environment model and extends it with temp, locale, XDG, and Windows variables needed for common cross-platform launch/config behavior. Proxy variables, provider credentials, cloud credentials, and arbitrary application variables are intentionally not inherited because they can contain secrets.

### Verification

- `bun test test/mcp/environment.test.ts` from `packages/opencode`
- `bun test test/mcp/environment.test.ts test/config/config.test.ts` from `packages/opencode`
- focused test with a minimal parent environment
- Prettier check for all changed files
- `git diff --check`

The test launches and initializes a real stdio MCP child, reads the environment observed by that child, and verifies parent secrets are absent while configured values and available platform baseline values are present. It uses no mocks or sleeps.