### PR TITLE
fix(ui): guard custom-answer textarea against IME composition Enter (#20850)

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.test.ts
+++ b/packages/app/src/pages/session/composer/session-question-dock.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { customInputKeyAction } from "./session-question-dock"
+
+const key = (init: KeyboardEventInit & { keyCode?: number }) => {
+  const event = new KeyboardEvent("keydown", init)
+  if (init.keyCode !== undefined) {
+    Object.defineProperty(event, "keyCode", { value: init.keyCode })
+  }
+  return event
+}
+
+describe("customInputKeyAction", () => {
+  test("commits on plain Enter", () => {
+    expect(customInputKeyAction(key({ key: "Enter" }))).toBe("commit")
+  })
+
+  test("ignores Enter while an IME is composing (isComposing)", () => {
+    expect(customInputKeyAction(key({ key: "Enter", isComposing: true }))).toBe("ignore")
+  })
+
+  test("ignores Enter while an IME is composing (keyCode 229 fallback)", () => {
+    expect(customInputKeyAction(key({ key: "Enter", keyCode: 229 }))).toBe("ignore")
+  })
+
+  test("ignores Shift+Enter (newline)", () => {
+    expect(customInputKeyAction(key({ key: "Enter", shiftKey: true }))).toBe("ignore")
+  })
+
+  test("escapes on Escape", () => {
+    expect(customInputKeyAction(key({ key: "Escape" }))).toBe("escape")
+  })
+
+  test("ignores Cmd/Ctrl+Enter so the dock-level handler can act", () => {
+    expect(customInputKeyAction(key({ key: "Enter", metaKey: true }))).toBe("ignore")
+    expect(customInputKeyAction(key({ key: "Enter", ctrlKey: true }))).toBe("ignore")
+  })
+
+  test("ignores non-Enter typing keys", () => {
+    expect(customInputKeyAction(key({ key: "a" }))).toBe("ignore")
+  })
+})

--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -15,6 +15,21 @@ import { ScopedKey } from "@/utils/server-scope"
 
 const cache = new Map<string, { tab: number; answers: QuestionAnswer[]; custom: string[]; customOn: boolean[] }>()
 
+export type CustomInputKeyAction = "ignore" | "escape" | "commit"
+
+// Resolves what the custom-answer textarea should do for a keydown event.
+// Guards against IME composition: while a CJK input method is composing,
+// Enter confirms the candidate and must not commit the answer (see #20850).
+export function customInputKeyAction(
+  e: Pick<KeyboardEvent, "key" | "shiftKey" | "metaKey" | "ctrlKey" | "altKey" | "isComposing" | "keyCode">,
+): CustomInputKeyAction {
+  if (e.isComposing || e.keyCode === 229) return "ignore"
+  if (e.key === "Escape") return "escape"
+  if ((e.metaKey || e.ctrlKey) && !e.altKey) return "ignore"
+  if (e.key !== "Enter" || e.shiftKey) return "ignore"
+  return "commit"
+}
+
 function Mark(props: { multi: boolean; picked: boolean; onClick?: (event: MouseEvent) => void }) {
   return (
     <span data-slot="question-option-check" aria-hidden="true" onClick={props.onClick}>
@@ -549,14 +564,14 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
                 rows={1}
                 disabled={sending()}
                 onKeyDown={(e) => {
-                  if (e.key === "Escape") {
+                  const action = customInputKeyAction(e)
+                  if (action === "ignore") return
+                  if (action === "escape") {
                     e.preventDefault()
                     setStore("editing", false)
                     focus(options().length)
                     return
                   }
-                  if ((e.metaKey || e.ctrlKey) && !e.altKey) return
-                  if (e.key !== "Enter" || e.shiftKey) return
                   e.preventDefault()
                   commitCustom()
                 }}


### PR DESCRIPTION
### Issue for this PR

Closes #20850

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The custom-answer textarea in the Question dock commits on Enter without checking for IME composition. So when a Japanese/Chinese/Korean input method confirms a candidate with Enter, that Enter gets eaten as a submit and the half-composed text is sent as the answer instead of finishing the word.

The fix is the same guard already merged here in #16361 and used in `prompt-input.tsx`: bail out of the keydown handler while `event.isComposing` is true, plus the `keyCode === 229` fallback that older WebKit reports while the IME is active. During composition the Enter just confirms the candidate; only a non-composing Enter commits.

I pulled the keydown logic out of the inline closure into a small pure function (`customInputKeyAction`) so it could actually be unit-tested — the handler had no coverage before. The order of the existing checks (Escape, Cmd/Ctrl, Shift+Enter, plain Enter) is unchanged; the only new branch is the composition guard. It's the identical pattern the repo already accepted for the comment editor, and the tests fail on the old behavior and pass on the new one.

### How did you verify your code works?

Added `session-question-dock.test.ts` (7 cases). The two IME cases — `isComposing`, and the `keyCode === 229` fallback — return `"commit"` without the guard (the bug) and `"ignore"` with it. Ran the whole composer dir: **19 pass / 0 fail**, no regressions. Typecheck is clean on the changed files.

```
bun test --conditions=browser --preload ./happydom.ts ./src/pages/session/composer/session-question-dock.test.ts
```

### Screenshots / recordings

No visual change — this is keydown behavior, covered by the unit tests above rather than a screenshot.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

