### PR TITLE
fix(opencode): cap retry backoff when response headers lack retry-after

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -58,7 +58,12 @@ export function delay(attempt: number, error?: SessionV1.APIError) {
         }
       }
 
-      return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1))
+      // Headers were present but carried no usable retry-after hint. Apply the
+      // same 30s cap as the no-headers branch so a flaky 5xx with normal
+      // response headers (content-type, date, ...) cannot grow the backoff
+      // past RETRY_MAX_DELAY_NO_HEADERS. Without this, attempt 10 waits ~17min,
+      // attempt 15 ~9h, attempt 20 ~12d.
+      return cap(Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS))
     }
   }
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -39,6 +39,19 @@ describe("session.retry.delay", () => {
     expect(delays).toStrictEqual([2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000])
   })
 
+  test("caps delay at 30 seconds when headers present but lack retry-after", () => {
+    // Real 5xx responses almost always carry headers (content-type, date, ...).
+    // The fallback path must still respect RETRY_MAX_DELAY_NO_HEADERS.
+    const error = apiError({ "content-type": "application/json" })
+    const delays = Array.from({ length: 10 }, (_, index) => SessionRetry.delay(index + 1, error))
+    expect(delays).toStrictEqual([2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000])
+  })
+
+  test("caps delay at 30 seconds when retry-after header is unparseable", () => {
+    const error = apiError({ "retry-after": "not-a-number" })
+    expect(SessionRetry.delay(8, error)).toBe(30000)
+  })
+
   test("prefers retry-after-ms when shorter than exponential", () => {
     const error = apiError({ "retry-after-ms": "1500" })
     expect(SessionRetry.delay(4, error)).toBe(1500)


### PR DESCRIPTION
### Issue for this PR

Closes #33728

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionRetry.delay()` in `packages/opencode/src/session/retry.ts` only applied the 30-second `RETRY_MAX_DELAY_NO_HEADERS` cap in the no-headers branch (line 65). When a retryable error carried any `responseHeaders` object — which real 502/503 responses almost always do, since they always send `content-type`, `date`, etc. — but the headers did not include a parseable `retry-after` / `retry-after-ms`, the fallback path used uncapped exponential backoff bounded only by `RETRY_MAX_DELAY` (2,147,483,647 ms, the setTimeout limit).

That meant a single flaky 5xx could grow the backoff to ~17 min by attempt 10, ~9 hours by attempt 15, and ~12 days by attempt 20. The 30 s cap was effectively dead in production because real responses always carry headers.

The fix applies the same `Math.min(..., RETRY_MAX_DELAY_NO_HEADERS)` to the headers-branch fallback that the no-headers branch already uses. One-line change.

### How did you verify your code works?

- Added two regression tests in `packages/opencode/test/session/retry.test.ts`:
  - `caps delay at 30 seconds when headers present but lack retry-after` — runs 10 attempts with `{ "content-type": "application/json" }` and asserts the same `[2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000]` shape the no-headers test already expects.
  - `caps delay at 30 seconds when retry-after header is unparseable` — `delay(8, ...)` with `{ "retry-after": "not-a-number" }` returns `30000` (was returning `256000` before the fix).
- Confirmed both new tests fail without the source fix and pass with it.
- `bun test test/session/retry.test.ts` from `packages/opencode` → 35 pass / 0 fail.
- `bun run typecheck` from `packages/opencode` → clean.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR