### PR TITLE
feat(tui): publish tui.session.select / tui.session.deselect on TUI session focus changes

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/tui.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/tui.ts
@@ -26,11 +26,16 @@ const EventTuiSessionSelect = Schema.Struct({
   type: Schema.Literal(TuiEvent.SessionSelect.type),
   properties: TuiEvent.SessionSelect.data,
 }).annotate({ identifier: "EventTuiSessionSelect" })
+const EventTuiSessionDeselect = Schema.Struct({
+  type: Schema.Literal(TuiEvent.SessionDeselect.type),
+  properties: TuiEvent.SessionDeselect.data,
+}).annotate({ identifier: "EventTuiSessionDeselect" })
 export const TuiPublishPayload = Schema.Union([
   EventTuiPromptAppend,
   EventTuiCommandExecute,
   EventTuiToastShow,
   EventTuiSessionSelect,
+  EventTuiSessionDeselect,
 ])
 
 export const TuiPaths = {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
@@ -101,8 +101,14 @@ export const tuiHandlers = HttpApiBuilder.group(InstanceHttpApi, "tui", (handler
       payload: typeof TuiEvent.SessionSelect.data.Type
     }) {
       if (!ctx.payload.sessionID.startsWith("ses")) return yield* new HttpApiError.BadRequest({})
-      yield* SessionError.mapStorageNotFound(session.get(ctx.payload.sessionID))
-      yield* events.publish(TuiEvent.SessionSelect, ctx.payload)
+      const info = yield* SessionError.mapStorageNotFound(session.get(ctx.payload.sessionID))
+      // Look up parentID server-side so external callers don't have to supply
+      // it. Plugins can use it to distinguish subagent sessions from
+      // top-level ones without an extra round-trip.
+      yield* events.publish(TuiEvent.SessionSelect, {
+        sessionID: ctx.payload.sessionID,
+        ...(info.parentID ? { parentID: info.parentID } : {}),
+      })
       return true
     })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
@@ -92,6 +92,8 @@ export const tuiHandlers = HttpApiBuilder.group(InstanceHttpApi, "tui", (handler
         yield* events.publish(TuiEvent.ToastShow, ctx.payload.properties)
       if (ctx.payload.type === TuiEvent.SessionSelect.type)
         yield* events.publish(TuiEvent.SessionSelect, ctx.payload.properties)
+      if (ctx.payload.type === TuiEvent.SessionDeselect.type)
+        yield* events.publish(TuiEvent.SessionDeselect, ctx.payload.properties)
       return true
     })
 

--- a/packages/schema/src/tui-event.ts
+++ b/packages/schema/src/tui-event.ts
@@ -2,7 +2,7 @@ export * as TuiEvent from "./tui-event"
 
 import { Effect, Schema } from "effect"
 import { Event } from "./event"
-import { PositiveInt } from "./schema"
+import { optionalOmitUndefined, PositiveInt } from "./schema"
 import { SessionID } from "./session-id"
 
 const DEFAULT_TOAST_DURATION = 5000
@@ -52,6 +52,9 @@ export const SessionSelect = Event.define({
   type: "tui.session.select",
   schema: {
     sessionID: SessionID.annotate({ description: "Session ID to navigate to" }),
+    parentID: SessionID.annotate({
+      description: "ID of the parent session if this is a subagent; absent for top-level sessions",
+    }).pipe(optionalOmitUndefined),
   },
 })
 

--- a/packages/schema/src/tui-event.ts
+++ b/packages/schema/src/tui-event.ts
@@ -55,4 +55,9 @@ export const SessionSelect = Event.define({
   },
 })
 
-export const Definitions = Event.inventory(PromptAppend, CommandExecute, ToastShow, SessionSelect)
+export const SessionDeselect = Event.define({
+  type: "tui.session.deselect",
+  schema: {},
+})
+
+export const Definitions = Event.inventory(PromptAppend, CommandExecute, ToastShow, SessionSelect, SessionDeselect)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -4985,6 +4985,7 @@ export class Tui extends HeyApiClient {
       directory?: string
       workspace?: string
       sessionID?: string
+      parentID?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -4996,6 +4997,7 @@ export class Tui extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
             { in: "body", key: "sessionID" },
+            { in: "body", key: "parentID" },
           ],
         },
       ],

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -27,6 +27,7 @@ import type {
   EventSubscribeResponses,
   EventTuiCommandExecute,
   EventTuiPromptAppend,
+  EventTuiSessionDeselect,
   EventTuiSessionSelect,
   EventTuiToastShow,
   ExperimentalCapabilitiesGetErrors,
@@ -4941,7 +4942,12 @@ export class Tui extends HeyApiClient {
     parameters?: {
       directory?: string
       workspace?: string
-      body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
+      body?:
+        | EventTuiPromptAppend
+        | EventTuiCommandExecute
+        | EventTuiToastShow
+        | EventTuiSessionSelect
+        | EventTuiSessionDeselect
     },
     options?: Options<never, ThrowOnError>,
   ) {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -75,6 +75,7 @@ export type Event =
   | EventTuiCommandExecute2
   | EventTuiToastShow2
   | EventTuiSessionSelect2
+  | EventTuiSessionDeselect2
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
   | EventCommandExecuted
@@ -1487,6 +1488,13 @@ export type GlobalEvent = {
       }
     | {
         id: string
+        type: "tui.session.deselect"
+        properties: {
+          [key: string]: unknown
+        }
+      }
+    | {
+        id: string
         type: "mcp.tools.changed"
         properties: {
           server: string
@@ -2707,6 +2715,13 @@ export type EventTuiSessionSelect = {
   }
 }
 
+export type EventTuiSessionDeselect = {
+  type: "tui.session.deselect"
+  properties: {
+    [key: string]: unknown
+  }
+}
+
 export type Workspace = {
   id: string
   type: string
@@ -2866,6 +2881,7 @@ export type V2Event =
   | V2EventTuiCommandExecute
   | V2EventTuiToastShow
   | V2EventTuiSessionSelect
+  | V2EventTuiSessionDeselect
   | V2EventMcpToolsChanged
   | V2EventMcpBrowserOpenFailed
   | V2EventCommandExecuted
@@ -2954,6 +2970,14 @@ export type EventTuiSessionSelect2 = {
      * Session ID to navigate to
      */
     sessionID: string
+  }
+}
+
+export type EventTuiSessionDeselect2 = {
+  id: string
+  type: "tui.session.deselect"
+  properties: {
+    [key: string]: unknown
   }
 }
 
@@ -5773,6 +5797,23 @@ export type V2EventTuiSessionSelect = {
      * Session ID to navigate to
      */
     sessionID: string
+  }
+}
+
+export type V2EventTuiSessionDeselect = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  type: "tui.session.deselect"
+  data: {
+    [key: string]: unknown
   }
 }
 
@@ -10947,7 +10988,12 @@ export type TuiShowToastResponses = {
 export type TuiShowToastResponse = TuiShowToastResponses[keyof TuiShowToastResponses]
 
 export type TuiPublishData = {
-  body?: EventTuiPromptAppend | EventTuiCommandExecute | EventTuiToastShow | EventTuiSessionSelect
+  body?:
+    | EventTuiPromptAppend
+    | EventTuiCommandExecute
+    | EventTuiToastShow
+    | EventTuiSessionSelect
+    | EventTuiSessionDeselect
   path?: never
   query?: {
     directory?: string

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1484,6 +1484,10 @@ export type GlobalEvent = {
            * Session ID to navigate to
            */
           sessionID: string
+          /**
+           * ID of the parent session if this is a subagent; absent for top-level sessions
+           */
+          parentID?: string
         }
       }
     | {
@@ -2712,6 +2716,10 @@ export type EventTuiSessionSelect = {
      * Session ID to navigate to
      */
     sessionID: string
+    /**
+     * ID of the parent session if this is a subagent; absent for top-level sessions
+     */
+    parentID?: string
   }
 }
 
@@ -2970,6 +2978,10 @@ export type EventTuiSessionSelect2 = {
      * Session ID to navigate to
      */
     sessionID: string
+    /**
+     * ID of the parent session if this is a subagent; absent for top-level sessions
+     */
+    parentID?: string
   }
 }
 
@@ -5797,6 +5809,10 @@ export type V2EventTuiSessionSelect = {
      * Session ID to navigate to
      */
     sessionID: string
+    /**
+     * ID of the parent session if this is a subagent; absent for top-level sessions
+     */
+    parentID?: string
   }
 }
 
@@ -11026,6 +11042,10 @@ export type TuiSelectSessionData = {
      * Session ID to navigate to
      */
     sessionID: string
+    /**
+     * ID of the parent session if this is a subagent; absent for top-level sessions
+     */
+    parentID?: string
   }
   path?: never
   query?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9077,6 +9077,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/EventTuiSessionSelect"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EventTuiSessionDeselect"
                   }
                 ]
               }
@@ -15135,6 +15138,9 @@
             "$ref": "#/components/schemas/Event.tui.session.select"
           },
           {
+            "$ref": "#/components/schemas/Event.tui.session.deselect"
+          },
+          {
             "$ref": "#/components/schemas/EventMcpToolsChanged"
           },
           {
@@ -19647,6 +19653,25 @@
                   },
                   "type": {
                     "type": "string",
+                    "enum": ["tui.session.deselect"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {}
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^evt_"
+                  },
+                  "type": {
+                    "type": "string",
                     "enum": ["mcp.tools.changed"]
                   },
                   "properties": {
@@ -23157,6 +23182,21 @@
         "required": ["type", "properties"],
         "additionalProperties": false
       },
+      "EventTuiSessionDeselect": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["tui.session.deselect"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "required": ["type", "properties"],
+        "additionalProperties": false
+      },
       "Workspace": {
         "type": "object",
         "properties": {
@@ -23666,6 +23706,9 @@
             "$ref": "#/components/schemas/V2EventTuiSessionSelect"
           },
           {
+            "$ref": "#/components/schemas/V2EventTuiSessionDeselect"
+          },
+          {
             "$ref": "#/components/schemas/V2EventMcpToolsChanged"
           },
           {
@@ -23903,6 +23946,25 @@
             },
             "required": ["sessionID"],
             "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "Event.tui.session.deselect": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.session.deselect"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {}
           }
         },
         "required": ["id", "type", "properties"],
@@ -32219,6 +32281,47 @@
             },
             "required": ["sessionID"],
             "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "data"],
+        "additionalProperties": false
+      },
+      "V2EventTuiSessionDeselect": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "durable": {
+            "type": "object",
+            "properties": {
+              "aggregateID": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "integer"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["aggregateID", "seq", "version"],
+            "additionalProperties": false
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationRef"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["tui.session.deselect"]
+          },
+          "data": {
+            "type": "object",
+            "properties": {}
           }
         },
         "required": ["id", "type", "data"],

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -9168,6 +9168,11 @@
                     "type": "string",
                     "pattern": "^ses",
                     "description": "Session ID to navigate to"
+                  },
+                  "parentID": {
+                    "type": "string",
+                    "pattern": "^ses",
+                    "description": "ID of the parent session if this is a subagent; absent for top-level sessions"
                   }
                 },
                 "required": ["sessionID"],
@@ -19635,6 +19640,11 @@
                         "type": "string",
                         "pattern": "^ses",
                         "description": "Session ID to navigate to"
+                      },
+                      "parentID": {
+                        "type": "string",
+                        "pattern": "^ses",
+                        "description": "ID of the parent session if this is a subagent; absent for top-level sessions"
                       }
                     },
                     "required": ["sessionID"],
@@ -23173,6 +23183,11 @@
                 "type": "string",
                 "pattern": "^ses",
                 "description": "Session ID to navigate to"
+              },
+              "parentID": {
+                "type": "string",
+                "pattern": "^ses",
+                "description": "ID of the parent session if this is a subagent; absent for top-level sessions"
               }
             },
             "required": ["sessionID"],
@@ -23942,6 +23957,11 @@
                 "type": "string",
                 "pattern": "^ses",
                 "description": "Session ID to navigate to"
+              },
+              "parentID": {
+                "type": "string",
+                "pattern": "^ses",
+                "description": "ID of the parent session if this is a subagent; absent for top-level sessions"
               }
             },
             "required": ["sessionID"],
@@ -32277,6 +32297,11 @@
                 "type": "string",
                 "pattern": "^ses",
                 "description": "Session ID to navigate to"
+              },
+              "parentID": {
+                "type": "string",
+                "pattern": "^ses",
+                "description": "ID of the parent session if this is a subagent; absent for top-level sessions"
               }
             },
             "required": ["sessionID"],

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -968,13 +968,14 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     })
   })
 
-  // Track the most recent inbound `tui.session.select` so the publish effect
-  // below doesn't echo it back to the bus when the inbound listener navigates
-  // in response. Cleared on the next microtask: if the inbound caused an
-  // actual route change, the effect runs synchronously in the same microtask
-  // and consumes the value; otherwise the entry is dropped so a later genuine
-  // navigation to the same sessionID is published normally.
+  // Track the most recent inbound `tui.session.select` / `tui.session.deselect`
+  // so the publish effect below doesn't echo them back to the bus when the
+  // inbound listeners navigate in response. Cleared on the next microtask: if
+  // the inbound caused an actual route change, the effect runs synchronously
+  // in the same microtask and consumes the value; otherwise the entry is
+  // dropped so a later genuine navigation publishes normally.
   let inboundSessionID: string | null = null
+  let inboundDeselect = false
 
   event.on("tui.session.select", (evt, { workspace }) => {
     if (workspace !== project.workspace.current()) return
@@ -988,24 +989,49 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     })
   })
 
-  // Publish `tui.session.select` whenever the TUI navigates to a session route
-  // from anywhere — session picker, quick-switch keybinds, prompt resolution,
-  // initial-route restore. Plugins can subscribe to detect session switches
-  // regardless of whether navigation originated externally (HTTP) or in-TUI.
-  // See https://github.com/anomalyco/opencode/issues/31051.
+  event.on("tui.session.deselect", (_evt, { workspace }) => {
+    if (workspace !== project.workspace.current()) return
+    inboundDeselect = true
+    queueMicrotask(() => {
+      inboundDeselect = false
+    })
+    route.navigate({ type: "home" })
+  })
+
+  // Publish `tui.session.select` / `tui.session.deselect` whenever the TUI's
+  // session-route focus changes (entering a session, switching sessions, or
+  // leaving for any non-session route). Plugins can subscribe to either to
+  // detect focus changes regardless of whether navigation originated
+  // externally (HTTP) or in-TUI. See https://github.com/anomalyco/opencode/issues/31051.
   createEffect(
     on(
       () => (route.data.type === "session" ? route.data.sessionID : null),
       (sessionID, previous) => {
-        if (!sessionID || sessionID === previous) return
-        if (sessionID === inboundSessionID) {
-          inboundSessionID = null
+        if (sessionID === previous) return
+        if (sessionID) {
+          if (sessionID === inboundSessionID) {
+            inboundSessionID = null
+            return
+          }
+          sdk.client.tui.publish({
+            body: {
+              type: "tui.session.select",
+              properties: { sessionID },
+            },
+          })
+          return
+        }
+        // sessionID transitioned to null — we just navigated away from a
+        // session route to home (or any non-session route).
+        if (previous == null) return
+        if (inboundDeselect) {
+          inboundDeselect = false
           return
         }
         sdk.client.tui.publish({
           body: {
-            type: "tui.session.select",
-            properties: { sessionID },
+            type: "tui.session.deselect",
+            properties: {},
           },
         })
       },

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1013,10 +1013,14 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
             inboundSessionID = null
             return
           }
+          // Best-effort parentID lookup from the sync store so plugins can
+          // distinguish subagent sessions. May be undefined if the session
+          // isn't hydrated yet — plugins can fall back to client.session.get.
+          const parentID = sync.session.get(sessionID)?.parentID
           sdk.client.tui.publish({
             body: {
               type: "tui.session.select",
-              properties: { sessionID },
+              properties: parentID ? { sessionID, parentID } : { sessionID },
             },
           })
           return

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -968,13 +968,49 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     })
   })
 
+  // Track the most recent inbound `tui.session.select` so the publish effect
+  // below doesn't echo it back to the bus when the inbound listener navigates
+  // in response. Cleared on the next microtask: if the inbound caused an
+  // actual route change, the effect runs synchronously in the same microtask
+  // and consumes the value; otherwise the entry is dropped so a later genuine
+  // navigation to the same sessionID is published normally.
+  let inboundSessionID: string | null = null
+
   event.on("tui.session.select", (evt, { workspace }) => {
     if (workspace !== project.workspace.current()) return
+    inboundSessionID = evt.properties.sessionID
+    queueMicrotask(() => {
+      inboundSessionID = null
+    })
     route.navigate({
       type: "session",
       sessionID: evt.properties.sessionID,
     })
   })
+
+  // Publish `tui.session.select` whenever the TUI navigates to a session route
+  // from anywhere — session picker, quick-switch keybinds, prompt resolution,
+  // initial-route restore. Plugins can subscribe to detect session switches
+  // regardless of whether navigation originated externally (HTTP) or in-TUI.
+  // See https://github.com/anomalyco/opencode/issues/31051.
+  createEffect(
+    on(
+      () => (route.data.type === "session" ? route.data.sessionID : null),
+      (sessionID, previous) => {
+        if (!sessionID || sessionID === previous) return
+        if (sessionID === inboundSessionID) {
+          inboundSessionID = null
+          return
+        }
+        sdk.client.tui.publish({
+          body: {
+            type: "tui.session.select",
+            properties: { sessionID },
+          },
+        })
+      },
+    ),
+  )
 
   event.on("session.deleted", (evt) => {
     if (route.data.type === "session" && route.data.sessionID === evt.properties.info.id) {

--- a/packages/tui/test/app-session-select.test.tsx
+++ b/packages/tui/test/app-session-select.test.tsx
@@ -32,28 +32,30 @@ test("publishes tui.session.select when the TUI navigates to a session route", a
   const core = await import("@opentui/core")
   mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
   const events = createEventSource()
+  const sessions: Record<string, unknown> = {
+    dummy: {
+      id: "dummy",
+      title: "Demo session",
+      slug: "dummy",
+      projectID: "project",
+      directory,
+      version: "0.0.0-test",
+      time: { created: 0, updated: 0 },
+    },
+    other: {
+      id: "other",
+      title: "Other session",
+      slug: "other",
+      projectID: "project",
+      directory,
+      version: "0.0.0-test",
+      time: { created: 0, updated: 0 },
+    },
+  }
   const calls = createFetch((url) => {
-    if (url.pathname === "/session")
-      return json([
-        {
-          id: "dummy",
-          title: "Demo session",
-          slug: "dummy",
-          projectID: "project",
-          directory,
-          version: "0.0.0-test",
-          time: { created: 0, updated: 0 },
-        },
-        {
-          id: "other",
-          title: "Other session",
-          slug: "other",
-          projectID: "project",
-          directory,
-          version: "0.0.0-test",
-          time: { created: 0, updated: 0 },
-        },
-      ])
+    if (url.pathname === "/session") return json(Object.values(sessions))
+    const m = url.pathname.match(/^\/session\/([^/]+)$/)
+    if (m && sessions[m[1]!]) return json(sessions[m[1]!])
   })
 
   let api: TuiPluginApi | undefined
@@ -108,14 +110,101 @@ test("publishes tui.session.select when the TUI navigates to a session route", a
     await setup.renderOnce()
     await Bun.sleep(20)
     await setup.renderOnce()
+    // No new publish in response to the inbound select.
+    const sinceInbound = calls.tuiPublish.slice(beforeInbound)
+    expect(sinceInbound).toEqual([])
 
     const publishes = parsePublishes(calls.tuiPublish.map((r) => r.body))
     const sessionIds = publishes.filter((p) => p.type === "tui.session.select").map((p) => p.properties?.sessionID)
 
     expect(sessionIds).toContain("dummy")
     expect(sessionIds).toContain("other")
-    // No echo from the inbound select event
+
+    api?.keymap.dispatchCommand("app.exit")
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})
+
+test("publishes tui.session.deselect when leaving a session route for home", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  const core = await import("@opentui/core")
+  mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+  const events = createEventSource()
+  const dummy = {
+    id: "dummy",
+    title: "Demo session",
+    slug: "dummy",
+    projectID: "project",
+    directory,
+    version: "0.0.0-test",
+    time: { created: 0, updated: 0 },
+  }
+  const calls = createFetch((url) => {
+    if (url.pathname === "/session") return json([dummy])
+    if (url.pathname === "/session/dummy") return json(dummy)
+  })
+
+  let api: TuiPluginApi | undefined
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch: calls.fetch,
+        events: events.source,
+        args: { continue: true },
+        pluginHost: {
+          async start(input) {
+            api = input.api
+            started()
+          },
+          async dispose() {},
+        },
+      }).pipe(Effect.provide(Global.defaultLayer)),
+    )
+
+    await ready
+    await setup.renderOnce()
+    await setup.renderOnce()
+
+    // Wait for the initial session.select publish to land
+    await wait(() => calls.tuiPublish.some((r) => r.body?.includes('"dummy"')))
+
+    // Navigate to home — should publish tui.session.deselect
+    api?.route.navigate("home")
+    await setup.renderOnce()
+    await wait(() => calls.tuiPublish.some((r) => r.body?.includes("tui.session.deselect")))
+
+    // Inbound tui.session.deselect echo guard: we're already on home, but emit
+    // anyway and confirm no duplicate publish.
+    const beforeInbound = calls.tuiPublish.length
+    events.emit({
+      directory,
+      project: "proj_test",
+      payload: {
+        type: "tui.session.deselect",
+        properties: {},
+      } as any,
+    })
+    await setup.renderOnce()
+    await Bun.sleep(20)
+    await setup.renderOnce()
     expect(calls.tuiPublish.length).toBe(beforeInbound)
+
+    const publishes = parsePublishes(calls.tuiPublish.map((r) => r.body))
+    const types = publishes.map((p) => p.type)
+    expect(types).toContain("tui.session.select")
+    expect(types).toContain("tui.session.deselect")
 
     api?.keymap.dispatchCommand("app.exit")
     await task

--- a/packages/tui/test/app-session-select.test.tsx
+++ b/packages/tui/test/app-session-select.test.tsx
@@ -6,7 +6,7 @@ import { Global } from "@opencode-ai/core/global"
 import { createTuiResolvedConfig } from "./fixture/tui-runtime"
 import { createEventSource, createFetch, directory, json } from "./fixture/tui-sdk"
 
-type PublishBody = { type: string; properties?: { sessionID?: string } }
+type PublishBody = { type: string; properties?: { sessionID?: string; parentID?: string } }
 
 function parsePublishes(bodies: (string | undefined)[]) {
   const out: PublishBody[] = []
@@ -43,7 +43,10 @@ test("publishes tui.session.select when the TUI navigates to a session route", a
       time: { created: 0, updated: 0 },
     },
     other: {
+      // Subagent session with a parentID — publish should carry it through so
+      // plugins can distinguish subagents from top-level sessions.
       id: "other",
+      parentID: "dummy",
       title: "Other session",
       slug: "other",
       projectID: "project",
@@ -115,10 +118,19 @@ test("publishes tui.session.select when the TUI navigates to a session route", a
     expect(sinceInbound).toEqual([])
 
     const publishes = parsePublishes(calls.tuiPublish.map((r) => r.body))
-    const sessionIds = publishes.filter((p) => p.type === "tui.session.select").map((p) => p.properties?.sessionID)
-
+    const selects = publishes.filter((p) => p.type === "tui.session.select")
+    const sessionIds = selects.map((p) => p.properties?.sessionID)
     expect(sessionIds).toContain("dummy")
     expect(sessionIds).toContain("other")
+
+    // The "other" session has parentID "dummy" — verify it's carried through.
+    const otherSelect = selects.find((p) => p.properties?.sessionID === "other")
+    expect(otherSelect?.properties?.parentID).toBe("dummy")
+
+    // The top-level "dummy" session has no parentID — verify the field is
+    // absent from the publish payload.
+    const dummySelect = selects.find((p) => p.properties?.sessionID === "dummy")
+    expect(dummySelect?.properties?.parentID).toBeUndefined()
 
     api?.keymap.dispatchCommand("app.exit")
     await task

--- a/packages/tui/test/app-session-select.test.tsx
+++ b/packages/tui/test/app-session-select.test.tsx
@@ -1,0 +1,126 @@
+import { expect, mock, test } from "bun:test"
+import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
+import { createTestRenderer } from "@opentui/core/testing"
+import { Effect } from "effect"
+import { Global } from "@opencode-ai/core/global"
+import { createTuiResolvedConfig } from "./fixture/tui-runtime"
+import { createEventSource, createFetch, directory, json } from "./fixture/tui-sdk"
+
+type PublishBody = { type: string; properties?: { sessionID?: string } }
+
+function parsePublishes(bodies: (string | undefined)[]) {
+  const out: PublishBody[] = []
+  for (const body of bodies) {
+    if (!body) continue
+    try {
+      out.push(JSON.parse(body) as PublishBody)
+    } catch {}
+  }
+  return out
+}
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+test("publishes tui.session.select when the TUI navigates to a session route", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  const core = await import("@opentui/core")
+  mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+  const events = createEventSource()
+  const calls = createFetch((url) => {
+    if (url.pathname === "/session")
+      return json([
+        {
+          id: "dummy",
+          title: "Demo session",
+          slug: "dummy",
+          projectID: "project",
+          directory,
+          version: "0.0.0-test",
+          time: { created: 0, updated: 0 },
+        },
+        {
+          id: "other",
+          title: "Other session",
+          slug: "other",
+          projectID: "project",
+          directory,
+          version: "0.0.0-test",
+          time: { created: 0, updated: 0 },
+        },
+      ])
+  })
+
+  let api: TuiPluginApi | undefined
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch: calls.fetch,
+        events: events.source,
+        // continue: true seeds the initial route as { type: "session", sessionID: "dummy" }
+        args: { continue: true },
+        pluginHost: {
+          async start(input) {
+            api = input.api
+            started()
+          },
+          async dispose() {},
+        },
+      }).pipe(Effect.provide(Global.defaultLayer)),
+    )
+
+    await ready
+    await setup.renderOnce()
+    await setup.renderOnce()
+
+    // Initial mount should publish for "dummy"
+    await wait(() => calls.tuiPublish.some((r) => r.body?.includes('"dummy"')))
+
+    // Navigate to a different session via the plugin API (in-TUI navigation path)
+    api?.route.navigate("session", { sessionID: "other" })
+    await setup.renderOnce()
+    await wait(() => calls.tuiPublish.some((r) => r.body?.includes('"other"')))
+
+    // Inbound tui.session.select for "back-to-dummy" — should NOT be re-published
+    const beforeInbound = calls.tuiPublish.length
+    events.emit({
+      directory,
+      project: "proj_test",
+      payload: {
+        type: "tui.session.select",
+        properties: { sessionID: "dummy" },
+      } as any,
+    })
+    await setup.renderOnce()
+    await Bun.sleep(20)
+    await setup.renderOnce()
+
+    const publishes = parsePublishes(calls.tuiPublish.map((r) => r.body))
+    const sessionIds = publishes.filter((p) => p.type === "tui.session.select").map((p) => p.properties?.sessionID)
+
+    expect(sessionIds).toContain("dummy")
+    expect(sessionIds).toContain("other")
+    // No echo from the inbound select event
+    expect(calls.tuiPublish.length).toBe(beforeInbound)
+
+    api?.keymap.dispatchCommand("app.exit")
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})

--- a/packages/tui/test/fixture/tui-sdk.ts
+++ b/packages/tui/test/fixture/tui-sdk.ts
@@ -59,14 +59,34 @@ export function createEventSource() {
   }
 }
 
-export type FetchHandler = (url: URL) => Response | Promise<Response> | undefined
+export type FetchHandler = (url: URL, init?: RequestInit) => Response | Promise<Response> | undefined
+
+export type RecordedRequest = { url: URL; init?: RequestInit; body?: string }
 
 export function createFetch(override?: FetchHandler, events?: ReturnType<typeof createEventSource>) {
   const session = [] as URL[]
-  const fetch = (async (input: RequestInfo | URL) => {
+  const tuiPublish = [] as RecordedRequest[]
+  const fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = new URL(input instanceof Request ? input.url : String(input))
     if (url.pathname === "/session") session.push(url)
-    const overridden = await override?.(url)
+    if (url.pathname === "/tui/publish") {
+      let body: string | undefined
+      if (input instanceof Request) {
+        body = await input.clone().text()
+      } else {
+        const raw = init?.body
+        body =
+          typeof raw === "string"
+            ? raw
+            : raw instanceof Uint8Array
+              ? new TextDecoder().decode(raw)
+              : raw instanceof ArrayBuffer
+                ? new TextDecoder().decode(new Uint8Array(raw))
+                : undefined
+      }
+      tuiPublish.push({ url, init, body })
+    }
+    const overridden = await override?.(url, init)
     if (overridden) return overridden
     if (url.pathname === "/api/event" && events) return events.response()
 
@@ -102,8 +122,9 @@ export function createFetch(override?: FetchHandler, events?: ReturnType<typeof 
       return json({ location: { directory, project: { id: "proj_test", directory } }, data: [] })
     if (url.pathname === "/provider") return json({ all: [], default: {}, connected: [] })
     if (url.pathname === "/session") return json([])
+    if (url.pathname === "/tui/publish") return json(true)
     if (url.pathname === "/vcs") return json({ branch: "main" })
     throw new Error(`unexpected request: ${url.pathname}`)
   }) as typeof globalThis.fetch
-  return { fetch, session }
+  return { fetch, session, tuiPublish }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #31051

### Type of change

- [x] New feature

### What does this PR do?

TUI session-focus state lives in a SolidJS `Route` store. `route.navigate()` only mutates that store — no bus event is published when the user enters, switches between, or leaves a session in-TUI (session picker, quick-switch keybinds, prompt resolution, initial-route restore, `/new`). Plugins subscribing to the event bus could only detect external `selectSession` HTTP calls, not user-driven navigation.

This PR adds a `createEffect` in `packages/tui/src/app.tsx` that watches `route.data.sessionID` and publishes one of two events via the existing `/tui/publish` endpoint whenever the focused sessionID changes:

- `tui.session.select` (existing event) — fires when transitioning to a session route. Pairs with an `inboundSessionID` guard so navigations triggered by an inbound `tui.session.select` event don't echo back to the bus.
- `tui.session.deselect` (new event, no payload) — fires when transitioning away from any session route (to `home`, a `plugin` route, etc). Symmetric inbound listener navigates to home; same echo guard.

This is the centralized-effect approach suggested in #31051. It avoids touching the ~16 individual `route.navigate` call sites scattered across the TUI.

The deselect event is needed for plugins that mirror focused-session state to an external surface (e.g. a workspace title, a status bar widget). Without it those plugins are stuck displaying a stale session title after the user runs `/new`.

### How did you verify your code works?

**Unit tests** in `packages/tui/test/app-session-select.test.tsx`:

1. Initial mount (`args: { continue: true }` seeds `session/dummy`) publishes `tui.session.select` for `"dummy"`.
2. `api.route.navigate("session", { sessionID: "other" })` publishes for `"other"`.
3. An inbound `tui.session.select` event for `"dummy"` does NOT produce an echo publish.
4. `api.route.navigate("home")` from a session route publishes `tui.session.deselect`.
5. An inbound `tui.session.deselect` event does NOT produce an echo publish.

To capture POST bodies the fixture in `packages/tui/test/fixture/tui-sdk.ts` was extended to record `/tui/publish` requests (URL + parsed body) and return a 200 stub for the endpoint. All existing fixture consumers still get the same `{ fetch, session }` shape plus an additional `tuiPublish` property.

```
$ bun test test/app-session-select.test.tsx test/app-lifecycle.test.tsx
5 pass, 0 fail
```

Full TUI suite: 180 pass, 8 fail — the 8 failures pre-exist on `dev` (sync + hydration tests, unrelated to this change). Confirmed by stashing my changes and re-running.

`packages/opencode/test/server/session-select.test.ts` (existing endpoint tests) still pass.

Typecheck (`bun run typecheck` in `packages/tui` and `packages/opencode`) is clean.

**E2E**: Built `opencode --single` from this branch and ran it locally with a plugin that subscribes to both events and renames a terminal-multiplexer workspace based on the focused session. Confirmed:

- Workspace title follows the focused session through `/new`, session picker, quick-switch keybinds.
- Workspace title resets to default when navigating to home via `/new`.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
