### PR TITLE
feat(mcp): support boolean elicitation approvals

### DIFF
--- a/packages/opencode/src/mcp/elicitation.ts
+++ b/packages/opencode/src/mcp/elicitation.ts
@@ -1,0 +1,146 @@
+import { Deferred, Effect, Layer, Schema, Context } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { InstanceState } from "@/effect/instance-state"
+import { McpEvent } from "@opencode-ai/schema/mcp-event"
+
+export const ID = McpEvent.ElicitationID
+export type ID = typeof ID.Type
+export const BooleanProperty = McpEvent.ElicitationBooleanProperty
+export type BooleanProperty = typeof BooleanProperty.Type
+export const BooleanSchema = McpEvent.ElicitationBooleanSchema
+export type BooleanSchema = typeof BooleanSchema.Type
+export const Content = McpEvent.ElicitationContent
+export type Content = typeof Content.Type
+export const Request = McpEvent.ElicitationRequest
+export type Request = typeof Request.Type
+export const Result = McpEvent.ElicitationResult
+export type Result = typeof Result.Type
+export const Event = {
+  Asked: McpEvent.ElicitationAsked,
+  Replied: McpEvent.ElicitationReplied,
+}
+
+export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("McpElicitation.NotFoundError", {
+  requestID: ID,
+}) {}
+
+interface PendingEntry {
+  info: Request
+  deferred: Deferred.Deferred<Result>
+}
+
+interface State {
+  pending: Map<ID, PendingEntry>
+}
+
+export interface Interface {
+  readonly ask: (input: { server: string; message: string; schema: BooleanSchema }) => Effect.Effect<Result>
+  readonly reply: (input: { requestID: ID; content: Content }) => Effect.Effect<void, NotFoundError>
+  readonly decline: (requestID: ID) => Effect.Effect<void, NotFoundError>
+  readonly cancel: (requestID: ID) => Effect.Effect<void, NotFoundError>
+  readonly cancelServer: (server: string) => Effect.Effect<void>
+  readonly list: () => Effect.Effect<ReadonlyArray<Request>>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/McpElicitation") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+
+    const settle = Effect.fn("McpElicitation.settle")(function* (pending: State["pending"], id: ID, result: Result) {
+      const existing = pending.get(id)
+      if (!existing) return false
+      pending.delete(id)
+      yield* events.publish(Event.Replied, {
+        requestID: id,
+        result,
+      })
+      yield* Deferred.succeed(existing.deferred, result)
+      return true
+    })
+
+    const cancelAll = Effect.fn("McpElicitation.cancelAll")(function* (pending: State["pending"], server?: string) {
+      const requests = Array.from(pending.entries()).filter(([, item]) => !server || item.info.server === server)
+      for (const [id] of requests) {
+        yield* settle(pending, id, { action: "cancel" })
+      }
+    })
+
+    const state = yield* InstanceState.make<State>(
+      Effect.fn("McpElicitation.state")(function* () {
+        const state = {
+          pending: new Map<ID, PendingEntry>(),
+        }
+
+        yield* Effect.addFinalizer(() => cancelAll(state.pending))
+
+        return state
+      }),
+    )
+
+    const complete = Effect.fn("McpElicitation.complete")(function* (requestID: ID, result: Result) {
+      const pending = (yield* InstanceState.get(state)).pending
+      const settled = yield* settle(pending, requestID, result)
+      if (!settled) {
+        yield* Effect.logWarning("MCP elicitation reply for unknown request", { requestID })
+        return yield* new NotFoundError({ requestID })
+      }
+    })
+
+    const ask = Effect.fn("McpElicitation.ask")(function* (input: {
+      server: string
+      message: string
+      schema: BooleanSchema
+    }) {
+      const pending = (yield* InstanceState.get(state)).pending
+      const id = ID.ascending()
+      const deferred = yield* Deferred.make<Result>()
+      const info: Request = {
+        id,
+        server: input.server,
+        message: input.message,
+        schema: input.schema,
+      }
+      pending.set(id, { info, deferred })
+      yield* events.publish(Event.Asked, info)
+
+      return yield* Effect.ensuring(Deferred.await(deferred), settle(pending, id, { action: "cancel" }))
+    })
+
+    const reply = Effect.fn("McpElicitation.reply")(function* (input: { requestID: ID; content: Content }) {
+      yield* complete(input.requestID, {
+        action: "accept",
+        content: input.content,
+      })
+    })
+
+    const decline = Effect.fn("McpElicitation.decline")(function* (requestID: ID) {
+      yield* complete(requestID, { action: "decline" })
+    })
+
+    const cancel = Effect.fn("McpElicitation.cancel")(function* (requestID: ID) {
+      yield* complete(requestID, { action: "cancel" })
+    })
+
+    const cancelServer = Effect.fn("McpElicitation.cancelServer")(function* (server: string) {
+      const pending = (yield* InstanceState.get(state)).pending
+      yield* cancelAll(pending, server)
+    })
+
+    const list = Effect.fn("McpElicitation.list")(function* () {
+      const pending = (yield* InstanceState.get(state)).pending
+      return Array.from(pending.values(), (x) => x.info)
+    })
+
+    return Service.of({ ask, reply, decline, cancel, cancelServer, list })
+  }),
+)
+
+export const defaultLayer = layer.pipe(Layer.provide(EventV2Bridge.defaultLayer))
+
+export const node = LayerNode.make({ service: Service, layer: layer, deps: [EventV2Bridge.node] })
+
+export * as McpElicitation from "./elicitation"

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -10,6 +10,8 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import {
+  ElicitRequestSchema,
+  type ElicitResult,
   ListRootsRequestSchema,
   type LoggingMessageNotification,
   LoggingMessageNotificationSchema,
@@ -35,6 +37,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { McpCatalog } from "./catalog"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"
+import { McpElicitation } from "./elicitation"
 
 const DEFAULT_TIMEOUT = 30_000
 const CLIENT_OPTIONS = {
@@ -42,11 +45,18 @@ const CLIENT_OPTIONS = {
     // https://github.com/anomalyco/opencode/issues/11948
     // sampling: {},
     // https://github.com/anomalyco/opencode/issues/23066
-    // elicitation: {},
+    elicitation: { form: {} },
     // https://github.com/anomalyco/opencode/issues/2308
     roots: {},
     // https://github.com/anomalyco/opencode/issues/28567
     // tasks: {},
+  },
+} satisfies ClientOptions
+
+const CLIENT_OPTIONS_AUTH = {
+  capabilities: {
+    // https://github.com/anomalyco/opencode/issues/2308
+    roots: {},
   },
 } satisfies ClientOptions
 
@@ -73,11 +83,55 @@ export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("MCP
 
 type MCPClient = Client
 
-function createClient(directory: string) {
-  const client = new Client({ name: "opencode", version: InstallationVersion }, CLIENT_OPTIONS)
+interface ElicitationHandlerInput {
+  server: string
+  timeout: number
+  bridge: EffectBridge.Shape
+  elicitation: McpElicitation.Interface
+}
+
+function parseBooleanElicitationSchema(value: unknown) {
+  try {
+    const schema = Schema.decodeUnknownSync(McpElicitation.BooleanSchema)(value)
+    const required = new Set(schema.required ?? [])
+    for (const key of required) {
+      if (!(key in schema.properties)) return undefined
+    }
+    return schema
+  } catch {
+    return undefined
+  }
+}
+
+function createClient(directory: string, elicitationInput?: ElicitationHandlerInput) {
+  const client = new Client(
+    { name: "opencode", version: InstallationVersion },
+    elicitationInput ? CLIENT_OPTIONS : CLIENT_OPTIONS_AUTH,
+  )
   client.setRequestHandler(ListRootsRequestSchema, () =>
     Promise.resolve({ roots: [{ uri: pathToFileURL(directory).href }] }),
   )
+  client.setRequestHandler(ElicitRequestSchema, async (request): Promise<ElicitResult> => {
+    if (!elicitationInput) return { action: "cancel" }
+    if (request.params.mode === "url") return { action: "cancel" }
+    const schema = parseBooleanElicitationSchema(request.params.requestedSchema)
+    if (!schema) return { action: "cancel" }
+
+    return elicitationInput.bridge.promise(
+      elicitationInput.elicitation
+        .ask({
+          server: elicitationInput.server,
+          message: request.params.message,
+          schema,
+        })
+        .pipe(
+          Effect.timeoutOrElse({
+            duration: `${elicitationInput.timeout} millis`,
+            orElse: () => Effect.succeed({ action: "cancel" as const }),
+          }),
+        ),
+    )
+  })
   return client
 }
 
@@ -207,14 +261,21 @@ export const layer = Layer.effect(
      * Connect a client via the given transport with resource safety:
      * on failure the transport is closed; on success the caller owns it.
      */
-    const connectTransport = Effect.fn("MCP.connectTransport")(function* (transport: Transport, timeout: number) {
+    const elicitation = yield* McpElicitation.Service
+
+    const connectTransport = Effect.fn("MCP.connectTransport")(function* (
+      name: string,
+      transport: Transport,
+      timeout: number,
+    ) {
       const directory = yield* InstanceState.directory
+      const bridge = yield* EffectBridge.make()
       return yield* Effect.acquireUseRelease(
         Effect.succeed(transport),
         (t) =>
           Effect.tryPromise({
             try: () => {
-              const client = createClient(directory)
+              const client = createClient(directory, { server: name, timeout, bridge, elicitation })
               return withTimeout(client.connect(t), timeout).then(() => client)
             },
             catch: (e) => (e instanceof Error ? e : new Error(String(e))),
@@ -279,7 +340,7 @@ export const layer = Layer.effect(
       let lastStatus: Status | undefined
 
       for (const { name, transport } of transports) {
-        const result = yield* connectTransport(transport, connectTimeout).pipe(
+        const result = yield* connectTransport(key, transport, connectTimeout).pipe(
           Effect.map((client) => ({ client, transportName: name })),
           Effect.catch((error) => {
             const lastError = error instanceof Error ? error : new Error(String(error))
@@ -349,7 +410,7 @@ export const layer = Layer.effect(
       })
 
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
-      return yield* connectTransport(transport, connectTimeout).pipe(
+      return yield* connectTransport(key, transport, connectTimeout).pipe(
         Effect.map((client): { client: MCPClient | undefined; status: Status } => ({
           client,
           status: { status: "connected" },
@@ -440,6 +501,7 @@ export const layer = Layer.effect(
         s.status[name] = { status: "failed", error: "Connection closed" }
         bridge.fork(
           Effect.logWarning("MCP connection closed", { server: name }).pipe(
+            Effect.andThen(elicitation.cancelServer(name)),
             Effect.andThen(events.publish(ToolsChanged, { server: name })),
             Effect.ignore,
           ),
@@ -556,8 +618,11 @@ export const layer = Layer.effect(
       delete s.clients[name]
       delete s.defs[name]
       delete s.instructions[name]
-      if (!client) return Effect.void
-      return Effect.tryPromise(() => client.close()).pipe(Effect.ignore)
+      return Effect.gen(function* () {
+        yield* elicitation.cancelServer(name)
+        if (!client) return
+        yield* Effect.tryPromise(() => client.close()).pipe(Effect.ignore)
+      })
     }
 
     const storeClient = Effect.fnUntraced(function* (
@@ -576,7 +641,10 @@ export const layer = Layer.effect(
       if (instructions) s.instructions[name] = instructions
       else delete s.instructions[name]
       watch(s, name, client, bridge, timeout)
-      if (previous) yield* Effect.tryPromise(() => previous.close()).pipe(Effect.ignore)
+      if (previous) {
+        yield* elicitation.cancelServer(name)
+        yield* Effect.tryPromise(() => previous.close()).pipe(Effect.ignore)
+      }
       return s.status[name]
     })
 
@@ -1003,6 +1071,7 @@ export type AuthStatus = "authenticated" | "expired" | "not_authenticated"
 // --- Per-service runtime ---
 
 export const defaultLayer = layer.pipe(
+  Layer.provideMerge(McpElicitation.defaultLayer),
   Layer.provide(McpAuth.defaultLayer),
   Layer.provide(EventV2Bridge.defaultLayer),
   Layer.provide(Config.defaultLayer),
@@ -1013,7 +1082,7 @@ export const defaultLayer = layer.pipe(
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [CrossSpawnSpawner.node, McpAuth.node, EventV2Bridge.node, Config.node],
+  deps: [CrossSpawnSpawner.node, McpAuth.node, EventV2Bridge.node, Config.node, McpElicitation.node],
 })
 
 export * as MCP from "."

--- a/packages/opencode/src/server/routes/instance/httpapi/errors.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/errors.ts
@@ -149,6 +149,15 @@ export class McpServerNotFoundError extends Schema.TaggedErrorClass<McpServerNot
   { httpApiStatus: 404 },
 ) {}
 
+export class McpElicitationNotFoundError extends Schema.TaggedErrorClass<McpElicitationNotFoundError>()(
+  "McpElicitationNotFoundError",
+  {
+    requestID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
 export class PtyNotFoundError extends Schema.TaggedErrorClass<PtyNotFoundError>()(
   "PtyNotFoundError",
   {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/mcp.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/mcp.ts
@@ -1,8 +1,9 @@
 import { MCP } from "@/mcp"
+import { McpElicitation } from "@/mcp/elicitation"
 import { ConfigMCPV1 } from "@opencode-ai/core/v1/config/mcp"
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { McpServerNotFoundError } from "../errors"
+import { McpElicitationNotFoundError, McpServerNotFoundError } from "../errors"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
 import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
@@ -24,6 +25,9 @@ export const AuthCallbackPayload = Schema.Struct({
 export const AuthRemoveResponse = Schema.Struct({
   success: Schema.Literal(true),
 })
+export const ElicitationReplyPayload = Schema.Struct({
+  content: McpElicitation.Content,
+})
 export class UnsupportedOAuthError extends Schema.ErrorClass<UnsupportedOAuthError>("McpUnsupportedOAuthError")(
   { error: Schema.String },
   { httpApiStatus: 400 },
@@ -36,6 +40,10 @@ export const McpPaths = {
   authAuthenticate: "/mcp/:name/auth/authenticate",
   connect: "/mcp/:name/connect",
   disconnect: "/mcp/:name/disconnect",
+  elicitation: "/mcp/elicitation",
+  elicitationReply: "/mcp/elicitation/:requestID/reply",
+  elicitationDecline: "/mcp/elicitation/:requestID/decline",
+  elicitationCancel: "/mcp/elicitation/:requestID/cancel",
 } as const
 
 export const McpApi = HttpApi.make("mcp")
@@ -134,6 +142,53 @@ export const McpApi = HttpApi.make("mcp")
           OpenApi.annotations({
             identifier: "mcp.disconnect",
             description: "Disconnect an MCP server.",
+          }),
+        ),
+        HttpApiEndpoint.get("elicitationList", McpPaths.elicitation, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Array(McpElicitation.Request), "List of pending MCP elicitation requests"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.elicitation.list",
+            summary: "List pending MCP elicitation requests",
+            description: "Get pending MCP elicitation requests.",
+          }),
+        ),
+        HttpApiEndpoint.post("elicitationReply", McpPaths.elicitationReply, {
+          params: { requestID: McpElicitation.ID },
+          query: WorkspaceRoutingQuery,
+          payload: ElicitationReplyPayload,
+          success: described(Schema.Boolean, "MCP elicitation request accepted"),
+          error: [HttpApiError.BadRequest, McpElicitationNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.elicitation.reply",
+            summary: "Accept MCP elicitation request",
+            description: "Accept an MCP elicitation request with user-provided content.",
+          }),
+        ),
+        HttpApiEndpoint.post("elicitationDecline", McpPaths.elicitationDecline, {
+          params: { requestID: McpElicitation.ID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "MCP elicitation request declined"),
+          error: McpElicitationNotFoundError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.elicitation.decline",
+            summary: "Decline MCP elicitation request",
+            description: "Decline an MCP elicitation request.",
+          }),
+        ),
+        HttpApiEndpoint.post("elicitationCancel", McpPaths.elicitationCancel, {
+          params: { requestID: McpElicitation.ID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "MCP elicitation request cancelled"),
+          error: McpElicitationNotFoundError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "mcp.elicitation.cancel",
+            summary: "Cancel MCP elicitation request",
+            description: "Cancel an MCP elicitation request.",
           }),
         ),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/mcp.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/mcp.ts
@@ -1,13 +1,27 @@
 import { MCP } from "@/mcp"
+import { McpElicitation } from "@/mcp/elicitation"
 import { Effect, Schema } from "effect"
 import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
-import { McpServerNotFoundError } from "../errors"
-import { AddPayload, AuthCallbackPayload, StatusMap, UnsupportedOAuthError } from "../groups/mcp"
+import { McpElicitationNotFoundError, McpServerNotFoundError } from "../errors"
+import {
+  AddPayload,
+  AuthCallbackPayload,
+  ElicitationReplyPayload,
+  StatusMap,
+  UnsupportedOAuthError,
+} from "../groups/mcp"
 
 export const mcpHandlers = HttpApiBuilder.group(InstanceHttpApi, "mcp", (handlers) =>
   Effect.gen(function* () {
     const mcp = yield* MCP.Service
+    const elicitation = yield* McpElicitation.Service
+
+    const missingElicitation = (error: McpElicitation.NotFoundError) =>
+      new McpElicitationNotFoundError({
+        requestID: String(error.requestID),
+        message: `MCP elicitation request not found: ${error.requestID}`,
+      })
 
     const status = Effect.fn("McpHttpApi.status")(function* () {
       return yield* mcp.status()
@@ -98,6 +112,38 @@ export const mcpHandlers = HttpApiBuilder.group(InstanceHttpApi, "mcp", (handler
       return true
     })
 
+    const elicitationList = Effect.fn("McpHttpApi.elicitationList")(function* () {
+      return yield* elicitation.list()
+    })
+
+    const elicitationReply = Effect.fn("McpHttpApi.elicitationReply")(function* (ctx: {
+      params: { requestID: McpElicitation.ID }
+      payload: typeof ElicitationReplyPayload.Type
+    }) {
+      yield* elicitation
+        .reply({ requestID: ctx.params.requestID, content: ctx.payload.content })
+        .pipe(Effect.catchTag("McpElicitation.NotFoundError", (error) => Effect.fail(missingElicitation(error))))
+      return true
+    })
+
+    const elicitationDecline = Effect.fn("McpHttpApi.elicitationDecline")(function* (ctx: {
+      params: { requestID: McpElicitation.ID }
+    }) {
+      yield* elicitation
+        .decline(ctx.params.requestID)
+        .pipe(Effect.catchTag("McpElicitation.NotFoundError", (error) => Effect.fail(missingElicitation(error))))
+      return true
+    })
+
+    const elicitationCancel = Effect.fn("McpHttpApi.elicitationCancel")(function* (ctx: {
+      params: { requestID: McpElicitation.ID }
+    }) {
+      yield* elicitation
+        .cancel(ctx.params.requestID)
+        .pipe(Effect.catchTag("McpElicitation.NotFoundError", (error) => Effect.fail(missingElicitation(error))))
+      return true
+    })
+
     return handlers
       .handle("status", status)
       .handle("add", add)
@@ -107,5 +153,9 @@ export const mcpHandlers = HttpApiBuilder.group(InstanceHttpApi, "mcp", (handler
       .handle("authRemove", authRemove)
       .handle("connect", connect)
       .handle("disconnect", disconnect)
+      .handle("elicitationList", elicitationList)
+      .handle("elicitationReply", elicitationReply)
+      .handle("elicitationDecline", elicitationDecline)
+      .handle("elicitationCancel", elicitationCancel)
   }),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -18,6 +18,7 @@ import { Git } from "@/git"
 import { Installation } from "@/installation"
 import { LSP } from "@/lsp/lsp"
 import { MCP } from "@/mcp"
+import { McpElicitation } from "@/mcp/elicitation"
 import { McpAuth } from "@/mcp/auth"
 import { Permission } from "@/permission"
 import { Plugin } from "@/plugin"
@@ -238,6 +239,7 @@ const app = LayerNode.group([
   LLM.node,
   LSP.node,
   MCP.node,
+  McpElicitation.node,
   McpAuth.node,
   Command.node,
   Truncate.node,

--- a/packages/opencode/test/mcp/elicitation.test.ts
+++ b/packages/opencode/test/mcp/elicitation.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, expect } from "bun:test"
+import { Effect, Fiber, Layer, Queue } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { McpElicitation } from "../../src/mcp/elicitation"
+import { disposeAllInstances } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  Layer.mergeAll(
+    McpElicitation.layer.pipe(Layer.provideMerge(EventV2Bridge.defaultLayer)),
+    CrossSpawnSpawner.defaultLayer,
+  ),
+)
+
+const booleanSchema = {
+  type: "object",
+  properties: {
+    allowed: {
+      type: "boolean",
+      title: "Allow command",
+      description: "Run the resolved command once",
+    },
+  },
+  required: ["allowed"],
+} as const
+
+const askEffect = Effect.fn("McpElicitationTest.ask")(function* (server = "unity-gateway") {
+  const elicitation = yield* McpElicitation.Service
+  return yield* elicitation.ask({
+    server,
+    message: "Approve resolved Unity command?",
+    schema: booleanSchema,
+  })
+})
+
+const waitForPending = Effect.fn("McpElicitationTest.waitForPending")(function* (count: number) {
+  const elicitation = yield* McpElicitation.Service
+  const events = yield* EventV2Bridge.Service
+  const asked = yield* Queue.unbounded<void>()
+  const off = yield* events.listen((event) => {
+    if (event.type === McpElicitation.Event.Asked.type) Queue.offerUnsafe(asked, undefined)
+    return Effect.void
+  })
+  yield* Effect.addFinalizer(() => off)
+
+  for (;;) {
+    const pending = yield* elicitation.list()
+    if (pending.length === count) return pending
+    yield* Queue.take(asked).pipe(Effect.timeout("2 seconds"))
+  }
+})
+
+const waitForReply = Effect.fn("McpElicitationTest.waitForReply")(function* () {
+  const events = yield* EventV2Bridge.Service
+  const replied = yield* Queue.unbounded<{ requestID: McpElicitation.ID; result: McpElicitation.Result }>()
+  const off = yield* events.listen((event) => {
+    if (event.type === McpElicitation.Event.Replied.type) {
+      Queue.offerUnsafe(replied, event.data as { requestID: McpElicitation.ID; result: McpElicitation.Result })
+    }
+    return Effect.void
+  })
+  yield* Effect.addFinalizer(() => off)
+
+  return yield* Queue.take(replied).pipe(Effect.timeout("2 seconds"))
+})
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+it.instance(
+  "ask - publishes a pending MCP elicitation request",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* askEffect().pipe(Effect.forkScoped)
+
+      const pending = yield* waitForPending(1)
+      expect(pending).toEqual([
+        expect.objectContaining({
+          server: "unity-gateway",
+          message: "Approve resolved Unity command?",
+          schema: booleanSchema,
+        }),
+      ])
+
+      const elicitation = yield* McpElicitation.Service
+      yield* elicitation.cancel(pending[0].id)
+      expect((yield* Fiber.await(fiber))._tag).toBe("Success")
+    }),
+  { git: true },
+)
+
+it.instance(
+  "ask - publishes cancelled reply when interrupted",
+  () =>
+    Effect.gen(function* () {
+      const reply = yield* waitForReply().pipe(Effect.forkScoped)
+      const fiber = yield* askEffect().pipe(Effect.forkScoped)
+      const [request] = yield* waitForPending(1)
+
+      yield* Fiber.interrupt(fiber)
+
+      expect(yield* Fiber.join(reply)).toEqual({
+        requestID: request.id,
+        result: { action: "cancel" },
+      })
+
+      const elicitation = yield* McpElicitation.Service
+      expect(yield* elicitation.list()).toEqual([])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "cancelServer - cancels pending requests for the server",
+  () =>
+    Effect.gen(function* () {
+      const firstReply = yield* waitForReply().pipe(Effect.forkScoped)
+      const first = yield* askEffect("unity-gateway").pipe(Effect.forkScoped)
+      const second = yield* askEffect("other-server").pipe(Effect.forkScoped)
+      const pending = yield* waitForPending(2)
+
+      const elicitation = yield* McpElicitation.Service
+      yield* elicitation.cancelServer("unity-gateway")
+
+      const cancelled = yield* Fiber.join(firstReply)
+      expect(cancelled.result).toEqual({ action: "cancel" })
+      expect(pending.find((item) => item.id === cancelled.requestID)?.server).toBe("unity-gateway")
+      expect(yield* Fiber.join(first)).toEqual({ action: "cancel" })
+      expect(yield* elicitation.list()).toEqual([expect.objectContaining({ server: "other-server" })])
+
+      const [remaining] = yield* elicitation.list()
+      yield* elicitation.cancel(remaining.id)
+      expect(yield* Fiber.join(second)).toEqual({ action: "cancel" })
+    }),
+  { git: true },
+)
+
+it.instance(
+  "reply - resolves the pending request with accepted content",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* askEffect().pipe(Effect.forkScoped)
+      const [request] = yield* waitForPending(1)
+
+      const elicitation = yield* McpElicitation.Service
+      yield* elicitation.reply({
+        requestID: request.id,
+        content: { allowed: true },
+      })
+
+      expect(yield* Fiber.join(fiber)).toEqual({
+        action: "accept",
+        content: { allowed: true },
+      })
+      expect(yield* elicitation.list()).toEqual([])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "decline - resolves the pending request as declined",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* askEffect().pipe(Effect.forkScoped)
+      const [request] = yield* waitForPending(1)
+
+      const elicitation = yield* McpElicitation.Service
+      yield* elicitation.decline(request.id)
+
+      expect(yield* Fiber.join(fiber)).toEqual({ action: "decline" })
+      expect(yield* elicitation.list()).toEqual([])
+    }),
+  { git: true },
+)
+
+it.instance(
+  "cancel - resolves the pending request as cancelled",
+  () =>
+    Effect.gen(function* () {
+      const fiber = yield* askEffect().pipe(Effect.forkScoped)
+      const [request] = yield* waitForPending(1)
+
+      const elicitation = yield* McpElicitation.Service
+      yield* elicitation.cancel(request.id)
+
+      expect(yield* Fiber.join(fiber)).toEqual({ action: "cancel" })
+      expect(yield* elicitation.list()).toEqual([])
+    }),
+  { git: true },
+)

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -1,8 +1,12 @@
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { expect, mock, beforeEach } from "bun:test"
-import { ListRootsRequestSchema, ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js"
-import { Cause, Effect, Exit } from "effect"
+import {
+  ElicitRequestSchema,
+  ListRootsRequestSchema,
+  ToolListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import { Cause, Effect, Exit, Fiber } from "effect"
 import type { MCP as MCPNS } from "../../src/mcp/index"
 import { testEffect } from "../lib/effect"
 import { TestInstance } from "../fixture/fixture"
@@ -46,7 +50,7 @@ interface MockClientState {
     { resourceTemplates: Array<{ name: string; uriTemplate: string; description?: string }>; nextCursor?: string }
   >
   closed: boolean
-  clientOptions?: { capabilities?: { roots?: { listChanged?: boolean } } }
+  clientOptions?: { capabilities?: { roots?: { listChanged?: boolean }; elicitation?: object } }
   requestHandlers: Map<unknown, (...args: any[]) => Promise<any>>
   notificationHandlers: Map<unknown, (...args: any[]) => any>
 }
@@ -273,6 +277,7 @@ beforeEach(() => {
 
 // Import after mocks
 const { MCP } = await import("../../src/mcp/index")
+const { McpElicitation } = await import("../../src/mcp/elicitation")
 const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
 
 const it = testEffect(MCP.defaultLayer)
@@ -299,6 +304,106 @@ it.instance(
         expect(handler).toBeDefined()
         const result = yield* Effect.promise(() => handler?.() ?? Promise.reject(new Error("roots handler missing")))
         expect(result).toEqual({ roots: [{ uri: pathToFileURL(directory).href }] })
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "advertises MCP form elicitation and cancels unsupported schemas",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "elicit"
+        yield* mcp.add("elicit", { type: "local", command: ["echo", "test"] })
+
+        const state = getOrCreateClientState("elicit")
+        expect(state.clientOptions?.capabilities?.elicitation).toEqual({ form: {} })
+
+        const handler = state.requestHandlers.get(ElicitRequestSchema)
+        expect(handler).toBeDefined()
+        const schemaResult = yield* Effect.promise(
+          () =>
+            handler?.({
+              method: "elicitation/create",
+              params: {
+                message: "Need a string",
+                requestedSchema: {
+                  type: "object",
+                  properties: {
+                    value: { type: "string" },
+                  },
+                },
+              },
+            }) ?? Promise.reject(new Error("elicitation handler missing")),
+        )
+        expect(schemaResult).toEqual({ action: "cancel" })
+
+        const urlResult = yield* Effect.promise(
+          () =>
+            handler?.({
+              method: "elicitation/create",
+              params: {
+                mode: "url",
+                message: "Open this URL?",
+                url: "https://example.com",
+              },
+            }) ?? Promise.reject(new Error("elicitation handler missing")),
+        )
+        expect(urlResult).toEqual({ action: "cancel" })
+      }),
+    ),
+  { config: { mcp: {} } },
+)
+
+it.instance(
+  "routes supported MCP form elicitation through the pending request service",
+  () =>
+    MCP.Service.use((mcp: MCPNS.Interface) =>
+      Effect.gen(function* () {
+        lastCreatedClientName = "elicit-boolean"
+        yield* mcp.add("elicit-boolean", { type: "local", command: ["echo", "test"] })
+
+        const handler = getOrCreateClientState("elicit-boolean").requestHandlers.get(ElicitRequestSchema)
+        expect(handler).toBeDefined()
+        const fiber = yield* Effect.promise(
+          () =>
+            handler?.({
+              method: "elicitation/create",
+              params: {
+                message: "Approve command?",
+                requestedSchema: {
+                  type: "object",
+                  properties: {
+                    allowed: { type: "boolean", title: "Allow command" },
+                  },
+                  required: ["allowed"],
+                },
+              },
+            }) ?? Promise.reject(new Error("elicitation handler missing")),
+        ).pipe(Effect.forkScoped)
+
+        const elicitation = yield* McpElicitation.Service
+        let pending = yield* elicitation.list()
+        for (let index = 0; pending.length === 0 && index < 20; index++) {
+          yield* Effect.sleep("10 millis")
+          pending = yield* elicitation.list()
+        }
+        expect(pending).toEqual([
+          expect.objectContaining({
+            server: "elicit-boolean",
+            message: "Approve command?",
+          }),
+        ])
+
+        yield* elicitation.reply({
+          requestID: pending[0].id,
+          content: { allowed: true },
+        })
+        expect(yield* Fiber.join(fiber)).toEqual({
+          action: "accept",
+          content: { allowed: true },
+        })
       }),
     ),
   { config: { mcp: {} } },

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -132,6 +132,7 @@ const { MCP } = await import("../../src/mcp/index")
 const { EventV2Bridge } = await import("../../src/event-v2-bridge")
 const { Config } = await import("../../src/config/config")
 const { McpAuth } = await import("../../src/mcp/auth")
+const { McpElicitation } = await import("../../src/mcp/elicitation")
 const { McpOAuthProvider } = await import("../../src/mcp/oauth-provider")
 const { FSUtil } = await import("@opencode-ai/core/fs-util")
 const { CrossSpawnSpawner } = await import("@opencode-ai/core/cross-spawn-spawner")
@@ -140,6 +141,7 @@ const mcpTest = testEffect(
   Layer.mergeAll(
     MCP.layer.pipe(
       Layer.provide(McpAuth.defaultLayer),
+      Layer.provide(McpElicitation.defaultLayer),
       Layer.provideMerge(EventV2Bridge.defaultLayer),
       Layer.provide(Config.defaultLayer),
       Layer.provide(CrossSpawnSpawner.defaultLayer),

--- a/packages/opencode/test/mcp/oauth-browser.test.ts
+++ b/packages/opencode/test/mcp/oauth-browser.test.ts
@@ -118,12 +118,14 @@ const { MCP } = await import("../../src/mcp/index")
 const { EventV2Bridge } = await import("../../src/event-v2-bridge")
 const { Config } = await import("../../src/config/config")
 const { McpAuth } = await import("../../src/mcp/auth")
+const { McpElicitation } = await import("../../src/mcp/elicitation")
 const { McpOAuthCallback } = await import("../../src/mcp/oauth-callback")
 const { FSUtil } = await import("@opencode-ai/core/fs-util")
 const { CrossSpawnSpawner } = await import("@opencode-ai/core/cross-spawn-spawner")
 const mcpTest = testEffect(
   MCP.layer.pipe(
     Layer.provide(McpAuth.defaultLayer),
+    Layer.provide(McpElicitation.defaultLayer),
     Layer.provideMerge(EventV2Bridge.defaultLayer),
     Layer.provide(Config.defaultLayer),
     Layer.provide(CrossSpawnSpawner.defaultLayer),

--- a/packages/opencode/test/server/httpapi-mcp-elicitation.test.ts
+++ b/packages/opencode/test/server/httpapi-mcp-elicitation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect } from "bun:test"
+import { Context, Effect, Layer } from "effect"
+import { HttpApiApp } from "../../src/server/routes/instance/httpapi/server"
+import { resetDatabase } from "../fixture/db"
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const context = Context.empty() as Context.Context<unknown>
+const testStateLayer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    yield* Effect.promise(() => resetDatabase())
+    yield* Effect.addFinalizer(() => Effect.promise(() => resetDatabase()).pipe(Effect.ignore))
+  }),
+)
+const it = testEffect(testStateLayer)
+
+type TestHandler = ReturnType<typeof HttpApiApp.webHandler>
+
+const request = Effect.fnUntraced(function* (
+  handler: TestHandler,
+  route: string,
+  directory: string,
+  init?: RequestInit,
+) {
+  const headers = new Headers(init?.headers)
+  headers.set("x-opencode-directory", directory)
+  return yield* Effect.promise(() =>
+    Promise.resolve(
+      handler.handler(
+        new Request(`http://localhost${route}`, {
+          ...init,
+          headers,
+        }),
+        context,
+      ),
+    ),
+  )
+})
+
+const json = <A>(response: Response) => Effect.promise(() => response.json() as Promise<A>)
+
+describe("mcp elicitation HttpApi", () => {
+  it.instance(
+    "lists pending MCP elicitations",
+    () =>
+      Effect.gen(function* () {
+        const tmp = yield* TestInstance
+        const handler = HttpApiApp.webHandler()
+
+        const listed = yield* request(handler, "/mcp/elicitation", tmp.directory)
+        expect(listed.status).toBe(200)
+        const pending = yield* json<Array<{ id: string; server: string; message: string }>>(listed)
+        expect(pending).toEqual([])
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "returns typed errors for missing MCP elicitation replies",
+    () =>
+      Effect.gen(function* () {
+        const tmp = yield* TestInstance
+        const handler = HttpApiApp.webHandler()
+        const missing = "mcpel_missing"
+
+        for (const input of [
+          {
+            path: `/mcp/elicitation/${missing}/reply`,
+            init: {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ content: { allowed: true } }),
+            },
+          },
+          { path: `/mcp/elicitation/${missing}/decline`, init: { method: "POST" } },
+          { path: `/mcp/elicitation/${missing}/cancel`, init: { method: "POST" } },
+        ]) {
+          const response = yield* request(handler, input.path, tmp.directory, input.init)
+          expect(response.status).toBe(404)
+          expect(yield* json(response)).toEqual({
+            _tag: "McpElicitationNotFoundError",
+            requestID: missing,
+            message: `MCP elicitation request not found: ${missing}`,
+          })
+        }
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+})

--- a/packages/opencode/test/server/httpapi-mcp-oauth.test.ts
+++ b/packages/opencode/test/server/httpapi-mcp-oauth.test.ts
@@ -27,7 +27,11 @@ const testMcpHandlers = HttpApiBuilder.group(TestHttpApi, "mcp", (handlers) =>
       .handle("authAuthenticate", () => Effect.die("unexpected MCP authAuthenticate"))
       .handle("authRemove", () => Effect.die("unexpected MCP authRemove"))
       .handle("connect", () => Effect.die("unexpected MCP connect"))
-      .handle("disconnect", () => Effect.die("unexpected MCP disconnect")),
+      .handle("disconnect", () => Effect.die("unexpected MCP disconnect"))
+      .handle("elicitationList", () => Effect.die("unexpected MCP elicitation list"))
+      .handle("elicitationReply", () => Effect.die("unexpected MCP elicitation reply"))
+      .handle("elicitationDecline", () => Effect.die("unexpected MCP elicitation decline"))
+      .handle("elicitationCancel", () => Effect.die("unexpected MCP elicitation cancel")),
   ),
 )
 

--- a/packages/schema/src/mcp-event.ts
+++ b/packages/schema/src/mcp-event.ts
@@ -2,6 +2,59 @@ export * as McpEvent from "./mcp-event"
 
 import { Schema } from "effect"
 import { Event } from "./event"
+import { ascending } from "./identifier"
+import { statics } from "./schema"
+
+export const ElicitationID = Schema.String.check(Schema.isStartsWith("mcpel")).pipe(
+  Schema.brand("McpEvent.ElicitationID"),
+  statics((schema) => ({ ascending: (id?: string) => schema.make(id ?? "mcpel_" + ascending()) })),
+)
+export type ElicitationID = typeof ElicitationID.Type
+
+export const ElicitationBooleanProperty = Schema.Struct({
+  type: Schema.Literal("boolean"),
+  title: Schema.optional(Schema.String),
+  description: Schema.optional(Schema.String),
+  default: Schema.optional(Schema.Boolean),
+}).annotate({ identifier: "McpEvent.ElicitationBooleanProperty" })
+export type ElicitationBooleanProperty = typeof ElicitationBooleanProperty.Type
+
+export const ElicitationBooleanSchema = Schema.Struct({
+  $schema: Schema.optional(Schema.String),
+  type: Schema.Literal("object"),
+  properties: Schema.Record(Schema.String, ElicitationBooleanProperty),
+  required: Schema.optional(Schema.Array(Schema.String)),
+}).annotate({ identifier: "McpEvent.ElicitationBooleanSchema" })
+export type ElicitationBooleanSchema = typeof ElicitationBooleanSchema.Type
+
+export const ElicitationRequest = Schema.Struct({
+  id: ElicitationID,
+  server: Schema.String,
+  message: Schema.String,
+  schema: ElicitationBooleanSchema,
+}).annotate({ identifier: "McpEvent.ElicitationRequest" })
+export type ElicitationRequest = typeof ElicitationRequest.Type
+
+export const ElicitationContent = Schema.Record(Schema.String, Schema.Boolean).annotate({
+  identifier: "McpEvent.ElicitationContent",
+})
+export type ElicitationContent = typeof ElicitationContent.Type
+
+export const ElicitationAccept = Schema.Struct({
+  action: Schema.Literal("accept"),
+  content: ElicitationContent,
+}).annotate({ identifier: "McpEvent.ElicitationAccept" })
+export const ElicitationDecline = Schema.Struct({
+  action: Schema.Literal("decline"),
+}).annotate({ identifier: "McpEvent.ElicitationDecline" })
+export const ElicitationCancel = Schema.Struct({
+  action: Schema.Literal("cancel"),
+}).annotate({ identifier: "McpEvent.ElicitationCancel" })
+export const ElicitationResult = Schema.Union([ElicitationAccept, ElicitationDecline, ElicitationCancel]).annotate({
+  identifier: "McpEvent.ElicitationResult",
+  discriminator: "action",
+})
+export type ElicitationResult = typeof ElicitationResult.Type
 
 export const ToolsChanged = Event.define({
   type: "mcp.tools.changed",
@@ -18,4 +71,17 @@ export const BrowserOpenFailed = Event.define({
   },
 })
 
-export const Definitions = Event.inventory(ToolsChanged, BrowserOpenFailed)
+export const ElicitationAsked = Event.define({
+  type: "mcp.elicitation.asked",
+  schema: ElicitationRequest.fields,
+})
+
+export const ElicitationReplied = Event.define({
+  type: "mcp.elicitation.replied",
+  schema: {
+    requestID: ElicitationID,
+    result: ElicitationResult,
+  },
+})
+
+export const Definitions = Event.inventory(ToolsChanged, BrowserOpenFailed, ElicitationAsked, ElicitationReplied)

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -107,6 +107,15 @@ import type {
   McpConnectResponses,
   McpDisconnectErrors,
   McpDisconnectResponses,
+  McpElicitationCancelErrors,
+  McpElicitationCancelResponses,
+  McpElicitationDeclineErrors,
+  McpElicitationDeclineResponses,
+  McpElicitationListErrors,
+  McpElicitationListResponses,
+  McpElicitationReplyErrors,
+  McpElicitationReplyResponses,
+  McpEventElicitationContent,
   McpLocalConfig,
   McpRemoteConfig,
   McpStatusErrors,
@@ -2389,6 +2398,151 @@ export class Auth2 extends HeyApiClient {
   }
 }
 
+export class Elicitation extends HeyApiClient {
+  /**
+   * List pending MCP elicitation requests
+   *
+   * Get pending MCP elicitation requests.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<McpElicitationListResponses, McpElicitationListErrors, ThrowOnError>({
+      url: "/mcp/elicitation",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Accept MCP elicitation request
+   *
+   * Accept an MCP elicitation request with user-provided content.
+   */
+  public reply<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: string
+      directory?: string
+      workspace?: string
+      content?: McpEventElicitationContent
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "content" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<McpElicitationReplyResponses, McpElicitationReplyErrors, ThrowOnError>(
+      {
+        url: "/mcp/elicitation/{requestID}/reply",
+        ...options,
+        ...params,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+          ...params.headers,
+        },
+      },
+    )
+  }
+
+  /**
+   * Decline MCP elicitation request
+   *
+   * Decline an MCP elicitation request.
+   */
+  public decline<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      McpElicitationDeclineResponses,
+      McpElicitationDeclineErrors,
+      ThrowOnError
+    >({
+      url: "/mcp/elicitation/{requestID}/decline",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Cancel MCP elicitation request
+   *
+   * Cancel an MCP elicitation request.
+   */
+  public cancel<ThrowOnError extends boolean = false>(
+    parameters: {
+      requestID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "requestID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      McpElicitationCancelResponses,
+      McpElicitationCancelErrors,
+      ThrowOnError
+    >({
+      url: "/mcp/elicitation/{requestID}/cancel",
+      ...options,
+      ...params,
+    })
+  }
+}
+
 export class Mcp extends HeyApiClient {
   /**
    * Get MCP status
@@ -2522,6 +2676,11 @@ export class Mcp extends HeyApiClient {
   private _auth?: Auth2
   get auth(): Auth2 {
     return (this._auth ??= new Auth2({ client: this.client }))
+  }
+
+  private _elicitation?: Elicitation
+  get elicitation(): Elicitation {
+    return (this._elicitation ??= new Elicitation({ client: this.client }))
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -77,6 +77,8 @@ export type Event =
   | EventTuiSessionSelect2
   | EventMcpToolsChanged
   | EventMcpBrowserOpenFailed
+  | EventMcpElicitationAsked
+  | EventMcpElicitationReplied
   | EventCommandExecuted
   | EventProjectUpdated
   | EventSessionStatus
@@ -1468,6 +1470,24 @@ export type GlobalEvent = {
       }
     | {
         id: string
+        type: "mcp.elicitation.asked"
+        properties: {
+          id: string
+          server: string
+          message: string
+          schema: McpEventElicitationBooleanSchema
+        }
+      }
+    | {
+        id: string
+        type: "mcp.elicitation.replied"
+        properties: {
+          requestID: string
+          result: McpEventElicitationResult
+        }
+      }
+    | {
+        id: string
         type: "command.executed"
         properties: {
           name: string
@@ -2416,6 +2436,12 @@ export type McpServerNotFoundError = {
   message: string
 }
 
+export type McpElicitationNotFoundError = {
+  _tag: "McpElicitationNotFoundError"
+  requestID: string
+  message: string
+}
+
 export type Project = {
   id: string
   worktree: string
@@ -2812,6 +2838,8 @@ export type V2Event =
   | V2EventTuiSessionSelect
   | V2EventMcpToolsChanged
   | V2EventMcpBrowserOpenFailed
+  | V2EventMcpElicitationAsked
+  | V2EventMcpElicitationReplied
   | V2EventCommandExecuted
   | V2EventProjectUpdated
   | V2EventSessionStatus
@@ -3046,6 +3074,44 @@ export type QuestionV2Tool = {
 }
 
 export type QuestionV2Answer = Array<string>
+
+export type McpEventElicitationBooleanProperty = {
+  type: "boolean"
+  title?: string
+  description?: string
+  default?: boolean
+}
+
+export type McpEventElicitationBooleanSchema = {
+  $schema?: string
+  type: "object"
+  properties: {
+    [key: string]: McpEventElicitationBooleanProperty
+  }
+  required?: Array<string>
+}
+
+export type McpEventElicitationContent = {
+  [key: string]: boolean
+}
+
+export type McpEventElicitationAccept = {
+  action: "accept"
+  content: McpEventElicitationContent
+}
+
+export type McpEventElicitationDecline = {
+  action: "decline"
+}
+
+export type McpEventElicitationCancel = {
+  action: "cancel"
+}
+
+export type McpEventElicitationResult =
+  | McpEventElicitationAccept
+  | McpEventElicitationDecline
+  | McpEventElicitationCancel
 
 export type ProjectVcs = "git"
 
@@ -3727,6 +3793,13 @@ export type ConfigV2ExperimentalPolicy = {
   action: "provider.use"
   effect: PolicyEffect
   resource: string
+}
+
+export type McpEventElicitationRequest = {
+  id: string
+  server: string
+  message: string
+  schema: McpEventElicitationBooleanSchema
 }
 
 export type ProjectDirectories = Array<{
@@ -6349,6 +6422,44 @@ export type V2EventMcpBrowserOpenFailed = {
   }
 }
 
+export type V2EventMcpElicitationAsked = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  type: "mcp.elicitation.asked"
+  data: {
+    id: string
+    server: string
+    message: string
+    schema: McpEventElicitationBooleanSchema
+  }
+}
+
+export type V2EventMcpElicitationReplied = {
+  id: string
+  metadata?: {
+    [key: string]: unknown
+  }
+  durable?: {
+    aggregateID: string
+    seq: number
+    version: number
+  }
+  location?: LocationRef
+  type: "mcp.elicitation.replied"
+  data: {
+    requestID: string
+    result: McpEventElicitationResult
+  }
+}
+
 export type V2EventCommandExecuted = {
   id: string
   metadata?: {
@@ -7437,6 +7548,26 @@ export type EventMcpBrowserOpenFailed = {
   properties: {
     mcpName: string
     url: string
+  }
+}
+
+export type EventMcpElicitationAsked = {
+  id: string
+  type: "mcp.elicitation.asked"
+  properties: {
+    id: string
+    server: string
+    message: string
+    schema: McpEventElicitationBooleanSchema
+  }
+}
+
+export type EventMcpElicitationReplied = {
+  id: string
+  type: "mcp.elicitation.replied"
+  properties: {
+    requestID: string
+    result: McpEventElicitationResult
   }
 }
 
@@ -9239,6 +9370,138 @@ export type McpDisconnectResponses = {
 }
 
 export type McpDisconnectResponse = McpDisconnectResponses[keyof McpDisconnectResponses]
+
+export type McpElicitationListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/mcp/elicitation"
+}
+
+export type McpElicitationListErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type McpElicitationListError = McpElicitationListErrors[keyof McpElicitationListErrors]
+
+export type McpElicitationListResponses = {
+  /**
+   * List of pending MCP elicitation requests
+   */
+  200: Array<McpEventElicitationRequest>
+}
+
+export type McpElicitationListResponse = McpElicitationListResponses[keyof McpElicitationListResponses]
+
+export type McpElicitationReplyData = {
+  body?: {
+    content: McpEventElicitationContent
+  }
+  path: {
+    requestID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/mcp/elicitation/{requestID}/reply"
+}
+
+export type McpElicitationReplyErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * McpElicitationNotFoundError
+   */
+  404: McpElicitationNotFoundError
+}
+
+export type McpElicitationReplyError = McpElicitationReplyErrors[keyof McpElicitationReplyErrors]
+
+export type McpElicitationReplyResponses = {
+  /**
+   * MCP elicitation request accepted
+   */
+  200: boolean
+}
+
+export type McpElicitationReplyResponse = McpElicitationReplyResponses[keyof McpElicitationReplyResponses]
+
+export type McpElicitationDeclineData = {
+  body?: never
+  path: {
+    requestID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/mcp/elicitation/{requestID}/decline"
+}
+
+export type McpElicitationDeclineErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * McpElicitationNotFoundError
+   */
+  404: McpElicitationNotFoundError
+}
+
+export type McpElicitationDeclineError = McpElicitationDeclineErrors[keyof McpElicitationDeclineErrors]
+
+export type McpElicitationDeclineResponses = {
+  /**
+   * MCP elicitation request declined
+   */
+  200: boolean
+}
+
+export type McpElicitationDeclineResponse = McpElicitationDeclineResponses[keyof McpElicitationDeclineResponses]
+
+export type McpElicitationCancelData = {
+  body?: never
+  path: {
+    requestID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/mcp/elicitation/{requestID}/cancel"
+}
+
+export type McpElicitationCancelErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * McpElicitationNotFoundError
+   */
+  404: McpElicitationNotFoundError
+}
+
+export type McpElicitationCancelError = McpElicitationCancelErrors[keyof McpElicitationCancelErrors]
+
+export type McpElicitationCancelResponses = {
+  /**
+   * MCP elicitation request cancelled
+   */
+  200: boolean
+}
+
+export type McpElicitationCancelResponse = McpElicitationCancelResponses[keyof McpElicitationCancelResponses]
 
 export type ProjectListData = {
   body?: never

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -3599,6 +3599,309 @@
         ]
       }
     },
+    "/mcp/elicitation": {
+      "get": {
+        "tags": ["mcp"],
+        "operationId": "mcp.elicitation.list",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of pending MCP elicitation requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/McpEventElicitationRequest"
+                  },
+                  "description": "List of pending MCP elicitation requests"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get pending MCP elicitation requests.",
+        "summary": "List pending MCP elicitation requests",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.mcp.elicitation.list({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mcp/elicitation/{requestID}/reply": {
+      "post": {
+        "tags": ["mcp"],
+        "operationId": "mcp.elicitation.reply",
+        "parameters": [
+          {
+            "name": "requestID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^mcpel"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MCP elicitation request accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "MCP elicitation request accepted"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest | InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/effect_HttpApiError_BadRequest"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "McpElicitationNotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpElicitationNotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Accept an MCP elicitation request with user-provided content.",
+        "summary": "Accept MCP elicitation request",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": {
+                    "$ref": "#/components/schemas/McpEventElicitationContent"
+                  }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.mcp.elicitation.reply({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mcp/elicitation/{requestID}/decline": {
+      "post": {
+        "tags": ["mcp"],
+        "operationId": "mcp.elicitation.decline",
+        "parameters": [
+          {
+            "name": "requestID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^mcpel"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MCP elicitation request declined",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "MCP elicitation request declined"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "McpElicitationNotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpElicitationNotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Decline an MCP elicitation request.",
+        "summary": "Decline MCP elicitation request",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.mcp.elicitation.decline({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/mcp/elicitation/{requestID}/cancel": {
+      "post": {
+        "tags": ["mcp"],
+        "operationId": "mcp.elicitation.cancel",
+        "parameters": [
+          {
+            "name": "requestID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^mcpel"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MCP elicitation request cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "MCP elicitation request cancelled"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "McpElicitationNotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpElicitationNotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Cancel an MCP elicitation request.",
+        "summary": "Cancel MCP elicitation request",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.mcp.elicitation.cancel({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/project": {
       "get": {
         "tags": ["project"],
@@ -15473,6 +15776,12 @@
             "$ref": "#/components/schemas/EventMcpBrowserOpenFailed"
           },
           {
+            "$ref": "#/components/schemas/EventMcpElicitationAsked"
+          },
+          {
+            "$ref": "#/components/schemas/EventMcpElicitationReplied"
+          },
+          {
             "$ref": "#/components/schemas/EventCommandExecuted"
           },
           {
@@ -19954,6 +20263,70 @@
                   },
                   "type": {
                     "type": "string",
+                    "enum": ["mcp.elicitation.asked"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "pattern": "^mcpel"
+                      },
+                      "server": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "schema": {
+                        "$ref": "#/components/schemas/McpEventElicitationBooleanSchema"
+                      }
+                    },
+                    "required": ["id", "server", "message", "schema"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^evt_"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": ["mcp.elicitation.replied"]
+                  },
+                  "properties": {
+                    "type": "object",
+                    "properties": {
+                      "requestID": {
+                        "type": "string",
+                        "pattern": "^mcpel"
+                      },
+                      "result": {
+                        "$ref": "#/components/schemas/McpEventElicitationResult"
+                      }
+                    },
+                    "required": ["requestID", "result"],
+                    "additionalProperties": false
+                  }
+                },
+                "required": ["id", "type", "properties"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "pattern": "^evt_"
+                  },
+                  "type": {
+                    "type": "string",
                     "enum": ["command.executed"]
                   },
                   "properties": {
@@ -22686,6 +23059,23 @@
         "required": ["_tag", "name", "message"],
         "additionalProperties": false
       },
+      "McpElicitationNotFoundError": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["McpElicitationNotFoundError"]
+          },
+          "requestID": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "requestID", "message"],
+        "additionalProperties": false
+      },
       "Project": {
         "type": "object",
         "properties": {
@@ -23865,6 +24255,12 @@
             "$ref": "#/components/schemas/V2EventMcpBrowserOpenFailed"
           },
           {
+            "$ref": "#/components/schemas/V2EventMcpElicitationAsked"
+          },
+          {
+            "$ref": "#/components/schemas/V2EventMcpElicitationReplied"
+          },
+          {
             "$ref": "#/components/schemas/V2EventCommandExecuted"
           },
           {
@@ -24475,6 +24871,107 @@
         "items": {
           "type": "string"
         }
+      },
+      "McpEventElicitationBooleanProperty": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["boolean"]
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          }
+        },
+        "required": ["type"],
+        "additionalProperties": false
+      },
+      "McpEventElicitationBooleanSchema": {
+        "type": "object",
+        "properties": {
+          "$schema": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["object"]
+          },
+          "properties": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/McpEventElicitationBooleanProperty"
+            }
+          },
+          "required": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["type", "properties"],
+        "additionalProperties": false
+      },
+      "McpEventElicitationContent": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "boolean"
+        }
+      },
+      "McpEventElicitationAccept": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["accept"]
+          },
+          "content": {
+            "$ref": "#/components/schemas/McpEventElicitationContent"
+          }
+        },
+        "required": ["action", "content"],
+        "additionalProperties": false
+      },
+      "McpEventElicitationDecline": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["decline"]
+          }
+        },
+        "required": ["action"],
+        "additionalProperties": false
+      },
+      "McpEventElicitationCancel": {
+        "type": "object",
+        "properties": {
+          "action": {
+            "type": "string",
+            "enum": ["cancel"]
+          }
+        },
+        "required": ["action"],
+        "additionalProperties": false
+      },
+      "McpEventElicitationResult": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/McpEventElicitationAccept"
+          },
+          {
+            "$ref": "#/components/schemas/McpEventElicitationDecline"
+          },
+          {
+            "$ref": "#/components/schemas/McpEventElicitationCancel"
+          }
+        ]
       },
       "ProjectVcs": {
         "type": "string",
@@ -26706,6 +27203,26 @@
           }
         },
         "required": ["action", "effect", "resource"],
+        "additionalProperties": false
+      },
+      "McpEventElicitationRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^mcpel"
+          },
+          "server": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "schema": {
+            "$ref": "#/components/schemas/McpEventElicitationBooleanSchema"
+          }
+        },
+        "required": ["id", "server", "message", "schema"],
         "additionalProperties": false
       },
       "ProjectDirectories": {
@@ -35310,6 +35827,114 @@
         "required": ["id", "type", "data"],
         "additionalProperties": false
       },
+      "V2EventMcpElicitationAsked": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "durable": {
+            "type": "object",
+            "properties": {
+              "aggregateID": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "integer"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["aggregateID", "seq", "version"],
+            "additionalProperties": false
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationRef"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["mcp.elicitation.asked"]
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^mcpel"
+              },
+              "server": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/McpEventElicitationBooleanSchema"
+              }
+            },
+            "required": ["id", "server", "message", "schema"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "data"],
+        "additionalProperties": false
+      },
+      "V2EventMcpElicitationReplied": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "durable": {
+            "type": "object",
+            "properties": {
+              "aggregateID": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "integer"
+              },
+              "version": {
+                "type": "integer"
+              }
+            },
+            "required": ["aggregateID", "seq", "version"],
+            "additionalProperties": false
+          },
+          "location": {
+            "$ref": "#/components/schemas/LocationRef"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["mcp.elicitation.replied"]
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "requestID": {
+                "type": "string",
+                "pattern": "^mcpel"
+              },
+              "result": {
+                "$ref": "#/components/schemas/McpEventElicitationResult"
+              }
+            },
+            "required": ["requestID", "result"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "data"],
+        "additionalProperties": false
+      },
       "V2EventCommandExecuted": {
         "type": "object",
         "properties": {
@@ -38636,6 +39261,70 @@
               }
             },
             "required": ["mcpName", "url"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventMcpElicitationAsked": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["mcp.elicitation.asked"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^mcpel"
+              },
+              "server": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/McpEventElicitationBooleanSchema"
+              }
+            },
+            "required": ["id", "server", "message", "schema"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["id", "type", "properties"],
+        "additionalProperties": false
+      },
+      "EventMcpElicitationReplied": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^evt_"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["mcp.elicitation.replied"]
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "requestID": {
+                "type": "string",
+                "pattern": "^mcpel"
+              },
+              "result": {
+                "$ref": "#/components/schemas/McpEventElicitationResult"
+              }
+            },
+            "required": ["requestID", "result"],
             "additionalProperties": false
           }
         },

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -12,6 +12,7 @@ import type {
   LspStatus,
   McpStatus,
   McpResource,
+  McpEventElicitationRequest,
   FormatterStatus,
   SessionStatus,
   ProviderListResponse,
@@ -101,6 +102,7 @@ export const {
       mcp_resource: {
         [key: string]: McpResource
       }
+      mcp_elicitation: McpEventElicitationRequest[]
       formatter: FormatterStatus[]
       vcs: VcsInfo | undefined
     }>({
@@ -131,6 +133,7 @@ export const {
       lsp: [],
       mcp: {},
       mcp_resource: {},
+      mcp_elicitation: [],
       formatter: [],
       vcs: undefined,
     })
@@ -240,6 +243,34 @@ export const {
             request.sessionID,
             produce((draft) => {
               draft.splice(match.index, 0, request)
+            }),
+          )
+          break
+        }
+
+        case "mcp.elicitation.asked": {
+          const request = event.properties
+          const match = search(store.mcp_elicitation, request.id, (item) => item.id)
+          if (match.found) {
+            setStore("mcp_elicitation", match.index, reconcile(request))
+            break
+          }
+          setStore(
+            "mcp_elicitation",
+            produce((draft) => {
+              draft.splice(match.index, 0, request)
+            }),
+          )
+          break
+        }
+
+        case "mcp.elicitation.replied": {
+          const match = search(store.mcp_elicitation, event.properties.requestID, (item) => item.id)
+          if (!match.found) break
+          setStore(
+            "mcp_elicitation",
+            produce((draft) => {
+              draft.splice(match.index, 1)
             }),
           )
           break
@@ -506,6 +537,9 @@ export const {
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
             sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
+            sdk.client.mcp.elicitation
+              .list({ workspace })
+              .then((x) => setStore("mcp_elicitation", reconcile(x.data ?? []))),
             sdk.client.experimental.resource
               .list({ workspace })
               .then((x) => setStore("mcp_resource", reconcile(x.data ?? {}))),

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -66,6 +66,7 @@ import { useEpilogue } from "../../context/epilogue"
 import { normalizePath } from "../../util/path"
 import { PermissionPrompt } from "./permission"
 import { QuestionPrompt } from "./question"
+import { McpElicitationPrompt } from "./mcp-elicitation"
 import { DialogExportOptions } from "../../ui/dialog-export-options"
 import * as Model from "../../util/model"
 import { formatTranscript } from "../../util/transcript"
@@ -232,8 +233,15 @@ export function Session() {
     if (session()?.parentID) return []
     return children().flatMap((x) => sync.data.question[x.id] ?? [])
   })
-  const visible = createMemo(() => !session()?.parentID && permissions().length === 0 && questions().length === 0)
-  const disabled = createMemo(() => permissions().length > 0 || questions().length > 0)
+  const mcpElicitations = createMemo(() => {
+    if (session()?.parentID) return []
+    return sync.data.mcp_elicitation
+  })
+  const visible = createMemo(
+    () =>
+      !session()?.parentID && permissions().length === 0 && mcpElicitations().length === 0 && questions().length === 0,
+  )
+  const disabled = createMemo(() => permissions().length > 0 || mcpElicitations().length > 0 || questions().length > 0)
 
   const pending = createMemo(() => {
     const completed = messages().findLast((x) => x.role === "assistant" && x.time.completed)?.id
@@ -1286,7 +1294,10 @@ export function Session() {
                     directory={sync.session.get(permissions()[0].sessionID)?.directory}
                   />
                 </Show>
-                <Show when={permissions().length === 0 && questions().length > 0}>
+                <Show when={permissions().length === 0 && mcpElicitations().length > 0}>
+                  <McpElicitationPrompt request={mcpElicitations()[0]} directory={session()?.directory} />
+                </Show>
+                <Show when={permissions().length === 0 && mcpElicitations().length === 0 && questions().length > 0}>
                   <QuestionPrompt
                     request={questions()[0]}
                     directory={sync.session.get(questions()[0].sessionID)?.directory}

--- a/packages/tui/src/routes/session/mcp-elicitation.tsx
+++ b/packages/tui/src/routes/session/mcp-elicitation.tsx
@@ -1,0 +1,169 @@
+import { createEffect, createMemo, For, onCleanup, onMount } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useRenderer } from "@opentui/solid"
+import type { McpEventElicitationRequest } from "@opencode-ai/sdk/v2"
+import { tint, useTheme } from "../../context/theme"
+import { useSDK } from "../../context/sdk"
+import { SplitBorder } from "../../ui/border"
+import { useBindings, useOpencodeModeStack } from "../../keymap"
+
+const MCP_ELICITATION_MODE = "mcp-elicitation"
+
+function values(request: McpEventElicitationRequest) {
+  return Object.fromEntries(
+    Object.entries(request.schema.properties).map(([key, prop]) => [key, prop.default ?? false]),
+  )
+}
+
+export function McpElicitationPrompt(props: { request: McpEventElicitationRequest; directory?: string }) {
+  const sdk = useSDK()
+  const renderer = useRenderer()
+  const { theme } = useTheme()
+  const modeStack = useOpencodeModeStack()
+  const fields = createMemo(() => Object.entries(props.request.schema.properties))
+  const [store, setStore] = createStore({
+    requestID: props.request.id,
+    selected: 0,
+    values: values(props.request),
+  })
+
+  createEffect(() => {
+    if (store.requestID === props.request.id) return
+    setStore({
+      requestID: props.request.id,
+      selected: 0,
+      values: values(props.request),
+    })
+  })
+
+  function move(delta: number) {
+    const total = fields().length
+    if (total === 0) return
+    setStore("selected", (store.selected + delta + total) % total)
+  }
+
+  function toggle(index = store.selected) {
+    const field = fields()[index]
+    if (!field) return
+    setStore("values", field[0], !store.values[field[0]])
+  }
+
+  function reply() {
+    void sdk.client.mcp.elicitation.reply({
+      requestID: props.request.id,
+      directory: props.directory,
+      content: { ...store.values },
+    })
+  }
+
+  function decline() {
+    void sdk.client.mcp.elicitation.decline({
+      requestID: props.request.id,
+      directory: props.directory,
+    })
+  }
+
+  function cancel() {
+    void sdk.client.mcp.elicitation.cancel({
+      requestID: props.request.id,
+      directory: props.directory,
+    })
+  }
+
+  onMount(() => {
+    const popMode = modeStack.push(MCP_ELICITATION_MODE)
+    onCleanup(popMode)
+  })
+
+  useBindings(() => ({
+    mode: MCP_ELICITATION_MODE,
+    commands: [
+      {
+        name: "app.exit",
+        title: "Cancel MCP request",
+        category: "MCP",
+        run() {
+          cancel()
+        },
+      },
+    ],
+    bindings: [
+      { key: "up", desc: "Previous field", group: "MCP", cmd: () => move(-1) },
+      { key: "k", desc: "Previous field", group: "MCP", cmd: () => move(-1) },
+      { key: "down", desc: "Next field", group: "MCP", cmd: () => move(1) },
+      { key: "j", desc: "Next field", group: "MCP", cmd: () => move(1) },
+      { key: "space", desc: "Toggle field", group: "MCP", cmd: () => toggle() },
+      { key: "return", desc: "Accept MCP request", group: "MCP", cmd: () => reply() },
+      { key: "escape", desc: "Cancel MCP request", group: "MCP", cmd: () => cancel() },
+      { key: "d", desc: "Decline MCP request", group: "MCP", cmd: () => decline() },
+    ],
+  }))
+
+  return (
+    <box
+      backgroundColor={theme.backgroundPanel}
+      border={["left"]}
+      borderColor={theme.warning}
+      customBorderChars={SplitBorder.customBorderChars}
+    >
+      <box gap={1} paddingLeft={1} paddingRight={3} paddingTop={1} paddingBottom={1}>
+        <box paddingLeft={1}>
+          <text fg={theme.text}>
+            MCP request from <span style={{ fg: theme.warning }}>{props.request.server}</span>
+          </text>
+        </box>
+        <box paddingLeft={1}>
+          <text fg={theme.textMuted}>{props.request.message}</text>
+        </box>
+        <box paddingLeft={1}>
+          <For each={fields()}>
+            {([key, field], index) => {
+              const active = () => index() === store.selected
+              const checked = () => store.values[key]
+              return (
+                <box
+                  onMouseOver={() => setStore("selected", index())}
+                  onMouseDown={() => setStore("selected", index())}
+                  onMouseUp={() => {
+                    if (renderer.getSelection()?.getSelectedText()) return
+                    toggle(index())
+                  }}
+                >
+                  <box flexDirection="row">
+                    <box backgroundColor={active() ? theme.backgroundElement : undefined} paddingRight={1}>
+                      <text fg={active() ? tint(theme.textMuted, theme.secondary, 0.6) : theme.textMuted}>
+                        {`${index() + 1}.`}
+                      </text>
+                    </box>
+                    <box backgroundColor={active() ? theme.backgroundElement : undefined}>
+                      <text fg={theme.text}>
+                        [{checked() ? "x" : " "}] {field.title ?? key}
+                      </text>
+                    </box>
+                  </box>
+                  <box paddingLeft={3}>
+                    <text fg={theme.textMuted}>{field.description ?? key}</text>
+                  </box>
+                </box>
+              )
+            }}
+          </For>
+        </box>
+      </box>
+      <box flexDirection="row" flexShrink={0} gap={2} paddingLeft={2} paddingRight={3} paddingBottom={1}>
+        <text fg={theme.text}>
+          enter <span style={{ fg: theme.textMuted }}>accept</span>
+        </text>
+        <text fg={theme.text}>
+          space <span style={{ fg: theme.textMuted }}>toggle</span>
+        </text>
+        <text fg={theme.text}>
+          d <span style={{ fg: theme.textMuted }}>decline</span>
+        </text>
+        <text fg={theme.text}>
+          esc <span style={{ fg: theme.textMuted }}>cancel</span>
+        </text>
+      </box>
+    </box>
+  )
+}

--- a/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
@@ -3,10 +3,10 @@ import { testRender } from "@opentui/solid"
 import { onMount } from "solid-js"
 import { ArgsProvider } from "../../../../src/context/args"
 import { KVProvider, useKV } from "../../../../src/context/kv"
+import { ExitProvider } from "../../../../src/context/exit"
 import { ProjectProvider, useProject } from "../../../../src/context/project"
 import { SDKProvider } from "../../../../src/context/sdk"
 import { SyncProvider, useSync } from "../../../../src/context/sync"
-import { ExitProvider } from "../../../../src/context/exit"
 import { createEventSource, createFetch, type FetchHandler, directory } from "../../../fixture/tui-sdk"
 import { TestTuiContexts } from "../../../fixture/tui-environment"
 export { createEventSource, createFetch, directory, eventSource, json, worktree } from "../../../fixture/tui-sdk"
@@ -46,17 +46,21 @@ export async function mount(override?: FetchHandler, state?: string) {
   const app = await testRender(() => (
     <TestTuiContexts paths={state ? { state } : undefined}>
       <ArgsProvider>
-        <KVProvider>
-          <SDKProvider url="http://test" directory={directory} fetch={calls.fetch} events={events.source}>
-            <ProjectProvider>
-              <ExitProvider exit={() => {}}>
+        <ExitProvider
+          exit={(reason) => {
+            throw reason
+          }}
+        >
+          <KVProvider>
+            <SDKProvider url="http://test" directory={directory} fetch={calls.fetch} events={events.source}>
+              <ProjectProvider>
                 <SyncProvider>
                   <Probe />
                 </SyncProvider>
-              </ExitProvider>
-            </ProjectProvider>
-          </SDKProvider>
-        </KVProvider>
+              </ProjectProvider>
+            </SDKProvider>
+          </KVProvider>
+        </ExitProvider>
       </ArgsProvider>
     </TestTuiContexts>
   ))

--- a/packages/tui/test/cli/cmd/tui/sync.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync.test.tsx
@@ -17,6 +17,44 @@ function branchEvent(branch: string, workspace?: string): GlobalEvent {
   }
 }
 
+function elicitationAsked(id: string): GlobalEvent {
+  return {
+    directory: "/tmp/opencode/packages/tui",
+    project: "proj_test",
+    payload: {
+      id: `evt_elicitation_${id}`,
+      type: "mcp.elicitation.asked",
+      properties: {
+        id,
+        server: "unity-gateway",
+        message: "Approve resolved Unity command?",
+        schema: {
+          type: "object",
+          properties: {
+            allowed: { type: "boolean", title: "Allow command" },
+          },
+          required: ["allowed"],
+        },
+      },
+    },
+  }
+}
+
+function elicitationReplied(requestID: string): GlobalEvent {
+  return {
+    directory: "/tmp/opencode/packages/tui",
+    project: "proj_test",
+    payload: {
+      id: `evt_elicitation_replied_${requestID}`,
+      type: "mcp.elicitation.replied",
+      properties: {
+        requestID,
+        result: { action: "cancel" },
+      },
+    },
+  }
+}
+
 describe("tui sync", () => {
   test("refresh scopes sessions by default and lists project sessions when disabled", async () => {
     await using tmp = await tmpdir()
@@ -58,6 +96,31 @@ describe("tui sync", () => {
       await wait(() => sync.data.vcs?.branch === "feature")
 
       expect(sync.data.vcs?.branch).toBe("feature")
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("tracks pending MCP elicitations", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+    const { app, emit, sync } = await mount(undefined, tmp.path)
+
+    try {
+      emit(elicitationAsked("mcpel_test"))
+      await wait(() => sync.data.mcp_elicitation.length === 1)
+
+      expect(sync.data.mcp_elicitation).toEqual([
+        expect.objectContaining({
+          id: "mcpel_test",
+          server: "unity-gateway",
+          message: "Approve resolved Unity command?",
+        }),
+      ])
+
+      emit(elicitationReplied("mcpel_test"))
+      await wait(() => sync.data.mcp_elicitation.length === 0)
+      expect(sync.data.mcp_elicitation).toEqual([])
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/fixture/tui-sdk.ts
+++ b/packages/tui/test/fixture/tui-sdk.ts
@@ -83,6 +83,7 @@ export function createFetch(override?: FetchHandler, events?: ReturnType<typeof 
       return json([])
     if (["/config", "/experimental/resource", "/mcp", "/provider/auth", "/session/status"].includes(url.pathname))
       return json({})
+    if (url.pathname === "/mcp/elicitation") return json([])
     if (url.pathname === "/config/providers") return json({ providers: {}, default: {} })
     if (url.pathname === "/experimental/console") return json({ consoleManagedProviders: [], switchableOrgCount: 0 })
     if (url.pathname === "/experimental/capabilities") return json({ backgroundSubagents: false })


### PR DESCRIPTION
### Issue for this PR

Refs #23066
Refs #28567

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the first MCP elicitation path for TUI sessions. The MCP client now handles `elicitation/create` form requests for flat boolean schemas during tool calls, stores pending requests, emits asked/replied events, and exposes instance HTTP/SDK endpoints for the TUI.

The TUI renders a human approval prompt with the requesting server name and distinct accept, decline, and cancel actions. Unsupported schemas, URL mode, auth probe clients, timeouts, and disconnect cleanup return `cancel` so tool calls do not wait forever.

This slice does not add URL mode, broader JSON Schema form types, web UI, desktop UI, or model-callable approval tools.

### How did you verify your code works?

- `bun run typecheck`
- `cd packages/opencode && bun test --timeout 30000 test/mcp/elicitation.test.ts test/mcp/lifecycle.test.ts test/mcp/oauth-auto-connect.test.ts test/mcp/oauth-browser.test.ts test/server/httpapi-mcp-elicitation.test.ts test/server/httpapi-mcp-oauth.test.ts`
- `cd packages/tui && bun test --timeout 30000 test/cli/cmd/tui/sync.test.tsx`
- `bun run --filter @opencode-ai/tui typecheck`
- `bun run --cwd packages/opencode build`
- Manual dev-build test: started the rebuilt TUI from this branch, connected a repo-local stdio MCP demo server, called `elicitation-demo_request_approval`, confirmed the TUI prompt rendered with the server name and checkbox label, accepted the prompt, and verified the MCP tool returned `{"action":"accept","content":{"allowDemo":false}}`.
- `git diff --check`

### Screenshots / recordings

Live TUI prompt from the dev build:

![MCP elicitation TUI prompt](https://gist.githubusercontent.com/Nomadcxx/a249288a0bf5006f0909d669d13c7409/raw/cd9d5d5722348c12c0b16c784c6c8ca9eac9919f/mcp-elicitation-live-prompt.svg)

Manual round trip after accepting the prompt:

![MCP elicitation accepted result](https://gist.githubusercontent.com/Nomadcxx/a249288a0bf5006f0909d669d13c7409/raw/fba3386b053dc18800d9509d32dae0aa00940efb/mcp-elicitation-live-result.svg)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR