### PR TITLE
fix(app): clear late session notifications

### DIFF
--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -18,6 +18,7 @@ export default function NewLayout(props: ParentProps) {
   createEffect(() => setV2Toast(true))
   createEffect(() => {
     if (!notification.ready() || !params.id) return
+    if (notification.session.unseenCount(params.id) === 0) return
     notification.session.markViewed(params.id)
   })
 


### PR DESCRIPTION
If a session's unseenCount changes we need to markViewed again