### PR TITLE
refactor(protocol): define current event surface

### DIFF
--- a/packages/protocol/src/groups/event.ts
+++ b/packages/protocol/src/groups/event.ts
@@ -54,6 +54,6 @@ const make = (definitions: ReadonlyArray<Definition>) => {
 
 export const makeEventGroup = (definitions: ReadonlyArray<Definition>) => make(definitions).group
 
-const event = make(EventManifest.ServerDefinitions)
+const event = make(EventManifest.CurrentServerDefinitions)
 export const EventGroup = event.group
 export type Event = typeof event.schema.Type

--- a/packages/protocol/test/event-boundary.test.ts
+++ b/packages/protocol/test/event-boundary.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "bun:test"
 import { EventManifest } from "@opencode-ai/schema/event-manifest"
 import { SessionV1 } from "@opencode-ai/schema/session-v1"
+import { HttpApi, OpenApi } from "effect/unstable/httpapi"
+import { EventGroup } from "../src/groups/event"
+
+const currentOpenApi = OpenApi.fromApi(HttpApi.make("test").add(EventGroup))
+const currentEventOpenApi = JSON.stringify(currentOpenApi.components.schemas?.V2Event)
 
 test("current Protocol events exclude V1-only session events", () => {
   const current = new Set<string>(EventManifest.CurrentServerDefinitions.map((definition) => definition.type))
@@ -22,6 +27,9 @@ test("current Protocol events exclude V1-only session events", () => {
   expect(current.has("permission.v2.asked")).toBe(true)
   expect(current.has("question.v2.asked")).toBe(true)
   expect(current.has("command.executed")).toBe(false)
+  expect(currentEventOpenApi).toContain("session.next.prompted")
+  expect(currentEventOpenApi).not.toContain("message.updated")
+  expect(currentEventOpenApi).not.toContain("message.part.updated")
 })
 
 test("compatibility server inventory retains V1 events", () => {

--- a/packages/protocol/test/event-boundary.test.ts
+++ b/packages/protocol/test/event-boundary.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test"
+import { EventManifest } from "@opencode-ai/schema/event-manifest"
+import { SessionV1 } from "@opencode-ai/schema/session-v1"
+
+test("current Protocol events exclude V1-only session events", () => {
+  const current = new Set<string>(EventManifest.CurrentServerDefinitions.map((definition) => definition.type))
+  const v1Only = SessionV1.Event.Definitions.filter((definition) => definition.durable !== undefined).map(
+    (definition) => definition.type,
+  )
+
+  expect(v1Only).toEqual([
+    "session.created",
+    "session.updated",
+    "session.deleted",
+    "message.updated",
+    "message.removed",
+    "message.part.updated",
+    "message.part.removed",
+  ])
+  expect(v1Only.filter((type) => current.has(type))).toEqual([])
+  expect(current.has("session.next.prompted")).toBe(true)
+  expect(current.has("permission.v2.asked")).toBe(true)
+  expect(current.has("question.v2.asked")).toBe(true)
+  expect(current.has("command.executed")).toBe(false)
+})
+
+test("compatibility server inventory retains V1 events", () => {
+  const compatibility = new Set(EventManifest.ServerDefinitions.map((definition) => definition.type))
+
+  expect(compatibility.has("session.created")).toBe(true)
+  expect(compatibility.has("message.updated")).toBe(true)
+  expect(compatibility.has("message.part.updated")).toBe(true)
+})

--- a/packages/schema/src/event-manifest.ts
+++ b/packages/schema/src/event-manifest.ts
@@ -37,18 +37,10 @@ const sessionV1LiveDefinitions = SessionV1.Event.Definitions.filter((definition)
 const currentCoreDefinitions = Event.inventory(...SessionEvent.Definitions)
 const compatibilityCoreDefinitions = Event.inventory(...sessionV1DurableDefinitions, ...currentCoreDefinitions)
 
-const currentFoundationDefinitions = Event.inventory(
+const foundationDefinitions = Event.inventory(
   ...ModelsDev.Event.Definitions,
   ...Integration.Event.Definitions,
   ...Catalog.Event.Definitions,
-  ...currentCoreDefinitions,
-)
-
-const compatibilityFoundationDefinitions = Event.inventory(
-  ...ModelsDev.Event.Definitions,
-  ...Integration.Event.Definitions,
-  ...Catalog.Event.Definitions,
-  ...compatibilityCoreDefinitions,
 )
 
 const featureDefinitions = Event.inventory(
@@ -63,19 +55,22 @@ const featureDefinitions = Event.inventory(
 )
 
 export const CurrentServerDefinitions = Event.inventory(
-  ...currentFoundationDefinitions,
+  ...foundationDefinitions,
+  ...currentCoreDefinitions,
   ...featureDefinitions,
   ...SessionTodo.Event.Definitions,
 )
 
 export const ServerDefinitions = Event.inventory(
-  ...compatibilityFoundationDefinitions,
+  ...foundationDefinitions,
+  ...compatibilityCoreDefinitions,
   ...featureDefinitions,
   ...SessionTodo.Event.Definitions,
 )
 
 export const Definitions = Event.inventory(
-  ...compatibilityFoundationDefinitions,
+  ...foundationDefinitions,
+  ...compatibilityCoreDefinitions,
   ...sessionV1LiveDefinitions,
   ...InstallationEvent.Definitions,
   ...featureDefinitions,

--- a/packages/schema/src/event-manifest.ts
+++ b/packages/schema/src/event-manifest.ts
@@ -54,19 +54,16 @@ const featureDefinitions = Event.inventory(
   ...Question.Event.Definitions,
 )
 
-export const CurrentServerDefinitions = Event.inventory(
-  ...foundationDefinitions,
-  ...currentCoreDefinitions,
-  ...featureDefinitions,
-  ...SessionTodo.Event.Definitions,
-)
+const serverDefinitions = (coreDefinitions: ReadonlyArray<Event.Definition>) =>
+  Event.inventory(
+    ...foundationDefinitions,
+    ...coreDefinitions,
+    ...featureDefinitions,
+    ...SessionTodo.Event.Definitions,
+  )
 
-export const ServerDefinitions = Event.inventory(
-  ...foundationDefinitions,
-  ...compatibilityCoreDefinitions,
-  ...featureDefinitions,
-  ...SessionTodo.Event.Definitions,
-)
+export const CurrentServerDefinitions = serverDefinitions(currentCoreDefinitions)
+export const ServerDefinitions = serverDefinitions(compatibilityCoreDefinitions)
 
 export const Definitions = Event.inventory(
   ...foundationDefinitions,

--- a/packages/schema/src/event-manifest.ts
+++ b/packages/schema/src/event-manifest.ts
@@ -34,13 +34,21 @@ import { WorktreeEvent } from "./worktree-event"
 const sessionV1DurableDefinitions = SessionV1.Event.Definitions.filter((definition) => definition.durable !== undefined)
 const sessionV1LiveDefinitions = SessionV1.Event.Definitions.filter((definition) => definition.durable === undefined)
 
-const coreDefinitions = Event.inventory(...sessionV1DurableDefinitions, ...SessionEvent.Definitions)
+const currentCoreDefinitions = Event.inventory(...SessionEvent.Definitions)
+const compatibilityCoreDefinitions = Event.inventory(...sessionV1DurableDefinitions, ...currentCoreDefinitions)
 
-const foundationDefinitions = Event.inventory(
+const currentFoundationDefinitions = Event.inventory(
   ...ModelsDev.Event.Definitions,
   ...Integration.Event.Definitions,
   ...Catalog.Event.Definitions,
-  ...coreDefinitions,
+  ...currentCoreDefinitions,
+)
+
+const compatibilityFoundationDefinitions = Event.inventory(
+  ...ModelsDev.Event.Definitions,
+  ...Integration.Event.Definitions,
+  ...Catalog.Event.Definitions,
+  ...compatibilityCoreDefinitions,
 )
 
 const featureDefinitions = Event.inventory(
@@ -54,14 +62,20 @@ const featureDefinitions = Event.inventory(
   ...Question.Event.Definitions,
 )
 
+export const CurrentServerDefinitions = Event.inventory(
+  ...currentFoundationDefinitions,
+  ...featureDefinitions,
+  ...SessionTodo.Event.Definitions,
+)
+
 export const ServerDefinitions = Event.inventory(
-  ...foundationDefinitions,
+  ...compatibilityFoundationDefinitions,
   ...featureDefinitions,
   ...SessionTodo.Event.Definitions,
 )
 
 export const Definitions = Event.inventory(
-  ...foundationDefinitions,
+  ...compatibilityFoundationDefinitions,
   ...sessionV1LiveDefinitions,
   ...InstallationEvent.Definitions,
   ...featureDefinitions,


### PR DESCRIPTION
## Summary

- add a current-only server event inventory alongside the compatibility inventory
- make Protocol and SDK Next consume the current event boundary
- retain the full compatibility inventory for existing App, TUI, CLI, and SDK V2 consumers
- add manifest and OpenAPI regression coverage excluding V1-only events

## Testing

- `bun turbo typecheck`
- Schema, Protocol, Client, and SDK Next focused tests
- `bun run check:generated` in `packages/client`
- SDK V2 regeneration with zero generated diff

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #33768
2. #33770
3. #33771
4. #33769
5. **#33772** 👈 current
<!-- stack:links:end -->