### PR TITLE
fix(skill): provide directory context in system prompt and slash-command paths

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import path from "path"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectBridge } from "@/effect/bridge"
 import type { InstanceContext } from "@/project/instance-context"
@@ -132,12 +133,20 @@ export const layer = Layer.effect(
 
       for (const item of yield* skill.all()) {
         if (commands[item.name]) continue
+        // Built-in skills have no on-disk directory, so omit the base-directory hint.
+        const dir = item.location === "<built-in>" ? undefined : path.dirname(item.location)
         commands[item.name] = {
           name: item.name,
           description: item.description,
           source: "skill",
           get template() {
-            return item.content
+            if (!dir) return item.content
+            return [
+              item.content,
+              "",
+              `Base directory for this skill: ${dir}`,
+              "Relative paths in this skill (e.g., scripts/, references/) are relative to this base directory.",
+            ].join("\n")
           },
           hints: [],
         }

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -1,6 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import path from "path"
-import { pathToFileURL } from "url"
 import { Effect, Layer, Context, Schema } from "effect"
 import { NamedError } from "@opencode-ai/core/util/error"
 import type { Agent } from "@/agent/agent"
@@ -339,7 +338,7 @@ export function fmt(list: Info[], opts: { verbose: boolean }) {
           "  <skill>",
           `    <name>${skill.name}</name>`,
           `    <description>${skill.description}</description>`,
-          `    <location>${pathToFileURL(skill.location).href}</location>`,
+          `    <location>${skill.location}</location>`,
           "  </skill>",
         ]),
       "</available_skills>",

--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -51,7 +51,7 @@ export const SkillTool = Tool.define(
               info.content.trim(),
               "",
               `Base directory for this skill: ${base}`,
-              "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",
+              "Relative paths in this skill (e.g., scripts/, references/) are relative to this base directory.",
               "Note: file list is sampled.",
               "",
               "<skill_files>",


### PR DESCRIPTION
### Issue for this PR

Closes #33786

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The skill's base directory was missing or URL-encoded in two code paths, preventing the agent from resolving bundled resources (references/, scripts/) relative to the skill install directory.

**1. System prompt `<available_skills>` URL-encoded `<location>`**

`Skill.fmt()` in `packages/opencode/src/skill/index.ts` used `pathToFileURL(skill.location).href` for the `<location>` field. This is the same bug #33580 fixed in the `skill` tool's base directory, but this second occurrence in the system prompt was missed. When a skill lives in a git-tagged plugin cache dir (e.g. `...git#v1.3.0`), the agent sees `...git%23v1.3.0` and cannot use the path. Changed to emit `skill.location` directly.

**2. Slash-command skills had no directory context**

When a user types `/skill-name`, the skill is registered as a command (`packages/opencode/src/command/index.ts`) whose `template` returned only `item.content` — the raw SKILL.md body. Unlike the `skill` tool, there was no `Base directory` hint, so the agent had no way to locate bundled files. Added the base directory + relative-path hint to the template, matching the `skill` tool's output format.

### How did you verify your code works?

- `bun test test/skill/skill.test.ts` — 16 tests pass
- `bun test test/tool/skill.test.ts` — 2 tests pass
- Confirmed both code paths by reading the source: `Skill.fmt()` now emits a plain path, and skill-as-command templates now include the base directory line

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
