### PR TITLE
fix(acp): list known sessions across projects on empty cwd

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -243,9 +243,12 @@ export function make(input: {
   const listSessions = Effect.fn("ACP.listSessions")(function* (params: ListSessionsRequest) {
     const cursor = params.cursor ? Number(params.cursor) : undefined
     const limit = 100
+    // Route through the cross-project session listing so an omitted cwd
+    // returns every known session, per the ACP session/list spec, instead of
+    // being scoped to the ACP process's own project.
     const sessions = yield* request(
       () =>
-        input.sdk.session.list(
+        input.sdk.experimental.session.list(
           {
             ...(params.cwd ? { directory: params.cwd } : {}),
             roots: true,

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -160,6 +160,10 @@ describe("ACP service sessions", () => {
       title: `Session ${index + 1}`,
       time: { created: index + 1, updated: index + 1 },
     }))
+    const list = (input: { directory?: string }) =>
+      Promise.resolve({
+        data: input.directory ? sessions.filter((session) => session.directory === input.directory) : sessions,
+      })
     const sdk = {
       config: {
         providers: () => Promise.resolve({ data: { providers: [provider], default: { test: modelID } } }),
@@ -188,10 +192,7 @@ describe("ACP service sessions", () => {
       session: {
         create: () => Promise.resolve({ data: { id: "ses_new" } }),
         get: () => Promise.resolve({ data: { id: "ses_loaded" } }),
-        list: (input: { directory?: string }) =>
-          Promise.resolve({
-            data: input.directory ? sessions.filter((session) => session.directory === input.directory) : sessions,
-          }),
+        list,
         messages: () => Promise.resolve({ data: messages }),
         prompt: (input: unknown) => {
           prompts.push(input)
@@ -232,6 +233,11 @@ describe("ACP service sessions", () => {
         fork: (input: { sessionID: string }) => {
           forks.push(input.sessionID)
           return Promise.resolve({ data: { id: `fork_${input.sessionID}` } })
+        },
+      },
+      experimental: {
+        session: {
+          list,
         },
       },
       mcp: {


### PR DESCRIPTION
### Issue for this PR

Closes #33036

### Type of change

- [x] Bug fix

### What does this PR do?

ACP `session/list` was routed through the project-scoped `/session` endpoint (`sdk.session.list`), so a request with no `cwd` only returned sessions for the ACP process's own project instead of every known session. Per the ACP spec, empty params must return the first page of known sessions, and `cwd` is an optional filter.

This switches `listSessions` to the cross-project listing (`sdk.experimental.session.list`, backed by `Session.listGlobal`). When `cwd` is omitted it returns all known sessions; when `cwd` is supplied it filters by that directory. The existing live/in-memory ACP entries are still merged on top.

### How did you verify your code works?

- `bun typecheck` in `packages/opencode` (and `bun turbo typecheck --filter=opencode`) — clean.
- `bun test test/acp` — 121 pass (updated the service-session mock to expose `experimental.session.list`).
- `bun test test/server/session-list.test.ts test/server/global-session-list.test.ts` — 14 pass.
- `bun test test/cli/acp` — 15 pass.
- `prettier --check` and `oxlint` on the changed files — clean.

### Screenshots / recordings

N/A (logic change, no UI).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
