### PR TITLE
fix(tui): add permission prompt number shortcuts

### DIFF
--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -697,7 +697,7 @@ function Prompt<const T extends Record<string, string>>(props: {
                 }}
               >
                 <text fg={option === store.selected ? selectedForeground(theme, theme.warning) : theme.textMuted}>
-                  {props.numbered ? `${index() + 1}. ${props.options[option]}` : props.options[option]}
+                  {props.numbered && index() < 9 ? `${index() + 1}. ${props.options[option]}` : props.options[option]}
                 </text>
               </box>
             )}

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -404,6 +404,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               body={current.body}
               options={{ once: "Allow once", always: "Allow always", reject: "Reject" }}
               escapeKey="reject"
+              numbered
               fullscreen
               onSelect={(option) => {
                 if (option === "always") {
@@ -527,6 +528,7 @@ function Prompt<const T extends Record<string, string>>(props: {
   body: JSX.Element
   options: T
   escapeKey?: keyof T
+  numbered?: boolean
   fullscreen?: boolean
   onSelect: (option: keyof T) => void
 }) {
@@ -564,6 +566,14 @@ function Prompt<const T extends Record<string, string>>(props: {
       },
     ],
     bindings: [
+      ...(props.numbered
+        ? keys.slice(0, 9).map((option, index) => ({
+            key: String(index + 1),
+            desc: `Select permission option ${index + 1}`,
+            group: "Permission",
+            cmd: () => props.onSelect(option),
+          }))
+        : []),
       {
         key: "left",
         desc: "Previous permission option",
@@ -675,7 +685,7 @@ function Prompt<const T extends Record<string, string>>(props: {
       >
         <box flexDirection="row" gap={1} flexShrink={0}>
           <For each={keys}>
-            {(option) => (
+            {(option, index) => (
               <box
                 paddingLeft={1}
                 paddingRight={1}
@@ -687,7 +697,7 @@ function Prompt<const T extends Record<string, string>>(props: {
                 }}
               >
                 <text fg={option === store.selected ? selectedForeground(theme, theme.warning) : theme.textMuted}>
-                  {props.options[option]}
+                  {props.numbered ? `${index() + 1}. ${props.options[option]}` : props.options[option]}
                 </text>
               </box>
             )}

--- a/packages/tui/test/cli/tui/permission-prompt.test.tsx
+++ b/packages/tui/test/cli/tui/permission-prompt.test.tsx
@@ -22,12 +22,19 @@ import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 import { TestTuiContexts } from "../../fixture/tui-environment"
 import { createFetch, eventSource } from "../../fixture/tui-sdk"
 
-async function wait(fn: () => boolean, timeout = 2000) {
+async function wait(fn: () => boolean | Promise<boolean>, timeout = 2000) {
   const start = Date.now()
-  while (!fn()) {
+  while (!(await fn())) {
     if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
     await Bun.sleep(10)
   }
+}
+
+async function waitForFrame(app: Awaited<ReturnType<typeof mount>>["app"], match: (frame: string) => boolean) {
+  await wait(async () => {
+    await app.renderOnce()
+    return match(app.captureCharFrame())
+  })
 }
 
 async function mount(input: { root: string; onReply: (reply: string) => void }) {
@@ -111,7 +118,10 @@ async function captureReply(
   const prompt = await mount({ root: tmp.path, onReply: (reply) => replies.push(reply) })
 
   try {
-    await Bun.sleep(10)
+    await waitForFrame(
+      prompt.app,
+      (frame) => frame.includes("1. Allow once") && frame.includes("2. Allow always") && frame.includes("3. Reject"),
+    )
     prompt.app.mockInput.pressKey(key)
     await confirm?.(prompt, replies)
 
@@ -126,7 +136,10 @@ test("permission prompt number keys choose matching permission responses", async
   expect(await captureReply("1")).toBe("once")
   expect(
     await captureReply("2", async (prompt, replies) => {
-      await Bun.sleep(20)
+      await waitForFrame(
+        prompt.app,
+        (frame) => frame.includes("Always allow") && frame.includes("Confirm") && frame.includes("Cancel"),
+      )
       expect(replies).toEqual([])
       prompt.app.mockInput.pressEnter()
     }),

--- a/packages/tui/test/cli/tui/permission-prompt.test.tsx
+++ b/packages/tui/test/cli/tui/permission-prompt.test.tsx
@@ -1,0 +1,135 @@
+/** @jsxImportSource @opentui/solid */
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import type { PermissionRequest } from "@opencode-ai/sdk/v2"
+import { expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { onCleanup } from "solid-js"
+import { TuiConfigProvider } from "../../../src/config"
+import { ArgsProvider } from "../../../src/context/args"
+import { ExitProvider } from "../../../src/context/exit"
+import { KVProvider } from "../../../src/context/kv"
+import { LocationProvider } from "../../../src/context/location"
+import { ProjectProvider } from "../../../src/context/project"
+import { SDKProvider } from "../../../src/context/sdk"
+import { SyncProvider } from "../../../src/context/sync"
+import { ThemeProvider } from "../../../src/context/theme"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "../../../src/keymap"
+import { PermissionPrompt } from "../../../src/routes/session/permission"
+import { tmpdir } from "../../fixture/fixture"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+import { TestTuiContexts } from "../../fixture/tui-environment"
+import { createFetch, eventSource } from "../../fixture/tui-sdk"
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+async function mount(input: { root: string; onReply: (reply: string) => void }) {
+  const state = path.join(input.root, "state")
+  await mkdir(state, { recursive: true })
+  await Bun.write(path.join(state, "kv.json"), "{}")
+  const request = {
+    id: "perm_test",
+    sessionID: "ses_test",
+    permission: "bash",
+    patterns: ["*"],
+    metadata: {},
+    always: ["*"],
+  } satisfies PermissionRequest
+
+  const fallback = createFetch().fetch
+  const fetch = (async (raw, init) => {
+    const url = new URL(raw instanceof Request ? raw.url : String(raw))
+    if (url.pathname === "/project/proj_test/directories") {
+      return new Response(JSON.stringify([]), { headers: { "content-type": "application/json" } })
+    }
+    if (url.pathname === "/permission/perm_test/reply") {
+      const body = raw instanceof Request ? await raw.json() : JSON.parse(String(init?.body ?? "{}"))
+      const reply = typeof body === "object" && body && "reply" in body ? body.reply : undefined
+      if (typeof reply !== "string") throw new Error("missing permission reply")
+      input.onReply(reply)
+      return new Response(JSON.stringify({}), { headers: { "content-type": "application/json" } })
+    }
+    return fallback(raw, init)
+  }) as typeof globalThis.fetch
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const off = registerOpencodeKeymap(keymap, renderer, config)
+    onCleanup(off)
+
+    return (
+      <TestTuiContexts directory={input.root} paths={{ home: input.root, state, worktree: input.root }}>
+        <OpencodeKeymapProvider keymap={keymap}>
+          <TuiConfigProvider config={config}>
+            <ArgsProvider>
+              <ExitProvider exit={() => {}}>
+                <KVProvider>
+                  <ThemeProvider mode="dark" source={{ discover: async () => ({}) }}>
+                    <SDKProvider url="http://test" directory={input.root} fetch={fetch} events={eventSource()}>
+                      <ProjectProvider>
+                        <LocationProvider>
+                          <SyncProvider>
+                            <PermissionPrompt request={request} directory={input.root} />
+                          </SyncProvider>
+                        </LocationProvider>
+                      </ProjectProvider>
+                    </SDKProvider>
+                  </ThemeProvider>
+                </KVProvider>
+              </ExitProvider>
+            </ArgsProvider>
+          </TuiConfigProvider>
+        </OpencodeKeymapProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { kittyKeyboard: true })
+  return {
+    app,
+    async cleanup() {
+      app.renderer.destroy()
+    },
+  }
+}
+
+async function captureReply(
+  key: string,
+  confirm?: (input: Awaited<ReturnType<typeof mount>>, replies: string[]) => void | Promise<void>,
+) {
+  await using tmp = await tmpdir()
+  const replies: string[] = []
+  const prompt = await mount({ root: tmp.path, onReply: (reply) => replies.push(reply) })
+
+  try {
+    await Bun.sleep(10)
+    prompt.app.mockInput.pressKey(key)
+    await confirm?.(prompt, replies)
+
+    await wait(() => replies.length === 1)
+    return replies[0]
+  } finally {
+    await prompt.cleanup()
+  }
+}
+
+test("permission prompt number keys choose matching permission responses", async () => {
+  expect(await captureReply("1")).toBe("once")
+  expect(
+    await captureReply("2", async (prompt, replies) => {
+      await Bun.sleep(20)
+      expect(replies).toEqual([])
+      prompt.app.mockInput.pressEnter()
+    }),
+  ).toBe("always")
+  expect(await captureReply("3")).toBe("reject")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33123

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds number shortcuts to the main TUI permission prompt so `1` allows once, `2` opens the existing Allow always confirmation flow, and `3` rejects. The existing arrow keys, `h`/`l`, Enter, Escape, fullscreen toggle, and Always Allow confirmation behavior are preserved.

Numbered labels are only shown on the main permission prompt, so confirmation prompts keep their existing shape. A focused TUI regression test covers the shortcut behavior against the actual prompt component.

### How did you verify your code works?

From `packages/tui`:

- `npm exec --yes bun@1.3.14 -- run typecheck`
- `npm exec --yes bun@1.3.14 -- test test/cli/tui/permission-prompt.test.tsx test/cli/tui/dialog-prompt.test.tsx`
- `npm exec --yes bun@1.3.14 -- run prettier --check src/routes/session/permission.tsx test/cli/tui/permission-prompt.test.tsx`
- `git diff --check -- src/routes/session/permission.tsx test/cli/tui/permission-prompt.test.tsx`

### Screenshots / recordings

Not included; terminal keyboard interaction is covered by focused TUI tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
