### PR TITLE
fix(storybook): support prompt state capture

### DIFF
--- a/packages/storybook/.storybook/mocks/app/context/prompt.ts
+++ b/packages/storybook/.storybook/mocks/app/context/prompt.ts
@@ -73,7 +73,7 @@ export function createPromptState() {
     key: item.key ?? `ctx:${++index}`,
   })
 
-  return {
+  const value = {
     ready,
     current: () => store.prompt,
     cursor: () => store.cursor,
@@ -87,6 +87,7 @@ export function createPromptState() {
       setStore("cursor", 0)
       setStore("items", (current) => current.filter((item) => !!item.comment?.trim()))
     },
+    capture: () => value,
     context: {
       items: () => store.items,
       add(item: Omit<ContextItem, "key"> & { key?: string }) {
@@ -116,6 +117,7 @@ export function createPromptState() {
       },
     },
   }
+  return value
 }
 
 const prompt = createPromptState()


### PR DESCRIPTION
## Summary

- add `capture()` to the Storybook prompt-state mock
- return the same stable prompt state object, matching the application prompt API
- fix PromptInput stories failing with `prompt.capture is not a function`

## Validation

- `bun typecheck` in `packages/app`
- `bun run build` in `packages/storybook`
- pre-push `bun turbo typecheck` (29 packages passed)