### PR TITLE
fix(opencode): re-download skills when declared version changes

### DIFF
--- a/packages/opencode/src/skill/discovery.ts
+++ b/packages/opencode/src/skill/discovery.ts
@@ -43,8 +43,10 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Path.Path | Htt
     })
 
     const writeManifest = Effect.fn("Discovery.writeManifest")(function* (manifest: Record<string, string>) {
-      yield* fs.ensureDir(cache).pipe(Effect.orDie)
-      yield* fs.writeFileString(manifestPath, JSON.stringify(manifest, null, 2)).pipe(
+      yield* Effect.gen(function* () {
+        yield* fs.ensureDir(cache)
+        yield* fs.writeFileString(manifestPath, JSON.stringify(manifest, null, 2))
+      }).pipe(
         Effect.catch((err) => Effect.logError("failed to persist skill version manifest", { error: err })),
       )
     })

--- a/packages/opencode/src/skill/discovery.ts
+++ b/packages/opencode/src/skill/discovery.ts
@@ -1,7 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient, path } from "@opencode-ai/core/effect/layer-node-platform"
 import { NodePath } from "@effect/platform-node"
-import { Effect, Layer, Path, Schema, Context } from "effect"
+import { Effect, Layer, Option, Path, Schema, Context } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -13,6 +13,7 @@ const fileConcurrency = 8
 class IndexSkill extends Schema.Class<IndexSkill>("IndexSkill")({
   name: Schema.String,
   files: Schema.Array(Schema.String),
+  version: Schema.optional(Schema.String),
 }) {}
 
 class Index extends Schema.Class<Index>("Index")({
@@ -32,9 +33,24 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Path.Path | Htt
     const path = yield* Path.Path
     const http = HttpClient.filterStatusOk(withTransientReadRetry(yield* HttpClient.HttpClient))
     const cache = path.join(Global.Path.cache, "skills")
+    const manifestPath = path.join(cache, "versions.json")
+    const parseManifest = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
+    const decodeManifest = Schema.decodeUnknownOption(Schema.Record(Schema.String, Schema.String))
 
-    const download = Effect.fn("Discovery.download")(function* (url: string, dest: string) {
-      if (yield* fs.exists(dest).pipe(Effect.orDie)) return true
+    const readManifest = Effect.fn("Discovery.readManifest")(function* () {
+      const text = yield* fs.readFileString(manifestPath).pipe(Effect.catch(() => Effect.succeed("")))
+      return Option.getOrElse(Option.flatMap(parseManifest(text), decodeManifest), () => ({}) as Record<string, string>)
+    })
+
+    const writeManifest = Effect.fn("Discovery.writeManifest")(function* (manifest: Record<string, string>) {
+      yield* fs.ensureDir(cache).pipe(Effect.orDie)
+      yield* fs.writeFileString(manifestPath, JSON.stringify(manifest, null, 2)).pipe(
+        Effect.catch((err) => Effect.logError("failed to persist skill version manifest", { error: err })),
+      )
+    })
+
+    const download = Effect.fn("Discovery.download")(function* (url: string, dest: string, force = false) {
+      if (!force && (yield* fs.exists(dest).pipe(Effect.orDie))) return true
 
       return yield* HttpClientRequest.get(url).pipe(
         http.execute,
@@ -71,26 +87,33 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | Path.Path | Htt
       )
       const list = data.skills.filter((skill) => skill.files.includes("SKILL.md"))
 
+      const manifest = yield* readManifest()
+      const next: Record<string, string> = {}
+
       const dirs = yield* Effect.forEach(
         list,
         (skill) =>
           Effect.gen(function* () {
             const root = path.join(cache, skill.name)
+            const force = skill.version !== undefined && manifest[skill.name] !== skill.version
 
             yield* Effect.forEach(
               skill.files,
-              (file) => download(new URL(file, `${host}/${skill.name}/`).href, path.join(root, file)),
+              (file) => download(new URL(file, `${host}/${skill.name}/`).href, path.join(root, file), force),
               {
                 concurrency: fileConcurrency,
               },
             )
 
             const md = path.join(root, "SKILL.md")
-            return (yield* fs.exists(md).pipe(Effect.orDie)) ? root : null
+            const exists = yield* fs.exists(md).pipe(Effect.orDie)
+            if (exists && skill.version !== undefined) next[skill.name] = skill.version
+            return exists ? root : null
           }),
         { concurrency: skillConcurrency },
       )
 
+      if (Object.keys(next).length > 0 || Object.keys(manifest).length > 0) yield* writeManifest(next)
       return dirs.filter((dir): dir is string => dir !== null)
     })
 

--- a/packages/opencode/test/skill/discovery.test.ts
+++ b/packages/opencode/test/skill/discovery.test.ts
@@ -136,4 +136,61 @@ describe("Discovery.pull", () => {
       expect(downloadCount).toBe(firstCount)
     }),
   )
+
+  it.live("re-downloads a skill when its version changes and caches when it does not", () =>
+    Effect.gen(function* () {
+      const fsys = yield* FSUtil.Service
+      const discovery = yield* Discovery.Service
+
+      let version = "1"
+      let skillBody = "version-1-content"
+      let count = 0
+
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url)
+          if (url.pathname === "/index.json") {
+            return new Response(
+              JSON.stringify({ skills: [{ name: "versioned", files: ["SKILL.md"], version }] }),
+              { headers: { "content-type": "application/json" } },
+            )
+          }
+          if (url.pathname === "/versioned/SKILL.md") {
+            count++
+            return new Response(skillBody)
+          }
+          return new Response("Not Found", { status: 404 })
+        },
+      })
+
+      const base = `http://localhost:${server.port}/`
+      const skillDir = path.join(cacheDir, "versioned")
+      const manifest = path.join(cacheDir, "versions.json")
+      yield* Effect.promise(() => rm(skillDir, { recursive: true, force: true }))
+      yield* Effect.promise(() => rm(manifest, { force: true }))
+
+      try {
+        yield* discovery.pull(base)
+        expect(count).toBe(1)
+        expect(yield* fsys.readFileString(path.join(skillDir, "SKILL.md"))).toBe("version-1-content")
+
+        yield* discovery.pull(base)
+        expect(count).toBe(1)
+
+        version = "2"
+        skillBody = "version-2-content"
+        yield* discovery.pull(base)
+        expect(count).toBe(2)
+        expect(yield* fsys.readFileString(path.join(skillDir, "SKILL.md"))).toBe("version-2-content")
+
+        yield* discovery.pull(base)
+        expect(count).toBe(2)
+      } finally {
+        void server.stop()
+        yield* Effect.promise(() => rm(skillDir, { recursive: true, force: true }))
+        yield* Effect.promise(() => rm(manifest, { force: true }))
+      }
+    }),
+  )
 })

--- a/packages/opencode/test/skill/discovery.test.ts
+++ b/packages/opencode/test/skill/discovery.test.ts
@@ -193,4 +193,53 @@ describe("Discovery.pull", () => {
       }
     }),
   )
+
+  it.live("does not crash on a corrupt versions manifest and self-heals it", () =>
+    Effect.gen(function* () {
+      const fsys = yield* FSUtil.Service
+      const discovery = yield* Discovery.Service
+      let count = 0
+
+      const server = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          const url = new URL(req.url)
+          if (url.pathname === "/index.json") {
+            return new Response(
+              JSON.stringify({ skills: [{ name: "selfheal", files: ["SKILL.md"], version: "1" }] }),
+              { headers: { "content-type": "application/json" } },
+            )
+          }
+          if (url.pathname === "/selfheal/SKILL.md") {
+            count++
+            return new Response("healed-content")
+          }
+          return new Response("Not Found", { status: 404 })
+        },
+      })
+
+      const base = `http://localhost:${server.port}/`
+      const skillDir = path.join(cacheDir, "selfheal")
+      const manifest = path.join(cacheDir, "versions.json")
+      yield* Effect.promise(() => rm(skillDir, { recursive: true, force: true }))
+      yield* Effect.promise(() => rm(manifest, { force: true }))
+      // seed a corrupt manifest and a stale skill file
+      yield* Effect.promise(() => Bun.write(manifest, "{not valid json"))
+      yield* Effect.promise(() => Bun.write(path.join(skillDir, "SKILL.md"), "stale"))
+
+      try {
+        // pull must not throw despite the corrupt manifest; the stale file is
+        // re-downloaded because the unreadable manifest is treated as empty
+        yield* discovery.pull(base)
+        expect(count).toBe(1)
+        expect(yield* fsys.readFileString(path.join(skillDir, "SKILL.md"))).toBe("healed-content")
+        // manifest is rewritten as valid json
+        expect(yield* fsys.readFileString(manifest)).toBe(JSON.stringify({ selfheal: "1" }, null, 2))
+      } finally {
+        void server.stop()
+        yield* Effect.promise(() => rm(skillDir, { recursive: true, force: true }))
+        yield* Effect.promise(() => rm(manifest, { force: true }))
+      }
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #33548

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

Skills pulled from `skills.urls` were cached on disk by file existence and never refreshed — `packages/opencode/src/skill/discovery.ts` short-circuits `download` as soon as the destination exists. The `index.json` is re-fetched every run but is only used to enumerate files, so once `SKILL.md` exists locally, any update published at the URL is ignored until the user manually `rm -rf`s the cache.

This adds an optional `version` field to `index.json` skill entries. On `pull`, a skill's files are re-downloaded only when its declared `version` differs from the cached one. Cached versions are persisted in `~/.cache/opencode/skills/versions.json`, and writing that manifest is fully non-fatal (disk/permission failures are logged, never crash a pull). Indexes without a `version` keep the existing existence-based behavior, and no manifest file is created for them.

### How did I verify your code works?

- `test/skill/discovery.test.ts`: a local HTTP server serves a versioned skill. First pull downloads (`count=1`); a second pull with the same version is a cache hit (`count=1`); bumping the version re-downloads with the new content (`count=2`); a final pull with the unchanged version is again a cache hit (`count=2`).
- Added a test proving a corrupt `versions.json` does not crash a pull — it is treated as empty and self-heals to a valid manifest.
- The existing `caches downloaded files on second pull` test still passes (no-version catalogs keep caching by existence).
- `bun typecheck` and `oxlint` pass on the changed files; the full `test/skill/` + `test/tool/skill.test.ts` suite passes (26 tests).

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
