### PR TITLE
feat(tui): auto-discover TUI plugins and improve error handling

### DIFF
--- a/packages/core/src/config/plugin/external.ts
+++ b/packages/core/src/config/plugin/external.ts
@@ -57,7 +57,7 @@ export const Plugin = define({
 
         if (entry.type === "directory") {
           const files = yield* fs
-            .glob("{plugin,plugins}/*.{ts,js}", {
+            .glob("{plugin,plugins}/*.{ts,js,tsx}", {
               cwd: entry.path,
               absolute: true,
               include: "file",

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -1,6 +1,7 @@
 export * as TuiConfig from "./tui"
 
 import path from "path"
+import { pathToFileURL } from "url"
 import { mergeDeep, unique } from "remeda"
 import { Cause, Context, Effect, Fiber, Layer } from "effect"
 import { ConfigParse } from "@/config/parse"
@@ -8,6 +9,7 @@ import * as ConfigPaths from "@/config/paths"
 import { migrateTuiConfig } from "./tui-migrate"
 import { resolveHostAttentionSoundPaths } from "./tui-host-attention"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { Glob } from "@opencode-ai/core/util/glob"
 import { isRecord } from "@opencode-ai/tui/util/record"
 import { Global } from "@opencode-ai/core/global"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -205,6 +207,33 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
     for (const file of ConfigPaths.fileInDirectory(dir, "tui")) {
       yield* mergeFile(acc, file)
     }
+  }
+
+  try {
+    // 5. Auto-discover TUI plugins from {plugin,plugins}/*.{ts,js,tsx} directories.
+    // Users can place TUI plugin files directly in these directories without
+    // needing to declare them in a tui.json plugin array.
+    const pluginDiscoveryDirs = unique([Global.Path.config, ...directories, ...dirs].filter(Boolean))
+    for (const dir of pluginDiscoveryDirs) {
+      if (!dir || typeof dir !== "string") continue
+      const files = yield* Effect.promise(() =>
+        Glob.scan("{plugin,plugins}/*.{ts,js,tsx}", { cwd: dir, absolute: true, dot: true, symlink: true }).catch(
+          () => [] as string[],
+        ),
+      )
+      for (const file of files) {
+        const href = pathToFileURL(file).href
+        if (acc.plugin_origins.some((p) => p.spec === href || p.source === file)) continue
+        acc.plugin_origins.push({
+          spec: href,
+          scope: pluginScope(file, ctx),
+          source: file,
+        })
+      }
+    }
+    acc.plugin_origins = ConfigPlugin.deduplicatePluginOrigins(acc.plugin_origins)
+  } catch (e) {
+    yield* Effect.logWarning("tui plugin auto-discovery failed", { error: e })
   }
 
   const result = TuiConfig.resolve(

--- a/packages/opencode/src/plugin/tui/runtime.ts
+++ b/packages/opencode/src/plugin/tui/runtime.ts
@@ -534,6 +534,11 @@ async function activatePluginEntry(state: RuntimeState, plugin: PluginEntry, per
         id: plugin.id,
         error,
       })
+      // Surface the error to the user via toast
+      try {
+        const msg = `Plugin "${plugin.id}" failed to load: ${errorMessage(error)}`
+        state.api.ui.toast({ message: msg, variant: "error" })
+      } catch {}
       return false
     })
 

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -171,7 +171,7 @@ export const layer = Layer.effect(
 
         const dirs = yield* config.directories()
         const matches = dirs.flatMap((dir) =>
-          Glob.scanSync("{tool,tools}/*.{js,ts}", { cwd: dir, absolute: true, dot: true, symlink: true }),
+          Glob.scanSync("{tool,tools}/*.{js,ts,tsx}", { cwd: dir, absolute: true, dot: true, symlink: true }),
         )
         if (matches.length) yield* config.waitForDependencies()
         for (const match of matches) {

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -404,6 +404,12 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     })
     .catch((error) => {
       console.error("Failed to load TUI plugins", error)
+      toast.show({
+        variant: "error",
+        title: "Plugin Load Error",
+        message: errorMessage(error),
+        duration: 8000,
+      })
     })
     .finally(() => {
       setReady(true)


### PR DESCRIPTION
## Summary
Auto-discover TUI plugins from `{plugin,plugins}/*.{ts,js,tsx}` directories, surface plugin load errors as toasts, and add `.tsx` to all discovery globs for consistency.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactoring / improvement

## How did you verify your code works?
- [x] Built the binary (`bun run build`) — smoke test passed
- [x] Tested auto-discovery by placing a `.js` TUI plugin in `~/.config/opencode/plugins/` — command appeared in palette
- [x] Tested error toast by placing a malformed plugin — error toast appeared
- [x] Tested `.tsx` glob change by placing a `.tsx` file in discovery directory — file was found
- [x] Existing built-in plugins (PluginManager, Sidebar, etc.) all work unchanged

## Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes
- [x] My changes are backward compatible