### PR TITLE
fix(core): include ancestor directories in fff search

### DIFF
--- a/packages/core/src/filesystem/find.ts
+++ b/packages/core/src/filesystem/find.ts
@@ -1,0 +1,62 @@
+import path from "path"
+import { Entry } from "@opencode-ai/schema/filesystem"
+import fuzzysort from "fuzzysort"
+import { RelativePath } from "../schema"
+
+type FindItem = {
+  path: string
+  type: "file" | "directory"
+  score: number
+}
+
+function normalizedRelativePath(input: string) {
+  return input.replaceAll("\\", "/").replace(/\/$/, "")
+}
+
+function directoryMatchesQuery(query: string, directory: string) {
+  const normalized = query.trim().replaceAll("\\", "/").replace(/\/$/, "")
+  if (!normalized) return false
+  if (normalized.includes("/")) return fuzzysort.single(normalized, directory) !== null
+  return fuzzysort.single(normalized, path.posix.basename(directory)) !== null
+}
+
+export function normalizeFindEntries(
+  query: string,
+  limit: number,
+  items: FindItem[],
+  includeAncestorDirectories = true,
+) {
+  const byPath = new Map<string, FindItem>()
+  const add = (item: FindItem) => {
+    const relative = normalizedRelativePath(item.path)
+    if (!relative) return
+    const existing = byPath.get(relative)
+    if (!existing || item.score > existing.score || (item.type === "directory" && existing.type !== "directory")) {
+      byPath.set(relative, { ...item, path: relative })
+    }
+  }
+
+  for (const item of items) {
+    const relative = normalizedRelativePath(item.path)
+    add({ ...item, path: relative })
+    if (!includeAncestorDirectories) continue
+
+    const parts = relative.split("/").filter(Boolean)
+    const directoryDepth = parts.length - 1
+    for (let index = 1; index <= directoryDepth; index++) {
+      const directory = parts.slice(0, index).join("/")
+      if (!directoryMatchesQuery(query, directory)) continue
+      add({ path: directory, type: "directory", score: item.score })
+    }
+  }
+
+  return Array.from(byPath.values())
+    .sort((a, b) => b.score - a.score || a.path.length - b.path.length || a.path.localeCompare(b.path))
+    .slice(0, limit)
+    .map((item) =>
+      Entry.make({
+        path: RelativePath.make(item.path + (item.type === "directory" ? path.sep : "")),
+        type: item.type,
+      }),
+    )
+}

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -10,6 +10,7 @@ import { Location } from "../location"
 import { Ripgrep } from "../ripgrep"
 import { RelativePath } from "../schema"
 import { Flag } from "../flag/flag"
+import { normalizeFindEntries } from "./find"
 
 export interface Interface {
   readonly find: (input: FileSystem.FindInput) => Effect.Effect<FileSystem.Entry[]>
@@ -215,15 +216,7 @@ export const fffLayer = Layer.effect(
               score: found.value.scores[index]?.total ?? 0,
             }))
           })()
-          return items
-            .sort((a, b) => b.score - a.score || a.path.length - b.path.length)
-            .map((item) => {
-              const relative = item.path.replaceAll("\\", "/").replace(/\/$/, "")
-              return FileSystem.Entry.make({
-                path: RelativePath.make(relative + (item.type === "directory" ? path.sep : "")),
-                type: item.type,
-              })
-            })
+          return normalizeFindEntries(input.query, input.limit ?? 50, items, input.type !== "file")
         }),
     })
   }),

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { normalizeFindEntries } from "@opencode-ai/core/filesystem/find"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
@@ -40,4 +41,27 @@ describe("Ripgrep", () => {
       }),
     ),
   )
+})
+
+describe("FileSystemSearch", () => {
+  test("includes matching ancestor directories from fff file results", () => {
+    const result = normalizeFindEntries("feature", 10, [
+      { path: "feature/client/index.ts", type: "file", score: 100 },
+    ])
+
+    expect(result.map((item) => ({ path: item.path, type: item.type }))).toEqual([
+      { path: RelativePath.make("feature" + path.sep), type: "directory" },
+      { path: RelativePath.make("feature/client/index.ts"), type: "file" },
+    ])
+  })
+
+  test("does not add ancestors when only the file name matches", () => {
+    const result = normalizeFindEntries("index", 10, [
+      { path: "feature/client/index.ts", type: "file", score: 100 },
+    ])
+
+    expect(result.map((item) => ({ path: item.path, type: item.type }))).toEqual([
+      { path: RelativePath.make("feature/client/index.ts"), type: "file" },
+    ])
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #33751

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After the fff-backed search path, `@` autocomplete can miss ancestor directories that only contain subdirectories. For example, a matched descendant like `feature/client/index.ts` should also make `feature/` available when searching for `feature`.

This normalizes fff find results by backfilling matching ancestor directories from returned descendant paths. File-only searches stay unchanged, and file-name-only matches do not add unrelated parent directories.

### How did you verify your code works?

- `cd packages/core && bun test test/filesystem/search.test.ts --timeout 30000`
- `cd packages/core && bun run typecheck`

I also temporarily disabled the ancestor-directory backfill and confirmed the new regression test fails.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR