### PR TITLE
fix(app): refresh v2 tab titles on session title change

### DIFF
--- a/packages/app/src/components/titlebar-tab-nav.tsx
+++ b/packages/app/src/components/titlebar-tab-nav.tsx
@@ -18,6 +18,8 @@ export function TabNavItem(props: {
   href: string
   server: ServerConnection.Key
   session: () => Session | undefined
+  sessionData?: Record<string, Session | undefined>
+  sessionId?: string
   onTitleChange?: (title: string) => void
   onTitleChangeFailed?: (title: string) => void
   onClose: () => void
@@ -130,7 +132,8 @@ export function TabNavItem(props: {
   createEffect(() => {
     if (editing()) return
     if (!titleEl) return
-    const title = props.session()?.title
+    const title =
+      (props.sessionData?.[props.sessionId ?? ""] ?? props.session())?.title
     if (title === undefined) return
     titleEl.textContent = title
   })

--- a/packages/app/src/components/titlebar-tab-strip.tsx
+++ b/packages/app/src/components/titlebar-tab-strip.tsx
@@ -117,6 +117,8 @@ function SessionTabSlot(props: {
         href={tabHref(props.tab)}
         server={props.tab.server}
         session={session}
+        sessionData={props.serverCtx()?.sync.session.data.info}
+        sessionId={props.tab.sessionId}
         onTitleChange={(title) => {
           const value = session()
           const ctx = props.serverCtx()

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -95,4 +95,17 @@ describe("server session", () => {
 
     expect(ctx.store.data.message.active?.map((message) => message.id)).toEqual(["message"])
   })
+
+  test("reflects title update in store after session.updated event", () => {
+    const ctx = setup({})
+    ctx.store.apply({ type: "session.created", properties: { info: session("s1") } })
+    expect(ctx.store.data.info.s1!.title).toBe("s1")
+
+    const updated = { ...session("s1"), title: "renamed" }
+    ctx.store.apply({ type: "session.updated", properties: { info: updated } })
+
+    expect(ctx.store.data.info.s1!.title).toBe("renamed")
+    expect(ctx.store.get("s1")?.title).toBe("renamed")
+    expect(ctx.store.peek("s1")?.title).toBe("renamed")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #30329

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the v2 layout, the tab bar does not refresh when the LLM generates a session title. The `createEffect` in `TabNavItem` that updates `titleEl.textContent` reads `props.session()?.title` — but `session()` is a `createResource` that performs an async fetch and does not track reactive store updates from SSE `session.updated` events.

This change passes `sessionData` (the reactive `sync.session.data.info` record) and `sessionId` through to `TabNavItem`. The effect reads from `sessionData?.[sessionId]` first, which properly tracks reactive dependencies on the store. When a title update arrives via SSE → `session.remember()`, the store record updates and the effect fires.

### How did you verify your code works?

- `bun test src/context/server-session.test.ts` from `packages/app`: 5 pass (including new test for title update propagation)
- `bun typecheck` from `packages/app`: no new errors
- Manual verification: v2 tab bar now refreshes title when LLM generates session title

### Screenshots / recordings

_Not applicable — this is a reactive update fix, not a visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR