### PR TITLE
feat(tui): add /session-id and /session-info slash commands

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -528,6 +528,48 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Copy session ID",
+        desc: "Copy the current session ID to clipboard",
+        name: "session.copy-id",
+        category: "Session",
+        slashName: "session-id",
+        enabled: Boolean(props.sessionID),
+        run: async () => {
+          if (!props.sessionID || !clipboard.write) return
+          await clipboard.write(props.sessionID)
+          toast.show({
+            variant: "success",
+            message: `Copied: ${props.sessionID}`,
+            duration: 3000,
+          })
+          dialog.clear()
+        },
+      },
+      {
+        title: "Copy session info",
+        desc: "Copy project path, session title, and session ID to clipboard",
+        name: "session.copy-info",
+        category: "Session",
+        slashName: "session-info",
+        enabled: Boolean(props.sessionID),
+        run: async () => {
+          if (!props.sessionID || !clipboard.write) return
+          const dir =
+            (project.instance.path().worktree === "/" ? undefined : project.instance.path().worktree) ||
+            project.instance.directory() ||
+            ""
+          const session = sync.session.get(props.sessionID)
+          const title = session?.title ?? ""
+          await clipboard.write(`Project ${dir}; Session ${title}; ID ${props.sessionID}`)
+          toast.show({
+            variant: "success",
+            message: "Copied project, session title, and ID to clipboard",
+            duration: 3000,
+          })
+          dialog.clear()
+        },
+      },
+      {
         title: "Warp",
         desc: "Change the workspace for the session",
         name: "workspace.set",

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -536,13 +536,19 @@ export function Prompt(props: PromptProps) {
         enabled: Boolean(props.sessionID),
         run: async () => {
           if (!props.sessionID || !clipboard.write) return
+          // Clear input synchronously before the async clipboard write.
+          // The input's onSubmit fires a double-deferred submit() via setTimeout;
+          // if the input still contains "/session-id" when that fires, it sends
+          // the text to the LLM as a prompt.
+          input.setText("")
+          setStore("prompt", { input: "", parts: [] })
+          dialog.clear()
           await clipboard.write(props.sessionID)
           toast.show({
             variant: "success",
             message: `Copied: ${props.sessionID}`,
             duration: 3000,
           })
-          dialog.clear()
         },
       },
       {
@@ -554,6 +560,10 @@ export function Prompt(props: PromptProps) {
         enabled: Boolean(props.sessionID),
         run: async () => {
           if (!props.sessionID || !clipboard.write) return
+          // Clear input synchronously — see /session-id command for rationale.
+          input.setText("")
+          setStore("prompt", { input: "", parts: [] })
+          dialog.clear()
           const dir =
             (project.instance.path().worktree === "/" ? undefined : project.instance.path().worktree) ||
             project.instance.directory() ||
@@ -566,7 +576,6 @@ export function Prompt(props: PromptProps) {
             message: "Copied project, session title, and ID to clipboard",
             duration: 3000,
           })
-          dialog.clear()
         },
       },
       {


### PR DESCRIPTION
### Issue for this PR

Closes #11937

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds two TUI slash commands that copy session info to the clipboard — no LLM round-trip, no plugin required.

- `/session-id` copies the current session ID
- `/session-info` copies `Project <dir>; Session <title>; ID <session-id>`

Both show up in the slash command palette under Session, use the existing `useClipboard()` context, and show a toast on success. They are disabled when no session is active.

The input is cleared synchronously in the `run` handler before the async clipboard write. This prevents the input's deferred `onSubmit` from sending `/session-id` as a prompt to the LLM after the palette selection.

Supersedes #11938 (closed by automated PR cleanup, not technical rejection). That PR only had `/session-id`; this adds `/session-info` as well.

### How did you verify your code works?

- `tsgo --noEmit` passes for the `@opencode-ai/tui` package (0 new errors)
- Pre-push CI: 25/25 packages typecheck
- Manual: type `/session-id` → session ID copied to clipboard, toast appears, no LLM activity. Same for `/session-info`.

### Screenshots / recordings

N/A — no visual layout change, just two new palette entries and a toast.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR