### PR TITLE
fix(read): emit instruction reminders for media reads

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -306,9 +306,13 @@ export const ReadTool = Tool.define<
       if (isImage || isPdfAttachment(mime)) {
         const bytes = yield* fs.readFile(filepath)
         const msg = isPdfAttachment(mime) ? "PDF read successfully" : "Image read successfully"
+        const output =
+          loaded.length > 0
+            ? `${msg}\n\n<system-reminder>\n${loaded.map((item) => item.content).join("\n\n")}\n</system-reminder>`
+            : msg
         return {
           title,
-          output: msg,
+          output,
           metadata: {
             preview: msg,
             truncated: false,

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -579,6 +579,25 @@ describe("tool.read loaded instructions", () => {
       expect(result.metadata.loaded).toContain(path.join(dir, "subdir", "AGENTS.md"))
     }),
   )
+
+  it.live("emits loaded AGENTS.md reminders when reading image attachments", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const png = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+        "base64",
+      )
+      yield* put(path.join(dir, "subdir", "AGENTS.md"), "# Image Instructions\nRemember the image context.")
+      yield* put(path.join(dir, "subdir", "nested", "image.png"), png)
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "subdir", "nested", "image.png") })
+      expect(result.output).toContain("Image read successfully")
+      expect(result.output).toContain("system-reminder")
+      expect(result.output).toContain("Image Instructions")
+      expect(result.attachments).toBeDefined()
+      expect(result.metadata.loaded).toContain(path.join(dir, "subdir", "AGENTS.md"))
+    }),
+  )
 })
 
 describe("tool.read binary detection", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #33823

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`read` resolves nearby AGENTS instructions before deciding whether a file is text, image, or PDF. The text-file path appends those resolved instructions to the model-facing output as a `<system-reminder>`, but the media path only returned `Image read successfully` or `PDF read successfully` while still recording the instruction file in `metadata.loaded`.

This makes media reads include the same reminder text when instructions were loaded, so later reads do not skip instructions the model never saw.

### How did you verify your code works?

- `cd packages/opencode && bun test test/tool/read.test.ts --timeout 30000`
- `cd packages/opencode && bun run typecheck`

The new regression test fails before the fix because image reads only return `Image read successfully`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR