### PR TITLE
fix(config): error on missing {env:VAR} in config templates

### DIFF
--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -33,15 +33,35 @@ function dir(input: ParseSource) {
 /** Apply {env:VAR} and {file:path} substitutions to config text. */
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
+  const configSource = source(input)
+
+  // {env:VAR} is handled like a missing {file:path}: empty under "empty" mode,
+  // but a hard error under "error" mode so an unset variable surfaces at config
+  // load instead of as an opaque downstream failure (e.g. an empty auth header
+  // spawning an MCP server that then exits with -32000).
+  const absent = new Set<string>()
   let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-    return (input.env?.[varName] ?? process.env[varName]) || ""
+    const value = input.env?.[varName] ?? process.env[varName]
+    if (value === undefined || value === "") {
+      if (missing === "error") absent.add(varName)
+      return ""
+    }
+    return value
   })
+  if (absent.size) {
+    const names = Array.from(absent)
+    throw new InvalidError({
+      path: configSource,
+      message: `missing environment variable${names.length > 1 ? "s" : ""}: ${names
+        .map((name) => `{env:${name}}`)
+        .join(", ")}`,
+    })
+  }
 
   const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))
   if (!fileMatches.length) return text
 
   const configDir = dir(input)
-  const configSource = source(input)
   let out = ""
   let cursor = 0
 

--- a/packages/opencode/test/config/variable.test.ts
+++ b/packages/opencode/test/config/variable.test.ts
@@ -1,0 +1,89 @@
+import { test, expect, describe } from "bun:test"
+import { ConfigVariable } from "@/config/variable"
+import { NamedError } from "@opencode-ai/core/util/error"
+
+const source = { type: "path", path: "/tmp/opencode.json" } as const
+
+async function rejection(text: string, extra?: Parameters<typeof ConfigVariable.substitute>[0]) {
+  try {
+    await ConfigVariable.substitute({ text, ...source, ...extra })
+  } catch (error) {
+    return error
+  }
+  throw new Error("expected substitute to reject, but it resolved")
+}
+
+describe("ConfigVariable.substitute {env:} missing handling", () => {
+  const MISSING = "OPENCODE_TEST_MISSING_VAR_XYZ"
+  const SET = "OPENCODE_TEST_SET_VAR_XYZ"
+
+  test("missing env var throws ConfigInvalidError naming the var in the default (error) mode", async () => {
+    delete process.env[MISSING]
+    const error = await rejection(`{"username":"{env:${MISSING}}"}`)
+    expect(NamedError.hasName(error, "ConfigInvalidError")).toBe(true)
+    expect((error as { data: { message: string } }).data.message).toContain(MISSING)
+  })
+
+  test("missing env var resolves to empty string in empty mode", async () => {
+    delete process.env[MISSING]
+    const out = await ConfigVariable.substitute({
+      text: `{"username":"{env:${MISSING}}"}`,
+      ...source,
+      missing: "empty",
+    })
+    expect(out).toBe(`{"username":""}`)
+  })
+
+  test("set env var resolves to its value (happy path, error mode)", async () => {
+    process.env[SET] = "resolved-value"
+    try {
+      const out = await ConfigVariable.substitute({ text: `{"username":"{env:${SET}}"}`, ...source })
+      expect(out).toBe(`{"username":"resolved-value"}`)
+    } finally {
+      delete process.env[SET]
+    }
+  })
+
+  test("explicit input.env override resolves and counts as present", async () => {
+    delete process.env[MISSING]
+    const out = await ConfigVariable.substitute({
+      text: `{"username":"{env:${MISSING}}"}`,
+      ...source,
+      env: { [MISSING]: "from-input-env" },
+    })
+    expect(out).toBe(`{"username":"from-input-env"}`)
+  })
+
+  test("error names every missing variable when several are absent", async () => {
+    delete process.env["OPENCODE_TEST_MISSING_A"]
+    delete process.env["OPENCODE_TEST_MISSING_B"]
+    const error = await rejection(`{"a":"{env:OPENCODE_TEST_MISSING_A}","b":"{env:OPENCODE_TEST_MISSING_B}"}`)
+    const message = (error as { data: { message: string } }).data.message
+    expect(message).toContain("OPENCODE_TEST_MISSING_A")
+    expect(message).toContain("OPENCODE_TEST_MISSING_B")
+  })
+
+  test("an unset env var in a wrapped MCP server's environment map fails loudly", async () => {
+    // Repro of the original symptom: a wrapped remote MCP server stores
+    // {env:USER_TOKEN} in its environment map; an unset USER_TOKEN must surface
+    // at config load, not as an opaque downstream gateway -32000.
+    delete process.env["OPENCODE_TEST_USER_TOKEN"]
+    const text = JSON.stringify({
+      mcp: {
+        wrapped: {
+          type: "local",
+          command: ["npx", "-y", "@onyxsecurity/mcp-gateway"],
+          environment: { MCP_GATEWAY_HEADER_AUTHORIZATION: "{env:OPENCODE_TEST_USER_TOKEN}" },
+        },
+      },
+    })
+    const error = await rejection(text)
+    expect(NamedError.hasName(error, "ConfigInvalidError")).toBe(true)
+    expect((error as { data: { message: string } }).data.message).toContain("OPENCODE_TEST_USER_TOKEN")
+  })
+
+  test("missing {file:} still throws (unchanged) — env change did not regress it", async () => {
+    const error = await rejection(`{"x":"{file:./definitely-missing-file.txt}"}`)
+    expect(NamedError.hasName(error, "ConfigInvalidError")).toBe(true)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33853

### Type of change

- [x] Bug fix

### What does this PR do?

`ConfigVariable.substitute()` resolves `{file:path}` and `{env:VAR}` in config. A missing file already throws `ConfigInvalidError` under the default `error` mode, but a missing env var fell through `(input.env?.[name] ?? process.env[name]) || ""` and silently became `""`. That empty value is hard to trace when it's an MCP server's auth — the server starts with an empty header and only fails later with an opaque `-32000`.

This makes `{env:}` honor the same `missing` mode as `{file:}`: under `error` mode it throws `ConfigInvalidError` naming the missing variable(s); `empty` mode (tui.json) still resolves to `""`. The explicit `input.env` override is still honored, and a var set to `""` is treated as missing (matching the old `|| ""`).

Design note: this **throws** under `error` mode to mirror the existing `{file:}` behavior. The alternative is to **warn** and keep substituting `""`. Throwing is more consistent with `{file:}` and prevents the broken spawn, but it is a behavior change for anyone relying on a missing `{env:}` silently becoming `""` on the strict config path — happy to switch to warn-only if you prefer (one-branch change).

### How did you verify your code works?

- Added `packages/opencode/test/config/variable.test.ts` covering: missing var throws and names the var(s) under `error`; missing var → `""` under `empty`; a set var resolves; the `input.env` override resolves; a wrapped MCP `environment` map with an unset var fails loudly; `{file:}` still throws (unchanged).
- `bun test test/config/` — green (188 pass / 0 fail). `bun run typecheck` clean.
- Ran `opencode mcp list` against a local MCP server that requires a bearer token and logs the header it receives: with the var set it connects and gets the real token; with it unset OpenCode now reports `missing environment variable: {env:...}` instead of a silent empty header + opaque `-32000`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
