### PR TITLE
fix(cli): ignore stale mini turn events

### DIFF
--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -82,6 +82,7 @@ type StreamInput = {
 
 type Wait = {
   tick: number
+  promptMessageID?: string
   armed: boolean
   live: boolean
   onVisibleOutput?: (anchor: LocalReplayAnchor) => void
@@ -206,13 +207,17 @@ function isMatchingDisposeEvent(value: unknown, directory: string | undefined): 
   return value.payload.type === "server.instance.disposed"
 }
 
-function active(event: Event, sessionID: string): boolean {
+function active(event: Event, sessionID: string, promptMessageID?: string): boolean {
   if (sid(event) !== sessionID) {
     return false
   }
 
   if (event.type === "message.updated") {
-    return event.properties.info.role === "assistant"
+    if (event.properties.info.role !== "assistant") {
+      return false
+    }
+
+    return promptMessageID === undefined || event.properties.info.parentID === promptMessageID
   }
 
   if (event.type === "message.part.delta" || event.type === "message.part.updated") {
@@ -221,6 +226,10 @@ function active(event: Event, sessionID: string): boolean {
 
   if (event.type !== "session.status") {
     return true
+  }
+
+  if (promptMessageID !== undefined) {
+    return false
   }
 
   return event.properties.status.type !== "idle"
@@ -826,7 +835,7 @@ function createLayer(input: StreamInput) {
 
         const touch = (event: Event) => {
           const next = state.wait
-          if (!next || !active(event, input.sessionID)) {
+          if (!next || !active(event, input.sessionID, next.promptMessageID)) {
             return
           }
 
@@ -1201,6 +1210,7 @@ function createLayer(input: StreamInput) {
 
           const item: Wait = {
             tick: state.tick,
+            promptMessageID: next.prompt.messageID,
             armed: false,
             live: false,
             onVisibleOutput: next.onVisibleOutput,

--- a/packages/opencode/test/cli/run/stream.transport.test.ts
+++ b/packages/opencode/test/cli/run/stream.transport.test.ts
@@ -84,7 +84,7 @@ function retry(sessionID: string, attempt: number, message: string) {
   } satisfies SdkEvent
 }
 
-function assistant(id: string) {
+function assistant(id: string, parentID = "msg-user-1") {
   return {
     id: `evt-${id}`,
     type: "message.updated",
@@ -94,6 +94,7 @@ function assistant(id: string) {
         sessionID: "session-1",
         id,
         parts: [],
+        parentID,
       }).info,
     },
   } satisfies SdkEvent
@@ -186,7 +187,12 @@ function statusMap(busy: boolean): SessionStatusMap {
   return {}
 }
 
-function assistantMessage(input: { sessionID: string; id: string; parts: SessionMessage["parts"] }): SessionMessage {
+function assistantMessage(input: {
+  sessionID: string
+  id: string
+  parts: SessionMessage["parts"]
+  parentID?: string
+}): SessionMessage {
   return {
     info: {
       id: input.id,
@@ -195,7 +201,7 @@ function assistantMessage(input: { sessionID: string; id: string; parts: Session
       time: {
         created: 1,
       },
-      parentID: "msg-user-1",
+      parentID: input.parentID ?? "msg-user-1",
       modelID: "gpt-5",
       providerID: "openai",
       mode: "chat",
@@ -2059,6 +2065,60 @@ describe("run stream transport", () => {
         }),
         expect.objectContaining({
           parts: [{ type: "text", text: "again" }],
+        }),
+      ])
+    } finally {
+      src.close()
+      await transport.close()
+    }
+  })
+
+  test("ignores stale assistant events while waiting for the current prompt", async () => {
+    const src = eventFeed()
+    const ui = footer()
+    let promptCalls = 0
+    const transport = await createSessionTransport({
+      sdk: sdk({
+        stream: src.stream,
+        promptAsync: async () => {
+          promptCalls += 1
+          return ok(undefined)
+        },
+        status: async () => ok(statusMap(false)),
+      }),
+      sessionID: "session-1",
+      thinking: true,
+      limits: () => ({}),
+      footer: ui.api,
+    })
+
+    const run = transport.runPromptTurn({
+      agent: undefined,
+      model: undefined,
+      variant: undefined,
+      prompt: { text: "current", messageID: "msg-user-2", parts: [] },
+      files: [],
+      includeFiles: false,
+    })
+
+    try {
+      await waitFor(() => (promptCalls === 1 ? true : undefined))
+      await waitFor(() => ui.events.find((event) => event.type === "turn.wait"))
+
+      src.push(assistant("msg-old", "msg-user-1"))
+      src.push(idle())
+
+      expect(
+        await Promise.race([run.then(() => "done" as const), Bun.sleep(100).then(() => "pending" as const)]),
+      ).toBe("pending")
+
+      src.push(assistant("msg-current", "msg-user-2"))
+      src.push(idle())
+
+      await Promise.race([
+        run,
+        Bun.sleep(1_000).then(() => {
+          throw new Error("turn timed out")
         }),
       ])
     } finally {


### PR DESCRIPTION
### Issue for this PR

Closes #33761

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In mini mode, a queued prompt can start while old events from the previous turn are still arriving. `runPromptTurn` treated any assistant `message.updated` event for the main session as activity for the current wait, so an old assistant event followed by idle could resolve the new prompt before its own assistant started.

This keeps the current prompt message id on the wait state and only lets assistant `message.updated` events mark the turn live when their `parentID` matches that prompt. Turns without a prompt message id keep the existing status-event fallback.

### How did you verify your code works?

- Added a regression test in `test/cli/run/stream.transport.test.ts`; it fails before the fix because an old assistant + idle resolves the current prompt.
- `bun test test/cli/run/stream.transport.test.ts --timeout 10000`
- `bun run typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._