### PR TITLE
fix(mcp): render prompt commands with real args

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -1,6 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceState } from "@/effect/instance-state"
-import { EffectBridge } from "@/effect/bridge"
 import type { InstanceContext } from "@/project/instance-context"
 import { Effect, Layer, Context, Schema } from "effect"
 import { Config } from "@/config/config"
@@ -30,7 +29,14 @@ export const Info = Schema.Struct({
   hints: Schema.Array(Schema.String),
 }).annotate({ identifier: "Command" })
 
-export type Info = Omit<Schema.Schema.Type<typeof Info>, "template"> & { template: Promise<string> | string }
+export type Info = Omit<Schema.Schema.Type<typeof Info>, "template"> & {
+  template: Promise<string> | string
+  mcp?: {
+    client: string
+    name: string
+    arguments?: Array<{ name: string }>
+  }
+}
 
 export function hints(template: string) {
   const result: string[] = []
@@ -63,7 +69,6 @@ export const layer = Layer.effect(
 
     const init = Effect.fn("Command.state")(function* (ctx: InstanceContext) {
       const cfg = yield* config.get()
-      const bridge = yield* EffectBridge.make()
       const commands: Record<string, Info> = {}
 
       commands[Default.INIT] = {
@@ -102,31 +107,20 @@ export const layer = Layer.effect(
       }
 
       for (const [name, prompt] of Object.entries(yield* mcp.prompts())) {
+        const placeholders = prompt.arguments?.map((_, i) => `$${i + 1}`) ?? []
         commands[name] = {
           name,
           source: "mcp",
           description: prompt.description,
           get template() {
-            return bridge.promise(
-              mcp
-                .getPrompt(
-                  prompt.client,
-                  prompt.name,
-                  prompt.arguments
-                    ? Object.fromEntries(prompt.arguments.map((argument, i) => [argument.name, `$${i + 1}`]))
-                    : {},
-                )
-                .pipe(
-                  Effect.map(
-                    (template) =>
-                      template?.messages
-                        .map((message) => (message.content.type === "text" ? message.content.text : ""))
-                        .join("\n") || "",
-                  ),
-                ),
-            )
+            return placeholders.join(" ")
           },
-          hints: prompt.arguments?.map((_, i) => `$${i + 1}`) ?? [],
+          mcp: {
+            client: prompt.client,
+            name: prompt.name,
+            arguments: prompt.arguments?.map((argument) => ({ name: argument.name })),
+          },
+          hints: placeholders,
         }
       }
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1473,27 +1473,50 @@ export const layer = Layer.effect(
 
       const raw = input.arguments.match(argsRegex) ?? []
       const args = raw.map((arg) => arg.replace(quoteTrimRegex, ""))
-      const templateCommand = yield* Effect.promise(async () => cmd.template)
+      const templateCommand = cmd.mcp
+        ? yield* mcp
+            .getPrompt(
+              cmd.mcp.client,
+              cmd.mcp.name,
+              Object.fromEntries(
+                (cmd.mcp.arguments ?? []).flatMap((argument, i) => {
+                  const value = i === (cmd.mcp?.arguments?.length ?? 0) - 1 ? args.slice(i).join(" ") : args[i]
+                  return value === undefined || value === "" ? [] : [[argument.name, value]]
+                }),
+              ),
+            )
+            .pipe(
+              Effect.map(
+                (template) =>
+                  template?.messages
+                    .map((message) => (message.content.type === "text" ? message.content.text : ""))
+                    .join("\n") || "",
+              ),
+            )
+        : yield* Effect.promise(async () => cmd.template)
 
-      const placeholders = templateCommand.match(placeholderRegex) ?? []
-      let last = 0
-      for (const item of placeholders) {
-        const value = Number(item.slice(1))
-        if (value > last) last = value
-      }
+      let template = templateCommand
+      if (!cmd.mcp) {
+        const placeholders = templateCommand.match(placeholderRegex) ?? []
+        let last = 0
+        for (const item of placeholders) {
+          const value = Number(item.slice(1))
+          if (value > last) last = value
+        }
 
-      const withArgs = templateCommand.replaceAll(placeholderRegex, (_, index) => {
-        const position = Number(index)
-        const argIndex = position - 1
-        if (argIndex >= args.length) return ""
-        if (position === last) return args.slice(argIndex).join(" ")
-        return args[argIndex]
-      })
-      const usesArgumentsPlaceholder = templateCommand.includes("$ARGUMENTS")
-      let template = withArgs.replaceAll("$ARGUMENTS", input.arguments)
+        const withArgs = templateCommand.replaceAll(placeholderRegex, (_, index) => {
+          const position = Number(index)
+          const argIndex = position - 1
+          if (argIndex >= args.length) return ""
+          if (position === last) return args.slice(argIndex).join(" ")
+          return args[argIndex]
+        })
+        const usesArgumentsPlaceholder = templateCommand.includes("$ARGUMENTS")
+        template = withArgs.replaceAll("$ARGUMENTS", input.arguments)
 
-      if (placeholders.length === 0 && !usesArgumentsPlaceholder && input.arguments.trim()) {
-        template = template + "\n\n" + input.arguments
+        if (placeholders.length === 0 && !usesArgumentsPlaceholder && input.arguments.trim()) {
+          template = template + "\n\n" + input.arguments
+        }
       }
 
       const shellMatches = ConfigMarkdown.shell(template)

--- a/packages/opencode/test/command/command.test.ts
+++ b/packages/opencode/test/command/command.test.ts
@@ -1,0 +1,79 @@
+import { expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Command } from "../../src/command"
+import { MCP } from "../../src/mcp"
+import { Skill } from "../../src/skill"
+import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+
+const getPromptCalls: Array<readonly unknown[]> = []
+
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    instructions: () => Effect.succeed([]),
+    tools: () => Effect.succeed({}),
+    prompts: () =>
+      Effect.succeed({
+        "math:scientific_calculation": {
+          client: "math",
+          name: "scientific_calculation",
+          description: "Run a typed scientific calculation",
+          arguments: [{ name: "precision" }, { name: "calc_type" }],
+        },
+      } as any),
+    resources: () => Effect.succeed({}),
+    resourceTemplates: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: (...args) =>
+      Effect.sync(() => {
+        getPromptCalls.push(args)
+        throw new Error("command listing should not render MCP prompts")
+      }),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in command tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in command tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in command tests"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const skills = Layer.succeed(
+  Skill.Service,
+  Skill.Service.of({
+    get: () => Effect.succeed(undefined),
+    require: () => Effect.die("unexpected skill lookup in command tests"),
+    all: () => Effect.succeed([]),
+    dirs: () => Effect.succeed([]),
+    available: () => Effect.succeed([]),
+  }),
+)
+
+const layer = Command.layer.pipe(Layer.provide(Layer.mergeAll(TestConfig.layer(), mcp, skills)))
+const it = testEffect(layer)
+
+it.instance("lists MCP prompts without rendering typed prompt arguments", () =>
+  Effect.gen(function* () {
+    getPromptCalls.length = 0
+
+    const command = yield* Command.Service
+    const found = (yield* command.list()).find((item) => item.name === "math:scientific_calculation")
+
+    expect(found?.source).toBe("mcp")
+    expect(found?.hints).toEqual(["$1", "$2"])
+    expect(yield* Effect.promise(() => Promise.resolve(found?.template))).toBe("$1 $2")
+    expect(found?.mcp).toEqual({
+      client: "math",
+      name: "scientific_calculation",
+      arguments: [{ name: "precision" }, { name: "calc_type" }],
+    })
+    expect(getPromptCalls).toEqual([])
+  }),
+)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -109,13 +109,14 @@ function errorTool(parts: SessionV1.Part[]) {
   return part?.state.status === "error" ? (part as ErrorToolPart) : undefined
 }
 
-function makeMcp(instructions: MCP.ServerInstructions[] = []) {
+function makeMcp(input: MCP.ServerInstructions[] | Partial<MCP.Interface> = []) {
+  const overrides = Array.isArray(input) ? { instructions: () => Effect.succeed(input) } : input
   return Layer.succeed(
     MCP.Service,
     MCP.Service.of({
       status: () => Effect.succeed({}),
       clients: () => Effect.succeed({}),
-      instructions: () => Effect.succeed(instructions),
+      instructions: () => Effect.succeed([]),
       tools: () => Effect.succeed({}),
       prompts: () => Effect.succeed({}),
       resources: () => Effect.succeed({}),
@@ -132,6 +133,7 @@ function makeMcp(instructions: MCP.ServerInstructions[] = []) {
       supportsOAuth: () => Effect.succeed(false),
       hasStoredTokens: () => Effect.succeed(false),
       getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+      ...overrides,
     }),
   )
 }
@@ -168,20 +170,28 @@ const blockingProcessor = Layer.succeed(
   }),
 )
 
-function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makePrompt(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  mcp?: Partial<MCP.Interface>
+  processor?: "blocking"
+}) {
+  const mcpLayer = makeMcp(input?.mcp ?? input?.mcpInstructions)
+  const commandLayer = Command.layer.pipe(
+    Layer.provide(Layer.mergeAll(Config.defaultLayer, mcpLayer, Skill.defaultLayer)),
+  )
   const deps = Layer.mergeAll(
     Session.defaultLayer,
     Snapshot.defaultLayer,
     LLM.defaultLayer,
     Env.defaultLayer,
     AgentSvc.defaultLayer,
-    Command.defaultLayer,
+    commandLayer,
     Permission.defaultLayer,
     Plugin.defaultLayer,
     Config.defaultLayer,
     ProviderSvc.defaultLayer,
     lsp,
-    makeMcp(input?.mcpInstructions),
+    mcpLayer,
     FSUtil.defaultLayer,
     BackgroundJob.defaultLayer,
     status,
@@ -240,11 +250,19 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
   )
 }
 
-function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttp(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  mcp?: Partial<MCP.Interface>
+  processor?: "blocking"
+}) {
   return Layer.mergeAll(TestLLMServer.layer, makePrompt(input))
 }
 
-function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttpNoLLMServer(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  mcp?: Partial<MCP.Interface>
+  processor?: "blocking"
+}) {
   return makePrompt(input)
 }
 
@@ -260,6 +278,37 @@ const withMcpInstructions = testEffect(
         tools: ["guide-server_lookup"],
       },
     ],
+  }),
+)
+const mcpPromptCalls: Array<{ client: string; name: string; args?: Record<string, string> }> = []
+const withMcpPrompt = testEffect(
+  makeHttp({
+    mcp: {
+      prompts: () =>
+        Effect.succeed({
+          "math:scientific_calculation": {
+            client: "math",
+            name: "scientific_calculation",
+            description: "Run a typed scientific calculation",
+            arguments: [{ name: "precision" }, { name: "calc_type" }],
+          },
+        } as any),
+      getPrompt: (client, name, args) =>
+        Effect.sync(() => {
+          mcpPromptCalls.push({ client, name, args })
+          return {
+            messages: [
+              {
+                role: "user",
+                content: {
+                  type: "text",
+                  text: `precision=${args?.precision}; calc_type=${args?.calc_type}`,
+                },
+              },
+            ],
+          } as any
+        }),
+    },
   }),
 )
 const unix = process.platform !== "win32" ? it.instance : it.instance.skip
@@ -1735,6 +1784,36 @@ unix(
         expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("configured")
       }),
     ),
+  30_000,
+)
+
+withMcpPrompt.instance(
+  "MCP slash commands render prompts with the submitted arguments",
+  () =>
+    Effect.gen(function* () {
+      mcpPromptCalls.length = 0
+      const { llm } = yield* useServerConfig(providerCfg)
+      const { prompt, chat } = yield* boot()
+      yield* llm.text("done")
+
+      const result = yield* prompt.command({
+        sessionID: chat.id,
+        command: "math:scientific_calculation",
+        arguments: "5 batch",
+      })
+
+      expect(result.info.role).toBe("assistant")
+      expect(mcpPromptCalls).toEqual([
+        {
+          client: "math",
+          name: "scientific_calculation",
+          args: { precision: "5", calc_type: "batch" },
+        },
+      ])
+      const inputs = yield* llm.inputs
+      expect(JSON.stringify(inputs.at(-1)?.messages)).toContain("precision=5; calc_type=batch")
+    }),
+  { config: cfg },
   30_000,
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #33564

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP prompt commands were rendered while commands were being listed, using placeholder arguments like `$1` and `$2`. Servers with typed prompt arguments can reject those placeholders before the user runs the command.

This keeps MCP command listing lazy and stores the prompt metadata instead. When the slash command is executed, it calls `prompts/get` with the submitted arguments and uses the rendered prompt directly.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

- `bun test test/command/command.test.ts test/session/prompt.test.ts --timeout 30000 -t "MCP slash commands|lists MCP prompts"`
- `bun run typecheck`
- `bun x prettier --check packages/opencode/src/command/index.ts packages/opencode/src/session/prompt.ts packages/opencode/test/command/command.test.ts packages/opencode/test/session/prompt.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._