### PR TITLE
fix(app): point desktop issue links at real forms

### DIFF
--- a/packages/app/src/desktop-menu.test.ts
+++ b/packages/app/src/desktop-menu.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test"
-import { DESKTOP_MENU } from "./desktop-menu"
+import { existsSync } from "node:fs"
+import path from "node:path"
+import { DESKTOP_MENU, type DesktopMenuEntry } from "./desktop-menu"
+
+function entries(items: DesktopMenuEntry[]): DesktopMenuEntry[] {
+  return items.flatMap((item) => ("items" in item ? entries(item.items) : [item]))
+}
 
 describe("desktop menu", () => {
   test("exports logs through the desktop command registry", () => {
@@ -9,5 +15,20 @@ describe("desktop menu", () => {
 
     expect(items).toHaveLength(2)
     expect(items.every((item) => item.type === "item" && item.command === "logs.export" && !item.action)).toBe(true)
+  })
+
+  test("GitHub issue links reference existing issue templates", () => {
+    const templateDir = path.resolve(import.meta.dir, "../../../.github/ISSUE_TEMPLATE")
+    const issueLinks = entries(DESKTOP_MENU.flatMap((menu) => menu.items)).filter(
+      (item) => "href" in item && item.href.startsWith("https://github.com/anomalyco/opencode/issues/new"),
+    )
+
+    expect(issueLinks.length).toBeGreaterThan(0)
+    for (const item of issueLinks) {
+      if (!("href" in item)) continue
+      const template = new URL(item.href).searchParams.get("template")
+      expect(template).toBeTruthy()
+      expect(existsSync(path.join(templateDir, template ?? ""))).toBe(true)
+    }
   })
 })

--- a/packages/app/src/desktop-menu.ts
+++ b/packages/app/src/desktop-menu.ts
@@ -207,12 +207,12 @@ export const DESKTOP_MENU: DesktopMenu[] = [
       {
         type: "item",
         label: "Share Feedback",
-        href: "https://github.com/anomalyco/opencode/issues/new?template=feature_request.yml",
+        href: "https://github.com/anomalyco/opencode/issues/new?template=feature-request.yml",
       },
       {
         type: "item",
         label: "Report a Bug",
-        href: "https://github.com/anomalyco/opencode/issues/new?template=bug_report.yml",
+        href: "https://github.com/anomalyco/opencode/issues/new?template=bug-report.yml",
       },
     ],
   },


### PR DESCRIPTION
### Issue for this PR

Closes #33855

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The desktop Help menu linked GitHub issue forms with `feature_request.yml` and `bug_report.yml`, but the repo's issue form files use hyphenated names. GitHub ignores the missing template name, so users can land on an issue page without the expected form.

This updates the links to `feature-request.yml` and `bug-report.yml`, then adds a small menu test that checks GitHub issue links point at real issue template files.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/desktop-menu.test.ts --timeout 10000`
- `bun x prettier --check packages/app/src/desktop-menu.ts packages/app/src/desktop-menu.test.ts`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._