### PR TITLE
fix(tui): search files under reference aliases

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete-reference.ts
+++ b/packages/tui/src/component/prompt/autocomplete-reference.ts
@@ -1,0 +1,41 @@
+import type { LocationRef, ReferenceInfo } from "@opencode-ai/sdk/v2"
+
+export type ReferenceFileSearch = {
+  reference: ReferenceInfo
+  query: string
+  prefix: string
+  location: LocationRef
+}
+
+export function findExactReferenceAlias(query: string, references: readonly ReferenceInfo[]) {
+  if (!query || query.includes("/")) return
+  return references.find((reference) => !reference.hidden && reference.name === query)
+}
+
+export function resolveReferenceFileSearch(
+  query: string,
+  references: readonly ReferenceInfo[],
+): ReferenceFileSearch | undefined {
+  const slash = query.indexOf("/")
+  if (slash === -1) return
+
+  const alias = query.slice(0, slash)
+  if (!alias) return
+
+  const reference = references.find((item) => !item.hidden && item.name === alias)
+  if (!reference) return
+
+  return {
+    reference,
+    query: query.slice(slash + 1),
+    prefix: `${alias}/`,
+    location: {
+      directory: reference.path,
+    },
+  }
+}
+
+export function withReferenceFilePrefix(prefix: string, filePath: string) {
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\/+/, "")
+  return `${prefix}${normalized}`
+}

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -23,6 +23,7 @@ import { useFrecency } from "../../prompt/frecency"
 import { useBindings, useCommandSlashes, useOpencodeModeStack } from "../../keymap"
 import { displayCharAt, mentionTriggerIndex } from "../../prompt/display"
 import type { FileSystemEntry } from "@opencode-ai/sdk/v2"
+import { findExactReferenceAlias, resolveReferenceFileSearch, withReferenceFilePrefix } from "./autocomplete-reference"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -282,9 +283,13 @@ export function Autocomplete(props: {
   const referenceMatch = createMemo(() => {
     if (!store.visible || store.visible === "/") return
     const { baseQuery } = extractLineRange(search())
-    const slash = baseQuery.indexOf("/")
-    const alias = slash === -1 ? baseQuery : baseQuery.slice(0, slash)
-    return references().find((item) => !item.hidden && item.name === alias)
+    return findExactReferenceAlias(baseQuery, references())
+  })
+
+  const referenceFileSearch = createMemo(() => {
+    if (!store.visible || store.visible === "/") return
+    const { baseQuery } = extractLineRange(search())
+    return resolveReferenceFileSearch(baseQuery, references())
   })
 
   function normalizeMentionPath(filePath: string) {
@@ -314,17 +319,18 @@ export function Autocomplete(props: {
   }
 
   const [files] = createResource(
-    () => ({ query: search(), location: location() }),
+    () => ({ query: search(), location: location(), references: references() }),
     async (input) => {
       if (!store.visible || store.visible === "/") return []
-      if (referenceMatch()) return []
       const { lineRange, baseQuery } = extractLineRange(input.query ?? "")
+      if (findExactReferenceAlias(baseQuery, input.references)) return []
+      const referenceSearch = resolveReferenceFileSearch(baseQuery, input.references)
 
       // Get files from SDK
       const result = await sdk.client.v2.fs.find({
-        query: baseQuery,
+        query: referenceSearch?.query ?? baseQuery,
         limit: "20",
-        location: {
+        location: referenceSearch?.location ?? {
           directory: input.location?.directory,
           workspace: input.location?.workspaceID ?? project.workspace.current(),
         },
@@ -338,8 +344,9 @@ export function Autocomplete(props: {
         const width = props.anchor().width - 4
         options.push(
           ...result.data.data.map((item): AutocompleteOption => {
+            const itemPath = referenceSearch ? withReferenceFilePrefix(referenceSearch.prefix, item.path) : item.path
             const { filename, part } = createFilePart(
-              item,
+              { ...item, path: itemPath },
               path.join(result.data.location.directory, item.path),
               lineRange,
             )
@@ -347,7 +354,7 @@ export function Autocomplete(props: {
               display: Locale.truncateMiddle(filename, width),
               value: filename,
               isDirectory: item.type === "directory",
-              path: item.path,
+              path: itemPath,
               onSelect: () => {
                 insertPart(filename, part)
               },
@@ -476,6 +483,7 @@ export function Autocomplete(props: {
   const options = createMemo((prev: AutocompleteOption[] | undefined) => {
     const filesValue = files()
     const referenceMatchValue = referenceMatch()
+    const referenceFileSearchValue = referenceFileSearch()
     const agentsValue = agents()
     const referenceAliasesValue = referenceAliases()
     const commandsValue = commands()
@@ -489,7 +497,9 @@ export function Autocomplete(props: {
     // it shouldn't be additionally sorted by fuzzysort as it will loose the results
     const fileOptions: AutocompleteOption[] = store.visible === "@" ? filesValue || [] : []
     const nonFileOptions: AutocompleteOption[] =
-      store.visible === "@" ? [...referenceAliasesValue, ...agentsValue, ...mcpResources()] : [...commandsValue]
+      store.visible === "@"
+        ? [...(referenceFileSearchValue ? [] : referenceAliasesValue), ...agentsValue, ...mcpResources()]
+        : [...commandsValue]
 
     if (!searchValue) {
       return [...nonFileOptions, ...fileOptions]

--- a/packages/tui/test/component/prompt/autocomplete-reference.test.ts
+++ b/packages/tui/test/component/prompt/autocomplete-reference.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import type { ReferenceInfo } from "@opencode-ai/sdk/v2"
+import {
+  findExactReferenceAlias,
+  resolveReferenceFileSearch,
+  withReferenceFilePrefix,
+} from "../../../src/component/prompt/autocomplete-reference"
+
+function reference(name: string, referencePath: string, hidden = false): ReferenceInfo {
+  return {
+    name,
+    path: referencePath,
+    ...(hidden ? { hidden } : {}),
+    source: {
+      type: "local",
+      path: referencePath,
+      ...(hidden ? { hidden } : {}),
+    },
+  }
+}
+
+describe("autocomplete reference search", () => {
+  const references = [reference("docs", "D:\\docs"), reference("hidden", "D:\\hidden", true)]
+
+  test("uses the reference directory when the query contains an alias slash", () => {
+    expect(resolveReferenceFileSearch("docs/guide", references)).toEqual({
+      reference: references[0],
+      query: "guide",
+      prefix: "docs/",
+      location: {
+        directory: "D:\\docs",
+      },
+    })
+  })
+
+  test("keeps the slash query empty when browsing a reference root", () => {
+    expect(resolveReferenceFileSearch("docs/", references)?.query).toBe("")
+  })
+
+  test("does not treat alias slash queries as exact reference aliases", () => {
+    expect(findExactReferenceAlias("docs/guide", references)).toBeUndefined()
+    expect(findExactReferenceAlias("docs", references)).toBe(references[0])
+  })
+
+  test("prefixes reference file results with the alias", () => {
+    expect(withReferenceFilePrefix("docs/", "nested\\guide.md")).toBe("docs/nested/guide.md")
+  })
+
+  test("ignores hidden references", () => {
+    expect(resolveReferenceFileSearch("hidden/secret", references)).toBeUndefined()
+    expect(findExactReferenceAlias("hidden", references)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33573

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`@docs` worked because autocomplete matched the reference alias directly. `@docs/...` used the same alias match, so file search was skipped and the menu could only offer the reference root again.

This keeps exact alias matches for attaching the reference root, but treats alias paths as file searches rooted at the reference directory. File results are displayed and inserted with the alias prefix, e.g. `docs/guide.md`, while the attachment URL points at the real reference file.

### How did you verify your code works?

- `bun test test/component/prompt/autocomplete-reference.test.ts --timeout 10000`
- `bun x prettier --check src/component/prompt/autocomplete.tsx src/component/prompt/autocomplete-reference.ts test/component/prompt/autocomplete-reference.test.ts`
- `bun run typecheck`

### Screenshots / recordings

Not a UI layout change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._