### PR TITLE
fix(tui): ignore empty slash commands

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -36,6 +36,7 @@ import { expandPastedTextPlaceholders, expandTrackedPastedText } from "../../pro
 import { usePromptStash } from "../../prompt/stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
+import { parsePromptSlashCommand } from "./submit-command"
 import { useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { AssistantMessage, FilePart, UserMessage } from "@opencode-ai/sdk/v2"
 import { Locale } from "../../util/locale"
@@ -1029,6 +1030,7 @@ export function Prompt(props: PromptProps) {
 
     // Filter out text parts (pasted content) since they're now expanded inline
     const nonTextParts = store.prompt.parts.filter((part) => part.type !== "text")
+    const parsedSlashCommand = parsePromptSlashCommand(inputText, sync.data.command)
 
     // Capture mode before it gets reset
     const currentMode = store.mode
@@ -1062,22 +1064,13 @@ export function Prompt(props: PromptProps) {
         command: inputText,
       })
       setStore("mode", "normal")
-    } else if (
-      inputText.startsWith("/") &&
-      sync.data.command.some((x) => x.name === inputText.split("\n")[0].split(" ")[0].slice(1))
-    ) {
+    } else if (parsedSlashCommand) {
       move.startSubmit()
-      // Parse command from first line, preserve multi-line content in arguments
-      const firstLineEnd = inputText.indexOf("\n")
-      const firstLine = firstLineEnd === -1 ? inputText : inputText.slice(0, firstLineEnd)
-      const [command, ...firstLineArgs] = firstLine.split(" ")
-      const restOfInput = firstLineEnd === -1 ? "" : inputText.slice(firstLineEnd + 1)
-      const args = firstLineArgs.join(" ") + (restOfInput ? "\n" + restOfInput : "")
 
       void sdk.client.session.command({
         sessionID,
-        command: command.slice(1),
-        arguments: args,
+        command: parsedSlashCommand.command,
+        arguments: parsedSlashCommand.arguments,
         agent: agent.name,
         model: `${selectedModel.providerID}/${selectedModel.modelID}`,
         variant,

--- a/packages/tui/src/component/prompt/submit-command.ts
+++ b/packages/tui/src/component/prompt/submit-command.ts
@@ -1,0 +1,28 @@
+type CommandInfo = {
+  name: string
+}
+
+export type PromptSlashCommand = {
+  command: string
+  arguments: string
+}
+
+export function parsePromptSlashCommand(
+  inputText: string,
+  commands: readonly CommandInfo[],
+): PromptSlashCommand | undefined {
+  if (!inputText.startsWith("/")) return
+
+  const firstLineEnd = inputText.indexOf("\n")
+  const firstLine = firstLineEnd === -1 ? inputText : inputText.slice(0, firstLineEnd)
+  const [head, ...firstLineArgs] = firstLine.split(" ")
+  const command = head.slice(1)
+  if (!command) return
+  if (!commands.some((item) => item.name === command)) return
+
+  const restOfInput = firstLineEnd === -1 ? "" : inputText.slice(firstLineEnd + 1)
+  return {
+    command,
+    arguments: firstLineArgs.join(" ") + (restOfInput ? "\n" + restOfInput : ""),
+  }
+}

--- a/packages/tui/test/component/prompt/submit-command.test.ts
+++ b/packages/tui/test/component/prompt/submit-command.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { parsePromptSlashCommand } from "../../../src/component/prompt/submit-command"
+
+describe("parsePromptSlashCommand", () => {
+  test("does not treat a bare slash as an empty command", () => {
+    expect(parsePromptSlashCommand("/", [{ name: "" }])).toBeUndefined()
+  })
+
+  test("parses known slash commands and preserves multiline arguments", () => {
+    expect(parsePromptSlashCommand("/init one two\nrest", [{ name: "init" }])).toEqual({
+      command: "init",
+      arguments: "one two\nrest",
+    })
+  })
+
+  test("ignores unknown slash commands", () => {
+    expect(parsePromptSlashCommand("/missing", [{ name: "init" }])).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33867

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A standalone `/` could be parsed as an empty slash command if the command list contained an empty command name. That lets the TUI send an empty `session.command` request instead of treating the input as non-command text.

This moves prompt slash command parsing into a small helper and requires a non-empty command name before matching registered commands. Existing slash command argument handling is preserved, including multiline arguments.

### How did you verify your code works?

- `bun test test/component/prompt/submit-command.test.ts --timeout 10000`
- `bun test test/cli/tui/prompt-submit-race.test.ts --timeout 10000`
- `bun x prettier --check src/component/prompt/index.tsx src/component/prompt/submit-command.ts test/component/prompt/submit-command.test.ts`
- `bun run typecheck`

### Screenshots / recordings

Not a UI layout change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._