### PR TITLE
fix: disable Kitty keyboard on Windows to fix IME crash

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.lifecycle.ts
@@ -186,7 +186,7 @@ export async function createRuntimeLifecycle(input: LifecycleInput): Promise<Lif
       autoFocus: false,
       openConsoleOnError: false,
       exitOnCtrlC: false,
-      useKittyKeyboard: { events: process.platform === "win32" },
+      useKittyKeyboard: process.platform === "win32" ? null : { events: false },
       screenMode: "split-footer",
       footerHeight: FOOTER_HEIGHT,
       externalOutputMode: "capture-stdout",


### PR DESCRIPTION
## Problem

Chinese/Japanese IME input causes OpenCode TUI to crash on Windows. Root cause: Kitty keyboard protocol intercepts IME keystrokes and encodes them as CSI escape sequences, bypassing IME composition. Combined with Windows console code page not being UTF-8, the garbled bytes trigger an unhandled exception.

## Fix

On Windows, pass \useKittyKeyboard: null\ to the renderer to completely disable the Kitty keyboard protocol. On other platforms, behavior is unchanged (\{ events: false }\ → enabled with default flags).

## Depends on

This PR requires anomalyco/opentui#??? (fix for \?? {}\ fallback that prevented \
ull\ from disabling the protocol) to take effect. Without the opentui fix, this change is a no-op — the \?? {}\ fallback in the renderer converts \
ull\ back to \{}\.

## Related issues
- #14761 - Chinese IME input intermittently stops working
- #29994 - Chinese IME input shows underscores in TUI
- #7891 - TUI Chinese Text Display Issue
- #10946 - CJK IME not working - input bypasses IME