### PR TITLE
fix(cli): keep plugin list aliases out of installs

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -11,6 +11,8 @@ import { Process } from "@/util/process"
 import { UI } from "../ui"
 import { effectCmd } from "../effect-cmd"
 import { InstanceRef } from "@/effect/instance-ref"
+import { Config } from "@/config/config"
+import { ConfigPlugin } from "@/config/plugin"
 
 type Spin = {
   start: (msg: string) => void
@@ -44,6 +46,11 @@ export type PlugCtx = {
   directory: string
 }
 
+type PluginListItem = {
+  spec: string
+  scopes: Set<string>
+}
+
 const defaultPlugDeps: PlugDeps = {
   spinner: () => spinner(),
   log: {
@@ -66,6 +73,50 @@ function cause(err: unknown) {
   if (!("cause" in err)) return
   return (err as { cause?: unknown }).cause
 }
+
+function isPluginListToken(mod: string) {
+  return mod === "list" || mod === "ls"
+}
+
+function addPluginListItems(items: Map<string, PluginListItem>, origins: ConfigPlugin.Origin[] | undefined) {
+  for (const origin of origins ?? []) {
+    const spec = ConfigPlugin.pluginSpecifier(origin.spec)
+    const item =
+      items.get(spec) ??
+      ({
+        spec,
+        scopes: new Set<string>(),
+      } satisfies PluginListItem)
+    item.scopes.add(origin.scope)
+    items.set(spec, item)
+  }
+}
+
+function formatSet(values: Set<string>) {
+  return Array.from(values).sort().join(", ")
+}
+
+const listPlugins = Effect.fn("Cli.plug.list")(function* () {
+  UI.empty()
+  intro("Plugins")
+
+  const config = yield* Config.Service.use((cfg) => cfg.get())
+
+  const items = new Map<string, PluginListItem>()
+  addPluginListItems(items, config.plugin_origins)
+
+  if (items.size === 0) {
+    log.warn("No plugins configured")
+    outro("Install plugins with: opencode plugin <module>")
+    return
+  }
+
+  for (const item of Array.from(items.values()).sort((a, b) => a.spec.localeCompare(b.spec))) {
+    const hint = formatSet(item.scopes)
+    log.info(`${item.spec} ${UI.Style.TEXT_DIM}${hint}${UI.Style.TEXT_NORMAL}`)
+  }
+  outro(`${items.size} plugin(s)`)
+})
 
 export function createPlugTask(input: PlugInput, dep: PlugDeps = defaultPlugDeps) {
   const mod = input.mod
@@ -202,6 +253,11 @@ export const PluginCommand = effectCmd({
     if (!mod) {
       UI.error("module is required")
       process.exitCode = 1
+      return
+    }
+
+    if (isPluginListToken(mod)) {
+      yield* listPlugins()
       return
     }
 

--- a/packages/opencode/test/cli/smokes/read-only.test.ts
+++ b/packages/opencode/test/cli/smokes/read-only.test.ts
@@ -16,6 +16,7 @@
 // cuts per-spawn cost when this suite gets bigger.
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
+import path from "path"
 import { cliIt } from "../../lib/cli-process"
 
 describe("opencode read-only commands (smoke)", () => {
@@ -28,6 +29,40 @@ describe("opencode read-only commands (smoke)", () => {
       Effect.gen(function* () {
         const r = yield* opencode.spawn(["mcp", "list"])
         opencode.expectExit(r, 0, "mcp list")
+      }),
+    60_000,
+  )
+
+  // `plugin ls/list` are read-only aliases. They must not be parsed as
+  // `plugin <module>` and try to install npm packages named after the aliases.
+  cliIt.live(
+    "plugin list aliases: exit 0 without installing alias packages",
+    ({ home, opencode }) =>
+      Effect.gen(function* () {
+        for (const alias of ["ls", "list"] as const) {
+          const r = yield* opencode.spawn(["plugin", alias], {
+            env: {
+              NPM_CONFIG_OFFLINE: "true",
+              npm_config_offline: "true",
+            },
+          })
+          opencode.expectExit(r, 0, `plugin ${alias}`)
+          const installed = yield* Effect.promise(() =>
+            Bun.file(
+              path.join(
+                home,
+                ".cache",
+                "opencode",
+                "packages",
+                `${alias}@latest`,
+                "node_modules",
+                alias,
+                "package.json",
+              ),
+            ).exists(),
+          )
+          expect(installed).toBe(false)
+        }
       }),
     60_000,
   )


### PR DESCRIPTION
### Issue for this PR

Closes #33749

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode plugin ls` and `opencode plugin list` were parsed as `plugin <module>`, so the install path resolved `ls` or `list` as npm packages and wrote phantom entries into the plugin cache.

This treats those two tokens as read-only plugin list aliases before the install flow starts. The list path reads configured plugin origins and never calls the npm resolver.

### How did you verify your code works?

- `bun test test/cli/smokes/read-only.test.ts --timeout 180000`
- `bun run --cwd packages/opencode typecheck`
- `bun lint`
- Ran `opencode plugin ls` and `opencode plugin list` with an isolated home/cache and confirmed no `ls@latest` or `list@latest` package directory was created.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
