### PR TITLE
fix(session): bound diff summary payload

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -35,6 +35,7 @@ import { isMedia } from "@/util/media"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
 import { Effect, Schema } from "effect"
+import { limitSummaryDiffs } from "./summary-diffs"
 
 export const node = LayerNode.group([Database.node])
 
@@ -79,12 +80,16 @@ export const cursor = {
   },
 }
 
-const info = (row: typeof MessageTable.$inferSelect) =>
-  ({
+const info = (row: typeof MessageTable.$inferSelect) => {
+  const summary = row.data.summary
+  const diffs = summary?.diffs ? limitSummaryDiffs(summary.diffs) : undefined
+  return {
     ...row.data,
+    ...(summary ? { summary: diffs ? { ...summary, diffs } : summary } : {}),
     id: row.id,
     sessionID: row.session_id,
-  }) as Info
+  } as Info
+}
 
 const part = (row: typeof PartTable.$inferSelect) =>
   ({

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -44,6 +44,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { SessionMessageID } from "@opencode-ai/schema/session-message-id"
+import { limitSummaryDiffs } from "./summary-diffs"
 
 const runtime = makeRuntime(Database.Service, Database.defaultLayer)
 
@@ -65,7 +66,7 @@ export function fromRow(row: SessionRow): Info {
           additions: row.summary_additions ?? 0,
           deletions: row.summary_deletions ?? 0,
           files: row.summary_files ?? 0,
-          diffs: row.summary_diffs ?? undefined,
+          diffs: row.summary_diffs ? limitSummaryDiffs(row.summary_diffs) : undefined,
         }
       : undefined
   const share = row.share_url ? { url: row.share_url } : undefined
@@ -136,7 +137,7 @@ export function toRow(info: Info) {
     summary_additions: info.summary?.additions,
     summary_deletions: info.summary?.deletions,
     summary_files: info.summary?.files,
-    summary_diffs: info.summary?.diffs,
+    summary_diffs: info.summary?.diffs ? limitSummaryDiffs(info.summary.diffs) : undefined,
     metadata: info.metadata,
     cost: info.cost ?? 0,
     tokens_input: (info.tokens ?? EmptyTokens).input,

--- a/packages/opencode/src/session/summary-diffs.ts
+++ b/packages/opencode/src/session/summary-diffs.ts
@@ -1,0 +1,7 @@
+const MAX_SUMMARY_DIFFS = 200
+
+export function limitSummaryDiffs<T>(diffs: T[]) {
+  // Keep turn summaries bounded so a pathological workspace diff cannot bloat message JSON.
+  if (diffs.length <= MAX_SUMMARY_DIFFS) return diffs
+  return diffs.slice(0, MAX_SUMMARY_DIFFS)
+}

--- a/packages/opencode/src/session/summary-diffs.ts
+++ b/packages/opencode/src/session/summary-diffs.ts
@@ -1,7 +1,40 @@
-const MAX_SUMMARY_DIFFS = 200
+export const MAX_SUMMARY_DIFFS = 200
+export const MAX_SUMMARY_PATCH_BYTES = 10_000_000
+export const MAX_SUMMARY_TOTAL_PATCH_BYTES = 10_000_000
 
-export function limitSummaryDiffs<T>(diffs: T[]) {
-  // Keep turn summaries bounded so a pathological workspace diff cannot bloat message JSON.
-  if (diffs.length <= MAX_SUMMARY_DIFFS) return diffs
-  return diffs.slice(0, MAX_SUMMARY_DIFFS)
+type SummaryDiff = {
+  readonly patch?: string
+}
+
+// Bound both the number of files and the total patch payload so one huge
+// workspace diff cannot balloon a stored session/message record.
+export function limitSummaryDiffs<T extends SummaryDiff>(diffs: readonly T[]) {
+  const result: T[] = []
+  let totalPatchBytes = 0
+
+  for (const diff of diffs) {
+    if (result.length >= MAX_SUMMARY_DIFFS) break
+
+    const patch = diff.patch
+    if (typeof patch !== "string") {
+      result.push(diff)
+      continue
+    }
+
+    const patchBytes = Buffer.byteLength(patch)
+    if (patchBytes > MAX_SUMMARY_PATCH_BYTES) {
+      result.push({ ...diff, patch: "" })
+      continue
+    }
+
+    if (totalPatchBytes + patchBytes > MAX_SUMMARY_TOTAL_PATCH_BYTES) {
+      result.push({ ...diff, patch: "" })
+      continue
+    }
+
+    totalPatchBytes += patchBytes
+    result.push(diff)
+  }
+
+  return result
 }

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -6,7 +6,12 @@ import { Snapshot } from "@/snapshot"
 import { Session } from "./session"
 import { SessionID, MessageID } from "./schema"
 import { Config } from "@/config/config"
-import { limitSummaryDiffs } from "./summary-diffs"
+import {
+  MAX_SUMMARY_DIFFS,
+  MAX_SUMMARY_PATCH_BYTES,
+  MAX_SUMMARY_TOTAL_PATCH_BYTES,
+  limitSummaryDiffs,
+} from "./summary-diffs"
 
 function unquoteGitPath(input: string) {
   if (!input.startsWith('"')) return input
@@ -67,7 +72,10 @@ function unquoteGitPath(input: string) {
 export interface Interface {
   readonly summarize: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<void>
   readonly diff: (input: { sessionID: SessionID; messageID?: MessageID }) => Effect.Effect<Snapshot.FileDiff[]>
-  readonly computeDiff: (input: { messages: SessionV1.WithParts[] }) => Effect.Effect<Snapshot.FileDiff[]>
+  readonly computeDiff: (input: {
+    messages: SessionV1.WithParts[]
+    limit?: number
+  }) => Effect.Effect<Snapshot.FileDiff[]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionSummary") {}
@@ -80,7 +88,10 @@ export const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const config = yield* Config.Service
 
-    const computeDiff = Effect.fn("SessionSummary.computeDiff")(function* (input: { messages: SessionV1.WithParts[] }) {
+    const computeDiff = Effect.fn("SessionSummary.computeDiff")(function* (input: {
+      messages: SessionV1.WithParts[]
+      limit?: number
+    }) {
       let from: string | undefined
       let to: string | undefined
       for (const item of input.messages) {
@@ -96,7 +107,18 @@ export const layer = Layer.effect(
           if (part.type === "step-finish" && part.snapshot) to = part.snapshot
         }
       }
-      if (from && to) return yield* snapshot.diffFull(from, to)
+      if (from && to)
+        return yield* snapshot.diffFull(
+          from,
+          to,
+          input.limit === undefined
+            ? undefined
+            : {
+                limit: input.limit,
+                maxPatchBytes: MAX_SUMMARY_PATCH_BYTES,
+                maxTotalPatchBytes: MAX_SUMMARY_TOTAL_PATCH_BYTES,
+              },
+        )
       return []
     })
 
@@ -122,7 +144,9 @@ export const layer = Layer.effect(
       )
       const target = messages.find((m) => m.info.id === input.messageID)
       if (!target || target.info.role !== "user") return
-      const msgDiffs = limitSummaryDiffs(yield* computeDiff({ messages }))
+      const msgDiffs = limitSummaryDiffs(
+        yield* computeDiff({ messages, limit: MAX_SUMMARY_DIFFS }),
+      )
       target.info.summary = { ...target.info.summary, diffs: msgDiffs }
       yield* sessions.updateMessage(target.info)
     })

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -6,6 +6,7 @@ import { Snapshot } from "@/snapshot"
 import { Session } from "./session"
 import { SessionID, MessageID } from "./schema"
 import { Config } from "@/config/config"
+import { limitSummaryDiffs } from "./summary-diffs"
 
 function unquoteGitPath(input: string) {
   if (!input.startsWith('"')) return input
@@ -121,7 +122,7 @@ export const layer = Layer.effect(
       )
       const target = messages.find((m) => m.info.id === input.messageID)
       if (!target || target.info.role !== "user") return
-      const msgDiffs = yield* computeDiff({ messages })
+      const msgDiffs = limitSummaryDiffs(yield* computeDiff({ messages }))
       target.info.summary = { ...target.info.summary, diffs: msgDiffs }
       yield* sessions.updateMessage(target.info)
     })
@@ -132,7 +133,7 @@ export const layer = Layer.effect(
         (item) => item.info.id === input.messageID,
       )
       if (!message || message.info.role !== "user") return []
-      const diffs = message.info.summary?.diffs ?? []
+      const diffs = limitSummaryDiffs(message.info.summary?.diffs ?? [])
       return diffs.map((item) => {
         if (item.file === undefined) return item
         const file = unquoteGitPath(item.file)

--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -29,9 +29,16 @@ interface GitResult {
   readonly code: ChildProcessSpawner.ExitCode
   readonly text: string
   readonly stderr: string
+  readonly truncated: boolean
 }
 
 type State = Omit<Interface, "init">
+
+type DiffOptions = {
+  readonly limit?: number
+  readonly maxPatchBytes?: number
+  readonly maxTotalPatchBytes?: number
+}
 
 export interface Interface {
   readonly init: () => Effect.Effect<void>
@@ -41,7 +48,7 @@ export interface Interface {
   readonly restore: (snapshot: string) => Effect.Effect<void>
   readonly revert: (patches: Patch[]) => Effect.Effect<void>
   readonly diff: (hash: string) => Effect.Effect<string>
-  readonly diffFull: (from: string, to: string) => Effect.Effect<FileDiff[]>
+  readonly diffFull: (from: string, to: string, options?: DiffOptions) => Effect.Effect<FileDiff[]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Snapshot") {}
@@ -79,15 +86,19 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           encodeNulTerminatedPaths(files.map((file) => `:(top,literal)${file}`))
 
         const git = Effect.fnUntraced(
-          function* (cmd: string[], opts?: { cwd?: string; env?: Record<string, string>; stdin?: string }) {
+          function* (
+            cmd: string[],
+            opts?: { cwd?: string; env?: Record<string, string>; stdin?: string; maxOutputBytes?: number },
+          ) {
             const result = yield* appProcess.run(
               ChildProcess.make("git", cmd, { cwd: opts?.cwd, env: opts?.env, extendEnv: true }),
-              { stdin: opts?.stdin },
+              { stdin: opts?.stdin, maxOutputBytes: opts?.maxOutputBytes },
             )
             return {
               code: ChildProcessSpawner.ExitCode(result.exitCode),
               text: result.stdout.toString("utf8"),
               stderr: result.stderr.toString("utf8"),
+              truncated: result.stdoutTruncated,
             } satisfies GitResult
           },
           Effect.catch((err) =>
@@ -95,6 +106,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               code: ChildProcessSpawner.ExitCode(1),
               text: "",
               stderr: err instanceof Error ? err.message : String(err),
+              truncated: false,
             }),
           ),
         )
@@ -543,7 +555,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
           )
         })
 
-        const diffFull = Effect.fnUntraced(function* (from: string, to: string) {
+        const diffFull = Effect.fnUntraced(function* (from: string, to: string, options?: DiffOptions) {
           return yield* locked(
             Effect.gen(function* () {
               type Row = {
@@ -560,27 +572,28 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
                 ref: string
               }
 
+              const maxPatchBytes = options?.maxPatchBytes ?? options?.maxTotalPatchBytes
+              const maxTotalPatchBytes = options?.maxTotalPatchBytes
+              const limit = options?.limit ?? Number.POSITIVE_INFINITY
+
+              const read = Effect.fnUntraced(function* (ref: string) {
+                const result = yield* git(
+                  [...cfg, ...args(["show", ref])],
+                  maxPatchBytes === undefined ? undefined : { maxOutputBytes: maxPatchBytes },
+                )
+                return result.truncated ? "" : result.text
+              })
+
               const show = Effect.fnUntraced(function* (row: Row) {
                 if (row.binary) return ["", ""]
                 if (row.status === "added") {
-                  return [
-                    "",
-                    yield* git([...cfg, ...args(["show", `${to}:${row.file}`])]).pipe(Effect.map((item) => item.text)),
-                  ]
+                  return ["", yield* read(`${to}:${row.file}`)]
                 }
                 if (row.status === "deleted") {
-                  return [
-                    yield* git([...cfg, ...args(["show", `${from}:${row.file}`])]).pipe(
-                      Effect.map((item) => item.text),
-                    ),
-                    "",
-                  ]
+                  return [yield* read(`${from}:${row.file}`), ""]
                 }
                 return yield* Effect.all(
-                  [
-                    git([...cfg, ...args(["show", `${from}:${row.file}`])]).pipe(Effect.map((item) => item.text)),
-                    git([...cfg, ...args(["show", `${to}:${row.file}`])]).pipe(Effect.map((item) => item.text)),
-                  ],
+                  [read(`${from}:${row.file}`), read(`${to}:${row.file}`)],
                   { concurrency: 2 },
                 )
               })
@@ -606,9 +619,12 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
                       cwd: state.directory,
                       extendEnv: true,
                     }),
-                    { stdin: refs.map((item) => item.ref).join("\n") + "\n" },
+                    {
+                      stdin: refs.map((item) => item.ref).join("\n") + "\n",
+                      ...(maxTotalPatchBytes === undefined ? {} : { maxOutputBytes: maxTotalPatchBytes }),
+                    },
                   )
-                  if (batch.exitCode !== 0) {
+                  if (batch.exitCode !== 0 || batch.stdoutTruncated) {
                     yield* Effect.logInfo(
                       "git cat-file --batch failed during snapshot diff, falling back to per-file git show",
                       {
@@ -683,6 +699,7 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
 
               const result: FileDiff[] = []
               const status = new Map<string, "added" | "deleted" | "modified">()
+              let totalPatchBytes = 0
 
               const statuses = yield* git(
                 [...quote, ...args(["diff", "--no-ext-diff", "--name-status", "--no-renames", from, to, "--", "."])],
@@ -736,16 +753,41 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
               const patch = (file: string, before: string, after: string) =>
                 formatPatch(structuredPatch(file, file, before, after, "", "", { context: Number.MAX_SAFE_INTEGER }))
 
-              for (let i = 0; i < rows.length; i += step) {
-                const run = rows.slice(i, i + step)
+              for (let i = 0; i < rows.length && result.length < limit; i += step) {
+                const remaining = limit - result.length
+                const run = rows.slice(i, i + Math.min(step, remaining))
+                if (!run.length) break
                 const text = yield* load(run)
 
                 for (const row of run) {
                   const hit = text?.get(row.file) ?? { before: "", after: "" }
                   const [before, after] = row.binary ? ["", ""] : text ? [hit.before, hit.after] : yield* show(row)
+                  const nextPatch = row.binary ? "" : patch(row.file, before, after)
+                  const patchBytes = Buffer.byteLength(nextPatch)
+                  if (maxPatchBytes !== undefined && patchBytes > maxPatchBytes) {
+                    result.push({
+                      file: row.file,
+                      patch: "",
+                      additions: row.additions,
+                      deletions: row.deletions,
+                      status: row.status,
+                    })
+                    continue
+                  }
+                  if (maxTotalPatchBytes !== undefined && totalPatchBytes + patchBytes > maxTotalPatchBytes) {
+                    result.push({
+                      file: row.file,
+                      patch: "",
+                      additions: row.additions,
+                      deletions: row.deletions,
+                      status: row.status,
+                    })
+                    return result
+                  }
+                  totalPatchBytes += patchBytes
                   result.push({
                     file: row.file,
-                    patch: row.binary ? "" : patch(row.file, before, after),
+                    patch: nextPatch,
                     additions: row.additions,
                     deletions: row.deletions,
                     status: row.status,
@@ -791,8 +833,8 @@ export const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Serv
       diff: Effect.fn("Snapshot.diff")(function* (hash: string) {
         return yield* InstanceState.useEffect(state, (s) => s.diff(hash))
       }),
-      diffFull: Effect.fn("Snapshot.diffFull")(function* (from: string, to: string) {
-        return yield* InstanceState.useEffect(state, (s) => s.diffFull(from, to))
+      diffFull: Effect.fn("Snapshot.diffFull")(function* (from: string, to: string, options?: DiffOptions) {
+        return yield* InstanceState.useEffect(state, (s) => s.diffFull(from, to, options))
       }),
     })
   }),

--- a/packages/opencode/test/session/summary-diffs.test.ts
+++ b/packages/opencode/test/session/summary-diffs.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { limitSummaryDiffs } from "../../src/session/summary-diffs"
+import { MAX_SUMMARY_TOTAL_PATCH_BYTES, limitSummaryDiffs } from "../../src/session/summary-diffs"
 
 test("caps summary diffs to a bounded payload", () => {
   const diffs = Array.from({ length: 201 }, (_, index) => ({
@@ -15,4 +15,30 @@ test("caps summary diffs to a bounded payload", () => {
   expect(limited).toHaveLength(200)
   expect(limited[0]).toEqual(diffs[0])
   expect(limited[199]).toEqual(diffs[199])
+})
+
+test("caps summary diffs by total patch bytes", () => {
+  const patch = "x".repeat(MAX_SUMMARY_TOTAL_PATCH_BYTES / 2 + 1)
+  const diffs = [
+    {
+      file: "src/large-1.ts",
+      patch,
+      additions: 1,
+      deletions: 1,
+      status: "modified" as const,
+    },
+    {
+      file: "src/large-2.ts",
+      patch,
+      additions: 1,
+      deletions: 1,
+      status: "modified" as const,
+    },
+  ]
+
+  const limited = limitSummaryDiffs(diffs)
+
+  expect(limited).toHaveLength(2)
+  expect(limited[0].patch).toBe(patch)
+  expect(limited[1].patch).toBe("")
 })

--- a/packages/opencode/test/session/summary-diffs.test.ts
+++ b/packages/opencode/test/session/summary-diffs.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test"
+import { limitSummaryDiffs } from "../../src/session/summary-diffs"
+
+test("caps summary diffs to a bounded payload", () => {
+  const diffs = Array.from({ length: 201 }, (_, index) => ({
+    file: `src/file-${index}.ts`,
+    patch: "@@ -1 +1 @@\n-old\n+new\n",
+    additions: 1,
+    deletions: 1,
+    status: "modified" as const,
+  }))
+
+  const limited = limitSummaryDiffs(diffs)
+
+  expect(limited).toHaveLength(200)
+  expect(limited[0]).toEqual(diffs[0])
+  expect(limited[199]).toEqual(diffs[199])
+})

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, expect } from "bun:test"
 import { $ } from "bun"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppProcess } from "@opencode-ai/core/process"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import fs from "fs/promises"
 import path from "path"
-import { Effect, Fiber, Layer } from "effect"
+import { Effect, Fiber, Layer, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { Config } from "@/config/config"
 import { Snapshot } from "../../src/snapshot"
 import {
   disposeAllInstances,
@@ -45,6 +48,33 @@ const exists = (file: string) => FSUtil.Service.use((fs) => fs.existsSafe(file))
 const mkdirp = (dir: string) => FSUtil.Service.use((fs) => fs.ensureDir(dir))
 const rm = (file: string) =>
   FSUtil.Service.use((fs) => fs.remove(file, { recursive: true, force: true }).pipe(Effect.ignore))
+const encoder = new TextEncoder()
+
+function mockSpawner(
+  handler: (cmd: string, args: readonly string[]) => string | { code: number; stdout?: string; stderr?: string },
+) {
+  const spawner = ChildProcessSpawner.make((command) => {
+    const std = ChildProcess.isStandardCommand(command) ? command : undefined
+    const result = handler(std?.command ?? "", std?.args ?? [])
+    const output = typeof result === "string" ? { code: 0, stdout: result, stderr: "" } : result
+    return Effect.succeed(
+      ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(0),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(output.code)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: { [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") } as any,
+        stdout: output.stdout ? Stream.make(encoder.encode(output.stdout)) : Stream.empty,
+        stderr: output.stderr ? Stream.make(encoder.encode(output.stderr)) : Stream.empty,
+        all: Stream.empty,
+        getInputFd: () => ({ [Symbol.for("effect/Sink/TypeId")]: Symbol.for("effect/Sink/TypeId") }) as any,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      }),
+    )
+  })
+  return Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)
+}
 
 const initialize = Effect.fn("SnapshotTest.initialize")(function* (dir: string) {
   const unique = Math.random().toString(36).slice(2)
@@ -101,6 +131,40 @@ const withGitConfigGlobal = <A, E, R>(config: string, self: Effect.Effect<A, E, 
         else delete process.env.GIT_CONFIG_GLOBAL
       }),
   )
+
+const diffFullCommandCounts = { show: 0, catFile: 0 }
+const diffFullLayer = Layer.mergeAll(
+  Snapshot.layer.pipe(
+    Layer.provide(
+      AppProcess.layer.pipe(
+        Layer.provide(
+          mockSpawner((cmd, args) => {
+            if (cmd !== "git") return ""
+            if (args.includes("cat-file")) {
+              diffFullCommandCounts.catFile += 1
+              return { code: 1, stderr: "batch unavailable" }
+            }
+            if (args.includes("show")) {
+              diffFullCommandCounts.show += 1
+              const ref = args.at(-1) ?? ""
+              return `${ref}\ncontent\n`
+            }
+            if (args.includes("check-ignore")) return { code: 1, stdout: "" }
+            if (args.includes("--name-status"))
+              return "M\tfile-1.txt\nM\tfile-2.txt\nM\tfile-3.txt\n"
+            if (args.includes("--numstat"))
+              return "1\t1\tfile-1.txt\n1\t1\tfile-2.txt\n1\t1\tfile-3.txt\n"
+            return ""
+          }),
+        ),
+      ),
+    ),
+    Layer.provide(FSUtil.defaultLayer),
+    Layer.provide(Config.defaultLayer),
+  ),
+  testInstanceStoreLayer,
+)
+const diffFullIt = testEffect(diffFullLayer)
 
 it.instance(
   "tracks deleted files correctly",
@@ -1209,6 +1273,23 @@ it.instance(
     yield* snapshot.revert([patch])
     for (let i = 0; i < base.length; i++) expect(yield* readText(base[i])).toBe(`base-${i}`)
     for (const file of fresh) expect(yield* exists(file)).toBe(false)
+  }),
+  { git: true },
+)
+
+diffFullIt.instance(
+  "diffFull stops loading rows once the limit is reached",
+  Effect.gen(function* () {
+    diffFullCommandCounts.show = 0
+    diffFullCommandCounts.catFile = 0
+
+    const snapshot = yield* Snapshot.Service
+    const diffs = yield* snapshot.diffFull("before", "after", { limit: 2 })
+
+    expect(diffs).toHaveLength(2)
+    expect(diffs.map((item) => item.file)).toEqual(["file-1.txt", "file-2.txt"])
+    expect(diffFullCommandCounts.catFile).toBe(1)
+    expect(diffFullCommandCounts.show).toBe(4)
   }),
   { git: true },
 )


### PR DESCRIPTION
### Issue for this PR

Closes #33106

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Caps session summary diffs before generating, persisting, and serving them so a pathological workspace diff cannot bloat session or message JSON.
The snapshot diff path now stops once the summary budget is reached, and oversized rows are trimmed on read and write as a safety net.

### How did you verify your code works?

- `bun test test/session/summary-diffs.test.ts`
- Targeted regression coverage for `Snapshot.diffFull(..., { limit })`
- Inspected the affected SQLite session data to confirm the oversized payload source
- Repo-wide `bun test` / pre-push typecheck still hit unrelated pre-existing module-resolution errors

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
