### PR TITLE
fix(provider): apply provider npm to existing models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1394,13 +1394,20 @@ export const layer = Layer.effect(
         // extend database from config
         for (const [providerID, provider] of configProviders) {
           const existing = database[providerID]
+          const providerNpm = provider.npm
+          const existingModels = existing?.models ?? {}
           const parsed: Info = {
             id: ProviderV2.ID.make(providerID),
             name: provider.name ?? existing?.name ?? providerID,
             env: provider.env ?? existing?.env ?? [],
             options: mergeDeep(existing?.options ?? {}, provider.options ?? {}),
             source: "config",
-            models: existing?.models ?? {},
+            models: providerNpm
+              ? mapValues(existingModels, (model) => ({
+                  ...model,
+                  api: { ...model.api, npm: providerNpm },
+                }))
+              : existingModels,
           }
 
           for (const [modelID, model] of Object.entries(provider.models ?? {})) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -124,6 +124,25 @@ it.instance(
 )
 
 it.instance(
+  "provider-level npm applies to existing models without model overrides",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.anthropic].models["claude-sonnet-4-20250514"]
+    expect(model.api.npm).toBe("@ai-sdk/openai-compatible")
+  }),
+  {
+    config: {
+      provider: {
+        anthropic: {
+          npm: "@ai-sdk/openai-compatible",
+          options: { apiKey: "config-api-key" },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
   "disabled_providers excludes provider",
   Effect.gen(function* () {
     yield* setProcessEnv("ANTHROPIC_API_KEY", "test-api-key")


### PR DESCRIPTION
### Issue for this PR

Closes #33888

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Provider-level `npm` now updates existing catalog models when config overrides a provider without enumerating `models`. Per-model `provider.npm` still wins through the existing model merge path.

### How did you verify your code works?

- Added a provider test that failed before the fix with `@ai-sdk/anthropic` still selected.
- `bun test test/provider/provider.test.ts -t "provider-level npm" --timeout 120000`
- `bun test test/provider/provider.test.ts --timeout 180000`
- `bun run --cwd packages/opencode typecheck`
- `bun lint` exits 0; existing warnings remain

### Screenshots / recordings

Not a UI change.

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
