### PR TITLE
fix(app): hide mobile titlebar setting in production

### DIFF
--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -336,7 +336,7 @@ export const SettingsGeneralV2: Component = () => {
           </div>
         </SettingsRowV2>
 
-        <Show when={mobile()}>
+        <Show when={mobile() && import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"}>
           <SettingsRowV2
             title={language.t("settings.general.row.mobileTitlebarBottom.title")}
             description={language.t("settings.general.row.mobileTitlebarBottom.description")}


### PR DESCRIPTION
## Summary

- hide the mobile bottom-navigation setting in production builds
- keep the setting available in dev and beta channels

## Testing

- `bun typecheck` (from `packages/app`)