### PR TITLE
fix(lsp): send pyright venv initialization

### DIFF
--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -509,6 +509,8 @@ export const Pyright: Info = {
         : path.join(venvPath, "bin", "python")
       if (await Filesystem.exists(potentialPythonPath)) {
         initialization["pythonPath"] = potentialPythonPath
+        initialization["venvPath"] = path.dirname(venvPath)
+        initialization["venv"] = path.basename(venvPath)
         break
       }
     }

--- a/packages/opencode/test/lsp/index.test.ts
+++ b/packages/opencode/test/lsp/index.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, spyOn } from "bun:test"
+import { describe, expect, spyOn, test } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { Deferred, Effect, Layer } from "effect"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -7,7 +8,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { LSP } from "@/lsp/lsp"
 import * as LSPServer from "@/lsp/server"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import { TestInstance } from "../fixture/fixture"
+import { TestInstance, tmpdir } from "../fixture/fixture"
 import { awaitWithTimeout, testEffect } from "../lib/effect"
 
 const lspLayer = (flags: Parameters<typeof RuntimeFlags.layer>[0] = {}) =>
@@ -27,6 +28,50 @@ const disabledDownloadIt = testEffect(
 )
 
 describe("lsp.spawn", () => {
+  test("pyright initialization includes project venv settings", async () => {
+    await using tmp = await tmpdir()
+    const bin = path.join(tmp.path, "bin")
+    const fakePyright = path.join(bin, process.platform === "win32" ? "pyright-langserver.cmd" : "pyright-langserver")
+    const venv = path.join(tmp.path, ".venv")
+    const python = path.join(
+      venv,
+      process.platform === "win32" ? path.join("Scripts", "python.exe") : path.join("bin", "python"),
+    )
+
+    await fs.mkdir(bin, { recursive: true })
+    await fs.mkdir(path.dirname(python), { recursive: true })
+    await Bun.write(fakePyright, process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n")
+    await Bun.write(python, "")
+    if (process.platform !== "win32") {
+      await fs.chmod(fakePyright, 0o755)
+      await fs.chmod(python, 0o755)
+    }
+
+    const originalPath = process.env.PATH
+    const originalVirtualEnv = process.env.VIRTUAL_ENV
+    process.env.PATH = bin + path.delimiter + (originalPath ?? "")
+    delete process.env.VIRTUAL_ENV
+
+    try {
+      const handle = await LSPServer.Pyright.spawn(tmp.path, {} as any, {
+        disableLspDownload: false,
+      } as RuntimeFlags.Info)
+
+      expect(handle).toBeDefined()
+      await (handle?.process as { exited?: Promise<unknown> } | undefined)?.exited
+      expect(handle?.initialization).toMatchObject({
+        pythonPath: python,
+        venvPath: tmp.path,
+        venv: ".venv",
+      })
+    } finally {
+      if (originalPath === undefined) delete process.env.PATH
+      else process.env.PATH = originalPath
+      if (originalVirtualEnv === undefined) delete process.env.VIRTUAL_ENV
+      else process.env.VIRTUAL_ENV = originalVirtualEnv
+    }
+  })
+
   it.instance(
     "does not spawn builtin LSP for files outside instance",
     () =>


### PR DESCRIPTION
### Issue for this PR

Closes #32733

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When Pyright finds a project virtual environment, it now sends both the interpreter path and Pyright's native `venvPath` / `venv` initialization settings. This lets Pyright resolve packages from a local `.venv` without requiring users to add a `pyrightconfig.json` workaround.

### How did you verify your code works?

- Added a Pyright spawn test that failed before the fix because initialization only contained `pythonPath`.
- `bun test test/lsp/index.test.ts -t "pyright initialization includes project venv settings" --timeout 120000`
- `bun test test/lsp/index.test.ts --timeout 180000`
- `bun run --cwd packages/opencode typecheck`
- `bun lint` exits 0; existing warnings remain

### Screenshots / recordings

Not a UI change.

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
