### PR TITLE
fix(provider): ensure non-empty assistant content for openai-compatible (#33280)

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -473,7 +473,31 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
     })
   }
 
+  if (model.api.npm === "@ai-sdk/openai-compatible") {
+    msgs = ensureNonEmptyAssistantContent(msgs)
+  }
+
   return msgs
+}
+
+// OpenAI-compatible proxies (e.g. GLM-5.2 fronted by svips-style gateways)
+// sanitise an assistant message whose `content` serialises to an empty string
+// by injecting a visible placeholder ("[System: Empty message content
+// sanitised to satisfy protocol]") into the transcript. The Vercel AI SDK
+// emits `content: ""` for assistant turns that carry only tool calls (no text
+// parts), so every tool-call turn leaks the placeholder back into history.
+// Give those turns a single-space text part so the wire content is non-empty.
+// This only shapes the messages handed to the provider; it does not touch
+// persisted session history.
+function ensureNonEmptyAssistantContent(msgs: ModelMessage[]): ModelMessage[] {
+  return msgs.map((msg) => {
+    if (msg.role !== "assistant" || typeof msg.content === "string") return msg
+    if (!Array.isArray(msg.content)) return msg
+    const hasText = msg.content.some((part) => part.type === "text" && part.text !== "")
+    const hasToolCall = msg.content.some((part) => part.type === "tool-call")
+    if (hasText || !hasToolCall) return msg
+    return { ...msg, content: [{ type: "text", text: " " }, ...msg.content] }
+  })
 }
 
 export function temperature(model: Provider.Model) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2067,6 +2067,79 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
   })
 })
 
+describe("ProviderTransform.message - openai-compatible non-empty assistant content", () => {
+  const oaiModel = {
+    id: "custom/glm-5.2",
+    providerID: "custom",
+    api: { id: "glm-5.2", url: "https://api.example.com", npm: "@ai-sdk/openai-compatible" },
+    name: "GLM 5.2",
+    capabilities: { temperature: true, reasoning: false, attachment: true, toolcall: true, input: { text: true, audio: false, image: true, video: false, pdf: true }, output: { text: true, audio: false, image: false, video: false, pdf: false }, interleaved: false },
+    cost: { input: 0.003, output: 0.015, cache: { read: 0.0003, write: 0.00375 } },
+    limit: { context: 200000, output: 8192 },
+    status: "active", options: {}, headers: {},
+  } as any
+
+  test("prepends a space text part to tool-call-only assistant messages", () => {
+    const msgs = [{
+      role: "assistant",
+      content: [
+        { type: "tool-call", toolCallId: "tc1", toolName: "bash", input: { command: "ls" } },
+        { type: "tool-call", toolCallId: "tc2", toolName: "read", input: { filePath: "foo" } },
+      ],
+    }] as any[]
+
+    const result = ProviderTransform.message(msgs, oaiModel, {}) as any[]
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(3)
+    expect(result[0].content[0]).toEqual({ type: "text", text: " " })
+    expect(result[0].content[1].type).toBe("tool-call")
+    expect(result[0].content[2].type).toBe("tool-call")
+  })
+
+  test("does not add space when assistant message already has text", () => {
+    const msgs = [{
+      role: "assistant",
+      content: [
+        { type: "text", text: "Let me check" },
+        { type: "tool-call", toolCallId: "tc1", toolName: "bash", input: { command: "ls" } },
+      ],
+    }] as any[]
+
+    const result = ProviderTransform.message(msgs, oaiModel, {}) as any[]
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(2)
+    expect(result[0].content[0].text).toBe("Let me check")
+  })
+
+  test("does not modify non-assistant messages", () => {
+    const msgs = [
+      { role: "user", content: "Hello" },
+      { role: "user", content: [{ type: "text", text: "world" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, oaiModel, {}) as any[]
+
+    expect(result).toHaveLength(2)
+    expect(result[0].content).toBe("Hello")
+  })
+
+  test("does not apply to non-openai-compatible providers", () => {
+    const fpModel = { ...oaiModel, api: { id: "claude-3-5-sonnet-20241022", url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" } } as any
+    const msgs = [{
+      role: "assistant",
+      content: [{ type: "tool-call", toolCallId: "tc1", toolName: "bash", input: { command: "ls" } }],
+    }] as any[]
+
+    const result = ProviderTransform.message(msgs, fpModel, {}) as any[]
+
+    expect(result).toHaveLength(1)
+    expect(result[0].content).toHaveLength(1)
+    expect(result[0].content[0].type).toBe("tool-call")
+  })
+})
+
 describe("ProviderTransform.message - strip openai metadata when store=false", () => {
   const openaiModel = {
     id: "openai/gpt-5",


### PR DESCRIPTION
### Issue for this PR

Closes #33280

### Type of change

- [x] Bug fix

### What does this PR do?

When an assistant message contains only tool calls (no text), the Vercel AI SDK emits `content: ""` on the wire. OpenAI-compatible proxies (e.g. GLM-5.2 via api.svips.org) sanitise empty content by injecting a visible placeholder — `[System: Empty message content sanitised to satisfy protocol]` — which then leaks into the stored conversation on every tool-call turn.

The fix adds a targeted transform for `@ai-sdk/openai-compatible` that prepends a single-space text part to assistant messages that have tool-call parts but no non-empty text part. This keeps the wire content non-empty so the proxy passes it through unchanged. The space is ephemeral — it only exists in the messages handed to the provider, not in persisted session history.

### How did you verify your code works?

Added 4 regression tests in `test/provider/transform.test.ts`:
1. Tool-call-only assistant message gets a space text part prepended
2. Assistant message with existing text is unchanged
3. Non-assistant messages are unchanged
4. Fix does not apply to non-openai-compatible providers

All 4 tests pass. Existing anthropic/bedrock empty-content tests unchanged (9/9 pass). Typecheck clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR