### PR TITLE
fix(upgrade): authenticate GitHub release checks

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -51,6 +51,10 @@ export function isLocal() {
   return InstallationChannel === "local"
 }
 
+function githubToken() {
+  return process.env.GITHUB_TOKEN?.trim() || undefined
+}
+
 export class UpgradeFailedError extends Schema.TaggedErrorClass<UpgradeFailedError>()("UpgradeFailedError", {
   stderr: Schema.String,
 }) {
@@ -253,11 +257,12 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProce
           return data.version
         }
 
-        const response = yield* httpOk.execute(
-          HttpClientRequest.get("https://api.github.com/repos/anomalyco/opencode/releases/latest").pipe(
-            HttpClientRequest.acceptJson,
-          ),
+        const token = githubToken()
+        const request = HttpClientRequest.get("https://api.github.com/repos/anomalyco/opencode/releases/latest").pipe(
+          HttpClientRequest.acceptJson,
+          token ? HttpClientRequest.bearerToken(token) : (request) => request,
         )
+        const response = yield* httpOk.execute(request)
         const data = yield* HttpClientResponse.schemaBodyJson(GitHubRelease)(response)
         return data.tag_name.replace(/^v/, "")
       }, Effect.orDie),

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -76,6 +76,27 @@ describe("installation", () => {
         }),
     )
 
+    let githubReleaseAuth: string | undefined
+    testEffect(
+      testLayer((request) => {
+        githubReleaseAuth = request.headers.authorization
+        return jsonResponse({ tag_name: "v5.0.0" })
+      }),
+    ).effect("uses GITHUB_TOKEN for GitHub release requests", () =>
+      Effect.gen(function* () {
+        const previous = process.env.GITHUB_TOKEN
+        process.env.GITHUB_TOKEN = "test-token"
+        try {
+          const result = yield* Installation.use.latest("curl")
+          expect(result).toBe("5.0.0")
+          expect(githubReleaseAuth).toBe("Bearer test-token")
+        } finally {
+          if (previous === undefined) delete process.env.GITHUB_TOKEN
+          else process.env.GITHUB_TOKEN = previous
+        }
+      }),
+    )
+
     const npmCalls: string[] = []
     testEffect(
       testLayer((request) => {


### PR DESCRIPTION
### Issue for this PR

Closes #23461

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Uses `GITHUB_TOKEN` as a bearer token when the upgrade/version check falls back to GitHub Releases. This prevents `opencode upgrade` from using the low unauthenticated GitHub API rate limit behind shared proxies or VPNs.

### How did you verify your code works?

- `bun test test/installation/installation.test.ts`
- `bun run --cwd packages/opencode typecheck`
- `bun run lint` exits 0; existing warnings remain.

### Screenshots / recordings

_Not applicable; CLI/network request behavior only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
