### PR TITLE
fix(task): remind agent to update todos when delegated task completes

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -68,14 +68,23 @@ function renderOutput(input: {
   text: string
 }) {
   const tag = input.state === "error" ? "task_error" : "task_result"
-  return [
+  const parts = [
     `<task id="${input.sessionID}" state="${input.state}">`,
     ...(input.summary ? [`<summary>${input.summary}</summary>`] : []),
     `<${tag}>`,
     input.text,
     `</${tag}>`,
     "</task>",
-  ].join("\n")
+  ]
+  if (input.state === "completed" || input.state === "error") {
+    parts.push(
+      "",
+      "<system-reminder>",
+      "The task you delegated has finished. If you were tracking this task in a todo list, you MUST call the todowrite tool now to mark the corresponding todo as completed. Do not proceed with other work before updating the todo list.",
+      "</system-reminder>",
+    )
+  }
+  return parts.join("\n")
 }
 
 export const TaskTool = Tool.define(


### PR DESCRIPTION
## Problem

When the `task` tool returns a completed or errored result, the parent agent often forgets to call `todowrite` to mark the corresponding todo as completed. This causes stale todo items that show as `pending` or `in_progress` even though the delegated work is done.

The prompt instructions (anthropic.txt:27) say "It is critical that you mark todos as completed as soon as you are done with a task", but this is easy to miss in context when the agent is focused on processing the task result.

## Fix

Add a `<system-reminder>` after the `</task>` closing tag when the task state is `completed` or `error`, explicitly instructing the agent to call `todowrite` before proceeding with other work.

## Changes

- `packages/opencode/src/tool/task.ts`: append system-reminder to `renderOutput` when state is terminal

## Verification

1. Create a todo list with multiple items
2. Delegate one item via the `task` tool
3. After the task completes, verify the agent calls `todowrite` to mark the item as completed