### PR TITLE
fix(skill): include v2 plugin skills in legacy list

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -1,12 +1,16 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import path from "path"
-import { Effect, Layer, Context, Schema } from "effect"
+import { Effect, Layer, Context, Option, Schema } from "effect"
 import { NamedError } from "@opencode-ai/core/util/error"
 import type { Agent } from "@/agent/agent"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { Global } from "@opencode-ai/core/global"
 import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
+import { SkillV2 } from "@opencode-ai/core/skill"
+import { Location } from "@opencode-ai/core/location"
+import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Permission } from "@/permission"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Config } from "@/config/config"
@@ -286,21 +290,47 @@ const layer = Layer.effect(
       }),
     )
 
-    const get = Effect.fn("Skill.get")(function* (name: string) {
+    const mergedSkills = Effect.fn("Skill.merged")(function* () {
       const s = yield* InstanceState.get(state)
-      return s.skills[name]
+      const skills = { ...s.skills }
+      const v2Skills = yield* Effect.gen(function* () {
+        const service = Option.getOrUndefined(yield* Effect.serviceOption(SkillV2.Service))
+        if (service) return yield* service.list()
+
+        const locations = Option.getOrUndefined(yield* Effect.serviceOption(LocationServiceMap.Service))
+        if (!locations) return []
+
+        const ctx = yield* InstanceState.context
+        return yield* SkillV2.Service.use((skill) => skill.list()).pipe(
+          Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(ctx.directory) }))),
+        )
+      })
+      for (const item of v2Skills) {
+        if (skills[item.name]) continue
+        skills[item.name] = {
+          name: item.name,
+          description: item.description,
+          location: item.location,
+          content: item.content,
+        }
+      }
+      return skills
+    })
+
+    const get = Effect.fn("Skill.get")(function* (name: string) {
+      const skills = yield* mergedSkills()
+      return skills[name]
     })
 
     const require = Effect.fn("Skill.require")(function* (name: string) {
-      const s = yield* InstanceState.get(state)
-      const info = s.skills[name]
+      const skills = yield* mergedSkills()
+      const info = skills[name]
       if (info) return info
-      return yield* new NotFoundError({ name, available: Object.keys(s.skills).toSorted() })
+      return yield* new NotFoundError({ name, available: Object.keys(skills).toSorted() })
     })
 
     const all = Effect.fn("Skill.all")(function* () {
-      const s = yield* InstanceState.get(state)
-      return Object.values(s.skills)
+      return Object.values(yield* mergedSkills())
     })
 
     const dirs = Effect.fn("Skill.dirs")(function* () {
@@ -308,8 +338,7 @@ const layer = Layer.effect(
     })
 
     const available = Effect.fn("Skill.available")(function* (agent?: Agent.Info) {
-      const s = yield* InstanceState.get(state)
-      const list = Object.values(s.skills).toSorted((a, b) => a.name.localeCompare(b.name))
+      const list = Object.values(yield* mergedSkills()).toSorted((a, b) => a.name.localeCompare(b.name))
       if (!agent) return list
       return list.filter((skill) => Permission.evaluate("skill", skill.name, agent.permission).action !== "deny")
     })

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -9,12 +9,25 @@ import { Config } from "../../src/config/config"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { SkillV2 } from "@opencode-ai/core/skill"
 import { provideInstance, provideTmpdirInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import path from "path"
 import fs from "fs/promises"
 
 const node = LayerNode.compile(CrossSpawnSpawner.node)
+
+const v2Skills = (skills: SkillV2.Info[]) =>
+  Layer.succeed(
+    SkillV2.Service,
+    SkillV2.Service.of({
+      transform: () => Effect.die("unexpected v2 skill transform in legacy skill tests"),
+      reload: () => Effect.void,
+      sources: () => Effect.succeed([]),
+      list: () => Effect.succeed(skills),
+    }),
+  )
 
 const it = testEffect(Layer.mergeAll(LayerNode.compile(Skill.node), node, testInstanceStoreLayer))
 const itWithoutClaudeCodeSkills = testEffect(
@@ -30,6 +43,17 @@ const itWithoutExternalSkills = testEffect(
     node,
     testInstanceStoreLayer,
   ),
+)
+const v2LocationSkills = v2Skills([
+  {
+    name: "plugin-skill",
+    description: "A skill registered by a v2 plugin.",
+    location: AbsolutePath.make("/builtin/plugin-skill.md"),
+    content: "Use plugin conventions.",
+  },
+])
+const itWithV2Skills = testEffect(
+  Layer.mergeAll(LayerNode.compile(Skill.node), v2LocationSkills, node, testInstanceStoreLayer),
 )
 
 async function createGlobalSkill(homeDir: string) {
@@ -300,6 +324,21 @@ description: A skill in the .claude/skills directory.
         Effect.gen(function* () {
           const skill = yield* Skill.Service
           expect((yield* skill.all()).filter((s) => s.location !== "<built-in>")).toEqual([])
+        }),
+      { git: true },
+    ),
+  )
+
+  itWithV2Skills.live("includes skills registered through the v2 skill service", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const skill = yield* Skill.Service
+          const list = yield* skill.all()
+          expect(list.find((item) => item.name === "plugin-skill")).toMatchObject({
+            description: "A skill registered by a v2 plugin.",
+            content: "Use plugin conventions.",
+          })
         }),
       { git: true },
     ),


### PR DESCRIPTION
### Issue for this PR

Closes #33896

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Includes v2 plugin-registered skills in the legacy skill list used by `/skills` and the instance skill API, while preserving existing legacy skill precedence.

### How did you verify your code works?

- `bun test test/skill/skill.test.ts`
- `bun run --cwd packages/opencode typecheck`
- `bun oxlint packages/opencode/test/skill/skill.test.ts packages/opencode/src/skill/index.ts`
- `bun run lint` (exits 0; existing warnings remain)

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._