### PR TITLE
fix(mcp): reconnect after OAuth even when server is disabled

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -943,7 +943,7 @@ export const layer = Layer.effect(
 
       const mcpConfig = yield* requireMcpConfig(mcpName)
 
-      return yield* createAndStore(mcpName, mcpConfig)
+      return yield* createAndStore(mcpName, { ...mcpConfig, enabled: true })
     })
 
     const removeAuth = Effect.fn("MCP.removeAuth")(function* (mcpName: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #33915

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode mcp auth <name>` prints "Unexpected status: disabled" after a successful OAuth flow when the server is set to `"enabled": false` in the config. The token saves fine, but the server never connects and it looks like auth failed.

`finishAuth` was passing the raw config to `createAndStore`, so `enabled: false` made `create()` short-circuit and return `disabled`. `connect()` already handles this by forcing `enabled: true` before reconnecting — this does the same in `finishAuth`.

Same fix as #20279, which was closed before it got merged.

### How did you verify your code works?

Added a remote OAuth MCP server with `"enabled": false`, ran `bun dev mcp auth <name>`, and completed the browser flow. It now prints "Authentication successful!" and the server connects. The same steps before the change gave "Unexpected status: disabled".

### Screenshots / recordings

_N/A — CLI output change only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR