### PR TITLE
fix(app): suspend while recent models load

### DIFF
--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -152,6 +152,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
         return recent
       },
       (p) => p,
+      { initialValue: [] },
     )
     return {
       ready,

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -1,4 +1,4 @@
-import { type Accessor, createMemo } from "solid-js"
+import { type Accessor, createMemo, createResource } from "solid-js"
 import { createStore } from "solid-js/store"
 import { DateTime } from "luxon"
 import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
@@ -145,6 +145,14 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       setStore("variant", key, value)
     }
 
+    const [recentModels] = createResource(
+      async () => {
+        const recent = store.recent
+        await ready.promise
+        return recent
+      },
+      (p) => p,
+    )
     return {
       ready,
       list,
@@ -152,7 +160,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
       visible,
       setVisibility,
       recent: {
-        list: createMemo(() => store.recent),
+        list: () => recentModels()!,
         push,
       },
       variant: {


### PR DESCRIPTION
## Summary

- expose recent models through a resource that waits for persisted model state
- suspend model consumers until recent selections are hydrated
- prevent the default model from flashing when switching New Session tabs

## Testing

- `bun typecheck` in `packages/app`
- `bun turbo typecheck`