### PR TITLE
fix(mcp): scope auth status to server URL

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -669,14 +669,20 @@ export const McpDebugCommand = effectCmd({
     const config = yield* Config.Service.use((cfg) => cfg.get())
     const mcp = yield* MCP.Service
     const auth = yield* McpAuth.Service
+    const serverConfig = config.mcp?.[args.name]
+    const authInfo =
+      serverConfig && isMcpRemote(serverConfig) && serverConfig.oauth !== false
+        ? yield* Effect.all({
+            authStatus: mcp.getAuthStatus(args.name),
+            entry: auth.get(args.name),
+          })
+        : undefined
     yield* Effect.promise(async () => {
       UI.empty()
       prompts.intro("MCP OAuth Debug")
 
-      const mcpServers = config.mcp ?? {}
       const serverName = args.name
 
-      const serverConfig = mcpServers[serverName]
       if (!serverConfig) {
         prompts.log.error(`MCP server not found: ${serverName}`)
         prompts.outro("Done")
@@ -698,13 +704,7 @@ export const McpDebugCommand = effectCmd({
       prompts.log.info(`Server: ${serverName}`)
       prompts.log.info(`URL: ${serverConfig.url}`)
 
-      // Check stored auth status — services already in hand, run inline.
-      const { authStatus, entry } = await Effect.runPromise(
-        Effect.all({
-          authStatus: mcp.getAuthStatus(serverName),
-          entry: auth.get(serverName),
-        }),
-      )
+      const { authStatus, entry } = authInfo!
       prompts.log.info(`Auth status: ${getAuthStatusIcon(authStatus)} ${getAuthStatusText(authStatus)}`)
 
       if (entry?.tokens) {

--- a/packages/opencode/src/mcp/auth.ts
+++ b/packages/opencode/src/mcp/auth.ts
@@ -50,7 +50,6 @@ export interface Interface {
   readonly updateOAuthState: (mcpName: string, oauthState: string) => Effect.Effect<void>
   readonly getOAuthState: (mcpName: string) => Effect.Effect<string | undefined>
   readonly clearOAuthState: (mcpName: string) => Effect.Effect<void>
-  readonly isTokenExpired: (mcpName: string) => Effect.Effect<boolean | null>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/McpAuth") {}
@@ -142,13 +141,6 @@ export const layer = Layer.effect(
       return entry?.oauthState
     })
 
-    const isTokenExpired = Effect.fn("McpAuth.isTokenExpired")(function* (mcpName: string) {
-      const entry = yield* get(mcpName)
-      if (!entry?.tokens) return null
-      if (!entry.tokens.expiresAt) return false
-      return entry.tokens.expiresAt < Date.now() / 1000
-    })
-
     return Service.of({
       all,
       get,
@@ -162,7 +154,6 @@ export const layer = Layer.effect(
       updateOAuthState,
       getOAuthState,
       clearOAuthState,
-      isTokenExpired,
     })
   }),
 )

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -963,10 +963,12 @@ export const layer = Layer.effect(
     })
 
     const getAuthStatus = Effect.fn("MCP.getAuthStatus")(function* (mcpName: string) {
-      const entry = yield* auth.get(mcpName)
+      const mcpConfig = yield* getMcpConfig(mcpName)
+      if (mcpConfig?.type !== "remote") return "not_authenticated"
+      const entry = yield* auth.getForUrl(mcpName, mcpConfig.url)
       if (!entry?.tokens) return "not_authenticated"
-      const expired = yield* auth.isTokenExpired(mcpName)
-      return expired ? "expired" : "authenticated"
+      if (entry.tokens.expiresAt && entry.tokens.expiresAt < Date.now() / 1000) return "expired"
+      return "authenticated"
     })
 
     return Service.of({

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -963,12 +963,11 @@ export const layer = Layer.effect(
     })
 
     const getAuthStatus = Effect.fn("MCP.getAuthStatus")(function* (mcpName: string) {
-      const initialized = yield* InstanceState.has(state)
-      const runtimeConfig = initialized ? (yield* InstanceState.get(state)).config[mcpName] : undefined
-      const config = runtimeConfig ? undefined : yield* cfgSvc.get()
-      const configured = config?.mcp?.[mcpName]
-      const mcpConfig = runtimeConfig ?? (configured && isMcpConfigured(configured) ? configured : undefined)
-      if (mcpConfig?.type !== "remote") return "not_authenticated"
+      const runtimeConfig = (yield* InstanceState.has(state))
+        ? (yield* InstanceState.get(state)).config[mcpName]
+        : undefined
+      const mcpConfig = runtimeConfig ?? (yield* cfgSvc.get()).mcp?.[mcpName]
+      if (!mcpConfig || !isMcpConfigured(mcpConfig) || mcpConfig.type !== "remote") return "not_authenticated"
       const entry = yield* auth.getForUrl(mcpName, mcpConfig.url)
       if (!entry?.tokens) return "not_authenticated"
       if (entry.tokens.expiresAt && entry.tokens.expiresAt < Date.now() / 1000) return "expired"

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -963,7 +963,11 @@ export const layer = Layer.effect(
     })
 
     const getAuthStatus = Effect.fn("MCP.getAuthStatus")(function* (mcpName: string) {
-      const mcpConfig = yield* getMcpConfig(mcpName)
+      const initialized = yield* InstanceState.has(state)
+      const runtimeConfig = initialized ? (yield* InstanceState.get(state)).config[mcpName] : undefined
+      const config = runtimeConfig ? undefined : yield* cfgSvc.get()
+      const configured = config?.mcp?.[mcpName]
+      const mcpConfig = runtimeConfig ?? (configured && isMcpConfigured(configured) ? configured : undefined)
       if (mcpConfig?.type !== "remote") return "not_authenticated"
       const entry = yield* auth.getForUrl(mcpName, mcpConfig.url)
       if (!entry?.tokens) return "not_authenticated"

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -228,6 +228,36 @@ mcpTest.instance("state() returns existing state when one is saved", () =>
 )
 
 mcpTest.instance(
+  "auth status only reports credentials stored for the configured server URL",
+  () =>
+    Effect.gen(function* () {
+      const mcp = yield* MCP.Service
+      yield* McpAuth.use.updateTokens(
+        "test-status-url",
+        { accessToken: "old-token" },
+        "https://old.example.com/mcp",
+      )
+
+      expect(yield* mcp.getAuthStatus("test-status-url")).toBe("not_authenticated")
+
+      yield* McpAuth.use.updateTokens(
+        "test-status-url",
+        { accessToken: "current-token" },
+        "https://example.com/mcp",
+      )
+      expect(yield* mcp.getAuthStatus("test-status-url")).toBe("authenticated")
+
+      yield* McpAuth.use.updateTokens(
+        "test-status-url",
+        { accessToken: "expired-token", expiresAt: 1 },
+        "https://example.com/mcp",
+      )
+      expect(yield* mcp.getAuthStatus("test-status-url")).toBe("expired")
+    }),
+  { config: config("test-status-url") },
+)
+
+mcpTest.instance(
   "authenticate() stores a connected client when auth completes without redirect",
   () =>
     MCP.Service.use((mcp) =>

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -232,6 +232,7 @@ mcpTest.instance(
   () =>
     Effect.gen(function* () {
       const mcp = yield* MCP.Service
+      expect(transportCalls).toHaveLength(0)
       yield* McpAuth.use.updateTokens(
         "test-status-url",
         { accessToken: "old-token" },
@@ -253,6 +254,7 @@ mcpTest.instance(
         "https://example.com/mcp",
       )
       expect(yield* mcp.getAuthStatus("test-status-url")).toBe("expired")
+      expect(transportCalls).toHaveLength(0)
     }),
   { config: config("test-status-url") },
 )


### PR DESCRIPTION
## Summary

- resolve MCP auth status against the currently configured remote server URL
- report stale credentials from a previous URL as `not_authenticated`
- derive expiry from the matched credential entry without a second auth-store read

## Tests

- `bun test test/mcp/oauth-auto-connect.test.ts`
- `bun typecheck` from `packages/opencode`