### PR TITLE
fix(app): restore new layout shortcuts

### DIFF
--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -3,12 +3,18 @@ import { useNavigate, useParams } from "@solidjs/router"
 import { DebugBar } from "@/components/debug-bar"
 import { HelpButton } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { useCommand } from "@/context/command"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { useLanguage } from "@/context/language"
 import { useNotification } from "@/context/notification"
 import { usePlatform } from "@/context/platform"
 import { setNavigate } from "@/utils/notification-click"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
 
 export default function NewLayout(props: ParentProps) {
+  const command = useCommand()
+  const dialog = useDialog()
+  const language = useLanguage()
   const platform = usePlatform()
   const notification = useNotification()
   const navigate = useNavigate()
@@ -21,6 +27,20 @@ export default function NewLayout(props: ParentProps) {
     if (notification.session.unseenCount(params.id) === 0) return
     notification.session.markViewed(params.id)
   })
+
+  command.register("layout", () => [
+    {
+      id: "settings.open",
+      title: language.t("command.settings.open"),
+      category: language.t("command.category.settings"),
+      keybind: "mod+comma",
+      onSelect: () => {
+        void import("@/components/settings-v2").then((x) => {
+          dialog.show(() => <x.DialogSettings />)
+        })
+      },
+    },
+  ])
 
   const update: TitlebarUpdate = {
     version: () => {

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -2,11 +2,14 @@ import { createEffect, createMemo, onMount, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useSearchParams } from "@solidjs/router"
 import { NewSessionDesignView } from "@/components/session"
+import { useCommand } from "@/context/command"
 import { useComments } from "@/context/comments"
+import { useLanguage } from "@/context/language"
 import { usePrompt } from "@/context/prompt"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { useServerSync } from "@/context/server-sync"
+import { useTabs } from "@/context/tabs"
 import {
   createSessionComposerControls,
   createSessionComposerState,
@@ -20,13 +23,16 @@ import { useSessionKey } from "@/pages/session/session-layout"
  * timeline. Submitting promotes the draft into a real session (see prompt-input/submit).
  */
 export default function NewSessionPage() {
+  const command = useCommand()
   const prompt = usePrompt()
   const sdk = useSDK()
   const sync = useSync()
   const serverSync = useServerSync()
   const comments = useComments()
+  const language = useLanguage()
+  const tabs = useTabs()
   const route = useSessionKey()
-  const [searchParams, setSearchParams] = useSearchParams<{ prompt?: string }>()
+  const [searchParams, setSearchParams] = useSearchParams<{ draftId?: string; prompt?: string }>()
 
   let inputRef: HTMLDivElement | undefined
 
@@ -57,6 +63,18 @@ export default function NewSessionPage() {
       setSearchParams({ ...searchParams, prompt: undefined })
     })
   })
+
+  command.register("new-session", () => [
+    {
+      id: "tab.close",
+      title: language.t("command.tab.close"),
+      keybind: "mod+w",
+      onSelect: () => {
+        const index = tabs.store.findIndex((tab) => tab.type === "draft" && tab.draftID === searchParams.draftId)
+        if (index !== -1) tabs.removeTab(index)
+      },
+    },
+  ])
 
   onMount(() => {
     requestAnimationFrame(() => inputRef?.focus())

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -2,14 +2,11 @@ import { createEffect, createMemo, onMount, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useSearchParams } from "@solidjs/router"
 import { NewSessionDesignView } from "@/components/session"
-import { useCommand } from "@/context/command"
 import { useComments } from "@/context/comments"
-import { useLanguage } from "@/context/language"
 import { usePrompt } from "@/context/prompt"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { useServerSync } from "@/context/server-sync"
-import { useTabs } from "@/context/tabs"
 import {
   createSessionComposerControls,
   createSessionComposerState,
@@ -23,14 +20,11 @@ import { useSessionKey } from "@/pages/session/session-layout"
  * timeline. Submitting promotes the draft into a real session (see prompt-input/submit).
  */
 export default function NewSessionPage() {
-  const command = useCommand()
   const prompt = usePrompt()
   const sdk = useSDK()
   const sync = useSync()
   const serverSync = useServerSync()
   const comments = useComments()
-  const language = useLanguage()
-  const tabs = useTabs()
   const route = useSessionKey()
   const [searchParams, setSearchParams] = useSearchParams<{ draftId?: string; prompt?: string }>()
 
@@ -63,18 +57,6 @@ export default function NewSessionPage() {
       setSearchParams({ ...searchParams, prompt: undefined })
     })
   })
-
-  command.register("new-session", () => [
-    {
-      id: "tab.close",
-      title: language.t("command.tab.close"),
-      keybind: "mod+w",
-      onSelect: () => {
-        const index = tabs.store.findIndex((tab) => tab.type === "draft" && tab.draftID === searchParams.draftId)
-        if (index !== -1) tabs.removeTab(index)
-      },
-    },
-  ])
 
   onMount(() => {
     requestAnimationFrame(() => inputRef?.focus())


### PR DESCRIPTION
## Summary

- register the settings command in the new layout so `Cmd+,` opens settings
- register the close-tab command on new-session draft pages so `Cmd+W` closes the active draft tab

## Validation

- `bun typecheck` from `packages/app`
- repository pre-push typecheck (29 packages)