### PR TITLE
fix(app): restore timeline scroll position

### DIFF
--- a/packages/app/e2e/smoke/session-timeline.fixture.ts
+++ b/packages/app/e2e/smoke/session-timeline.fixture.ts
@@ -222,7 +222,10 @@ function turn(index: number): Message[] {
   return [user, assistantMessage(targetID, index, user.info.id, parts)]
 }
 
-const targetMessages = Array.from({ length: 72 }, (_, index) => turn(index)).flat()
+export const timelineMessages = (count: number, start = 0) =>
+  Array.from({ length: count }, (_, index) => turn(start + index)).flat()
+
+const targetMessages = timelineMessages(72)
 const sourceMessages = Array.from({ length: 12 }, (_, index) => [
   userMessage(sourceID, index + 1000, 120),
   assistantMessage(sourceID, index + 1000, id("msg_user", index + 1000), [textPart(index + 1000, 0, 240)]),
@@ -301,6 +304,10 @@ export const fixture = {
 
 export function pageMessages(sessionID: string, limit: number, before?: string) {
   const messages = fixture.messages[sessionID as keyof typeof fixture.messages] ?? []
+  return pageMessageList(messages, limit, before)
+}
+
+export function pageMessageList(messages: Message[], limit: number, before?: string) {
   const end = before
     ? Math.max(
         0,

--- a/packages/app/e2e/smoke/session-timeline.spec.ts
+++ b/packages/app/e2e/smoke/session-timeline.spec.ts
@@ -115,7 +115,7 @@ test.describe("smoke: session timeline", () => {
       .toBeLessThanOrEqual(1)
   })
 
-  test("restores the persisted timeline position after reload", async ({ page }) => {
+  test("restores the persisted timeline position across tabs and reload", async ({ page }) => {
     let messages = timelineMessages(140)
     await mockOpenCodeServer(page, {
       sessions: fixture.sessions,
@@ -126,8 +126,25 @@ test.describe("smoke: session timeline", () => {
         sessionID === fixture.targetID ? pageMessageList(messages, limit, before) : pageMessages(sessionID, limit, before),
     })
     await configureSmokePage(page, fixture.directory)
+    await page.addInitScript(
+      ({ dirBase64, sourceID, targetID }) => {
+        localStorage.setItem(
+          "opencode.global.dat:tabs",
+          JSON.stringify(
+            [sourceID, targetID].map((sessionId) => ({
+              type: "session",
+              server: "http://127.0.0.1:4096",
+              dirBase64,
+              sessionId,
+            })),
+          ),
+        )
+      },
+      { dirBase64: base64Encode(fixture.directory), sourceID: fixture.sourceID, targetID: fixture.targetID },
+    )
 
-    await navigateToSession(page, fixture.directory, fixture.targetID, fixture.expected.targetTitle)
+    await navigateToSession(page, fixture.directory, fixture.sourceID, fixture.expected.sourceTitle)
+    await switchTitlebarSession(page, fixture.targetID, fixture.expected.targetTitle)
     await waitForTimelineStable(page)
     await pointAtTimeline(page)
     await page.mouse.wheel(0, -1_000)
@@ -145,8 +162,12 @@ test.describe("smoke: session timeline", () => {
         (element) => element.scrollHeight - element.clientHeight - element.scrollTop,
       ),
     ).toBeGreaterThan(100)
-    const anchor = await firstVisibleMessage(page)
-    expect(anchor).toBeTruthy()
+    const anchor = await firstVisibleTimelineRow(page)
+    expect(anchor?.id).toBeTruthy()
+    expect(anchor?.key).toBeTruthy()
+    await switchTitlebarSession(page, fixture.sourceID, fixture.expected.sourceTitle)
+    await switchTitlebarSession(page, fixture.targetID, fixture.expected.targetTitle)
+    await expect.poll(() => firstVisibleTimelineRow(page)).toEqual(anchor)
     messages = [...messages, ...timelineMessages(120, 140)]
     await page.reload()
     await waitForTimelineStable(page)
@@ -158,7 +179,7 @@ test.describe("smoke: session timeline", () => {
         ),
       )
       .toBeGreaterThan(100)
-    await expect.poll(() => firstVisibleMessage(page)).toBe(anchor)
+    await expect.poll(() => firstVisibleTimelineRow(page)).toEqual(anchor)
   })
 
   test("paints cached session tabs at the latest message", async ({ page }) => {
@@ -603,13 +624,20 @@ function timelineScroller(page: Page) {
   return page.locator(".scroll-view__viewport", { has: page.locator("[data-timeline-row]") })
 }
 
-function firstVisibleMessage(page: Page) {
+function firstVisibleTimelineRow(page: Page) {
   return timelineScroller(page).evaluate((element) => {
     const box = element.getBoundingClientRect()
-    return [...element.querySelectorAll<HTMLElement>("[data-message-id]")]
-      .map((message) => ({ id: message.dataset.messageId, rect: message.getBoundingClientRect() }))
-      .filter((message) => message.rect.bottom > box.top && message.rect.top < box.bottom)
-      .sort((a, b) => a.rect.top - b.rect.top)[0]?.id
+    const row = [...element.querySelectorAll<HTMLElement>("[data-timeline-key]")]
+      .map((row) => ({
+        id: row.querySelector<HTMLElement>("[data-message-id]")?.dataset.messageId,
+        key: row.dataset.timelineKey,
+        offset: Math.round(row.getBoundingClientRect().top - box.top),
+        rect: row.getBoundingClientRect(),
+      }))
+      .filter((row) => row.rect.bottom > box.top && row.rect.top < box.bottom)
+      .sort((a, b) => a.rect.top - b.rect.top)[0]
+    if (!row) return
+    return { id: row.id, key: row.key, offset: row.offset }
   })
 }
 

--- a/packages/app/e2e/smoke/session-timeline.spec.ts
+++ b/packages/app/e2e/smoke/session-timeline.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test"
 import { base64Encode } from "@opencode-ai/core/util/encode"
-import { fixture, pageMessages } from "./session-timeline.fixture"
+import { fixture, pageMessageList, pageMessages, timelineMessages } from "./session-timeline.fixture"
 import { trackPageErrors, expectNoSmokeErrors } from "../utils/errors"
 import { mockOpenCodeServer } from "../utils/mock-server"
 import { APP_READY_TIMEOUT, expectAppVisible, expectSessionTitle } from "../utils/waits"
@@ -116,12 +116,14 @@ test.describe("smoke: session timeline", () => {
   })
 
   test("restores the persisted timeline position after reload", async ({ page }) => {
+    let messages = timelineMessages(140)
     await mockOpenCodeServer(page, {
       sessions: fixture.sessions,
       provider: fixture.provider,
       directory: fixture.directory,
       project: fixture.project,
-      pageMessages,
+      pageMessages: (sessionID, limit, before) =>
+        sessionID === fixture.targetID ? pageMessageList(messages, limit, before) : pageMessages(sessionID, limit, before),
     })
     await configureSmokePage(page, fixture.directory)
 
@@ -143,6 +145,9 @@ test.describe("smoke: session timeline", () => {
         (element) => element.scrollHeight - element.clientHeight - element.scrollTop,
       ),
     ).toBeGreaterThan(100)
+    const anchor = await firstVisibleMessage(page)
+    expect(anchor).toBeTruthy()
+    messages = [...messages, ...timelineMessages(120, 140)]
     await page.reload()
     await waitForTimelineStable(page)
     await expect.poll(() => timelineScroller(page).evaluate((element) => element.scrollTop)).toBeGreaterThan(100)
@@ -153,6 +158,7 @@ test.describe("smoke: session timeline", () => {
         ),
       )
       .toBeGreaterThan(100)
+    await expect.poll(() => firstVisibleMessage(page)).toBe(anchor)
   })
 
   test("paints cached session tabs at the latest message", async ({ page }) => {
@@ -595,6 +601,16 @@ async function timelineState(page: Page) {
 
 function timelineScroller(page: Page) {
   return page.locator(".scroll-view__viewport", { has: page.locator("[data-timeline-row]") })
+}
+
+function firstVisibleMessage(page: Page) {
+  return timelineScroller(page).evaluate((element) => {
+    const box = element.getBoundingClientRect()
+    return [...element.querySelectorAll<HTMLElement>("[data-message-id]")]
+      .map((message) => ({ id: message.dataset.messageId, rect: message.getBoundingClientRect() }))
+      .filter((message) => message.rect.bottom > box.top && message.rect.top < box.bottom)
+      .sort((a, b) => a.rect.top - b.rect.top)[0]?.id
+  })
 }
 
 async function pointAtTimeline(page: Page) {

--- a/packages/app/e2e/smoke/session-timeline.spec.ts
+++ b/packages/app/e2e/smoke/session-timeline.spec.ts
@@ -115,6 +115,46 @@ test.describe("smoke: session timeline", () => {
       .toBeLessThanOrEqual(1)
   })
 
+  test("restores the persisted timeline position after reload", async ({ page }) => {
+    await mockOpenCodeServer(page, {
+      sessions: fixture.sessions,
+      provider: fixture.provider,
+      directory: fixture.directory,
+      project: fixture.project,
+      pageMessages,
+    })
+    await configureSmokePage(page, fixture.directory)
+
+    await navigateToSession(page, fixture.directory, fixture.targetID, fixture.expected.targetTitle)
+    await waitForTimelineStable(page)
+    await pointAtTimeline(page)
+    await page.mouse.wheel(0, -1_000)
+    await expect
+      .poll(() =>
+        timelineScroller(page).evaluate(
+          (element) => element.scrollHeight - element.clientHeight - element.scrollTop,
+        ),
+      )
+      .toBeGreaterThan(100)
+    await page.waitForTimeout(500)
+    expect(await timelineScroller(page).evaluate((element) => element.scrollTop)).toBeGreaterThan(100)
+    expect(
+      await timelineScroller(page).evaluate(
+        (element) => element.scrollHeight - element.clientHeight - element.scrollTop,
+      ),
+    ).toBeGreaterThan(100)
+    await page.reload()
+    await waitForTimelineStable(page)
+    await expect.poll(() => timelineScroller(page).evaluate((element) => element.scrollTop)).toBeGreaterThan(100)
+    await expect
+      .poll(() =>
+        timelineScroller(page).evaluate(
+          (element) => element.scrollHeight - element.clientHeight - element.scrollTop,
+        ),
+      )
+      .toBeGreaterThan(100)
+  })
+
   test("paints cached session tabs at the latest message", async ({ page }) => {
     await mockOpenCodeServer(page, {
       sessions: fixture.sessions,

--- a/packages/app/src/context/layout-scroll.test.ts
+++ b/packages/app/src/context/layout-scroll.test.ts
@@ -65,7 +65,7 @@ describe("createScrollPersistence", () => {
   test("persists semantic scroll anchors", () => {
     vi.useFakeTimers()
     try {
-      let snapshot: Record<string, { x: number; y: number; anchor?: { id: string; offset: number } }> = {}
+      let snapshot: Record<string, { x: number; y: number; anchor?: { id: string; key?: string; offset: number } }> = {}
       const scroll = createScrollPersistence({
         debounceMs: 10,
         getSnapshot: () => snapshot,
@@ -77,14 +77,14 @@ describe("createScrollPersistence", () => {
       scroll.setScroll("session", "timeline", {
         x: 1_000,
         y: 400,
-        anchor: { id: "message-1", offset: 24 },
+        anchor: { id: "message-1", key: "assistant-part:message-1:part-2", offset: 24 },
       })
       vi.advanceTimersByTime(10)
 
       expect(snapshot.timeline).toEqual({
         x: 1_000,
         y: 400,
-        anchor: { id: "message-1", offset: 24 },
+        anchor: { id: "message-1", key: "assistant-part:message-1:part-2", offset: 24 },
       })
       scroll.dispose()
     } finally {

--- a/packages/app/src/context/layout-scroll.test.ts
+++ b/packages/app/src/context/layout-scroll.test.ts
@@ -61,4 +61,34 @@ describe("createScrollPersistence", () => {
     expect(scroll.scroll("session", "review")).toEqual({ x: 12, y: 34 })
     scroll.dispose()
   })
+
+  test("persists semantic scroll anchors", () => {
+    vi.useFakeTimers()
+    try {
+      let snapshot: Record<string, { x: number; y: number; anchor?: { id: string; offset: number } }> = {}
+      const scroll = createScrollPersistence({
+        debounceMs: 10,
+        getSnapshot: () => snapshot,
+        onFlush: (_sessionKey, next) => {
+          snapshot = next
+        },
+      })
+
+      scroll.setScroll("session", "timeline", {
+        x: 1_000,
+        y: 400,
+        anchor: { id: "message-1", offset: 24 },
+      })
+      vi.advanceTimersByTime(10)
+
+      expect(snapshot.timeline).toEqual({
+        x: 1_000,
+        y: 400,
+        anchor: { id: "message-1", offset: 24 },
+      })
+      scroll.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/packages/app/src/context/layout-scroll.ts
+++ b/packages/app/src/context/layout-scroll.ts
@@ -5,6 +5,7 @@ export type SessionScroll = {
   y: number
   anchor?: {
     id: string
+    key?: string
     offset: number
   }
 }
@@ -33,7 +34,7 @@ export function createScrollPersistence(opts: Options) {
       out[key] = {
         x: pos.x,
         y: pos.y,
-        anchor: pos.anchor ? { id: pos.anchor.id, offset: pos.anchor.offset } : undefined,
+        anchor: pos.anchor ? { id: pos.anchor.id, key: pos.anchor.key, offset: pos.anchor.offset } : undefined,
       }
     }
 
@@ -75,6 +76,7 @@ export function createScrollPersistence(opts: Options) {
       prev?.x === pos.x &&
       prev?.y === pos.y &&
       prev?.anchor?.id === pos.anchor?.id &&
+      prev?.anchor?.key === pos.anchor?.key &&
       prev?.anchor?.offset === pos.anchor?.offset
     )
       return
@@ -82,7 +84,7 @@ export function createScrollPersistence(opts: Options) {
     setCache(sessionKey, tab, {
       x: pos.x,
       y: pos.y,
-      anchor: pos.anchor ? { id: pos.anchor.id, offset: pos.anchor.offset } : undefined,
+      anchor: pos.anchor ? { id: pos.anchor.id, key: pos.anchor.key, offset: pos.anchor.offset } : undefined,
     })
     dirty.add(sessionKey)
     schedule(sessionKey)

--- a/packages/app/src/context/layout-scroll.ts
+++ b/packages/app/src/context/layout-scroll.ts
@@ -3,6 +3,10 @@ import { createStore, produce } from "solid-js/store"
 export type SessionScroll = {
   x: number
   y: number
+  anchor?: {
+    id: string
+    offset: number
+  }
 }
 
 type ScrollMap = Record<string, SessionScroll>
@@ -26,7 +30,11 @@ export function createScrollPersistence(opts: Options) {
     for (const key of Object.keys(input)) {
       const pos = input[key]
       if (!pos) continue
-      out[key] = { x: pos.x, y: pos.y }
+      out[key] = {
+        x: pos.x,
+        y: pos.y,
+        anchor: pos.anchor ? { id: pos.anchor.id, offset: pos.anchor.offset } : undefined,
+      }
     }
 
     return out
@@ -63,9 +71,19 @@ export function createScrollPersistence(opts: Options) {
     seed(sessionKey)
 
     const prev = cache[sessionKey]?.[tab]
-    if (prev?.x === pos.x && prev?.y === pos.y) return
+    if (
+      prev?.x === pos.x &&
+      prev?.y === pos.y &&
+      prev?.anchor?.id === pos.anchor?.id &&
+      prev?.anchor?.offset === pos.anchor?.offset
+    )
+      return
 
-    setCache(sessionKey, tab, { x: pos.x, y: pos.y })
+    setCache(sessionKey, tab, {
+      x: pos.x,
+      y: pos.y,
+      anchor: pos.anchor ? { id: pos.anchor.id, offset: pos.anchor.offset } : undefined,
+    })
     dirty.add(sessionKey)
     schedule(sessionKey)
   }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1134,16 +1134,24 @@ export default function Page() {
     if (!layout.ready() || timelineScrollSession !== sessionKey()) return
     const max = el.scrollHeight - el.clientHeight
     const box = el.getBoundingClientRect()
-    const anchor = [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
-      .map((element) => ({ element, rect: element.getBoundingClientRect() }))
+    const anchor = [...el.querySelectorAll<HTMLElement>("[data-timeline-key]")]
+      .map((element) => ({
+        element,
+        message: element.querySelector<HTMLElement>("[data-message-id]"),
+        rect: element.getBoundingClientRect(),
+      }))
       .filter((item) => item.rect.bottom > box.top && item.rect.top < box.bottom)
       .sort((a, b) => a.rect.top - b.rect.top)[0]
     view().setScroll("timeline", {
       x: max,
       y: max <= 1 || max - el.scrollTop <= 2 ? Number.MAX_SAFE_INTEGER : el.scrollTop,
       anchor:
-        max > 1 && max - el.scrollTop > 2 && anchor?.element.dataset.messageId
-          ? { id: anchor.element.dataset.messageId, offset: anchor.rect.top - box.top }
+        max > 1 && max - el.scrollTop > 2 && anchor?.message?.dataset.messageId && anchor.element.dataset.timelineKey
+          ? {
+              id: anchor.message.dataset.messageId,
+              key: anchor.element.dataset.timelineKey,
+              offset: anchor.rect.top - box.top,
+            }
           : undefined,
     })
   }
@@ -1564,9 +1572,11 @@ export default function Page() {
         if (!scroller || !current()) return
         autoScroll.pause()
         const max = scroller.scrollHeight - scroller.clientHeight
-        const target = saved.anchor
-          ? scroller.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(saved.anchor.id)}"]`)
-          : undefined
+        const target = saved.anchor?.key
+          ? scroller.querySelector<HTMLElement>(`[data-timeline-key="${CSS.escape(saved.anchor.key)}"]`)
+          : saved.anchor
+            ? scroller.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(saved.anchor.id)}"]`)
+            : undefined
         if (saved.anchor && !target) {
           revealMessage(saved.anchor.id)
           return false

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -35,6 +35,7 @@ import { useComments } from "@/context/comments"
 import { useServerSync } from "@/context/server-sync"
 import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
+import type { SessionScroll } from "@/context/layout-scroll"
 import { usePrompt } from "@/context/prompt"
 import { usePlatform } from "@/context/platform"
 import { useSDK } from "@/context/sdk"
@@ -1079,6 +1080,7 @@ export default function Page() {
   const timelineScroll = () => view().scroll("timeline")
   const hasTimelineScroll = createMemo(() => layout.ready() && !!timelineScroll())
   let timelineScrollSession = ""
+  let timelineRestoreGeneration = 0
   const timelineScrollTop = () => {
     const y = timelineScroll()?.y
     if (y === Number.MAX_SAFE_INTEGER) return
@@ -1124,16 +1126,31 @@ export default function Page() {
       if (!target) return
 
       updateScrollState(target)
+      persistTimelineScroll(target)
     })
   }
 
   const persistTimelineScroll = (el: HTMLDivElement) => {
     if (!layout.ready() || timelineScrollSession !== sessionKey()) return
     const max = el.scrollHeight - el.clientHeight
+    const box = el.getBoundingClientRect()
+    const anchor = [...el.querySelectorAll<HTMLElement>("[data-message-id]")]
+      .map((element) => ({ element, rect: element.getBoundingClientRect() }))
+      .filter((item) => item.rect.bottom > box.top && item.rect.top < box.bottom)
+      .sort((a, b) => a.rect.top - b.rect.top)[0]
     view().setScroll("timeline", {
       x: max,
       y: max <= 1 || max - el.scrollTop <= 2 ? Number.MAX_SAFE_INTEGER : el.scrollTop,
+      anchor:
+        max > 1 && max - el.scrollTop > 2 && anchor?.element.dataset.messageId
+          ? { id: anchor.element.dataset.messageId, offset: anchor.rect.top - box.top }
+          : undefined,
     })
+  }
+
+  const cancelTimelineScrollRestore = () => {
+    timelineRestoreGeneration += 1
+    timelineScrollSession = sessionKey()
   }
 
   const resumeScroll = () => {
@@ -1533,18 +1550,32 @@ export default function Page() {
     },
   )
 
-  const restoreTimelineScroll = (saved: { x: number; y: number }) => {
+  const restoreTimelineScroll = (saved: SessionScroll) => {
     const id = params.id
     const owner = sessionOwnership.capture()
     const key = sessionKey()
+    const generation = ++timelineRestoreGeneration
     if (!id) return
+
+    const current = () => owner.current() && timelineRestoreGeneration === generation
 
     const apply = () =>
       owner.run(() => {
-        if (!scroller) return
+        if (!scroller || !current()) return
         autoScroll.pause()
         const max = scroller.scrollHeight - scroller.clientHeight
-        const top = max < saved.y + 100 && !historyMore() && saved.x > 0 ? (saved.y / saved.x) * max : saved.y
+        const target = saved.anchor
+          ? scroller.querySelector<HTMLElement>(`[data-message-id="${CSS.escape(saved.anchor.id)}"]`)
+          : undefined
+        if (saved.anchor && !target) {
+          revealMessage(saved.anchor.id)
+          return false
+        }
+        const top = target
+          ? scroller.scrollTop + target.getBoundingClientRect().top - scroller.getBoundingClientRect().top - saved.anchor!.offset
+          : max < saved.y + 100 && !historyMore() && saved.x > 0
+            ? (saved.y / saved.x) * max
+            : saved.y
         const stable = Math.abs(scroller.scrollTop - top) < 1
         scroller.scrollTop = top
         scheduleScrollState(scroller)
@@ -1553,20 +1584,29 @@ export default function Page() {
     apply()
 
     const load = async () => {
-      while (owner.current()) {
-        const el = scroller
-        if (!el || el.scrollHeight - el.clientHeight >= saved.y + 100 || !historyMore()) break
-        const before = timeline.messages().length
-        await sync().session.history.loadMore(id)
-        if (!owner.current() || timeline.messages().length <= before) break
-        await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
-        apply()
+      try {
+        while (current()) {
+          const found = !saved.anchor || visibleUserMessages().some((message) => message.id === saved.anchor?.id)
+          const tall = !!scroller && scroller.scrollHeight - scroller.clientHeight >= saved.y + 100
+          if ((found && tall) || !historyMore()) break
+          const before = timeline.messages().length
+          await sync().session.history.loadMore(id)
+          if (!current() || timeline.messages().length <= before) break
+          await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+          apply()
+        }
+      } catch (error) {
+        if (current()) {
+          timelineScrollSession = key
+          console.error("[session] failed to restore timeline scroll", error)
+        }
+        return
       }
       apply()
       let frames = 0
       let stable = 0
       const settle = () => {
-        if (!owner.current()) return
+        if (!current()) return
         stable = apply() ? stable + 1 : 0
         frames += 1
         if (stable >= 10 || frames >= 180) {
@@ -1810,7 +1850,7 @@ export default function Page() {
                         onResumeScroll={resumeScroll}
                         setScrollRef={setScrollRef}
                         onScheduleScrollState={scheduleScrollState}
-                        onPersistScroll={persistTimelineScroll}
+                        onCancelScrollRestore={cancelTimelineScrollRestore}
                         onAutoScrollHandleScroll={autoScroll.handleScroll}
                         onMarkScrollGesture={markScrollGesture}
                         hasScrollGesture={hasScrollGesture}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1076,6 +1076,14 @@ export default function Page() {
     working: () => true,
     overflowAnchor: "none",
   })
+  const timelineScroll = () => view().scroll("timeline")
+  const hasTimelineScroll = createMemo(() => layout.ready() && !!timelineScroll())
+  let timelineScrollSession = ""
+  const timelineScrollTop = () => {
+    const y = timelineScroll()?.y
+    if (y === Number.MAX_SAFE_INTEGER) return
+    return y
+  }
   createEffect(
     on(
       () => params.id,
@@ -1116,6 +1124,15 @@ export default function Page() {
       if (!target) return
 
       updateScrollState(target)
+    })
+  }
+
+  const persistTimelineScroll = (el: HTMLDivElement) => {
+    if (!layout.ready() || timelineScrollSession !== sessionKey()) return
+    const max = el.scrollHeight - el.clientHeight
+    view().setScroll("timeline", {
+      x: max,
+      y: max <= 1 || max - el.scrollTop <= 2 ? Number.MAX_SAFE_INTEGER : el.scrollTop,
     })
   }
 
@@ -1516,6 +1533,53 @@ export default function Page() {
     },
   )
 
+  const restoreTimelineScroll = (saved: { x: number; y: number }) => {
+    const id = params.id
+    const owner = sessionOwnership.capture()
+    const key = sessionKey()
+    if (!id) return
+
+    const apply = () =>
+      owner.run(() => {
+        if (!scroller) return
+        autoScroll.pause()
+        const max = scroller.scrollHeight - scroller.clientHeight
+        const top = max < saved.y + 100 && !historyMore() && saved.x > 0 ? (saved.y / saved.x) * max : saved.y
+        const stable = Math.abs(scroller.scrollTop - top) < 1
+        scroller.scrollTop = top
+        scheduleScrollState(scroller)
+        return stable
+      })
+    apply()
+
+    const load = async () => {
+      while (owner.current()) {
+        const el = scroller
+        if (!el || el.scrollHeight - el.clientHeight >= saved.y + 100 || !historyMore()) break
+        const before = timeline.messages().length
+        await sync().session.history.loadMore(id)
+        if (!owner.current() || timeline.messages().length <= before) break
+        await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+        apply()
+      }
+      apply()
+      let frames = 0
+      let stable = 0
+      const settle = () => {
+        if (!owner.current()) return
+        stable = apply() ? stable + 1 : 0
+        frames += 1
+        if (stable >= 10 || frames >= 180) {
+          timelineScrollSession = key
+          return
+        }
+        requestAnimationFrame(settle)
+      }
+      requestAnimationFrame(settle)
+    }
+    void load()
+  }
+
   const { clearMessageHash, scrollToMessage } = useSessionHashScroll({
     sessionKey,
     sessionID: () => params.id,
@@ -1538,6 +1602,18 @@ export default function Page() {
     scroller: () => scroller,
     anchor,
     revealMessage: (id) => revealMessage(id),
+    scrollReady: layout.ready,
+    hasSavedScroll: hasTimelineScroll,
+    restoreScroll: () => {
+      const saved = timelineScroll()
+      const el = scroller
+      if (!saved || saved.y === Number.MAX_SAFE_INTEGER || !el) return false
+      restoreTimelineScroll(saved)
+      return true
+    },
+    onApplyScroll: () => {
+      timelineScrollSession = sessionKey()
+    },
     scheduleScrollState,
     consumePendingMessage: layout.pendingMessage.consume,
   })
@@ -1734,6 +1810,7 @@ export default function Page() {
                         onResumeScroll={resumeScroll}
                         setScrollRef={setScrollRef}
                         onScheduleScrollState={scheduleScrollState}
+                        onPersistScroll={persistTimelineScroll}
                         onAutoScrollHandleScroll={autoScroll.handleScroll}
                         onMarkScrollGesture={markScrollGesture}
                         hasScrollGesture={hasScrollGesture}
@@ -1741,8 +1818,13 @@ export default function Page() {
                         onHistoryScroll={onHistoryScroll}
                         onAutoScrollInteraction={autoScroll.handleInteraction}
                         shouldAnchorBottom={() =>
-                          !location.hash && !store.messageId && !ui.pendingMessage && !autoScroll.userScrolled()
+                          !location.hash &&
+                          !store.messageId &&
+                          !ui.pendingMessage &&
+                          !autoScroll.userScrolled() &&
+                          timelineScrollTop() === undefined
                         }
+                        initialScrollTop={timelineScrollTop}
                         centered={centered()}
                         setContentRef={(el) => {
                           content = el

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -235,7 +235,7 @@ export function MessageTimeline(props: {
   onResumeScroll: () => void
   setScrollRef: (el: HTMLDivElement | undefined) => void
   onScheduleScrollState: (el: HTMLDivElement) => void
-  onPersistScroll: (el: HTMLDivElement) => void
+  onCancelScrollRestore: () => void
   onAutoScrollHandleScroll: () => void
   onMarkScrollGesture: (target?: EventTarget | null) => void
   hasScrollGesture: () => boolean
@@ -554,6 +554,7 @@ export function MessageTimeline(props: {
   }
 
   const handleListWheel = (event: WheelEvent & { currentTarget: HTMLDivElement }) => {
+    props.onCancelScrollRestore()
     if (!prependLoading) clearPrependAnchor()
     const root = event.currentTarget
     const delta = normalizeWheelDelta({
@@ -566,6 +567,7 @@ export function MessageTimeline(props: {
   }
 
   const handleListTouchStart = (event: TouchEvent) => {
+    props.onCancelScrollRestore()
     if (!prependLoading) clearPrependAnchor()
     touchGesture = event.touches[0]?.clientY
   }
@@ -592,15 +594,20 @@ export function MessageTimeline(props: {
   }
 
   const handleListPointerDown = (event: PointerEvent & { currentTarget: HTMLDivElement }) => {
+    props.onCancelScrollRestore()
     if (!prependLoading) clearPrependAnchor()
     if (event.target !== event.currentTarget) return
     props.onMarkScrollGesture(event.currentTarget)
   }
 
+  const handleListKeyDown = (event: KeyboardEvent) => {
+    if (!["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " "].includes(event.key)) return
+    props.onCancelScrollRestore()
+  }
+
   const handleListScroll = (event: Event & { currentTarget: HTMLDivElement }) => {
     if (prependLoading) updatePrependAnchor()
     props.onScheduleScrollState(event.currentTarget)
-    props.onPersistScroll(event.currentTarget)
     props.onHistoryScroll()
     if (!props.hasScrollGesture()) return
     props.onUserScroll()
@@ -1280,6 +1287,7 @@ export function MessageTimeline(props: {
         onTouchEnd={handleListTouchEnd}
         onTouchCancel={handleListTouchEnd}
         onPointerDown={handleListPointerDown}
+        onKeyDown={handleListKeyDown}
         onScroll={handleListScroll}
         onClick={props.onAutoScrollInteraction}
         class="relative min-w-0 w-full h-full"

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -235,6 +235,7 @@ export function MessageTimeline(props: {
   onResumeScroll: () => void
   setScrollRef: (el: HTMLDivElement | undefined) => void
   onScheduleScrollState: (el: HTMLDivElement) => void
+  onPersistScroll: (el: HTMLDivElement) => void
   onAutoScrollHandleScroll: () => void
   onMarkScrollGesture: (target?: EventTarget | null) => void
   hasScrollGesture: () => boolean
@@ -242,6 +243,7 @@ export function MessageTimeline(props: {
   onHistoryScroll: () => void
   onAutoScrollInteraction: (event: MouseEvent) => void
   shouldAnchorBottom: () => boolean
+  initialScrollTop: () => number | undefined
   centered: boolean
   setContentRef: (el: HTMLDivElement) => void
   userMessages: UserMessage[]
@@ -400,7 +402,7 @@ export function MessageTimeline(props: {
       return timelineRows().length
     },
     getScrollElement: () => listRoot() ?? null,
-    initialOffset: () => (props.shouldAnchorBottom() ? Number.MAX_SAFE_INTEGER : 0),
+    initialOffset: () => (props.shouldAnchorBottom() ? Number.MAX_SAFE_INTEGER : (props.initialScrollTop() ?? 0)),
     initialMeasurementsCache: initialMeasurements,
     estimateSize: () => timelineFallbackItemSize,
     scrollToFn: (offset, options, instance) => {
@@ -598,6 +600,7 @@ export function MessageTimeline(props: {
   const handleListScroll = (event: Event & { currentTarget: HTMLDivElement }) => {
     if (prependLoading) updatePrependAnchor()
     props.onScheduleScrollState(event.currentTarget)
+    props.onPersistScroll(event.currentTarget)
     props.onHistoryScroll()
     if (!props.hasScrollGesture()) return
     props.onUserScroll()

--- a/packages/app/src/pages/session/use-session-hash-scroll.ts
+++ b/packages/app/src/pages/session/use-session-hash-scroll.ts
@@ -19,12 +19,17 @@ export const useSessionHashScroll = (input: {
   scroller: () => HTMLDivElement | undefined
   anchor: (id: string) => string
   revealMessage?: (id: string) => void
+  scrollReady: () => boolean
+  hasSavedScroll: () => boolean
+  restoreScroll: () => boolean
+  onApplyScroll: () => void
   scheduleScrollState: (el: HTMLDivElement) => void
   consumePendingMessage: (key: string) => string | undefined
 }) => {
   const visibleUserMessages = createMemo(() => input.visibleUserMessages())
   const messageById = createMemo(() => new Map(visibleUserMessages().map((m) => [m.id, m])))
   let pendingKey = ""
+  let restoredKey = ""
   let clearing = false
 
   const location = useLocation()
@@ -99,13 +104,23 @@ export const useSessionHashScroll = (input: {
   }
 
   const applyHash = (behavior: ScrollBehavior) => {
+    const key = input.sessionKey()
+    const initial = restoredKey !== key
     const hash = location.hash.slice(1)
     if (!hash) {
+      if (initial && input.restoreScroll()) {
+        restoredKey = key
+        return
+      }
       input.autoScroll.forceScrollToBottom()
       const el = input.scroller()
       if (el) input.scheduleScrollState(el)
+      if (input.scrollReady()) input.onApplyScroll()
       return
     }
+
+    restoredKey = key
+    input.onApplyScroll()
 
     const messageId = messageIdFromHash(hash)
     if (messageId) {
@@ -132,6 +147,8 @@ export const useSessionHashScroll = (input: {
 
   createEffect(() => {
     const hash = location.hash
+    input.scrollReady()
+    input.hasSavedScroll()
     if (!hash) clearing = false
     if (!input.sessionID() || !input.messagesReady()) return
     cancel()


### PR DESCRIPTION
## Summary

- persist each session timeline position through the existing debounced layout scroll store
- restore the exact visible virtual row and viewport offset across titlebar tab switches and reloads
- load older history when newer messages shift the latest page
- cancel restoration on user input and recover cleanly from history loading failures
- preserve message-hash navigation and latest-message bottom anchoring precedence
- add smoke coverage for exact row restoration across tabs and after appending 240 messages

## Validation

- `bun typecheck` from `packages/app`
- focused layout-scroll and hash-scroll unit tests: 6 passed
- exact-row titlebar switch and shifted-history reload smoke test passed
- production timeline streaming benchmark passed with no geometry drift or remounts

## Benchmark

- baseline completion: 60.7s; long-task time: 14.0s
- latest completion: 57.0s; long-task time: 10.0s
- machine-dependent measurements; no regression observed