### PR TITLE
feat(opencode): add /goal stop-condition command

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -54,6 +54,7 @@ export function hints(template: string) {
 export const Default = {
   INIT: "init",
   REVIEW: "review",
+  GOAL: "goal",
 } as const
 
 export interface Interface {
@@ -93,6 +94,16 @@ export const layer = Layer.effect(
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      }
+      commands[Default.GOAL] = {
+        name: Default.GOAL,
+        description: "set a stop-condition goal; runs until a judge says it's met. /goal clear to abort",
+        source: "command",
+        subtask: false,
+        get template() {
+          return "$ARGUMENTS"
+        },
+        hints: ["$ARGUMENTS"],
       }
 
       for (const [name, command] of Object.entries(cfg.command ?? {})) {

--- a/packages/opencode/src/session/goal.ts
+++ b/packages/opencode/src/session/goal.ts
@@ -1,0 +1,178 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { InstanceState } from "@/effect/instance-state"
+import { SessionID } from "./schema"
+import { Effect, Layer, Context, Schema, Cause } from "effect"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { EventV2 } from "@opencode-ai/core/event"
+import { Provider } from "@/provider/provider"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { MessageV2 } from "./message-v2"
+import { generateObject, streamObject, type ModelMessage } from "ai"
+import { ProviderTransform } from "@/provider/transform"
+import { Auth } from "@/auth"
+
+export type Goal = {
+  condition: string
+  react: number
+}
+
+export const Verdict = Schema.Struct({
+  ok: Schema.Boolean,
+  impossible: Schema.optional(Schema.Boolean),
+  reason: Schema.String,
+})
+export type Verdict = Schema.Schema.Type<typeof Verdict>
+
+const VerdictWithMeta = Schema.Struct({
+  ok: Schema.Boolean,
+  impossible: Schema.optional(Schema.Boolean),
+  reason: Schema.String,
+  attempt: Schema.Number,
+  messageID: Schema.optional(Schema.String),
+  error: Schema.optional(Schema.Boolean),
+})
+
+export const Event = {
+  Updated: EventV2.define({
+    type: "session.goal",
+    schema: {
+      sessionID: SessionID,
+      goal: Schema.optional(Schema.Struct({ condition: Schema.String })),
+      lastVerdict: Schema.optional(VerdictWithMeta),
+    },
+  }),
+}
+
+const JUDGE_SYSTEM = `You are evaluating a stop-condition hook in opencode. Read the
+conversation transcript carefully, then judge whether the user-provided
+condition is satisfied.
+
+Your response must be a JSON object with one of these shapes:
+- {"ok": true, "reason": "<quote evidence>"}
+- {"ok": false, "reason": "<quote what is missing>"}
+- {"ok": false, "impossible": true, "reason": "<explain why>"}
+
+Always include a "reason" field, quoting specific text from the
+transcript whenever possible. If the transcript does not contain clear
+evidence that the condition is satisfied, return {"ok": false,
+"reason": "insufficient evidence in transcript"}.`
+
+const judgeUser = (condition: string) =>
+  `Based on the conversation transcript above, has the following stopping condition been satisfied? Answer based on transcript evidence only.\nCondition: ${condition}`
+
+export const MAX_GOAL_REACT = 12
+
+export interface Interface {
+  readonly set: (sessionID: SessionID, condition: string) => Effect.Effect<void>
+  readonly get: (sessionID: SessionID) => Effect.Effect<Goal | undefined>
+  readonly clear: (sessionID: SessionID) => Effect.Effect<void>
+  readonly bumpReact: (sessionID: SessionID) => Effect.Effect<number>
+  readonly evaluate: (input: EvaluateInput) => Effect.Effect<Verdict, Provider.ModelNotFoundError>
+}
+
+export type EvaluateInput = {
+  condition: string
+  msgs: SessionV1.WithParts[]
+  model: Provider.Model
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SessionGoal") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const events = yield* EventV2Bridge.Service
+    const provider = yield* Provider.Service
+    const auth = yield* Auth.Service
+
+    const state = yield* InstanceState.make(
+      Effect.fn("SessionGoal.state")(() => Effect.succeed(new Map<SessionID, Goal>())),
+    )
+
+    const set = Effect.fn("SessionGoal.set")(function* (sessionID: SessionID, condition: string) {
+      const data = yield* InstanceState.get(state)
+      const goal: Goal = { condition, react: 0 }
+      data.set(sessionID, goal)
+      yield* events.publish(Event.Updated, { sessionID, goal: { condition } })
+    })
+
+    const get = Effect.fn("SessionGoal.get")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      return data.get(sessionID)
+    })
+
+    const clear = Effect.fn("SessionGoal.clear")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      data.delete(sessionID)
+      yield* events.publish(Event.Updated, { sessionID, goal: undefined })
+    })
+
+    const bumpReact = Effect.fn("SessionGoal.bumpReact")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      const goal = data.get(sessionID)
+      if (!goal) return 0
+      goal.react += 1
+      return goal.react
+    })
+
+    const evaluate = Effect.fn("SessionGoal.evaluate")(function* (input: EvaluateInput) {
+      const language = yield* provider.getLanguage(input.model)
+      const modelMessages = yield* MessageV2.toModelMessagesEffect(input.msgs, input.model)
+
+      const authInfo = yield* auth.get(input.model.providerID).pipe(Effect.orDie)
+      const isOpenaiOauth = input.model.providerID === "openai" && authInfo?.type === "oauth"
+
+      const system: string[] = [JUDGE_SYSTEM]
+      const user: ModelMessage = { role: "user", content: judgeUser(input.condition) }
+
+      const messages: ModelMessage[] = [
+        ...(isOpenaiOauth
+          ? []
+          : system.map((item): ModelMessage => ({ role: "system", content: item }))),
+        ...modelMessages,
+        user,
+      ]
+
+      const params = {
+        temperature: 0,
+        messages,
+        model: language,
+        schema: Object.assign(
+          Schema.toStandardSchemaV1(Verdict),
+          Schema.toStandardJSONSchemaV1(Verdict),
+        ),
+      } satisfies Parameters<typeof generateObject>[0]
+
+      if (isOpenaiOauth) {
+        return yield* Effect.promise(async () => {
+          const result = streamObject({
+            ...params,
+            providerOptions: ProviderTransform.providerOptions(input.model, {
+              instructions: system.join("\n"),
+              store: false,
+            }),
+            onError: () => {},
+          })
+          for await (const part of result.fullStream) {
+            if (part.type === "error") throw part.error
+          }
+          return result.object
+        })
+      }
+
+      return yield* Effect.promise(() => generateObject(params).then((r) => r.object))
+    })
+
+    return Service.of({ set, get, clear, bumpReact, evaluate })
+  }),
+)
+
+export const defaultLayer = layer.pipe(
+  Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(Provider.defaultLayer),
+  Layer.provide(Auth.defaultLayer),
+)
+
+export const node = LayerNode.make(layer, [EventV2Bridge.node, Provider.node, Auth.node])
+
+export * as SessionGoal from "./goal"

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -48,6 +48,7 @@ import { TaskTool, type TaskPromptOps } from "@/tool/task"
 import { SessionRunState } from "./run-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionGoal } from "./goal"
 import { Database } from "@opencode-ai/core/database/database"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionMessage } from "@opencode-ai/core/session/message"
@@ -123,6 +124,7 @@ export const layer = Layer.effect(
     const llm = yield* LLM.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
+    const goal = yield* SessionGoal.Service
     const database = yield* Database.Service
     const { db } = database
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
@@ -136,6 +138,7 @@ export const layer = Layer.effect(
     const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
       yield* Effect.logInfo("cancel", { "session.id": sessionID })
       yield* state.cancel(sessionID)
+      yield* goal.clear(sessionID)
     })
 
     const resolvePromptParts = Effect.fn("SessionPrompt.resolvePromptParts")(function* (template: string) {
@@ -1377,7 +1380,57 @@ export const layer = Layer.effect(
             Effect.ensuring(instruction.clear(handle.message.id)),
             Effect.onInterrupt(() => finalizeInterruptedAssistant),
           )
-          if (outcome === "break") break
+          if (outcome === "break") {
+            const activeGoal = yield* goal.get(sessionID)
+            if (activeGoal && agent.mode !== "subagent") {
+              const verdict = yield* goal
+                .evaluate({ condition: activeGoal.condition, msgs, model })
+                .pipe(
+                  Effect.catchCause((cause) =>
+                    Effect.gen(function* () {
+                      yield* Effect.logWarning("goal judge failed; allowing stop", {
+                        error: String(Cause.squash(cause)),
+                      })
+                      return { ok: true, reason: "judge error", error: true } as SessionGoal.Verdict
+                    }),
+                  ),
+                )
+              const reactCount = yield* goal.bumpReact(sessionID)
+              if (verdict.ok || verdict.impossible || reactCount > SessionGoal.MAX_GOAL_REACT) {
+                yield* events.publish(SessionGoal.Event.Updated, {
+                  sessionID,
+                  goal: undefined,
+                  lastVerdict: { ...verdict, attempt: reactCount, messageID: handle.message.id },
+                })
+                yield* goal.clear(sessionID)
+                break
+              }
+              yield* events.publish(SessionGoal.Event.Updated, {
+                sessionID,
+                goal: { condition: activeGoal.condition },
+                lastVerdict: { ...verdict, attempt: reactCount, messageID: handle.message.id },
+              })
+              const syntheticMsg: SessionV1.User = {
+                id: MessageID.ascending(),
+                sessionID,
+                role: "user",
+                time: { created: Date.now() },
+                agent: lastUser.agent,
+                model: lastUser.model,
+              }
+              yield* sessions.updateMessage(syntheticMsg)
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: syntheticMsg.id,
+                sessionID,
+                type: "text",
+                text: `Goal not yet satisfied: ${verdict.reason}\n\nContinue working toward: ${activeGoal.condition}`,
+                synthetic: true,
+              } satisfies SessionV1.TextPart)
+              continue
+            }
+            break
+          }
           continue
         }
 
@@ -1405,6 +1458,19 @@ export const layer = Layer.effect(
         command: input.command,
         agent: input.agent,
       })
+
+      if (input.command === Command.Default.GOAL) {
+        const trimmed = input.arguments.trim()
+        if (trimmed === "clear") {
+          yield* goal.clear(input.sessionID)
+          return yield* lastAssistant(input.sessionID)
+        }
+        if (trimmed.length > 0) {
+          yield* goal.set(input.sessionID, trimmed)
+        }
+        return yield* lastAssistant(input.sessionID)
+      }
+
       const cmd = yield* commands.get(input.command)
       if (!cmd) {
         const available = (yield* commands.list()).map((c) => c.name)
@@ -1567,6 +1633,7 @@ export const defaultLayer = Layer.suspend(() =>
         CrossSpawnSpawner.defaultLayer,
         RuntimeFlags.defaultLayer,
         EventV2Bridge.defaultLayer,
+        SessionGoal.defaultLayer,
       ),
     ),
   ),
@@ -1676,6 +1743,7 @@ const placeholderRegex = /\$(\d+)/g
 const quoteTrimRegex = /^["']|["']$/g
 
 export const node = LayerNode.make(layer, [
+  SessionGoal.node,
   SessionStatus.node,
   Session.node,
   Agent.node,

--- a/packages/opencode/test/session/goal.test.ts
+++ b/packages/opencode/test/session/goal.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer, Schema } from "effect"
+import { SessionGoal } from "@/session/goal"
+import { SessionID } from "@/session/schema"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Provider } from "@/provider/provider"
+import { Auth } from "@/auth"
+import { testEffect } from "../lib/effect"
+import { testInstanceStoreLayer, provideInstance, tmpdirScoped } from "../fixture/fixture"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+
+const mockProviderLayer = Layer.mock(Provider.Service, {
+  getLanguage: () => Effect.die(new Error("not implemented")),
+  getModel: () => Effect.die(new Error("not implemented")),
+  getSmallModel: () => Effect.die(new Error("not implemented")),
+  list: () => Effect.succeed({}),
+})
+
+const mockAuthLayer = Layer.mock(Auth.Service, {
+  get: () => Effect.succeed(undefined),
+})
+
+const goalTestLayer = Layer.mergeAll(
+  SessionGoal.layer.pipe(
+    Layer.provide(EventV2Bridge.defaultLayer),
+    Layer.provide(mockProviderLayer),
+    Layer.provide(mockAuthLayer),
+  ),
+  testInstanceStoreLayer,
+  CrossSpawnSpawner.defaultLayer,
+)
+
+const it = testEffect(goalTestLayer)
+
+const sid = SessionID.make("ses_test-1")
+
+describe("SessionGoal.Service", () => {
+  it.live("set and get a goal", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const result = yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        yield* goal.set(sid, "all tests pass")
+        return yield* goal.get(sid)
+      }).pipe(provideInstance(dir))
+      expect(result).toEqual({ condition: "all tests pass", react: 0 })
+    }),
+  )
+
+  it.live("get returns undefined when no goal set", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const result = yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        return yield* goal.get(sid)
+      }).pipe(provideInstance(dir))
+      expect(result).toBeUndefined()
+    }),
+  )
+
+  it.live("clear removes a goal", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const result = yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        yield* goal.set(sid, "fix the bug")
+        yield* goal.clear(sid)
+        return yield* goal.get(sid)
+      }).pipe(provideInstance(dir))
+      expect(result).toBeUndefined()
+    }),
+  )
+
+  it.live("clear is idempotent when no goal exists", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const result = yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        yield* goal.clear(sid)
+        return yield* goal.get(sid)
+      }).pipe(provideInstance(dir))
+      expect(result).toBeUndefined()
+    }),
+  )
+
+  it.live("bumpReact increments react counter", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const result = yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        yield* goal.set(sid, "ship it")
+        const r1 = yield* goal.bumpReact(sid)
+        expect(r1).toBe(1)
+        const r2 = yield* goal.bumpReact(sid)
+        expect(r2).toBe(2)
+        const r3 = yield* goal.bumpReact(sid)
+        expect(r3).toBe(3)
+        const g = yield* goal.get(sid)
+        expect(g?.react).toBe(3)
+      }).pipe(provideInstance(dir))
+    }),
+  )
+
+  it.live("bumpReact returns 0 when no goal exists", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      const result = yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        return yield* goal.bumpReact(sid)
+      }).pipe(provideInstance(dir))
+      expect(result).toBe(0)
+    }),
+  )
+
+  it.live("set replaces existing goal and resets react", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        yield* goal.set(sid, "first goal")
+        yield* goal.bumpReact(sid)
+        yield* goal.bumpReact(sid)
+        yield* goal.set(sid, "second goal")
+        const g = yield* goal.get(sid)
+        expect(g?.condition).toBe("second goal")
+        expect(g?.react).toBe(0)
+      }).pipe(provideInstance(dir))
+    }),
+  )
+
+  it.live("goals are isolated per session", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      yield* Effect.gen(function* () {
+        const goal = yield* SessionGoal.Service
+        const sid2 = SessionID.make("ses_test-2")
+        yield* goal.set(sid, "goal for session 1")
+        yield* goal.set(sid2, "goal for session 2")
+        const g1 = yield* goal.get(sid)
+        const g2 = yield* goal.get(sid2)
+        expect(g1?.condition).toBe("goal for session 1")
+        expect(g2?.condition).toBe("goal for session 2")
+        yield* goal.clear(sid)
+        const g1After = yield* goal.get(sid)
+        const g2After = yield* goal.get(sid2)
+        expect(g1After).toBeUndefined()
+        expect(g2After?.condition).toBe("goal for session 2")
+      }).pipe(provideInstance(dir))
+    }),
+  )
+})
+
+describe("SessionGoal types", () => {
+  test("Verdict schema decodes ok verdict", () => {
+    const result = Schema.decodeUnknownSync(SessionGoal.Verdict)({ ok: true, reason: "done" })
+    expect(result).toEqual({ ok: true, reason: "done" })
+  })
+
+  test("Verdict schema decodes impossible verdict", () => {
+    const result = Schema.decodeUnknownSync(SessionGoal.Verdict)({ ok: false, impossible: true, reason: "cannot be done" })
+    expect(result).toEqual({ ok: false, impossible: true, reason: "cannot be done" })
+  })
+
+  test("MAX_GOAL_REACT is 12", () => {
+    expect(SessionGoal.MAX_GOAL_REACT).toBe(12)
+  })
+})

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -34,6 +34,7 @@ import { SessionCompaction } from "../../src/session/compaction"
 import { SessionSummary } from "../../src/session/summary"
 import { Instruction } from "../../src/session/instruction"
 import { SessionProcessor } from "../../src/session/processor"
+import { SessionGoal } from "@/session/goal"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionRevert } from "../../src/session/revert"
 import { SessionRunState } from "../../src/session/run-state"
@@ -182,6 +183,7 @@ function makePrompt(input?: { processor?: "blocking" }) {
     status,
     Database.defaultLayer,
     EventV2Bridge.defaultLayer,
+    SessionGoal.defaultLayer,
   ).pipe(Layer.provideMerge(infra))
   const question = Question.layer.pipe(Layer.provideMerge(deps))
   const todo = Todo.layer.pipe(Layer.provideMerge(deps))


### PR DESCRIPTION
## Summary

Adds a `/goal <condition>` command that sets a stop-condition gate in the main run loop. When active, an independent judge model evaluates whether the condition is satisfied before allowing the agent to stop. If not satisfied, a synthetic continuation message is injected and the loop continues. A safety valve (`MAX_GOAL_REACT = 12`) prevents infinite loops.

Closes #27167.

## How it works

1. **`/goal <condition>`** — stores the goal in per-session `InstanceState`. The next prompt run's loop exit is gated.
2. **`/goal clear`** — removes the active goal.
3. **goalGate** — intercepts `outcome === "break"` in `prompt.ts`'s run loop. Calls the judge model (`generateObject` with a `Verdict` schema: `{ ok, impossible?, reason }`). On denial, creates a **new** `SessionV1.User` message with a synthetic continuation part (appending to the existing user message would trigger the loop's early-exit guard). On `ok`, `impossible`, or `reactCount > MAX_GOAL_REACT`, clears the goal and allows stop.
4. **Judge errors fail-open** — logged via `Effect.logWarning` and the verdict carries `error: true` so the TUI can distinguish errors from real approvals.

## Files changed

| File | Change |
|------|--------|
| `src/session/goal.ts` (new, 178 lines) | Goal type, Verdict schema, Event.Updated, `SessionGoal.Service` with set/get/clear/bumpReact/evaluate |
| `src/session/prompt.ts` (+70/-1) | goalGate at `outcome === "break"`, `SessionGoal.defaultLayer` wired into `SessionPrompt.layer` |
| `src/command/index.ts` (+11) | `Default.GOAL` command + dispatch to `Goal.Service.set`/`clear` |
| `test/session/goal.test.ts` (new, 167 lines) | 11 unit tests: set/get/clear idempotency, per-session isolation, bumpReact, Verdict schema |
| `test/session/prompt.test.ts` (+2) | `SessionGoal.defaultLayer` in test deps |

## Design decisions

- **New `SessionV1.User` for continuation** (not appending a part to the existing user message): appending would leave `lastUser.id < lastAssistant.id`, triggering the loop's early-exit guard at `prompt.ts:1185`. Creating a new message mirrors the task-tool continuation pattern at `prompt.ts:419`.
- **Gate excludes subagent runs** (`agent.mode !== "subagent"`): subtasks run in child sessions and shouldn't be gated by the parent's goal.
- **Judge uses `generateObject`** with `Schema.Struct` Verdict (not Zod — follows codebase convention). OpenAI OAuth path uses `streamObject` (mirrors `agent.ts`).
- **`temperature: 0`** on the judge for reproducible verdicts.
- **Fail-open on judge errors**: better to allow stop (user can re-run) than trap the user in an infinite loop when the judge is broken.

## Testing

- `bun typecheck` — clean (exit 0)
- `bun test test/session/goal.test.ts` — 11/11 pass
- `bun test test/session/` — 373/373 pass (0 fail, 7 skip, 1 todo)

## Not included (deferred)

TUI goal indicator and verdict markers (`packages/tui/`) — requires SDK regeneration + server route registration. The backend infrastructure (`Goal.Service`, `Event.Updated`, verdict publishing) is complete and will surface events when the TUI phase lands.