### PR TITLE
fix(tui): avoid rendering "1000.0K" in compact number formatting

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -31,7 +31,10 @@ export function number(num: number): string {
   if (num >= 1000000) {
     return (num / 1000000).toFixed(1) + "M"
   } else if (num >= 1000) {
-    return (num / 1000).toFixed(1) + "K"
+    const value = (num / 1000).toFixed(1)
+    // 999_950+ rounds up to "1000.0K", so promote to "M" rather than showing a 4-digit thousands value.
+    if (value === "1000.0") return (num / 1000000).toFixed(1) + "M"
+    return value + "K"
   }
   return num.toString()
 }

--- a/packages/tui/test/util/locale.test.ts
+++ b/packages/tui/test/util/locale.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { Locale } from "../../src/util/locale"
+
+describe("util.locale", () => {
+  describe("number", () => {
+    test("returns the raw value below 1,000", () => {
+      expect(Locale.number(0)).toBe("0")
+      expect(Locale.number(999)).toBe("999")
+    })
+
+    test("formats thousands with a K suffix", () => {
+      expect(Locale.number(1000)).toBe("1.0K")
+      expect(Locale.number(1500)).toBe("1.5K")
+      expect(Locale.number(999499)).toBe("999.5K")
+      expect(Locale.number(999949)).toBe("999.9K")
+    })
+
+    test("formats millions with an M suffix", () => {
+      expect(Locale.number(1000000)).toBe("1.0M")
+      expect(Locale.number(1500000)).toBe("1.5M")
+    })
+
+    test("promotes to M when the thousands value rounds up to 1000.0K", () => {
+      expect(Locale.number(999950)).toBe("1.0M")
+      expect(Locale.number(999999)).toBe("1.0M")
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33947

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Locale.number` formats compact counts shown in the TUI context panel, the subagent footer, and the CLI `run` summary. The thousands branch returned `(num / 1000).toFixed(1) + "K"`; `toFixed(1)` rounds 999,950-999,999 up to `1000.0`, so they rendered as `1000.0K` instead of rolling over to `1.0M` (a session near a 1M-token context window showed `1000.0K (100%)`).

The fix promotes the value to the `M` suffix when the rounded thousands value is `1000.0`. Only the thousands branch changes; every other output is unchanged.

### How did you verify your code works?

Added `packages/tui/test/util/locale.test.ts` covering the K/M boundaries (999,949 -> `999.9K`; 999,950 and 999,999 -> `1.0M`; 1,000,000 -> `1.0M`). `bun test test/util/locale.test.ts` passes (4 tests); I confirmed it fails before the fix (`1000.0K`) and passes after (`1.0M`). `bun run typecheck` (tui) passes and `oxlint` is clean on the changed files.

### Screenshots / recordings

N/A - text formatting only, not a visual UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR