### PR TITLE
fix(app): enable composer shortcuts on drafts

### DIFF
--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -13,6 +13,7 @@ import {
   SessionComposerRegion,
 } from "@/pages/session/composer"
 import { useSessionKey } from "@/pages/session/session-layout"
+import { useComposerCommands } from "@/pages/session/use-composer-commands"
 
 /**
  * The `/new-session` draft page. Unlike `session.tsx`, this only renders the prompt
@@ -27,6 +28,8 @@ export default function NewSessionPage() {
   const comments = useComments()
   const route = useSessionKey()
   const [searchParams, setSearchParams] = useSearchParams<{ draftId?: string; prompt?: string }>()
+
+  useComposerCommands()
 
   let inputRef: HTMLDivElement | undefined
 

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -63,6 +63,7 @@ import { useSessionLayout } from "@/pages/session/session-layout"
 import { syncSessionModel } from "@/pages/session/session-model-helpers"
 import { SessionSidePanel } from "@/pages/session/session-side-panel"
 import { TerminalPanel } from "@/pages/session/terminal-panel"
+import { useComposerCommands } from "@/pages/session/use-composer-commands"
 import { useSessionCommands } from "@/pages/session/use-session-commands"
 import { useSessionHashScroll } from "@/pages/session/use-session-hash-scroll"
 import { Identifier } from "@/utils/id"
@@ -783,6 +784,7 @@ export default function Page() {
     inputRef?.focus()
   }
 
+  useComposerCommands()
   useSessionCommands({
     navigateMessageByOffset,
     setActiveMessage,

--- a/packages/app/src/pages/session/use-composer-commands.tsx
+++ b/packages/app/src/pages/session/use-composer-commands.tsx
@@ -1,0 +1,69 @@
+import { useCommand, type CommandOption } from "@/context/command"
+import { useLanguage } from "@/context/language"
+import { useLocal } from "@/context/local"
+import { useSettings } from "@/context/settings"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { useSessionLayout } from "./session-layout"
+import { createSessionOwnership } from "./session-ownership"
+
+const withCategory = (category: string) => {
+  return (option: Omit<CommandOption, "category">): CommandOption => ({
+    ...option,
+    category,
+  })
+}
+
+export const useComposerCommands = () => {
+  const command = useCommand()
+  const dialog = useDialog()
+  const language = useLanguage()
+  const local = useLocal()
+  const settings = useSettings()
+  const { sessionKey } = useSessionLayout()
+  const sessionOwnership = createSessionOwnership(sessionKey)
+  const modelCommand = withCategory(language.t("command.category.model"))
+  const agentCommand = withCategory(language.t("command.category.agent"))
+
+  const chooseModel = async () => {
+    const owner = sessionOwnership.capture()
+    const { DialogSelectModel } = await import("@/components/dialog-select-model")
+    owner.run(() => {
+      void dialog.show(() => <DialogSelectModel model={local.model} />)
+    })
+  }
+
+  command.register("composer", () => [
+    modelCommand({
+      id: "model.choose",
+      title: language.t("command.model.choose"),
+      description: language.t("command.model.choose.description"),
+      keybind: "mod+'",
+      slash: "model",
+      onSelect: chooseModel,
+    }),
+    modelCommand({
+      id: "model.variant.cycle",
+      title: language.t("command.model.variant.cycle"),
+      description: language.t("command.model.variant.cycle.description"),
+      keybind: "shift+mod+d",
+      onSelect: () => local.model.variant.cycle(),
+    }),
+    agentCommand({
+      id: "agent.cycle",
+      title: language.t("command.agent.cycle"),
+      description: language.t("command.agent.cycle.description"),
+      keybind: "mod+.",
+      slash: "agent",
+      disabled: !settings.visibility.customAgents(),
+      onSelect: () => local.agent.move(1),
+    }),
+    agentCommand({
+      id: "agent.cycle.reverse",
+      title: language.t("command.agent.cycle.reverse"),
+      description: language.t("command.agent.cycle.reverse.description"),
+      keybind: "shift+mod+.",
+      disabled: !settings.visibility.customAgents(),
+      onSelect: () => local.agent.move(-1),
+    }),
+  ])
+}

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -136,9 +136,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const contextCommand = withCategory(language.t("command.category.context"))
   const viewCommand = withCategory(language.t("command.category.view"))
   const terminalCommand = withCategory(language.t("command.category.terminal"))
-  const modelCommand = withCategory(language.t("command.category.model"))
   const mcpCommand = withCategory(language.t("command.category.mcp"))
-  const agentCommand = withCategory(language.t("command.category.agent"))
   const permissionsCommand = withCategory(language.t("command.category.permissions"))
 
   const isAutoAcceptActive = () => {
@@ -269,13 +267,6 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   const openTerminal = () => {
     if (terminal.all().length > 0) terminal.new()
     view().terminal.open()
-  }
-
-  const chooseModel = () => {
-    void openDialog(
-      () => import("@/components/dialog-select-model"),
-      (x) => dialog.show(() => <x.DialogSelectModel model={local.model} />),
-    )
   }
 
   const chooseMcp = () => {
@@ -555,24 +546,6 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     }),
   ]
 
-  const modelCmds = () => [
-    modelCommand({
-      id: "model.choose",
-      title: language.t("command.model.choose"),
-      description: language.t("command.model.choose.description"),
-      keybind: "mod+'",
-      slash: "model",
-      onSelect: chooseModel,
-    }),
-    modelCommand({
-      id: "model.variant.cycle",
-      title: language.t("command.model.variant.cycle"),
-      description: language.t("command.model.variant.cycle.description"),
-      keybind: "shift+mod+d",
-      onSelect: () => local.model.variant.cycle(),
-    }),
-  ]
-
   const mcpCmds = () => [
     mcpCommand({
       id: "mcp.toggle",
@@ -581,26 +554,6 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       keybind: "mod+;",
       slash: "mcp",
       onSelect: chooseMcp,
-    }),
-  ]
-
-  const agentCmds = () => [
-    agentCommand({
-      id: "agent.cycle",
-      title: language.t("command.agent.cycle"),
-      description: language.t("command.agent.cycle.description"),
-      keybind: "mod+.",
-      slash: "agent",
-      disabled: !settings.visibility.customAgents(),
-      onSelect: () => local.agent.move(1),
-    }),
-    agentCommand({
-      id: "agent.cycle.reverse",
-      title: language.t("command.agent.cycle.reverse"),
-      description: language.t("command.agent.cycle.reverse.description"),
-      keybind: "shift+mod+.",
-      disabled: !settings.visibility.customAgents(),
-      onSelect: () => local.agent.move(-1),
     }),
   ]
 
@@ -624,9 +577,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     ...viewCmds(),
     ...terminalCmds(),
     ...messageCmds(),
-    ...modelCmds(),
     ...mcpCmds(),
-    ...agentCmds(),
     ...permissionsCmds(),
   ])
 }


### PR DESCRIPTION
## Summary

- extract model and agent commands into composer-scoped registration
- register model selection, thinking effort cycling, and agent cycling on the new-session draft page
- preserve existing session behavior and async dialog route ownership

## Testing

- `bun typecheck` in `packages/app`
- `bun run test:unit` in `packages/app`
- `bun run test:bench` before and after the change
- `bun run lint -- packages/app/src/pages/session/use-composer-commands.tsx`
- repository pre-push typecheck