### PR TITLE
fix(tui): respect per-agent variant when TAB-cycling shared models

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -360,6 +360,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           selected() {
             const m = currentModel()
             if (!m) return undefined
+            // Prefer agent-configured variant so TAB-cycling between agents
+            // that share the same model shows the correct variant.
+            const a = agent.current()
+            if (a?.model?.variant) return a.model.variant
             const key = `${m.providerID}/${m.modelID}`
             return modelStore.variant[key]
           },


### PR DESCRIPTION
When two agents share the same model but have different variants (e.g. `build` with `variant: max` and `x-teach` with `variant: high`), TAB-cycling between them showed the wrong variant because `variant.selected()` only looked up by model key — causing both agents to display the same variant.

**Root cause:** `variant.selected()` stored and retrieved variant by `"providerID/modelID"` key. When two agents share a model, the second agent inherits the first agent's variant.

**Fix:** Check the current agent's configured variant (`a.model.variant`) first, then fall back to the per-model global store. This makes agent-configured variants authoritative while preserving DialogVariant manual overrides for agents without a configured variant.

**Before:**
```ts
selected() {
  const m = currentModel()
  if (!m) return undefined
  const key = `${m.providerID}/${m.modelID}`
  return modelStore.variant[key]
},
```

**After:**
```ts
selected() {
  const m = currentModel()
  if (!m) return undefined
  // Prefer agent-configured variant so TAB-cycling between agents
  // that share the same model shows the correct variant.
  const a = agent.current()
  if (a?.model?.variant) return a.model.variant
  const key = `${m.providerID}/${m.modelID}`
  return modelStore.variant[key]
},
```