### PR TITLE
fix(plan-mode): deny bash and scope subagent permission inheritance

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -155,7 +155,7 @@ export const layer = Layer.effect(
           },
           plan: {
             name: "plan",
-            description: "Plan mode. Disallows all edit tools.",
+            description: "Plan mode. Disallows all edit tools and bash commands.",
             options: {},
             permission: Permission.merge(
               defaults,
@@ -172,6 +172,9 @@ export const layer = Layer.effect(
                   "*": "deny",
                   [path.join(".opencode", "plans", "*.md")]: "allow",
                   [path.relative(ctx.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
+                },
+                bash: {
+                  "*": "deny",
                 },
               }),
               user,

--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -5,12 +5,16 @@ import type { Agent } from "./agent"
  * Build the `permission` ruleset for a subagent's session when it's spawned
  * via the task tool. Combines:
  *
- * 1. The parent session's deny rules and external_directory rules.
- *    Parent agent restrictions only govern that agent; the subagent's own
- *    permissions determine its capabilities.
+ * 1. The parent session's external_directory rules, plus deny rules for
+ *    write-capable permissions (edit, write, apply_patch, bash).
+ *    Broadly inheriting ALL parent denies (as done prior to this fix) breaks
+ *    subagents like `explore` that explicitly allow `bash` for read-only
+ *    operations — their own permission rules are overridden by inherited denies.
  * 2. Default `todowrite` and `task` denies if the subagent's own ruleset
  *    doesn't already permit them.
  */
+const WRITE_PERMISSIONS = new Set(["edit", "write", "apply_patch", "bash"])
+
 export function deriveSubagentSessionPermission(input: {
   parentSessionPermission: PermissionV1.Ruleset
   subagent: Agent.Info
@@ -19,7 +23,9 @@ export function deriveSubagentSessionPermission(input: {
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
   return [
     ...input.parentSessionPermission.filter(
-      (rule) => rule.permission === "external_directory" || rule.action === "deny",
+      (rule) =>
+        rule.permission === "external_directory" ||
+        (rule.action === "deny" && WRITE_PERMISSIONS.has(rule.permission)),
     ),
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),


### PR DESCRIPTION
### Issue for this PR

Closes #22641
Addresses #26700

### Type of change

- [X] Bug fix

### What does this PR do?

Plan mode blocks edit tools via the permission system, but bash is unrestricted because the plan agent config only denies the "edit" permission. The bash tool follows the default `"*": "allow"` rule, so the model can run arbitrary shell commands including writes.

**Fix 1 — agent/agent.ts**: Added `bash: { "*": "deny" }` to the plan agent permission config. Hides bash from the LLM tool list and throws DeniedError if called.

**Fix 2 — agent/subagent-permissions.ts**: The deriveSubagentSessionPermission function (from #26597) inherited ALL parent deny rules into subagent sessions, overriding subagents like `explore` that explicitly allow bash for read-only operations. Changed to only inherit denies for write-capable permissions (edit, write, apply_patch, bash) plus external_directory rules.

### How did you verify your code works?

All 95 existing tests pass including the plan-mode-subagent-bypass test suite. The bash: deny from parent IS still inherited (bash is in WRITE_PERMISSIONS), while unrelated denies are not.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR