### PR TITLE
fix(tui): handle rounding overflow in compact number formatter

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -31,7 +31,11 @@ export function number(num: number): string {
   if (num >= 1000000) {
     return (num / 1000000).toFixed(1) + "M"
   } else if (num >= 1000) {
-    return (num / 1000).toFixed(1) + "K"
+    const k = (num / 1000).toFixed(1)
+    if (k === "1000.0") {
+      return (num / 1000000).toFixed(1) + "M"
+    }
+    return k + "K"
   }
   return num.toString()
 }


### PR DESCRIPTION
Fixes #33947

`Locale.number()` in `packages/tui/src/util/locale.ts` rounds thousands with `.toFixed(1)`, so values from 999,950 to 999,999 render as `"1000.0K"` instead of `"1.0M"`.

The fix checks if the rounded thousands value equals `"1000.0"` and if so, formats as millions instead.