### PR TITLE
docs: clarify that local and global AGENTS.md are both loaded

### DIFF
--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -94,13 +94,13 @@ export OPENCODE_DISABLE_CLAUDE_CODE_SKILLS=1 # Disable only .claude/skills
 
 ## Precedence
 
-When opencode starts, it looks for rule files in this order:
+OpenCode loads and concatenates rule files from multiple layers. All three layers below are loaded in order, with later layers appended after earlier ones:
 
 1. **Local files** by traversing up from the current directory (`AGENTS.md`, `CLAUDE.md`)
 2. **Global file** at `~/.config/opencode/AGENTS.md`
 3. **Claude Code file** at `~/.claude/CLAUDE.md` (unless disabled)
 
-The first matching file wins in each category. For example, if you have both `AGENTS.md` and `CLAUDE.md`, only `AGENTS.md` is used. Similarly, `~/.config/opencode/AGENTS.md` takes precedence over `~/.claude/CLAUDE.md`.
+Within each layer, the first matching file wins. For example, if your project root has both `AGENTS.md` and `CLAUDE.md`, only `AGENTS.md` from that layer is used — `CLAUDE.md` is skipped. Similarly, a global `~/.config/opencode/AGENTS.md` takes precedence over `~/.claude/CLAUDE.md`, but both layers are still included after the local layer.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #33908

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Rephrase the Precedence section of the rules docs to make it explicit that:
- All three layers (local, global, Claude Code) are loaded and concatenated in order
- "First wins" only applies within each layer (AGENTS.md beats CLAUDE.md)

Previously the wording sounded like only one file was selected overall.

### How did you verify your code works?

Documentation only change — reviewed the rendered markdown locally.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR