### PR TITLE
fix(sdk): wake embedded session execution

### DIFF
--- a/packages/core/src/control-plane/move-session.ts
+++ b/packages/core/src/control-plane/move-session.ts
@@ -8,6 +8,7 @@ import { ProjectV2 } from "../project"
 import { SessionV2 } from "../session"
 import { SessionEvent } from "../session/event"
 import { SessionSchema } from "../session/schema"
+import { SessionStore } from "../session/store"
 import { AbsolutePath, RelativePath } from "../schema"
 import path from "path"
 
@@ -70,10 +71,11 @@ export const layer = Layer.effect(
     const git = yield* Git.Service
     const events = yield* EventV2.Service
     const project = yield* ProjectV2.Service
-    const session = yield* SessionV2.Service
+    const sessions = yield* SessionStore.Service
 
     const moveSession = Effect.fn("MoveSession.moveSession")(function* (input: Input) {
-      const current = yield* session.get(input.sessionID)
+      const current = yield* sessions.get(input.sessionID)
+      if (!current) return yield* new SessionV2.NotFoundError({ sessionID: input.sessionID })
       const directory = AbsolutePath.make(input.destination.directory)
       if (current.location.directory === directory) return
 
@@ -142,4 +144,5 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Git.defaultLayer),
   Layer.provide(EventV2.defaultLayer),
   Layer.provide(ProjectV2.defaultLayer),
+  Layer.provide(SessionStore.defaultLayer),
 )

--- a/packages/core/src/control-plane/move-session.ts
+++ b/packages/core/src/control-plane/move-session.ts
@@ -6,7 +6,6 @@ import { Git } from "../git"
 import { Location } from "../location"
 import { ProjectV2 } from "../project"
 import { SessionV2 } from "../session"
-import { SessionExecution } from "../session/execution"
 import { SessionEvent } from "../session/event"
 import { SessionSchema } from "../session/schema"
 import { AbsolutePath, RelativePath } from "../schema"
@@ -143,6 +142,4 @@ export const defaultLayer = layer.pipe(
   Layer.provide(Git.defaultLayer),
   Layer.provide(EventV2.defaultLayer),
   Layer.provide(ProjectV2.defaultLayer),
-  Layer.provide(SessionExecution.noopLayer),
-  Layer.provide(SessionV2.defaultLayer),
 )

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -443,7 +443,6 @@ export const defaultLayer = layer.pipe(
   Layer.provide(
     Layer.unwrap(Effect.promise(() => import("./location-layer")).pipe(Effect.map((m) => m.LocationServiceMap.layer))),
   ),
-  Layer.provide(SessionExecution.noopLayer),
   Layer.provide(SessionStore.defaultLayer),
   Layer.provide(SessionProjector.defaultLayer),
   Layer.provide(EventV2.defaultLayer),

--- a/packages/core/test/move-session.test.ts
+++ b/packages/core/test/move-session.test.ts
@@ -42,7 +42,7 @@ const layer = MoveSession.layer.pipe(
   Layer.provide(Git.defaultLayer),
   Layer.provide(EventV2.defaultLayer),
   Layer.provide(project),
-  Layer.provide(sessions),
+  Layer.provide(SessionStore.defaultLayer),
 )
 const it = testEffect(
   Layer.mergeAll(
@@ -53,7 +53,6 @@ const it = testEffect(
     project,
     SessionProjector.defaultLayer,
     SessionStore.defaultLayer,
-    SessionExecution.noopLayer,
     sessions,
   ),
 )

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -94,7 +94,7 @@ import { questionHandlers } from "./handlers/question"
 import { sessionHandlers } from "./handlers/session"
 import { syncHandlers } from "./handlers/sync"
 import { tuiHandlers } from "./handlers/tui"
-import { handlers } from "@opencode-ai/server/handlers"
+import { handlers, sessionRuntime } from "@opencode-ai/server/handlers"
 import { schemaErrorLayer as v2SchemaErrorLayer } from "@opencode-ai/server/middleware/schema-error"
 import { workspaceHandlers } from "./handlers/workspace"
 import { instanceContextLayer } from "./middleware/instance-context"
@@ -276,7 +276,7 @@ export function createRoutes(
       corsVaryFix,
       fenceLayer,
       cors(corsOptions),
-      MoveSession.defaultLayer,
+      MoveSession.defaultLayer.pipe(Layer.provide(sessionRuntime)),
       HttpServer.layerServices,
     ]),
     Layer.provide(LayerNode.buildLayer(app)),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -94,7 +94,7 @@ import { questionHandlers } from "./handlers/question"
 import { sessionHandlers } from "./handlers/session"
 import { syncHandlers } from "./handlers/sync"
 import { tuiHandlers } from "./handlers/tui"
-import { handlers, sessionRuntime } from "@opencode-ai/server/handlers"
+import { handlers } from "@opencode-ai/server/handlers"
 import { schemaErrorLayer as v2SchemaErrorLayer } from "@opencode-ai/server/middleware/schema-error"
 import { workspaceHandlers } from "./handlers/workspace"
 import { instanceContextLayer } from "./middleware/instance-context"
@@ -276,7 +276,7 @@ export function createRoutes(
       corsVaryFix,
       fenceLayer,
       cors(corsOptions),
-      MoveSession.defaultLayer.pipe(Layer.provide(sessionRuntime)),
+      MoveSession.defaultLayer,
       HttpServer.layerServices,
     ]),
     Layer.provide(LayerNode.buildLayer(app)),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -11,6 +11,9 @@ import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Database } from "@opencode-ai/core/database/database"
 import { makeRuntime } from "@opencode-ai/core/effect/runtime"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { SessionV2 } from "@opencode-ai/core/session"
+import * as SessionExecutionLocal from "@opencode-ai/core/session/execution/local"
+import { LocationServiceMap } from "@opencode-ai/core/location-layer"
 
 import { NotFoundError } from "@/storage/storage"
 import { eq } from "drizzle-orm"
@@ -921,6 +924,12 @@ export const defaultLayer = layer.pipe(
   Layer.provide(BackgroundJob.defaultLayer),
   Layer.provide(Database.defaultLayer),
   Layer.provide(EventV2Bridge.defaultLayer),
+  Layer.provide(
+    SessionV2.defaultLayer.pipe(
+      Layer.provide(SessionExecutionLocal.defaultLayer),
+      Layer.provide(LocationServiceMap.layer),
+    ),
+  ),
   Layer.provide(RuntimeFlags.defaultLayer),
 )
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -11,8 +11,6 @@ import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Database } from "@opencode-ai/core/database/database"
 import { makeRuntime } from "@opencode-ai/core/effect/runtime"
 import { EventV2Bridge } from "@/event-v2-bridge"
-import { SessionV2 } from "@opencode-ai/core/session"
-import { SessionExecution } from "@opencode-ai/core/session/execution"
 
 import { NotFoundError } from "@/storage/storage"
 import { eq } from "drizzle-orm"
@@ -923,8 +921,6 @@ export const defaultLayer = layer.pipe(
   Layer.provide(BackgroundJob.defaultLayer),
   Layer.provide(Database.defaultLayer),
   Layer.provide(EventV2Bridge.defaultLayer),
-  Layer.provide(SessionExecution.noopLayer),
-  Layer.provide(SessionV2.defaultLayer),
   Layer.provide(RuntimeFlags.defaultLayer),
 )
 

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -4,7 +4,7 @@ import { NodeHttpServer, NodeServices } from "@effect/platform-node"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
-import { Cause, Config, Effect, Exit, Layer, Schedule } from "effect"
+import { Cause, Config, Effect, Exit, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse, HttpRouter, HttpServer } from "effect/unstable/http"
 import { layerWebSocketConstructorGlobal } from "effect/unstable/socket/Socket"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -34,7 +34,7 @@ import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, provideInstanceEffect, TestInstance, tmpdirScoped } from "../fixture/fixture"
 import { TestLLMServer } from "../lib/llm-server"
 import { testProviderConfig } from "../lib/test-provider"
-import { testEffect } from "../lib/effect"
+import { pollWithTimeout, testEffect } from "../lib/effect"
 
 const originalWorkspaces = Flag.OPENCODE_EXPERIMENTAL_WORKSPACES
 const workspaceLayer = Workspace.defaultLayer.pipe(
@@ -624,40 +624,22 @@ describe("session HttpApi", () => {
           message: "Prompt message ID conflicts with an existing durable record: msg_http_prompt",
           resource: "msg_http_prompt",
         })
-      }),
-    { git: true, config: { formatter: false, lsp: false } },
-  )
 
-  it.instance(
-    "wakes v2 session execution by default",
-    () =>
-      Effect.gen(function* () {
-        const test = yield* TestInstance
-        const headers = { "x-opencode-directory": test.directory }
-        const session = yield* createSession({
-          title: "v2 prompt wake",
-          model: { providerID: ProviderV2.ID.make("test"), id: ModelV2.ID.make("embedded") },
-        })
-        const response = yield* request(`/api/session/${session.id}/prompt`, {
+        const wakeID = SessionMessage.ID.make("msg_http_wake")
+        const wake = yield* request(`/api/session/${session.id}/prompt`, {
           method: "POST",
           headers: { ...headers, "content-type": "application/json" },
-          body: JSON.stringify({ id: "msg_http_wake", prompt: { text: "hello" } }),
+          body: JSON.stringify({ id: wakeID, prompt: { text: "hello again" } }),
         })
-
-        expect(response.status).toBe(200)
-        const promoted = yield* Database.Service.use(({ db }) =>
-          db
-            .select({ promoted_seq: SessionInputTable.promoted_seq })
-            .from(SessionInputTable)
-            .where(eq(SessionInputTable.id, SessionMessage.ID.make("msg_http_wake")))
-            .get()
-            .pipe(Effect.orDie),
-        ).pipe(
-          Effect.filterOrFail((row): row is { promoted_seq: number } => typeof row?.promoted_seq === "number"),
-          Effect.retry(Schedule.spaced("10 millis")),
-          Effect.timeout("10 seconds"),
+        expect(wake.status).toBe(200)
+        const message = yield* pollWithTimeout(
+          requestJson<{ data: SessionMessage.Message[] }>(`/api/session/${session.id}/message`, { headers }).pipe(
+            Effect.map(({ data }) => data.find((message) => message.id === wakeID)),
+          ),
+          "V2 prompt was not promoted after wake",
+          "10 seconds",
         )
-        expect(promoted.promoted_seq).toBeNumber()
+        expect(message).toMatchObject({ id: wakeID, type: "user" })
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -4,7 +4,7 @@ import { NodeHttpServer, NodeServices } from "@effect/platform-node"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
-import { Cause, Config, Effect, Exit, Layer } from "effect"
+import { Cause, Config, Effect, Exit, Layer, Schedule } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse, HttpRouter, HttpServer } from "effect/unstable/http"
 import { layerWebSocketConstructorGlobal } from "effect/unstable/socket/Socket"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -581,7 +581,7 @@ describe("session HttpApi", () => {
           request(`/api/session/${session.id}/prompt`, {
             method: "POST",
             headers: { ...headers, "content-type": "application/json" },
-            body: JSON.stringify({ id: "msg_http_prompt", prompt: { text: "hello" } }),
+            body: JSON.stringify({ id: "msg_http_prompt", prompt: { text: "hello" }, resume: false }),
           })
         const first = yield* recordPrompt()
         const retried = yield* recordPrompt()
@@ -624,6 +624,40 @@ describe("session HttpApi", () => {
           message: "Prompt message ID conflicts with an existing durable record: msg_http_prompt",
           resource: "msg_http_prompt",
         })
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "wakes v2 session execution by default",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const session = yield* createSession({
+          title: "v2 prompt wake",
+          model: { providerID: ProviderV2.ID.make("test"), id: ModelV2.ID.make("embedded") },
+        })
+        const response = yield* request(`/api/session/${session.id}/prompt`, {
+          method: "POST",
+          headers: { ...headers, "content-type": "application/json" },
+          body: JSON.stringify({ id: "msg_http_wake", prompt: { text: "hello" } }),
+        })
+
+        expect(response.status).toBe(200)
+        const promoted = yield* Database.Service.use(({ db }) =>
+          db
+            .select({ promoted_seq: SessionInputTable.promoted_seq })
+            .from(SessionInputTable)
+            .where(eq(SessionInputTable.id, SessionMessage.ID.make("msg_http_wake")))
+            .get()
+            .pipe(Effect.orDie),
+        ).pipe(
+          Effect.filterOrFail((row): row is { promoted_seq: number } => typeof row?.promoted_seq === "number"),
+          Effect.retry(Schedule.spaced("10 millis")),
+          Effect.timeout("10 seconds"),
+        )
+        expect(promoted.promoted_seq).toBeNumber()
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -613,8 +613,7 @@ describe("session.compaction.create", () => {
         })
 
         const v2 = yield* SessionV2.Service.use((svc) => svc.messages({ sessionID: info.id })).pipe(
-          Effect.provide(SessionExecution.noopLayer),
-          Effect.provide(SessionV2.defaultLayer),
+          Effect.provide(SessionV2.defaultLayer.pipe(Layer.provide(SessionExecution.noopLayer))),
         )
         expect(v2.at(-1)).toMatchObject({
           type: "compaction",

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -654,8 +654,7 @@ noLLMServer.instance.skip(
       })
 
       const messages = yield* SessionV2.Service.use((session) => session.messages({ sessionID: chat.id })).pipe(
-        Effect.provide(SessionExecution.noopLayer),
-        Effect.provide(SessionV2.defaultLayer),
+        Effect.provide(SessionV2.defaultLayer.pipe(Layer.provide(SessionExecution.noopLayer))),
       )
       const { db } = yield* Database.Service
       const row = yield* db

--- a/packages/sdk-next/test/embedded.test.ts
+++ b/packages/sdk-next/test/embedded.test.ts
@@ -115,7 +115,7 @@ test("embedded client wakes session execution after prompt admission", async () 
       const context = yield* opencode.sessions.context({ sessionID }).pipe(
         Effect.filterOrFail((messages) => messages.some((message) => message.id === admitted.id)),
         Effect.retry(Schedule.spaced("10 millis")),
-        Effect.timeout("2 seconds"),
+        Effect.timeout("10 seconds"),
       )
 
       expect(context).toContainEqual(expect.objectContaining({ id: admitted.id, type: "user" }))

--- a/packages/sdk-next/test/embedded.test.ts
+++ b/packages/sdk-next/test/embedded.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Flag } from "@opencode-ai/core/flag/flag"
-import { Effect, Option, Schema, Stream } from "effect"
+import { Effect, Option, Schedule, Schema, Stream } from "effect"
 
 test("embedded client uses the real router and handlers", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-"))
@@ -80,6 +80,45 @@ test("embedded client uses the real router and handlers", async () => {
         "SessionNotFoundError",
       ])
       expect(missingMessage._tag).toBe("MessageNotFoundError")
+    })
+    await Effect.runPromise(Effect.scoped(program))
+  } finally {
+    Flag.OPENCODE_DB = database
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test("embedded client wakes session execution after prompt admission", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-wake-"))
+  const database = Flag.OPENCODE_DB
+  Flag.OPENCODE_DB = join(directory, "opencode.sqlite")
+  const { AbsolutePath, Location, Model, OpenCode, Prompt, Provider, Session } = await import("../src")
+  const sessionID = Session.ID.make(`ses_embedded_${crypto.randomUUID()}`)
+
+  try {
+    const program = Effect.gen(function* () {
+      const opencode = yield* OpenCode.create()
+      const admitted = yield* opencode.sessions
+        .create({
+          id: sessionID,
+          location: Location.Ref.make({ directory: AbsolutePath.make(directory) }),
+          model: Model.Ref.make({ id: Model.ID.make("embedded"), providerID: Provider.ID.make("test") }),
+        })
+        .pipe(
+          Effect.andThen(
+            opencode.sessions.prompt({
+              sessionID,
+              prompt: Prompt.make({ text: "Promote this input" }),
+            }),
+          ),
+        )
+      const context = yield* opencode.sessions.context({ sessionID }).pipe(
+        Effect.filterOrFail((messages) => messages.some((message) => message.id === admitted.id)),
+        Effect.retry(Schedule.spaced("10 millis")),
+        Effect.timeout("2 seconds"),
+      )
+
+      expect(context).toContainEqual(expect.objectContaining({ id: admitted.id, type: "user" }))
     })
     await Effect.runPromise(Effect.scoped(program))
   } finally {

--- a/packages/sdk-next/test/embedded.test.ts
+++ b/packages/sdk-next/test/embedded.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Flag } from "@opencode-ai/core/flag/flag"
-import { Effect, Option, Schedule, Schema, Stream } from "effect"
+import { Effect, Option, Schema, Stream } from "effect"
 
 test("embedded client uses the real router and handlers", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-"))
@@ -39,6 +39,17 @@ test("embedded client uses the real router and handlers", async () => {
         resume: false,
       })
       const context = yield* opencode.sessions.context({ sessionID })
+      const wake = yield* opencode.sessions.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Promote this input" }),
+      })
+      const prompted = yield* opencode.sessions.events({ sessionID }).pipe(
+        Stream.filter((event) => event.type === "session.next.prompted" && event.data.messageID === wake.id),
+        Stream.runHead,
+        Effect.timeout("10 seconds"),
+        Effect.map(Option.getOrThrow),
+      )
+      const wakeContext = yield* opencode.sessions.context({ sessionID })
       const event = yield* opencode.sessions
         .events({ sessionID })
         .pipe(Stream.take(1), Stream.runHead, Effect.map(Option.getOrUndefined))
@@ -71,6 +82,8 @@ test("embedded client uses the real router and handlers", async () => {
       expect(selected.model?.providerID).toBe(model.providerID)
       expect(page.data.some((session) => session.id === sessionID)).toBe(true)
       expect(admitted.sessionID).toBe(sessionID)
+      expect(prompted.type).toBe("session.next.prompted")
+      expect(wakeContext).toContainEqual(expect.objectContaining({ id: wake.id, type: "user" }))
       expect(context.some((message) => message.type === "model-switched")).toBe(true)
       expect(event).toMatchObject({ type: "session.next.model.switched", durable: { seq: 1 } })
       expect(message).toEqual(modelMessage)
@@ -80,45 +93,6 @@ test("embedded client uses the real router and handlers", async () => {
         "SessionNotFoundError",
       ])
       expect(missingMessage._tag).toBe("MessageNotFoundError")
-    })
-    await Effect.runPromise(Effect.scoped(program))
-  } finally {
-    Flag.OPENCODE_DB = database
-    await rm(directory, { recursive: true, force: true })
-  }
-})
-
-test("embedded client wakes session execution after prompt admission", async () => {
-  const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-wake-"))
-  const database = Flag.OPENCODE_DB
-  Flag.OPENCODE_DB = join(directory, "opencode.sqlite")
-  const { AbsolutePath, Location, Model, OpenCode, Prompt, Provider, Session } = await import("../src")
-  const sessionID = Session.ID.make(`ses_embedded_${crypto.randomUUID()}`)
-
-  try {
-    const program = Effect.gen(function* () {
-      const opencode = yield* OpenCode.create()
-      const admitted = yield* opencode.sessions
-        .create({
-          id: sessionID,
-          location: Location.Ref.make({ directory: AbsolutePath.make(directory) }),
-          model: Model.Ref.make({ id: Model.ID.make("embedded"), providerID: Provider.ID.make("test") }),
-        })
-        .pipe(
-          Effect.andThen(
-            opencode.sessions.prompt({
-              sessionID,
-              prompt: Prompt.make({ text: "Promote this input" }),
-            }),
-          ),
-        )
-      const context = yield* opencode.sessions.context({ sessionID }).pipe(
-        Effect.filterOrFail((messages) => messages.some((message) => message.id === admitted.id)),
-        Effect.retry(Schedule.spaced("10 millis")),
-        Effect.timeout("10 seconds"),
-      )
-
-      expect(context).toContainEqual(expect.objectContaining({ id: admitted.id, type: "user" }))
     })
     await Effect.runPromise(Effect.scoped(program))
   } finally {

--- a/packages/server/src/handlers.ts
+++ b/packages/server/src/handlers.ts
@@ -26,7 +26,7 @@ import { CredentialHandler } from "./handlers/credential"
 import { Credential } from "@opencode-ai/core/credential"
 import { ProjectCopyHandler } from "./handlers/project-copy"
 
-export const sessionRuntime = SessionV2.defaultLayer.pipe(
+const sessionLayer = SessionV2.defaultLayer.pipe(
   Layer.provide(SessionExecutionLocal.defaultLayer),
   Layer.provide(LocationServiceMap.layer),
 )
@@ -53,7 +53,7 @@ export const handlers = Layer.mergeAll(
 ).pipe(
   Layer.provide(sessionLocationLayer),
   Layer.provide(locationLayer),
-  Layer.provide(sessionRuntime),
+  Layer.provide(sessionLayer),
   Layer.provide(PermissionSaved.defaultLayer),
   Layer.provide(PtyTicket.defaultLayer),
   Layer.provide(LocationServiceMap.layer),

--- a/packages/server/src/handlers.ts
+++ b/packages/server/src/handlers.ts
@@ -26,6 +26,11 @@ import { CredentialHandler } from "./handlers/credential"
 import { Credential } from "@opencode-ai/core/credential"
 import { ProjectCopyHandler } from "./handlers/project-copy"
 
+export const sessionRuntime = SessionV2.defaultLayer.pipe(
+  Layer.provide(SessionExecutionLocal.defaultLayer),
+  Layer.provide(LocationServiceMap.layer),
+)
+
 export const handlers = Layer.mergeAll(
   HealthHandler,
   LocationHandler,
@@ -48,8 +53,7 @@ export const handlers = Layer.mergeAll(
 ).pipe(
   Layer.provide(sessionLocationLayer),
   Layer.provide(locationLayer),
-  Layer.provide(SessionV2.defaultLayer),
-  Layer.provide(SessionExecutionLocal.defaultLayer),
+  Layer.provide(sessionRuntime),
   Layer.provide(PermissionSaved.defaultLayer),
   Layer.provide(PtyTicket.defaultLayer),
   Layer.provide(LocationServiceMap.layer),


### PR DESCRIPTION
## Summary

- leave `SessionExecution` as an explicit host dependency of `SessionV2.defaultLayer` instead of capturing the recording-only no-op
- build one private local Session layer for the V2 HTTP handlers
- make `MoveSession` depend only on `SessionStore` instead of constructing or sharing an execution runtime
- remove redundant V2 runtime construction from the existing Session compatibility layer
- make recording-only tests explicitly provide `SessionExecution.noopLayer`

## Root cause

The server provided `SessionV2.defaultLayer` and `SessionExecutionLocal.defaultLayer` as siblings, but `SessionV2.defaultLayer` had already closed over `SessionExecution.noopLayer`. Embedded prompts were durably admitted and emitted `session.next.prompt.admitted`, but `wake()` did nothing, leaving every input unpromoted.

## Verification

- `packages/sdk-next`: embedded router test waits for the durable `session.next.prompted` event and confirms the public Session context contains the promoted Input
- `packages/opencode`: 18 focused Session HTTP tests pass, including default wake and explicit `resume: false`
- `packages/core`: 43 Session and MoveSession tests pass
- wake regressions use intentionally unavailable test model IDs and make no external model API requests
- affected Core, Server, sdk-next, and OpenCode package typechecks pass
- repository pre-push hook: all 29 package typechecks pass uncached
- formatting and diff checks pass