### PR TITLE
fix(opencode): preserve media mime types for run files

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -22,6 +22,7 @@ import { UI } from "../ui"
 import { effectCmd } from "../effect-cmd"
 import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
+import { isMedia } from "@/util/media"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
@@ -356,7 +357,7 @@ export const RunCommand = effectCmd({
           }
 
           const content = await (async () => {
-            if (!args.attach) return
+            if (!args.attach && !isMedia(FSUtil.mimeType(resolvedPath))) return
             const handle = await open(resolvedPath, "r")
             try {
               const opened = await handle.stat()
@@ -382,7 +383,9 @@ export const RunCommand = effectCmd({
           const mime = !args.attach
             ? isDirectory
               ? "application/x-directory"
-              : "text/plain"
+              : isMedia(detected)
+                ? detected
+                : "text/plain"
             : content && text !== undefined && Buffer.from(text, "utf8").equals(content)
               ? "text/plain"
               : detected

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -5,7 +5,7 @@ export function isPdfAttachment(mime: string) {
 }
 
 export function isMedia(mime: string) {
-  return mime.startsWith("image/") || isPdfAttachment(mime)
+  return mime.startsWith("image/") || mime.startsWith("audio/") || mime.startsWith("video/") || isPdfAttachment(mime)
 }
 
 export function isImageAttachment(mime: string) {

--- a/packages/opencode/test/util/media.test.ts
+++ b/packages/opencode/test/util/media.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { isMedia, isImageAttachment, isPdfAttachment } from "@/util/media"
+
+describe("isMedia", () => {
+  test("recognizes images", () => {
+    expect(isMedia("image/png")).toBe(true)
+    expect(isMedia("image/jpeg")).toBe(true)
+    expect(isMedia("image/webp")).toBe(true)
+    expect(isMedia("image/gif")).toBe(true)
+  })
+
+  test("recognizes video", () => {
+    expect(isMedia("video/mp4")).toBe(true)
+    expect(isMedia("video/webm")).toBe(true)
+    expect(isMedia("video/quicktime")).toBe(true)
+  })
+
+  test("recognizes audio", () => {
+    expect(isMedia("audio/mp3")).toBe(true)
+    expect(isMedia("audio/mpeg")).toBe(true)
+    expect(isMedia("audio/wav")).toBe(true)
+    expect(isMedia("audio/ogg")).toBe(true)
+  })
+
+  test("recognizes pdf", () => {
+    expect(isMedia("application/pdf")).toBe(true)
+  })
+
+  test("rejects non-media types", () => {
+    expect(isMedia("text/plain")).toBe(false)
+    expect(isMedia("application/json")).toBe(false)
+    expect(isMedia("text/html")).toBe(false)
+  })
+})
+
+describe("isImageAttachment", () => {
+  test("matches image mime types", () => {
+    expect(isImageAttachment("image/png")).toBe(true)
+    expect(isImageAttachment("video/mp4")).toBe(false)
+  })
+})
+
+describe("isPdfAttachment", () => {
+  test("matches pdf mime type", () => {
+    expect(isPdfAttachment("application/pdf")).toBe(true)
+    expect(isPdfAttachment("image/png")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

`opencode run --file video.mp4` silently sets the mime type to `text/plain` when no `--attach` flag is provided. This prevents multimodal models from receiving video, audio, or PDF content in their native format.

## Changes

- **`packages/opencode/src/util/media.ts`**: Extend `isMedia()` to cover `video/*` and `audio/*` types alongside existing `image/*` and `application/pdf`.
- **`packages/opencode/src/cli/cmd/run.ts`**: Read file content for media files in non-attach mode so they enter the normal attachment pipeline. Preserve the detected mime type instead of falling back to `text/plain`.
- **`packages/opencode/test/util/media.test.ts`**: Unit tests for `isMedia`, `isImageAttachment`, and `isPdfAttachment`.

## Before

```bash
opencode run --file clip.mp4 -p "describe this video"
# mime type: text/plain — model receives raw bytes as text
```

## After

```bash
opencode run --file clip.mp4 -p "describe this video"
# mime type: video/mp4 — model receives native video content
```

## Test plan

- `bun test test/util/media.test.ts` (7 tests, all pass)
- Turborepo typecheck passes across all 29 packages