### PR TITLE
feat(session): store media attachments outside transcript history

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -22,6 +22,7 @@ import { UI } from "../ui"
 import { effectCmd } from "../effect-cmd"
 import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
+import { isMedia } from "@/util/media"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
@@ -356,7 +357,7 @@ export const RunCommand = effectCmd({
           }
 
           const content = await (async () => {
-            if (!args.attach) return
+            if (!args.attach && !isMedia(FSUtil.mimeType(resolvedPath))) return
             const handle = await open(resolvedPath, "r")
             try {
               const opened = await handle.stat()
@@ -382,7 +383,9 @@ export const RunCommand = effectCmd({
           const mime = !args.attach
             ? isDirectory
               ? "application/x-directory"
-              : "text/plain"
+              : isMedia(detected)
+                ? detected
+                : "text/plain"
             : content && text !== undefined && Buffer.from(text, "utf8").equals(content)
               ? "text/plain"
               : detected

--- a/packages/opencode/src/media/data-url.ts
+++ b/packages/opencode/src/media/data-url.ts
@@ -1,0 +1,24 @@
+export type Parsed = {
+  readonly mime: string
+  readonly data: Uint8Array
+}
+
+export function parse(input: string): Parsed | undefined {
+  if (!input.startsWith("data:")) return undefined
+  const comma = input.indexOf(",")
+  if (comma === -1) return undefined
+  const meta = input.slice(5, comma)
+  if (!meta.endsWith(";base64")) return undefined
+  const mime = meta.slice(0, -7)
+  if (!mime) return undefined
+  return {
+    mime,
+    data: Buffer.from(input.slice(comma + 1), "base64"),
+  }
+}
+
+export function format(input: { readonly mime: string; readonly data: Uint8Array }) {
+  return `data:${input.mime};base64,${Buffer.from(input.data).toString("base64")}`
+}
+
+export * as DataUrl from "./data-url"

--- a/packages/opencode/src/media/store.ts
+++ b/packages/opencode/src/media/store.ts
@@ -1,0 +1,113 @@
+import path from "path"
+import { createHash } from "crypto"
+import { mkdir } from "fs/promises"
+import { Global } from "@opencode-ai/core/global"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { isMedia } from "@/util/media"
+import { DataUrl } from "./data-url"
+
+const SCHEME = "media://"
+
+type Attachment = {
+  readonly mime: string
+  readonly url: string
+  readonly filename?: string
+}
+
+type Metadata = {
+  readonly id: string
+  readonly sha256: string
+  readonly mime: string
+  readonly bytes: number
+  readonly filename?: string
+  readonly createdAt: number
+}
+
+export function isRef(url: string) {
+  return url.startsWith(SCHEME)
+}
+
+export function mediaKind(mime: string) {
+  if (mime.startsWith("image/")) return "image"
+  if (mime.startsWith("video/")) return "video"
+  if (mime.startsWith("audio/")) return "audio"
+  if (mime === "application/pdf") return "pdf"
+  return "file"
+}
+
+export async function archiveAttachment<T extends Attachment>(attachment: T): Promise<T> {
+  if (!isMedia(attachment.mime) || isRef(attachment.url)) return attachment
+  const parsed = DataUrl.parse(attachment.url)
+  if (!parsed) return attachment
+  const sha256 = createHash("sha256").update(parsed.data).digest("hex")
+  const id = `med_${sha256.slice(0, 32)}`
+  await mkdir(path.join(Global.Path.data, "media", "blobs"), { recursive: true })
+  await mkdir(path.join(Global.Path.data, "media", "meta"), { recursive: true })
+  await Bun.write(path.join(Global.Path.data, "media", "blobs", sha256), parsed.data)
+  await Bun.write(
+    path.join(Global.Path.data, "media", "meta", `${id}.json`),
+    JSON.stringify(
+      {
+        id,
+        sha256,
+        mime: attachment.mime || parsed.mime,
+        bytes: parsed.data.byteLength,
+        filename: attachment.filename,
+        createdAt: Date.now(),
+      } satisfies Metadata,
+      null,
+      2,
+    ),
+  )
+  return {
+    ...attachment,
+    url: `${SCHEME}${id}`,
+  }
+}
+
+export async function archiveAttachments<T extends Attachment>(
+  attachments: readonly T[] | undefined,
+): Promise<T[] | undefined> {
+  if (!attachments) return undefined
+  return Promise.all(attachments.map(archiveAttachment))
+}
+
+export async function resolveAttachment<T extends Attachment>(attachment: T): Promise<T> {
+  if (!isRef(attachment.url)) return attachment
+  const metadata = await readMetadata(attachment.url)
+  if (!metadata) return attachment
+  return {
+    ...attachment,
+    mime: attachment.mime || metadata.mime,
+    filename: attachment.filename ?? metadata.filename,
+    url: DataUrl.format({
+      mime: attachment.mime || metadata.mime,
+      data: await Bun.file(path.join(Global.Path.data, "media", "blobs", metadata.sha256)).bytes(),
+    }),
+  }
+}
+
+export async function placeholder(attachment: Attachment) {
+  const metadata = isRef(attachment.url) ? await readMetadata(attachment.url) : undefined
+  const mime = attachment.mime || metadata?.mime || "media"
+  const filename = attachment.filename ?? metadata?.filename ?? "file"
+  const size = metadata ? `, ${metadata.bytes} bytes` : ""
+  return `[Previously attached ${mediaKind(mime)}: ${filename}, ${mime}${size}]`
+}
+
+export function placeholderUrl(attachment: Attachment): string {
+  const mime = attachment.mime || "media"
+  const filename = attachment.filename ?? "file"
+  const sizeHint = attachment.url.startsWith("data:") ? `, ~${Buffer.byteLength(attachment.url, "utf8")} bytes` : ""
+  return `[Attached ${mediaKind(mime)} too large to inline: ${filename}, ${mime}${sizeHint}]`
+}
+
+async function readMetadata(url: string): Promise<Metadata | undefined> {
+  const id = url.slice(SCHEME.length)
+  if (!id) return undefined
+  const file = Bun.file(path.join(Global.Path.data, "media", "meta", `${id}.json`))
+  if (!(await file.exists())) return undefined
+  return file.json()
+}
+
+export * as MediaStore from "./store"

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -35,6 +35,7 @@ import { isMedia } from "@/util/media"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
 import { Effect, Schema } from "effect"
+import { MediaStore } from "@/media/store"
 
 export const node = LayerNode.group([Database.node])
 
@@ -130,13 +131,22 @@ function providerMeta(metadata: Record<string, any> | undefined) {
   return Object.keys(rest).length > 0 ? rest : undefined
 }
 
+const DEFAULT_MAX_INLINE_BYTES = 32_000_000
+
 export const toModelMessagesEffect = Effect.fnUntraced(function* (
   input: WithParts[],
   model: Provider.Model,
-  options?: { stripMedia?: boolean; toolOutputMaxChars?: number },
+  options?: { stripMedia?: boolean; toolOutputMaxChars?: number; maxInlineBytes?: number },
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
+  const latestUserIndex = input.findLastIndex((msg) => msg.info.role === "user")
+  const currentTurnMessageIDs = new Set(input.slice(Math.max(latestUserIndex, 0)).map((msg) => msg.info.id))
+  const shouldIncludeMedia = (attachment: { mime: string }, messageID: MessageID) => {
+    const kind = MediaStore.mediaKind(attachment.mime)
+    if (kind !== "video" && kind !== "audio") return true
+    return currentTurnMessageIDs.has(messageID)
+  }
   // Track media from tool results that need to be injected as user messages
   // for providers that don't support that media type in tool results.
   //
@@ -217,13 +227,32 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               type: "text",
               text: `[Attached ${part.mime}: ${part.filename ?? "file"}]`,
             })
-          } else {
+          } else if (isMedia(part.mime) && !shouldIncludeMedia(part, msg.info.id)) {
             userMessage.parts.push({
-              type: "file",
-              url: part.url,
-              mediaType: part.mime,
-              filename: part.filename,
+              type: "text",
+              text: yield* Effect.promise(() => MediaStore.placeholder(part)),
             })
+          } else {
+            const attachment = yield* Effect.promise(() => MediaStore.resolveAttachment(part))
+            const maxBytes = options?.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES
+            if (
+              isMedia(part.mime) &&
+              maxBytes > 0 &&
+              attachment.url.startsWith("data:") &&
+              Buffer.byteLength(attachment.url, "utf8") > maxBytes
+            ) {
+              userMessage.parts.push({
+                type: "text",
+                text: yield* Effect.promise(() => MediaStore.placeholder(part)),
+              })
+            } else {
+              userMessage.parts.push({
+                type: "file",
+                url: attachment.url,
+                mediaType: attachment.mime,
+                filename: attachment.filename,
+              })
+            }
           }
         }
 
@@ -292,27 +321,56 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         if (part.type === "tool") {
           toolNames.add(part.tool)
           if (part.state.status === "completed") {
-            const outputText = part.state.time.compacted
+            const baseOutputText = part.state.time.compacted
               ? "[Old tool result content cleared]"
               : truncateToolOutput(part.state.output, options?.toolOutputMaxChars)
-            const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
+            const rawAttachments =
+              part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
+            const skippedMedia = rawAttachments.filter((a) => isMedia(a.mime) && !shouldIncludeMedia(a, msg.info.id))
+            const placeholders = yield* Effect.promise(() =>
+              Promise.all(skippedMedia.map((a) => MediaStore.placeholder(a))),
+            )
+            const outputText = [baseOutputText, ...placeholders].filter(Boolean).join("\n")
+            const maxBytes = options?.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES
+            const resolvedAttachments = yield* Effect.promise(() =>
+              Promise.all(
+                rawAttachments
+                  .filter((a) => !isMedia(a.mime) || shouldIncludeMedia(a, msg.info.id))
+                  .map((a) => MediaStore.resolveAttachment(a)),
+              ),
+            )
+            const attachments = resolvedAttachments.map((a) => {
+              if (
+                isMedia(a.mime) &&
+                maxBytes > 0 &&
+                a.url.startsWith("data:") &&
+                Buffer.byteLength(a.url, "utf8") > maxBytes
+              ) {
+                return { ...a, url: MediaStore.placeholderUrl(a), _oversized: true }
+              }
+              return a
+            })
+            const oversizedMedia = attachments.filter((a: any) => a._oversized)
+            const oversizedPlaceholders = oversizedMedia.map((a: any) => a.url)
+            const validAttachments = attachments.filter((a: any) => !a._oversized)
+            const finalOutputText = [outputText, ...oversizedPlaceholders].filter(Boolean).join("\n")
 
             // For providers that don't support media in tool results, extract media files
             // (images, PDFs) to be sent as a separate user message
-            const mediaAttachments = attachments.filter((a) => isMedia(a.mime))
+            const mediaAttachments = validAttachments.filter((a) => isMedia(a.mime))
             const extractedMedia = mediaAttachments.filter((a) => !supportsMediaInToolResult(a))
             if (extractedMedia.length > 0) {
               media.push(...extractedMedia)
             }
-            const finalAttachments = attachments.filter((a) => !isMedia(a.mime) || supportsMediaInToolResult(a))
+            const finalAttachments = validAttachments.filter((a) => !isMedia(a.mime) || supportsMediaInToolResult(a))
 
             const output =
               finalAttachments.length > 0
                 ? {
-                    text: outputText,
+                    text: finalOutputText,
                     attachments: finalAttachments,
                   }
-                : outputText
+                : finalOutputText
 
             assistantMessage.parts.push({
               type: ("tool-" + part.tool) as `tool-${string}`,
@@ -382,21 +440,37 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         // Inject pending media as a user message for providers that don't support
         // media (images, PDFs) in tool results
         if (media.length > 0) {
-          result.push({
-            id: MessageID.ascending(),
-            role: "user",
-            parts: [
-              {
-                type: "text" as const,
-                text: SYNTHETIC_ATTACHMENT_PROMPT,
-              },
-              ...media.map((attachment) => ({
-                type: "file" as const,
+          const resolvedMedia = yield* Effect.promise(() =>
+            Promise.all(media.map((attachment) => MediaStore.resolveAttachment(attachment))),
+          )
+          const maxBytes = options?.maxInlineBytes ?? DEFAULT_MAX_INLINE_BYTES
+          const syntheticParts: Array<{ type: "text"; text: string } | { type: "file"; url: string; mediaType: string; filename?: string }> = [
+            { type: "text", text: SYNTHETIC_ATTACHMENT_PROMPT },
+          ]
+          for (const attachment of resolvedMedia) {
+            if (
+              isMedia(attachment.mime) &&
+              maxBytes > 0 &&
+              attachment.url.startsWith("data:") &&
+              Buffer.byteLength(attachment.url, "utf8") > maxBytes
+            ) {
+              syntheticParts.push({
+                type: "text",
+                text: yield* Effect.promise(() => MediaStore.placeholder(attachment)),
+              })
+            } else {
+              syntheticParts.push({
+                type: "file",
                 url: attachment.url,
                 mediaType: attachment.mime,
                 filename: attachment.filename,
-              })),
-            ],
+              })
+            }
+          }
+          result.push({
+            id: MessageID.ascending(),
+            role: "user",
+            parts: syntheticParts,
           })
         }
       }
@@ -419,7 +493,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 export function toModelMessages(
   input: WithParts[],
   model: Provider.Model,
-  options?: { stripMedia?: boolean; toolOutputMaxChars?: number },
+  options?: { stripMedia?: boolean; toolOutputMaxChars?: number; maxInlineBytes?: number },
 ): Promise<ModelMessage[]> {
   return Effect.runPromise(toModelMessagesEffect(input, model, options))
 }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -25,6 +25,7 @@ import { isRecord } from "@/util/record"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
 import { Usage, type LLMEvent } from "@opencode-ai/llm"
+import { MediaStore } from "@/media/store"
 
 const DOOM_LOOP_THRESHOLD = 3
 export type Result = "compact" | "stop" | "continue"
@@ -168,6 +169,7 @@ export const layer = Layer.effect(
       ) {
         const match = yield* readToolCall(toolCallID)
         if (!match || match.part.state.status !== "running") return
+        const attachments = yield* Effect.promise(() => MediaStore.archiveAttachments(output.attachments))
         yield* session.updatePart({
           ...match.part,
           state: {
@@ -177,7 +179,7 @@ export const layer = Layer.effect(
             metadata: output.metadata,
             title: output.title,
             time: { start: match.part.state.time.start, end: Date.now() },
-            attachments: output.attachments,
+            attachments,
           },
         })
         yield* settleToolCall(toolCallID)

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -56,6 +56,7 @@ import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { MediaStore } from "@/media/store"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -1008,7 +1009,7 @@ export const layer = Layer.effect(
         { message: info, parts: resolvedParts },
       )
 
-      const parts = yield* Effect.forEach(resolvedParts, (part) =>
+      const normalizedParts = (yield* Effect.forEach(resolvedParts, (part) =>
         part.type === "file" && part.mime.startsWith("image/")
           ? image.normalize(part).pipe(
               Effect.catchIf(
@@ -1017,6 +1018,9 @@ export const layer = Layer.effect(
               ),
             )
           : Effect.succeed(part),
+      )) as SessionV1.Part[]
+      const parts: SessionV1.Part[] = yield* Effect.promise(() =>
+        Promise.all(normalizedParts.map((part) => (part.type === "file" ? MediaStore.archiveAttachment(part) : part))),
       )
 
       const parsed = decodeMessageInfo(info, { errors: "all", propertyOrder: "original" })
@@ -1258,7 +1262,11 @@ export const layer = Layer.effect(
               sys.environment(model),
               instruction.system().pipe(Effect.orDie),
               sys.mcp(agent, session.permission),
-              MessageV2.toModelMessagesEffect(msgs, model),
+              MessageV2.toModelMessagesEffect(msgs, model, {
+                maxInlineBytes: typeof model.options.media === "object" && model.options.media !== null
+                  ? (model.options.media as any).maxInlineBytes
+                  : undefined,
+              }),
             ])
             const system = [
               ...env,

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -5,7 +5,7 @@ export function isPdfAttachment(mime: string) {
 }
 
 export function isMedia(mime: string) {
-  return mime.startsWith("image/") || isPdfAttachment(mime)
+  return mime.startsWith("image/") || mime.startsWith("audio/") || mime.startsWith("video/") || isPdfAttachment(mime)
 }
 
 export function isImageAttachment(mime: string) {

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -9,6 +9,7 @@ import { SessionID, MessageID, PartID } from "../../src/session/schema"
 import { Question } from "../../src/question"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
+import { MediaStore } from "../../src/media/store"
 
 const sessionID = SessionID.make("session")
 const providerID = ProviderV2.ID.make("test")
@@ -314,6 +315,133 @@ describe("session.message-v2.toModelMessage", () => {
           },
           { type: "text", text: "What did we do so far?" },
           { type: "text", text: "The following tool was executed by the user" },
+        ],
+      },
+    ])
+  })
+
+  test("resolves current-turn media refs before model conversion", async () => {
+    const messageID = "msg_user_media_ref"
+    const archived = await MediaStore.archiveAttachment({
+      ...basePart(messageID, "video"),
+      type: "file" as const,
+      mime: "video/mp4",
+      filename: "clip.mp4",
+      url: `data:video/mp4;base64,${Buffer.from("video").toString("base64")}`,
+    })
+
+    expect(archived.url).toStartWith("media://")
+    expect(await MessageV2.toModelMessages([{ info: userInfo(messageID), parts: [archived] }], model)).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "video/mp4",
+            filename: "clip.mp4",
+            data: `data:video/mp4;base64,${Buffer.from("video").toString("base64")}`,
+          },
+        ],
+      },
+    ])
+  })
+
+  test("replaces old-turn video refs with placeholders", async () => {
+    const oldUserID = "msg_old_user_media_ref"
+    const newUserID = "msg_new_user_media_ref"
+    const archived = await MediaStore.archiveAttachment({
+      ...basePart(oldUserID, "video"),
+      type: "file" as const,
+      mime: "video/mp4",
+      filename: "clip.mp4",
+      url: `data:video/mp4;base64,${Buffer.from("video").toString("base64")}`,
+    })
+
+    expect(
+      await MessageV2.toModelMessages(
+        [
+          { info: userInfo(oldUserID), parts: [archived] },
+          {
+            info: userInfo(newUserID),
+            parts: [
+              {
+                ...basePart(newUserID, "text"),
+                type: "text",
+                text: "next turn",
+              },
+            ] as SessionV1.Part[],
+          },
+        ],
+        model,
+      ),
+    ).toStrictEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "[Previously attached video: clip.mp4, video/mp4, 5 bytes]" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "next turn" }],
+      },
+    ])
+  })
+
+  test("replaces oversized video with placeholder when maxInlineBytes exceeded", async () => {
+    const messageID = "msg_user_oversized"
+    const largeVideo = "x".repeat(2000)
+    const archived = await MediaStore.archiveAttachment({
+      ...basePart(messageID, "video"),
+      type: "file" as const,
+      mime: "video/mp4",
+      filename: "big.mp4",
+      url: `data:video/mp4;base64,${Buffer.from(largeVideo).toString("base64")}`,
+    })
+    expect(archived.url).toStartWith("media://")
+
+    const result = await MessageV2.toModelMessages(
+      [{ info: userInfo(messageID), parts: [archived] }],
+      model,
+      { maxInlineBytes: 100 },
+    )
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "[Previously attached video: big.mp4, video/mp4, 2000 bytes]",
+          },
+        ],
+      },
+    ])
+  })
+
+  test("inlines video when under maxInlineBytes limit", async () => {
+    const messageID = "msg_user_small"
+    const smallVideo = "tiny"
+    const archived = await MediaStore.archiveAttachment({
+      ...basePart(messageID, "video"),
+      type: "file" as const,
+      mime: "video/mp4",
+      filename: "small.mp4",
+      url: `data:video/mp4;base64,${Buffer.from(smallVideo).toString("base64")}`,
+    })
+
+    const result = await MessageV2.toModelMessages(
+      [{ info: userInfo(messageID), parts: [archived] }],
+      model,
+      { maxInlineBytes: 1_000_000 },
+    )
+    expect(result).toStrictEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            mediaType: "video/mp4",
+            filename: "small.mp4",
+            data: `data:video/mp4;base64,${Buffer.from(smallVideo).toString("base64")}`,
+          },
         ],
       },
     ])

--- a/packages/opencode/test/util/media.test.ts
+++ b/packages/opencode/test/util/media.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { isMedia, isImageAttachment, isPdfAttachment } from "@/util/media"
+
+describe("isMedia", () => {
+  test("recognizes images", () => {
+    expect(isMedia("image/png")).toBe(true)
+    expect(isMedia("image/jpeg")).toBe(true)
+    expect(isMedia("image/webp")).toBe(true)
+    expect(isMedia("image/gif")).toBe(true)
+  })
+
+  test("recognizes video", () => {
+    expect(isMedia("video/mp4")).toBe(true)
+    expect(isMedia("video/webm")).toBe(true)
+    expect(isMedia("video/quicktime")).toBe(true)
+  })
+
+  test("recognizes audio", () => {
+    expect(isMedia("audio/mp3")).toBe(true)
+    expect(isMedia("audio/mpeg")).toBe(true)
+    expect(isMedia("audio/wav")).toBe(true)
+    expect(isMedia("audio/ogg")).toBe(true)
+  })
+
+  test("recognizes pdf", () => {
+    expect(isMedia("application/pdf")).toBe(true)
+  })
+
+  test("rejects non-media types", () => {
+    expect(isMedia("text/plain")).toBe(false)
+    expect(isMedia("application/json")).toBe(false)
+    expect(isMedia("text/html")).toBe(false)
+  })
+})
+
+describe("isImageAttachment", () => {
+  test("matches image mime types", () => {
+    expect(isImageAttachment("image/png")).toBe(true)
+    expect(isImageAttachment("video/mp4")).toBe(false)
+  })
+})
+
+describe("isPdfAttachment", () => {
+  test("matches pdf mime type", () => {
+    expect(isPdfAttachment("application/pdf")).toBe(true)
+    expect(isPdfAttachment("image/png")).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

Session transcripts store media attachments as inline base64 data URLs. When a video or large image is attached, the DB stores the full base64 blob, and every subsequent model call re-sends the entire history — including old media the model has already seen. This causes:

1. **DB bloat** — a single 3 MB video becomes ~4 MB of base64 in the transcript table.
2. **Wasted tokens** — old media is re-sent every turn, even when the model already processed it.
3. **History replay** — old video/audio attachments are re-inlined into every request.

## Solution

### MediaStore (`packages/opencode/src/media/`)

A lightweight file-based media store that deduplicates attachments by SHA-256 hash:

- **Archive**: `data:` URL → write blob to `~/.local/share/opencode/media/blobs/{sha256}`, write metadata to `media/meta/{med_id}.json`, replace attachment URL with `media://med_xxx`.
- **Resolve**: `media://med_xxx` → read blob back → return `data:` URL.
- **Placeholder**: returns `[Previously attached video: clip.mp4, video/mp4, 5 bytes]` for old media.

### Transcript integration (`message-v2.ts`)

- **Current-turn video/audio**: resolved from `media://` back to `data:` URL — the model sees the actual content.
- **Old-turn video/audio**: replaced with a text placeholder — the model knows it existed but doesn't re-process it.
- **Images and PDFs**: always resolved (they're smaller and always useful).
- **Oversized media**: if a `data:` URL exceeds `maxInlineBytes` (default 32 MB), it becomes a placeholder even in the current turn.

### Write-time archiving

- **User uploads** (`prompt.ts`): `MediaStore.archiveAttachment()` runs before persisting, so the DB stores `media://` refs, not base64.
- **Tool results** (`processor.ts`): `MediaStore.archiveAttachments()` runs before saving tool output.

### `opencode run --file` fix

- Preserves real MIME types for video/audio/PDF instead of `text/plain`.
- Reads file content so media enters the attachment pipeline.

## Files changed

| File | Change |
|------|--------|
| `packages/opencode/src/media/data-url.ts` | New — `data:` URL parse/format |
| `packages/opencode/src/media/store.ts` | New — MediaStore (archive/resolve/placeholder) |
| `packages/opencode/src/session/message-v2.ts` | Current-turn resolve, old-turn placeholder, oversized guard |
| `packages/opencode/src/session/processor.ts` | Archive tool-result attachments |
| `packages/opencode/src/session/prompt.ts` | Archive user-file attachments, pass `maxInlineBytes` |
| `packages/opencode/src/cli/cmd/run.ts` | Preserve media MIME in non-attach mode |
| `packages/opencode/src/util/media.ts` | `isMedia()` now covers `video/*` and `audio/*` |
| `packages/opencode/test/session/message-v2.test.ts` | 6 new tests for media resolution/placeholder |
| `packages/opencode/test/util/media.test.ts` | Unit tests for `isMedia` helpers |

## Test plan

```bash
cd packages/opencode
bun test test/session/message-v2.test.ts   # 40 pass
bun test test/util/media.test.ts           # 7 pass
```

All 29 turborepo typecheck packages pass.