### PR TITLE
feat(core): support video, audio, and PDF in openai-compatible converter

### DIFF
--- a/packages/core/src/github-copilot/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/core/src/github-copilot/chat/convert-to-openai-compatible-chat-messages.ts
@@ -7,7 +7,21 @@ import type { OpenAICompatibleChatPrompt } from "./openai-compatible-api-types"
 import { convertToBase64 } from "@ai-sdk/provider-utils"
 
 function getOpenAIMetadata(message: { providerOptions?: SharedV3ProviderOptions }) {
-  return message?.providerOptions?.copilot ?? {}
+  const options = message?.providerOptions
+  if (!options) return {}
+  return options.copilot ?? options.openaiCompatible ?? options.openai ?? {}
+}
+
+function audioFormatFromMime(mime: string): "wav" | "mp3" | null {
+  switch (mime) {
+    case "audio/wav":
+      return "wav"
+    case "audio/mp3":
+    case "audio/mpeg":
+      return "mp3"
+    default:
+      return null
+  }
 }
 
 export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Prompt): OpenAICompatibleChatPrompt {
@@ -56,6 +70,51 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
                     },
                     ...partMetadata,
                   }
+                } else if (part.mediaType.startsWith("video/")) {
+                  return {
+                    type: "video_url",
+                    video_url: {
+                      url:
+                        part.data instanceof URL
+                          ? part.data.toString()
+                          : `data:${part.mediaType};base64,${convertToBase64(part.data)}`,
+                    },
+                    ...partMetadata,
+                  }
+                } else if (part.mediaType.startsWith("audio/")) {
+                  if (part.data instanceof URL) {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: "audio file parts with URLs",
+                    })
+                  }
+                  const format = audioFormatFromMime(part.mediaType)
+                  if (!format) {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: `audio media type ${part.mediaType}`,
+                    })
+                  }
+                  return {
+                    type: "input_audio",
+                    input_audio: {
+                      data: convertToBase64(part.data),
+                      format,
+                    },
+                    ...partMetadata,
+                  }
+                } else if (part.mediaType === "application/pdf") {
+                  if (part.data instanceof URL) {
+                    throw new UnsupportedFunctionalityError({
+                      functionality: "PDF file parts with URLs",
+                    })
+                  }
+                  return {
+                    type: "file",
+                    file: {
+                      filename: part.filename ?? "document.pdf",
+                      file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
+                    },
+                    ...partMetadata,
+                  }
                 } else {
                   throw new UnsupportedFunctionalityError({
                     functionality: `file part media type ${part.mediaType}`,
@@ -74,6 +133,7 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
         let text = ""
         let reasoningText: string | undefined
         let reasoningOpaque: string | undefined
+        let reasoningCombined = ""
         const toolCalls: Array<{
           id: string
           type: "function"
@@ -95,7 +155,10 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
               break
             }
             case "reasoning": {
-              if (part.text) reasoningText = part.text
+              if (part.text) {
+                reasoningText = part.text
+                reasoningCombined += part.text
+              }
               break
             }
             case "tool-call": {
@@ -119,6 +182,9 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           reasoning_text: reasoningOpaque ? reasoningText : undefined,
           reasoning_opaque: reasoningOpaque,
+          ...(reasoningCombined.length > 0 && !reasoningOpaque
+            ? { reasoning_content: reasoningCombined }
+            : {}),
           ...metadata,
         })
 

--- a/packages/core/src/github-copilot/chat/openai-compatible-api-types.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-api-types.ts
@@ -27,7 +27,12 @@ export interface OpenAICompatibleUserMessage extends JsonRecord<OpenAICompatible
   content: string | Array<OpenAICompatibleContentPart>
 }
 
-export type OpenAICompatibleContentPart = OpenAICompatibleContentPartText | OpenAICompatibleContentPartImage
+export type OpenAICompatibleContentPart =
+  | OpenAICompatibleContentPartText
+  | OpenAICompatibleContentPartImage
+  | OpenAICompatibleContentPartVideo
+  | OpenAICompatibleContentPartAudio
+  | OpenAICompatibleContentPartFile
 
 export interface OpenAICompatibleContentPartImage extends JsonRecord {
   type: "image_url"
@@ -39,6 +44,21 @@ export interface OpenAICompatibleContentPartText extends JsonRecord {
   text: string
 }
 
+export interface OpenAICompatibleContentPartVideo extends JsonRecord {
+  type: "video_url"
+  video_url: { url: string }
+}
+
+export interface OpenAICompatibleContentPartAudio extends JsonRecord {
+  type: "input_audio"
+  input_audio: { data: string; format: string }
+}
+
+export interface OpenAICompatibleContentPartFile extends JsonRecord {
+  type: "file"
+  file: { filename?: string; file_data: string }
+}
+
 export interface OpenAICompatibleAssistantMessage extends JsonRecord<OpenAICompatibleMessageToolCall> {
   role: "assistant"
   content?: string | null
@@ -46,6 +66,8 @@ export interface OpenAICompatibleAssistantMessage extends JsonRecord<OpenAICompa
   // Copilot-specific reasoning fields
   reasoning_text?: string
   reasoning_opaque?: string
+  // OpenAI-compatible reasoning field for non-Copilot providers
+  reasoning_content?: string
 }
 
 export interface OpenAICompatibleMessageToolCall extends JsonRecord {

--- a/packages/core/test/github-copilot/convert-to-copilot-messages.test.ts
+++ b/packages/core/test/github-copilot/convert-to-copilot-messages.test.ts
@@ -137,6 +137,100 @@ describe("user messages", () => {
       },
     ])
   })
+
+  test("should convert video file parts to video_url", () => {
+    const videoData = Buffer.from([0, 1, 2, 3]).toString("base64")
+    const result = convertToCopilotMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this video" },
+          {
+            type: "file",
+            data: videoData,
+            mediaType: "video/mp4",
+          },
+        ],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe this video" },
+          {
+            type: "video_url",
+            video_url: { url: `data:video/mp4;base64,${videoData}` },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("should convert audio file parts to input_audio", () => {
+    const audioData = Buffer.from([0, 1, 2, 3]).toString("base64")
+    const result = convertToCopilotMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Transcribe this" },
+          {
+            type: "file",
+            data: audioData,
+            mediaType: "audio/wav",
+          },
+        ],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Transcribe this" },
+          {
+            type: "input_audio",
+            input_audio: { data: audioData, format: "wav" },
+          },
+        ],
+      },
+    ])
+  })
+
+  test("should convert PDF file parts to file", () => {
+    const pdfData = Buffer.from([0, 1, 2, 3]).toString("base64")
+    const result = convertToCopilotMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Summarize this" },
+          {
+            type: "file",
+            data: pdfData,
+            mediaType: "application/pdf",
+            filename: "report.pdf",
+          },
+        ],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Summarize this" },
+          {
+            type: "file",
+            file: {
+              filename: "report.pdf",
+              file_data: `data:application/pdf;base64,${pdfData}`,
+            },
+          },
+        ],
+      },
+    ])
+  })
 })
 
 describe("assistant messages", () => {
@@ -383,6 +477,9 @@ describe("reasoning (copilot-specific)", () => {
       },
     ])
 
+    // When there is no Copilot-specific reasoning_opaque, the converter must
+    // not surface reasoning_text. Reasoning is still preserved for generic
+    // OpenAI-compatible providers via reasoning_content.
     expect(result).toEqual([
       {
         role: "assistant",
@@ -390,6 +487,7 @@ describe("reasoning (copilot-specific)", () => {
         tool_calls: undefined,
         reasoning_text: undefined,
         reasoning_opaque: undefined,
+        reasoning_content: "Let me think about this...",
       },
     ])
   })

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -114,7 +114,8 @@ const BUNDLED_PROVIDERS: Record<string, () => Promise<(opts: any) => BundledSDK>
   "@ai-sdk/google-vertex/anthropic": () =>
     import("@ai-sdk/google-vertex/anthropic").then((m) => m.createVertexAnthropic),
   "@ai-sdk/openai": () => import("@ai-sdk/openai").then((m) => m.createOpenAI),
-  "@ai-sdk/openai-compatible": () => import("@ai-sdk/openai-compatible").then((m) => m.createOpenAICompatible),
+  "@ai-sdk/openai-compatible": () =>
+    import("@opencode-ai/core/github-copilot/copilot-provider").then((m) => m.createOpenaiCompatible),
   "@openrouter/ai-sdk-provider": () => import("@openrouter/ai-sdk-provider").then((m) => m.createOpenRouter),
   "@ai-sdk/xai": () => import("@ai-sdk/xai").then((m) => m.createXai),
   "@ai-sdk/mistral": () => import("@ai-sdk/mistral").then((m) => m.createMistral),


### PR DESCRIPTION
## Problem

The OpenAI-compatible message converter only handles `image/*` content parts. When a multimodal model (like MiMo, Gemini, or any provider supporting `video_url`) receives a video, audio, or PDF attachment, the converter throws `UnsupportedFunctionalityError`.

## Changes

### Content type support (`convert-to-openai-compatible-chat-messages.ts`)

| MIME type | OpenAI-compatible format |
|-----------|------------------------|
| `video/*` | `video_url` |
| `audio/wav`, `audio/mp3`, `audio/mpeg` | `input_audio` |
| `application/pdf` | `file` |
| `image/*` | `image_url` (unchanged) |

Unsupported audio formats and URL-based PDFs throw `UnsupportedFunctionalityError` with a clear message.

### Reasoning preservation

For non-Copilot OpenAI-compatible providers (no `reasoning_opaque`), reasoning content is now surfaced via `reasoning_content` on assistant messages. This preserves chain-of-thought across turns for reasoning models.

### Provider wiring (`provider.ts`)

Wire `@ai-sdk/openai-compatible` through the OpenCode `copilot-provider` fork, which contains the multimodal converter. This ensures all OpenAI-compatible providers benefit from the new content type support.

### API types (`openai-compatible-api-types.ts`)

Add `OpenAICompatibleContentPartVideo`, `OpenAICompatibleContentPartAudio`, and `OpenAICompatibleContentPartFile` types. Add `reasoning_content` field to `OpenAICompatibleAssistantMessage`.

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/github-copilot/chat/convert-to-openai-compatible-chat-messages.ts` | video/audio/pdf conversion, reasoning_content, expanded metadata resolution |
| `packages/core/src/github-copilot/chat/openai-compatible-api-types.ts` | New content part types, reasoning_content field |
| `packages/core/test/github-copilot/convert-to-copilot-messages.test.ts` | 3 new tests for video/audio/pdf, updated reasoning test |
| `packages/opencode/src/provider/provider.ts` | Wire openai-compatible through copilot-provider fork |

## Test plan

```bash
cd packages/core
bun test test/github-copilot/convert-to-copilot-messages.test.ts   # 21 pass
```

All 29 turborepo typecheck packages pass.