### PR TITLE
fix(core): replay OpenAI reasoning statelessly

### DIFF
--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -3,7 +3,7 @@ export * as SessionRunnerModel from "./model"
 import { type Model } from "@opencode-ai/llm"
 import * as AnthropicMessages from "@opencode-ai/llm/protocols/anthropic-messages"
 import * as OpenAICompatibleChat from "@opencode-ai/llm/protocols/openai-compatible-chat"
-import * as OpenAIResponses from "@opencode-ai/llm/protocols/openai-responses"
+import * as OpenAI from "@opencode-ai/llm/providers/openai"
 import { Auth, type AnyRoute } from "@opencode-ai/llm/route"
 import { Context, Effect, Layer, Schema } from "effect"
 import { produce } from "immer"
@@ -139,8 +139,12 @@ export const fromCatalogModel = (
         })
   const key = apiKey(resolved, credential)
   if (resolved.api.type === "aisdk" && resolved.api.package === "@ai-sdk/openai") {
+    const store = resolved.request.body.store
+    const route = OpenAI.configure({
+      providerOptions: typeof store === "boolean" ? { openai: { store } } : undefined,
+    }).responses(resolved.api.id).route
     return Effect.succeed(
-      withDefaults(resolved, OpenAIResponses.route)
+      withDefaults(resolved, route)
         .with({ auth: key === undefined ? Auth.none : Auth.bearer(key) })
         .model({ id: resolved.api.id }),
     )

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
-import { LLM } from "@opencode-ai/llm"
+import { LLM, Message, ToolCallPart, ToolResultPart } from "@opencode-ai/llm"
+import * as OpenAIResponses from "@opencode-ai/llm/protocols/openai-responses"
 import { LLMClient } from "@opencode-ai/llm/route"
 import { DateTime, Effect } from "effect"
 import { Headers } from "effect/unstable/http"
@@ -69,6 +70,82 @@ describe("SessionRunnerModel", () => {
 
       expect(JSON.stringify(prepared.body)).not.toContain("apiKey")
       expect(JSON.stringify(prepared.body)).not.toContain("secret")
+    }),
+  )
+
+  it.effect("replays encrypted reasoning for stateless catalog OpenAI tool continuations", () =>
+    Effect.gen(function* () {
+      const catalog = ModelV2.Info.make({
+        ...model({ type: "aisdk", package: "@ai-sdk/openai", url: "https://openai.example/v1" }),
+        api: {
+          type: "aisdk",
+          package: "@ai-sdk/openai",
+          id: ModelV2.ID.make("custom-reasoning-model"),
+          url: "https://openai.example/v1",
+        },
+        request: {
+          headers: {},
+          body: { include: ["reasoning.encrypted_content"] },
+        },
+      })
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(catalog)
+      const continuation = LLM.request({
+        model: resolved,
+        messages: [
+          Message.user("Inspect the fixture."),
+          Message.assistant([
+            {
+              type: "reasoning",
+              text: "I should use the fixture tool.",
+              providerMetadata: {
+                openai: {
+                  itemId: "rs_fixture_1",
+                  reasoningEncryptedContent: "encrypted-fixture-state",
+                },
+              },
+            },
+            ToolCallPart.make({ id: "call_fixture_1", name: "inspect_fixture", input: { id: "fixture" } }),
+          ]),
+          Message.tool(
+            ToolResultPart.make({
+              id: "call_fixture_1",
+              name: "inspect_fixture",
+              result: { status: "ok" },
+            }),
+          ),
+        ],
+      })
+      const prepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(continuation)
+
+      expect(prepared.body.input.some((item) => "type" in item && item.type === "item_reference")).toBe(false)
+      expect(prepared.body.store).toBe(false)
+      expect(resolved.route.defaults.http?.body).toMatchObject({ include: ["reasoning.encrypted_content"] })
+      expect(prepared.body.input).toContainEqual({
+        type: "reasoning",
+        id: "rs_fixture_1",
+        summary: [{ type: "summary_text", text: "I should use the fixture tool." }],
+        encrypted_content: "encrypted-fixture-state",
+      })
+      expect(prepared.body.input).toContainEqual({
+        type: "function_call_output",
+        call_id: "call_fixture_1",
+        output: '{"status":"ok"}',
+      })
+
+      const stateful = yield* SessionRunnerModel.fromCatalogModel(
+        ModelV2.Info.make({
+          ...catalog,
+          request: { ...catalog.request, body: { ...catalog.request.body, store: true } },
+        }),
+      )
+      const statefulPrepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(
+        LLM.updateRequest(continuation, {
+          model: stateful,
+        }),
+      )
+
+      expect(statefulPrepared.body.store).toBe(true)
+      expect(statefulPrepared.body.input).toContainEqual({ type: "item_reference", id: "rs_fixture_1" })
     }),
   )
 


### PR DESCRIPTION
## Summary

- resolve Core catalog `@ai-sdk/openai` models through the LLM OpenAI provider facade so they inherit its stateless Responses defaults
- preserve an explicit catalog `store` override as a semantic provider option
- cover a deterministic encrypted-reasoning tool continuation and its explicit stateful counterpart

Fixes #33999.

## Production root cause

Core resolved catalog models using `@ai-sdk/openai` directly from the low-level `OpenAIResponses.route`. That bypassed the OpenAI provider facade, which owns the default `store: false` policy.

Frank's custom model requested `reasoning.encrypted_content`, and the first Responses request successfully produced reasoning plus a tool call. The same-turn continuation then reconstructed that reasoning with `store` still undefined. The Responses lowerer treats every value other than explicit `false` as stateful, so it emitted only:

```json
{ "type": "item_reference", "id": "rs_..." }
```

OpenAI rejected that continuation because items are not persisted when `store: false`.

## Why encrypted replay is required

A tool call does not end the user turn. After the local tool result is available, the next Responses request must carry the reasoning state that led to that call.

Under `store: false`, the provider cannot resolve an `rs_*` handle from server-side storage. The continuation must therefore replay the complete locally retained item:

```json
{
  "type": "reasoning",
  "id": "rs_...",
  "summary": [],
  "encrypted_content": "..."
}
```

Routing catalog OpenAI models through the existing provider facade supplies semantic `store: false`, so the protocol selects that encrypted replay path. Explicit `store: true` remains supported and continues to emit an item reference.

## Tests

Passed:

- `bun run test test/session-runner-model.test.ts test/session-runner-message.test.ts test/session-runner.test.ts` in `packages/core`: 99 passed
- `bun run test` in `packages/llm`: 281 passed, 30 skipped
- `bun run typecheck` in `packages/core`
- `bun run typecheck` in `packages/llm`
- repository-wide `bun turbo typecheck` push hook: 29 packages passed
- `bunx prettier --check packages/core/src/session/runner/model.ts packages/core/test/session-runner-model.test.ts`
- `bunx oxlint packages/core/src/session/runner/model.ts packages/core/test/session-runner-model.test.ts`: zero errors; one pre-existing `consistent-return` warning in unchanged `apiKey` code
- `git diff --check`

The new regression asserts that a custom catalog model with encrypted reasoning and no explicit `store`:

- resolves with `store: false`
- replays `reasoning.encrypted_content`
- carries the function-call output
- emits no bare `item_reference`

It also asserts that explicit `store: true` still emits the reasoning item reference.

The full Core package run completed 1,023 of 1,024 tests. The unrelated filesystem watcher test failed because macOS reported a rewrite of `.git/HEAD` as `add` instead of the expected `change`; the same failure reproduced when that test file was run alone.

## Provider failure preservation

This is complementary to the separate provider-failure preservation work from `f8e5b12f41` and its evolved failed-turn metadata handling already on `dev`. Failed turns continue to discard provider-native continuation metadata; this PR fixes successful same-turn tool continuation by choosing stateless encrypted replay at model resolution.

This PR does not include the transient stream retry work or any files from #34010.