### PR TITLE
fix(core): handle aborted overflow compaction

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -1,7 +1,7 @@
 export * as SessionCompaction from "./compaction"
 
 import { LLM, LLMError, LLMEvent, Message, type LLMRequest, type Model } from "@opencode-ai/llm"
-import { DateTime, Effect, Stream } from "effect"
+import { Cause, DateTime, Effect, Stream } from "effect"
 import type { Config } from "../config"
 import type { EventV2 } from "../event"
 import { SessionEvent } from "./event"
@@ -213,7 +213,7 @@ export const make = (dependencies: Dependencies) => {
           return Effect.void
         }),
         Effect.as(true),
-        Effect.catchTag("LLM.Error", () => Effect.succeed(false)),
+        Effect.catchCause((cause) => (Cause.hasInterrupts(cause) ? Effect.failCause(cause) : Effect.succeed(false))),
       )
     const summary = chunks.join("")
     if (!summarized || failed || !summary.trim()) return false

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -62,6 +62,7 @@ const requests: LLMRequest[] = []
 let response: LLMEvent[] = []
 let responses: LLMEvent[][] | undefined
 let responseStream: Stream.Stream<LLMEvent, LLMError> | undefined
+let responseStreams: Stream.Stream<LLMEvent, LLMError>[] | undefined
 let streamGate: Deferred.Deferred<void> | undefined
 let streamStarted: Deferred.Deferred<void> | undefined
 let streamFailure: LLMError | undefined
@@ -76,6 +77,7 @@ const client = Layer.succeed(
     prepare: () => Effect.die("unused"),
     stream: ((request: LLMRequest) => {
       requests.push(request)
+      if (responseStreams) return responseStreams.shift() ?? Stream.empty
       if (responseStream) {
         const stream = responseStream
         responseStream = undefined
@@ -326,6 +328,7 @@ const setup = Effect.gen(function* () {
   responses = undefined
   streamFailure = undefined
   responseStream = undefined
+  responseStreams = undefined
   streamGate = undefined
   streamStarted = undefined
   toolExecutionGate = undefined
@@ -1196,6 +1199,28 @@ describe("SessionRunnerLLM", () => {
       expect(requests).toHaveLength(3)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "compaction" },
+        { type: "assistant", finish: "error", error: { message: "prompt too long" } },
+      ])
+    }),
+  )
+
+  it.effect("publishes the original overflow when recovery summarization aborts", () =>
+    Effect.gen(function* () {
+      const session = yield* setupOverflowRecovery
+      const overflow = () => [
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
+      ]
+      responseStreams = [
+        Stream.fromIterable(overflow()),
+        Stream.die(new Error("MessageAbortedError")) as Stream.Stream<LLMEvent, LLMError>,
+      ]
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Continue" }), resume: false })
+      yield* session.resume(sessionID)
+
+      expect(requests).toHaveLength(2)
+      expect((yield* session.context(sessionID)).slice(-2)).toMatchObject([
+        { type: "user", text: "Continue" },
         { type: "assistant", finish: "error", error: { message: "prompt too long" } },
       ])
     }),


### PR DESCRIPTION
### Issue for this PR

Fixes #27924

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Handles aborted overflow recovery compaction without re-entering the compaction loop.

When the provider reports context overflow before assistant output, OpenCode tries to summarize and retry once. If that summary stream aborts or dies with a non-interrupt failure, this PR treats the summary as failed and persists the original provider overflow as the assistant error.

Real user/session interrupts still propagate as interrupts.

### How did you verify your code works?

- `bun test test/session-runner.test.ts --test-name-pattern "publishes the original overflow when recovery summarization aborts"` from `packages/core`
- `bun test test/session-runner.test.ts --test-name-pattern "overflow"` from `packages/core`
- `bun typecheck` from `packages/core`
- Push hook ran `bun turbo typecheck`: 29 successful, 29 total

### Screenshots / recordings

N/A. Core session recovery fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR