### PR TITLE
fix(tui): autocomplete files inside references

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,11 +1,12 @@
 export * as FileSystem from "./filesystem"
 
 import path from "path"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Schema, Scope } from "effect"
 import { FSUtil } from "./fs-util"
 import { Location } from "./location"
 import { PositiveInt, RelativePath } from "./schema"
 import { FileSystemSearch } from "./filesystem/search"
+import { Ripgrep } from "./ripgrep"
 import { Entry, FileSystem, FindInput, Match } from "@opencode-ai/schema/filesystem"
 export { Entry, Match, Submatch } from "@opencode-ai/schema/filesystem"
 
@@ -60,8 +61,23 @@ const baseLayer = Layer.effect(
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
     const location = yield* Location.Service
-    const search = yield* FileSystemSearch.Service
+    const ripgrep = yield* Ripgrep.Service
+    const scope = yield* Scope.Scope
     const root = yield* fs.realPath(location.directory).pipe(Effect.orDie)
+    const search = yield* Effect.cached(
+      Layer.buildWithScope(
+        FileSystemSearch.locationLayer.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.succeed(FSUtil.Service, fs),
+              Layer.succeed(Location.Service, location),
+              Layer.succeed(Ripgrep.Service, ripgrep),
+            ),
+          ),
+        ),
+        scope,
+      ).pipe(Effect.map((context) => Context.get(context, FileSystemSearch.Service))),
+    )
     const resolve = Effect.fnUntraced(function* (input?: RelativePath) {
       const absolute = path.resolve(location.directory, input ?? ".")
       if (!FSUtil.contains(location.directory, absolute))
@@ -70,46 +86,75 @@ const baseLayer = Layer.effect(
       if (!FSUtil.contains(root, real)) return yield* Effect.die(new Error("Path escapes the location"))
       return { absolute, real, directory: location.directory, root }
     })
+    const list: Interface["list"] = Effect.fn("FileSystem.list")(function* (input = {}) {
+      const target = yield* resolve(input.path)
+      const info = yield* fs.stat(target.real).pipe(Effect.orDie)
+      if (info.type !== "Directory") return yield* Effect.die(new Error("Path is not a directory"))
+      return yield* fs.readDirectoryEntries(target.real).pipe(
+        Effect.orDie,
+        Effect.map((items) =>
+          items
+            .flatMap((item) => {
+              if (item.type !== "file" && item.type !== "directory") return []
+              const absolute = path.join(target.absolute, item.name)
+              const relative = path.relative(target.directory, absolute)
+              return [
+                Entry.make({
+                  path: RelativePath.make(relative + (item.type === "directory" ? path.sep : "")),
+                  type: item.type,
+                }),
+              ]
+            })
+            .sort(compareEntry),
+        ),
+      )
+    })
+    const find: Interface["find"] = Effect.fn("FileSystem.find")(function* (input) {
+      if (input.query.trim() === "") {
+        const entries = yield* list()
+        return entries
+          .filter((entry) => input.type === undefined || entry.type === input.type)
+          .slice(0, input.limit ?? 50)
+      }
+      const service = yield* search
+      return yield* service.find(input)
+    })
+    const glob: Interface["glob"] = Effect.fn("FileSystem.glob")(function* (input) {
+      const service = yield* search
+      return yield* service.glob(input)
+    })
+    const grep: Interface["grep"] = Effect.fn("FileSystem.grep")(function* (input) {
+      const service = yield* search
+      return yield* service.grep(input)
+    })
+    const read: Interface["read"] = Effect.fn("FileSystem.read")(function* (input) {
+      const target = yield* resolve(input.path)
+      const info = yield* fs.stat(target.real).pipe(Effect.orDie)
+      if (info.type !== "File") return yield* Effect.die(new Error("Path is not a file"))
+      return {
+        content: yield* fs.readFile(target.real).pipe(Effect.orDie),
+        mime: FSUtil.mimeType(target.real),
+      }
+    })
     return Service.of({
-      find: search.find,
-      glob: search.glob,
-      grep: search.grep,
-      read: Effect.fn("FileSystem.read")(function* (input) {
-        const target = yield* resolve(input.path)
-        const info = yield* fs.stat(target.real).pipe(Effect.orDie)
-        if (info.type !== "File") return yield* Effect.die(new Error("Path is not a file"))
-        return {
-          content: yield* fs.readFile(target.real).pipe(Effect.orDie),
-          mime: FSUtil.mimeType(target.real),
-        }
-      }),
-      list: Effect.fn("FileSystem.list")(function* (input = {}) {
-        const target = yield* resolve(input.path)
-        const info = yield* fs.stat(target.real).pipe(Effect.orDie)
-        if (info.type !== "Directory") return yield* Effect.die(new Error("Path is not a directory"))
-        return yield* fs.readDirectoryEntries(target.real).pipe(
-          Effect.orDie,
-          Effect.map((items) =>
-            items
-              .flatMap((item) => {
-                if (item.type !== "file" && item.type !== "directory") return []
-                const absolute = path.join(target.absolute, item.name)
-                const relative = path.relative(target.directory, absolute)
-                return [
-                  Entry.make({
-                    path: RelativePath.make(relative + (item.type === "directory" ? path.sep : "")),
-                    type: item.type,
-                  }),
-                ]
-              })
-              .sort((a, b) => (a.type === b.type ? a.path.localeCompare(b.path) : a.type === "directory" ? -1 : 1)),
-          ),
-        )
-      }),
+      find,
+      glob,
+      grep,
+      read,
+      list,
     })
   }),
 )
 
-export const layer = baseLayer.pipe(Layer.provide(FileSystemSearch.locationLayer), Layer.provide(FSUtil.defaultLayer))
+export const layer = baseLayer.pipe(Layer.provide(FSUtil.defaultLayer))
 
 export const locationLayer = layer
+
+function compareEntry(a: Entry, b: Entry) {
+  if (a.type !== b.type) return a.type === "directory" ? -1 : 1
+  return hiddenRank(a) - hiddenRank(b) || a.path.localeCompare(b.path)
+}
+
+function hiddenRank(entry: Entry) {
+  return path.basename(entry.path).startsWith(".") ? 1 : 0
+}

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -31,20 +31,23 @@ export const ripgrepLayer = Layer.effect(
       directories: [] as string[],
     }
     const directories = new Set<string>()
-    yield* ripgrep
-      .find({
-        cwd: location.directory,
-        pattern: "*",
-        limit: location.vcs ? Number.MAX_SAFE_INTEGER : 100_000,
-        onEntry: (entry) =>
-          Effect.sync(() => {
-            state.files.push(entry.path)
-            const parts = entry.path.split("/")
-            parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
-            state.directories = Array.from(directories)
-          }),
-      })
-      .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))
+    const loadIndex = yield* Effect.cached(
+      ripgrep
+        .find({
+          cwd: location.directory,
+          pattern: "*",
+          limit: location.vcs ? Number.MAX_SAFE_INTEGER : 100_000,
+          onEntry: (entry) =>
+            Effect.sync(() => {
+              state.files.push(entry.path)
+              const parts = entry.path.split("/")
+              parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
+              state.directories = Array.from(directories)
+            }),
+        })
+        .pipe(Effect.orDie, Effect.asVoid),
+    )
+    yield* loadIndex.pipe(Effect.forkIn(scope, { startImmediately: true }))
     return Service.of({
       glob: (input) =>
         Effect.gen(function* () {
@@ -99,6 +102,7 @@ export const ripgrepLayer = Layer.effect(
         }),
       find: (input) =>
         Effect.gen(function* () {
+          yield* loadIndex
           const items =
             input.type === "file"
               ? state.files

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -3,6 +3,7 @@ import path from "path"
 import { describe, expect } from "bun:test"
 import { Effect, Exit, Layer } from "effect"
 import { FileSystem } from "@opencode-ai/core/filesystem"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Location } from "@opencode-ai/core/location"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
@@ -11,24 +12,60 @@ import { location } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
 import { it } from "./lib/effect"
 
-const provide = (directory: string) =>
-  Effect.provide(
-    FileSystem.layer.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          FSUtil.defaultLayer,
-          Ripgrep.defaultLayer,
-          Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
-        ),
+const provideLayer = (directory: string, ripgrep: Layer.Layer<Ripgrep.Service>) =>
+  FileSystem.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        FSUtil.defaultLayer,
+        ripgrep,
+        Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
       ),
     ),
   )
+
+const provide = (directory: string) => Effect.provide(provideLayer(directory, Ripgrep.defaultLayer))
+
+const provideWithRipgrep = (directory: string, ripgrep: Ripgrep.Interface) =>
+  Effect.provide(provideLayer(directory, Layer.succeed(Ripgrep.Service, Ripgrep.Service.of(ripgrep))))
 
 const withTmp = <A, E, R>(f: (directory: string) => Effect.Effect<A, E, R>) =>
   Effect.acquireRelease(
     Effect.promise(() => tmpdir()),
     (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
   ).pipe(Effect.flatMap((tmp) => f(tmp.path)))
+
+const withRipgrepSearch = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.acquireRelease(
+    Effect.sync(() => {
+      const previous = Flag.OPENCODE_DISABLE_FFF
+      Flag.OPENCODE_DISABLE_FFF = true
+      return previous
+    }),
+    (previous) =>
+      Effect.sync(() => {
+        Flag.OPENCODE_DISABLE_FFF = previous
+      }),
+  ).pipe(Effect.flatMap(() => effect))
+
+const trackRipgrep = (entries: readonly FileSystem.Entry[] = []) => {
+  let findCalls = 0
+  return {
+    calls: () => findCalls,
+    ripgrep: {
+      find: (input) =>
+        Effect.gen(function* () {
+          yield* Effect.sync(() => {
+            findCalls += 1
+          })
+          yield* Effect.yieldNow
+          yield* Effect.forEach(entries, (entry) => input.onEntry?.(entry) ?? Effect.void, { discard: true })
+          return entries
+        }),
+      glob: () => Effect.succeed([]),
+      grep: () => Effect.succeed([]),
+    } satisfies Ripgrep.Interface,
+  }
+}
 
 describe("FileSystem", () => {
   it.live("reads text and binary files", () =>
@@ -51,7 +88,8 @@ describe("FileSystem", () => {
       Effect.gen(function* () {
         yield* Effect.promise(() => fs.mkdir(path.join(directory, "src")))
         yield* Effect.promise(() => fs.writeFile(path.join(directory, "README.md"), "# Test"))
-        const entries = yield* (yield* FileSystem.Service).list()
+        const service = yield* FileSystem.Service
+        const entries = yield* service.list()
         expect(entries.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
           { path: RelativePath.make("src" + path.sep), type: "directory" },
           { path: RelativePath.make("README.md"), type: "file" },
@@ -60,12 +98,145 @@ describe("FileSystem", () => {
     ),
   )
 
+  it.live("finds direct children for empty queries", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => fs.mkdir(path.join(directory, "src")))
+        yield* Effect.promise(() => fs.mkdir(path.join(directory, "src", "nested")))
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "src", "nested", "deep.txt"), "deep"))
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "README.md"), "# Test"))
+
+        const service = yield* FileSystem.Service
+        const entries = yield* service.find({ query: "" })
+
+        expect(entries.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
+          { path: RelativePath.make("src" + path.sep), type: "directory" },
+          { path: RelativePath.make("README.md"), type: "file" },
+        ])
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("filters and limits empty query find results", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => fs.mkdir(path.join(directory, "alpha")))
+        yield* Effect.promise(() => fs.mkdir(path.join(directory, "beta")))
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "a.txt"), "a"))
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "b.txt"), "b"))
+
+        const service = yield* FileSystem.Service
+        const directories = yield* service.find({ query: "   ", type: "directory", limit: 1 })
+        const files = yield* service.find({ query: "", type: "file", limit: 1 })
+
+        expect(directories.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
+          { path: RelativePath.make("alpha" + path.sep), type: "directory" },
+        ])
+        expect(files.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
+          { path: RelativePath.make("a.txt"), type: "file" },
+        ])
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("prioritizes visible direct children before hidden entries for empty query limits", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        yield* Effect.forEach(
+          [".config", ".cache", ".local", "alpha", "beta"],
+          (name) => Effect.promise(() => fs.mkdir(path.join(directory, name))),
+          { discard: true },
+        )
+
+        const service = yield* FileSystem.Service
+        const entries = yield* service.find({ query: "", type: "directory", limit: 2 })
+
+        expect(entries.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
+          { path: RelativePath.make("alpha" + path.sep), type: "directory" },
+          { path: RelativePath.make("beta" + path.sep), type: "directory" },
+        ])
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("does not start recursive search for empty queries", () =>
+    withTmp((directory) => {
+      const ripgrep = trackRipgrep()
+      return withRipgrepSearch(
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.mkdir(path.join(directory, "src")))
+          yield* Effect.promise(() => fs.writeFile(path.join(directory, "README.md"), "# Test"))
+
+          const service = yield* FileSystem.Service
+          const entries = yield* service.find({ query: "" })
+          yield* Effect.yieldNow
+
+          expect(entries.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
+            { path: RelativePath.make("src" + path.sep), type: "directory" },
+            { path: RelativePath.make("README.md"), type: "file" },
+          ])
+          expect(ripgrep.calls()).toBe(0)
+        }).pipe(provideWithRipgrep(directory, ripgrep.ripgrep)),
+      )
+    }),
+  )
+
+  it.live("keeps non-empty find deterministic after an empty query", () =>
+    withTmp((directory) => {
+      const target = FileSystem.Entry.make({ path: RelativePath.make("src/target.ts"), type: "file" })
+      const ripgrep = trackRipgrep([
+        target,
+        FileSystem.Entry.make({ path: RelativePath.make("src/other.ts"), type: "file" }),
+      ])
+      return withRipgrepSearch(
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.mkdir(path.join(directory, "src")))
+          yield* Effect.promise(() => fs.writeFile(path.join(directory, "src", "target.ts"), "target"))
+          yield* Effect.promise(() => fs.writeFile(path.join(directory, "src", "other.ts"), "other"))
+          yield* Effect.promise(() => fs.writeFile(path.join(directory, "README.md"), "# Test"))
+
+          const service = yield* FileSystem.Service
+          const empty = yield* service.find({ query: "" })
+          const found = yield* service.find({ query: "target" })
+
+          expect(empty.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
+            { path: RelativePath.make("src" + path.sep), type: "directory" },
+            { path: RelativePath.make("README.md"), type: "file" },
+          ])
+          expect(found.map((entry) => ({ path: entry.path, type: entry.type }))).toEqual([
+            { path: target.path, type: "file" },
+          ])
+          expect(ripgrep.calls()).toBe(1)
+        }).pipe(provideWithRipgrep(directory, ripgrep.ripgrep)),
+      )
+    }),
+  )
+
+  it.live("runs non-empty glob and grep through lazy search", () =>
+    withTmp((directory) =>
+      withRipgrepSearch(
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.mkdir(path.join(directory, "src")))
+          yield* Effect.promise(() => fs.writeFile(path.join(directory, "src", "match.ts"), "needle\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(directory, "src", "skip.txt"), "needle\n"))
+
+          const service = yield* FileSystem.Service
+          const glob = yield* service.glob({ pattern: "**/*.ts" })
+          const grep = yield* service.grep({ pattern: "needle", include: "*.ts" })
+
+          expect(glob.map((entry) => entry.path)).toEqual([RelativePath.make("src/match.ts")])
+          expect(grep).toHaveLength(1)
+          expect(grep[0]?.entry.path).toBe(RelativePath.make("src/match.ts"))
+        }).pipe(provide(directory)),
+      ),
+    ),
+  )
+
   it.live("rejects lexical escapes", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
-        const result = yield* (yield* FileSystem.Service)
-          .read({ path: RelativePath.make("../outside.txt") })
-          .pipe(Effect.exit)
+        const service = yield* FileSystem.Service
+        const result = yield* service.read({ path: RelativePath.make("../outside.txt") }).pipe(Effect.exit)
         expect(Exit.isFailure(result)).toBe(true)
       }).pipe(provide(directory)),
     ),

--- a/packages/tui/src/component/prompt/autocomplete-reference.ts
+++ b/packages/tui/src/component/prompt/autocomplete-reference.ts
@@ -1,0 +1,28 @@
+export type AutocompleteReference = {
+  name: string
+  path: string
+  hidden?: boolean
+}
+
+export function findReferenceAlias(query: string, references: readonly AutocompleteReference[]) {
+  const slash = query.indexOf("/")
+  const alias = slash === -1 ? query : query.slice(0, slash)
+  return references.find((item) => !item.hidden && item.name === alias)
+}
+
+export function findReferencePath(query: string, references: readonly AutocompleteReference[]) {
+  const slash = query.indexOf("/")
+  if (slash === -1) return
+
+  const reference = findReferenceAlias(query, references)
+  if (!reference) return
+
+  return {
+    reference,
+    query: query.slice(slash + 1),
+  }
+}
+
+export function referenceMentionPath(referenceName: string, filePath: string) {
+  return `${referenceName}/${filePath.replaceAll("\\", "/").replace(/^\/+/, "")}`
+}

--- a/packages/tui/src/component/prompt/autocomplete-reference.ts
+++ b/packages/tui/src/component/prompt/autocomplete-reference.ts
@@ -1,7 +1,63 @@
+import path from "path"
+
 export type AutocompleteReference = {
   name: string
   path: string
   hidden?: boolean
+}
+
+export type AutocompleteFileRequest = {
+  reference: AutocompleteReference | undefined
+  directory: string
+  query: string
+  mentionDirectory: string
+}
+
+type LocalReference = AutocompleteReference & {
+  source: {
+    type: "local"
+    path: string
+  }
+}
+
+type HomeReference = LocalReference
+type RootReference = LocalReference
+
+export function createHomeReference(home: string): HomeReference {
+  return {
+    name: "~",
+    path: home,
+    source: {
+      type: "local" as const,
+      path: home,
+    },
+  }
+}
+
+export function createRootReference(root: string): RootReference {
+  return {
+    name: "",
+    path: root,
+    hidden: true,
+    source: {
+      type: "local" as const,
+      path: root,
+    },
+  }
+}
+
+export function withHomeReference<Reference extends AutocompleteReference>(
+  references: readonly Reference[],
+  home: string,
+) {
+  return [createHomeReference(home), ...references.filter((reference) => reference.name !== "~")]
+}
+
+export function withRootReference<Reference extends AutocompleteReference>(
+  references: readonly Reference[],
+  root: string,
+) {
+  return [createRootReference(root), ...references.filter((reference) => reference.name !== "")]
 }
 
 export function findReferenceAlias(query: string, references: readonly AutocompleteReference[]) {
@@ -11,11 +67,26 @@ export function findReferenceAlias(query: string, references: readonly Autocompl
 }
 
 export function findReferencePath(query: string, references: readonly AutocompleteReference[]) {
-  const slash = query.indexOf("/")
-  if (slash === -1) return
+  if (query.startsWith("/")) {
+    const reference = references.find((item) => item.name === "")
+    if (!reference) return
+    return {
+      reference,
+      query: query.replace(/^\/+/, ""),
+    }
+  }
 
+  const slash = query.indexOf("/")
   const reference = findReferenceAlias(query, references)
   if (!reference) return
+
+  if (slash === -1) {
+    if (query !== "~") return
+    return {
+      reference,
+      query: "",
+    }
+  }
 
   return {
     reference,
@@ -24,5 +95,68 @@ export function findReferencePath(query: string, references: readonly Autocomple
 }
 
 export function referenceMentionPath(referenceName: string, filePath: string) {
-  return `${referenceName}/${filePath.replaceAll("\\", "/").replace(/^\/+/, "")}`
+  const path = filePath.replaceAll("\\", "/").replace(/^\/+/, "")
+  if (!referenceName) return `/${path}`
+  return `${referenceName}/${path}`
+}
+
+export function createFileSearchRequest(
+  query: string,
+  baseDirectory: string,
+  references: readonly AutocompleteReference[],
+): AutocompleteFileRequest {
+  const reference = findReferencePath(query, references)
+  if (reference) return splitFileSearchRequest(reference.query, reference.reference.path, reference.reference)
+  return splitFileSearchRequest(query, baseDirectory)
+}
+
+export function fileSearchMentionPath(request: AutocompleteFileRequest, filePath: string) {
+  const mentionPath = joinMentionPath(request.mentionDirectory, filePath)
+  if (request.reference) return referenceMentionPath(request.reference.name, mentionPath)
+  return mentionPath
+}
+
+function splitFileSearchRequest(query: string, baseDirectory: string, reference?: AutocompleteReference) {
+  const split = splitDirectoryQuery(query)
+  return {
+    reference,
+    directory: path.resolve(baseDirectory, split.directory),
+    query: split.query,
+    mentionDirectory: split.directory,
+  }
+}
+
+function splitDirectoryQuery(query: string) {
+  const normalized = query.replaceAll("\\", "/")
+  if (normalized.endsWith("/")) {
+    return {
+      directory: trimMentionPathSlashes(normalized),
+      query: "",
+    }
+  }
+
+  const slash = normalized.lastIndexOf("/")
+  if (slash === -1) {
+    return {
+      directory: "",
+      query: normalized,
+    }
+  }
+
+  return {
+    directory: trimMentionPathSlashes(normalized.slice(0, slash)),
+    query: normalized.slice(slash + 1),
+  }
+}
+
+function joinMentionPath(directory: string, filePath: string) {
+  const prefix = trimMentionPathSlashes(directory)
+  const suffix = filePath.replaceAll("\\", "/").replace(/^\/+/, "")
+  if (!prefix) return suffix
+  if (!suffix) return prefix
+  return `${prefix}/${suffix}`
+}
+
+function trimMentionPathSlashes(filePath: string) {
+  return filePath.replaceAll("\\", "/").replace(/^\/+/, "").replace(/\/+$/, "")
 }

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -1,6 +1,7 @@
 import type { BoxRenderable, TextareaRenderable, ScrollBoxRenderable } from "@opentui/core"
 import { pathToFileURL } from "bun"
 import fuzzysort from "fuzzysort"
+import os from "node:os"
 import path from "path"
 import { firstBy } from "remeda"
 import { createMemo, createResource, createEffect, onMount, onCleanup, Index, Show, createSignal } from "solid-js"
@@ -23,7 +24,13 @@ import { useFrecency } from "../../prompt/frecency"
 import { useBindings, useCommandSlashes, useOpencodeModeStack } from "../../keymap"
 import { displayCharAt, mentionTriggerIndex } from "../../prompt/display"
 import type { FileSystemEntry } from "@opencode-ai/sdk/v2"
-import { findReferenceAlias, findReferencePath, referenceMentionPath } from "./autocomplete-reference"
+import {
+  createFileSearchRequest,
+  fileSearchMentionPath,
+  findReferenceAlias,
+  withHomeReference,
+  withRootReference,
+} from "./autocomplete-reference"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -240,21 +247,22 @@ export function Autocomplete(props: {
     }
   }
 
-  function createFilePart(
-    item: FileSystemEntry,
-    filePath: string,
-    lineRange?: { startLine: number; endLine?: number },
-  ) {
-    const urlObj = pathToFileURL(filePath)
+  function createFilePart(input: {
+    entry: FileSystemEntry
+    absolutePath: string
+    lineRange?: { startLine: number; endLine?: number }
+    sourcePath?: string
+  }) {
+    const urlObj = pathToFileURL(input.absolutePath)
     const filename =
-      lineRange && item.type !== "directory"
-        ? `${item.path}#${lineRange.startLine}${lineRange.endLine ? `-${lineRange.endLine}` : ""}`
-        : item.path
+      input.lineRange && input.entry.type !== "directory"
+        ? `${input.entry.path}#${input.lineRange.startLine}${input.lineRange.endLine ? `-${input.lineRange.endLine}` : ""}`
+        : input.entry.path
 
-    if (lineRange && item.type !== "directory") {
-      urlObj.searchParams.set("start", String(lineRange.startLine))
-      if (lineRange.endLine !== undefined) {
-        urlObj.searchParams.set("end", String(lineRange.endLine))
+    if (input.lineRange && input.entry.type !== "directory") {
+      urlObj.searchParams.set("start", String(input.lineRange.startLine))
+      if (input.lineRange.endLine !== undefined) {
+        urlObj.searchParams.set("end", String(input.lineRange.endLine))
       }
     }
 
@@ -262,7 +270,7 @@ export function Autocomplete(props: {
       filename,
       part: {
         type: "file" as const,
-        mime: item.type === "directory" ? "application/x-directory" : "text/plain",
+        mime: input.entry.type === "directory" ? "application/x-directory" : "text/plain",
         filename,
         url: urlObj.href,
         source: {
@@ -272,26 +280,29 @@ export function Autocomplete(props: {
             end: 0,
             value: "",
           },
-          path: item.path,
+          path: input.sourcePath ?? input.entry.path,
         },
       },
     }
   }
 
-  const references = createMemo(() => data.location.reference.list() ?? [])
+  const baseDirectory = createMemo(() => location()?.directory || sync.path.directory || paths.cwd)
+  const references = createMemo(() =>
+    withRootReference(withHomeReference(data.location.reference.list() ?? [], os.homedir()), path.parse(baseDirectory()).root),
+  )
 
   const referenceMatch = createMemo(() => {
     if (!store.visible || store.visible === "/") return
     return findReferenceAlias(extractLineRange(search()).baseQuery, references())
   })
 
-  const referencePathMatch = createMemo(() => {
+  const fileSearchRequest = createMemo(() => {
     if (!store.visible || store.visible === "/") return
-    return findReferencePath(extractLineRange(search()).baseQuery, references())
+    return createFileSearchRequest(extractLineRange(search()).baseQuery, baseDirectory(), references())
   })
 
-  function normalizeMentionPath(filePath: string) {
-    const baseDir = location()?.directory || sync.path.directory || paths.cwd
+  function toBaseRelativeMentionPath(filePath: string) {
+    const baseDir = baseDirectory()
     const absolute = path.resolve(filePath)
     const relative = path.relative(baseDir, absolute)
 
@@ -303,12 +314,16 @@ export function Autocomplete(props: {
   }
 
   function insertFileMention(input: { filePath: string; lineStart: number; lineEnd: number }) {
-    const item = normalizeMentionPath(input.filePath)
+    const mentionPath = toBaseRelativeMentionPath(input.filePath)
     const lineRange = {
       startLine: input.lineStart,
       endLine: input.lineEnd > input.lineStart ? input.lineEnd : undefined,
     }
-    const { filename, part } = createFilePart({ path: item, type: "file" }, input.filePath, lineRange)
+    const { filename, part } = createFilePart({
+      entry: { path: mentionPath, type: "file" },
+      absolutePath: input.filePath,
+      lineRange,
+    })
     const index = store.visible === "@" ? store.index : props.input().cursorOffset
 
     setStore("visible", false)
@@ -317,20 +332,21 @@ export function Autocomplete(props: {
   }
 
   const [files] = createResource(
-    () => ({ query: search(), location: location(), reference: referencePathMatch() }),
+    () => ({ query: search(), location: location(), request: fileSearchRequest() }),
     async (input) => {
       if (!store.visible || store.visible === "/") return []
-      const { lineRange, baseQuery } = extractLineRange(input.query ?? "")
-      const reference = input.reference
+      const { lineRange } = extractLineRange(input.query ?? "")
+      const request = input.request
 
-      if (!reference && referenceMatch()) return []
+      if (!request) return []
+      if (!request.reference && referenceMatch()) return []
 
       // Get files from SDK
       const result = await sdk.client.v2.fs.find({
-        query: reference?.query ?? baseQuery,
+        query: request.query,
         limit: "20",
         location: {
-          directory: reference?.reference.path ?? input.location?.directory,
+          directory: request.directory,
           workspace: input.location?.workspaceID ?? project.workspace.current(),
         },
       })
@@ -343,12 +359,14 @@ export function Autocomplete(props: {
         const width = props.anchor().width - 4
         options.push(
           ...result.data.data.map((item): AutocompleteOption => {
-            const mentionPath = reference ? referenceMentionPath(reference.reference.name, item.path) : item.path
-            const { filename, part } = createFilePart(
-              { ...item, path: mentionPath },
-              path.join(result.data.location.directory, item.path),
+            const mentionPath = fileSearchMentionPath(request, item.path)
+            const filePath = path.join(result.data.location.directory, item.path)
+            const { filename, part } = createFilePart({
+              entry: { ...item, path: mentionPath },
+              absolutePath: filePath,
               lineRange,
-            )
+              sourcePath: request.reference ? filePath : mentionPath,
+            })
             return {
               display: Locale.truncateMiddle(filename, width),
               value: filename,
@@ -482,13 +500,13 @@ export function Autocomplete(props: {
   const options = createMemo((prev: AutocompleteOption[] | undefined) => {
     const filesValue = files()
     const referenceMatchValue = referenceMatch()
-    const referencePathMatchValue = referencePathMatch()
+    const fileSearchRequestValue = fileSearchRequest()
     const agentsValue = agents()
     const referenceAliasesValue = referenceAliases()
     const commandsValue = commands()
     const searchValue = search()
 
-    if (store.visible === "@" && referenceMatchValue && !referencePathMatchValue) {
+    if (store.visible === "@" && referenceMatchValue && !fileSearchRequestValue?.reference) {
       return referenceAliasesValue.filter((item) => item.display === `@${referenceMatchValue.name}`)
     }
 
@@ -506,7 +524,7 @@ export function Autocomplete(props: {
       return prev
     }
 
-    if (store.visible === "@" && referencePathMatchValue) {
+    if (store.visible === "@" && fileSearchRequestValue?.reference) {
       return fileOptions
     }
 
@@ -575,7 +593,7 @@ export function Autocomplete(props: {
     const input = props.input()
     const currentCursorOffset = input.cursorOffset
 
-    const displayText = (selected.value ?? selected.display).trimEnd()
+    const displayText = (selected.path ?? selected.value ?? selected.display).trimEnd()
     const path = displayText.startsWith("@") ? displayText.slice(1) : displayText
 
     input.cursorOffset = store.index
@@ -584,7 +602,7 @@ export function Autocomplete(props: {
     const endCursor = input.logicalCursor
 
     input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
-    input.insertText("@" + path + "/")
+    input.insertText("@" + path.replace(/\/+$/, "") + "/")
 
     setStore("selected", 0)
   }

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -23,6 +23,7 @@ import { useFrecency } from "../../prompt/frecency"
 import { useBindings, useCommandSlashes, useOpencodeModeStack } from "../../keymap"
 import { displayCharAt, mentionTriggerIndex } from "../../prompt/display"
 import type { FileSystemEntry } from "@opencode-ai/sdk/v2"
+import { findReferenceAlias, findReferencePath, referenceMentionPath } from "./autocomplete-reference"
 
 function removeLineRange(input: string) {
   const hashIndex = input.lastIndexOf("#")
@@ -281,10 +282,12 @@ export function Autocomplete(props: {
 
   const referenceMatch = createMemo(() => {
     if (!store.visible || store.visible === "/") return
-    const { baseQuery } = extractLineRange(search())
-    const slash = baseQuery.indexOf("/")
-    const alias = slash === -1 ? baseQuery : baseQuery.slice(0, slash)
-    return references().find((item) => !item.hidden && item.name === alias)
+    return findReferenceAlias(extractLineRange(search()).baseQuery, references())
+  })
+
+  const referencePathMatch = createMemo(() => {
+    if (!store.visible || store.visible === "/") return
+    return findReferencePath(extractLineRange(search()).baseQuery, references())
   })
 
   function normalizeMentionPath(filePath: string) {
@@ -314,18 +317,20 @@ export function Autocomplete(props: {
   }
 
   const [files] = createResource(
-    () => ({ query: search(), location: location() }),
+    () => ({ query: search(), location: location(), reference: referencePathMatch() }),
     async (input) => {
       if (!store.visible || store.visible === "/") return []
-      if (referenceMatch()) return []
       const { lineRange, baseQuery } = extractLineRange(input.query ?? "")
+      const reference = input.reference
+
+      if (!reference && referenceMatch()) return []
 
       // Get files from SDK
       const result = await sdk.client.v2.fs.find({
-        query: baseQuery,
+        query: reference?.query ?? baseQuery,
         limit: "20",
         location: {
-          directory: input.location?.directory,
+          directory: reference?.reference.path ?? input.location?.directory,
           workspace: input.location?.workspaceID ?? project.workspace.current(),
         },
       })
@@ -338,8 +343,9 @@ export function Autocomplete(props: {
         const width = props.anchor().width - 4
         options.push(
           ...result.data.data.map((item): AutocompleteOption => {
+            const mentionPath = reference ? referenceMentionPath(reference.reference.name, item.path) : item.path
             const { filename, part } = createFilePart(
-              item,
+              { ...item, path: mentionPath },
               path.join(result.data.location.directory, item.path),
               lineRange,
             )
@@ -347,7 +353,7 @@ export function Autocomplete(props: {
               display: Locale.truncateMiddle(filename, width),
               value: filename,
               isDirectory: item.type === "directory",
-              path: item.path,
+              path: mentionPath,
               onSelect: () => {
                 insertPart(filename, part)
               },
@@ -476,12 +482,13 @@ export function Autocomplete(props: {
   const options = createMemo((prev: AutocompleteOption[] | undefined) => {
     const filesValue = files()
     const referenceMatchValue = referenceMatch()
+    const referencePathMatchValue = referencePathMatch()
     const agentsValue = agents()
     const referenceAliasesValue = referenceAliases()
     const commandsValue = commands()
     const searchValue = search()
 
-    if (store.visible === "@" && referenceMatchValue) {
+    if (store.visible === "@" && referenceMatchValue && !referencePathMatchValue) {
       return referenceAliasesValue.filter((item) => item.display === `@${referenceMatchValue.name}`)
     }
 
@@ -497,6 +504,10 @@ export function Autocomplete(props: {
 
     if (files.loading && prev && prev.length > 0) {
       return prev
+    }
+
+    if (store.visible === "@" && referencePathMatchValue) {
+      return fileOptions
     }
 
     const fuzziedNonFiles = fuzzysort

--- a/packages/tui/test/prompt/autocomplete-reference.test.ts
+++ b/packages/tui/test/prompt/autocomplete-reference.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "bun:test"
-import { findReferenceAlias, findReferencePath, referenceMentionPath } from "../../src/component/prompt/autocomplete-reference"
+import {
+  createFileSearchRequest,
+  createHomeReference,
+  createRootReference,
+  fileSearchMentionPath,
+  findReferenceAlias,
+  findReferencePath,
+  referenceMentionPath,
+  withHomeReference,
+  withRootReference,
+} from "../../src/component/prompt/autocomplete-reference"
 
 const references = [
   { name: "home", path: "/home/jescudero" },
@@ -7,7 +17,7 @@ const references = [
 ]
 
 describe("prompt reference autocomplete", () => {
-  test("keeps bare aliases as alias matches", () => {
+  test("keeps non-home bare aliases as alias matches", () => {
     expect(findReferenceAlias("home", references)?.path).toBe("/home/jescudero")
     expect(findReferencePath("home", references)).toBeUndefined()
   })
@@ -27,5 +37,144 @@ describe("prompt reference autocomplete", () => {
   test("preserves alias paths for inserted file mentions", () => {
     expect(referenceMentionPath("home", "docs/readme.md")).toBe("home/docs/readme.md")
     expect(referenceMentionPath("home", "docs\\readme.md")).toBe("home/docs/readme.md")
+  })
+
+  test("creates a visible home directory alias", () => {
+    expect(createHomeReference("/home/jescudero")).toEqual({
+      name: "~",
+      path: "/home/jescudero",
+      source: {
+        type: "local",
+        path: "/home/jescudero",
+      },
+    })
+  })
+
+  test("searches inside the home alias after a slash", () => {
+    const referencesWithHome = withHomeReference(references, "/home/jescudero")
+
+    expect(findReferenceAlias("~", referencesWithHome)?.path).toBe("/home/jescudero")
+    expect(findReferencePath("~/projects", referencesWithHome)).toEqual({
+      reference: referencesWithHome[0],
+      query: "projects",
+    })
+  })
+
+  test("searches from home for the bare home alias", () => {
+    const referencesWithHome = withHomeReference(references, "/home/jescudero")
+
+    expect(findReferencePath("~", referencesWithHome)).toEqual({
+      reference: referencesWithHome[0],
+      query: "",
+    })
+  })
+
+  test("keeps home alias mentions rooted at tilde", () => {
+    expect(referenceMentionPath("~", "docs/readme.md")).toBe("~/docs/readme.md")
+    expect(referenceMentionPath("~", "docs\\readme.md")).toBe("~/docs/readme.md")
+  })
+
+  test("prefers the synthetic home alias over server references named tilde", () => {
+    const referencesWithHome = withHomeReference(
+      [
+        { name: "~", path: "/tmp/not-home" },
+        { name: "docs", path: "/docs" },
+      ],
+      "/home/jescudero",
+    )
+
+    expect(referencesWithHome).toEqual([createHomeReference("/home/jescudero"), { name: "docs", path: "/docs" }])
+  })
+
+  test("creates a hidden filesystem root reference", () => {
+    expect(createRootReference("/")).toEqual({
+      name: "",
+      path: "/",
+      hidden: true,
+      source: {
+        type: "local",
+        path: "/",
+      },
+    })
+  })
+
+  test("searches from filesystem root for slash-prefixed queries", () => {
+    const referencesWithRoot = withRootReference(withHomeReference(references, "/home/jescudero"), "/")
+
+    expect(findReferenceAlias("/", referencesWithRoot)).toBeUndefined()
+    expect(findReferencePath("/", referencesWithRoot)).toEqual({
+      reference: referencesWithRoot[0],
+      query: "",
+    })
+    expect(findReferencePath("/etc", referencesWithRoot)).toEqual({
+      reference: referencesWithRoot[0],
+      query: "etc",
+    })
+  })
+
+  test("keeps filesystem root mentions rooted at slash", () => {
+    expect(referenceMentionPath("", "etc/hosts")).toBe("/etc/hosts")
+    expect(referenceMentionPath("", "/etc/hosts")).toBe("/etc/hosts")
+    expect(referenceMentionPath("", "etc\\hosts")).toBe("/etc/hosts")
+  })
+
+  test("splits filesystem root paths into request directory and leaf query", () => {
+    const referencesWithRoot = withRootReference(withHomeReference(references, "/home/jescudero"), "/")
+    const directoryRequest = createFileSearchRequest("/home/", "/workspace", referencesWithRoot)
+    const leafRequest = createFileSearchRequest("/home/je", "/workspace", referencesWithRoot)
+
+    expect(directoryRequest).toEqual({
+      reference: referencesWithRoot[0],
+      directory: "/home",
+      query: "",
+      mentionDirectory: "home",
+    })
+    expect(leafRequest).toEqual({
+      reference: referencesWithRoot[0],
+      directory: "/home",
+      query: "je",
+      mentionDirectory: "home",
+    })
+    expect(fileSearchMentionPath(directoryRequest, "user/")).toBe("/home/user/")
+  })
+
+  test("splits home paths into request directory and keeps tilde mentions", () => {
+    const referencesWithHome = withHomeReference(references, "/home/jescudero")
+    const request = createFileSearchRequest("~/projects/", "/workspace", referencesWithHome)
+
+    expect(request).toEqual({
+      reference: referencesWithHome[0],
+      directory: "/home/jescudero/projects",
+      query: "",
+      mentionDirectory: "projects",
+    })
+    expect(fileSearchMentionPath(request, "opencode/")).toBe("~/projects/opencode/")
+  })
+
+  test("splits project-relative paths into request directory and leaf query", () => {
+    const directoryRequest = createFileSearchRequest("src/", "/workspace", references)
+    const nestedDirectoryRequest = createFileSearchRequest("src/components/", "/workspace", references)
+    const leafRequest = createFileSearchRequest("src/components", "/workspace", references)
+
+    expect(directoryRequest).toEqual({
+      reference: undefined,
+      directory: "/workspace/src",
+      query: "",
+      mentionDirectory: "src",
+    })
+    expect(leafRequest).toEqual({
+      reference: undefined,
+      directory: "/workspace/src",
+      query: "components",
+      mentionDirectory: "src",
+    })
+    expect(fileSearchMentionPath(directoryRequest, "components/")).toBe("src/components/")
+    expect(nestedDirectoryRequest).toEqual({
+      reference: undefined,
+      directory: "/workspace/src/components",
+      query: "",
+      mentionDirectory: "src/components",
+    })
+    expect(fileSearchMentionPath(nestedDirectoryRequest, "button.tsx")).toBe("src/components/button.tsx")
   })
 })

--- a/packages/tui/test/prompt/autocomplete-reference.test.ts
+++ b/packages/tui/test/prompt/autocomplete-reference.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { findReferenceAlias, findReferencePath, referenceMentionPath } from "../../src/component/prompt/autocomplete-reference"
+
+const references = [
+  { name: "home", path: "/home/jescudero" },
+  { name: "hidden", path: "/tmp/hidden", hidden: true },
+]
+
+describe("prompt reference autocomplete", () => {
+  test("keeps bare aliases as alias matches", () => {
+    expect(findReferenceAlias("home", references)?.path).toBe("/home/jescudero")
+    expect(findReferencePath("home", references)).toBeUndefined()
+  })
+
+  test("searches inside visible references after the alias slash", () => {
+    expect(findReferencePath("home/projects", references)).toEqual({
+      reference: references[0],
+      query: "projects",
+    })
+  })
+
+  test("does not autocomplete hidden references", () => {
+    expect(findReferenceAlias("hidden", references)).toBeUndefined()
+    expect(findReferencePath("hidden/file", references)).toBeUndefined()
+  })
+
+  test("preserves alias paths for inserted file mentions", () => {
+    expect(referenceMentionPath("home", "docs/readme.md")).toBe("home/docs/readme.md")
+    expect(referenceMentionPath("home", "docs\\readme.md")).toBe("home/docs/readme.md")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #34040

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes TUI `@` reference autocomplete so `@alias/partial` searches inside the configured reference directory and inserts the selected file as `@alias/relative`.

Previously, autocomplete matched the reference alias but did not continue file lookup for nested paths.

Related: #33658

### How did you verify your code works?

Verified with the focused autocomplete behavior for configured reference paths.

### Screenshots / recordings

N/A. This changes autocomplete behavior, not visual layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
