### PR TITLE
fix(session): stop malformed tool-call loops

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1284,6 +1284,25 @@ export const layer = Layer.effect(
               toolChoice: format.type === "json_schema" ? "required" : undefined,
             })
 
+            if (handle.message.finish === "tool-calls") {
+              const parts = yield* MessageV2.parts(handle.message.id).pipe(
+                Effect.provideService(Database.Service, database),
+              )
+              const hasToolPart = parts.some((part) => part.type === "tool")
+              if (!hasToolPart) {
+                handle.message.error = new SessionV1.APIError({
+                  message: "Provider finished with tool-calls but did not emit any tool calls",
+                  isRetryable: false,
+                  metadata: { finish: "tool-calls" },
+                }).toObject()
+                handle.message.finish = "error"
+                handle.message.time.completed = Date.now()
+                yield* sessions.updateMessage(handle.message)
+                yield* events.publish(Session.Event.Error, { sessionID, error: handle.message.error })
+                return "break" as const
+              }
+            }
+
             if (structured !== undefined) {
               handle.message.structured = structured
               handle.message.finish = handle.message.finish ?? "stop"

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -814,6 +814,55 @@ it.instance("loop continues when finish is tool-calls", () =>
   }),
 )
 
+it.instance("loop stops when finish is tool-calls without tool parts", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const events = yield* EventV2Bridge.Service
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "Malformed tool call finish",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    const errors: NonNullable<SessionV1.Assistant["error"]>[] = []
+    const off = yield* events.listen((event) => {
+      if (event.type !== Session.Event.Error.type) return Effect.void
+      const data = event.data as typeof Session.Event.Error.data.Type
+      if (data.sessionID === session.id && data.error) errors.push(data.error)
+      return Effect.void
+    })
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.push(reply().text("<invoke name=\"read\">").toolCalls())
+
+    const result = yield* prompt.loop({ sessionID: session.id })
+    const stored = yield* MessageV2.get({ sessionID: session.id, messageID: result.info.id })
+    yield* off
+
+    expect(yield* llm.calls).toBe(1)
+    expect(result.info.role).toBe("assistant")
+    expect(stored.info.role).toBe("assistant")
+    if (result.info.role === "assistant" && stored.info.role === "assistant") {
+      const error = result.info.error
+      expect(error).toBeDefined()
+      if (!error) return
+      expect(result.info.finish).toBe("error")
+      expect(error.name).toBe("APIError")
+      expect(JSON.stringify(error.data)).toContain("finished with tool-calls")
+      expect(stored.info.error).toEqual(error)
+      expect(errors).toContainEqual(error)
+      expect(result.parts.some((part) => part.type === "tool")).toBe(false)
+      expect(result.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: "text", text: '<invoke name="read">' })]),
+      )
+    }
+  }),
+)
+
 it.instance("glob tool keeps instance context during prompt runs", () =>
   Effect.gen(function* () {
     const { dir, llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Fixes #31247

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Copilot Claude Opus 4.8 can return `finish=tool-calls` without sending a structured tool call. OpenCode treated that as a tool-loop turn and asked the provider again, which can lead to Copilot rejecting the next request as assistant prefill.

This PR stops the loop when that malformed response shape appears. It records a session `APIError`, marks the assistant turn as `finish=error`, publishes the existing session error event, and leaves valid tool-call turns unchanged.

### How did you verify your code works?

```bash
cd packages/opencode
bun test --timeout 30000 test/session/prompt.test.ts -t "loop stops when finish is tool-calls without tool parts"
bun test --timeout 30000 test/session/prompt.test.ts
```

Observed:

```text
targeted regression: 1 pass, 0 fail, 11 expect() calls
prompt.test.ts: 57 pass, 1 skip, 0 fail, 232 expect() calls
```

From repo root:

```bash
bun run typecheck
git diff --check HEAD~1..HEAD
```

Observed:

```text
typecheck: 29 successful, 29 total
git diff --check: no output
```

### Screenshots / recordings

Not applicable. This PR changes session-loop behavior, not UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
