### PR TITLE
fix(app): reconcile session pages with concurrent events

### DIFF
--- a/packages/app/src/context/server-sdk.test.ts
+++ b/packages/app/src/context/server-sdk.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { coalesceServerEvents, resumeStreamAfterPageShow } from "./server-sdk"
+import { coalesceServerEvents, enqueueServerEvent, resumeStreamAfterPageShow } from "./server-sdk"
 import type { Event } from "@opencode-ai/sdk/v2/client"
 
 describe("resumeStreamAfterPageShow", () => {
@@ -15,19 +15,23 @@ describe("resumeStreamAfterPageShow", () => {
 })
 
 describe("coalesceServerEvents", () => {
-  const delta = (value: string, field = "text") => ({
+  const delta = (value: string, field = "text", partID = "part") => ({
     directory: "/repo",
     payload: {
       type: "message.part.delta",
-      properties: { messageID: "msg", partID: "part", field, delta: value },
+      properties: { messageID: "msg", partID, field, delta: value },
     } as Event,
   })
 
   test("merges adjacent deltas for the same field", () => {
-    const result = coalesceServerEvents([delta("hello "), delta("world")])
+    const first = delta("hello ")
+    const second = delta("world")
+    first.payload.id = "first"
+    second.payload.id = "second"
+    const result = coalesceServerEvents([first, second])
 
     expect(result).toHaveLength(1)
-    expect(result[0]?.payload).toMatchObject({ properties: { delta: "hello world" } })
+    expect(result[0]?.payload).toMatchObject({ id: "second", properties: { delta: "hello world" } })
   })
 
   test("preserves event boundaries and distinct fields", () => {
@@ -45,9 +49,113 @@ describe("coalesceServerEvents", () => {
     ])
   })
 
-  test("drops stale deltas", () => {
-    const result = coalesceServerEvents([delta("stale")], new Set(["/repo:msg:part"]))
+  test("preserves event ID order across interleaved deltas", () => {
+    const first = delta("a")
+    const other = delta("b", "text", "other")
+    const last = delta("c")
+    first.payload.id = "1"
+    other.payload.id = "2"
+    last.payload.id = "3"
 
-    expect(result).toEqual([])
+    const result = coalesceServerEvents([first, other, last])
+
+    expect(result.map((event) => event.payload.id)).toEqual(["1", "2", "3"])
+  })
+
+})
+
+describe("enqueueServerEvent", () => {
+  const partUpdated = (text: string) =>
+    ({
+      type: "message.part.updated",
+      properties: {
+        sessionID: "session",
+        part: { id: "part", sessionID: "session", messageID: "message", type: "text", text },
+      },
+    }) as Event
+
+  test("preserves part updates across message remove and re-add barriers", () => {
+    const events: Array<{ directory: string; payload: Event }> = []
+    const enqueue = (payload: Event) => enqueueServerEvent(events, { directory: "/repo", payload })
+
+    enqueue(partUpdated("old"))
+    enqueue({ type: "message.removed", properties: { sessionID: "session", messageID: "message" } } as Event)
+    enqueue({
+      type: "message.updated",
+      properties: {
+        sessionID: "session",
+        info: {
+          id: "message",
+          sessionID: "session",
+          role: "user",
+          time: { created: 1 },
+          agent: "build",
+          model: { providerID: "provider", modelID: "model" },
+        },
+      },
+    } as Event)
+    enqueue(partUpdated("new"))
+
+    expect(events.map((event) => event.payload.type)).toEqual([
+      "message.part.updated",
+      "message.removed",
+      "message.updated",
+      "message.part.updated",
+    ])
+  })
+
+  test("preserves deltas after a replacement snapshot", () => {
+    const events: Array<{ directory: string; payload: Event }> = []
+    const enqueue = (payload: Event) => enqueueServerEvent(events, { directory: "/repo", payload })
+
+    enqueue(partUpdated("a"))
+    enqueue(partUpdated("ab"))
+    enqueue({
+      type: "message.part.delta",
+      properties: { sessionID: "session", messageID: "message", partID: "part", field: "text", delta: "c" },
+    } as Event)
+
+    const result = coalesceServerEvents(events)
+    expect(result.map((event) => event.payload.type)).toEqual(["message.part.updated", "message.part.delta"])
+    expect(result[0]?.payload).toMatchObject({ properties: { part: { text: "ab" } } })
+    expect(result[1]?.payload).toMatchObject({ properties: { delta: "c" } })
+  })
+
+  test("preserves updates after session deletion", () => {
+    const events: Array<{ directory: string; payload: Event }> = []
+    const enqueue = (payload: Event) => enqueueServerEvent(events, { directory: "/repo", payload })
+
+    enqueue(partUpdated("old"))
+    enqueue({
+      type: "session.deleted",
+      properties: { sessionID: "session", info: { id: "session" } },
+    } as Event)
+    enqueue(partUpdated("new"))
+
+    expect(events.map((event) => event.payload.type)).toEqual([
+      "message.part.updated",
+      "session.deleted",
+      "message.part.updated",
+    ])
+  })
+
+  test("does not coalesce edge-triggered session statuses", () => {
+    const events: Array<{ directory: string; payload: Event }> = []
+    const enqueue = (status: "retry" | "busy") =>
+      enqueueServerEvent(events, {
+        directory: "/repo",
+        payload: {
+          type: "session.status",
+          properties: {
+            sessionID: "session",
+            status: status === "retry" ? { type: "retry", attempt: 1, message: "retry", next: 1 } : { type: "busy" },
+          },
+        } as Event,
+      })
+
+    enqueue("retry")
+    enqueue("busy")
+
+    expect(events).toHaveLength(2)
   })
 })

--- a/packages/app/src/context/server-sdk.tsx
+++ b/packages/app/src/context/server-sdk.tsx
@@ -17,34 +17,59 @@ const isAbortError = (error: unknown) =>
 const isStreamClosed = (error: unknown, signal?: AbortSignal) => isAbortError(error) || signal?.aborted === true
 type QueuedServerEvent = { directory: string; payload: Event }
 
-const deltaKey = (directory: string, messageID: string, partID: string) => `${directory}:${messageID}:${partID}`
+const coalescedKey = (event: QueuedServerEvent) => {
+  if (event.payload.type === "lsp.updated") return `lsp.updated:${event.directory}`
+  if (event.payload.type === "message.part.updated") {
+    const part = event.payload.properties.part
+    return `message.part.updated:${event.directory}:${part.messageID}:${part.id}`
+  }
+  return undefined
+}
 
-export function coalesceServerEvents(events: QueuedServerEvent[], stale?: Set<string>) {
+export function enqueueServerEvent(
+  queue: QueuedServerEvent[],
+  event: QueuedServerEvent,
+) {
+  const key = coalescedKey(event)
+  const previous = queue[queue.length - 1]
+  if (key && previous && coalescedKey(previous) === key) {
+    queue[queue.length - 1] = event
+    return false
+  }
+  queue.push(event)
+  return true
+}
+
+export function coalesceServerEvents(events: QueuedServerEvent[]) {
   const output: QueuedServerEvent[] = []
-  const deltas = new Map<string, number>()
   events.forEach((event) => {
-    if (stale && event.payload.type === "message.part.delta") {
-      const props = event.payload.properties
-      if (stale.has(deltaKey(event.directory, props.messageID, props.partID))) return
-    }
     if (event.payload.type !== "message.part.delta") {
-      deltas.clear()
       output.push(event)
       return
     }
     const props = event.payload.properties
-    const id = `${deltaKey(event.directory, props.messageID, props.partID)}:${props.field}`
-    const index = deltas.get(id)
-    const existing = index === undefined ? undefined : output[index]
-    if (!existing || existing.payload.type !== "message.part.delta") {
-      deltas.set(id, output.length)
+    const previous = output[output.length - 1]
+    if (
+      !previous ||
+      previous.payload.type !== "message.part.delta" ||
+      previous.directory !== event.directory ||
+      previous.payload.properties.messageID !== props.messageID ||
+      previous.payload.properties.partID !== props.partID ||
+      previous.payload.properties.field !== props.field
+    ) {
       output.push({
         directory: event.directory,
         payload: { ...event.payload, properties: { ...props } },
       })
       return
     }
-    existing.payload.properties.delta += props.delta
+    output[output.length - 1] = {
+      directory: event.directory,
+      payload: {
+        ...event.payload,
+        properties: { ...props, delta: previous.payload.properties.delta + props.delta },
+      },
+    }
   })
   return output
 }
@@ -85,19 +110,8 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
 
   let queue: Queued[] = []
   let buffer: Queued[] = []
-  const coalesced = new Map<string, number>()
-  const staleDeltas = new Set<string>()
   let timer: ReturnType<typeof setTimeout> | undefined
   let last = 0
-
-  const key = (directory: string, payload: Event) => {
-    if (payload.type === "session.status") return `session.status:${directory}:${payload.properties.sessionID}`
-    if (payload.type === "lsp.updated") return `lsp.updated:${directory}`
-    if (payload.type === "message.part.updated") {
-      const part = payload.properties.part
-      return `message.part.updated:${directory}:${part.messageID}:${part.id}`
-    }
-  }
 
   const flush = () => {
     if (timer) clearTimeout(timer)
@@ -106,15 +120,12 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
     if (queue.length === 0) return
 
     const events = queue
-    const skip = staleDeltas.size > 0 ? new Set(staleDeltas) : undefined
     queue = buffer
     buffer = events
     queue.length = 0
-    coalesced.clear()
-    staleDeltas.clear()
 
     last = Date.now()
-    const output = coalesceServerEvents(events, skip)
+    const output = coalesceServerEvents(events)
     batch(() => {
       output.forEach((event) => emitter.emit(event.directory, event.payload))
     })
@@ -184,28 +195,11 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
           for await (const event of events.stream) {
             resetHeartbeat()
             streamErrorLogged = false
-            const directory = event.directory ?? "global"
-            if (event.payload.type === "sync") {
-              continue
+            if (event.payload.type !== "sync") {
+              const directory = event.directory ?? "global"
+              const payload = event.payload as Event
+              if (enqueueServerEvent(queue, { directory, payload })) schedule()
             }
-
-            const payload = event.payload as Event
-
-            const k = key(directory, payload)
-            if (k) {
-              const i = coalesced.get(k)
-              if (i !== undefined) {
-                queue[i] = { directory, payload }
-                if (payload.type === "message.part.updated") {
-                  const part = payload.properties.part
-                  staleDeltas.add(deltaKey(directory, part.messageID, part.id))
-                }
-                continue
-              }
-              coalesced.set(k, queue.length)
-            }
-            queue.push({ directory, payload })
-            schedule()
 
             if (Date.now() - yielded < STREAM_YIELD_MS) continue
             yielded = Date.now()

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import type { OpencodeClient, Session } from "@opencode-ai/sdk/v2/client"
+import type { Message, OpencodeClient, Session } from "@opencode-ai/sdk/v2/client"
 import { createServerSession } from "./server-session"
 
 const session = (id: string, parentID?: string): Session => ({
@@ -53,6 +53,35 @@ describe("server session", () => {
     expect(ctx.get).toEqual([{ sessionID: "root" }])
     expect(ctx.messages).toEqual([{ sessionID: "root", limit: 2, before: undefined }])
     expect(ctx.store.data.message.root).toEqual([])
+  })
+
+  test("preserves live messages received during the initial load", async () => {
+    let resolveMessages: ((value: { data: []; response: { headers: Headers } }) => void) | undefined
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: []; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    const loading = store.sync("child")
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+
+    store.apply({ type: "message.updated", properties: { info: message } })
+    resolveMessages?.({ data: [], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.message.child).toEqual([message])
   })
 
   test("applies events without a directory store", () => {

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -266,6 +266,74 @@ describe("server session", () => {
     expect(store.data.message.child?.[0]?.time.created).toBe(2)
   })
 
+  test("preserves a newer message event over a stale initial page", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const stale: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const live: Message = { ...stale, time: { created: 2 } }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.apply({ type: "message.updated", properties: { info: stale } })
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.updated", properties: { info: live } })
+    resolveMessages?.({ data: [{ info: stale, parts: [] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.message.child?.[0]?.time.created).toBe(2)
+  })
+
+  test("preserves a newer initial message over an older removal event", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const stale: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.apply({ type: "message.updated", properties: { info: stale } })
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: stale.id } })
+    resolveMessages?.({
+      data: [{ info: { ...stale, time: { created: 2 } }, parts: [] }],
+      response: { headers: new Headers() },
+    })
+    await loading
+
+    expect(store.data.message.child?.[0]?.time.created).toBe(2)
+  })
+
   test("applies events without a directory store", () => {
     const ctx = setup({})
     ctx.store.apply({ type: "session.created", properties: { info: session("root") } })

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -150,6 +150,46 @@ describe("server session", () => {
     expect(store.data.part[kept.id]).toBeUndefined()
   })
 
+  test("does not restore removed optimistic content on refresh", async () => {
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const part: Part = {
+      id: "part",
+      sessionID: "child",
+      messageID: message.id,
+      type: "text",
+      text: "removed",
+    }
+    const kept = { ...message, id: "kept" }
+    const keptPart = { ...part, id: "kept-part", messageID: kept.id }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: async () => ({ data: [{ info: kept, parts: [] }], response: { headers: new Headers() } }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    store.optimistic.add({ sessionID: "child", message: kept, parts: [keptPart] })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    store.apply({
+      type: "message.part.removed",
+      properties: { sessionID: "child", messageID: kept.id, partID: keptPart.id },
+    })
+    await store.sync("child", { force: true })
+
+    expect(store.data.message.child).toEqual([kept])
+    expect(store.data.part[message.id]).toBeUndefined()
+    expect(store.data.part[kept.id]).toBeUndefined()
+  })
+
   test("applies events without a directory store", () => {
     const ctx = setup({})
     ctx.store.apply({ type: "session.created", properties: { info: session("root") } })

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import type { retry } from "@opencode-ai/core/util/retry"
 import type { Message, OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client"
 import { createServerSession } from "./server-session"
 
@@ -49,24 +50,36 @@ const deferredResponse = () => Promise.withResolvers<MessageResponse>()
 function messageClient(...responses: Array<MessageResponse | Promise<MessageResponse>>) {
   let index = 0
   const requests: unknown[] = []
+  const waiting = new Map<number, () => void>()
   const client = {
     session: {
       get: async () => ({ data: session("child", "root") }),
       messages: (input: unknown) => {
         requests.push(input)
+        waiting.get(requests.length)?.()
+        waiting.delete(requests.length)
         return responses[index++]
       },
     },
   } as unknown as OpencodeClient
-  return Object.assign(client, { requests })
+  return Object.assign(client, {
+    requests,
+    requested(count: number) {
+      if (requests.length >= count) return Promise.resolve()
+      return new Promise<void>((resolve) => waiting.set(count, resolve))
+    },
+  })
 }
 
-async function waitForRequests(client: { requests: unknown[] }, count: number) {
-  for (let attempt = 0; attempt < 100; attempt++) {
-    if (client.requests.length >= count) return
-    await Bun.sleep(0)
+const retryImmediately: typeof retry = async (task, options = {}) => {
+  const attempts = options.attempts ?? 3
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await task()
+    } catch (error) {
+      if (attempt === attempts - 1) throw error
+    }
   }
-  throw new Error(`Expected ${count} message requests, received ${client.requests.length}`)
 }
 
 function setup(sessions: Record<string, Session>) {
@@ -587,14 +600,14 @@ describe("server session", () => {
     const intermediate = { ...stale, text: "intermediate" }
     const fetched = { ...stale, text: "fetched" }
     const client = messageClient(failed.promise, retried.promise)
-    const store = createServerSession(client, { retryDelay: 0 })
+    const store = createServerSession(client, { retry: retryImmediately })
     store.apply({ type: "message.updated", properties: { info: message } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: stale, time: 1 } })
     const loading = store.sync("child")
 
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: intermediate, time: 2 } })
     failed.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 2)
+    await client.requested(2)
     retried.resolve(response([{ info: message, parts: [fetched] }]))
     await loading
 
@@ -607,7 +620,7 @@ describe("server session", () => {
     const message = userMessage("message")
     const part = textPart(message.id, { text: "stale" })
     const client = messageClient(failed.promise, retried.promise)
-    const store = createServerSession(client, { retryDelay: 0 })
+    const store = createServerSession(client, { retry: retryImmediately })
     store.apply({ type: "message.updated", properties: { info: message } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 1 } })
     const loading = store.sync("child")
@@ -617,7 +630,7 @@ describe("server session", () => {
       properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: " delta" },
     })
     failed.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 2)
+    await client.requested(2)
     retried.resolve(response([{ info: message, parts: [part] }]))
     await loading
 
@@ -630,7 +643,7 @@ describe("server session", () => {
     const message = userMessage("message")
     const part = textPart(message.id)
     const client = messageClient(response([{ info: message, parts: [part] }]), failed.promise, retried.promise)
-    const store = createServerSession(client, { retryDelay: 0 })
+    const store = createServerSession(client, { retry: retryImmediately })
     await store.sync("child")
     const loading = store.sync("child", { force: true })
 
@@ -639,7 +652,7 @@ describe("server session", () => {
       properties: { sessionID: "child", messageID: message.id, partID: part.id },
     })
     failed.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 3)
+    await client.requested(3)
     retried.resolve(response([{ info: message, parts: [part] }]))
     await loading
 
@@ -652,13 +665,13 @@ describe("server session", () => {
     const message = userMessage("message")
     const part = textPart(message.id)
     const client = messageClient(response([{ info: message, parts: [part] }]), failed.promise, retried.promise)
-    const store = createServerSession(client, { retryDelay: 0 })
+    const store = createServerSession(client, { retry: retryImmediately })
     await store.sync("child")
     const loading = store.sync("child", { force: true })
 
     store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
     failed.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 3)
+    await client.requested(3)
     retried.resolve(response([{ info: message, parts: [part] }]))
     await loading
 
@@ -673,14 +686,14 @@ describe("server session", () => {
     const stale = textPart(message.id, { id: "stale", text: "stale" })
     const optimistic = textPart(message.id, { id: "optimistic", text: "optimistic" })
     const client = messageClient(response([{ info: message, parts: [stale] }]), failed.promise, retried.promise)
-    const store = createServerSession(client, { retryDelay: 0 })
+    const store = createServerSession(client, { retry: retryImmediately })
     await store.sync("child")
     const loading = store.sync("child", { force: true })
 
     store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
     store.optimistic.add({ sessionID: "child", message, parts: [optimistic] })
     failed.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 3)
+    await client.requested(3)
     retried.resolve(response([{ info: message, parts: [stale] }]))
     await loading
 
@@ -694,7 +707,7 @@ describe("server session", () => {
     const message = userMessage("message")
     const part = textPart(message.id)
     const client = messageClient(response([{ info: message, parts: [part] }]), failed.promise, retried.promise)
-    const store = createServerSession(client, { retryDelay: 0 })
+    const store = createServerSession(client, { retry: retryImmediately })
     await store.sync("child")
     const loading = store.sync("child", { force: true })
 
@@ -703,7 +716,7 @@ describe("server session", () => {
       properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: " delta" },
     })
     failed.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 3)
+    await client.requested(3)
     retried.resolve(response([{ info: message, parts: [] }]))
     await loading
 
@@ -718,14 +731,14 @@ describe("server session", () => {
     const message = userMessage("message")
     const part = textPart(message.id)
     const client = messageClient(first.promise, second.promise, third.promise)
-    const store = createServerSession(client, { retryDelay: 0 })
+    const store = createServerSession(client, { retry: retryImmediately })
     const loading = store.sync("child").catch((error) => error)
 
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 2 } })
     first.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 2)
+    await client.requested(2)
     second.reject(new Error("failed to fetch"))
-    await waitForRequests(client, 3)
+    await client.requested(3)
     third.reject(new Error("failed to fetch"))
     await loading
 

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import type { Message, OpencodeClient, Session } from "@opencode-ai/sdk/v2/client"
+import type { Message, OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client"
 import { createServerSession } from "./server-session"
 
 const session = (id: string, parentID?: string): Session => ({
@@ -82,6 +82,73 @@ describe("server session", () => {
     await loading
 
     expect(store.data.message.child).toEqual([message])
+  })
+
+  test("preserves live message removals received during the initial load", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    resolveMessages?.({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.message.child).toEqual([])
+  })
+
+  test("preserves live part updates received during the initial load", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const stale: Part = { id: "part", sessionID: "child", messageID: message.id, type: "text", text: "stale" }
+    const live: Part = { ...stale, text: "live" }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    const loading = store.sync("child")
+
+    store.apply({
+      type: "message.part.updated",
+      properties: { sessionID: "child", part: live, time: 2 },
+    })
+    resolveMessages?.({ data: [{ info: message, parts: [stale] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.part[message.id]).toEqual([live])
   })
 
   test("applies events without a directory store", () => {

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -188,7 +188,7 @@ describe("server session", () => {
     expect(store.data.part[message.id]).toEqual([live])
   })
 
-  test("discards a stale initial page when the event journal fills", async () => {
+  test("does not replay deltas already included in the initial page", async () => {
     let resolveMessages:
       | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
       | undefined
@@ -222,11 +222,48 @@ describe("server session", () => {
         properties: { sessionID: "child", messageID: message.id, partID: live.id, field: "text", delta: "x" },
       })
     }
-    resolveMessages?.({ data: [{ info: message, parts: [stale] }], response: { headers: new Headers() } })
+    resolveMessages?.({
+      data: [{ info: message, parts: [{ ...stale, text: `live${"x".repeat(4_097)}` }] }],
+      response: { headers: new Headers() },
+    })
     await loading
 
     const part = store.data.part[message.id]?.find((part) => part.type === "text")
     expect(part?.text).toBe(`live${"x".repeat(4_097)}`)
+  })
+
+  test("prefers a newer initial page over an older message event", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.updated", properties: { info: message } })
+    resolveMessages?.({
+      data: [{ info: { ...message, time: { created: 2 } }, parts: [] }],
+      response: { headers: new Headers() },
+    })
+    await loading
+
+    expect(store.data.message.child?.[0]?.time.created).toBe(2)
   })
 
   test("applies events without a directory store", () => {

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -190,6 +190,45 @@ describe("server session", () => {
     expect(store.data.part[kept.id]).toBeUndefined()
   })
 
+  test("clears stale parts when the initial page has none", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const part: Part = {
+      id: "part",
+      sessionID: "child",
+      messageID: message.id,
+      type: "text",
+      text: "stale",
+    }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.apply({ type: "message.updated", properties: { info: message } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 1 } })
+    const loading = store.sync("child")
+
+    resolveMessages?.({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
   test("applies events without a directory store", () => {
     const ctx = setup({})
     ctx.store.apply({ type: "session.created", properties: { info: session("root") } })

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -151,6 +151,84 @@ describe("server session", () => {
     expect(store.data.part[message.id]).toEqual([live])
   })
 
+  test("preserves events when the first message arrives before the initial load", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const stale: Part = { id: "part", sessionID: "child", messageID: message.id, type: "text", text: "stale" }
+    const live: Part = { ...stale, text: "live" }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.apply({ type: "message.updated", properties: { info: message } })
+    const loading = store.sync("child")
+
+    store.apply({
+      type: "message.part.updated",
+      properties: { sessionID: "child", part: live, time: 2 },
+    })
+    resolveMessages?.({ data: [{ info: message, parts: [stale] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.part[message.id]).toEqual([live])
+  })
+
+  test("discards a stale initial page when the event journal fills", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const stale: Part = { id: "part", sessionID: "child", messageID: message.id, type: "text", text: "stale" }
+    const live: Part = { ...stale, text: "live" }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.apply({ type: "message.updated", properties: { info: message } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: live, time: 1 } })
+    const loading = store.sync("child")
+
+    for (let index = 0; index < 4_097; index++) {
+      store.apply({
+        type: "message.part.delta",
+        properties: { sessionID: "child", messageID: message.id, partID: live.id, field: "text", delta: "x" },
+      })
+    }
+    resolveMessages?.({ data: [{ info: message, parts: [stale] }], response: { headers: new Headers() } })
+    await loading
+
+    const part = store.data.part[message.id]?.find((part) => part.type === "text")
+    expect(part?.text).toBe(`live${"x".repeat(4_097)}`)
+  })
+
   test("applies events without a directory store", () => {
     const ctx = setup({})
     ctx.store.apply({ type: "session.created", properties: { info: session("root") } })

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -100,6 +100,48 @@ describe("server session", () => {
     expect(store.data.part[live.id]).toEqual([livePart])
   })
 
+  test("preserves same-ID live updates over the initial page", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const fetched: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const fetchedPart: Part = {
+      id: "part",
+      sessionID: "child",
+      messageID: fetched.id,
+      type: "text",
+      text: "fetched",
+    }
+    const live = { ...fetched, time: { created: 2 } }
+    const livePart = { ...fetchedPart, text: "live" }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.updated", properties: { info: live } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: livePart, time: 2 } })
+    resolveMessages?.({ data: [{ info: fetched, parts: [fetchedPart] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.message.child).toEqual([live])
+    expect(store.data.part[live.id]).toEqual([livePart])
+  })
+
   test("preserves removals received during the initial load", async () => {
     let resolveMessages:
       | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
@@ -150,6 +192,79 @@ describe("server session", () => {
     expect(store.data.part[kept.id]).toBeUndefined()
   })
 
+  test("keeps removal tracking isolated across load generations", async () => {
+    const resolveMessages: Array<
+      (value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void
+    > = []
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages.push(resolve)
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    const first = store.sync("child")
+    store.apply({ type: "session.deleted", properties: { info: session("child", "root") } })
+    const second = store.sync("child")
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    resolveMessages[0]?.({ data: [], response: { headers: new Headers() } })
+    await first
+    resolveMessages[1]?.({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
+    await second
+
+    expect(store.data.message.child).toEqual([])
+  })
+
+  test("preserves remove then re-add during a refresh", async () => {
+    let resolveRefresh:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    let calls = 0
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () => {
+          calls += 1
+          if (calls === 1)
+            return Promise.resolve({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
+          return new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveRefresh = resolve
+          })
+        },
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    await store.sync("child")
+    const refreshing = store.sync("child", { force: true })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    store.apply({ type: "message.updated", properties: { info: message } })
+    resolveRefresh?.({ data: [], response: { headers: new Headers() } })
+    await refreshing
+
+    expect(store.data.message.child).toEqual([message])
+  })
+
   test("does not restore removed optimistic content on refresh", async () => {
     const message: Message = {
       id: "message",
@@ -190,6 +305,30 @@ describe("server session", () => {
     expect(store.data.part[kept.id]).toBeUndefined()
   })
 
+  test("replaces confirmed optimistic content with the initial page", async () => {
+    const optimistic: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const fetched = { ...optimistic, time: { created: 2 } }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: async () => ({ data: [{ info: fetched, parts: [] }], response: { headers: new Headers() } }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.optimistic.add({ sessionID: "child", message: optimistic, parts: [] })
+
+    await store.sync("child")
+
+    expect(store.data.message.child).toEqual([fetched])
+  })
+
   test("clears stale parts when the initial page has none", async () => {
     let resolveMessages:
       | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
@@ -227,6 +366,180 @@ describe("server session", () => {
     await loading
 
     expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("clears delta buffers for parts omitted by the initial page", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const kept: Part = { id: "part-1", sessionID: "child", messageID: message.id, type: "text", text: "kept" }
+    const removed: Part = { ...kept, id: "part-2", text: "removed" }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    store.apply({ type: "message.updated", properties: { info: message } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: kept, time: 1 } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: removed, time: 1 } })
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: removed.id, field: "text", delta: " delta" },
+    })
+    const loading = store.sync("child")
+
+    resolveMessages?.({ data: [{ info: message, parts: [kept] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.part[message.id]).toEqual([kept])
+    expect(store.data.part_text_accum_delta[removed.id]).toBeUndefined()
+  })
+
+  test("preserves live updates during a forced refresh", async () => {
+    let resolveRefresh:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const stale: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const stalePart: Part = {
+      id: "part",
+      sessionID: "child",
+      messageID: stale.id,
+      type: "text",
+      text: "stale",
+    }
+    let calls = 0
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () => {
+          calls += 1
+          if (calls === 1)
+            return Promise.resolve({ data: [{ info: stale, parts: [stalePart] }], response: { headers: new Headers() } })
+          return new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveRefresh = resolve
+          })
+        },
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    await store.sync("child")
+    const refreshing = store.sync("child", { force: true })
+    const live = { ...stale, time: { created: 2 } }
+    const livePart = { ...stalePart, text: "live" }
+
+    store.apply({ type: "message.updated", properties: { info: live } })
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: stale.id, partID: stalePart.id, field: "text", delta: " live" },
+    })
+    resolveRefresh?.({ data: [{ info: stale, parts: [stalePart] }], response: { headers: new Headers() } })
+    await refreshing
+
+    expect(store.data.message.child).toEqual([live])
+    expect(store.data.part[stale.id]).toEqual([{ ...livePart, text: "stale live" }])
+  })
+
+  test("preserves removals during history prepend", async () => {
+    let resolveHistory:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const latest: Message = {
+      id: "message-2",
+      sessionID: "child",
+      role: "user",
+      time: { created: 2 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const older = { ...latest, id: "message-1", time: { created: 1 } }
+    let calls = 0
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () => {
+          calls += 1
+          if (calls === 1)
+            return Promise.resolve({
+              data: [{ info: latest, parts: [] }],
+              response: { headers: new Headers({ "x-next-cursor": "older" }) },
+            })
+          return new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveHistory = resolve
+          })
+        },
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    await store.sync("child")
+    const loading = store.history.loadMore("child")
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: older.id } })
+    resolveHistory?.({ data: [{ info: older, parts: [] }], response: { headers: new Headers() } })
+    await loading
+
+    expect(store.data.message.child).toEqual([latest])
+  })
+
+  test("clears orphaned parts when a refresh drops a message", async () => {
+    const message: Message = {
+      id: "message",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const part: Part = {
+      id: "part",
+      sessionID: "child",
+      messageID: message.id,
+      type: "text",
+      text: "stale",
+    }
+    let calls = 0
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: async () => {
+          calls += 1
+          return {
+            data: calls === 1 ? [{ info: message, parts: [part] }] : [],
+            response: { headers: new Headers() },
+          }
+        },
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    await store.sync("child")
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: " delta" },
+    })
+    await store.sync("child", { force: true })
+
+    expect(store.data.message.child).toEqual([])
+    expect(store.data.part[message.id]).toBeUndefined()
+    expect(store.data.part_text_accum_delta[part.id]).toBeUndefined()
   })
 
   test("applies events without a directory store", () => {

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -13,6 +13,62 @@ const session = (id: string, parentID?: string): Session => ({
   time: { created: 1, updated: 1 },
 })
 
+type UserMessage = Extract<Message, { role: "user" }>
+type TextPart = Extract<Part, { type: "text" }>
+type MessageResponse = {
+  data: { info: Message; parts: Part[] }[]
+  response: { headers: Headers }
+}
+
+const userMessage = (id: string, input: Partial<UserMessage> = {}): UserMessage => ({
+  id,
+  sessionID: "child",
+  role: "user",
+  time: { created: 1 },
+  agent: "build",
+  model: { providerID: "provider", modelID: "model" },
+  ...input,
+})
+
+const textPart = (messageID: string, input: Partial<TextPart> = {}): TextPart => ({
+  id: "part",
+  sessionID: "child",
+  messageID,
+  type: "text",
+  text: "text",
+  ...input,
+})
+
+const response = (data: MessageResponse["data"] = [], cursor?: string): MessageResponse => ({
+  data,
+  response: { headers: new Headers(cursor ? { "x-next-cursor": cursor } : undefined) },
+})
+
+const deferredResponse = () => Promise.withResolvers<MessageResponse>()
+
+function messageClient(...responses: Array<MessageResponse | Promise<MessageResponse>>) {
+  let index = 0
+  const requests: unknown[] = []
+  const client = {
+    session: {
+      get: async () => ({ data: session("child", "root") }),
+      messages: (input: unknown) => {
+        requests.push(input)
+        return responses[index++]
+      },
+    },
+  } as unknown as OpencodeClient
+  return Object.assign(client, { requests })
+}
+
+async function waitForRequests(client: { requests: unknown[] }, count: number) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (client.requests.length >= count) return
+    await Bun.sleep(0)
+  }
+  throw new Error(`Expected ${count} message requests, received ${client.requests.length}`)
+}
+
 function setup(sessions: Record<string, Session>) {
   const get: unknown[] = []
   const messages: unknown[] = []
@@ -25,7 +81,7 @@ function setup(sessions: Record<string, Session>) {
       },
       messages: async (input: unknown) => {
         messages.push(input)
-        return { data: [], response: { headers: new Headers() } }
+        return response()
       },
       diff: async () => ({ data: [] }),
       todo: async () => ({ data: [] }),
@@ -56,44 +112,16 @@ describe("server session", () => {
   })
 
   test("merges live events into the initial page", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const user: Message = {
-      id: "message-1",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const live: Message = {
-      ...user,
-      id: "message-2",
-      time: { created: 2 },
-    }
-    const livePart: Part = {
-      id: "part",
-      sessionID: "child",
-      messageID: live.id,
-      type: "text",
-      text: "live",
-    }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const pending = deferredResponse()
+    const user = userMessage("message-1")
+    const live = userMessage("message-2", { time: { created: 2 } })
+    const livePart = textPart(live.id, { text: "live" })
+    const store = createServerSession(messageClient(pending.promise))
     const loading = store.sync("child")
 
     store.apply({ type: "message.updated", properties: { info: live } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: livePart, time: 2 } })
-    resolveMessages?.({ data: [{ info: user, parts: [] }], response: { headers: new Headers() } })
+    pending.resolve(response([{ info: user, parts: [] }]))
     await loading
 
     expect(store.data.message.child).toEqual([user, live])
@@ -101,41 +129,17 @@ describe("server session", () => {
   })
 
   test("preserves same-ID live updates over the initial page", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const fetched: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const fetchedPart: Part = {
-      id: "part",
-      sessionID: "child",
-      messageID: fetched.id,
-      type: "text",
-      text: "fetched",
-    }
+    const pending = deferredResponse()
+    const fetched = userMessage("message")
+    const fetchedPart = textPart(fetched.id, { text: "fetched" })
     const live = { ...fetched, time: { created: 2 } }
     const livePart = { ...fetchedPart, text: "live" }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const store = createServerSession(messageClient(pending.promise))
     const loading = store.sync("child")
 
     store.apply({ type: "message.updated", properties: { info: live } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: livePart, time: 2 } })
-    resolveMessages?.({ data: [{ info: fetched, parts: [fetchedPart] }], response: { headers: new Headers() } })
+    pending.resolve(response([{ info: fetched, parts: [fetchedPart] }]))
     await loading
 
     expect(store.data.message.child).toEqual([live])
@@ -143,35 +147,11 @@ describe("server session", () => {
   })
 
   test("preserves removals received during the initial load", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const removed: Message = {
-      id: "message-1",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
+    const pending = deferredResponse()
+    const removed = userMessage("message-1")
     const kept = { ...removed, id: "message-2" }
-    const part: Part = {
-      id: "part",
-      sessionID: "child",
-      messageID: kept.id,
-      type: "text",
-      text: "removed",
-    }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const part = textPart(kept.id, { text: "removed" })
+    const store = createServerSession(messageClient(pending.promise))
     const loading = store.sync("child")
 
     store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: removed.id } })
@@ -179,13 +159,12 @@ describe("server session", () => {
       type: "message.part.removed",
       properties: { sessionID: "child", messageID: kept.id, partID: part.id },
     })
-    resolveMessages?.({
-      data: [
+    pending.resolve(
+      response([
         { info: removed, parts: [] },
         { info: kept, parts: [part] },
-      ],
-      response: { headers: new Headers() },
-    })
+      ]),
+    )
     await loading
 
     expect(store.data.message.child).toEqual([kept])
@@ -193,103 +172,129 @@ describe("server session", () => {
   })
 
   test("keeps removal tracking isolated across load generations", async () => {
-    const resolveMessages: Array<
-      (value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void
-    > = []
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages.push(resolve)
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const firstResponse = deferredResponse()
+    const secondResponse = deferredResponse()
+    const message = userMessage("message")
+    const store = createServerSession(messageClient(firstResponse.promise, secondResponse.promise))
     const first = store.sync("child")
-    store.apply({ type: "session.deleted", properties: { info: session("child", "root") } })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    store.apply({
+      type: "session.deleted",
+      properties: { sessionID: "child", info: session("child", "root") },
+    })
+    const second = store.sync("child")
+
+    firstResponse.resolve(response())
+    await first
+    secondResponse.resolve(response([{ info: message, parts: [] }]))
+    await second
+
+    expect(store.data.message.child).toEqual([message])
+  })
+
+  test("tracks removals in a replacement load generation", async () => {
+    const firstResponse = deferredResponse()
+    const secondResponse = deferredResponse()
+    const message = userMessage("message")
+    const store = createServerSession(messageClient(firstResponse.promise, secondResponse.promise))
+    const first = store.sync("child")
+    store.apply({
+      type: "session.deleted",
+      properties: { sessionID: "child", info: session("child", "root") },
+    })
     const second = store.sync("child")
 
     store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
-    resolveMessages[0]?.({ data: [], response: { headers: new Headers() } })
+    firstResponse.resolve(response())
     await first
-    resolveMessages[1]?.({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
+    secondResponse.resolve(response([{ info: message, parts: [] }]))
     await second
 
     expect(store.data.message.child).toEqual([])
   })
 
-  test("preserves remove then re-add during a refresh", async () => {
-    let resolveRefresh:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    let calls = 0
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () => {
-          calls += 1
-          if (calls === 1)
-            return Promise.resolve({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
-          return new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveRefresh = resolve
-          })
-        },
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+  test("preserves remove then re-add when a refresh omits the message", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const store = createServerSession(messageClient(response([{ info: message, parts: [] }]), pending.promise))
     await store.sync("child")
     const refreshing = store.sync("child", { force: true })
 
     store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
     store.apply({ type: "message.updated", properties: { info: message } })
-    resolveRefresh?.({ data: [], response: { headers: new Headers() } })
+    pending.resolve(response())
     await refreshing
 
     expect(store.data.message.child).toEqual([message])
   })
 
+  test("preserves a re-added message without restoring removed parts", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "stale" })
+    const store = createServerSession(messageClient(response([{ info: message, parts: [] }]), pending.promise))
+    await store.sync("child")
+    const refreshing = store.sync("child", { force: true })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    store.apply({ type: "message.updated", properties: { info: message } })
+    pending.resolve(response([{ info: message, parts: [part] }]))
+    await refreshing
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("preserves optimistic parts re-added after removal during a refresh", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const stale = textPart(message.id, { id: "stale", text: "stale" })
+    const part = textPart(message.id, { id: "optimistic", text: "optimistic" })
+    const store = createServerSession(messageClient(response([{ info: message, parts: [] }]), pending.promise, response()))
+    await store.sync("child")
+    const refreshing = store.sync("child", { force: true })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    pending.resolve(response([{ info: message, parts: [stale] }]))
+    await refreshing
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toEqual([part])
+
+    await store.sync("child", { force: true })
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toEqual([part])
+  })
+
+  test("drops stale event content omitted by a complete initial page", async () => {
+    const stale = userMessage("stale")
+    const store = createServerSession(messageClient(response()))
+    store.apply({ type: "message.updated", properties: { info: stale } })
+
+    await store.sync("child")
+
+    expect(store.data.message.child).toEqual([])
+  })
+
+  test("preserves event content outside an incomplete initial page", async () => {
+    const live = userMessage("message-1")
+    const fetched = userMessage("message-2", { time: { created: 2 } })
+    const store = createServerSession(messageClient(response([{ info: fetched, parts: [] }], "older")))
+    store.apply({ type: "message.updated", properties: { info: live } })
+
+    await store.sync("child")
+
+    expect(store.data.message.child).toEqual([live, fetched])
+  })
+
   test("does not restore removed optimistic content on refresh", async () => {
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const part: Part = {
-      id: "part",
-      sessionID: "child",
-      messageID: message.id,
-      type: "text",
-      text: "removed",
-    }
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "removed" })
     const kept = { ...message, id: "kept" }
     const keptPart = { ...part, id: "kept-part", messageID: kept.id }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: async () => ({ data: [{ info: kept, parts: [] }], response: { headers: new Headers() } }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const store = createServerSession(messageClient(response([{ info: kept, parts: [] }])))
     store.optimistic.add({ sessionID: "child", message, parts: [part] })
     store.optimistic.add({ sessionID: "child", message: kept, parts: [keptPart] })
 
@@ -306,22 +311,9 @@ describe("server session", () => {
   })
 
   test("replaces confirmed optimistic content with the initial page", async () => {
-    const optimistic: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
+    const optimistic = userMessage("message")
     const fetched = { ...optimistic, time: { created: 2 } }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: async () => ({ data: [{ info: fetched, parts: [] }], response: { headers: new Headers() } }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const store = createServerSession(messageClient(response([{ info: fetched, parts: [] }])))
     store.optimistic.add({ sessionID: "child", message: optimistic, parts: [] })
 
     await store.sync("child")
@@ -329,69 +321,154 @@ describe("server session", () => {
     expect(store.data.message.child).toEqual([fetched])
   })
 
+  test("replaces a confirmed optimistic part with fetched content", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const optimistic = textPart(message.id, { text: "optimistic" })
+    const fetched = { ...optimistic, text: "fetched" }
+    const store = createServerSession(messageClient(pending.promise))
+    const loading = store.sync("child")
+
+    store.optimistic.add({ sessionID: "child", message, parts: [optimistic] })
+    pending.resolve(response([{ info: message, parts: [fetched] }]))
+    await loading
+
+    expect(store.data.part[message.id]).toEqual([fetched])
+  })
+
+  test("rolls back only unconfirmed optimistic parts", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const confirmed = textPart(message.id, { id: "confirmed", text: "confirmed" })
+    const pendingPart = textPart(message.id, { id: "pending", text: "pending" })
+    const store = createServerSession(messageClient(pending.promise))
+    const loading = store.sync("child")
+    store.optimistic.add({ sessionID: "child", message, parts: [confirmed, pendingPart] })
+
+    pending.resolve(response([{ info: message, parts: [confirmed] }]))
+    await loading
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toEqual([confirmed])
+  })
+
+  test("updates confirmed optimistic parts from later pages", async () => {
+    const message = userMessage("message")
+    const confirmed = textPart(message.id, { id: "confirmed", text: "first" })
+    const updated = { ...confirmed, text: "updated" }
+    const pendingPart = textPart(message.id, { id: "pending", text: "pending" })
+    const store = createServerSession(
+      messageClient(
+        response([{ info: message, parts: [confirmed] }]),
+        response([{ info: message, parts: [updated] }]),
+      ),
+    )
+    store.optimistic.add({ sessionID: "child", message, parts: [confirmed, pendingPart] })
+    await store.sync("child")
+
+    await store.sync("child", { force: true })
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.part[message.id]).toEqual([updated])
+  })
+
+  test("does not restore a confirmed optimistic part after its removal event", async () => {
+    const message = userMessage("message")
+    const confirmed = textPart(message.id, { id: "confirmed", text: "confirmed" })
+    const pendingPart = textPart(message.id, { id: "pending", text: "pending" })
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [confirmed] }]), response([{ info: message, parts: [] }])),
+    )
+    store.optimistic.add({ sessionID: "child", message, parts: [confirmed, pendingPart] })
+    await store.sync("child")
+    store.apply({
+      type: "message.part.removed",
+      properties: { sessionID: "child", messageID: message.id, partID: confirmed.id },
+    })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toEqual([pendingPart])
+  })
+
+  test("clears delta buffers when removing optimistic content", () => {
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "optimistic" })
+    const store = setup({ child: session("child") }).store
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: " delta" },
+    })
+
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.part[message.id]).toBeUndefined()
+    expect(store.data.part_text_accum_delta[part.id]).toBeUndefined()
+  })
+
+  test("does not remove content confirmed by a message event", () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = setup({ child: session("child") }).store
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    store.apply({ type: "message.updated", properties: { sessionID: "child", info: message } })
+
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("does not remove parts confirmed by part events", () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = setup({ child: session("child") }).store
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    store.apply({ type: "message.updated", properties: { sessionID: "child", info: message } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 2 } })
+
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toEqual([part])
+  })
+
+  test("treats a part event as confirmation when it precedes the message event", () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = setup({ child: session("child") }).store
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 2 } })
+
+    store.optimistic.remove({ sessionID: "child", messageID: message.id })
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toEqual([part])
+  })
+
   test("clears stale parts when the initial page has none", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const part: Part = {
-      id: "part",
-      sessionID: "child",
-      messageID: message.id,
-      type: "text",
-      text: "stale",
-    }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "stale" })
+    const store = createServerSession(messageClient(pending.promise))
     store.apply({ type: "message.updated", properties: { info: message } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 1 } })
     const loading = store.sync("child")
 
-    resolveMessages?.({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
+    pending.resolve(response([{ info: message, parts: [] }]))
     await loading
 
     expect(store.data.part[message.id]).toBeUndefined()
   })
 
   test("clears delta buffers for parts omitted by the initial page", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const kept: Part = { id: "part-1", sessionID: "child", messageID: message.id, type: "text", text: "kept" }
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const kept = textPart(message.id, { id: "part-1", text: "kept" })
     const removed: Part = { ...kept, id: "part-2", text: "removed" }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const store = createServerSession(messageClient(pending.promise))
     store.apply({ type: "message.updated", properties: { info: message } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: kept, time: 1 } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: removed, time: 1 } })
@@ -401,135 +478,585 @@ describe("server session", () => {
     })
     const loading = store.sync("child")
 
-    resolveMessages?.({ data: [{ info: message, parts: [kept] }], response: { headers: new Headers() } })
+    pending.resolve(response([{ info: message, parts: [kept] }]))
     await loading
 
     expect(store.data.part[message.id]).toEqual([kept])
     expect(store.data.part_text_accum_delta[removed.id]).toBeUndefined()
   })
 
+  test("clears a stale delta buffer when a refresh replaces its part", async () => {
+    const message = userMessage("message")
+    const stale = textPart(message.id, { text: "stale" })
+    const fetched = { ...stale, text: "fetched" }
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [stale] }]), response([{ info: message, parts: [fetched] }])),
+    )
+    await store.sync("child")
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: stale.id, field: "text", delta: " delta" },
+    })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toEqual([fetched])
+    expect(store.data.part_text_accum_delta[stale.id]).toBeUndefined()
+  })
+
+  test("preserves a non-durable delta received before refresh", async () => {
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "stale" })
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [part] }]), response([{ info: message, parts: [{ ...part }] }])),
+    )
+    await store.sync("child")
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: " delta" },
+    })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toEqual([{ ...part, text: "stale delta" }])
+    expect(store.data.part_text_accum_delta[part.id]).toBe("stale delta")
+  })
+
+  test("accepts fetched text that intentionally replaces an accumulated prefix", async () => {
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "abc" })
+    const fetched = { ...part, text: "ab" }
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [part] }]), response([{ info: message, parts: [fetched] }])),
+    )
+    await store.sync("child")
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: "def" },
+    })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toEqual([fetched])
+    expect(store.data.part_text_accum_delta[part.id]).toBeUndefined()
+  })
+
+  test("preserves an unpersisted delta suffix after partial server catch-up", async () => {
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "a" })
+    const fetched = { ...part, text: "ab" }
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [part] }]), response([{ info: message, parts: [fetched] }])),
+    )
+    await store.sync("child")
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: "bc" },
+    })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toEqual([{ ...part, text: "abc" }])
+    expect(store.data.part_text_accum_delta[part.id]).toBe("abc")
+  })
+
+  test("clears delta state after exact server catch-up", async () => {
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "a" })
+    const fetched = { ...part, text: "ab" }
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [part] }]), response([{ info: message, parts: [fetched] }])),
+    )
+    await store.sync("child")
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: "b" },
+    })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toEqual([fetched])
+    expect(store.data.part_text_accum_delta[part.id]).toBeUndefined()
+  })
+
+  test("uses the successful retry response over events from a failed attempt", async () => {
+    const failed = Promise.withResolvers<MessageResponse>()
+    const retried = Promise.withResolvers<MessageResponse>()
+    const message = userMessage("message")
+    const stale = textPart(message.id, { text: "stale" })
+    const intermediate = { ...stale, text: "intermediate" }
+    const fetched = { ...stale, text: "fetched" }
+    const client = messageClient(failed.promise, retried.promise)
+    const store = createServerSession(client, { retryDelay: 0 })
+    store.apply({ type: "message.updated", properties: { info: message } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: stale, time: 1 } })
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: intermediate, time: 2 } })
+    failed.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 2)
+    retried.resolve(response([{ info: message, parts: [fetched] }]))
+    await loading
+
+    expect(store.data.part[message.id]).toEqual([fetched])
+  })
+
+  test("preserves non-durable deltas across message retries", async () => {
+    const failed = Promise.withResolvers<MessageResponse>()
+    const retried = Promise.withResolvers<MessageResponse>()
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "stale" })
+    const client = messageClient(failed.promise, retried.promise)
+    const store = createServerSession(client, { retryDelay: 0 })
+    store.apply({ type: "message.updated", properties: { info: message } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 1 } })
+    const loading = store.sync("child")
+
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: " delta" },
+    })
+    failed.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 2)
+    retried.resolve(response([{ info: message, parts: [part] }]))
+    await loading
+
+    expect(store.data.part[message.id]).toEqual([{ ...part, text: "stale delta" }])
+  })
+
+  test("preserves part removals across message retries", async () => {
+    const failed = Promise.withResolvers<MessageResponse>()
+    const retried = Promise.withResolvers<MessageResponse>()
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const client = messageClient(response([{ info: message, parts: [part] }]), failed.promise, retried.promise)
+    const store = createServerSession(client, { retryDelay: 0 })
+    await store.sync("child")
+    const loading = store.sync("child", { force: true })
+
+    store.apply({
+      type: "message.part.removed",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id },
+    })
+    failed.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 3)
+    retried.resolve(response([{ info: message, parts: [part] }]))
+    await loading
+
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("preserves message removals across message retries", async () => {
+    const failed = Promise.withResolvers<MessageResponse>()
+    const retried = Promise.withResolvers<MessageResponse>()
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const client = messageClient(response([{ info: message, parts: [part] }]), failed.promise, retried.promise)
+    const store = createServerSession(client, { retryDelay: 0 })
+    await store.sync("child")
+    const loading = store.sync("child", { force: true })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    failed.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 3)
+    retried.resolve(response([{ info: message, parts: [part] }]))
+    await loading
+
+    expect(store.data.message.child).toEqual([])
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("preserves optimistic re-adds across message retries", async () => {
+    const failed = Promise.withResolvers<MessageResponse>()
+    const retried = Promise.withResolvers<MessageResponse>()
+    const message = userMessage("message")
+    const stale = textPart(message.id, { id: "stale", text: "stale" })
+    const optimistic = textPart(message.id, { id: "optimistic", text: "optimistic" })
+    const client = messageClient(response([{ info: message, parts: [stale] }]), failed.promise, retried.promise)
+    const store = createServerSession(client, { retryDelay: 0 })
+    await store.sync("child")
+    const loading = store.sync("child", { force: true })
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    store.optimistic.add({ sessionID: "child", message, parts: [optimistic] })
+    failed.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 3)
+    retried.resolve(response([{ info: message, parts: [stale] }]))
+    await loading
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toEqual([optimistic])
+  })
+
+  test("accepts part omission from a successful retry after an earlier delta", async () => {
+    const failed = Promise.withResolvers<MessageResponse>()
+    const retried = Promise.withResolvers<MessageResponse>()
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const client = messageClient(response([{ info: message, parts: [part] }]), failed.promise, retried.promise)
+    const store = createServerSession(client, { retryDelay: 0 })
+    await store.sync("child")
+    const loading = store.sync("child", { force: true })
+
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id, field: "text", delta: " delta" },
+    })
+    failed.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 3)
+    retried.resolve(response([{ info: message, parts: [] }]))
+    await loading
+
+    expect(store.data.part[message.id]).toBeUndefined()
+    expect(store.data.part_text_accum_delta[part.id]).toBeUndefined()
+  })
+
+  test("clears load-owned orphan parts when all retries fail", async () => {
+    const first = Promise.withResolvers<MessageResponse>()
+    const second = Promise.withResolvers<MessageResponse>()
+    const third = Promise.withResolvers<MessageResponse>()
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const client = messageClient(first.promise, second.promise, third.promise)
+    const store = createServerSession(client, { retryDelay: 0 })
+    const loading = store.sync("child").catch((error) => error)
+
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 2 } })
+    first.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 2)
+    second.reject(new Error("failed to fetch"))
+    await waitForRequests(client, 3)
+    third.reject(new Error("failed to fetch"))
+    await loading
+
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
   test("preserves live updates during a forced refresh", async () => {
-    let resolveRefresh:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const stale: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const stalePart: Part = {
-      id: "part",
-      sessionID: "child",
-      messageID: stale.id,
-      type: "text",
-      text: "stale",
-    }
-    let calls = 0
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () => {
-          calls += 1
-          if (calls === 1)
-            return Promise.resolve({ data: [{ info: stale, parts: [stalePart] }], response: { headers: new Headers() } })
-          return new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveRefresh = resolve
-          })
-        },
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const pending = deferredResponse()
+    const stale = userMessage("message")
+    const stalePart = textPart(stale.id, { text: "stale" })
+    const store = createServerSession(messageClient(response([{ info: stale, parts: [stalePart] }]), pending.promise))
     await store.sync("child")
     const refreshing = store.sync("child", { force: true })
     const live = { ...stale, time: { created: 2 } }
-    const livePart = { ...stalePart, text: "live" }
 
     store.apply({ type: "message.updated", properties: { info: live } })
     store.apply({
       type: "message.part.delta",
       properties: { sessionID: "child", messageID: stale.id, partID: stalePart.id, field: "text", delta: " live" },
     })
-    resolveRefresh?.({ data: [{ info: stale, parts: [stalePart] }], response: { headers: new Headers() } })
+    pending.resolve(response([{ info: stale, parts: [stalePart] }]))
     await refreshing
 
     expect(store.data.message.child).toEqual([live])
-    expect(store.data.part[stale.id]).toEqual([{ ...livePart, text: "stale live" }])
+    expect(store.data.part[stale.id]).toEqual([{ ...stalePart, text: "stale live" }])
+  })
+
+  test("keeps fetched message metadata when only a part changes", async () => {
+    const pending = deferredResponse()
+    const stale = userMessage("message")
+    const fetched = { ...stale, time: { created: 2 } }
+    const part = textPart(stale.id, { text: "stale" })
+    const store = createServerSession(messageClient(response([{ info: stale, parts: [part] }]), pending.promise))
+    await store.sync("child")
+    const refreshing = store.sync("child", { force: true })
+
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: stale.id, partID: part.id, field: "text", delta: " live" },
+    })
+    pending.resolve(response([{ info: fetched, parts: [part] }]))
+    await refreshing
+
+    expect(store.data.message.child).toEqual([fetched])
+    expect(store.data.part[stale.id]).toEqual([{ ...part, text: "stale live" }])
+  })
+
+  test("preserves a part update when a forced refresh omits its message", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const stale = textPart(message.id, { text: "stale" })
+    const live = { ...stale, text: "live" }
+    const store = createServerSession(messageClient(response([{ info: message, parts: [stale] }]), pending.promise))
+    await store.sync("child")
+    const refreshing = store.sync("child", { force: true })
+
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: live, time: 2 } })
+    pending.resolve(response())
+    await refreshing
+
+    expect(store.data.message.child).toEqual([message])
+    expect(store.data.part[message.id]).toEqual([live])
+  })
+
+  test("ignores a late part update after its message is removed", async () => {
+    const pending = deferredResponse()
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = createServerSession(messageClient(pending.promise))
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.updated", properties: { info: message } })
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 2 } })
+    pending.resolve(response([{ info: message, parts: [part] }]))
+    await loading
+
+    expect(store.data.message.child).toEqual([])
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("ignores a late part update after a completed message removal", () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = setup({ child: session("child") }).store
+    store.apply({ type: "message.updated", properties: { info: message } })
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 2 } })
+
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("does not restore a completed message removal from a stale refresh", async () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [part] }]), response([{ info: message, parts: [part] }])),
+    )
+    await store.sync("child")
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.message.child).toEqual([])
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("does not restore a completed part removal from a stale refresh", async () => {
+    const message = userMessage("message")
+    const part = textPart(message.id)
+    const store = createServerSession(
+      messageClient(response([{ info: message, parts: [part] }]), response([{ info: message, parts: [part] }])),
+    )
+    await store.sync("child")
+    store.apply({
+      type: "message.part.removed",
+      properties: { sessionID: "child", messageID: message.id, partID: part.id },
+    })
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toBeUndefined()
+  })
+
+  test("does not cache skipped optimistic parts", () => {
+    const message = userMessage("message")
+    const part = { id: "part", sessionID: "child", messageID: message.id, type: "step-start" as const }
+    const store = setup({ child: session("child") }).store
+
+    store.optimistic.add({ sessionID: "child", message, parts: [part] })
+
+    expect(store.data.part[message.id]).toEqual([])
+  })
+
+  test("clears stale delta buffers when replacing optimistic parts", () => {
+    const message = userMessage("message")
+    const stale = textPart(message.id, { id: "stale", text: "stale" })
+    const optimistic = textPart(message.id, { id: "optimistic", text: "optimistic" })
+    const store = setup({ child: session("child") }).store
+    store.optimistic.add({ sessionID: "child", message, parts: [stale] })
+    store.apply({
+      type: "message.part.delta",
+      properties: { sessionID: "child", messageID: message.id, partID: stale.id, field: "text", delta: " delta" },
+    })
+
+    store.optimistic.add({ sessionID: "child", message, parts: [optimistic] })
+
+    expect(store.data.part_text_accum_delta[stale.id]).toBeUndefined()
+    expect(store.data.part_text_accum_delta[optimistic.id]).toBeUndefined()
   })
 
   test("preserves removals during history prepend", async () => {
-    let resolveHistory:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const latest: Message = {
-      id: "message-2",
-      sessionID: "child",
-      role: "user",
-      time: { created: 2 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
+    const pending = deferredResponse()
+    const latest = userMessage("message-2", { time: { created: 2 } })
     const older = { ...latest, id: "message-1", time: { created: 1 } }
-    let calls = 0
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () => {
-          calls += 1
-          if (calls === 1)
-            return Promise.resolve({
-              data: [{ info: latest, parts: [] }],
-              response: { headers: new Headers({ "x-next-cursor": "older" }) },
-            })
-          return new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveHistory = resolve
-          })
-        },
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const store = createServerSession(messageClient(response([{ info: latest, parts: [] }], "older"), pending.promise))
     await store.sync("child")
     const loading = store.history.loadMore("child")
 
     store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: older.id } })
-    resolveHistory?.({ data: [{ info: older, parts: [] }], response: { headers: new Headers() } })
+    pending.resolve(response([{ info: older, parts: [] }]))
     await loading
 
     expect(store.data.message.child).toEqual([latest])
   })
 
+  test("preserves loaded history during an incomplete refresh", async () => {
+    const older = userMessage("message-1")
+    const latest = userMessage("message-2", { time: { created: 2 } })
+    const fresh = userMessage("message-3", { time: { created: 3 } })
+    const store = createServerSession(
+      messageClient(
+        response(
+          [
+            { info: older, parts: [] },
+            { info: latest, parts: [] },
+          ],
+          "older",
+        ),
+        response(
+          [
+            { info: latest, parts: [] },
+            { info: fresh, parts: [] },
+          ],
+          "older",
+        ),
+      ),
+    )
+    await store.sync("child")
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.message.child).toEqual([older, latest, fresh])
+  })
+
+  test("drops stale recent messages omitted by an incomplete refresh", async () => {
+    const third = userMessage("message-3", { time: { created: 3 } })
+    const fourth = userMessage("message-4", { time: { created: 4 } })
+    const stale = userMessage("message-5", { time: { created: 5 } })
+    const store = createServerSession(
+      messageClient(
+        response(
+          [
+            { info: fourth, parts: [] },
+            { info: stale, parts: [] },
+          ],
+          "older",
+        ),
+        response(
+          [
+            { info: third, parts: [] },
+            { info: fourth, parts: [] },
+          ],
+          "older",
+        ),
+      ),
+    )
+    await store.sync("child")
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.message.child).toEqual([third, fourth])
+  })
+
+  test("uses message creation time for incomplete refresh boundaries", async () => {
+    const older = userMessage("msg_z", { time: { created: 1 } })
+    const boundary = userMessage("msg_m", { time: { created: 2 } })
+    const stale = userMessage("msg_a", { time: { created: 3 } })
+    const store = createServerSession(
+      messageClient(
+        response(
+          [
+            { info: older, parts: [] },
+            { info: stale, parts: [] },
+          ],
+          "older",
+        ),
+        response([{ info: boundary, parts: [] }], "older"),
+      ),
+    )
+    await store.sync("child")
+
+    await store.sync("child", { force: true })
+
+    expect(store.data.message.child).toEqual([boundary, older])
+  })
+
+  test("preserves a part update for a message being loaded from history", async () => {
+    const pending = deferredResponse()
+    const latest = userMessage("message-2", { time: { created: 2 } })
+    const older = userMessage("message-1")
+    const stale = textPart(older.id, { text: "stale" })
+    const live = { ...stale, text: "live" }
+    const store = createServerSession(messageClient(response([{ info: latest, parts: [] }], "older"), pending.promise))
+    await store.sync("child")
+    const loading = store.history.loadMore("child")
+
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: live, time: 2 } })
+    pending.resolve(response([{ info: older, parts: [stale] }]))
+    await loading
+
+    expect(store.data.part[older.id]).toEqual([live])
+  })
+
+  test("does not clear newer orphan parts after terminal history prepend", async () => {
+    const pending = deferredResponse()
+    const latest = userMessage("message-2", { time: { created: 2 } })
+    const older = userMessage("message-1")
+    const newer = userMessage("message-3", { time: { created: 3 } })
+    const part = textPart(newer.id, { text: "live" })
+    const store = createServerSession(messageClient(response([{ info: latest, parts: [] }], "older"), pending.promise))
+    await store.sync("child")
+    const loading = store.history.loadMore("child")
+
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 3 } })
+    pending.resolve(response([{ info: older, parts: [] }]))
+    await loading
+    store.apply({ type: "message.updated", properties: { sessionID: "child", info: newer } })
+
+    expect(store.data.part[newer.id]).toEqual([part])
+  })
+
+  test("accepts an authoritative history part after an earlier unknown-parent update", async () => {
+    const pending = deferredResponse()
+    const history = deferredResponse()
+    const latest = userMessage("message-2", { time: { created: 2 } })
+    const older = userMessage("message-1")
+    const part = textPart(older.id, { text: "live" })
+    const store = createServerSession(messageClient(pending.promise, history.promise))
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part, time: 2 } })
+    pending.resolve(response([{ info: latest, parts: [] }], "older"))
+    await loading
+
+    expect(store.data.part[older.id]).toEqual([part])
+
+    const loadingHistory = store.history.loadMore("child")
+    history.resolve(response([{ info: older, parts: [{ ...part, text: "stale" }] }]))
+    await loadingHistory
+
+    expect(store.data.part[older.id]).toEqual([{ ...part, text: "stale" }])
+  })
+
+  test("preserves an unknown-parent part removal across pages", async () => {
+    const initial = deferredResponse()
+    const history = deferredResponse()
+    const latest = userMessage("message-2", { time: { created: 2 } })
+    const older = userMessage("message-1")
+    const part = textPart(older.id)
+    const store = createServerSession(messageClient(initial.promise, history.promise))
+    const loading = store.sync("child")
+
+    store.apply({
+      type: "message.part.removed",
+      properties: { sessionID: "child", messageID: older.id, partID: part.id },
+    })
+    initial.resolve(response([{ info: latest, parts: [] }], "older"))
+    await loading
+    const loadingHistory = store.history.loadMore("child")
+    history.resolve(response([{ info: older, parts: [part] }]))
+    await loadingHistory
+
+    expect(store.data.part[older.id]).toBeUndefined()
+  })
+
   test("clears orphaned parts when a refresh drops a message", async () => {
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const part: Part = {
-      id: "part",
-      sessionID: "child",
-      messageID: message.id,
-      type: "text",
-      text: "stale",
-    }
-    let calls = 0
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: async () => {
-          calls += 1
-          return {
-            data: calls === 1 ? [{ info: message, parts: [part] }] : [],
-            response: { headers: new Headers() },
-          }
-        },
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
+    const message = userMessage("message")
+    const part = textPart(message.id, { text: "stale" })
+    const store = createServerSession(messageClient(response([{ info: message, parts: [part] }]), response()))
     await store.sync("child")
     store.apply({
       type: "message.part.delta",
@@ -544,11 +1071,12 @@ describe("server session", () => {
 
   test("applies events without a directory store", () => {
     const ctx = setup({})
-    ctx.store.apply({ type: "session.created", properties: { info: session("root") } })
+    ctx.store.apply({ type: "session.created", properties: { sessionID: "root", info: session("root") } })
     ctx.store.apply({ type: "session.status", properties: { sessionID: "root", status: { type: "busy" } } })
 
     expect(ctx.store.get("root")?.directory).toBe("/repo")
     expect(ctx.store.data.session_working("root")).toBe(true)
+    expect(ctx.get).toEqual([])
   })
 
   test("preserves pinned session content under server-wide cache pressure", () => {
@@ -574,12 +1102,14 @@ describe("server session", () => {
     })
 
     for (let index = 0; index < 50; index++) {
+      ctx.store.remember(session(`session-${index}`))
       ctx.store.apply({
         type: "session.status",
-        properties: { sessionID: `session-${index}`, status: { type: "busy" } },
+        properties: { sessionID: `session-${index}`, status: { type: "idle" } },
       })
     }
 
     expect(ctx.store.data.message.active?.map((message) => message.id)).toEqual(["message"])
+    expect(ctx.store.data.session_status["session-0"]).toBeUndefined()
   })
 })

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -100,6 +100,56 @@ describe("server session", () => {
     expect(store.data.part[live.id]).toEqual([livePart])
   })
 
+  test("preserves removals received during the initial load", async () => {
+    let resolveMessages:
+      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
+      | undefined
+    const removed: Message = {
+      id: "message-1",
+      sessionID: "child",
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    }
+    const kept = { ...removed, id: "message-2" }
+    const part: Part = {
+      id: "part",
+      sessionID: "child",
+      messageID: kept.id,
+      type: "text",
+      text: "removed",
+    }
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: () =>
+          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
+            resolveMessages = resolve
+          }),
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    const loading = store.sync("child")
+
+    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: removed.id } })
+    store.apply({
+      type: "message.part.removed",
+      properties: { sessionID: "child", messageID: kept.id, partID: part.id },
+    })
+    resolveMessages?.({
+      data: [
+        { info: removed, parts: [] },
+        { info: kept, parts: [part] },
+      ],
+      response: { headers: new Headers() },
+    })
+    await loading
+
+    expect(store.data.message.child).toEqual([kept])
+    expect(store.data.part[kept.id]).toBeUndefined()
+  })
+
   test("applies events without a directory store", () => {
     const ctx = setup({})
     ctx.store.apply({ type: "session.created", properties: { info: session("root") } })

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -55,24 +55,29 @@ describe("server session", () => {
     expect(ctx.store.data.message.root).toEqual([])
   })
 
-  test("discards an initial page made stale by live events", async () => {
+  test("merges live events into the initial page", async () => {
     let resolveMessages:
       | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
       | undefined
-    const stale: Message = {
-      id: "message",
+    const user: Message = {
+      id: "message-1",
       sessionID: "child",
       role: "user",
       time: { created: 1 },
       agent: "build",
       model: { providerID: "provider", modelID: "model" },
     }
-    const stalePart: Part = {
+    const live: Message = {
+      ...user,
+      id: "message-2",
+      time: { created: 2 },
+    }
+    const livePart: Part = {
       id: "part",
       sessionID: "child",
-      messageID: stale.id,
+      messageID: live.id,
       type: "text",
-      text: "stale",
+      text: "live",
     }
     const client = {
       session: {
@@ -85,16 +90,14 @@ describe("server session", () => {
     } as unknown as OpencodeClient
     const store = createServerSession(client)
     const loading = store.sync("child")
-    const live = { ...stale, time: { created: 2 } }
-    const livePart = { ...stalePart, text: "live" }
 
     store.apply({ type: "message.updated", properties: { info: live } })
     store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: livePart, time: 2 } })
-    resolveMessages?.({ data: [{ info: stale, parts: [stalePart] }], response: { headers: new Headers() } })
+    resolveMessages?.({ data: [{ info: user, parts: [] }], response: { headers: new Headers() } })
     await loading
 
-    expect(store.data.message.child).toEqual([live])
-    expect(store.data.part[stale.id]).toEqual([livePart])
+    expect(store.data.message.child).toEqual([user, live])
+    expect(store.data.part[live.id]).toEqual([livePart])
   })
 
   test("applies events without a directory store", () => {

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -55,218 +55,7 @@ describe("server session", () => {
     expect(ctx.store.data.message.root).toEqual([])
   })
 
-  test("preserves live messages received during the initial load", async () => {
-    let resolveMessages: ((value: { data: []; response: { headers: Headers } }) => void) | undefined
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: []; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
-    const loading = store.sync("child")
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-
-    store.apply({ type: "message.updated", properties: { info: message } })
-    resolveMessages?.({ data: [], response: { headers: new Headers() } })
-    await loading
-
-    expect(store.data.message.child).toEqual([message])
-  })
-
-  test("preserves live message removals received during the initial load", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
-    const loading = store.sync("child")
-
-    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: message.id } })
-    resolveMessages?.({ data: [{ info: message, parts: [] }], response: { headers: new Headers() } })
-    await loading
-
-    expect(store.data.message.child).toEqual([])
-  })
-
-  test("preserves live part updates received during the initial load", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const stale: Part = { id: "part", sessionID: "child", messageID: message.id, type: "text", text: "stale" }
-    const live: Part = { ...stale, text: "live" }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
-    const loading = store.sync("child")
-
-    store.apply({
-      type: "message.part.updated",
-      properties: { sessionID: "child", part: live, time: 2 },
-    })
-    resolveMessages?.({ data: [{ info: message, parts: [stale] }], response: { headers: new Headers() } })
-    await loading
-
-    expect(store.data.part[message.id]).toEqual([live])
-  })
-
-  test("preserves events when the first message arrives before the initial load", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const stale: Part = { id: "part", sessionID: "child", messageID: message.id, type: "text", text: "stale" }
-    const live: Part = { ...stale, text: "live" }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
-    store.apply({ type: "message.updated", properties: { info: message } })
-    const loading = store.sync("child")
-
-    store.apply({
-      type: "message.part.updated",
-      properties: { sessionID: "child", part: live, time: 2 },
-    })
-    resolveMessages?.({ data: [{ info: message, parts: [stale] }], response: { headers: new Headers() } })
-    await loading
-
-    expect(store.data.part[message.id]).toEqual([live])
-  })
-
-  test("does not replay deltas already included in the initial page", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const stale: Part = { id: "part", sessionID: "child", messageID: message.id, type: "text", text: "stale" }
-    const live: Part = { ...stale, text: "live" }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
-    store.apply({ type: "message.updated", properties: { info: message } })
-    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: live, time: 1 } })
-    const loading = store.sync("child")
-
-    for (let index = 0; index < 4_097; index++) {
-      store.apply({
-        type: "message.part.delta",
-        properties: { sessionID: "child", messageID: message.id, partID: live.id, field: "text", delta: "x" },
-      })
-    }
-    resolveMessages?.({
-      data: [{ info: message, parts: [{ ...stale, text: `live${"x".repeat(4_097)}` }] }],
-      response: { headers: new Headers() },
-    })
-    await loading
-
-    const part = store.data.part[message.id]?.find((part) => part.type === "text")
-    expect(part?.text).toBe(`live${"x".repeat(4_097)}`)
-  })
-
-  test("prefers a newer initial page over an older message event", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const message: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
-    const loading = store.sync("child")
-
-    store.apply({ type: "message.updated", properties: { info: message } })
-    resolveMessages?.({
-      data: [{ info: { ...message, time: { created: 2 } }, parts: [] }],
-      response: { headers: new Headers() },
-    })
-    await loading
-
-    expect(store.data.message.child?.[0]?.time.created).toBe(2)
-  })
-
-  test("preserves a newer message event over a stale initial page", async () => {
+  test("discards an initial page made stale by live events", async () => {
     let resolveMessages:
       | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
       | undefined
@@ -278,7 +67,13 @@ describe("server session", () => {
       agent: "build",
       model: { providerID: "provider", modelID: "model" },
     }
-    const live: Message = { ...stale, time: { created: 2 } }
+    const stalePart: Part = {
+      id: "part",
+      sessionID: "child",
+      messageID: stale.id,
+      type: "text",
+      text: "stale",
+    }
     const client = {
       session: {
         get: async () => ({ data: session("child", "root") }),
@@ -289,49 +84,17 @@ describe("server session", () => {
       },
     } as unknown as OpencodeClient
     const store = createServerSession(client)
-    store.apply({ type: "message.updated", properties: { info: stale } })
     const loading = store.sync("child")
+    const live = { ...stale, time: { created: 2 } }
+    const livePart = { ...stalePart, text: "live" }
 
     store.apply({ type: "message.updated", properties: { info: live } })
-    resolveMessages?.({ data: [{ info: stale, parts: [] }], response: { headers: new Headers() } })
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: livePart, time: 2 } })
+    resolveMessages?.({ data: [{ info: stale, parts: [stalePart] }], response: { headers: new Headers() } })
     await loading
 
-    expect(store.data.message.child?.[0]?.time.created).toBe(2)
-  })
-
-  test("preserves a newer initial message over an older removal event", async () => {
-    let resolveMessages:
-      | ((value: { data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }) => void)
-      | undefined
-    const stale: Message = {
-      id: "message",
-      sessionID: "child",
-      role: "user",
-      time: { created: 1 },
-      agent: "build",
-      model: { providerID: "provider", modelID: "model" },
-    }
-    const client = {
-      session: {
-        get: async () => ({ data: session("child", "root") }),
-        messages: () =>
-          new Promise<{ data: { info: Message; parts: Part[] }[]; response: { headers: Headers } }>((resolve) => {
-            resolveMessages = resolve
-          }),
-      },
-    } as unknown as OpencodeClient
-    const store = createServerSession(client)
-    store.apply({ type: "message.updated", properties: { info: stale } })
-    const loading = store.sync("child")
-
-    store.apply({ type: "message.removed", properties: { sessionID: "child", messageID: stale.id } })
-    resolveMessages?.({
-      data: [{ info: { ...stale, time: { created: 2 } }, parts: [] }],
-      response: { headers: new Headers() },
-    })
-    await loading
-
-    expect(store.data.message.child?.[0]?.time.created).toBe(2)
+    expect(store.data.message.child).toEqual([live])
+    expect(store.data.part[stale.id]).toEqual([livePart])
   })
 
   test("applies events without a directory store", () => {

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -75,6 +75,30 @@ function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
   return [...items.values()].sort((x, y) => cmp(x.id, y.id))
 }
 
+function mergeConcurrent<T extends { id: string }>(
+  fetched: T[],
+  current: readonly T[],
+  before: Map<string, string>,
+  partial = false,
+) {
+  const next = new Map(fetched.map((item) => [item.id, item]))
+  const live = new Map(current.map((item) => [item.id, item]))
+  for (const id of new Set([...next.keys(), ...live.keys(), ...before.keys()])) {
+    const fetchedItem = next.get(id)
+    const liveItem = live.get(id)
+    const previous = before.get(id)
+    if (partial && !fetchedItem && liveItem) {
+      next.set(id, liveItem)
+      continue
+    }
+    if (JSON.stringify(liveItem) === previous) continue
+    if (JSON.stringify(fetchedItem) !== previous) continue
+    if (liveItem) next.set(id, liveItem)
+    if (!liveItem) next.delete(id)
+  }
+  return [...next.values()].sort((a, b) => cmp(a.id, b.id))
+}
+
 export function createServerSession(client: OpencodeClient) {
   const [data, setData] = createStore({
     info: {} as Record<string, Session | undefined>,
@@ -95,7 +119,6 @@ export function createServerSession(client: OpencodeClient) {
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
-  const initialLoads = new Map<string, { dirty: boolean }>()
   const seen = new Set<string>()
   const infoSeen = new Set<string>()
   const pinned = new Map<string, number>()
@@ -205,7 +228,6 @@ export function createServerSession(client: OpencodeClient) {
       inflight.delete(sessionID)
       inflightDiff.delete(sessionID)
       inflightTodo.delete(sessionID)
-      initialLoads.delete(sessionID)
     })
     setData(
       produce((draft) => {
@@ -266,23 +288,37 @@ export function createServerSession(client: OpencodeClient) {
   const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
     if (meta.loading[sessionID]) return
     const generation = generations.get(sessionID) ?? 0
-    const initial = meta.limit[sessionID] === undefined ? { dirty: false } : undefined
-    if (initial) initialLoads.set(sessionID, initial)
+    const initial =
+      meta.limit[sessionID] === undefined
+        ? {
+            message: new Map((data.message[sessionID] ?? []).map((item) => [item.id, JSON.stringify(item)])),
+            part: new Map(
+              (data.message[sessionID] ?? []).map((message) => [
+                message.id,
+                new Map((data.part[message.id] ?? []).map((item) => [item.id, JSON.stringify(item)])),
+              ]),
+            ),
+          }
+        : undefined
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
-        if (initial?.dirty) {
-          if (data.message[sessionID] === undefined) setData("message", sessionID, [])
-          return
-        }
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
         next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const messages = mode === "prepend" ? merge(data.message[sessionID] ?? [], next.session) : next.session
+        const messages = initial
+          ? mergeConcurrent(next.session, data.message[sessionID] ?? [], initial.message, true)
+          : mode === "prepend"
+            ? merge(data.message[sessionID] ?? [], next.session)
+            : next.session
         batch(() => {
           setData("message", sessionID, reconcile(messages, { key: "id" }))
           for (const item of next.part) {
-            const parts = item.part.filter((part) => !SKIP_PARTS.has(part.type))
+            if (!messages.some((message) => message.id === item.id)) continue
+            const fetched = item.part.filter((part) => !SKIP_PARTS.has(part.type))
+            const parts = initial
+              ? mergeConcurrent(fetched, data.part[item.id] ?? [], initial.part.get(item.id) ?? new Map())
+              : fetched
             if (parts.length) setData("part", item.id, reconcile(parts, { key: "id" }))
           }
           setMeta("limit", sessionID, messages.length)
@@ -292,7 +328,6 @@ export function createServerSession(client: OpencodeClient) {
         })
       })
       .finally(() => {
-        if (initialLoads.get(sessionID) === initial) initialLoads.delete(sessionID)
         if ((generations.get(sessionID) ?? 0) === generation) setMeta("loading", sessionID, false)
       })
   }
@@ -347,10 +382,6 @@ export function createServerSession(client: OpencodeClient) {
   const apply = (event: { type: string; properties?: unknown }) => {
     const eventID = eventSessionID(event)
     if (eventID) {
-      if (event.type.startsWith("message.")) {
-        const initial = initialLoads.get(eventID)
-        if (initial) initial.dirty = true
-      }
       touch(eventID)
       if (!data.info[eventID]) void resolve(eventID).catch(() => {})
     }

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -29,7 +29,12 @@ type OptimisticItem = {
 }
 
 type SessionEvent = { type: string; properties?: unknown }
-type InitialEventJournal = { events: SessionEvent[]; overflow: boolean }
+type InitialEventJournal = {
+  removedMessages: Set<string>
+  parts: Map<string, Map<string, string | undefined>>
+  size: number
+  overflow: boolean
+}
 
 const initialEventLimit = 4_096
 
@@ -272,33 +277,59 @@ export function createServerSession(client: OpencodeClient) {
     if (meta.loading[sessionID]) return
     const generation = generations.get(sessionID) ?? 0
     const initiallyUnloaded = meta.limit[sessionID] === undefined
-    if (initiallyUnloaded) initialEvents.set(sessionID, { events: [], overflow: false })
+    if (initiallyUnloaded)
+      initialEvents.set(sessionID, { removedMessages: new Set(), parts: new Map(), size: 0, overflow: false })
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
         next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const messages = mode === "prepend" ? merge(data.message[sessionID] ?? [], next.session) : next.session
         const journal = initialEvents.get(sessionID)
         initialEvents.delete(sessionID)
         if (journal?.overflow) {
           if (data.message[sessionID] === undefined) setData("message", sessionID, [])
           return
         }
+        const liveMessages = data.message[sessionID] ?? []
+        const messages = mode === "prepend" || initiallyUnloaded ? merge(liveMessages, next.session) : next.session
+        const messageMap = new Map(messages.map((message) => [message.id, message]))
+        journal?.removedMessages.forEach((messageID) => messageMap.delete(messageID))
+        const mergedMessages = [...messageMap.values()].sort((a, b) => cmp(a.id, b.id))
         batch(() => {
-          if (initiallyUnloaded) setData("message", sessionID, messages)
-          if (!initiallyUnloaded) setData("message", sessionID, reconcile(messages, { key: "id" }))
-          for (const item of next.part) {
-            const parts = item.part.filter((part) => !SKIP_PARTS.has(part.type))
-            if (parts.length) setData("part", item.id, reconcile(parts, { key: "id" }))
+          if (initiallyUnloaded) setData("message", sessionID, mergedMessages)
+          if (!initiallyUnloaded) setData("message", sessionID, reconcile(mergedMessages, { key: "id" }))
+          const fetchedParts = new Map(
+            next.part.map((item) => [item.id, item.part.filter((part) => !SKIP_PARTS.has(part.type))]),
+          )
+          for (const message of mergedMessages) {
+            const fetched = fetchedParts.get(message.id) ?? []
+            if (!initiallyUnloaded) {
+              if (fetched.length) setData("part", message.id, reconcile(fetched, { key: "id" }))
+              continue
+            }
+            const parts = new Map(fetched.map((part) => [part.id, part]))
+            const live = new Map((data.part[message.id] ?? []).map((part) => [part.id, part]))
+            live.forEach((part, partID) => {
+              if (!parts.has(partID)) parts.set(partID, part)
+            })
+            journal?.parts.get(message.id)?.forEach((baseline, partID) => {
+              const current = live.get(partID)
+              if (!current) {
+                parts.delete(partID)
+                return
+              }
+              const fetched = parts.get(partID)
+              if (!fetched || JSON.stringify(fetched) === baseline) parts.set(partID, current)
+            })
+            const merged = [...parts.values()].sort((a, b) => cmp(a.id, b.id))
+            if (merged.length) setData("part", message.id, reconcile(merged, { key: "id" }))
           }
-          setMeta("limit", sessionID, messages.length)
+          setMeta("limit", sessionID, mergedMessages.length)
           setMeta("cursor", sessionID, next.cursor)
           setMeta("complete", sessionID, next.complete)
           setMeta("at", sessionID, Date.now())
         })
-        journal?.events.forEach(apply)
       })
       .finally(() => {
         initialEvents.delete(sessionID)
@@ -357,10 +388,7 @@ export function createServerSession(client: OpencodeClient) {
     const eventID = eventSessionID(event)
     if (eventID) {
       const journal = initialEvents.get(eventID)
-      if (journal && event.type.startsWith("message.")) {
-        if (journal.events.length < initialEventLimit) journal.events.push(event)
-        else journal.overflow = true
-      }
+      if (journal) recordInitialEvent(journal, event)
       touch(eventID)
       if (!data.info[eventID]) void resolve(eventID).catch(() => {})
     }
@@ -551,6 +579,58 @@ export function createServerSession(client: OpencodeClient) {
             if (result.found) draft.splice(result.index, 1)
           }),
         )
+      }
+    }
+  }
+
+  function recordInitialEvent(journal: InitialEventJournal, event: SessionEvent) {
+    if (journal.overflow) return
+    const properties = event.properties
+    if (!properties || typeof properties !== "object") return
+    if (event.type === "message.updated" && "info" in properties) {
+      const info = properties.info as Message
+      if (journal.removedMessages.delete(info.id)) journal.size -= 1
+    }
+    if (event.type === "message.removed" && "messageID" in properties) {
+      const messageID = properties.messageID as string
+      if (!journal.removedMessages.has(messageID) && journal.size >= initialEventLimit) {
+        journal.overflow = true
+        return
+      }
+      if (!journal.removedMessages.has(messageID)) journal.size += 1
+      journal.removedMessages.add(messageID)
+    }
+    if (
+      (event.type === "message.part.updated" || event.type === "message.part.removed" || event.type === "message.part.delta") &&
+      "messageID" in properties &&
+      "partID" in properties
+    ) {
+      const messageID = properties.messageID as string
+      const partID = properties.partID as string
+      const parts = journal.parts.get(messageID) ?? new Map<string, string | undefined>()
+      if (!parts.has(partID)) {
+        if (journal.size >= initialEventLimit) {
+          journal.overflow = true
+          return
+        }
+        journal.size += 1
+        const current = data.part[messageID]?.find((part) => part.id === partID)
+        parts.set(partID, current ? JSON.stringify(current) : undefined)
+        journal.parts.set(messageID, parts)
+      }
+    }
+    if (event.type === "message.part.updated" && "part" in properties) {
+      const part = properties.part as Part
+      const parts = journal.parts.get(part.messageID) ?? new Map<string, string | undefined>()
+      if (!parts.has(part.id)) {
+        if (journal.size >= initialEventLimit) {
+          journal.overflow = true
+          return
+        }
+        journal.size += 1
+        const current = data.part[part.messageID]?.find((item) => item.id === part.id)
+        parts.set(part.id, current ? JSON.stringify(current) : undefined)
+        journal.parts.set(part.messageID, parts)
       }
     }
   }

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -28,17 +28,6 @@ type OptimisticItem = {
   parts: Part[]
 }
 
-type SessionEvent = { type: string; properties?: unknown }
-type InitialEventJournal = {
-  messages: Map<string, string | undefined>
-  removedMessages: Set<string>
-  parts: Map<string, Map<string, string | undefined>>
-  size: number
-  overflow: boolean
-}
-
-const initialEventLimit = 4_096
-
 const hasParts = (parts: Part[] | undefined, want: Part[]) => {
   if (!parts) return want.length === 0
   return want.every((part) => Binary.search(parts, part.id, (item) => item.id).found)
@@ -106,7 +95,7 @@ export function createServerSession(client: OpencodeClient) {
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
-  const initialEvents = new Map<string, InitialEventJournal>()
+  const initialLoads = new Map<string, { dirty: boolean }>()
   const seen = new Set<string>()
   const infoSeen = new Set<string>()
   const pinned = new Map<string, number>()
@@ -216,7 +205,7 @@ export function createServerSession(client: OpencodeClient) {
       inflight.delete(sessionID)
       inflightDiff.delete(sessionID)
       inflightTodo.delete(sessionID)
-      initialEvents.delete(sessionID)
+      initialLoads.delete(sessionID)
     })
     setData(
       produce((draft) => {
@@ -277,80 +266,33 @@ export function createServerSession(client: OpencodeClient) {
   const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
     if (meta.loading[sessionID]) return
     const generation = generations.get(sessionID) ?? 0
-    const initiallyUnloaded = meta.limit[sessionID] === undefined
-    if (initiallyUnloaded)
-      initialEvents.set(sessionID, {
-        messages: new Map(),
-        removedMessages: new Set(),
-        parts: new Map(),
-        size: 0,
-        overflow: false,
-      })
+    const initial = meta.limit[sessionID] === undefined ? { dirty: false } : undefined
+    if (initial) initialLoads.set(sessionID, initial)
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
-        const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
-        next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const journal = initialEvents.get(sessionID)
-        initialEvents.delete(sessionID)
-        if (journal?.overflow) {
+        if (initial?.dirty) {
           if (data.message[sessionID] === undefined) setData("message", sessionID, [])
           return
         }
-        const liveMessages = data.message[sessionID] ?? []
-        const messages = mode === "prepend" || initiallyUnloaded ? merge(liveMessages, next.session) : next.session
-        const messageMap = new Map(messages.map((message) => [message.id, message]))
-        journal?.messages.forEach((baseline, messageID) => {
-          if (journal.removedMessages.has(messageID)) {
-            const fetched = messageMap.get(messageID)
-            if (!fetched || JSON.stringify(fetched) === baseline) messageMap.delete(messageID)
-            return
-          }
-          const current = liveMessages.find((message) => message.id === messageID)
-          if (!current) return
-          const fetched = messageMap.get(messageID)
-          if (!fetched || JSON.stringify(fetched) === baseline) messageMap.set(messageID, current)
-        })
-        const mergedMessages = [...messageMap.values()].sort((a, b) => cmp(a.id, b.id))
+        const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
+        next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
+        const messages = mode === "prepend" ? merge(data.message[sessionID] ?? [], next.session) : next.session
         batch(() => {
-          if (initiallyUnloaded) setData("message", sessionID, mergedMessages)
-          if (!initiallyUnloaded) setData("message", sessionID, reconcile(mergedMessages, { key: "id" }))
-          const fetchedParts = new Map(
-            next.part.map((item) => [item.id, item.part.filter((part) => !SKIP_PARTS.has(part.type))]),
-          )
-          for (const message of mergedMessages) {
-            const fetched = fetchedParts.get(message.id) ?? []
-            if (!initiallyUnloaded) {
-              if (fetched.length) setData("part", message.id, reconcile(fetched, { key: "id" }))
-              continue
-            }
-            const parts = new Map(fetched.map((part) => [part.id, part]))
-            const live = new Map((data.part[message.id] ?? []).map((part) => [part.id, part]))
-            live.forEach((part, partID) => {
-              if (!parts.has(partID)) parts.set(partID, part)
-            })
-            journal?.parts.get(message.id)?.forEach((baseline, partID) => {
-              const current = live.get(partID)
-              if (!current) {
-                const fetched = parts.get(partID)
-                if (!fetched || JSON.stringify(fetched) === baseline) parts.delete(partID)
-                return
-              }
-              const fetched = parts.get(partID)
-              if (!fetched || JSON.stringify(fetched) === baseline) parts.set(partID, current)
-            })
-            const merged = [...parts.values()].sort((a, b) => cmp(a.id, b.id))
-            if (merged.length) setData("part", message.id, reconcile(merged, { key: "id" }))
+          setData("message", sessionID, reconcile(messages, { key: "id" }))
+          for (const item of next.part) {
+            const parts = item.part.filter((part) => !SKIP_PARTS.has(part.type))
+            if (parts.length) setData("part", item.id, reconcile(parts, { key: "id" }))
           }
-          setMeta("limit", sessionID, mergedMessages.length)
+          setMeta("limit", sessionID, messages.length)
           setMeta("cursor", sessionID, next.cursor)
           setMeta("complete", sessionID, next.complete)
           setMeta("at", sessionID, Date.now())
         })
       })
       .finally(() => {
-        initialEvents.delete(sessionID)
+        if (initialLoads.get(sessionID) === initial) initialLoads.delete(sessionID)
         if ((generations.get(sessionID) ?? 0) === generation) setMeta("loading", sessionID, false)
       })
   }
@@ -380,7 +322,7 @@ export function createServerSession(client: OpencodeClient) {
     await runInflight(inflight, sessionID, () => loadMessages(sessionID, limit))
   }
 
-  const eventSessionID = (event: SessionEvent) => {
+  const eventSessionID = (event: { type: string; properties?: unknown }) => {
     const properties = event.properties
     if (!properties || typeof properties !== "object") return
     if ("sessionID" in properties && typeof properties.sessionID === "string") return properties.sessionID
@@ -402,11 +344,13 @@ export function createServerSession(client: OpencodeClient) {
       return properties.part.sessionID
   }
 
-  const apply = (event: SessionEvent) => {
+  const apply = (event: { type: string; properties?: unknown }) => {
     const eventID = eventSessionID(event)
     if (eventID) {
-      const journal = initialEvents.get(eventID)
-      if (journal) recordInitialEvent(journal, event)
+      if (event.type.startsWith("message.")) {
+        const initial = initialLoads.get(eventID)
+        if (initial) initial.dirty = true
+      }
       touch(eventID)
       if (!data.info[eventID]) void resolve(eventID).catch(() => {})
     }
@@ -597,72 +541,6 @@ export function createServerSession(client: OpencodeClient) {
             if (result.found) draft.splice(result.index, 1)
           }),
         )
-      }
-    }
-  }
-
-  function recordInitialEvent(journal: InitialEventJournal, event: SessionEvent) {
-    if (journal.overflow) return
-    const properties = event.properties
-    if (!properties || typeof properties !== "object") return
-    if (event.type === "message.updated" && "info" in properties) {
-      const info = properties.info as Message
-      if (!journal.messages.has(info.id)) {
-        if (journal.size >= initialEventLimit) {
-          journal.overflow = true
-          return
-        }
-        journal.size += 1
-        const current = data.message[info.sessionID]?.find((message) => message.id === info.id)
-        journal.messages.set(info.id, current ? JSON.stringify(current) : undefined)
-      }
-      journal.removedMessages.delete(info.id)
-    }
-    if (event.type === "message.removed" && "sessionID" in properties && "messageID" in properties) {
-      const messageID = properties.messageID as string
-      if (!journal.messages.has(messageID) && journal.size >= initialEventLimit) {
-        journal.overflow = true
-        return
-      }
-      if (!journal.messages.has(messageID)) {
-        journal.size += 1
-        const sessionID = properties.sessionID as string
-        const current = data.message[sessionID]?.find((message) => message.id === messageID)
-        journal.messages.set(messageID, current ? JSON.stringify(current) : undefined)
-      }
-      journal.removedMessages.add(messageID)
-    }
-    if (
-      (event.type === "message.part.updated" || event.type === "message.part.removed" || event.type === "message.part.delta") &&
-      "messageID" in properties &&
-      "partID" in properties
-    ) {
-      const messageID = properties.messageID as string
-      const partID = properties.partID as string
-      const parts = journal.parts.get(messageID) ?? new Map<string, string | undefined>()
-      if (!parts.has(partID)) {
-        if (journal.size >= initialEventLimit) {
-          journal.overflow = true
-          return
-        }
-        journal.size += 1
-        const current = data.part[messageID]?.find((part) => part.id === partID)
-        parts.set(partID, current ? JSON.stringify(current) : undefined)
-        journal.parts.set(messageID, parts)
-      }
-    }
-    if (event.type === "message.part.updated" && "part" in properties) {
-      const part = properties.part as Part
-      const parts = journal.parts.get(part.messageID) ?? new Map<string, string | undefined>()
-      if (!parts.has(part.id)) {
-        if (journal.size >= initialEventLimit) {
-          journal.overflow = true
-          return
-        }
-        journal.size += 1
-        const current = data.part[part.messageID]?.find((item) => item.id === part.id)
-        parts.set(part.id, current ? JSON.stringify(current) : undefined)
-        journal.parts.set(part.messageID, parts)
       }
     }
   }

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -30,6 +30,7 @@ type OptimisticItem = {
 
 type SessionEvent = { type: string; properties?: unknown }
 type InitialEventJournal = {
+  messages: Map<string, string | undefined>
   removedMessages: Set<string>
   parts: Map<string, Map<string, string | undefined>>
   size: number
@@ -278,7 +279,13 @@ export function createServerSession(client: OpencodeClient) {
     const generation = generations.get(sessionID) ?? 0
     const initiallyUnloaded = meta.limit[sessionID] === undefined
     if (initiallyUnloaded)
-      initialEvents.set(sessionID, { removedMessages: new Set(), parts: new Map(), size: 0, overflow: false })
+      initialEvents.set(sessionID, {
+        messages: new Map(),
+        removedMessages: new Set(),
+        parts: new Map(),
+        size: 0,
+        overflow: false,
+      })
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
@@ -294,7 +301,17 @@ export function createServerSession(client: OpencodeClient) {
         const liveMessages = data.message[sessionID] ?? []
         const messages = mode === "prepend" || initiallyUnloaded ? merge(liveMessages, next.session) : next.session
         const messageMap = new Map(messages.map((message) => [message.id, message]))
-        journal?.removedMessages.forEach((messageID) => messageMap.delete(messageID))
+        journal?.messages.forEach((baseline, messageID) => {
+          if (journal.removedMessages.has(messageID)) {
+            const fetched = messageMap.get(messageID)
+            if (!fetched || JSON.stringify(fetched) === baseline) messageMap.delete(messageID)
+            return
+          }
+          const current = liveMessages.find((message) => message.id === messageID)
+          if (!current) return
+          const fetched = messageMap.get(messageID)
+          if (!fetched || JSON.stringify(fetched) === baseline) messageMap.set(messageID, current)
+        })
         const mergedMessages = [...messageMap.values()].sort((a, b) => cmp(a.id, b.id))
         batch(() => {
           if (initiallyUnloaded) setData("message", sessionID, mergedMessages)
@@ -316,7 +333,8 @@ export function createServerSession(client: OpencodeClient) {
             journal?.parts.get(message.id)?.forEach((baseline, partID) => {
               const current = live.get(partID)
               if (!current) {
-                parts.delete(partID)
+                const fetched = parts.get(partID)
+                if (!fetched || JSON.stringify(fetched) === baseline) parts.delete(partID)
                 return
               }
               const fetched = parts.get(partID)
@@ -589,15 +607,29 @@ export function createServerSession(client: OpencodeClient) {
     if (!properties || typeof properties !== "object") return
     if (event.type === "message.updated" && "info" in properties) {
       const info = properties.info as Message
-      if (journal.removedMessages.delete(info.id)) journal.size -= 1
+      if (!journal.messages.has(info.id)) {
+        if (journal.size >= initialEventLimit) {
+          journal.overflow = true
+          return
+        }
+        journal.size += 1
+        const current = data.message[info.sessionID]?.find((message) => message.id === info.id)
+        journal.messages.set(info.id, current ? JSON.stringify(current) : undefined)
+      }
+      journal.removedMessages.delete(info.id)
     }
-    if (event.type === "message.removed" && "messageID" in properties) {
+    if (event.type === "message.removed" && "sessionID" in properties && "messageID" in properties) {
       const messageID = properties.messageID as string
-      if (!journal.removedMessages.has(messageID) && journal.size >= initialEventLimit) {
+      if (!journal.messages.has(messageID) && journal.size >= initialEventLimit) {
         journal.overflow = true
         return
       }
-      if (!journal.removedMessages.has(messageID)) journal.size += 1
+      if (!journal.messages.has(messageID)) {
+        journal.size += 1
+        const sessionID = properties.sessionID as string
+        const current = data.message[sessionID]?.find((message) => message.id === messageID)
+        journal.messages.set(messageID, current ? JSON.stringify(current) : undefined)
+      }
       journal.removedMessages.add(messageID)
     }
     if (

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -132,7 +132,7 @@ function reconcileFetched<T extends { id: string }>(
   return [...result.values()].sort((a, b) => cmp(a.id, b.id))
 }
 
-export function createServerSession(client: OpencodeClient, options?: { retryDelay?: number }) {
+export function createServerSession(client: OpencodeClient, options?: { retry?: typeof retry }) {
   const [data, setData] = createStore({
     info: {} as Record<string, Session | undefined>,
     session_status: {} as Record<string, SessionStatus>,
@@ -445,13 +445,10 @@ export function createServerSession(client: OpencodeClient, options?: { retryDel
     )
 
   const fetchMessages = async (sessionID: string, limit: number, before?: string, onAttempt?: () => void) => {
-    const response = await retry(
-      () => {
-        onAttempt?.()
-        return client.session.messages({ sessionID, limit, before })
-      },
-      { delay: options?.retryDelay },
-    )
+    const response = await (options?.retry ?? retry)(() => {
+      onAttempt?.()
+      return client.session.messages({ sessionID, limit, before })
+    })
     const items = (response.data ?? []).filter((item) => !!item?.info?.id)
     return {
       session: items.map((item) => cleanMessage(item.info)).sort((a, b) => cmp(a.id, b.id)),

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -336,6 +336,13 @@ export function createServerSession(client: OpencodeClient) {
               : fetched
             const kept = parts.filter((part) => !removed?.removedParts.get(item.id)?.has(part.id))
             if (kept.length) setData("part", item.id, reconcile(kept, { key: "id" }))
+            if (!kept.length)
+              setData(
+                produce((draft) => {
+                  for (const part of draft.part[item.id] ?? []) delete draft.part_text_accum_delta[part.id]
+                  delete draft.part[item.id]
+                }),
+              )
           }
           setMeta("limit", sessionID, messages.length)
           setMeta("cursor", sessionID, next.cursor)

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -29,6 +29,9 @@ type OptimisticItem = {
 }
 
 type SessionEvent = { type: string; properties?: unknown }
+type InitialEventJournal = { events: SessionEvent[]; overflow: boolean }
+
+const initialEventLimit = 4_096
 
 const hasParts = (parts: Part[] | undefined, want: Part[]) => {
   if (!parts) return want.length === 0
@@ -97,7 +100,7 @@ export function createServerSession(client: OpencodeClient) {
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
-  const initialEvents = new Map<string, SessionEvent[]>()
+  const initialEvents = new Map<string, InitialEventJournal>()
   const seen = new Set<string>()
   const infoSeen = new Set<string>()
   const pinned = new Map<string, number>()
@@ -207,6 +210,7 @@ export function createServerSession(client: OpencodeClient) {
       inflight.delete(sessionID)
       inflightDiff.delete(sessionID)
       inflightTodo.delete(sessionID)
+      initialEvents.delete(sessionID)
     })
     setData(
       produce((draft) => {
@@ -267,8 +271,8 @@ export function createServerSession(client: OpencodeClient) {
   const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
     if (meta.loading[sessionID]) return
     const generation = generations.get(sessionID) ?? 0
-    const initiallyUnloaded = data.message[sessionID] === undefined
-    if (initiallyUnloaded) initialEvents.set(sessionID, [])
+    const initiallyUnloaded = meta.limit[sessionID] === undefined
+    if (initiallyUnloaded) initialEvents.set(sessionID, { events: [], overflow: false })
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
@@ -276,8 +280,12 @@ export function createServerSession(client: OpencodeClient) {
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
         next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
         const messages = mode === "prepend" ? merge(data.message[sessionID] ?? [], next.session) : next.session
-        const events = initialEvents.get(sessionID) ?? []
+        const journal = initialEvents.get(sessionID)
         initialEvents.delete(sessionID)
+        if (journal?.overflow) {
+          if (data.message[sessionID] === undefined) setData("message", sessionID, [])
+          return
+        }
         batch(() => {
           if (initiallyUnloaded) setData("message", sessionID, messages)
           if (!initiallyUnloaded) setData("message", sessionID, reconcile(messages, { key: "id" }))
@@ -290,7 +298,7 @@ export function createServerSession(client: OpencodeClient) {
           setMeta("complete", sessionID, next.complete)
           setMeta("at", sessionID, Date.now())
         })
-        events.forEach(apply)
+        journal?.events.forEach(apply)
       })
       .finally(() => {
         initialEvents.delete(sessionID)
@@ -348,7 +356,11 @@ export function createServerSession(client: OpencodeClient) {
   const apply = (event: SessionEvent) => {
     const eventID = eventSessionID(event)
     if (eventID) {
-      if (event.type.startsWith("message.")) initialEvents.get(eventID)?.push(event)
+      const journal = initialEvents.get(eventID)
+      if (journal && event.type.startsWith("message.")) {
+        if (journal.events.length < initialEventLimit) journal.events.push(event)
+        else journal.overflow = true
+      }
       touch(eventID)
       if (!data.info[eventID]) void resolve(eventID).catch(() => {})
     }

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -78,21 +78,15 @@ function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
 function mergeConcurrent<T extends { id: string }>(
   fetched: T[],
   current: readonly T[],
-  before: Map<string, string>,
+  touched: Set<string>,
   partial = false,
 ) {
   const next = new Map(fetched.map((item) => [item.id, item]))
   const live = new Map(current.map((item) => [item.id, item]))
-  for (const id of new Set([...next.keys(), ...live.keys(), ...before.keys()])) {
-    const fetchedItem = next.get(id)
+  if (partial) live.forEach((item, id) => !next.has(id) && next.set(id, item))
+  // Events observed while the request is pending are the freshest client state for those identities.
+  for (const id of touched) {
     const liveItem = live.get(id)
-    const previous = before.get(id)
-    if (partial && !fetchedItem && liveItem) {
-      next.set(id, liveItem)
-      continue
-    }
-    if (JSON.stringify(liveItem) === previous) continue
-    if (JSON.stringify(fetchedItem) !== previous) continue
     if (liveItem) next.set(id, liveItem)
     if (!liveItem) next.delete(id)
   }
@@ -119,10 +113,7 @@ export function createServerSession(client: OpencodeClient) {
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
-  const initialLoads = new Map<
-    string,
-    { removedMessages: Set<string>; removedParts: Map<string, Set<string>> }
-  >()
+  const messageLoads = new Map<string, { messages: Set<string>; parts: Map<string, Set<string>> }>()
   const seen = new Set<string>()
   const infoSeen = new Set<string>()
   const pinned = new Map<string, number>()
@@ -239,7 +230,7 @@ export function createServerSession(client: OpencodeClient) {
       inflight.delete(sessionID)
       inflightDiff.delete(sessionID)
       inflightTodo.delete(sessionID)
-      initialLoads.delete(sessionID)
+      messageLoads.delete(sessionID)
     })
     setData(
       produce((draft) => {
@@ -300,43 +291,50 @@ export function createServerSession(client: OpencodeClient) {
   const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
     if (meta.loading[sessionID]) return
     const generation = generations.get(sessionID) ?? 0
-    const initial =
-      meta.limit[sessionID] === undefined
-        ? {
-            message: new Map((data.message[sessionID] ?? []).map((item) => [item.id, JSON.stringify(item)])),
-            part: new Map(
-              (data.message[sessionID] ?? []).map((message) => [
-                message.id,
-                new Map((data.part[message.id] ?? []).map((item) => [item.id, JSON.stringify(item)])),
-              ]),
-            ),
-          }
-        : undefined
-    if (initial) initialLoads.set(sessionID, { removedMessages: new Set(), removedParts: new Map() })
+    const initial = meta.limit[sessionID] === undefined
+    const active = { messages: new Set<string>(), parts: new Map<string, Set<string>>() }
+    messageLoads.set(sessionID, active)
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
-        const removed = initialLoads.get(sessionID)
+        const concurrent = messageLoads.get(sessionID) === active ? active : undefined
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
         next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const messages = (initial
-          ? mergeConcurrent(next.session, data.message[sessionID] ?? [], initial.message, true)
-          : mode === "prepend"
-            ? merge(data.message[sessionID] ?? [], next.session)
-            : next.session
-        ).filter((message) => !removed?.removedMessages.has(message.id))
+        const messages = mergeConcurrent(
+          next.session,
+          data.message[sessionID] ?? [],
+          concurrent?.messages ?? new Set(),
+          initial || mode === "prepend",
+        )
         const messageIDs = new Set(messages.map((message) => message.id))
         batch(() => {
+          const dropped = (data.message[sessionID] ?? []).filter((message) => !messageIDs.has(message.id))
           setData("message", sessionID, reconcile(messages, { key: "id" }))
+          setData(
+            produce((draft) => {
+              for (const message of dropped) {
+                for (const part of draft.part[message.id] ?? []) delete draft.part_text_accum_delta[part.id]
+                delete draft.part[message.id]
+              }
+            }),
+          )
           for (const item of next.part) {
             if (!messageIDs.has(item.id)) continue
             const fetched = item.part.filter((part) => !SKIP_PARTS.has(part.type))
-            const parts = initial
-              ? mergeConcurrent(fetched, data.part[item.id] ?? [], initial.part.get(item.id) ?? new Map())
-              : fetched
-            const kept = parts.filter((part) => !removed?.removedParts.get(item.id)?.has(part.id))
-            if (kept.length) setData("part", item.id, reconcile(kept, { key: "id" }))
+            const kept = mergeConcurrent(fetched, data.part[item.id] ?? [], concurrent?.parts.get(item.id) ?? new Set())
+            if (kept.length) {
+              const keptIDs = new Set(kept.map((part) => part.id))
+              setData(
+                "part_text_accum_delta",
+                produce((draft) => {
+                  for (const part of data.part[item.id] ?? []) {
+                    if (!keptIDs.has(part.id)) delete draft[part.id]
+                  }
+                }),
+              )
+              setData("part", item.id, reconcile(kept, { key: "id" }))
+            }
             if (!kept.length)
               setData(
                 produce((draft) => {
@@ -352,7 +350,7 @@ export function createServerSession(client: OpencodeClient) {
         })
       })
       .finally(() => {
-        initialLoads.delete(sessionID)
+        if (messageLoads.get(sessionID) === active) messageLoads.delete(sessionID)
         if ((generations.get(sessionID) ?? 0) === generation) setMeta("loading", sessionID, false)
       })
   }
@@ -447,7 +445,7 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.updated": {
         const info = cleanMessage((event.properties as { info: Message }).info)
-        initialLoads.get(info.sessionID)?.removedMessages.delete(info.id)
+        messageLoads.get(info.sessionID)?.messages.add(info.id)
         const messages = data.message[info.sessionID]
         if (!messages) {
           setData("message", info.sessionID, [info])
@@ -465,7 +463,7 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.removed": {
         const props = event.properties as { sessionID: string; messageID: string }
-        initialLoads.get(props.sessionID)?.removedMessages.add(props.messageID)
+        messageLoads.get(props.sessionID)?.messages.add(props.messageID)
         clearOptimistic(props.sessionID, props.messageID)
         setData(
           produce((draft) => {
@@ -483,7 +481,12 @@ export function createServerSession(client: OpencodeClient) {
       case "message.part.updated": {
         const part = (event.properties as { part: Part }).part
         if (SKIP_PARTS.has(part.type)) return
-        initialLoads.get(part.sessionID)?.removedParts.get(part.messageID)?.delete(part.id)
+        const load = messageLoads.get(part.sessionID)
+        if (load) {
+          const touched = load.parts.get(part.messageID) ?? new Set<string>()
+          touched.add(part.id)
+          load.parts.set(part.messageID, touched)
+        }
         setData(
           "part_text_accum_delta",
           produce((draft) => void delete draft[part.id]),
@@ -505,10 +508,12 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.part.removed": {
         const props = event.properties as { sessionID: string; messageID: string; partID: string }
-        const initial = initialLoads.get(props.sessionID)
-        const removed = initial?.removedParts.get(props.messageID) ?? new Set<string>()
-        removed.add(props.partID)
-        initial?.removedParts.set(props.messageID, removed)
+        const load = messageLoads.get(props.sessionID)
+        if (load) {
+          const touched = load.parts.get(props.messageID) ?? new Set<string>()
+          touched.add(props.partID)
+          load.parts.set(props.messageID, touched)
+        }
         clearOptimisticPart(props.sessionID, props.messageID, props.partID)
         setData(
           produce((draft) => {
@@ -523,11 +528,23 @@ export function createServerSession(client: OpencodeClient) {
         return
       }
       case "message.part.delta": {
-        const props = event.properties as { messageID: string; partID: string; field: string; delta: string }
+        const props = event.properties as {
+          sessionID: string
+          messageID: string
+          partID: string
+          field: string
+          delta: string
+        }
         const parts = data.part[props.messageID]
         if (!parts) return
         const result = Binary.search(parts, props.partID, (part) => part.id)
         if (!result.found) return
+        const load = messageLoads.get(props.sessionID)
+        if (load) {
+          const touched = load.parts.get(props.messageID) ?? new Set<string>()
+          touched.add(props.partID)
+          load.parts.set(props.messageID, touched)
+        }
         const field = props.field as keyof (typeof parts)[number]
         const current = parts[result.index]?.[field]
         setData(

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -119,6 +119,10 @@ export function createServerSession(client: OpencodeClient) {
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
+  const initialLoads = new Map<
+    string,
+    { removedMessages: Set<string>; removedParts: Map<string, Set<string>> }
+  >()
   const seen = new Set<string>()
   const infoSeen = new Set<string>()
   const pinned = new Map<string, number>()
@@ -228,6 +232,7 @@ export function createServerSession(client: OpencodeClient) {
       inflight.delete(sessionID)
       inflightDiff.delete(sessionID)
       inflightTodo.delete(sessionID)
+      initialLoads.delete(sessionID)
     })
     setData(
       produce((draft) => {
@@ -300,17 +305,20 @@ export function createServerSession(client: OpencodeClient) {
             ),
           }
         : undefined
+    if (initial) initialLoads.set(sessionID, { removedMessages: new Set(), removedParts: new Map() })
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
+        const removed = initialLoads.get(sessionID)
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
         next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const messages = initial
+        const messages = (initial
           ? mergeConcurrent(next.session, data.message[sessionID] ?? [], initial.message, true)
           : mode === "prepend"
             ? merge(data.message[sessionID] ?? [], next.session)
             : next.session
+        ).filter((message) => !removed?.removedMessages.has(message.id))
         batch(() => {
           setData("message", sessionID, reconcile(messages, { key: "id" }))
           for (const item of next.part) {
@@ -319,7 +327,8 @@ export function createServerSession(client: OpencodeClient) {
             const parts = initial
               ? mergeConcurrent(fetched, data.part[item.id] ?? [], initial.part.get(item.id) ?? new Map())
               : fetched
-            if (parts.length) setData("part", item.id, reconcile(parts, { key: "id" }))
+            const kept = parts.filter((part) => !removed?.removedParts.get(item.id)?.has(part.id))
+            if (kept.length) setData("part", item.id, reconcile(kept, { key: "id" }))
           }
           setMeta("limit", sessionID, messages.length)
           setMeta("cursor", sessionID, next.cursor)
@@ -328,6 +337,7 @@ export function createServerSession(client: OpencodeClient) {
         })
       })
       .finally(() => {
+        initialLoads.delete(sessionID)
         if ((generations.get(sessionID) ?? 0) === generation) setMeta("loading", sessionID, false)
       })
   }
@@ -422,6 +432,7 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.updated": {
         const info = cleanMessage((event.properties as { info: Message }).info)
+        initialLoads.get(info.sessionID)?.removedMessages.delete(info.id)
         const messages = data.message[info.sessionID]
         if (!messages) {
           setData("message", info.sessionID, [info])
@@ -439,6 +450,7 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.removed": {
         const props = event.properties as { sessionID: string; messageID: string }
+        initialLoads.get(props.sessionID)?.removedMessages.add(props.messageID)
         setData(
           produce((draft) => {
             const messages = draft.message[props.sessionID]
@@ -455,6 +467,7 @@ export function createServerSession(client: OpencodeClient) {
       case "message.part.updated": {
         const part = (event.properties as { part: Part }).part
         if (SKIP_PARTS.has(part.type)) return
+        initialLoads.get(part.sessionID)?.removedParts.get(part.messageID)?.delete(part.id)
         setData(
           "part_text_accum_delta",
           produce((draft) => void delete draft[part.id]),
@@ -475,7 +488,11 @@ export function createServerSession(client: OpencodeClient) {
         return
       }
       case "message.part.removed": {
-        const props = event.properties as { messageID: string; partID: string }
+        const props = event.properties as { sessionID: string; messageID: string; partID: string }
+        const initial = initialLoads.get(props.sessionID)
+        const removed = initial?.removedParts.get(props.messageID) ?? new Set<string>()
+        removed.add(props.partID)
+        initial?.removedParts.set(props.messageID, removed)
         setData(
           produce((draft) => {
             delete draft.part_text_accum_delta[props.partID]

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -28,6 +28,8 @@ type OptimisticItem = {
   parts: Part[]
 }
 
+type SessionEvent = { type: string; properties?: unknown }
+
 const hasParts = (parts: Part[] | undefined, want: Part[]) => {
   if (!parts) return want.length === 0
   return want.every((part) => Binary.search(parts, part.id, (item) => item.id).found)
@@ -95,6 +97,7 @@ export function createServerSession(client: OpencodeClient) {
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
+  const initialEvents = new Map<string, SessionEvent[]>()
   const seen = new Set<string>()
   const infoSeen = new Set<string>()
   const pinned = new Map<string, number>()
@@ -265,19 +268,19 @@ export function createServerSession(client: OpencodeClient) {
     if (meta.loading[sessionID]) return
     const generation = generations.get(sessionID) ?? 0
     const initiallyUnloaded = data.message[sessionID] === undefined
+    if (initiallyUnloaded) initialEvents.set(sessionID, [])
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
         next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const messages = mode === "prepend"
-          ? merge(data.message[sessionID] ?? [], next.session)
-          : initiallyUnloaded
-            ? merge(next.session, data.message[sessionID] ?? [])
-            : next.session
+        const messages = mode === "prepend" ? merge(data.message[sessionID] ?? [], next.session) : next.session
+        const events = initialEvents.get(sessionID) ?? []
+        initialEvents.delete(sessionID)
         batch(() => {
-          setData("message", sessionID, reconcile(messages, { key: "id" }))
+          if (initiallyUnloaded) setData("message", sessionID, messages)
+          if (!initiallyUnloaded) setData("message", sessionID, reconcile(messages, { key: "id" }))
           for (const item of next.part) {
             const parts = item.part.filter((part) => !SKIP_PARTS.has(part.type))
             if (parts.length) setData("part", item.id, reconcile(parts, { key: "id" }))
@@ -287,8 +290,10 @@ export function createServerSession(client: OpencodeClient) {
           setMeta("complete", sessionID, next.complete)
           setMeta("at", sessionID, Date.now())
         })
+        events.forEach(apply)
       })
       .finally(() => {
+        initialEvents.delete(sessionID)
         if ((generations.get(sessionID) ?? 0) === generation) setMeta("loading", sessionID, false)
       })
   }
@@ -318,7 +323,7 @@ export function createServerSession(client: OpencodeClient) {
     await runInflight(inflight, sessionID, () => loadMessages(sessionID, limit))
   }
 
-  const eventSessionID = (event: { type: string; properties?: unknown }) => {
+  const eventSessionID = (event: SessionEvent) => {
     const properties = event.properties
     if (!properties || typeof properties !== "object") return
     if ("sessionID" in properties && typeof properties.sessionID === "string") return properties.sessionID
@@ -340,9 +345,10 @@ export function createServerSession(client: OpencodeClient) {
       return properties.part.sessionID
   }
 
-  const apply = (event: { type: string; properties?: unknown }) => {
+  const apply = (event: SessionEvent) => {
     const eventID = eventSessionID(event)
     if (eventID) {
+      if (event.type.startsWith("message.")) initialEvents.get(eventID)?.push(event)
       touch(eventID)
       if (!data.info[eventID]) void resolve(eventID).catch(() => {})
     }

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -18,44 +18,70 @@ import { rootSession } from "@/utils/session-route"
 import { dropSessionCaches, pickSessionCacheEvictions, SESSION_CACHE_LIMIT } from "./global-sync/session-cache"
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0)
+const cmpMessage = (a: Message, b: Message) => a.time.created - b.time.created || cmp(a.id, b.id)
 const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 const initialMessagePageSize = 2
 const historyMessagePageSize = 200
 const sessionInfoLimit = 2_048
+const emptyIDs: ReadonlySet<string> = new Set()
 
 type OptimisticItem = {
   message: Message
   parts: Part[]
+  confirmedParts?: Part[]
+  confirmedMessage?: boolean
 }
 
-const hasParts = (parts: Part[] | undefined, want: Part[]) => {
-  if (!parts) return want.length === 0
-  return want.every((part) => Binary.search(parts, part.id, (item) => item.id).found)
+type MessagePage = {
+  session: Message[]
+  part: { id: string; part: Part[] }[]
+  cursor?: string
+  complete: boolean
+}
+
+// Most markers describe the current HTTP attempt; deltaParts persists non-durable stream state across retries.
+type MessageLoadState = {
+  touchedMessages: Set<string>
+  removedMessages: Set<string>
+  retainedMessages: Set<string>
+  touchedParts: Map<string, Set<string>>
+  deltaParts: Map<string, Set<string>>
+  carriedDeltaParts: Map<string, Set<string>>
+  removedParts: Map<string, Set<string>>
+  optimisticParts: Map<string, Set<string>>
+  orphanParents: Set<string>
+  clearedMessageParts: Set<string>
 }
 
 function mergeOptimisticPage(
-  page: { session: Message[]; part: { id: string; part: Part[] }[]; cursor?: string; complete: boolean },
+  page: MessagePage,
   items: OptimisticItem[],
 ) {
-  if (items.length === 0) return { ...page, confirmed: [] as string[] }
+  if (items.length === 0) return { ...page, observed: [] as { messageID: string; parts: Part[] }[] }
   const session = [...page.session]
   const part = new Map(page.part.map((item) => [item.id, item.part]))
-  const confirmed: string[] = []
+  const observed: { messageID: string; parts: Part[] }[] = []
   for (const item of items) {
     const result = Binary.search(session, item.message.id, (message) => message.id)
     if (!result.found) session.splice(result.index, 0, item.message)
     const current = part.get(item.message.id)
-    if (result.found && hasParts(current, item.parts)) {
-      confirmed.push(item.message.id)
-      continue
-    }
-    part.set(item.message.id, merge(current ?? [], item.parts))
+    const confirmed = result.found
+      ? item.parts.filter((part) => Binary.search(current ?? [], part.id, (value) => value.id).found)
+      : []
+    if (result.found) observed.push({ messageID: item.message.id, parts: confirmed })
+    part.set(
+      item.message.id,
+      merge(
+        result.found ? (current ?? []) : merge(item.confirmedParts ?? [], current ?? []),
+        item.parts.filter((part) => !confirmed.includes(part)),
+      ),
+    )
   }
   return {
     ...page,
     session,
     part: [...part.entries()].sort((a, b) => cmp(a[0], b[0])).map(([id, parts]) => ({ id, part: parts })),
-    confirmed,
+    observed,
   }
 }
 
@@ -75,25 +101,38 @@ function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
   return [...items.values()].sort((x, y) => cmp(x.id, y.id))
 }
 
-function mergeConcurrent<T extends { id: string }>(
+function reconcileFetched<T extends { id: string }>(
   fetched: T[],
   current: readonly T[],
-  touched: Set<string>,
-  partial = false,
+  options: {
+    touched?: ReadonlySet<string>
+    retained?: ReadonlySet<string>
+    preserveUnfetched?: boolean | ((item: T) => boolean)
+  } = {},
 ) {
-  const next = new Map(fetched.map((item) => [item.id, item]))
+  const result = new Map(fetched.map((item) => [item.id, item]))
   const live = new Map(current.map((item) => [item.id, item]))
-  if (partial) live.forEach((item, id) => !next.has(id) && next.set(id, item))
-  // Events observed while the request is pending are the freshest client state for those identities.
-  for (const id of touched) {
-    const liveItem = live.get(id)
-    if (liveItem) next.set(id, liveItem)
-    if (!liveItem) next.delete(id)
+  if (options.preserveUnfetched) {
+    for (const item of current) {
+      if (!result.has(item.id) && (options.preserveUnfetched === true || options.preserveUnfetched(item)))
+        result.set(item.id, item)
+    }
   }
-  return [...next.values()].sort((a, b) => cmp(a.id, b.id))
+  for (const id of options.retained ?? emptyIDs) {
+    if (result.has(id)) continue
+    const item = live.get(id)
+    if (item) result.set(id, item)
+  }
+  // Events observed while the request is pending are the freshest client state for those identities.
+  for (const id of options.touched ?? emptyIDs) {
+    const item = live.get(id)
+    if (item) result.set(id, item)
+    if (!item) result.delete(id)
+  }
+  return [...result.values()].sort((a, b) => cmp(a.id, b.id))
 }
 
-export function createServerSession(client: OpencodeClient) {
+export function createServerSession(client: OpencodeClient, options?: { retryDelay?: number }) {
   const [data, setData] = createStore({
     info: {} as Record<string, Session | undefined>,
     session_status: {} as Record<string, SessionStatus>,
@@ -113,11 +152,29 @@ export function createServerSession(client: OpencodeClient) {
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
-  const messageLoads = new Map<string, { messages: Set<string>; parts: Map<string, Set<string>> }>()
+  const messageLoads = new Map<string, MessageLoadState>()
+  const pendingParts = new Map<string, Map<string, Set<string>>>()
+  const orphanParts = new Map<string, Set<string>>()
+  const removedMessages = new Map<string, Set<string>>()
+  const deltaBases = new Map<string, { base: string; sessionID: string }>()
+  const deleteMessageParts = (cache: { part: Record<string, Part[] | undefined>; part_text_accum_delta: Record<string, string | undefined> }, messageID: string) => {
+    for (const part of cache.part[messageID] ?? []) {
+      delete cache.part_text_accum_delta[part.id]
+      deltaBases.delete(part.id)
+    }
+    delete cache.part[messageID]
+  }
   const seen = new Set<string>()
   const infoSeen = new Set<string>()
   const pinned = new Map<string, number>()
-  const generations = new Map<string, number>()
+  const generations = new Map<string, object>()
+  const generation = (sessionID: string) => {
+    const current = generations.get(sessionID)
+    if (current) return current
+    const created = {}
+    generations.set(sessionID, created)
+    return created
+  }
   const [meta, setMeta] = createStore({
     limit: {} as Record<string, number | undefined>,
     cursor: {} as Record<string, string | undefined>,
@@ -134,6 +191,11 @@ export function createServerSession(client: OpencodeClient) {
       const preserve = new Set([
         ...pinned.keys(),
         ...requests.keys(),
+        ...inflight.keys(),
+        ...inflightDiff.keys(),
+        ...inflightTodo.keys(),
+        ...messageLoads.keys(),
+        ...optimistic.keys(),
         ...Object.entries(data.permission)
           .filter(([, items]) => items.length > 0)
           .map(([sessionID]) => sessionID),
@@ -157,6 +219,7 @@ export function createServerSession(client: OpencodeClient) {
         if (!preserve.has(sessionID)) stale.push(sessionID)
       }
       stale.forEach((sessionID) => infoSeen.delete(sessionID))
+      stale.forEach((sessionID) => generations.delete(sessionID))
       setData(
         "info",
         produce((draft) => stale.forEach((sessionID) => delete draft[sessionID])),
@@ -170,20 +233,29 @@ export function createServerSession(client: OpencodeClient) {
     if (cached && !options?.force) return Promise.resolve(cached)
     const pending = requests.get(sessionID)
     if (pending) return pending
-    const generation = generations.get(sessionID) ?? 0
+    const active = generation(sessionID)
     const request = client.session.get({ sessionID }).then((result) => {
       if (!result.data) throw new Error(`Session not found: ${sessionID}`)
-      if ((generations.get(sessionID) ?? 0) !== generation) return result.data
+      if (generations.get(sessionID) !== active) return result.data
       return remember(result.data)
     })
     requests.set(sessionID, request)
+    const cleanup = () => {
+      if (requests.get(sessionID) === request) requests.delete(sessionID)
+      if (
+        generations.get(sessionID) === active &&
+        !data.info[sessionID] &&
+        !requests.has(sessionID) &&
+        !messageLoads.has(sessionID) &&
+        !inflight.has(sessionID) &&
+        !inflightDiff.has(sessionID) &&
+        !inflightTodo.has(sessionID)
+      )
+        generations.delete(sessionID)
+    }
     void request.then(
-      () => {
-        if (requests.get(sessionID) === request) requests.delete(sessionID)
-      },
-      () => {
-        if (requests.get(sessionID) === request) requests.delete(sessionID)
-      },
+      cleanup,
+      cleanup,
     )
     return request
   }
@@ -217,20 +289,117 @@ export function createServerSession(client: OpencodeClient) {
   const clearOptimisticPart = (sessionID: string, messageID: string, partID: string) => {
     const items = optimistic.get(sessionID)
     const item = items?.get(messageID)
-    if (!item) return
-    items?.set(messageID, { ...item, parts: item.parts.filter((part) => part.id !== partID) })
+    if (!items || !item) return
+    const parts = item.parts.filter((part) => part.id !== partID)
+    const confirmedParts = item.confirmedParts?.filter((part) => part.id !== partID)
+    if (parts.length === 0) {
+      clearOptimistic(sessionID, messageID)
+      return
+    }
+    items.set(messageID, { ...item, parts, confirmedParts, confirmedMessage: true })
+  }
+
+  const confirmOptimisticPart = (sessionID: string, messageID: string, part: Part) => {
+    const items = optimistic.get(sessionID)
+    const item = items?.get(messageID)
+    if (!items || !item) return
+    const parts = item.parts.filter((value) => value.id !== part.id)
+    if (parts.length === 0) {
+      clearOptimistic(sessionID, messageID)
+      return
+    }
+    items.set(messageID, {
+      ...item,
+      parts,
+      confirmedParts: merge(item.confirmedParts ?? [], [part]),
+      confirmedMessage: true,
+    })
+  }
+
+  const confirmOptimistic = (sessionID: string, messageID: string, confirmedParts: Part[]) => {
+    const items = optimistic.get(sessionID)
+    const item = items?.get(messageID)
+    if (!items || !item) return
+    const confirmed = new Set(confirmedParts.map((part) => part.id))
+    const parts = item.parts.filter((part) => !confirmed.has(part.id))
+    if (parts.length === 0) {
+      clearOptimistic(sessionID, messageID)
+      return
+    }
+    items.set(messageID, {
+      ...item,
+      parts,
+      confirmedParts: merge(item.confirmedParts ?? [], confirmedParts),
+      confirmedMessage: true,
+    })
+  }
+
+  const trackPartChange = (sessionID: string, messageID: string, partID: string) => {
+    const load = messageLoads.get(sessionID)
+    if (!load) return
+    // A part event keeps an existing parent when the fetched page omits it without overriding fetched metadata.
+    const messages = data.message[sessionID]
+    if (messages && Binary.search(messages, messageID, (message) => message.id).found) load.retainedMessages.add(messageID)
+    const parts = load.touchedParts.get(messageID)
+    if (parts) {
+      parts.add(partID)
+      return
+    }
+    load.touchedParts.set(messageID, new Set([partID]))
+  }
+
+  const resetMessageLoad = (sessionID: string, load: MessageLoadState) => {
+    load.touchedMessages.clear()
+    load.retainedMessages.clear()
+    load.touchedParts.clear()
+    load.carriedDeltaParts.clear()
+    load.clearedMessageParts.clear()
+    for (const messageID of load.removedMessages) {
+      load.touchedMessages.add(messageID)
+      load.clearedMessageParts.add(messageID)
+    }
+    for (const [messageID, parts] of load.deltaParts) {
+      load.touchedParts.set(messageID, new Set(parts))
+      load.carriedDeltaParts.set(messageID, new Set(parts))
+      const messages = data.message[sessionID]
+      if (messages && Binary.search(messages, messageID, (message) => message.id).found)
+        load.retainedMessages.add(messageID)
+    }
+    for (const [messageID, parts] of load.removedParts) {
+      const touched = load.touchedParts.get(messageID) ?? new Set<string>()
+      parts.forEach((partID) => touched.add(partID))
+      load.touchedParts.set(messageID, touched)
+      const messages = data.message[sessionID]
+      if (messages && Binary.search(messages, messageID, (message) => message.id).found)
+        load.retainedMessages.add(messageID)
+    }
+    for (const [messageID, parts] of load.optimisticParts) {
+      load.removedMessages.delete(messageID)
+      load.clearedMessageParts.add(messageID)
+      load.touchedMessages.add(messageID)
+      const touched = load.touchedParts.get(messageID) ?? new Set<string>()
+      parts.forEach((partID) => touched.add(partID))
+      load.touchedParts.set(messageID, touched)
+    }
   }
 
   const evict = (sessionIDs: string[]) => {
     if (sessionIDs.length === 0) return
+    const evicted = new Set(sessionIDs)
+    for (const [partID, item] of deltaBases) {
+      if (evicted.has(item.sessionID)) deltaBases.delete(partID)
+    }
     sessionIDs.forEach((sessionID) => {
-      generations.set(sessionID, (generations.get(sessionID) ?? 0) + 1)
+      generations.delete(sessionID)
       clearOptimistic(sessionID)
       requests.delete(sessionID)
       inflight.delete(sessionID)
       inflightDiff.delete(sessionID)
       inflightTodo.delete(sessionID)
       messageLoads.delete(sessionID)
+      pendingParts.delete(sessionID)
+      orphanParts.delete(sessionID)
+      removedMessages.delete(sessionID)
     })
     setData(
       produce((draft) => {
@@ -257,6 +426,7 @@ export function createServerSession(client: OpencodeClient) {
       ...inflight.keys(),
       ...inflightDiff.keys(),
       ...inflightTodo.keys(),
+      ...messageLoads.keys(),
       ...optimistic.keys(),
       ...Object.entries(data.permission)
         .filter(([, items]) => items.length > 0)
@@ -274,8 +444,14 @@ export function createServerSession(client: OpencodeClient) {
       pickSessionCacheEvictions({ seen, keep: sessionID, limit: SESSION_CACHE_LIMIT, preserve: protectedSessions() }),
     )
 
-  const fetchMessages = async (sessionID: string, limit: number, before?: string) => {
-    const response = await retry(() => client.session.messages({ sessionID, limit, before }))
+  const fetchMessages = async (sessionID: string, limit: number, before?: string, onAttempt?: () => void) => {
+    const response = await retry(
+      () => {
+        onAttempt?.()
+        return client.session.messages({ sessionID, limit, before })
+      },
+      { delay: options?.retryDelay },
+    )
     const items = (response.data ?? []).filter((item) => !!item?.info?.id)
     return {
       session: items.map((item) => cleanMessage(item.info)).sort((a, b) => cmp(a.id, b.id)),
@@ -288,70 +464,164 @@ export function createServerSession(client: OpencodeClient) {
     }
   }
 
+  const replaceMessages = (sessionID: string, messages: Message[]) => {
+    const messageIDs = new Set(messages.map((message) => message.id))
+    const dropped = (data.message[sessionID] ?? []).filter((message) => !messageIDs.has(message.id))
+    setData("message", sessionID, reconcile(messages, { key: "id" }))
+    setData(
+      produce((draft) => {
+        for (const message of dropped) deleteMessageParts(draft, message.id)
+      }),
+    )
+    return messageIDs
+  }
+
+  const replaceParts = (
+    sessionID: string,
+    items: MessagePage["part"],
+    messageIDs: Set<string>,
+    load?: MessageLoadState,
+  ) => {
+    for (const item of items) {
+      if (!messageIDs.has(item.id)) continue
+      const fetched = load?.clearedMessageParts.has(item.id)
+        ? []
+        : item.part.filter((part) => !SKIP_PARTS.has(part.type))
+      const fetchedIDs = new Set(fetched.map((part) => part.id))
+      const pending = pendingParts.get(sessionID)?.get(item.id)
+      const touched = new Set([...(load?.touchedParts.get(item.id) ?? []), ...(pending ?? [])])
+      for (const part of fetched) {
+        const accumulated = data.part_text_accum_delta[part.id]
+        const base = deltaBases.get(part.id)?.base
+        const preserveDelta =
+          base !== undefined &&
+          accumulated !== undefined &&
+          "text" in part &&
+          typeof part.text === "string" &&
+          part.text.startsWith(base) &&
+          accumulated.startsWith(part.text) &&
+          accumulated !== part.text
+        if (preserveDelta) touched.add(part.id)
+        if (load?.carriedDeltaParts.get(item.id)?.has(part.id) && !preserveDelta) touched.delete(part.id)
+      }
+      for (const partID of load?.carriedDeltaParts.get(item.id) ?? []) {
+        if (!fetchedIDs.has(partID)) touched.delete(partID)
+      }
+      const parts = reconcileFetched(
+        fetched,
+        data.part[item.id] ?? [],
+        { touched },
+      )
+      if (!parts.length) {
+        orphanParts.get(sessionID)?.delete(item.id)
+        setData(produce((draft) => deleteMessageParts(draft, item.id)))
+        continue
+      }
+      const partIDs = new Set(parts.map((part) => part.id))
+      setData(
+        "part_text_accum_delta",
+        produce((draft) => {
+          for (const part of data.part[item.id] ?? []) {
+            if (!partIDs.has(part.id) || !touched.has(part.id)) {
+              delete draft[part.id]
+              deltaBases.delete(part.id)
+            }
+          }
+        }),
+      )
+      setData("part", item.id, reconcile(parts, { key: "id" }))
+      orphanParts.get(sessionID)?.delete(item.id)
+    }
+  }
+
+  const applyMessagePage = (
+    sessionID: string,
+    page: MessagePage,
+    load: MessageLoadState | undefined,
+    preserveUnfetched: boolean | ((message: Message) => boolean),
+    cleanupOrphans: boolean,
+  ) => {
+    const merged = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
+    merged.observed.forEach((item) => {
+      if (!load?.clearedMessageParts.has(item.messageID)) confirmOptimistic(sessionID, item.messageID, item.parts)
+    })
+    const touchedMessages = new Set([
+      ...(load?.touchedMessages ?? []),
+      ...(removedMessages.get(sessionID) ?? []),
+    ])
+    const messages = reconcileFetched(
+      merged.session,
+      data.message[sessionID] ?? [],
+      {
+        touched: touchedMessages,
+        retained: load?.retainedMessages,
+        preserveUnfetched,
+      },
+    )
+    batch(() => {
+      const messageIDs = replaceMessages(sessionID, messages)
+      replaceParts(sessionID, merged.part, messageIDs, load)
+      const orphans = orphanParts.get(sessionID)
+      if (cleanupOrphans && page.complete && orphans) {
+        for (const messageID of orphans) {
+          if (!messageIDs.has(messageID)) setData(produce((draft) => deleteMessageParts(draft, messageID)))
+        }
+        orphanParts.delete(sessionID)
+      }
+      setMeta("limit", sessionID, messages.length)
+      setMeta("cursor", sessionID, merged.cursor)
+      setMeta("complete", sessionID, merged.complete)
+      setMeta("at", sessionID, Date.now())
+    })
+  }
+
   const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
     if (meta.loading[sessionID]) return
-    const generation = generations.get(sessionID) ?? 0
-    const initial = meta.limit[sessionID] === undefined
-    const active = { messages: new Set<string>(), parts: new Map<string, Set<string>>() }
-    messageLoads.set(sessionID, active)
+    const active = generation(sessionID)
+    const load: MessageLoadState = {
+      touchedMessages: new Set(),
+      removedMessages: new Set(),
+      retainedMessages: new Set(),
+      touchedParts: new Map(),
+      deltaParts: new Map(),
+      carriedDeltaParts: new Map(),
+      removedParts: new Map(),
+      optimisticParts: new Map(),
+      orphanParents: new Set(),
+      clearedMessageParts: new Set(),
+    }
+    messageLoads.set(sessionID, load)
     setMeta("loading", sessionID, true)
-    await fetchMessages(sessionID, limit, before)
+    let applied = false
+    await fetchMessages(sessionID, limit, before, () => resetMessageLoad(sessionID, load))
       .then((page) => {
-        if ((generations.get(sessionID) ?? 0) !== generation) return
-        const concurrent = messageLoads.get(sessionID) === active ? active : undefined
-        const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
-        next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const messages = mergeConcurrent(
-          next.session,
-          data.message[sessionID] ?? [],
-          concurrent?.messages ?? new Set(),
-          initial || mode === "prepend",
+        if (generations.get(sessionID) !== active) return
+        const first = page.session.reduce<Message | undefined>(
+          (oldest, message) => (!oldest || cmpMessage(message, oldest) < 0 ? message : oldest),
+          undefined,
         )
-        const messageIDs = new Set(messages.map((message) => message.id))
-        batch(() => {
-          const dropped = (data.message[sessionID] ?? []).filter((message) => !messageIDs.has(message.id))
-          setData("message", sessionID, reconcile(messages, { key: "id" }))
-          setData(
-            produce((draft) => {
-              for (const message of dropped) {
-                for (const part of draft.part[message.id] ?? []) delete draft.part_text_accum_delta[part.id]
-                delete draft.part[message.id]
-              }
-            }),
-          )
-          for (const item of next.part) {
-            if (!messageIDs.has(item.id)) continue
-            const fetched = item.part.filter((part) => !SKIP_PARTS.has(part.type))
-            const kept = mergeConcurrent(fetched, data.part[item.id] ?? [], concurrent?.parts.get(item.id) ?? new Set())
-            if (kept.length) {
-              const keptIDs = new Set(kept.map((part) => part.id))
-              setData(
-                "part_text_accum_delta",
-                produce((draft) => {
-                  for (const part of data.part[item.id] ?? []) {
-                    if (!keptIDs.has(part.id)) delete draft[part.id]
-                  }
-                }),
-              )
-              setData("part", item.id, reconcile(kept, { key: "id" }))
-            }
-            if (!kept.length)
-              setData(
-                produce((draft) => {
-                  for (const part of draft.part[item.id] ?? []) delete draft.part_text_accum_delta[part.id]
-                  delete draft.part[item.id]
-                }),
-              )
-          }
-          setMeta("limit", sessionID, messages.length)
-          setMeta("cursor", sessionID, next.cursor)
-          setMeta("complete", sessionID, next.complete)
-          setMeta("at", sessionID, Date.now())
-        })
+        const preserveUnfetched =
+          mode === "prepend" || (!page.complete && (!first || ((message: Message) => cmpMessage(message, first) < 0)))
+        applyMessagePage(
+          sessionID,
+          page,
+          messageLoads.get(sessionID) === load ? load : undefined,
+          preserveUnfetched,
+          mode !== "prepend",
+        )
+        applied = true
       })
       .finally(() => {
-        if (messageLoads.get(sessionID) === active) messageLoads.delete(sessionID)
-        if ((generations.get(sessionID) ?? 0) === generation) setMeta("loading", sessionID, false)
+        if (!applied && generations.get(sessionID) === active && messageLoads.get(sessionID) === load) {
+          for (const messageID of load.orphanParents) {
+            if (!orphanParts.get(sessionID)?.has(messageID)) continue
+            setData(produce((draft) => deleteMessageParts(draft, messageID)))
+            orphanParts.get(sessionID)?.delete(messageID)
+          }
+          if (orphanParts.get(sessionID)?.size === 0) orphanParts.delete(sessionID)
+        }
+        if (messageLoads.get(sessionID) === load) messageLoads.delete(sessionID)
+        if (generations.get(sessionID) === active) setMeta("loading", sessionID, false)
       })
   }
 
@@ -406,7 +676,13 @@ export function createServerSession(client: OpencodeClient) {
     const eventID = eventSessionID(event)
     if (eventID) {
       touch(eventID)
-      if (!data.info[eventID]) void resolve(eventID).catch(() => {})
+      if (
+        !data.info[eventID] &&
+        event.type !== "session.created" &&
+        event.type !== "session.updated" &&
+        event.type !== "session.deleted"
+      )
+        void resolve(eventID).catch(() => {})
     }
     switch (event.type) {
       case "session.created":
@@ -445,7 +721,21 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.updated": {
         const info = cleanMessage((event.properties as { info: Message }).info)
-        messageLoads.get(info.sessionID)?.messages.add(info.id)
+        const load = messageLoads.get(info.sessionID)
+        load?.touchedMessages.add(info.id)
+        load?.removedMessages.delete(info.id)
+        const items = optimistic.get(info.sessionID)
+        const item = items?.get(info.id)
+        if (items && item) {
+          if (item.parts.length === 0) clearOptimistic(info.sessionID, info.id)
+          if (item.parts.length > 0) items.set(info.id, { ...item, confirmedMessage: true })
+        }
+        const orphans = orphanParts.get(info.sessionID)
+        orphans?.delete(info.id)
+        if (orphans?.size === 0) orphanParts.delete(info.sessionID)
+        const removedMessagesForSession = removedMessages.get(info.sessionID)
+        removedMessagesForSession?.delete(info.id)
+        if (removedMessagesForSession?.size === 0) removedMessages.delete(info.sessionID)
         const messages = data.message[info.sessionID]
         if (!messages) {
           setData("message", info.sessionID, [info])
@@ -463,7 +753,19 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.removed": {
         const props = event.properties as { sessionID: string; messageID: string }
-        messageLoads.get(props.sessionID)?.messages.add(props.messageID)
+        const load = messageLoads.get(props.sessionID)
+        load?.touchedMessages.add(props.messageID)
+        load?.removedMessages.add(props.messageID)
+        load?.clearedMessageParts.add(props.messageID)
+        load?.deltaParts.delete(props.messageID)
+        load?.carriedDeltaParts.delete(props.messageID)
+        load?.removedParts.delete(props.messageID)
+        load?.optimisticParts.delete(props.messageID)
+        pendingParts.get(props.sessionID)?.delete(props.messageID)
+        if (pendingParts.get(props.sessionID)?.size === 0) pendingParts.delete(props.sessionID)
+        const removedMessagesForSession = removedMessages.get(props.sessionID) ?? new Set<string>()
+        removedMessagesForSession.add(props.messageID)
+        removedMessages.set(props.sessionID, removedMessagesForSession)
         clearOptimistic(props.sessionID, props.messageID)
         setData(
           produce((draft) => {
@@ -472,8 +774,7 @@ export function createServerSession(client: OpencodeClient) {
               const result = Binary.search(messages, props.messageID, (message) => message.id)
               if (result.found) messages.splice(result.index, 1)
             }
-            for (const part of draft.part[props.messageID] ?? []) delete draft.part_text_accum_delta[part.id]
-            delete draft.part[props.messageID]
+            deleteMessageParts(draft, props.messageID)
           }),
         )
         return
@@ -481,12 +782,40 @@ export function createServerSession(client: OpencodeClient) {
       case "message.part.updated": {
         const part = (event.properties as { part: Part }).part
         if (SKIP_PARTS.has(part.type)) return
+        const messages = data.message[part.sessionID]
         const load = messageLoads.get(part.sessionID)
-        if (load) {
-          const touched = load.parts.get(part.messageID) ?? new Set<string>()
-          touched.add(part.id)
-          load.parts.set(part.messageID, touched)
+        const missing = !messages || !Binary.search(messages, part.messageID, (message) => message.id).found
+        // Outside a page load, accepting a part without its ordered parent event would create an unbounded orphan.
+        if (
+          missing &&
+          (!load || load.clearedMessageParts.has(part.messageID) || removedMessages.get(part.sessionID)?.has(part.messageID))
+        )
+          return
+        if (missing) {
+          const orphans = orphanParts.get(part.sessionID) ?? new Set<string>()
+          orphans.add(part.messageID)
+          orphanParts.set(part.sessionID, orphans)
+          load?.orphanParents.add(part.messageID)
         }
+        const deltas = load?.deltaParts.get(part.messageID)
+        deltas?.delete(part.id)
+        if (deltas?.size === 0) load?.deltaParts.delete(part.messageID)
+        const carried = load?.carriedDeltaParts.get(part.messageID)
+        carried?.delete(part.id)
+        if (carried?.size === 0) load?.carriedDeltaParts.delete(part.messageID)
+        const removed = load?.removedParts.get(part.messageID)
+        removed?.delete(part.id)
+        if (removed?.size === 0) load?.removedParts.delete(part.messageID)
+        const pending = pendingParts.get(part.sessionID)?.get(part.messageID)
+        pending?.delete(part.id)
+        if (pending?.size === 0) pendingParts.get(part.sessionID)?.delete(part.messageID)
+        if (pendingParts.get(part.sessionID)?.size === 0) pendingParts.delete(part.sessionID)
+        const optimistic = load?.optimisticParts.get(part.messageID)
+        optimistic?.delete(part.id)
+        if (optimistic?.size === 0) load?.optimisticParts.delete(part.messageID)
+        deltaBases.delete(part.id)
+        trackPartChange(part.sessionID, part.messageID, part.id)
+        confirmOptimisticPart(part.sessionID, part.messageID, part)
         setData(
           "part_text_accum_delta",
           produce((draft) => void delete draft[part.id]),
@@ -508,16 +837,33 @@ export function createServerSession(client: OpencodeClient) {
       }
       case "message.part.removed": {
         const props = event.properties as { sessionID: string; messageID: string; partID: string }
+        // Part removal is event-only on the server, so its tombstone lasts until a later update or eviction.
+        const pending = pendingParts.get(props.sessionID) ?? new Map<string, Set<string>>()
+        const parts = pending.get(props.messageID) ?? new Set<string>()
+        parts.add(props.partID)
+        pending.set(props.messageID, parts)
+        pendingParts.set(props.sessionID, pending)
+        const deltas = messageLoads.get(props.sessionID)?.deltaParts.get(props.messageID)
+        deltas?.delete(props.partID)
+        if (deltas?.size === 0) messageLoads.get(props.sessionID)?.deltaParts.delete(props.messageID)
         const load = messageLoads.get(props.sessionID)
+        const carried = load?.carriedDeltaParts.get(props.messageID)
+        carried?.delete(props.partID)
+        if (carried?.size === 0) load?.carriedDeltaParts.delete(props.messageID)
         if (load) {
-          const touched = load.parts.get(props.messageID) ?? new Set<string>()
-          touched.add(props.partID)
-          load.parts.set(props.messageID, touched)
+          const parts = load.removedParts.get(props.messageID) ?? new Set<string>()
+          parts.add(props.partID)
+          load.removedParts.set(props.messageID, parts)
+          const optimistic = load.optimisticParts.get(props.messageID)
+          optimistic?.delete(props.partID)
+          if (optimistic?.size === 0) load.optimisticParts.delete(props.messageID)
         }
+        trackPartChange(props.sessionID, props.messageID, props.partID)
         clearOptimisticPart(props.sessionID, props.messageID, props.partID)
         setData(
           produce((draft) => {
             delete draft.part_text_accum_delta[props.partID]
+            deltaBases.delete(props.partID)
             const parts = draft.part[props.messageID]
             if (!parts) return
             const result = Binary.search(parts, props.partID, (part) => part.id)
@@ -539,14 +885,20 @@ export function createServerSession(client: OpencodeClient) {
         if (!parts) return
         const result = Binary.search(parts, props.partID, (part) => part.id)
         if (!result.found) return
+        trackPartChange(props.sessionID, props.messageID, props.partID)
         const load = messageLoads.get(props.sessionID)
         if (load) {
-          const touched = load.parts.get(props.messageID) ?? new Set<string>()
-          touched.add(props.partID)
-          load.parts.set(props.messageID, touched)
+          const parts = load.deltaParts.get(props.messageID) ?? new Set<string>()
+          parts.add(props.partID)
+          load.deltaParts.set(props.messageID, parts)
+          const carried = load.carriedDeltaParts.get(props.messageID)
+          carried?.delete(props.partID)
+          if (carried?.size === 0) load.carriedDeltaParts.delete(props.messageID)
         }
         const field = props.field as keyof (typeof parts)[number]
         const current = parts[result.index]?.[field]
+        if (!deltaBases.has(props.partID) && typeof current === "string")
+          deltaBases.set(props.partID, { base: current, sessionID: props.sessionID })
         setData(
           "part_text_accum_delta",
           props.partID,
@@ -654,32 +1006,67 @@ export function createServerSession(client: OpencodeClient) {
     },
     optimistic: {
       add(input: { sessionID: string; message: Message; parts: Part[] }) {
+        const parts = input.parts.filter((part) => !!part?.id && !SKIP_PARTS.has(part.type)).sort((a, b) => cmp(a.id, b.id))
+        const load = messageLoads.get(input.sessionID)
+        if (load?.clearedMessageParts.has(input.message.id)) {
+          const touched = load.touchedParts.get(input.message.id) ?? new Set<string>()
+          parts.forEach((part) => touched.add(part.id))
+          load.touchedParts.set(input.message.id, touched)
+        }
+        if (load) {
+          load.removedMessages.delete(input.message.id)
+          load.optimisticParts.set(input.message.id, new Set(parts.map((part) => part.id)))
+        }
         const items = optimistic.get(input.sessionID)
-        if (items) items.set(input.message.id, input)
-        if (!items) optimistic.set(input.sessionID, new Map([[input.message.id, input]]))
+        const removedMessagesForSession = removedMessages.get(input.sessionID)
+        removedMessagesForSession?.delete(input.message.id)
+        if (removedMessagesForSession?.size === 0) removedMessages.delete(input.sessionID)
+        if (items) items.set(input.message.id, { ...input, parts, confirmedParts: [] })
+        if (!items) optimistic.set(input.sessionID, new Map([[input.message.id, { ...input, parts, confirmedParts: [] }]]))
         setData("message", input.sessionID, (messages = []) => merge(messages, [input.message]))
         setData(
-          "part",
-          input.message.id,
-          input.parts.filter((part) => !!part?.id).sort((a, b) => cmp(a.id, b.id)),
+          "part_text_accum_delta",
+          produce((draft) => {
+            for (const part of [...(data.part[input.message.id] ?? []), ...parts]) {
+              delete draft[part.id]
+              deltaBases.delete(part.id)
+            }
+          }),
         )
+        setData("part", input.message.id, parts)
       },
       remove(input: { sessionID: string; messageID: string }) {
+        const item = optimistic.get(input.sessionID)?.get(input.messageID)
+        if (!item) return
+        messageLoads.get(input.sessionID)?.optimisticParts.delete(input.messageID)
         clearOptimistic(input.sessionID, input.messageID)
+        if (item.confirmedMessage) {
+          const partIDs = new Set(item.parts.map((part) => part.id))
+          setData(
+            produce((draft) => {
+              for (const part of item.parts) {
+                delete draft.part_text_accum_delta[part.id]
+                deltaBases.delete(part.id)
+              }
+              const parts = draft.part[input.messageID]
+              if (!parts) return
+              draft.part[input.messageID] = parts.filter((part) => !partIDs.has(part.id))
+              if (draft.part[input.messageID]?.length === 0) delete draft.part[input.messageID]
+            }),
+          )
+          return
+        }
         setData("message", input.sessionID, (messages) => messages?.filter((message) => message.id !== input.messageID))
-        setData(
-          "part",
-          produce((draft) => void delete draft[input.messageID]),
-        )
+        setData(produce((draft) => deleteMessageParts(draft, input.messageID)))
       },
     },
     diff(sessionID: string, options?: { force?: boolean }) {
       touch(sessionID)
       if (data.session_diff[sessionID] !== undefined && !options?.force) return Promise.resolve()
       return runInflight(inflightDiff, sessionID, () => {
-        const generation = generations.get(sessionID) ?? 0
+        const active = generation(sessionID)
         return retry(() => client.session.diff({ sessionID })).then((result) => {
-          if ((generations.get(sessionID) ?? 0) !== generation) return
+          if (generations.get(sessionID) !== active) return
           setData("session_diff", sessionID, reconcile(cleanDiffs(result.data), { key: "file" }))
         })
       })
@@ -688,9 +1075,9 @@ export function createServerSession(client: OpencodeClient) {
       touch(sessionID)
       if (data.todo[sessionID] !== undefined && !options?.force) return Promise.resolve()
       return runInflight(inflightTodo, sessionID, () => {
-        const generation = generations.get(sessionID) ?? 0
+        const active = generation(sessionID)
         return retry(() => client.session.todo({ sessionID })).then((result) => {
-          if ((generations.get(sessionID) ?? 0) !== generation) return
+          if (generations.get(sessionID) !== active) return
           setData("todo", sessionID, reconcile(result.data ?? [], { key: "id" }))
         })
       })

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -326,10 +326,11 @@ export function createServerSession(client: OpencodeClient) {
             ? merge(data.message[sessionID] ?? [], next.session)
             : next.session
         ).filter((message) => !removed?.removedMessages.has(message.id))
+        const messageIDs = new Set(messages.map((message) => message.id))
         batch(() => {
           setData("message", sessionID, reconcile(messages, { key: "id" }))
           for (const item of next.part) {
-            if (!messages.some((message) => message.id === item.id)) continue
+            if (!messageIDs.has(item.id)) continue
             const fetched = item.part.filter((part) => !SKIP_PARTS.has(part.type))
             const parts = initial
               ? mergeConcurrent(fetched, data.part[item.id] ?? [], initial.part.get(item.id) ?? new Map())

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -264,13 +264,18 @@ export function createServerSession(client: OpencodeClient) {
   const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
     if (meta.loading[sessionID]) return
     const generation = generations.get(sessionID) ?? 0
+    const initiallyUnloaded = data.message[sessionID] === undefined
     setMeta("loading", sessionID, true)
     await fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
         next.confirmed.forEach((messageID) => clearOptimistic(sessionID, messageID))
-        const messages = mode === "prepend" ? merge(data.message[sessionID] ?? [], next.session) : next.session
+        const messages = mode === "prepend"
+          ? merge(data.message[sessionID] ?? [], next.session)
+          : initiallyUnloaded
+            ? merge(next.session, data.message[sessionID] ?? [])
+            : next.session
         batch(() => {
           setData("message", sessionID, reconcile(messages, { key: "id" }))
           for (const item of next.part) {

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -223,6 +223,13 @@ export function createServerSession(client: OpencodeClient) {
     if (items.size === 0) optimistic.delete(sessionID)
   }
 
+  const clearOptimisticPart = (sessionID: string, messageID: string, partID: string) => {
+    const items = optimistic.get(sessionID)
+    const item = items?.get(messageID)
+    if (!item) return
+    items?.set(messageID, { ...item, parts: item.parts.filter((part) => part.id !== partID) })
+  }
+
   const evict = (sessionIDs: string[]) => {
     if (sessionIDs.length === 0) return
     sessionIDs.forEach((sessionID) => {
@@ -451,6 +458,7 @@ export function createServerSession(client: OpencodeClient) {
       case "message.removed": {
         const props = event.properties as { sessionID: string; messageID: string }
         initialLoads.get(props.sessionID)?.removedMessages.add(props.messageID)
+        clearOptimistic(props.sessionID, props.messageID)
         setData(
           produce((draft) => {
             const messages = draft.message[props.sessionID]
@@ -493,6 +501,7 @@ export function createServerSession(client: OpencodeClient) {
         const removed = initial?.removedParts.get(props.messageID) ?? new Set<string>()
         removed.add(props.partID)
         initial?.removedParts.set(props.messageID, removed)
+        clearOptimisticPart(props.sessionID, props.messageID, props.partID)
         setData(
           produce((draft) => {
             delete draft.part_text_accum_delta[props.partID]


### PR DESCRIPTION
## Summary

- reconcile every message page with message and part events observed while that request is pending
- preserve live additions, updates, deltas, removals, and remove/re-add sequences across initial loads, refreshes, and history prepend
- keep untouched same-ID fetched values authoritative while event-touched identities use final live state
- clear matching optimistic state, orphaned parts, and detached delta buffers when content is removed
- preserve current IDs outside partial initial/history pages

## Safety And Performance

- request-scoped touched-ID sets only; no transcript serialization or event payload journals
- generation-safe cleanup on request settlement and eviction
- no timers, retries, or background work added
- no per-token tracking allocation unless a message request is active
- linear reconciliation using maps and sets
- server protocol emits part.updated before part.delta and drops provider orphan deltas

## Covered Permutations

- cold initial additions and same-ID updates
- initial and refresh removals
- remove then re-add with identical content
- forced-refresh updates and streaming deltas
- history prepend removals
- overlapping load generations
- optimistic confirmation and optimistic removal cleanup
- empty/partial part cleanup and orphaned message caches

## Verification

- 16 focused server-session tests passed
- full app suite passed: 445 unit tests and 17 browser tests
- `bun typecheck` from `packages/app`
- repository pre-push typecheck passed (29 packages)
- child-session production benchmark passed with zero blank samples (59.6 ms stable destination)
- previous Linux Core failure was an unrelated process-readiness flake; fresh CI is running