### PR TITLE
docs(ecosystem): add oc-wechat-bridge plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -46,6 +46,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-conductor](https://github.com/derekbar90/opencode-conductor)                             | Protocol-Driven Workflow: Automation of the Context -> Spec -> Plan -> Implement lifecycle.        |
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                          |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                              |
+| [oc-wechat-bridge](https://github.com/Fengming-GH/oc-wechat-bridge) | WeChat ↔ OpenCode bidirectional bridge with zero dependencies, streaming output, cross-session forwarding, and auto-recovery |
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)              | Claude Code-style background agents with async delegation and context persistence                  |
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                    |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                             |


### PR DESCRIPTION
### Issue for this PR

None

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Add [oc-wechat-bridge](https://github.com/Fengming-GH/oc-wechat-bridge) to the Plugins table in the ecosystem documentation.

oc-wechat-bridge is the first full-featured WeChat (微信) bridge for OpenCode. Users can chat with OC AI directly from WeChat — no desktop, no terminal needed.

### How did you verify your code works?

Tested daily in production for multiple weeks.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR