### PR TITLE
feat(app): show favicons for timeline links

### DIFF
--- a/packages/app/test-browser/markdown-link-favicon.test.ts
+++ b/packages/app/test-browser/markdown-link-favicon.test.ts
@@ -2,18 +2,41 @@ import { describe, expect, test } from "bun:test"
 import { decorateLinkFavicons } from "@opencode-ai/session-ui/markdown-link-favicon"
 
 describe("markdown link favicons", () => {
-  test("prepends lazy favicons to web links", () => {
+  test("reserves a link placeholder while eagerly loading web favicons", () => {
     const root = document.createElement("div")
     root.innerHTML = '<a class="external-link" href="https://docs.example.com/guide">Guide</a>'
 
     decorateLinkFavicons(root)
 
-    const icon = root.querySelector("img")
+    const slot = root.querySelector<HTMLElement>('[data-slot="markdown-link-favicon"]')
+    const placeholder = slot?.querySelector('[data-slot="markdown-link-favicon-placeholder"]')
+    const icon = slot?.querySelector("img")
     expect(icon?.src).toBe("https://www.google.com/s2/favicons?domain=docs.example.com&sz=32")
-    expect(icon?.loading).toBe("lazy")
+    expect(icon?.hasAttribute("loading")).toBe(false)
     expect(icon?.decoding).toBe("async")
     expect(icon?.alt).toBe("")
-    expect(root.querySelector("a")?.firstElementChild).toBe(icon)
+    expect(placeholder).toBeInstanceOf(SVGElement)
+    expect(slot?.dataset.loaded).toBeUndefined()
+    expect(root.querySelector("a")?.firstElementChild).toBe(slot)
+
+    icon?.dispatchEvent(new Event("load"))
+
+    expect(slot?.dataset.loaded).toBe("true")
+  })
+
+  test("keeps the placeholder and reserved slot when the favicon fails", () => {
+    const root = document.createElement("div")
+    root.innerHTML = '<a class="external-link" href="https://example.com">Website</a>'
+
+    decorateLinkFavicons(root)
+
+    const slot = root.querySelector<HTMLElement>('[data-slot="markdown-link-favicon"]')
+    const icon = slot?.querySelector("img")
+    icon?.dispatchEvent(new Event("error"))
+
+    expect(root.contains(slot ?? null)).toBe(true)
+    expect(slot?.dataset.loaded).toBeUndefined()
+    expect(slot?.querySelector('[data-slot="markdown-link-favicon-placeholder"]')).toBeInstanceOf(SVGElement)
   })
 
   test("ignores non-web links and does not duplicate icons", () => {
@@ -27,6 +50,6 @@ describe("markdown link favicons", () => {
     decorateLinkFavicons(root)
     decorateLinkFavicons(root)
 
-    expect(root.querySelectorAll("img")).toHaveLength(1)
+    expect(root.querySelectorAll('[data-slot="markdown-link-favicon"]')).toHaveLength(1)
   })
 })

--- a/packages/app/test-browser/markdown-link-favicon.test.ts
+++ b/packages/app/test-browser/markdown-link-favicon.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { decorateLinkFavicons } from "@opencode-ai/session-ui/markdown-link-favicon"
+
+describe("markdown link favicons", () => {
+  test("prepends lazy favicons to web links", () => {
+    const root = document.createElement("div")
+    root.innerHTML = '<a class="external-link" href="https://docs.example.com/guide">Guide</a>'
+
+    decorateLinkFavicons(root)
+
+    const icon = root.querySelector("img")
+    expect(icon?.src).toBe("https://www.google.com/s2/favicons?domain=docs.example.com&sz=32")
+    expect(icon?.loading).toBe("lazy")
+    expect(icon?.decoding).toBe("async")
+    expect(icon?.alt).toBe("")
+    expect(root.querySelector("a")?.firstElementChild).toBe(icon)
+  })
+
+  test("ignores non-web links and does not duplicate icons", () => {
+    const root = document.createElement("div")
+    root.innerHTML = [
+      '<a class="external-link" href="mailto:hello@example.com">Email</a>',
+      '<a class="external-link" href="/docs">Docs</a>',
+      '<a class="external-link" href="https://example.com">Website</a>',
+    ].join("")
+
+    decorateLinkFavicons(root)
+    decorateLinkFavicons(root)
+
+    expect(root.querySelectorAll("img")).toHaveLength(1)
+  })
+})

--- a/packages/session-ui/src/components/markdown-link-favicon.tsx
+++ b/packages/session-ui/src/components/markdown-link-favicon.tsx
@@ -1,0 +1,24 @@
+export function decorateLinkFavicons(root: ParentNode) {
+  const links = Array.from(root.querySelectorAll("a.external-link"))
+  for (const link of links) {
+    if (!(link instanceof HTMLAnchorElement)) continue
+    if (Array.from(link.children).some((child) => child.getAttribute("data-slot") === "markdown-link-favicon"))
+      continue
+
+    const href = link.getAttribute("href")
+    if (!href || !/^https?:\/\//i.test(href) || !URL.canParse(href)) continue
+    const url = new URL(href)
+    if (url.protocol !== "http:" && url.protocol !== "https:") continue
+
+    const icon = document.createElement("img")
+    icon.src = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(url.hostname)}&sz=32`
+    icon.alt = ""
+    icon.loading = "lazy"
+    icon.decoding = "async"
+    icon.referrerPolicy = "no-referrer"
+    icon.setAttribute("aria-hidden", "true")
+    icon.setAttribute("data-slot", "markdown-link-favicon")
+    icon.addEventListener("error", () => icon.remove(), { once: true })
+    link.prepend(icon)
+  }
+}

--- a/packages/session-ui/src/components/markdown-link-favicon.tsx
+++ b/packages/session-ui/src/components/markdown-link-favicon.tsx
@@ -2,23 +2,33 @@ export function decorateLinkFavicons(root: HTMLDivElement) {
   const links = Array.from(root.querySelectorAll("a.external-link"))
   for (const link of links) {
     if (!(link instanceof HTMLAnchorElement)) continue
-    if (Array.from(link.children).some((child) => child.getAttribute("data-slot") === "markdown-link-favicon"))
-      continue
+    if (link.querySelector(':scope > [data-slot="markdown-link-favicon"]')) continue
 
     const href = link.getAttribute("href")
     if (!href || !/^https?:\/\//i.test(href) || !URL.canParse(href)) continue
     const url = new URL(href)
     if (url.protocol !== "http:" && url.protocol !== "https:") continue
 
-    const icon = document.createElement("img")
-    icon.src = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(url.hostname)}&sz=32`
-    icon.alt = ""
-    icon.loading = "lazy"
-    icon.decoding = "async"
-    icon.referrerPolicy = "no-referrer"
-    icon.setAttribute("aria-hidden", "true")
-    icon.setAttribute("data-slot", "markdown-link-favicon")
-    icon.addEventListener("error", () => icon.remove(), { once: true })
-    link.insertAdjacentElement("afterbegin", icon)
+    const slot = document.createElement("span")
+    slot.setAttribute("aria-hidden", "true")
+    slot.setAttribute("data-slot", "markdown-link-favicon")
+
+    const placeholder = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+    placeholder.setAttribute("data-slot", "markdown-link-favicon-placeholder")
+    placeholder.setAttribute("viewBox", "0 0 20 20")
+    const use = document.createElementNS("http://www.w3.org/2000/svg", "use")
+    use.setAttribute("href", "#opencode-icon-link")
+    placeholder.appendChild(use)
+
+    const image = document.createElement("img")
+    image.alt = ""
+    image.decoding = "async"
+    image.referrerPolicy = "no-referrer"
+    image.addEventListener("load", () => (slot.dataset.loaded = "true"), { once: true })
+    image.src = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(url.hostname)}&sz=32`
+
+    slot.appendChild(placeholder)
+    slot.appendChild(image)
+    link.insertAdjacentElement("afterbegin", slot)
   }
 }

--- a/packages/session-ui/src/components/markdown-link-favicon.tsx
+++ b/packages/session-ui/src/components/markdown-link-favicon.tsx
@@ -1,4 +1,4 @@
-export function decorateLinkFavicons(root: ParentNode) {
+export function decorateLinkFavicons(root: HTMLDivElement) {
   const links = Array.from(root.querySelectorAll("a.external-link"))
   for (const link of links) {
     if (!(link instanceof HTMLAnchorElement)) continue
@@ -19,6 +19,6 @@ export function decorateLinkFavicons(root: ParentNode) {
     icon.setAttribute("aria-hidden", "true")
     icon.setAttribute("data-slot", "markdown-link-favicon")
     icon.addEventListener("error", () => icon.remove(), { once: true })
-    link.prepend(icon)
+    link.insertAdjacentElement("afterbegin", icon)
   }
 }

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -85,6 +85,16 @@
     text-underline-offset: 2px;
   }
 
+  a > img[data-slot="markdown-link-favicon"] {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    margin: 0 6px 0 0;
+    border-radius: 2px;
+    object-fit: contain;
+    vertical-align: -3px;
+  }
+
   /* Lists */
   ul,
   ol {

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -85,14 +85,42 @@
     text-underline-offset: 2px;
   }
 
-  a > img[data-slot="markdown-link-favicon"] {
+  a > [data-slot="markdown-link-favicon"] {
+    position: relative;
     display: inline-block;
     width: 16px;
     height: 16px;
     margin: 0 6px 0 0;
+    vertical-align: -3px;
+  }
+
+  a > [data-slot="markdown-link-favicon"] > :is(img, svg) {
+    position: absolute;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    margin: 0;
+  }
+
+  a > [data-slot="markdown-link-favicon"] > svg {
+    color: currentColor;
+    fill: none;
+  }
+
+  a > [data-slot="markdown-link-favicon"] > img {
     border-radius: 2px;
     object-fit: contain;
-    vertical-align: -3px;
+    opacity: 0;
+  }
+
+  a > [data-slot="markdown-link-favicon"][data-loaded="true"] > svg {
+    opacity: 0;
+  }
+
+  a > [data-slot="markdown-link-favicon"][data-loaded="true"] > img {
+    opacity: 1;
   }
 
   /* Lists */

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -26,6 +26,7 @@ import { markdownBlockKey, type MarkdownToken } from "./markdown-worker-protocol
 import { shouldResetCodeTokens, type RenderedCodeState } from "./markdown-code-state"
 import { getCachedMarkdown, sanitizeMarkdown, touchCachedMarkdown, type MarkdownCacheEntry } from "./markdown-cache"
 import { inlineCodeKind } from "./markdown-inline-code-kind"
+import { decorateLinkFavicons } from "./markdown-link-favicon"
 
 type RenderedBlock =
   | (MarkdownCacheEntry & { key: string; mode: Exclude<Block["mode"], "code"> })
@@ -244,6 +245,7 @@ function decorate(root: HTMLDivElement, labels: CopyLabels) {
   for (const block of blocks) {
     ensureCodeWrapper(block, labels)
   }
+  decorateLinkFavicons(root)
   if (!document.body.hasAttribute("data-new-layout")) return
   markInlineCode(root)
   markCodeLinks(root)


### PR DESCRIPTION
## Summary
- reserve a fixed 16px slot for external web-link favicons in timeline markdown
- show the existing chain-link icon until the favicon loads successfully
- eagerly request favicon images when virtualized timeline content mounts
- retain the placeholder on load failure without shifting link text

## Testing
- package typechecks for app, session-ui, and enterprise
- session-ui unit test suite
- focused browser tests for eager loading, success, failure, and duplicate decoration
- full repository typecheck via pre-push hook
- controlled production Playwright video/trace verified identical link and icon-slot geometry before and after load