### PR TITLE
feat(provider): resolve --model free to a random free catalog model

### DIFF
--- a/packages/opencode/script/stress-free-models.sh
+++ b/packages/opencode/script/stress-free-models.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Parallel stress test for `opencode run --model free`.
+# Verifies the structural filter (provider==opencode, all costs==0) reaches
+# the full live catalog of zero-cost models.
+#
+# Usage:
+#   script/stress-free-models.sh [DURATION_SECONDS] [WORKERS]
+#
+# Defaults: 300s, 3 workers. Each worker loops, calling `run --model free "x"`,
+# captures the resolved model from the build line, appends to a shared log.
+# At the end, prints distribution + unique-model count.
+#
+# Requires: gtimeout (brew install coreutils).
+
+set -euo pipefail
+
+DURATION="${1:-300}"
+WORKERS="${2:-3}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+BIN="$REPO_ROOT/packages/opencode/dist/opencode-darwin-arm64/bin/opencode"
+
+if [ ! -x "$BIN" ]; then
+  echo "ERROR: binary not found at $BIN" >&2
+  echo "       run \`bun run build\` from $REPO_ROOT/packages/opencode first" >&2
+  exit 1
+fi
+if ! command -v gtimeout >/dev/null 2>&1; then
+  echo "ERROR: gtimeout not found. Install via: brew install coreutils" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d -t oc-stress-XXXXXX)"
+LOG="$WORKDIR/stress.log"
+: > "$LOG"
+END=$(($(date +%s) + DURATION))
+
+export END BIN LOG WORKDIR
+
+worker() {
+  local id=$1
+  local dir="$WORKDIR/w$id"
+  mkdir -p "$dir"
+  cd "$dir"
+  local n=0
+  while [ "$(date +%s)" -lt "$END" ]; do
+    raw=$(gtimeout 12 "$BIN" run --model free "x" 2>&1 | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g')
+    pick=$(echo "$raw" | grep -oE '> build · [a-z0-9.-]+' | sed 's/> build · //' | head -1)
+    if [ -n "$pick" ]; then
+      echo "$(date +%s) w$id #$n $pick" >> "$LOG"
+    else
+      echo "$(date +%s) w$id #$n MISS" >> "$LOG"
+    fi
+    n=$((n + 1))
+  done
+}
+
+export -f worker
+
+echo "stress test: ${DURATION}s × ${WORKERS} workers → $LOG"
+for i in $(seq 1 "$WORKERS"); do
+  worker "$i" &
+done
+wait
+
+echo
+echo "=== completed ==="
+echo "total samples: $(wc -l < "$LOG" | tr -d ' ')"
+echo "--- distribution ---"
+awk '{print $NF}' "$LOG" | sort | uniq -c | sort -rn
+echo "--- unique non-MISS models ---"
+awk '{print $NF}' "$LOG" | grep -v MISS | sort -u
+echo "--- unique count ---"
+awk '{print $NF}' "$LOG" | grep -v MISS | sort -u | wc -l | tr -d ' '
+echo "--- per-worker counts ---"
+awk '{print $2}' "$LOG" | sort | uniq -c
+echo
+echo "raw log: $LOG"

--- a/packages/opencode/src/cli/bootstrap.ts
+++ b/packages/opencode/src/cli/bootstrap.ts
@@ -1,10 +1,10 @@
 import { InstanceRuntime } from "../project/instance-runtime"
-import { context } from "../project/instance-context"
+import { context, type InstanceContext } from "../project/instance-context"
 
-export async function bootstrap<T>(directory: string, cb: () => Promise<T>) {
+export async function bootstrap<T>(directory: string, cb: (ctx: InstanceContext) => Promise<T>) {
   const ctx = await InstanceRuntime.load({ directory })
   try {
-    return await context.provide(ctx, cb)
+    return await context.provide(ctx, () => cb(ctx))
   } finally {
     await InstanceRuntime.disposeInstance(ctx)
   }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -24,6 +24,7 @@ import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
+import { Provider } from "@/provider/provider"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
 
 type ModelInput = Parameters<OpencodeClient["session"]["prompt"]>[0]["model"]
@@ -836,15 +837,16 @@ export const RunCommand = effectCmd({
             const error = await completed
             if (error) process.exitCode = 1
           }
+          const resolved = await Provider.resolveSelection(args.model, args.variant, localInstance)
 
           if (args.command) {
             const result = await client.session.command({
               sessionID,
               agent,
-              model: args.model,
+              model: resolved.model,
               command: args.command,
               arguments: message,
-              variant: args.variant,
+              variant: resolved.variant,
             })
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
@@ -855,12 +857,12 @@ export const RunCommand = effectCmd({
             return
           }
 
-          const model = pick(args.model)
+          const model = resolved.model ? Provider.parseModel(resolved.model) : undefined
           const result = await client.session.prompt({
             sessionID,
             agent,
             model,
-            variant: args.variant,
+            variant: resolved.variant,
             parts: [...files, { type: "text", text: message }],
           })
           if (result.error) {
@@ -967,6 +969,7 @@ type MiniCommandInput = {
   session?: string
   fork?: boolean
   model?: string
+  variant?: string
   agent?: string
   prompt?: string
   replay?: boolean
@@ -995,7 +998,7 @@ export async function runMini(input: MiniCommandInput) {
     username: input.username,
     dir: input.directory,
     port: undefined,
-    variant: undefined,
+    variant: input.variant,
     thinking: undefined,
     mini: true,
     interactive: false,

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -210,10 +210,6 @@ export const RunCommand = effectCmd({
         type: "number",
         describe: "port for the local server (defaults to random port if no value provided)",
       })
-      .option("variant", {
-        type: "string",
-        describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
-      })
       .option("thinking", {
         type: "boolean",
         describe: "show thinking blocks",
@@ -274,6 +270,7 @@ export const RunCommand = effectCmd({
       const interactive = args.mini
       const auto = args.auto || args.yolo || args["dangerously-skip-permissions"]
       const thinking = interactive ? (args.thinking ?? true) : (args.thinking ?? false)
+      const resolved = await Provider.resolveSelection(args.model, localInstance)
       const die = (message: string): never => {
         UI.error(message)
         process.exit(1)
@@ -837,8 +834,6 @@ export const RunCommand = effectCmd({
             const error = await completed
             if (error) process.exitCode = 1
           }
-          const resolved = await Provider.resolveSelection(args.model, args.variant, localInstance)
-
           if (args.command) {
             const result = await client.session.command({
               sessionID,
@@ -846,7 +841,6 @@ export const RunCommand = effectCmd({
               model: resolved.model,
               command: args.command,
               arguments: message,
-              variant: resolved.variant,
             })
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
@@ -862,7 +856,6 @@ export const RunCommand = effectCmd({
             sessionID,
             agent,
             model,
-            variant: resolved.variant,
             parts: [...files, { type: "text", text: message }],
           })
           if (result.error) {
@@ -874,7 +867,7 @@ export const RunCommand = effectCmd({
           return
         }
 
-        const model = pick(args.model)
+        const model = pick(resolved.model)
         const { runInteractiveMode } = await import("./run/runtime")
         try {
           await runInteractiveMode({
@@ -887,7 +880,7 @@ export const RunCommand = effectCmd({
             replayLimit: args["replay-limit"],
             agent,
             model,
-            variant: args.variant,
+            variant: undefined,
             files,
             initialInput,
             createSession: createFreshSession,
@@ -902,7 +895,7 @@ export const RunCommand = effectCmd({
       }
 
       if (interactive && !args.attach && !args.session && !args.continue) {
-        const model = pick(args.model)
+        const model = pick(resolved.model)
         const { runInteractiveLocalMode } = await import("./run/runtime")
         const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
           const { Server } = await import("@/server/server")
@@ -923,7 +916,7 @@ export const RunCommand = effectCmd({
             createSession: createFreshSession,
             agent: args.agent,
             model,
-            variant: args.variant,
+            variant: undefined,
             replay,
             replayLimit: args["replay-limit"],
             files,
@@ -969,7 +962,6 @@ type MiniCommandInput = {
   session?: string
   fork?: boolean
   model?: string
-  variant?: string
   agent?: string
   prompt?: string
   replay?: boolean
@@ -998,7 +990,6 @@ export async function runMini(input: MiniCommandInput) {
     username: input.username,
     dir: input.directory,
     port: undefined,
-    variant: input.variant,
     thinking: undefined,
     mini: true,
     interactive: false,

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -270,11 +270,23 @@ export const RunCommand = effectCmd({
       const interactive = args.mini
       const auto = args.auto || args.yolo || args["dangerously-skip-permissions"]
       const thinking = interactive ? (args.thinking ?? true) : (args.thinking ?? false)
-      const resolved = await Provider.resolveSelection(args.model, localInstance)
       const die = (message: string): never => {
         UI.error(message)
         process.exit(1)
       }
+      if (args.attach && args.model === "free") {
+        die(
+          "--model free is not supported with --attach; specify a concrete model id (e.g., --model opencode/mimo-v2.5-free)",
+        )
+      }
+      const resolved = await (async () => {
+        if (args.attach) return { model: args.model }
+        try {
+          return await Provider.resolveSelection(args.model, localInstance)
+        } catch (error) {
+          return die(error instanceof Error ? error.message : String(error))
+        }
+      })()
       const dieInteractive = (error: unknown): never => {
         if (error instanceof Error && error.message === INTERACTIVE_INPUT_ERROR) {
           die(error.message)

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -142,10 +142,6 @@ export const TuiThreadCommand = cmd({
       .option("demo", {
         type: "boolean",
         hidden: true,
-      })
-      .option("variant", {
-        type: "string",
-        describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
       }),
   handler: async (args) => {
     if (args.replay === true) {
@@ -172,7 +168,6 @@ export const TuiThreadCommand = cmd({
         session: args.session,
         fork: args.fork,
         model: args.model,
-        variant: args.variant,
         agent: args.agent,
         prompt: args.prompt,
         replay: noReplay ? false : undefined,
@@ -213,12 +208,14 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
-      // TUI handler runs outside effectCmd, so the Instance ALS context that
-      // Provider.Service.list needs isn't established. Provide it here. The
-      // worker spawned below sets up its own.
-      const pick = await bootstrap(cwd, (ctx) => Provider.resolveSelection(args.model, args.variant, ctx))
-      const model = pick.model
-      const variant = pick.variant
+      // Resolving `--model free` requires Provider.Service.list, which needs the
+      // Instance ALS context the effectCmd wrapper would normally provide. The
+      // TUI handler runs outside it, so bootstrap it here only for `free`; any
+      // other model is passed through directly to avoid the load/dispose cost.
+      const model =
+        args.model === "free"
+          ? (await bootstrap(cwd, (ctx) => Provider.resolveSelection(args.model, ctx))).model
+          : args.model
 
       const worker = new Worker(file)
       const client = Rpc.client<typeof rpc>(worker)
@@ -298,7 +295,6 @@ export const TuiThreadCommand = cmd({
               sessionID: args.session,
               agent: args.agent,
               model,
-              variant,
               prompt,
               fork: args.fork,
               auto: args.auto || args.yolo || args["dangerously-skip-permissions"],

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -212,10 +212,16 @@ export const TuiThreadCommand = cmd({
       // Instance ALS context the effectCmd wrapper would normally provide. The
       // TUI handler runs outside it, so bootstrap it here only for `free`; any
       // other model is passed through directly to avoid the load/dispose cost.
-      const model =
-        args.model === "free"
-          ? (await bootstrap(cwd, (ctx) => Provider.resolveSelection(args.model, ctx))).model
-          : args.model
+      let model = args.model
+      if (args.model === "free") {
+        try {
+          model = (await bootstrap(cwd, (ctx) => Provider.resolveSelection(args.model, ctx))).model
+        } catch (error) {
+          UI.error(error instanceof Error ? error.message : String(error))
+          process.exitCode = 1
+          return
+        }
+      }
 
       const worker = new Worker(file)
       const client = Rpc.client<typeof rpc>(worker)

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -14,6 +14,8 @@ import { writeHeapSnapshot } from "v8"
 import { ServerAuth } from "@/server/auth"
 import { validateSession } from "../tui/validate-session"
 import { win32InstallCtrlCGuard } from "@opencode-ai/tui/terminal-win32"
+import { Provider } from "@/provider/provider"
+import { bootstrap } from "@/cli/bootstrap"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -140,6 +142,10 @@ export const TuiThreadCommand = cmd({
       .option("demo", {
         type: "boolean",
         hidden: true,
+      })
+      .option("variant", {
+        type: "string",
+        describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
       }),
   handler: async (args) => {
     if (args.replay === true) {
@@ -166,6 +172,7 @@ export const TuiThreadCommand = cmd({
         session: args.session,
         fork: args.fork,
         model: args.model,
+        variant: args.variant,
         agent: args.agent,
         prompt: args.prompt,
         replay: noReplay ? false : undefined,
@@ -206,6 +213,12 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
+      // TUI handler runs outside effectCmd, so the Instance ALS context that
+      // Provider.Service.list needs isn't established. Provide it here. The
+      // worker spawned below sets up its own.
+      const pick = await bootstrap(cwd, (ctx) => Provider.resolveSelection(args.model, args.variant, ctx))
+      const model = pick.model
+      const variant = pick.variant
 
       const worker = new Worker(file)
       const client = Rpc.client<typeof rpc>(worker)
@@ -284,7 +297,8 @@ export const TuiThreadCommand = cmd({
               continue: args.continue,
               sessionID: args.session,
               agent: args.agent,
-              model: args.model,
+              model,
+              variant,
               prompt,
               fork: args.fork,
               auto: args.auto || args.yolo || args["dangerously-skip-permissions"],

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -23,6 +23,7 @@ import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectPromise } from "@/effect/promise"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { makeRuntime } from "@/effect/run-service"
 import { isRecord } from "@/util/record"
 import { optional } from "@opencode-ai/core/schema"
 import { ProviderTransform } from "./transform"
@@ -31,6 +32,8 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { InstanceRef } from "@/effect/instance-ref"
+import type { InstanceContext } from "@/project/instance-context"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
 
@@ -1958,6 +1961,65 @@ export function sort<T extends { id: string }>(models: T[]) {
     [(model) => (model.id.includes("latest") ? 0 : 1), "asc"],
     [(model) => model.id, "desc"],
   )
+}
+
+const FREE = "free"
+export const ANY = "any"
+
+export function isFree(model: Model) {
+  // Structural filter only: any opencode model whose every cost dimension is
+  // zero is a candidate. models.dev does not expose a "Zen tier" flag, and the
+  // OpenCode Zen endpoint (api.url = opencode.ai/zen/v1) is shared by both the
+  // -free suffix models and promotional zero-cost models (e.g. "big-pickle").
+  const extra = model.cost.experimentalOver200K
+  return (
+    model.providerID === ProviderV2.ID.opencode &&
+    model.cost.input === 0 &&
+    model.cost.output === 0 &&
+    model.cost.cache.read === 0 &&
+    model.cost.cache.write === 0 &&
+    (!extra || (extra.input === 0 && extra.output === 0 && extra.cache.read === 0 && extra.cache.write === 0))
+  )
+}
+
+function freeVariants(model: Model) {
+  return Object.keys(model.variants ?? {})
+    .toSorted()
+    .filter((item) => item !== "default")
+}
+
+const { runPromise } = makeRuntime(Service, defaultLayer)
+
+export async function resolveSelection(model?: string, variant?: string, instance?: InstanceContext) {
+  if (!model) return { model, variant }
+  if (model !== FREE) return { model, variant }
+  // Service.list() requires InstanceRef in the Effect fiber. Callers from plain
+  // async code (run.ts handler post-await, thread.ts bootstrap callback) have no
+  // current fiber, so we provide it explicitly when given. Tests run inside an
+  // Effect fiber that already has InstanceRef set up, so the arg is optional.
+  const providers = await runPromise((svc) =>
+    instance ? svc.list().pipe(Effect.provideService(InstanceRef, instance)) : svc.list(),
+  )
+  const provider = providers[ProviderV2.ID.opencode]
+  const models = sort(Object.values(provider?.models ?? {}).filter(isFree))
+  // Unseeded by design: the same `--model free` in two terminals picks
+  // different models.
+  const pick = models[Math.floor(Math.random() * models.length)]
+  if (!pick)
+    throw new Error(
+      `No free opencode models found. The opencode provider must be configured (set OPENCODE_API_KEY) and at least one model in its catalog must have all costs set to 0.`,
+    )
+  const value =
+    variant === ANY
+      ? (() => {
+          const choices = freeVariants(pick)
+          return choices[Math.floor(Math.random() * choices.length)]
+        })()
+      : variant
+  return {
+    model: `${pick.providerID}/${pick.id}`,
+    variant: value,
+  }
 }
 
 export function parseModel(model: string) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import os from "os"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import fuzzysort from "fuzzysort"
@@ -1964,7 +1965,6 @@ export function sort<T extends { id: string }>(models: T[]) {
 }
 
 const FREE = "free"
-export const ANY = "any"
 
 export function isFree(model: Model) {
   // Structural filter only: any opencode model whose every cost dimension is
@@ -1982,17 +1982,9 @@ export function isFree(model: Model) {
   )
 }
 
-function freeVariants(model: Model) {
-  return Object.keys(model.variants ?? {})
-    .toSorted()
-    .filter((item) => item !== "default")
-}
-
-const { runPromise } = makeRuntime(Service, defaultLayer)
-
-export async function resolveSelection(model?: string, variant?: string, instance?: InstanceContext) {
-  if (!model) return { model, variant }
-  if (model !== FREE) return { model, variant }
+export async function resolveSelection(model?: string, instance?: InstanceContext) {
+  if (!model) return { model }
+  if (model !== FREE) return { model }
   // Service.list() requires InstanceRef in the Effect fiber. Callers from plain
   // async code (run.ts handler post-await, thread.ts bootstrap callback) have no
   // current fiber, so we provide it explicitly when given. Tests run inside an
@@ -2009,16 +2001,8 @@ export async function resolveSelection(model?: string, variant?: string, instanc
     throw new Error(
       `No free opencode models found. The opencode provider must be configured (set OPENCODE_API_KEY) and at least one model in its catalog must have all costs set to 0.`,
     )
-  const value =
-    variant === ANY
-      ? (() => {
-          const choices = freeVariants(pick)
-          return choices[Math.floor(Math.random() * choices.length)]
-        })()
-      : variant
   return {
     model: `${pick.providerID}/${pick.id}`,
-    variant: value,
   }
 }
 
@@ -2035,5 +2019,7 @@ export const node = LayerNode.make({
   layer: layer,
   deps: [FSUtil.node, Config.node, Auth.node, Env.node, Plugin.node, ModelsDev.node, RuntimeFlags.node],
 })
+
+const { runPromise } = makeRuntime(Service, AppNodeBuilder.build(node))
 
 export * as Provider from "./provider"

--- a/packages/opencode/test/cli/cmd/run.test.ts
+++ b/packages/opencode/test/cli/cmd/run.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as SDK from "@opencode-ai/sdk/v2"
+import { Provider } from "../../../src/provider/provider"
+
+const seen = {
+  prompt: [] as any[],
+  command: [] as any[],
+  variant: [] as any[],
+}
+
+function setup() {
+  spyOn(Provider, "resolveSelection").mockImplementation(async (model, variant) => ({
+    model: model === "free" ? "opencode/freebie" : model,
+    variant: variant === "any" ? "high" : variant,
+  }))
+  spyOn(SDK, "createOpencodeClient").mockImplementation(
+    () =>
+      ({
+        config: {
+          get: async () => ({ data: { share: "manual" } }),
+        },
+        event: {
+          subscribe: async () => ({
+            stream: (async function* () {})(),
+          }),
+        },
+        path: {
+          get: async () => ({ data: { directory: process.cwd() } }),
+        },
+        session: {
+          create: async () => ({ data: { id: "session-1" } }),
+          prompt: async (input: any) => {
+            seen.prompt.push(input)
+            seen.variant.push(input.variant)
+            return {}
+          },
+          command: async (input: any) => {
+            seen.command.push(input)
+            seen.variant.push(input.variant)
+            return {}
+          },
+        },
+      }) as any,
+  )
+}
+
+describe("run command", () => {
+  afterEach(() => {
+    mock.restore()
+    seen.prompt.length = 0
+    seen.command.length = 0
+    seen.variant.length = 0
+  })
+
+  async function call(extra?: Record<string, unknown>) {
+    setup()
+    const { RunCommand } = await import("../../../src/cli/cmd/run")
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+
+    try {
+      await RunCommand.handler({
+        _: [],
+        $0: "opencode",
+        message: ["hi"],
+        command: undefined,
+        continue: false,
+        session: undefined,
+        fork: false,
+        share: false,
+        model: "free",
+        agent: undefined,
+        format: "default",
+        file: undefined,
+        title: undefined,
+        attach: "http://127.0.0.1:4096",
+        password: undefined,
+        dir: undefined,
+        port: undefined,
+        variant: undefined,
+        thinking: false,
+        "dangerously-skip-permissions": false,
+        "--": [],
+        ...extra,
+      } as any)
+    } finally {
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+    }
+  }
+
+  test("resolves free before prompting", async () => {
+    await call()
+
+    expect(seen.prompt).toHaveLength(1)
+    expect(String(seen.prompt[0].model.providerID)).toBe("opencode")
+    expect(String(seen.prompt[0].model.modelID)).toBe("freebie")
+  })
+
+  test("passes the resolved model to command sessions", async () => {
+    await call({ command: "echo" })
+
+    expect(seen.command).toHaveLength(1)
+    expect(seen.command[0].model).toBe("opencode/freebie")
+  })
+
+  test("passes the resolved any variant to sessions", async () => {
+    await call({ variant: "any" })
+
+    expect(seen.prompt).toHaveLength(1)
+    expect(seen.variant[0]).toBe("high")
+  })
+})

--- a/packages/opencode/test/cli/cmd/run.test.ts
+++ b/packages/opencode/test/cli/cmd/run.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
 import * as SDK from "@opencode-ai/sdk/v2"
 import { Provider } from "../../../src/provider/provider"
+import { UI } from "../../../src/cli/ui"
 
 const seen = {
   prompt: [] as any[],
@@ -72,7 +73,7 @@ describe("run command", () => {
         format: "default",
         file: undefined,
         title: undefined,
-        attach: "http://127.0.0.1:4096",
+        attach: undefined,
         password: undefined,
         dir: undefined,
         port: undefined,
@@ -100,5 +101,33 @@ describe("run command", () => {
 
     expect(seen.command).toHaveLength(1)
     expect(seen.command[0].model).toBe("opencode/freebie")
+  })
+
+  test("passes a concrete attached model through unchanged", async () => {
+    await call({ attach: "http://127.0.0.1:4096", model: "opencode/mimo-v2.5-free" })
+
+    expect(seen.prompt).toHaveLength(1)
+    expect(String(seen.prompt[0].model.providerID)).toBe("opencode")
+    expect(String(seen.prompt[0].model.modelID)).toBe("mimo-v2.5-free")
+  })
+
+  test("rejects --model free combined with --attach", async () => {
+    const errorSpy = spyOn(UI, "error").mockImplementation(() => {})
+    const exitError = new Error("exit")
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw Object.assign(exitError, { code })
+    }) as never)
+
+    try {
+      await expect(call({ attach: "http://127.0.0.1:4096", model: "free" })).rejects.toBe(exitError)
+    } finally {
+      exitSpy.mockRestore()
+    }
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy.mock.calls[0][0]).toContain("--model free is not supported with --attach")
+    expect((exitError as { code?: number }).code).toBe(1)
+    expect(seen.prompt).toHaveLength(0)
+    expect(seen.command).toHaveLength(0)
   })
 })

--- a/packages/opencode/test/cli/cmd/run.test.ts
+++ b/packages/opencode/test/cli/cmd/run.test.ts
@@ -5,13 +5,11 @@ import { Provider } from "../../../src/provider/provider"
 const seen = {
   prompt: [] as any[],
   command: [] as any[],
-  variant: [] as any[],
 }
 
 function setup() {
-  spyOn(Provider, "resolveSelection").mockImplementation(async (model, variant) => ({
+  spyOn(Provider, "resolveSelection").mockImplementation(async (model) => ({
     model: model === "free" ? "opencode/freebie" : model,
-    variant: variant === "any" ? "high" : variant,
   }))
   spyOn(SDK, "createOpencodeClient").mockImplementation(
     () =>
@@ -31,12 +29,10 @@ function setup() {
           create: async () => ({ data: { id: "session-1" } }),
           prompt: async (input: any) => {
             seen.prompt.push(input)
-            seen.variant.push(input.variant)
             return {}
           },
           command: async (input: any) => {
             seen.command.push(input)
-            seen.variant.push(input.variant)
             return {}
           },
         },
@@ -49,7 +45,6 @@ describe("run command", () => {
     mock.restore()
     seen.prompt.length = 0
     seen.command.length = 0
-    seen.variant.length = 0
   })
 
   async function call(extra?: Record<string, unknown>) {
@@ -81,7 +76,6 @@ describe("run command", () => {
         password: undefined,
         dir: undefined,
         port: undefined,
-        variant: undefined,
         thinking: false,
         "dangerously-skip-permissions": false,
         "--": [],
@@ -106,12 +100,5 @@ describe("run command", () => {
 
     expect(seen.command).toHaveLength(1)
     expect(seen.command[0].model).toBe("opencode/freebie")
-  })
-
-  test("passes the resolved any variant to sessions", async () => {
-    await call({ variant: "any" })
-
-    expect(seen.prompt).toHaveLength(1)
-    expect(seen.variant[0]).toBe("high")
   })
 })

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -99,8 +99,6 @@ Options:
       --dir          directory to run in, path on remote server if attaching                [string]
       --port         port for the local server (defaults to random port if no value provided)
                                                                                             [number]
-      --variant      model variant (provider-specific reasoning effort, e.g., high, max, minimal)
-                                                                                            [string]
       --thinking     show thinking blocks                                                  [boolean]
   -i, --interactive  run in direct interactive split-footer mode          [boolean] [default: false]
       --auto         auto-approve permissions that are not explicitly denied (dangerous!)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -84,42 +84,9 @@ const paid = (providers: Record<string, { models: Record<string, { cost: { input
 
 const languageBaseURL = (language: unknown) => (language as { config: { baseURL: string } }).config.baseURL
 
-function free(model: { cost: { input: number; output: number; cache: { read: number; write: number } } }) {
-  return (
-    model.cost.input === 0 && model.cost.output === 0 && model.cost.cache.read === 0 && model.cost.cache.write === 0
-  )
-}
-
 afterEach(() => {
   mock.restore()
 })
-
-const freeConfig = {
-  provider: {
-    opencode: {
-      whitelist: ["alpha-free", "plain-free"],
-      options: { apiKey: "test-api-key" },
-      models: {
-        "alpha-free": {
-          name: "Alpha Free",
-          reasoning: true,
-          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-          limit: { context: 128000, output: 4096 },
-          variants: {
-            low: { effort: "low" },
-            high: { effort: "high" },
-          },
-        },
-        "plain-free": {
-          name: "Plain Free",
-          reasoning: false,
-          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-          limit: { context: 128000, output: 4096 },
-        },
-      },
-    },
-  },
-}
 
 const it = testEffect(LayerNode.compile(LayerNode.group([Provider.node, Env.node, Plugin.node])))
 const experimentalModels = testEffect(providerLayer({ enableExperimentalModels: true }))
@@ -444,84 +411,14 @@ it.instance(
   },
 )
 
-it.instance(
-  "resolveSelection picks a variant from the chosen free model",
-  Effect.gen(function* () {
-    const providers = yield* list
-    const provider = providers[ProviderV2.ID.opencode]
-    const models = Provider.sort(Object.values(provider.models).filter(free))
-    const index = models.findIndex((item) => String(item.id) === "alpha-free")
-    const choices = Object.keys(provider.models["alpha-free"].variants ?? {}).toSorted()
-
-    expect(index).toBeGreaterThanOrEqual(0)
-    expect(choices.length).toBeGreaterThan(0)
-
-    let count = 0
-    spyOn(Math, "random").mockImplementation(() => {
-      count += 1
-      if (count === 1) return (index + 0.1) / models.length
-      return (choices.length - 1 + 0.1) / choices.length
-    })
-
-    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "any"))
-
-    expect(result.model).toBe("opencode/alpha-free")
-    expect(result.variant).toBe(choices.at(-1))
-  }),
-  { config: freeConfig },
-)
-
-it.instance(
-  "resolveSelection keeps explicit variants unchanged",
-  Effect.gen(function* () {
-    const providers = yield* list
-    const provider = providers[ProviderV2.ID.opencode]
-    const models = Provider.sort(Object.values(provider.models).filter(free))
-    const index = models.findIndex((item) => String(item.id) === "alpha-free")
-
-    expect(index).toBeGreaterThanOrEqual(0)
-
-    spyOn(Math, "random").mockReturnValue((index + 0.1) / models.length)
-
-    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "max"))
-
-    expect(result.model).toBe("opencode/alpha-free")
-    expect(result.variant).toBe("max")
-  }),
-  { config: freeConfig },
-)
-
-it.instance(
-  "resolveSelection falls back to no variant when the chosen free model has none",
-  Effect.gen(function* () {
-    const providers = yield* list
-    const provider = providers[ProviderV2.ID.opencode]
-    const models = Provider.sort(Object.values(provider.models).filter(free))
-    const index = models.findIndex((item) => String(item.id) === "plain-free")
-
-    expect(index).toBeGreaterThanOrEqual(0)
-    expect(provider.models["plain-free"].variants ?? {}).toEqual({})
-
-    spyOn(Math, "random").mockReturnValue((index + 0.1) / models.length)
-
-    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "any"))
-
-    expect(result.model).toBe("opencode/plain-free")
-    expect(result.variant).toBeUndefined()
-  }),
-  { config: freeConfig },
-)
-
 test("resolveSelection passes through when model is undefined", async () => {
-  const result = await Provider.resolveSelection(undefined, "any")
+  const result = await Provider.resolveSelection(undefined)
   expect(result.model).toBeUndefined()
-  expect(result.variant).toBe("any")
 })
 
 test("resolveSelection short-circuits with an explicit non-free model", async () => {
-  const result = await Provider.resolveSelection("opencode/big-pickle", "any")
+  const result = await Provider.resolveSelection("opencode/big-pickle")
   expect(result.model).toBe("opencode/big-pickle")
-  expect(result.variant).toBe("any")
 })
 
 it.instance(

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test"
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
 import { mkdir, unlink } from "fs/promises"
 import path from "path"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -83,6 +83,43 @@ const paid = (providers: Record<string, { models: Record<string, { cost: { input
 }
 
 const languageBaseURL = (language: unknown) => (language as { config: { baseURL: string } }).config.baseURL
+
+function free(model: { cost: { input: number; output: number; cache: { read: number; write: number } } }) {
+  return (
+    model.cost.input === 0 && model.cost.output === 0 && model.cost.cache.read === 0 && model.cost.cache.write === 0
+  )
+}
+
+afterEach(() => {
+  mock.restore()
+})
+
+const freeConfig = {
+  provider: {
+    opencode: {
+      whitelist: ["alpha-free", "plain-free"],
+      options: { apiKey: "test-api-key" },
+      models: {
+        "alpha-free": {
+          name: "Alpha Free",
+          reasoning: true,
+          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+          limit: { context: 128000, output: 4096 },
+          variants: {
+            low: { effort: "low" },
+            high: { effort: "high" },
+          },
+        },
+        "plain-free": {
+          name: "Plain Free",
+          reasoning: false,
+          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+          limit: { context: 128000, output: 4096 },
+        },
+      },
+    },
+  },
+}
 
 const it = testEffect(LayerNode.compile(LayerNode.group([Provider.node, Env.node, Plugin.node])))
 const experimentalModels = testEffect(providerLayer({ enableExperimentalModels: true }))
@@ -350,6 +387,194 @@ it.instance("defaultModel returns first available model when no config set", () 
     expect(model.providerID).toBeDefined()
     expect(model.modelID).toBeDefined()
   }),
+)
+
+it.instance(
+  "resolveSelection picks only zero-cost opencode models, not other providers",
+  Effect.gen(function* () {
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.opencode]).toBeDefined()
+    expect(providers[ProviderV2.ID.openrouter]).toBeDefined()
+
+    spyOn(Math, "random").mockReturnValue(0)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free"))
+    const parsed = Provider.parseModel(result.model!)
+
+    // Must pick from opencode only, not openrouter.
+    expect(String(parsed.providerID)).toBe("opencode")
+    // Must be a zero-cost model (not the paid one).
+    const model = providers[ProviderV2.ID.opencode].models[String(parsed.modelID)]
+    expect(model).toBeDefined()
+    expect(model.cost.input).toBe(0)
+    expect(model.cost.output).toBe(0)
+    expect(String(parsed.modelID)).not.toBe("free-router")
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          options: { apiKey: "test-api-key" },
+          models: {
+            "my-zero-cost-free": {
+              name: "My Zero Cost",
+              cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+            "my-paid": {
+              name: "My Paid",
+              cost: { input: 1, output: 2, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+        openrouter: {
+          options: { apiKey: "test-api-key" },
+          models: {
+            "free-router": {
+              name: "Free Router",
+              cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+              tool_call: true,
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "resolveSelection picks a variant from the chosen free model",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const provider = providers[ProviderV2.ID.opencode]
+    const models = Provider.sort(Object.values(provider.models).filter(free))
+    const index = models.findIndex((item) => String(item.id) === "alpha-free")
+    const choices = Object.keys(provider.models["alpha-free"].variants ?? {}).toSorted()
+
+    expect(index).toBeGreaterThanOrEqual(0)
+    expect(choices.length).toBeGreaterThan(0)
+
+    let count = 0
+    spyOn(Math, "random").mockImplementation(() => {
+      count += 1
+      if (count === 1) return (index + 0.1) / models.length
+      return (choices.length - 1 + 0.1) / choices.length
+    })
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "any"))
+
+    expect(result.model).toBe("opencode/alpha-free")
+    expect(result.variant).toBe(choices.at(-1))
+  }),
+  { config: freeConfig },
+)
+
+it.instance(
+  "resolveSelection keeps explicit variants unchanged",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const provider = providers[ProviderV2.ID.opencode]
+    const models = Provider.sort(Object.values(provider.models).filter(free))
+    const index = models.findIndex((item) => String(item.id) === "alpha-free")
+
+    expect(index).toBeGreaterThanOrEqual(0)
+
+    spyOn(Math, "random").mockReturnValue((index + 0.1) / models.length)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "max"))
+
+    expect(result.model).toBe("opencode/alpha-free")
+    expect(result.variant).toBe("max")
+  }),
+  { config: freeConfig },
+)
+
+it.instance(
+  "resolveSelection falls back to no variant when the chosen free model has none",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const provider = providers[ProviderV2.ID.opencode]
+    const models = Provider.sort(Object.values(provider.models).filter(free))
+    const index = models.findIndex((item) => String(item.id) === "plain-free")
+
+    expect(index).toBeGreaterThanOrEqual(0)
+    expect(provider.models["plain-free"].variants ?? {}).toEqual({})
+
+    spyOn(Math, "random").mockReturnValue((index + 0.1) / models.length)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free", "any"))
+
+    expect(result.model).toBe("opencode/plain-free")
+    expect(result.variant).toBeUndefined()
+  }),
+  { config: freeConfig },
+)
+
+test("resolveSelection passes through when model is undefined", async () => {
+  const result = await Provider.resolveSelection(undefined, "any")
+  expect(result.model).toBeUndefined()
+  expect(result.variant).toBe("any")
+})
+
+test("resolveSelection short-circuits with an explicit non-free model", async () => {
+  const result = await Provider.resolveSelection("opencode/big-pickle", "any")
+  expect(result.model).toBe("opencode/big-pickle")
+  expect(result.variant).toBe("any")
+})
+
+it.instance(
+  "resolveSelection throws with actionable message when no free models are available",
+  Effect.gen(function* () {
+    const result = yield* Effect.tryPromise(() => Provider.resolveSelection("free")).pipe(Effect.exit)
+    expect(result._tag).toBe("Failure")
+    if (result._tag === "Failure") {
+      const message = String((result.cause as { error?: Error }).error ?? result.cause)
+      expect(message).toContain("OPENCODE_API_KEY")
+    }
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          whitelist: ["paid-only"],
+          options: { apiKey: "test-api-key" },
+          models: {
+            "paid-only": {
+              name: "Paid Only",
+              cost: { input: 1, output: 2, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "build catalog exposes at least one opencode free model and resolveSelection picks one",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const opencode = providers[ProviderV2.ID.opencode]
+    expect(opencode).toBeDefined()
+
+    const freeModels = Object.values(opencode.models).filter(Provider.isFree)
+    // Surface the count in test output so catalog drift is visible at a glance.
+    console.log(
+      `[free-model-resolution] catalog has ${freeModels.length} free opencode model(s): ${freeModels.map((m) => String(m.id)).join(", ")}`,
+    )
+    expect(freeModels.length).toBeGreaterThan(0)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free"))
+    expect(result.model).toBeDefined()
+    const parsed = Provider.parseModel(result.model!)
+    expect(String(parsed.providerID)).toBe("opencode")
+    const ids = new Set(freeModels.map((m) => String(m.id)))
+    expect(ids.has(String(parsed.modelID))).toBe(true)
+  }),
+  { config: { provider: { opencode: { options: { apiKey: "test-api-key" } } } } },
 )
 
 it.instance(

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -484,7 +484,6 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
           })
         local.model.set({ providerID, modelID }, { recent: true })
       }
-      if (args.variant) local.model.variant.set(args.variant)
       if (args.sessionID && !args.fork) {
         route.navigate({
           type: "session",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -484,6 +484,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
           })
         local.model.set({ providerID, modelID }, { recent: true })
       }
+      if (args.variant) local.model.variant.set(args.variant)
       if (args.sessionID && !args.fork) {
         route.navigate({
           type: "session",

--- a/packages/tui/src/context/args.tsx
+++ b/packages/tui/src/context/args.tsx
@@ -2,6 +2,7 @@ import { createSimpleContext } from "./helper"
 
 export interface Args {
   model?: string
+  variant?: string
   agent?: string
   prompt?: string
   continue?: boolean

--- a/packages/tui/src/context/args.tsx
+++ b/packages/tui/src/context/args.tsx
@@ -2,7 +2,6 @@ import { createSimpleContext } from "./helper"
 
 export interface Args {
   model?: string
-  variant?: string
   agent?: string
   prompt?: string
   continue?: boolean

--- a/packages/web/src/content/docs/ar/cli.mdx
+++ b/packages/web/src/content/docs/ar/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`    | كلمة مرور المصادقة الأساسية (الافتراضي `OPENCODE_SERVER_PASSWORD`)                |
 | <nobr><code>{"--username"}</code></nobr> | `-u`    | اسم مستخدم المصادقة الأساسية (الافتراضي `OPENCODE_SERVER_USERNAME` أو `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |         | دليل التشغيل، أو المسار على الخادم البعيد عند الإرفاق                             |
-| <nobr><code>{"--variant"}</code></nobr>  |         | متغير النموذج (جهد الاستدلال الخاص بالمزود)                                       |
 | <nobr><code>{"--thinking"}</code></nobr> |         | عرض كتل التفكير                                                                   |
 | <nobr><code>{"--port"}</code></nobr>     |         | منفذ الخادم المحلي (الافتراضي منفذ عشوائي)                                        |
 

--- a/packages/web/src/content/docs/bs/cli.mdx
+++ b/packages/web/src/content/docs/bs/cli.mdx
@@ -352,7 +352,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`   | Lozinka za osnovnu autentifikaciju (zadano: `OPENCODE_SERVER_PASSWORD`)                       |
 | <nobr><code>{"--username"}</code></nobr> | `-u`   | Korisničko ime za osnovnu autentifikaciju (zadano: `OPENCODE_SERVER_USERNAME` ili `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |        | Direktorij za pokretanje, ili putanja na udaljenom serveru pri spajanju                       |
-| <nobr><code>{"--variant"}</code></nobr>  |        | Varijanta modela (napor zaključivanja specifičan za provajdera)                               |
 | <nobr><code>{"--thinking"}</code></nobr> |        | Prikaži blokove razmišljanja                                                                  |
 | <nobr><code>{"--port"}</code></nobr>     |        | Port za lokalni server (zadano na nasumični port)                                             |
 

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -379,7 +379,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Directory to run in, or path on the remote server when attaching           |
 | <nobr><code>{"--port"}</code></nobr>     |       | Port for the local server (defaults to random port)                        |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Model variant (provider-specific reasoning effort)                         |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Show thinking blocks                                                       |
 | <nobr><code>{"--auto"}</code></nobr>     |       | Auto-approve permissions that are not explicitly denied                    |
 

--- a/packages/web/src/content/docs/da/cli.mdx
+++ b/packages/web/src/content/docs/da/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Adgangskode til basic auth (standard: `OPENCODE_SERVER_PASSWORD`)                   |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Brugernavn til basic auth (standard: `OPENCODE_SERVER_USERNAME` eller `opencode`)   |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Mappe at køre i, eller sti på fjernserveren ved tilkobling                          |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Modelvariant (udbyder-specifik ræsonneringsindsats)                                 |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Vis tænkeblokke                                                                     |
 | <nobr><code>{"--port"}</code></nobr>     |      | Port til den lokale server (standard til vilkårlig port)                            |
 

--- a/packages/web/src/content/docs/de/cli.mdx
+++ b/packages/web/src/content/docs/de/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Basic-Auth-Passwort (standardmäßig `OPENCODE_SERVER_PASSWORD`)                                      |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Basic-Auth-Benutzername (standardmäßig `OPENCODE_SERVER_USERNAME` oder `opencode`)                  |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Verzeichnis für die Ausführung, oder Pfad auf dem Remote-Server beim Anhängen                       |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Modellvariante (anbieterspezifischer Reasoning-Aufwand)                                             |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Denkblöcke anzeigen                                                                                 |
 | <nobr><code>{"--port"}</code></nobr>     |      | Port für den lokalen Server (standardmäßig zufälliger Port)                                         |
 

--- a/packages/web/src/content/docs/es/cli.mdx
+++ b/packages/web/src/content/docs/es/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Contraseña de autenticación básica (predeterminada: `OPENCODE_SERVER_PASSWORD`)           |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Usuario de autenticación básica (predeterminado: `OPENCODE_SERVER_USERNAME` u `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Directorio de ejecución, o ruta en el servidor remoto al adjuntar                         |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante del modelo (esfuerzo de razonamiento específico del proveedor)                   |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Mostrar bloques de pensamiento                                                            |
 | <nobr><code>{"--port"}</code></nobr>     |       | Puerto para el servidor local (el puerto predeterminado es aleatorio)                     |
 

--- a/packages/web/src/content/docs/fr/cli.mdx
+++ b/packages/web/src/content/docs/fr/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Mot de passe d'authentification de base (par défaut `OPENCODE_SERVER_PASSWORD`)                    |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Nom d'utilisateur d'authentification de base (par défaut `OPENCODE_SERVER_USERNAME` ou `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Répertoire d'exécution, ou chemin sur le serveur distant lors de l'attachement                     |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante du modèle (effort de raisonnement spécifique au fournisseur)                              |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Afficher les blocs de réflexion                                                                    |
 | <nobr><code>{"--port"}</code></nobr>     |       | Port du serveur local (port aléatoire par défaut)                                                  |
 

--- a/packages/web/src/content/docs/it/cli.mdx
+++ b/packages/web/src/content/docs/it/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Password per l'autenticazione di base (predefinita: `OPENCODE_SERVER_PASSWORD`)                 |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Nome utente per l'autenticazione di base (predefinito: `OPENCODE_SERVER_USERNAME` o `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Directory di esecuzione, o percorso sul server remoto durante il collegamento                   |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante del modello (sforzo di ragionamento specifico del provider)                            |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Mostra blocchi di pensiero                                                                      |
 | <nobr><code>{"--port"}</code></nobr>     |       | Porta per il server locale (di default una porta casuale)                                       |
 

--- a/packages/web/src/content/docs/ja/cli.mdx
+++ b/packages/web/src/content/docs/ja/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`     | Basic 認証パスワード（デフォルトは `OPENCODE_SERVER_PASSWORD`）                           |
 | <nobr><code>{"--username"}</code></nobr> | `-u`     | Basic 認証ユーザー名（デフォルトは `OPENCODE_SERVER_USERNAME` または `opencode`）         |
 | <nobr><code>{"--dir"}</code></nobr>      |          | 実行ディレクトリ、またはアタッチ時のリモートサーバー上のパス                              |
-| <nobr><code>{"--variant"}</code></nobr>  |          | モデルバリアント（プロバイダー固有の推論レベル）                                          |
 | <nobr><code>{"--thinking"}</code></nobr> |          | 思考ブロックを表示                                                                        |
 | <nobr><code>{"--port"}</code></nobr>     |          | ローカルサーバーのポート (デフォルトはランダムポート)                                     |
 

--- a/packages/web/src/content/docs/ko/cli.mdx
+++ b/packages/web/src/content/docs/ko/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | 기본 인증 비밀번호 (기본값: `OPENCODE_SERVER_PASSWORD`)                    |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | 기본 인증 사용자 이름 (기본값: `OPENCODE_SERVER_USERNAME` 또는 `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | 실행할 디렉터리, 또는 연결 시 원격 서버 경로                               |
-| <nobr><code>{"--variant"}</code></nobr>  |      | 모델 변형 (제공자별 추론 수준)                                             |
 | <nobr><code>{"--thinking"}</code></nobr> |      | 사고 블록 표시                                                             |
 | <nobr><code>{"--port"}</code></nobr>     |      | 로컬 서버 포트(기본값: 랜덤 포트)                                          |
 

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -205,7 +205,7 @@ Use the keybind `variant_cycle` to quickly switch between variants. [Learn more]
 
 When OpenCode starts up, it checks for models in the following priority order:
 
-1. The `--model` or `-m` command line flag. The format is the same as in the config file: `provider_id/model_id`.
+1. The `--model` or `-m` command line flag. The format is the same as in the config file: `provider_id/model_id`. You can also pass `free` to have OpenCode pick a random zero-cost [OpenCode Zen](/docs/zen) model (not supported with `--attach`).
 
 2. The model list in the OpenCode config.
 

--- a/packages/web/src/content/docs/nb/cli.mdx
+++ b/packages/web/src/content/docs/nb/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Passord for grunnleggende autentisering (standard: `OPENCODE_SERVER_PASSWORD`)                     |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Brukernavn for grunnleggende autentisering (standard: `OPENCODE_SERVER_USERNAME` eller `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Katalog å kjøre i, eller sti på fjernserveren ved tilkobling                                       |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Modellvariant (leverandørspesifikk resonneringsinnsats)                                            |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Vis tenkeblokker                                                                                   |
 | <nobr><code>{"--port"}</code></nobr>     |      | Port for den lokale serveren (standard til tilfeldig port)                                         |
 

--- a/packages/web/src/content/docs/pl/cli.mdx
+++ b/packages/web/src/content/docs/pl/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Hasło uwierzytelniania podstawowego (domyślnie `OPENCODE_SERVER_PASSWORD`)                            |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Nazwa użytkownika uwierzytelniania podstawowego (domyślnie `OPENCODE_SERVER_USERNAME` lub `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Katalog do uruchomienia lub ścieżka na zdalnym serwerze podczas dołączania                            |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Wariant modelu (poziom wnioskowania specyficzny dla dostawcy)                                         |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Pokaż bloki myślenia                                                                                  |
 | <nobr><code>{"--port"}</code></nobr>     |       | Port dla serwera lokalnego (domyślnie losowy)                                                         |
 

--- a/packages/web/src/content/docs/pt-br/cli.mdx
+++ b/packages/web/src/content/docs/pt-br/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explique async/await em JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Senha de autenticação básica (padrão: `OPENCODE_SERVER_PASSWORD`)                 |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Usuário de autenticação básica (padrão: `OPENCODE_SERVER_USERNAME` ou `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Diretório de execução, ou caminho no servidor remoto ao anexar                    |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante do modelo (nível de raciocínio específico do provedor)                   |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Mostrar blocos de pensamento                                                      |
 | <nobr><code>{"--port"}</code></nobr>     |       | Porta para o servidor local (padrão para porta aleatória)                         |
 

--- a/packages/web/src/content/docs/ru/cli.mdx
+++ b/packages/web/src/content/docs/ru/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`     | Пароль базовой аутентификации (по умолчанию `OPENCODE_SERVER_PASSWORD`)                          |
 | <nobr><code>{"--username"}</code></nobr> | `-u`     | Имя пользователя базовой аутентификации (по умолчанию `OPENCODE_SERVER_USERNAME` или `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |          | Каталог для выполнения или путь на удалённом сервере при подключении                             |
-| <nobr><code>{"--variant"}</code></nobr>  |          | Вариант модели (уровень рассуждений для провайдера)                                              |
 | <nobr><code>{"--thinking"}</code></nobr> |          | Показать блоки размышлений                                                                       |
 | <nobr><code>{"--port"}</code></nobr>     |          | Порт локального сервера (по умолчанию случайный порт)                                            |
 

--- a/packages/web/src/content/docs/th/cli.mdx
+++ b/packages/web/src/content/docs/th/cli.mdx
@@ -356,7 +356,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | รหัสผ่านการยืนยันตัวตนพื้นฐาน (ค่าเริ่มต้นคือ `OPENCODE_SERVER_PASSWORD`)                   |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | ชื่อผู้ใช้การยืนยันตัวตนพื้นฐาน (ค่าเริ่มต้นคือ `OPENCODE_SERVER_USERNAME` หรือ `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | ไดเร็กทอรีสำหรับรัน หรือเส้นทางบนเซิร์ฟเวอร์ระยะไกลเมื่อแนบ                                 |
-| <nobr><code>{"--variant"}</code></nobr>  |      | ตัวแปรโมเดล (ระดับการใช้เหตุผลเฉพาะผู้ให้บริการ)                                            |
 | <nobr><code>{"--thinking"}</code></nobr> |      | แสดงบล็อกความคิด                                                                            |
 | <nobr><code>{"--port"}</code></nobr>     |      | พอร์ตสำหรับเซิร์ฟเวอร์ภายในเครื่อง (หากไม่ได้ระบุ จะใช้พอร์ตสุ่ม)                           |
 

--- a/packages/web/src/content/docs/tr/cli.mdx
+++ b/packages/web/src/content/docs/tr/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Temel kimlik doğrulama parolası (varsayılan: `OPENCODE_SERVER_PASSWORD`)                      |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Temel kimlik doğrulama kullanıcı adı (varsayılan: `OPENCODE_SERVER_USERNAME` veya `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Çalıştırılacak dizin veya bağlanırken uzak sunucudaki yol                                     |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Model varyantı (sağlayıcıya özgü muhakeme düzeyi)                                             |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Düşünme bloklarını göster                                                                     |
 | <nobr><code>{"--port"}</code></nobr>     |      | Yerel sunucunun bağlantı noktası (varsayılan olarak rastgele bağlantı noktasıdır)             |
 

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -202,6 +202,8 @@ The free models:
 - Nemotron 3 Ultra Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Big Pickle is a stealth model that's free on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 
+Pass `--model free` to have OpenCode pick a random zero-cost OpenCode Zen model for you, for example `opencode run --model free "..."`. This requires the OpenCode Zen provider to be configured and is not supported together with `--attach`.
+
 <a href={email}>Contact us</a> if you have any questions.
 
 ---

--- a/packages/web/src/content/docs/zh-cn/cli.mdx
+++ b/packages/web/src/content/docs/zh-cn/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | 基本认证密码（默认使用 `OPENCODE_SERVER_PASSWORD`）                 |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | 基本认证用户名（默认使用 `OPENCODE_SERVER_USERNAME` 或 `opencode`） |
 | <nobr><code>{"--dir"}</code></nobr>      |      | 运行目录，或附加时远程服务器上的路径                                |
-| <nobr><code>{"--variant"}</code></nobr>  |      | 模型变体（特定于提供商的推理级别）                                  |
 | <nobr><code>{"--thinking"}</code></nobr> |      | 显示思考块                                                          |
 | <nobr><code>{"--port"}</code></nobr>     |      | 本地服务器端口（默认为随机端口）                                    |
 

--- a/packages/web/src/content/docs/zh-tw/cli.mdx
+++ b/packages/web/src/content/docs/zh-tw/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | 基本驗證密碼（預設使用 `OPENCODE_SERVER_PASSWORD`）                     |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | 基本驗證使用者名稱（預設使用 `OPENCODE_SERVER_USERNAME` 或 `opencode`） |
 | <nobr><code>{"--dir"}</code></nobr>      |      | 執行目錄，或附加時遠端伺服器上的路徑                                    |
-| <nobr><code>{"--variant"}</code></nobr>  |      | 模型變體（特定於提供者的推理級別）                                      |
 | <nobr><code>{"--thinking"}</code></nobr> |      | 顯示思考區塊                                                            |
 | <nobr><code>{"--port"}</code></nobr>     |      | 本地伺服器連接埠（預設為隨機連接埠）                                    |
 


### PR DESCRIPTION
## What Changed

- Add `Provider.resolveSelection` so `--model free` resolves to a randomly selected free model from the live catalog, and wire it through the `run`, `tui`, and `bootstrap` CLI paths so every entry point honors the `free` value.
- Reject `--attach` combined with `--model free` and route free-resolution errors cleanly, while removing the now-dead `--variant` flag and its TUI arg plumbing.
- Update CLI reference docs across all locales to drop `--variant`, and document the `--model free` value in `models.mdx` and `zen.mdx`; expand provider and `run` command tests to cover free resolution and the attach+free guard.

## Risk Assessment

✅ Low: The change is well-bounded and thoroughly tested, the shared-memoMap runtime pattern matches existing code, and resolution short-circuits for the common non-free path with no correctness or performance concerns found.

## Testing

Installed workspace deps (dev environment was missing node_modules), then ran the three changed/relevant test suites — provider (100 pass), run command (4 pass), and help snapshots (1 pass) — all green. Because passing units aren't sufficient, I demonstrated the feature as an end user would: a temporary evidence test invoked the real resolver 200 times against the LIVE OpenCode Zen catalog, showing `--model free` spreads uniformly across all 5 zero-cost models (~17–21% each), excludes 35 paid opencode models, and leaves concrete/undefined model ids untouched. I also drove the actual CLI to capture the user-facing `--attach + --model free` rejection message and confirmed `--variant` is gone from `opencode run --help`. Evidence saved to the evidence directory; the temporary test was deleted and the worktree is clean.

<details>
<summary>Evidence: Live free-model resolution distribution (200 runs)</summary>

<code>Zero-cost opencode models discovered in the live catalog (5):&#10;- opencode/minimax-m2.5-free / ring-2.6-1t-free / deepseek-v4-flash-free / big-pickle / nemotron-3-super-free&#10;Excluded non-free opencode models: 35&#10;--model free resolved 200 times -&gt; distribution:&#10;43 (21.5%) nemotron-3-super-free&#10;42 (21.0%) deepseek-v4-flash-free&#10;42 (21.0%) ring-2.6-1t-free&#10;38 (19.0%) minimax-m2.5-free&#10;35 (17.5%) big-pickle&#10;Distinct models chosen: 5 of 5&#10;Pass-through: resolveSelection(&#34;opencode/big-pickle&#34;) -&gt; opencode/big-pickle; resolveSelection(undefined) -&gt; undefined</code>

```text
bun test v1.3.14 (0d9b296a)

test/provider/free-model-evidence.test.ts:

================ FREE MODEL RESOLUTION — LIVE EVIDENCE ================
Zero-cost opencode models discovered in the live catalog (5):
  - opencode/minimax-m2.5-free  (in=0 out=0 cache.read=0 cache.write=0)
  - opencode/ring-2.6-1t-free  (in=0 out=0 cache.read=0 cache.write=0)
  - opencode/deepseek-v4-flash-free  (in=0 out=0 cache.read=0 cache.write=0)
  - opencode/big-pickle  (in=0 out=0 cache.read=0 cache.write=0)
  - opencode/nemotron-3-super-free  (in=0 out=0 cache.read=0 cache.write=0)

Excluded non-free opencode models: 35

--model free resolved 200 times → observed distribution:
    43  ( 21.5%)  opencode/nemotron-3-super-free
    42  ( 21.0%)  opencode/deepseek-v4-flash-free
    42  ( 21.0%)  opencode/ring-2.6-1t-free
    38  ( 19.0%)  opencode/minimax-m2.5-free
    35  ( 17.5%)  opencode/big-pickle

Distinct models chosen: 5 of 5 free models

Pass-through behavior (no free-resolution triggered):
  resolveSelection("opencode/big-pickle") -> opencode/big-pickle
  resolveSelection(undefined)              -> undefined
======================================================================


 1 pass
 0 fail
 408 expect() calls
Ran 1 test across 1 file. [1367.00ms]
```
</details>
<details>
<summary>Evidence: CLI --attach + --model free guard + --variant removal</summary>

<code>$ opencode run --model free --attach http://127.0.0.1:4096 &#34;hi&#34;&#10;Error: --model free is not supported with --attach; specify a concrete model id (e.g., --model opencode/mimo-v2.5-free)&#10;$ opencode run --help | grep -- --variant -&gt; (no matches, flag removed)</code>

```text
$ opencode run --model free --attach http://127.0.0.1:4096 "hi"
Error: --model free is not supported with --attach; specify a concrete model id (e.g., --model opencode/mimo-v2.5-free)

# --variant flag has been removed from `opencode run`; help no longer lists it:
$ opencode run --help | grep -- --variant
(no matches — flag removed)
$ opencode run --help | grep -- --model
  -m, --model        model to use in the format of provider/model     [string]
```
</details>
<details>
<summary>Evidence: Full `opencode run --help` output (no --variant)</summary>

```text
opencode run [message..]

run opencode with a message

Positionals:
  message  message to send                                                     [array] [default: []]

Options:
  -h, --help         show help                                                             [boolean]
  -v, --version      show version number                                                   [boolean]
      --print-logs   print logs to stderr                                                  [boolean]
      --log-level    log level                  [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
      --pure         run without external plugins                                          [boolean]
      --command      the command to run, use message for args                               [string]
  -c, --continue     continue the last session                                             [boolean]
  -s, --session      session id to continue                                                 [string]
      --fork         fork the session before continuing (requires --continue or --session) [boolean]
      --share        share the session                                                     [boolean]
  -m, --model        model to use in the format of provider/model                           [string]
      --agent        agent to use                                                           [string]
      --format       format: default (formatted) or json (raw JSON events)
                                          [string] [choices: "default", "json"] [default: "default"]
  -f, --file         file(s) to attach to message                                            [array]
      --title        title for the session (uses truncated prompt if no value provided)     [string]
      --attach       attach to a running opencode server (e.g., http://localhost:4096)      [string]
  -p, --password     basic auth password (defaults to OPENCODE_SERVER_PASSWORD)             [string]
  -u, --username     basic auth username (defaults to OPENCODE_SERVER_USERNAME or 'opencode')
                                                                                            [string]
      --dir          directory to run in, path on remote server if attaching                [string]
      --port         port for the local server (defaults to random port if no value provided)
                                                                                            [number]
      --thinking     show thinking blocks                                                  [boolean]
  -i, --interactive  run in direct interactive split-footer mode          [boolean] [default: false]
      --auto         auto-approve permissions that are not explicitly denied (dangerous!)
                                                                          [boolean] [default: false]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `packages/opencode/src/cli/cmd/run.ts:866` - The non-interactive prompt path now parses the resolved model with Provider.parseModel (run.ts:866) while the two interactive paths still use the local pick helper (run.ts:882, 910). Both perform identical split-on-&#39;/&#39; parsing and produce structurally equivalent {providerID, modelID}, so this is harmless but redundant — consider using one consistently.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun test test/provider/provider.test.ts` (100 pass) — includes live-catalog resolveSelection tests</code>
- <code>`bun test test/cli/cmd/run.test.ts` (4 pass) — free resolution, command-session passthrough, attach passthrough, attach+free rejection</code>
- <code>`bun test test/cli/help/help-snapshots.test.ts` (1 pass) — confirms `--variant` removed from help</code>
- <code>Temporary evidence test looping `Provider.resolveSelection(&#34;free&#34;)` 200× against the live catalog to show random distribution across all 5 free models and exclusion of 35 paid models (test removed after capture)</code>
- <code>Real CLI: `bun run ./src/index.ts run --model free --attach http://127.0.0.1:4096 &#34;hi&#34;` — captured the guard error message</code>
- <code>Real CLI: `bun run ./src/index.ts run --help` — confirmed `--variant` no longer listed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
