### PR TITLE
fix(opencode): set OPENCODE for shell commands

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -422,6 +422,7 @@ export const ShellTool = Tool.define(
       return {
         ...process.env,
         ...extra.env,
+        OPENCODE: "1",
       }
     })
 

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -189,6 +189,20 @@ describe("tool.shell", () => {
     ),
   )
 
+  each("sets OPENCODE for child commands", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const command = `${bin} -e ${evalarg("process.stdout.write(process.env.OPENCODE??String())")}`
+        const result = yield* run({
+          command: PS.has(sh()) ? `& ${command}` : command,
+        })
+        expect(result.metadata.exit).toBe(0)
+        expect(result.output).toContain("1")
+      }),
+    ),
+  )
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })


### PR DESCRIPTION
### Issue for this PR

Closes #34065

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Sets `OPENCODE=1` in the shell tool environment so commands launched by opencode can detect that they are running under a coding agent.
The variable is applied after plugin-provided shell environment values so it is consistently present for child commands.

### How did you verify your code works?

Ran `bun test test/tool/shell.test.ts` and `bun typecheck` from `packages/opencode`.

### Screenshots / recordings

_Not applicable._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
