### PR TITLE
fix(acp): skip resume transcript replay

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -314,7 +314,6 @@ export function make(input: {
 
     yield* registerMcpServers(input.sdk, registeredMcp, params.cwd, state.id, params.mcpServers ?? [])
     yield* sendAvailableCommands(input.connection, state.id, snapshot)
-    yield* replayMessages(events, messages)
 
     return {
       configOptions: configOptions(snapshot, {

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -389,15 +389,29 @@ describe("ACP service sessions", () => {
     expect(second.sessions.map((session) => session.sessionId)).toEqual(["ses_2", "ses_1"])
   })
 
-  it("resumes a session and stores restored state", async () => {
-    const { service } = makeService([
+  it("resumes a session and stores restored state without replaying transcript chunks", async () => {
+    const { service, updates } = makeService([
       {
         info: {
+          id: "msg_user",
+          sessionID: "ses_resume",
           role: "user",
           model: { providerID: "test", modelID: "test-model", variant: "high" },
           agent: "plan",
         },
-        parts: [],
+        parts: [{ id: "part_user", sessionID: "ses_resume", messageID: "msg_user", type: "text", text: "hello" }],
+      },
+      {
+        info: { id: "msg_assistant", sessionID: "ses_resume", role: "assistant" },
+        parts: [
+          {
+            id: "part_assistant",
+            sessionID: "ses_resume",
+            messageID: "msg_assistant",
+            type: "text",
+            text: "hi there",
+          },
+        ],
       },
     ])
     const resumed = await Effect.runPromise(
@@ -409,6 +423,11 @@ describe("ACP service sessions", () => {
 
     expect(select(resumed, "effort")?.currentValue).toBe("high")
     expect(select(updated, "effort")?.currentValue).toBe("default")
+    expect(
+      updates
+        .map((item) => item.update)
+        .filter((item) => item.sessionUpdate === "user_message_chunk" || item.sessionUpdate === "agent_message_chunk"),
+    ).toEqual([])
   })
 
   it("closes local ACP state and aborts the backing session best-effort", async () => {


### PR DESCRIPTION
## Summary
- stop `resumeSession` from replaying prior transcript chunks via `session/update`
- keep resume state restoration from recent messages for model, effort, and mode
- add a regression test covering ACP resume without transcript replay

Fixes #30756

## Checks
- `bun test test/acp/service-session.test.ts`
- `bun typecheck`
- `PATH="/Users/nxl/.bun/bin:$PATH" bun test test/cli/acp/lifecycle.test.ts`
- pre-push `bun turbo typecheck`