### PR TITLE
fix(desktop): handle missing file list directories

### DIFF
--- a/packages/app/src/context/file.tsx
+++ b/packages/app/src/context/file.tsx
@@ -52,6 +52,14 @@ function errorMessage(error: unknown, fallback: string) {
   return fallback
 }
 
+function errorStatus(error: unknown) {
+  if (!(error instanceof Error)) return
+  const cause = error.cause
+  if (typeof cause !== "object" || cause === null) return
+  const status = "status" in cause ? cause.status : undefined
+  return typeof status === "number" ? status : undefined
+}
+
 export const { use: useFile, provider: FileProvider } = createSimpleContext({
   name: "File",
   gate: false,
@@ -82,7 +90,11 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
       list: (dir) =>
         sdk()
           .client.file.list({ path: dir })
-          .then((x) => x.data ?? []),
+          .then((x) => x.data ?? [])
+          .catch((error) => {
+            if (errorStatus(error) === 404) return [] // cause: directory not found
+            throw error
+          }),
       onError: (message) => {
         showToast({
           variant: "error",

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/file.ts
@@ -5,6 +5,7 @@ import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
+import { ApiNotFoundError } from "../errors"
 import {
   WorkspaceRoutingMiddleware,
   WorkspaceRoutingQuery,
@@ -138,6 +139,7 @@ export const FileApi = HttpApi.make("file")
         HttpApiEndpoint.get("list", FilePaths.list, {
           query: FileQuery,
           success: described(Schema.Array(LegacyEntry), "Files and directories"),
+          error: ApiNotFoundError,
         }).annotateMerge(
           OpenApi.annotations({
             identifier: "file.list",

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -10,6 +10,7 @@ import ignore from "ignore"
 import path from "path"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
+import { notFound } from "../errors"
 
 export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handlers) =>
   Effect.gen(function* () {
@@ -65,6 +66,9 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
 
     const list = Effect.fn("FileHttpApi.list")(function* (ctx: { query: { path: string } }) {
       const directory = (yield* InstanceState.context).directory
+      const target = path.resolve(directory, ctx.query.path)
+      if (!FSUtil.contains(directory, target)) return yield* Effect.die(new Error("Path escapes the location"))
+      if (!(yield* FSUtil.Service.use((fs) => fs.isDir(target)))) return yield* notFound("Directory not found")
       return yield* filesystem(
         Effect.gen(function* () {
           const fs = yield* FileSystem.Service

--- a/packages/opencode/test/server/httpapi-file.test.ts
+++ b/packages/opencode/test/server/httpapi-file.test.ts
@@ -52,6 +52,15 @@ describe("file HttpApi", () => {
     expect(await status.json()).toEqual([])
   })
 
+  test("returns not found for missing directory", async () => {
+    await using tmp = await tmpdir({ git: true })
+
+    const response = await request(FilePaths.list, tmp.path, { path: path.join("does", "not", "exist") })
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toMatchObject({ name: "NotFoundError", data: { message: "Directory not found" } })
+  })
+
   test("serves search endpoints", async () => {
     await using tmp = await tmpdir({ git: true })
     await Bun.write(path.join(tmp.path, "hello.txt"), "needle")

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2266,6 +2266,13 @@ export type FileNode = {
   ignored: boolean
 }
 
+export type NotFoundError = {
+  name: "NotFoundError"
+  data: {
+    message: string
+  }
+}
+
 export type FileContent = {
   type: "text" | "binary"
   content: string
@@ -2532,13 +2539,6 @@ export type ProviderAuthError1 = {
     field?: string
     message?: string
     kind?: string
-  }
-}
-
-export type NotFoundError = {
-  name: "NotFoundError"
-  data: {
-    message: string
   }
 }
 
@@ -8549,6 +8549,10 @@ export type FileListErrors = {
    * Bad request
    */
   400: BadRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
 }
 
 export type FileListError = FileListErrors[keyof FileListErrors]


### PR DESCRIPTION
### Issue for this PR

Closes #27056

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Issue:**

When git diff contains deleted files, the Changes file tree still needs to render their original paths. To do that, it creates synthetic parent directory nodes, even though that directory may no longer exist on disk. When the synthetic directory is expanded, the frontend calls `file.list` for that path. The server then calls realPath on the missing directory, gets ENOENT, converts it to a defect, and returns a 500.

**Fix:**
- Declared NotFoundError as a possible response for file.list.
- Added a server-side directory existence check before calling FileSystem.list.
- Return 404 NotFoundError when the requested list path is missing or no longer a directory.
- Updated the frontend file tree to catch only that 404 and treat it as an empty node.
- Regenerated SDK types so file.list includes the new 404 response.

### How did you verify your code works?

Added a server test for missing directories returning 404, regenerated SDK types, and ran focused tests/typechecks.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR