### PR TITLE
docs: route enterprise contact links

### DIFF
--- a/packages/web/src/content/docs/enterprise.mdx
+++ b/packages/web/src/content/docs/enterprise.mdx
@@ -3,8 +3,7 @@ title: Enterprise
 description: Using OpenCode securely in your organization.
 ---
 
-import config from "../../../config.mjs"
-export const email = `mailto:${config.email}`
+export const enterprise = "https://opencode.ai/enterprise"
 
 OpenCode Enterprise is for organizations that want to ensure that their code and data never leaves their infrastructure. It can do this by using a centralized config that integrates with your SSO and internal AI gateway.
 
@@ -15,7 +14,7 @@ OpenCode does not store any of your code or context data.
 To get started with OpenCode Enterprise:
 
 1. Do a trial internally with your team.
-2. **<a href={email}>Contact us</a>** to discuss pricing and implementation options.
+2. **<a href={enterprise}>Contact us</a>** to discuss pricing and implementation options.
 
 ---
 
@@ -63,14 +62,14 @@ We recommend you disable this for your trial.
 
 ## Pricing
 
-We use a per-seat model for OpenCode Enterprise. If you have your own LLM gateway, we do not charge for tokens used. For further details about pricing and implementation options, **<a href={email}>contact us</a>**.
+We use a per-seat model for OpenCode Enterprise. If you have your own LLM gateway, we do not charge for tokens used. For further details about pricing and implementation options, **<a href={enterprise}>contact us</a>**.
 
 ---
 
 ## Deployment
 
 Once you have completed your trial and you are ready to use OpenCode at
-your organization, you can **<a href={email}>contact us</a>** to discuss
+your organization, you can **<a href={enterprise}>contact us</a>** to discuss
 pricing and implementation options.
 
 ---
@@ -104,7 +103,7 @@ You can also disable all other AI providers, ensuring all requests go through yo
 While we recommend disabling the share pages to ensure your data never leaves
 your organization, we can also help you self-host them on your infrastructure.
 
-This is currently on our roadmap. If you're interested, **<a href={email}>let us know</a>**.
+This is currently on our roadmap. If you're interested, **<a href={enterprise}>let us know</a>**.
 
 ---
 
@@ -122,14 +121,14 @@ OpenCode Enterprise is for organizations that want to ensure that their code and
 
 Simply start with an internal trial with your team. OpenCode by default does not store your code or context data, making it easy to get started.
 
-Then **<a href={email}>contact us</a>** to discuss pricing and implementation options.
+Then **<a href={enterprise}>contact us</a>** to discuss pricing and implementation options.
 
 </details>
 
 <details>
 <summary>How does enterprise pricing work?</summary>
 
-We offer per-seat enterprise pricing. If you have your own LLM gateway, we do not charge for tokens used. For further details, **<a href={email}>contact us</a>** for a custom quote based on your organization's needs.
+We offer per-seat enterprise pricing. If you have your own LLM gateway, we do not charge for tokens used. For further details, **<a href={enterprise}>contact us</a>** for a custom quote based on your organization's needs.
 
 </details>
 


### PR DESCRIPTION
## Summary
- route enterprise documentation inquiry links to the enterprise landing page
- remove the unused support email config import

## Testing
- `bun run build` from `packages/web`
- repository pre-push typecheck (29 packages)