### PR TITLE
fix(core): enlarge OAuth callback card

### DIFF
--- a/packages/core/src/oauth/page.ts
+++ b/packages/core/src/oauth/page.ts
@@ -205,7 +205,7 @@ const STYLES = `
     text-rendering: optimizeLegibility;
   }
   .card {
-    width: min(100%, 25rem);
+    width: min(100%, 28rem);
     padding: 2.25rem 2rem 1.75rem;
     background: var(--oc-card);
     border: 1px solid var(--oc-border-weak);


### PR DESCRIPTION
## Summary
- increase the OAuth callback card max width from 25rem to 28rem
- preserve responsive sizing on narrow screens

## Testing
- not run (CSS-only change)