### PR TITLE
fix(acp): send partial completed tool updates

### DIFF
--- a/packages/opencode/src/acp/tool.ts
+++ b/packages/opencode/src/acp/tool.ts
@@ -192,11 +192,8 @@ export function completedToolUpdate(input: {
   return {
     toolCallId: input.toolCallId,
     status: "completed",
-    kind: toToolKind(input.toolName),
-    title: toolTitle(input.toolName, input.state.input, input.state.title),
-    locations: toLocations(input.toolName, input.state.input, input.cwd),
+    ...(input.state.title ? { title: input.state.title } : {}),
     content: completedToolContent(input.toolName, input.state),
-    rawInput: rawInput(input.toolName, input.state.input, input.cwd),
     rawOutput: completedToolRawOutput(input.state),
   }
 }

--- a/packages/opencode/test/acp/tool.test.ts
+++ b/packages/opencode/test/acp/tool.test.ts
@@ -2,9 +2,11 @@ import { resolve } from "path"
 import { describe, expect, test } from "bun:test"
 import {
   completedToolContent,
+  completedToolUpdate,
   completedToolRawOutput,
   extractImageAttachments,
   imageContents,
+  pendingToolCall,
   shellOutputSnapshot,
   toLocations,
   toToolKind,
@@ -109,6 +111,85 @@ describe("acp tool conversion", () => {
         content: { type: "text", text: "wrote /tmp/file.ts" },
       },
     ])
+  })
+
+  test("sends completed tool calls as partial updates", () => {
+    expect(
+      pendingToolCall({
+        toolCallId: "tool-1",
+        toolName: "edit",
+        state: {
+          input: {
+            filePath: "/tmp/file.ts",
+            oldString: "before",
+            newString: "after",
+          },
+        },
+      }),
+    ).toMatchObject({
+      kind: "edit",
+      locations: [{ path: "/tmp/file.ts" }],
+      rawInput: {
+        filePath: "/tmp/file.ts",
+        oldString: "before",
+        newString: "after",
+      },
+    })
+
+    expect(
+      completedToolUpdate({
+        toolCallId: "tool-1",
+        toolName: "edit",
+        state: {
+          status: "completed",
+          input: {
+            filePath: "/tmp/file.ts",
+            oldString: "before",
+            newString: "after",
+          },
+          output: "Edit applied successfully.",
+        },
+      }),
+    ).toEqual({
+      toolCallId: "tool-1",
+      status: "completed",
+      content: [
+        {
+          type: "content",
+          content: { type: "text", text: "Edit applied successfully." },
+        },
+        {
+          type: "diff",
+          path: "/tmp/file.ts",
+          oldText: "before",
+          newText: "after",
+        },
+      ],
+      rawOutput: {
+        output: "Edit applied successfully.",
+      },
+    })
+
+    expect(
+      completedToolUpdate({
+        toolCallId: "tool-1",
+        toolName: "edit",
+        state: {
+          status: "completed",
+          input: {
+            filePath: "/tmp/file.ts",
+            oldString: "before",
+            newString: "after",
+          },
+          title: "file.ts",
+          output: "Edit applied successfully.",
+        },
+      }),
+    ).toMatchObject({
+      toolCallId: "tool-1",
+      status: "completed",
+      title: "file.ts",
+    })
   })
 
   test("uses clean read display text for completed content", () => {


### PR DESCRIPTION
- send completed ACP tool calls as partial updates
- preserve completion titles without resending stable tool metadata
- avoid completed edit locations that trigger Xcode staging behavior

Closes #33502.