### PR TITLE
fix(opencode): strip required from type-less Gemini schemas

### DIFF
--- a/packages/llm/src/protocols/utils/gemini-tool-schema.ts
+++ b/packages/llm/src/protocols/utils/gemini-tool-schema.ts
@@ -50,7 +50,7 @@ const sanitizeNode = (schema: unknown): unknown => {
     if (isRecord(result.items) && !hasSchemaIntent(result.items)) result.items = { ...result.items, type: "string" }
   }
 
-  if (typeof result.type === "string" && result.type !== "object" && !hasCombiner(result)) {
+  if (!result.type || (typeof result.type === "string" && result.type !== "object" && !hasCombiner(result))) {
     delete result.properties
     delete result.required
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1525,8 +1525,11 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
         }
       }
 
-      // Remove properties/required from non-object types (Gemini rejects these)
-      if (result.type && result.type !== "object" && !hasCombiner(result)) {
+      // Remove properties/required from non-object types (Gemini rejects these).
+      // Also handle the case where type was deleted after array expansion
+      // (e.g. ["object","null"] → anyOf), leaving orphaned required on a
+      // combiner or type-less schema.
+      if (!result.type || (result.type !== "object" && !hasCombiner(result))) {
         delete result.properties
         delete result.required
       }


### PR DESCRIPTION
### Issue for this PR

Closes #34130

### Type of change

- [x] Bug fix

### What does this PR do?

Google's function calling API requires "required" to only appear on "type: object" schemas. When Effect Schema generates a nullable union, the sanitize code expands it into anyOf and deletes type, but leaves required behind - causing Google to reject with 400.

Fix two sanitize functions (sanitizeGemini in packages/opencode/src/provider/transform.ts, sanitizeNode in packages/llm/src/protocols/utils/gemini-tool-schema.ts) to also strip required and properties when type is absent after normalization.

### How did you verify your code works?

Tested locally with "opencode run -m google/gemini-2.5-flash". Before the fix Google returned 400 schema error; after the fix it responds normally.

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
