### PR TITLE
feat(client): generate complete protocol client

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -7,7 +7,7 @@ Private generation target for clients derived directly from OpenCode's authorita
 - `@opencode-ai/client`: zero-Effect Promise client using `fetch`.
 - `@opencode-ai/client/effect`: rich Effect network client using an environment-provided `HttpClient`.
 
-The generated surface starts with the Session group from Server's concrete API. The build compiler reads `@opencode-ai/server/api`; the generated Effect runtime imports a client-local projection built from Protocol, with a generation-equivalence test preventing transport drift. Run `bun run generate` after changing the contract and `bun run check:generated` to detect committed-output drift.
+The generated surface includes every group from Server's concrete API. The build compiler reads `@opencode-ai/server/api`; the generated Effect runtime imports a client-local projection built from Protocol, with a generation-equivalence test preventing transport drift. Run `bun run generate` after changing the contract and `bun run check:generated` to detect committed-output drift.
 
 The Effect entrypoint uses canonical decoded values such as `Session.ID`, `Location.Ref`, and `Prompt`. These datatypes come from the lightweight `@opencode-ai/schema` package and are re-exported so callers depend only on the client surface. Protocol owns endpoint construction and middleware placement; Server supplies the concrete middleware keys used by the build-time API.
 

--- a/packages/client/script/build.ts
+++ b/packages/client/script/build.ts
@@ -2,19 +2,17 @@ import { NodeFileSystem } from "@effect/platform-node"
 import { compile, emitEffectImported, emitPromise, write } from "@opencode-ai/httpapi-codegen"
 import { Api } from "@opencode-ai/server/api"
 import { Effect } from "effect"
-import { HttpApi } from "effect/unstable/httpapi"
 import { fileURLToPath } from "url"
+import { endpointNames, groupNames } from "../src/contract"
 
-const contract = compile(HttpApi.make("opencode-client").add(Api.groups["server.session"]), {
-  groupNames: { "server.session": "sessions" },
-})
+const contract = compile(Api, { groupNames, endpointNames })
 
 await Effect.runPromise(
   Effect.all(
     [
       write(emitPromise(contract), fileURLToPath(new URL("../src/generated", import.meta.url))),
       write(
-        emitEffectImported(contract, { module: "../contract", group: "SessionGroup" }),
+        emitEffectImported(contract, { module: "../contract", api: "Api" }),
         fileURLToPath(new URL("../src/generated-effect", import.meta.url)),
       ),
     ],

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -11,9 +11,41 @@ class SessionLocationMiddleware extends HttpApiMiddleware.Service<SessionLocatio
   { error: [InvalidRequestError, SessionNotFoundError] },
 ) {}
 
-const Api = makeDefaultApi({
+export const Api = makeDefaultApi({
   locationMiddleware: LocationMiddleware,
   sessionLocationMiddleware: SessionLocationMiddleware,
 })
 
-export const SessionGroup = Api.groups["server.session"]
+export const groupNames = {
+  "server.health": "health",
+  "server.location": "location",
+  "server.agent": "agents",
+  "server.session": "sessions",
+  "server.message": "messages",
+  "server.model": "models",
+  "server.provider": "providers",
+  "server.integration": "integrations",
+  "server.credential": "credentials",
+  "server.permission": "permissions",
+  "server.fs": "files",
+  "server.command": "commands",
+  "server.skill": "skills",
+  "server.event": "events",
+  "server.pty": "ptys",
+  "server.question": "questions",
+  "server.reference": "references",
+  "server.projectCopy": "projectCopies",
+} as const
+
+export const endpointNames = {
+  "session.messages": "list",
+  "integration.connect.key": "connectKey",
+  "integration.connect.oauth": "connectOauth",
+  "integration.attempt.status": "attemptStatus",
+  "integration.attempt.complete": "attemptComplete",
+  "integration.attempt.cancel": "attemptCancel",
+  "permission.request.list": "listRequests",
+  "permission.saved.list": "listSaved",
+  "permission.saved.remove": "removeSaved",
+  "question.request.list": "listRequests",
+} as const

--- a/packages/client/src/generated-effect/client.ts
+++ b/packages/client/src/generated-effect/client.ts
@@ -2,11 +2,9 @@
 import { Effect, Stream, Schema } from "effect"
 import { Sse } from "effect/unstable/encoding"
 import { HttpClientError } from "effect/unstable/http"
-import { HttpApi, HttpApiClient } from "effect/unstable/httpapi"
-import { SessionGroup } from "../contract"
+import { HttpApiClient } from "effect/unstable/httpapi"
+import { Api } from "../contract"
 import { ClientError } from "./client-error"
-
-const Api = HttpApi.make("generated").add(SessionGroup)
 
 type RawClient = HttpApiClient.ForApi<typeof Api>
 
@@ -15,18 +13,37 @@ const mapClientError = <E>(error: E) =>
     ? new ClientError({ cause: error })
     : error
 
-type Endpoint0_0Request = Parameters<RawClient["server.session"]["session.list"]>[0]
-type Endpoint0_0Input = {
-  readonly workspace?: Endpoint0_0Request["query"]["workspace"]
-  readonly limit?: Endpoint0_0Request["query"]["limit"]
-  readonly order?: Endpoint0_0Request["query"]["order"]
-  readonly search?: Endpoint0_0Request["query"]["search"]
-  readonly directory?: Endpoint0_0Request["query"]["directory"]
-  readonly project?: Endpoint0_0Request["query"]["project"]
-  readonly subpath?: Endpoint0_0Request["query"]["subpath"]
-  readonly cursor?: Endpoint0_0Request["query"]["cursor"]
+const Endpoint0_0 = (raw: RawClient["server.health"]) => () =>
+  raw["health.get"]({}).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup0 = (raw: RawClient["server.health"]) => ({ get: Endpoint0_0(raw) })
+
+type Endpoint1_0Request = Parameters<RawClient["server.location"]["location.get"]>[0]
+type Endpoint1_0Input = { readonly location?: Endpoint1_0Request["query"]["location"] }
+const Endpoint1_0 = (raw: RawClient["server.location"]) => (input?: Endpoint1_0Input) =>
+  raw["location.get"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup1 = (raw: RawClient["server.location"]) => ({ get: Endpoint1_0(raw) })
+
+type Endpoint2_0Request = Parameters<RawClient["server.agent"]["agent.list"]>[0]
+type Endpoint2_0Input = { readonly location?: Endpoint2_0Request["query"]["location"] }
+const Endpoint2_0 = (raw: RawClient["server.agent"]) => (input?: Endpoint2_0Input) =>
+  raw["agent.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup2 = (raw: RawClient["server.agent"]) => ({ list: Endpoint2_0(raw) })
+
+type Endpoint3_0Request = Parameters<RawClient["server.session"]["session.list"]>[0]
+type Endpoint3_0Input = {
+  readonly workspace?: Endpoint3_0Request["query"]["workspace"]
+  readonly limit?: Endpoint3_0Request["query"]["limit"]
+  readonly order?: Endpoint3_0Request["query"]["order"]
+  readonly search?: Endpoint3_0Request["query"]["search"]
+  readonly directory?: Endpoint3_0Request["query"]["directory"]
+  readonly project?: Endpoint3_0Request["query"]["project"]
+  readonly subpath?: Endpoint3_0Request["query"]["subpath"]
+  readonly cursor?: Endpoint3_0Request["query"]["cursor"]
 }
-const Endpoint0_0 = (raw: RawClient["server.session"]) => (input?: Endpoint0_0Input) =>
+const Endpoint3_0 = (raw: RawClient["server.session"]) => (input?: Endpoint3_0Input) =>
   raw["session.list"]({
     query: {
       workspace: input?.workspace,
@@ -40,14 +57,14 @@ const Endpoint0_0 = (raw: RawClient["server.session"]) => (input?: Endpoint0_0In
     },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint0_1Request = Parameters<RawClient["server.session"]["session.create"]>[0]
-type Endpoint0_1Input = {
-  readonly id?: Endpoint0_1Request["payload"]["id"]
-  readonly agent?: Endpoint0_1Request["payload"]["agent"]
-  readonly model?: Endpoint0_1Request["payload"]["model"]
-  readonly location?: Endpoint0_1Request["payload"]["location"]
+type Endpoint3_1Request = Parameters<RawClient["server.session"]["session.create"]>[0]
+type Endpoint3_1Input = {
+  readonly id?: Endpoint3_1Request["payload"]["id"]
+  readonly agent?: Endpoint3_1Request["payload"]["agent"]
+  readonly model?: Endpoint3_1Request["payload"]["model"]
+  readonly location?: Endpoint3_1Request["payload"]["location"]
 }
-const Endpoint0_1 = (raw: RawClient["server.session"]) => (input?: Endpoint0_1Input) =>
+const Endpoint3_1 = (raw: RawClient["server.session"]) => (input?: Endpoint3_1Input) =>
   raw["session.create"]({
     payload: { id: input?.id, agent: input?.agent, model: input?.model, location: input?.location },
   }).pipe(
@@ -55,49 +72,49 @@ const Endpoint0_1 = (raw: RawClient["server.session"]) => (input?: Endpoint0_1In
     Effect.map((value) => value.data),
   )
 
-const Endpoint0_2 = (raw: RawClient["server.session"]) => () =>
+const Endpoint3_2 = (raw: RawClient["server.session"]) => () =>
   raw["session.active"]({}).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint0_3Request = Parameters<RawClient["server.session"]["session.get"]>[0]
-type Endpoint0_3Input = { readonly sessionID: Endpoint0_3Request["params"]["sessionID"] }
-const Endpoint0_3 = (raw: RawClient["server.session"]) => (input: Endpoint0_3Input) =>
+type Endpoint3_3Request = Parameters<RawClient["server.session"]["session.get"]>[0]
+type Endpoint3_3Input = { readonly sessionID: Endpoint3_3Request["params"]["sessionID"] }
+const Endpoint3_3 = (raw: RawClient["server.session"]) => (input: Endpoint3_3Input) =>
   raw["session.get"]({ params: { sessionID: input.sessionID } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint0_4Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
-type Endpoint0_4Input = {
-  readonly sessionID: Endpoint0_4Request["params"]["sessionID"]
-  readonly agent: Endpoint0_4Request["payload"]["agent"]
+type Endpoint3_4Request = Parameters<RawClient["server.session"]["session.switchAgent"]>[0]
+type Endpoint3_4Input = {
+  readonly sessionID: Endpoint3_4Request["params"]["sessionID"]
+  readonly agent: Endpoint3_4Request["payload"]["agent"]
 }
-const Endpoint0_4 = (raw: RawClient["server.session"]) => (input: Endpoint0_4Input) =>
+const Endpoint3_4 = (raw: RawClient["server.session"]) => (input: Endpoint3_4Input) =>
   raw["session.switchAgent"]({ params: { sessionID: input.sessionID }, payload: { agent: input.agent } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint0_5Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
-type Endpoint0_5Input = {
-  readonly sessionID: Endpoint0_5Request["params"]["sessionID"]
-  readonly model: Endpoint0_5Request["payload"]["model"]
+type Endpoint3_5Request = Parameters<RawClient["server.session"]["session.switchModel"]>[0]
+type Endpoint3_5Input = {
+  readonly sessionID: Endpoint3_5Request["params"]["sessionID"]
+  readonly model: Endpoint3_5Request["payload"]["model"]
 }
-const Endpoint0_5 = (raw: RawClient["server.session"]) => (input: Endpoint0_5Input) =>
+const Endpoint3_5 = (raw: RawClient["server.session"]) => (input: Endpoint3_5Input) =>
   raw["session.switchModel"]({ params: { sessionID: input.sessionID }, payload: { model: input.model } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint0_6Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
-type Endpoint0_6Input = {
-  readonly sessionID: Endpoint0_6Request["params"]["sessionID"]
-  readonly id?: Endpoint0_6Request["payload"]["id"]
-  readonly prompt: Endpoint0_6Request["payload"]["prompt"]
-  readonly delivery?: Endpoint0_6Request["payload"]["delivery"]
-  readonly resume?: Endpoint0_6Request["payload"]["resume"]
+type Endpoint3_6Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint3_6Input = {
+  readonly sessionID: Endpoint3_6Request["params"]["sessionID"]
+  readonly id?: Endpoint3_6Request["payload"]["id"]
+  readonly prompt: Endpoint3_6Request["payload"]["prompt"]
+  readonly delivery?: Endpoint3_6Request["payload"]["delivery"]
+  readonly resume?: Endpoint3_6Request["payload"]["resume"]
 }
-const Endpoint0_6 = (raw: RawClient["server.session"]) => (input: Endpoint0_6Input) =>
+const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
   raw["session.prompt"]({
     params: { sessionID: input.sessionID },
     payload: { id: input.id, prompt: input.prompt, delivery: input.delivery, resume: input.resume },
@@ -106,23 +123,23 @@ const Endpoint0_6 = (raw: RawClient["server.session"]) => (input: Endpoint0_6Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint0_7Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
-type Endpoint0_7Input = { readonly sessionID: Endpoint0_7Request["params"]["sessionID"] }
-const Endpoint0_7 = (raw: RawClient["server.session"]) => (input: Endpoint0_7Input) =>
+type Endpoint3_7Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+type Endpoint3_7Input = { readonly sessionID: Endpoint3_7Request["params"]["sessionID"] }
+const Endpoint3_7 = (raw: RawClient["server.session"]) => (input: Endpoint3_7Input) =>
   raw["session.compact"]({ params: { sessionID: input.sessionID } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint0_8Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
-type Endpoint0_8Input = { readonly sessionID: Endpoint0_8Request["params"]["sessionID"] }
-const Endpoint0_8 = (raw: RawClient["server.session"]) => (input: Endpoint0_8Input) =>
+type Endpoint3_8Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+type Endpoint3_8Input = { readonly sessionID: Endpoint3_8Request["params"]["sessionID"] }
+const Endpoint3_8 = (raw: RawClient["server.session"]) => (input: Endpoint3_8Input) =>
   raw["session.wait"]({ params: { sessionID: input.sessionID } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint0_9Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-type Endpoint0_9Input = {
-  readonly sessionID: Endpoint0_9Request["params"]["sessionID"]
-  readonly messageID: Endpoint0_9Request["payload"]["messageID"]
-  readonly files?: Endpoint0_9Request["payload"]["files"]
+type Endpoint3_9Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+type Endpoint3_9Input = {
+  readonly sessionID: Endpoint3_9Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_9Request["payload"]["messageID"]
+  readonly files?: Endpoint3_9Request["payload"]["files"]
 }
-const Endpoint0_9 = (raw: RawClient["server.session"]) => (input: Endpoint0_9Input) =>
+const Endpoint3_9 = (raw: RawClient["server.session"]) => (input: Endpoint3_9Input) =>
   raw["session.revert.stage"]({
     params: { sessionID: input.sessionID },
     payload: { messageID: input.messageID, files: input.files },
@@ -131,30 +148,30 @@ const Endpoint0_9 = (raw: RawClient["server.session"]) => (input: Endpoint0_9Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint0_10Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-type Endpoint0_10Input = { readonly sessionID: Endpoint0_10Request["params"]["sessionID"] }
-const Endpoint0_10 = (raw: RawClient["server.session"]) => (input: Endpoint0_10Input) =>
+type Endpoint3_10Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
+type Endpoint3_10Input = { readonly sessionID: Endpoint3_10Request["params"]["sessionID"] }
+const Endpoint3_10 = (raw: RawClient["server.session"]) => (input: Endpoint3_10Input) =>
   raw["session.revert.clear"]({ params: { sessionID: input.sessionID } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint0_11Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
-type Endpoint0_11Input = { readonly sessionID: Endpoint0_11Request["params"]["sessionID"] }
-const Endpoint0_11 = (raw: RawClient["server.session"]) => (input: Endpoint0_11Input) =>
+type Endpoint3_11Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint3_11Input = { readonly sessionID: Endpoint3_11Request["params"]["sessionID"] }
+const Endpoint3_11 = (raw: RawClient["server.session"]) => (input: Endpoint3_11Input) =>
   raw["session.revert.commit"]({ params: { sessionID: input.sessionID } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint0_12Request = Parameters<RawClient["server.session"]["session.context"]>[0]
-type Endpoint0_12Input = { readonly sessionID: Endpoint0_12Request["params"]["sessionID"] }
-const Endpoint0_12 = (raw: RawClient["server.session"]) => (input: Endpoint0_12Input) =>
+type Endpoint3_12Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint3_12Input = { readonly sessionID: Endpoint3_12Request["params"]["sessionID"] }
+const Endpoint3_12 = (raw: RawClient["server.session"]) => (input: Endpoint3_12Input) =>
   raw["session.context"]({ params: { sessionID: input.sessionID } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint0_13Request = Parameters<RawClient["server.session"]["session.events"]>[0]
-type Endpoint0_13Input = {
-  readonly sessionID: Endpoint0_13Request["params"]["sessionID"]
-  readonly after?: Endpoint0_13Request["query"]["after"]
+type Endpoint3_13Request = Parameters<RawClient["server.session"]["session.events"]>[0]
+type Endpoint3_13Input = {
+  readonly sessionID: Endpoint3_13Request["params"]["sessionID"]
+  readonly after?: Endpoint3_13Request["query"]["after"]
 }
-const Endpoint0_13 = (raw: RawClient["server.session"]) => (input: Endpoint0_13Input) =>
+const Endpoint3_13 = (raw: RawClient["server.session"]) => (input: Endpoint3_13Input) =>
   Stream.unwrap(
     raw["session.events"]({ params: { sessionID: input.sessionID }, query: { after: input.after } }).pipe(
       Effect.mapError(mapClientError),
@@ -162,42 +179,525 @@ const Endpoint0_13 = (raw: RawClient["server.session"]) => (input: Endpoint0_13I
     ),
   )
 
-type Endpoint0_14Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-type Endpoint0_14Input = { readonly sessionID: Endpoint0_14Request["params"]["sessionID"] }
-const Endpoint0_14 = (raw: RawClient["server.session"]) => (input: Endpoint0_14Input) =>
+type Endpoint3_14Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
+type Endpoint3_14Input = { readonly sessionID: Endpoint3_14Request["params"]["sessionID"] }
+const Endpoint3_14 = (raw: RawClient["server.session"]) => (input: Endpoint3_14Input) =>
   raw["session.interrupt"]({ params: { sessionID: input.sessionID } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint0_15Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-type Endpoint0_15Input = {
-  readonly sessionID: Endpoint0_15Request["params"]["sessionID"]
-  readonly messageID: Endpoint0_15Request["params"]["messageID"]
+type Endpoint3_15Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+type Endpoint3_15Input = {
+  readonly sessionID: Endpoint3_15Request["params"]["sessionID"]
+  readonly messageID: Endpoint3_15Request["params"]["messageID"]
 }
-const Endpoint0_15 = (raw: RawClient["server.session"]) => (input: Endpoint0_15Input) =>
+const Endpoint3_15 = (raw: RawClient["server.session"]) => (input: Endpoint3_15Input) =>
   raw["session.message"]({ params: { sessionID: input.sessionID, messageID: input.messageID } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-const adaptGroup0 = (raw: RawClient["server.session"]) => ({
-  list: Endpoint0_0(raw),
-  create: Endpoint0_1(raw),
-  active: Endpoint0_2(raw),
-  get: Endpoint0_3(raw),
-  switchAgent: Endpoint0_4(raw),
-  switchModel: Endpoint0_5(raw),
-  prompt: Endpoint0_6(raw),
-  compact: Endpoint0_7(raw),
-  wait: Endpoint0_8(raw),
-  stage: Endpoint0_9(raw),
-  clear: Endpoint0_10(raw),
-  commit: Endpoint0_11(raw),
-  context: Endpoint0_12(raw),
-  events: Endpoint0_13(raw),
-  interrupt: Endpoint0_14(raw),
-  message: Endpoint0_15(raw),
+const adaptGroup3 = (raw: RawClient["server.session"]) => ({
+  list: Endpoint3_0(raw),
+  create: Endpoint3_1(raw),
+  active: Endpoint3_2(raw),
+  get: Endpoint3_3(raw),
+  switchAgent: Endpoint3_4(raw),
+  switchModel: Endpoint3_5(raw),
+  prompt: Endpoint3_6(raw),
+  compact: Endpoint3_7(raw),
+  wait: Endpoint3_8(raw),
+  stage: Endpoint3_9(raw),
+  clear: Endpoint3_10(raw),
+  commit: Endpoint3_11(raw),
+  context: Endpoint3_12(raw),
+  events: Endpoint3_13(raw),
+  interrupt: Endpoint3_14(raw),
+  message: Endpoint3_15(raw),
 })
 
-const adaptClient = (raw: RawClient) => ({ sessions: adaptGroup0(raw["server.session"]) })
+type Endpoint4_0Request = Parameters<RawClient["server.message"]["session.messages"]>[0]
+type Endpoint4_0Input = {
+  readonly sessionID: Endpoint4_0Request["params"]["sessionID"]
+  readonly limit?: Endpoint4_0Request["query"]["limit"]
+  readonly order?: Endpoint4_0Request["query"]["order"]
+  readonly cursor?: Endpoint4_0Request["query"]["cursor"]
+}
+const Endpoint4_0 = (raw: RawClient["server.message"]) => (input: Endpoint4_0Input) =>
+  raw["session.messages"]({
+    params: { sessionID: input.sessionID },
+    query: { limit: input.limit, order: input.order, cursor: input.cursor },
+  }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup4 = (raw: RawClient["server.message"]) => ({ list: Endpoint4_0(raw) })
+
+type Endpoint5_0Request = Parameters<RawClient["server.model"]["model.list"]>[0]
+type Endpoint5_0Input = { readonly location?: Endpoint5_0Request["query"]["location"] }
+const Endpoint5_0 = (raw: RawClient["server.model"]) => (input?: Endpoint5_0Input) =>
+  raw["model.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup5 = (raw: RawClient["server.model"]) => ({ list: Endpoint5_0(raw) })
+
+type Endpoint6_0Request = Parameters<RawClient["server.provider"]["provider.list"]>[0]
+type Endpoint6_0Input = { readonly location?: Endpoint6_0Request["query"]["location"] }
+const Endpoint6_0 = (raw: RawClient["server.provider"]) => (input?: Endpoint6_0Input) =>
+  raw["provider.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint6_1Request = Parameters<RawClient["server.provider"]["provider.get"]>[0]
+type Endpoint6_1Input = {
+  readonly providerID: Endpoint6_1Request["params"]["providerID"]
+  readonly location?: Endpoint6_1Request["query"]["location"]
+}
+const Endpoint6_1 = (raw: RawClient["server.provider"]) => (input: Endpoint6_1Input) =>
+  raw["provider.get"]({ params: { providerID: input.providerID }, query: { location: input.location } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+const adaptGroup6 = (raw: RawClient["server.provider"]) => ({ list: Endpoint6_0(raw), get: Endpoint6_1(raw) })
+
+type Endpoint7_0Request = Parameters<RawClient["server.integration"]["integration.list"]>[0]
+type Endpoint7_0Input = { readonly location?: Endpoint7_0Request["query"]["location"] }
+const Endpoint7_0 = (raw: RawClient["server.integration"]) => (input?: Endpoint7_0Input) =>
+  raw["integration.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint7_1Request = Parameters<RawClient["server.integration"]["integration.get"]>[0]
+type Endpoint7_1Input = {
+  readonly integrationID: Endpoint7_1Request["params"]["integrationID"]
+  readonly location?: Endpoint7_1Request["query"]["location"]
+}
+const Endpoint7_1 = (raw: RawClient["server.integration"]) => (input: Endpoint7_1Input) =>
+  raw["integration.get"]({ params: { integrationID: input.integrationID }, query: { location: input.location } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+type Endpoint7_2Request = Parameters<RawClient["server.integration"]["integration.connect.key"]>[0]
+type Endpoint7_2Input = {
+  readonly integrationID: Endpoint7_2Request["params"]["integrationID"]
+  readonly location?: Endpoint7_2Request["query"]["location"]
+  readonly key: Endpoint7_2Request["payload"]["key"]
+  readonly label?: Endpoint7_2Request["payload"]["label"]
+}
+const Endpoint7_2 = (raw: RawClient["server.integration"]) => (input: Endpoint7_2Input) =>
+  raw["integration.connect.key"]({
+    params: { integrationID: input.integrationID },
+    query: { location: input.location },
+    payload: { key: input.key, label: input.label },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint7_3Request = Parameters<RawClient["server.integration"]["integration.connect.oauth"]>[0]
+type Endpoint7_3Input = {
+  readonly integrationID: Endpoint7_3Request["params"]["integrationID"]
+  readonly location?: Endpoint7_3Request["query"]["location"]
+  readonly methodID: Endpoint7_3Request["payload"]["methodID"]
+  readonly inputs: Endpoint7_3Request["payload"]["inputs"]
+  readonly label?: Endpoint7_3Request["payload"]["label"]
+}
+const Endpoint7_3 = (raw: RawClient["server.integration"]) => (input: Endpoint7_3Input) =>
+  raw["integration.connect.oauth"]({
+    params: { integrationID: input.integrationID },
+    query: { location: input.location },
+    payload: { methodID: input.methodID, inputs: input.inputs, label: input.label },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint7_4Request = Parameters<RawClient["server.integration"]["integration.attempt.status"]>[0]
+type Endpoint7_4Input = {
+  readonly attemptID: Endpoint7_4Request["params"]["attemptID"]
+  readonly location?: Endpoint7_4Request["query"]["location"]
+}
+const Endpoint7_4 = (raw: RawClient["server.integration"]) => (input: Endpoint7_4Input) =>
+  raw["integration.attempt.status"]({
+    params: { attemptID: input.attemptID },
+    query: { location: input.location },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint7_5Request = Parameters<RawClient["server.integration"]["integration.attempt.complete"]>[0]
+type Endpoint7_5Input = {
+  readonly attemptID: Endpoint7_5Request["params"]["attemptID"]
+  readonly location?: Endpoint7_5Request["query"]["location"]
+  readonly code?: Endpoint7_5Request["payload"]["code"]
+}
+const Endpoint7_5 = (raw: RawClient["server.integration"]) => (input: Endpoint7_5Input) =>
+  raw["integration.attempt.complete"]({
+    params: { attemptID: input.attemptID },
+    query: { location: input.location },
+    payload: { code: input.code },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint7_6Request = Parameters<RawClient["server.integration"]["integration.attempt.cancel"]>[0]
+type Endpoint7_6Input = {
+  readonly attemptID: Endpoint7_6Request["params"]["attemptID"]
+  readonly location?: Endpoint7_6Request["query"]["location"]
+}
+const Endpoint7_6 = (raw: RawClient["server.integration"]) => (input: Endpoint7_6Input) =>
+  raw["integration.attempt.cancel"]({
+    params: { attemptID: input.attemptID },
+    query: { location: input.location },
+  }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup7 = (raw: RawClient["server.integration"]) => ({
+  list: Endpoint7_0(raw),
+  get: Endpoint7_1(raw),
+  connectKey: Endpoint7_2(raw),
+  connectOauth: Endpoint7_3(raw),
+  attemptStatus: Endpoint7_4(raw),
+  attemptComplete: Endpoint7_5(raw),
+  attemptCancel: Endpoint7_6(raw),
+})
+
+type Endpoint8_0Request = Parameters<RawClient["server.credential"]["credential.update"]>[0]
+type Endpoint8_0Input = {
+  readonly credentialID: Endpoint8_0Request["params"]["credentialID"]
+  readonly location?: Endpoint8_0Request["query"]["location"]
+  readonly label: Endpoint8_0Request["payload"]["label"]
+}
+const Endpoint8_0 = (raw: RawClient["server.credential"]) => (input: Endpoint8_0Input) =>
+  raw["credential.update"]({
+    params: { credentialID: input.credentialID },
+    query: { location: input.location },
+    payload: { label: input.label },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint8_1Request = Parameters<RawClient["server.credential"]["credential.remove"]>[0]
+type Endpoint8_1Input = {
+  readonly credentialID: Endpoint8_1Request["params"]["credentialID"]
+  readonly location?: Endpoint8_1Request["query"]["location"]
+}
+const Endpoint8_1 = (raw: RawClient["server.credential"]) => (input: Endpoint8_1Input) =>
+  raw["credential.remove"]({ params: { credentialID: input.credentialID }, query: { location: input.location } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+const adaptGroup8 = (raw: RawClient["server.credential"]) => ({ update: Endpoint8_0(raw), remove: Endpoint8_1(raw) })
+
+type Endpoint9_0Request = Parameters<RawClient["server.permission"]["permission.request.list"]>[0]
+type Endpoint9_0Input = { readonly location?: Endpoint9_0Request["query"]["location"] }
+const Endpoint9_0 = (raw: RawClient["server.permission"]) => (input?: Endpoint9_0Input) =>
+  raw["permission.request.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint9_1Request = Parameters<RawClient["server.permission"]["permission.saved.list"]>[0]
+type Endpoint9_1Input = { readonly projectID?: Endpoint9_1Request["query"]["projectID"] }
+const Endpoint9_1 = (raw: RawClient["server.permission"]) => (input?: Endpoint9_1Input) =>
+  raw["permission.saved.list"]({ query: { projectID: input?.projectID } }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint9_2Request = Parameters<RawClient["server.permission"]["permission.saved.remove"]>[0]
+type Endpoint9_2Input = { readonly id: Endpoint9_2Request["params"]["id"] }
+const Endpoint9_2 = (raw: RawClient["server.permission"]) => (input: Endpoint9_2Input) =>
+  raw["permission.saved.remove"]({ params: { id: input.id } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint9_3Request = Parameters<RawClient["server.permission"]["session.permission.create"]>[0]
+type Endpoint9_3Input = {
+  readonly sessionID: Endpoint9_3Request["params"]["sessionID"]
+  readonly id?: Endpoint9_3Request["payload"]["id"]
+  readonly action: Endpoint9_3Request["payload"]["action"]
+  readonly resources: Endpoint9_3Request["payload"]["resources"]
+  readonly save?: Endpoint9_3Request["payload"]["save"]
+  readonly metadata?: Endpoint9_3Request["payload"]["metadata"]
+  readonly source?: Endpoint9_3Request["payload"]["source"]
+  readonly agent?: Endpoint9_3Request["payload"]["agent"]
+}
+const Endpoint9_3 = (raw: RawClient["server.permission"]) => (input: Endpoint9_3Input) =>
+  raw["session.permission.create"]({
+    params: { sessionID: input.sessionID },
+    payload: {
+      id: input.id,
+      action: input.action,
+      resources: input.resources,
+      save: input.save,
+      metadata: input.metadata,
+      source: input.source,
+      agent: input.agent,
+    },
+  }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint9_4Request = Parameters<RawClient["server.permission"]["session.permission.list"]>[0]
+type Endpoint9_4Input = { readonly sessionID: Endpoint9_4Request["params"]["sessionID"] }
+const Endpoint9_4 = (raw: RawClient["server.permission"]) => (input: Endpoint9_4Input) =>
+  raw["session.permission.list"]({ params: { sessionID: input.sessionID } }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint9_5Request = Parameters<RawClient["server.permission"]["session.permission.get"]>[0]
+type Endpoint9_5Input = {
+  readonly sessionID: Endpoint9_5Request["params"]["sessionID"]
+  readonly requestID: Endpoint9_5Request["params"]["requestID"]
+}
+const Endpoint9_5 = (raw: RawClient["server.permission"]) => (input: Endpoint9_5Input) =>
+  raw["session.permission.get"]({ params: { sessionID: input.sessionID, requestID: input.requestID } }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint9_6Request = Parameters<RawClient["server.permission"]["session.permission.reply"]>[0]
+type Endpoint9_6Input = {
+  readonly sessionID: Endpoint9_6Request["params"]["sessionID"]
+  readonly requestID: Endpoint9_6Request["params"]["requestID"]
+  readonly reply: Endpoint9_6Request["payload"]["reply"]
+  readonly message?: Endpoint9_6Request["payload"]["message"]
+}
+const Endpoint9_6 = (raw: RawClient["server.permission"]) => (input: Endpoint9_6Input) =>
+  raw["session.permission.reply"]({
+    params: { sessionID: input.sessionID, requestID: input.requestID },
+    payload: { reply: input.reply, message: input.message },
+  }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup9 = (raw: RawClient["server.permission"]) => ({
+  listRequests: Endpoint9_0(raw),
+  listSaved: Endpoint9_1(raw),
+  removeSaved: Endpoint9_2(raw),
+  create: Endpoint9_3(raw),
+  list: Endpoint9_4(raw),
+  get: Endpoint9_5(raw),
+  reply: Endpoint9_6(raw),
+})
+
+type Endpoint10_0Request = Parameters<RawClient["server.fs"]["fs.read"]>[0]
+type Endpoint10_0Input = { readonly location?: Endpoint10_0Request["query"]["location"] }
+const Endpoint10_0 = (raw: RawClient["server.fs"]) => (input?: Endpoint10_0Input) =>
+  raw["fs.read"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint10_1Request = Parameters<RawClient["server.fs"]["fs.list"]>[0]
+type Endpoint10_1Input = {
+  readonly location?: Endpoint10_1Request["query"]["location"]
+  readonly path?: Endpoint10_1Request["query"]["path"]
+}
+const Endpoint10_1 = (raw: RawClient["server.fs"]) => (input?: Endpoint10_1Input) =>
+  raw["fs.list"]({ query: { location: input?.location, path: input?.path } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint10_2Request = Parameters<RawClient["server.fs"]["fs.find"]>[0]
+type Endpoint10_2Input = {
+  readonly location?: Endpoint10_2Request["query"]["location"]
+  readonly query: Endpoint10_2Request["query"]["query"]
+  readonly type?: Endpoint10_2Request["query"]["type"]
+  readonly limit?: Endpoint10_2Request["query"]["limit"]
+}
+const Endpoint10_2 = (raw: RawClient["server.fs"]) => (input: Endpoint10_2Input) =>
+  raw["fs.find"]({
+    query: { location: input.location, query: input.query, type: input.type, limit: input.limit },
+  }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup10 = (raw: RawClient["server.fs"]) => ({
+  read: Endpoint10_0(raw),
+  list: Endpoint10_1(raw),
+  find: Endpoint10_2(raw),
+})
+
+type Endpoint11_0Request = Parameters<RawClient["server.command"]["command.list"]>[0]
+type Endpoint11_0Input = { readonly location?: Endpoint11_0Request["query"]["location"] }
+const Endpoint11_0 = (raw: RawClient["server.command"]) => (input?: Endpoint11_0Input) =>
+  raw["command.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup11 = (raw: RawClient["server.command"]) => ({ list: Endpoint11_0(raw) })
+
+type Endpoint12_0Request = Parameters<RawClient["server.skill"]["skill.list"]>[0]
+type Endpoint12_0Input = { readonly location?: Endpoint12_0Request["query"]["location"] }
+const Endpoint12_0 = (raw: RawClient["server.skill"]) => (input?: Endpoint12_0Input) =>
+  raw["skill.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup12 = (raw: RawClient["server.skill"]) => ({ list: Endpoint12_0(raw) })
+
+const Endpoint13_0 = (raw: RawClient["server.event"]) => () =>
+  raw["event.subscribe"]({}).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup13 = (raw: RawClient["server.event"]) => ({ subscribe: Endpoint13_0(raw) })
+
+type Endpoint14_0Request = Parameters<RawClient["server.pty"]["pty.list"]>[0]
+type Endpoint14_0Input = { readonly location?: Endpoint14_0Request["query"]["location"] }
+const Endpoint14_0 = (raw: RawClient["server.pty"]) => (input?: Endpoint14_0Input) =>
+  raw["pty.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint14_1Request = Parameters<RawClient["server.pty"]["pty.create"]>[0]
+type Endpoint14_1Input = {
+  readonly location?: Endpoint14_1Request["query"]["location"]
+  readonly command?: Endpoint14_1Request["payload"]["command"]
+  readonly args?: Endpoint14_1Request["payload"]["args"]
+  readonly cwd?: Endpoint14_1Request["payload"]["cwd"]
+  readonly title?: Endpoint14_1Request["payload"]["title"]
+  readonly env?: Endpoint14_1Request["payload"]["env"]
+}
+const Endpoint14_1 = (raw: RawClient["server.pty"]) => (input?: Endpoint14_1Input) =>
+  raw["pty.create"]({
+    query: { location: input?.location },
+    payload: { command: input?.command, args: input?.args, cwd: input?.cwd, title: input?.title, env: input?.env },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint14_2Request = Parameters<RawClient["server.pty"]["pty.get"]>[0]
+type Endpoint14_2Input = {
+  readonly ptyID: Endpoint14_2Request["params"]["ptyID"]
+  readonly location?: Endpoint14_2Request["query"]["location"]
+}
+const Endpoint14_2 = (raw: RawClient["server.pty"]) => (input: Endpoint14_2Input) =>
+  raw["pty.get"]({ params: { ptyID: input.ptyID }, query: { location: input.location } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+type Endpoint14_3Request = Parameters<RawClient["server.pty"]["pty.update"]>[0]
+type Endpoint14_3Input = {
+  readonly ptyID: Endpoint14_3Request["params"]["ptyID"]
+  readonly location?: Endpoint14_3Request["query"]["location"]
+  readonly title?: Endpoint14_3Request["payload"]["title"]
+  readonly size?: Endpoint14_3Request["payload"]["size"]
+}
+const Endpoint14_3 = (raw: RawClient["server.pty"]) => (input: Endpoint14_3Input) =>
+  raw["pty.update"]({
+    params: { ptyID: input.ptyID },
+    query: { location: input.location },
+    payload: { title: input.title, size: input.size },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint14_4Request = Parameters<RawClient["server.pty"]["pty.remove"]>[0]
+type Endpoint14_4Input = {
+  readonly ptyID: Endpoint14_4Request["params"]["ptyID"]
+  readonly location?: Endpoint14_4Request["query"]["location"]
+}
+const Endpoint14_4 = (raw: RawClient["server.pty"]) => (input: Endpoint14_4Input) =>
+  raw["pty.remove"]({ params: { ptyID: input.ptyID }, query: { location: input.location } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+type Endpoint14_5Request = Parameters<RawClient["server.pty"]["pty.connectToken"]>[0]
+type Endpoint14_5Input = {
+  readonly ptyID: Endpoint14_5Request["params"]["ptyID"]
+  readonly location?: Endpoint14_5Request["query"]["location"]
+}
+const Endpoint14_5 = (raw: RawClient["server.pty"]) => (input: Endpoint14_5Input) =>
+  raw["pty.connectToken"]({ params: { ptyID: input.ptyID }, query: { location: input.location } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+type Endpoint14_6Request = Parameters<RawClient["server.pty"]["pty.connect"]>[0]
+type Endpoint14_6Input = { readonly ptyID: Endpoint14_6Request["params"]["ptyID"] }
+const Endpoint14_6 = (raw: RawClient["server.pty"]) => (input: Endpoint14_6Input) =>
+  raw["pty.connect"]({ params: { ptyID: input.ptyID } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup14 = (raw: RawClient["server.pty"]) => ({
+  list: Endpoint14_0(raw),
+  create: Endpoint14_1(raw),
+  get: Endpoint14_2(raw),
+  update: Endpoint14_3(raw),
+  remove: Endpoint14_4(raw),
+  connectToken: Endpoint14_5(raw),
+  connect: Endpoint14_6(raw),
+})
+
+type Endpoint15_0Request = Parameters<RawClient["server.question"]["question.request.list"]>[0]
+type Endpoint15_0Input = { readonly location?: Endpoint15_0Request["query"]["location"] }
+const Endpoint15_0 = (raw: RawClient["server.question"]) => (input?: Endpoint15_0Input) =>
+  raw["question.request.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint15_1Request = Parameters<RawClient["server.question"]["session.question.list"]>[0]
+type Endpoint15_1Input = { readonly sessionID: Endpoint15_1Request["params"]["sessionID"] }
+const Endpoint15_1 = (raw: RawClient["server.question"]) => (input: Endpoint15_1Input) =>
+  raw["session.question.list"]({ params: { sessionID: input.sessionID } }).pipe(
+    Effect.mapError(mapClientError),
+    Effect.map((value) => value.data),
+  )
+
+type Endpoint15_2Request = Parameters<RawClient["server.question"]["session.question.reply"]>[0]
+type Endpoint15_2Input = {
+  readonly sessionID: Endpoint15_2Request["params"]["sessionID"]
+  readonly requestID: Endpoint15_2Request["params"]["requestID"]
+  readonly answers: Endpoint15_2Request["payload"]["answers"]
+}
+const Endpoint15_2 = (raw: RawClient["server.question"]) => (input: Endpoint15_2Input) =>
+  raw["session.question.reply"]({
+    params: { sessionID: input.sessionID, requestID: input.requestID },
+    payload: { answers: input.answers },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint15_3Request = Parameters<RawClient["server.question"]["session.question.reject"]>[0]
+type Endpoint15_3Input = {
+  readonly sessionID: Endpoint15_3Request["params"]["sessionID"]
+  readonly requestID: Endpoint15_3Request["params"]["requestID"]
+}
+const Endpoint15_3 = (raw: RawClient["server.question"]) => (input: Endpoint15_3Input) =>
+  raw["session.question.reject"]({ params: { sessionID: input.sessionID, requestID: input.requestID } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+const adaptGroup15 = (raw: RawClient["server.question"]) => ({
+  listRequests: Endpoint15_0(raw),
+  list: Endpoint15_1(raw),
+  reply: Endpoint15_2(raw),
+  reject: Endpoint15_3(raw),
+})
+
+type Endpoint16_0Request = Parameters<RawClient["server.reference"]["reference.list"]>[0]
+type Endpoint16_0Input = { readonly location?: Endpoint16_0Request["query"]["location"] }
+const Endpoint16_0 = (raw: RawClient["server.reference"]) => (input?: Endpoint16_0Input) =>
+  raw["reference.list"]({ query: { location: input?.location } }).pipe(Effect.mapError(mapClientError))
+
+const adaptGroup16 = (raw: RawClient["server.reference"]) => ({ list: Endpoint16_0(raw) })
+
+type Endpoint17_0Request = Parameters<RawClient["server.projectCopy"]["projectCopy.create"]>[0]
+type Endpoint17_0Input = {
+  readonly projectID: Endpoint17_0Request["params"]["projectID"]
+  readonly location?: Endpoint17_0Request["query"]["location"]
+  readonly strategy: Endpoint17_0Request["payload"]["strategy"]
+  readonly directory: Endpoint17_0Request["payload"]["directory"]
+  readonly name?: Endpoint17_0Request["payload"]["name"]
+}
+const Endpoint17_0 = (raw: RawClient["server.projectCopy"]) => (input: Endpoint17_0Input) =>
+  raw["projectCopy.create"]({
+    params: { projectID: input.projectID },
+    query: { location: input.location },
+    payload: { strategy: input.strategy, directory: input.directory, name: input.name },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint17_1Request = Parameters<RawClient["server.projectCopy"]["projectCopy.remove"]>[0]
+type Endpoint17_1Input = {
+  readonly projectID: Endpoint17_1Request["params"]["projectID"]
+  readonly location?: Endpoint17_1Request["query"]["location"]
+  readonly directory: Endpoint17_1Request["payload"]["directory"]
+  readonly force: Endpoint17_1Request["payload"]["force"]
+}
+const Endpoint17_1 = (raw: RawClient["server.projectCopy"]) => (input: Endpoint17_1Input) =>
+  raw["projectCopy.remove"]({
+    params: { projectID: input.projectID },
+    query: { location: input.location },
+    payload: { directory: input.directory, force: input.force },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint17_2Request = Parameters<RawClient["server.projectCopy"]["projectCopy.refresh"]>[0]
+type Endpoint17_2Input = {
+  readonly projectID: Endpoint17_2Request["params"]["projectID"]
+  readonly location?: Endpoint17_2Request["query"]["location"]
+}
+const Endpoint17_2 = (raw: RawClient["server.projectCopy"]) => (input: Endpoint17_2Input) =>
+  raw["projectCopy.refresh"]({ params: { projectID: input.projectID }, query: { location: input.location } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+const adaptGroup17 = (raw: RawClient["server.projectCopy"]) => ({
+  create: Endpoint17_0(raw),
+  remove: Endpoint17_1(raw),
+  refresh: Endpoint17_2(raw),
+})
+
+const adaptClient = (raw: RawClient) => ({
+  health: adaptGroup0(raw["server.health"]),
+  location: adaptGroup1(raw["server.location"]),
+  agents: adaptGroup2(raw["server.agent"]),
+  sessions: adaptGroup3(raw["server.session"]),
+  messages: adaptGroup4(raw["server.message"]),
+  models: adaptGroup5(raw["server.model"]),
+  providers: adaptGroup6(raw["server.provider"]),
+  integrations: adaptGroup7(raw["server.integration"]),
+  credentials: adaptGroup8(raw["server.credential"]),
+  permissions: adaptGroup9(raw["server.permission"]),
+  files: adaptGroup10(raw["server.fs"]),
+  commands: adaptGroup11(raw["server.command"]),
+  skills: adaptGroup12(raw["server.skill"]),
+  events: adaptGroup13(raw["server.event"]),
+  ptys: adaptGroup14(raw["server.pty"]),
+  questions: adaptGroup15(raw["server.question"]),
+  references: adaptGroup16(raw["server.reference"]),
+  projectCopies: adaptGroup17(raw["server.projectCopy"]),
+})
 
 export const make = (options?: { readonly baseUrl?: URL | string }) =>
   HttpApiClient.make(Api, options).pipe(Effect.map(adaptClient))

--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -1,4 +1,9 @@
 import type {
+  HealthGetOutput,
+  LocationGetInput,
+  LocationGetOutput,
+  AgentsListInput,
+  AgentsListOutput,
   SessionsListInput,
   SessionsListOutput,
   SessionsCreateInput,
@@ -30,6 +35,87 @@ import type {
   SessionsInterruptOutput,
   SessionsMessageInput,
   SessionsMessageOutput,
+  MessagesListInput,
+  MessagesListOutput,
+  ModelsListInput,
+  ModelsListOutput,
+  ProvidersListInput,
+  ProvidersListOutput,
+  ProvidersGetInput,
+  ProvidersGetOutput,
+  IntegrationsListInput,
+  IntegrationsListOutput,
+  IntegrationsGetInput,
+  IntegrationsGetOutput,
+  IntegrationsConnectKeyInput,
+  IntegrationsConnectKeyOutput,
+  IntegrationsConnectOauthInput,
+  IntegrationsConnectOauthOutput,
+  IntegrationsAttemptStatusInput,
+  IntegrationsAttemptStatusOutput,
+  IntegrationsAttemptCompleteInput,
+  IntegrationsAttemptCompleteOutput,
+  IntegrationsAttemptCancelInput,
+  IntegrationsAttemptCancelOutput,
+  CredentialsUpdateInput,
+  CredentialsUpdateOutput,
+  CredentialsRemoveInput,
+  CredentialsRemoveOutput,
+  PermissionsListRequestsInput,
+  PermissionsListRequestsOutput,
+  PermissionsListSavedInput,
+  PermissionsListSavedOutput,
+  PermissionsRemoveSavedInput,
+  PermissionsRemoveSavedOutput,
+  PermissionsCreateInput,
+  PermissionsCreateOutput,
+  PermissionsListInput,
+  PermissionsListOutput,
+  PermissionsGetInput,
+  PermissionsGetOutput,
+  PermissionsReplyInput,
+  PermissionsReplyOutput,
+  FilesReadInput,
+  FilesReadOutput,
+  FilesListInput,
+  FilesListOutput,
+  FilesFindInput,
+  FilesFindOutput,
+  CommandsListInput,
+  CommandsListOutput,
+  SkillsListInput,
+  SkillsListOutput,
+  EventsSubscribeOutput,
+  PtysListInput,
+  PtysListOutput,
+  PtysCreateInput,
+  PtysCreateOutput,
+  PtysGetInput,
+  PtysGetOutput,
+  PtysUpdateInput,
+  PtysUpdateOutput,
+  PtysRemoveInput,
+  PtysRemoveOutput,
+  PtysConnectTokenInput,
+  PtysConnectTokenOutput,
+  PtysConnectInput,
+  PtysConnectOutput,
+  QuestionsListRequestsInput,
+  QuestionsListRequestsOutput,
+  QuestionsListInput,
+  QuestionsListOutput,
+  QuestionsReplyInput,
+  QuestionsReplyOutput,
+  QuestionsRejectInput,
+  QuestionsRejectOutput,
+  ReferencesListInput,
+  ReferencesListOutput,
+  ProjectCopiesCreateInput,
+  ProjectCopiesCreateOutput,
+  ProjectCopiesRemoveInput,
+  ProjectCopiesRemoveOutput,
+  ProjectCopiesRefreshInput,
+  ProjectCopiesRefreshOutput,
 } from "./types"
 import { ClientError } from "./client-error"
 
@@ -53,6 +139,7 @@ interface RequestDescriptor {
   readonly successStatus: number
   readonly declaredStatuses: ReadonlyArray<number>
   readonly empty: boolean
+  readonly binary: boolean
 }
 
 export function make(options: ClientOptions) {
@@ -103,6 +190,13 @@ export function make(options: ClientOptions) {
         await response.body?.cancel()
       } catch {}
       return undefined as A
+    }
+    if (descriptor.binary) {
+      try {
+        return new Uint8Array(await response.arrayBuffer()) as A
+      } catch (cause) {
+        throw new ClientError("Transport", { cause })
+      }
     }
     return (await json(response)) as A
   }
@@ -165,6 +259,50 @@ export function make(options: ClientOptions) {
   })
 
   return {
+    health: {
+      get: (requestOptions?: RequestOptions) =>
+        request<HealthGetOutput>(
+          {
+            method: "GET",
+            path: `/api/health`,
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    location: {
+      get: (input?: LocationGetInput, requestOptions?: RequestOptions) =>
+        request<LocationGetOutput>(
+          {
+            method: "GET",
+            path: `/api/location`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    agents: {
+      list: (input?: AgentsListInput, requestOptions?: RequestOptions) =>
+        request<AgentsListOutput>(
+          {
+            method: "GET",
+            path: `/api/agent`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
     sessions: {
       list: (input?: SessionsListInput, requestOptions?: RequestOptions) =>
         request<SessionsListOutput>(
@@ -184,6 +322,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [400, 401],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ),
@@ -196,6 +335,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [401, 400],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ).then((value) => value.data),
@@ -207,6 +347,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [401, 400],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ).then((value) => value.data),
@@ -218,6 +359,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [404, 400, 401],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ).then((value) => value.data),
@@ -230,6 +372,7 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 400, 401],
             empty: true,
+            binary: false,
           },
           requestOptions,
         ),
@@ -242,6 +385,7 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 400, 401],
             empty: true,
+            binary: false,
           },
           requestOptions,
         ),
@@ -254,6 +398,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [409, 404, 400, 401],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ).then((value) => value.data),
@@ -265,6 +410,7 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 503, 400, 401],
             empty: true,
+            binary: false,
           },
           requestOptions,
         ),
@@ -276,6 +422,7 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 503, 400, 401],
             empty: true,
+            binary: false,
           },
           requestOptions,
         ),
@@ -288,6 +435,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [404, 500, 400, 401],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ).then((value) => value.data),
@@ -299,6 +447,7 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 500, 400, 401],
             empty: true,
+            binary: false,
           },
           requestOptions,
         ),
@@ -310,6 +459,7 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 400, 401],
             empty: true,
+            binary: false,
           },
           requestOptions,
         ),
@@ -321,6 +471,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [404, 500, 400, 401],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ).then((value) => value.data),
@@ -333,6 +484,7 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [404, 400, 401],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ),
@@ -344,6 +496,7 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 400, 401],
             empty: true,
+            binary: false,
           },
           requestOptions,
         ),
@@ -355,9 +508,580 @@ export function make(options: ClientOptions) {
             successStatus: 200,
             declaredStatuses: [404, 400, 401],
             empty: false,
+            binary: false,
           },
           requestOptions,
         ).then((value) => value.data),
+    },
+    messages: {
+      list: (input: MessagesListInput, requestOptions?: RequestOptions) =>
+        request<MessagesListOutput>(
+          {
+            method: "GET",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/message`,
+            query: { limit: input.limit, order: input.order, cursor: input.cursor },
+            successStatus: 200,
+            declaredStatuses: [400, 404, 500, 401],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    models: {
+      list: (input?: ModelsListInput, requestOptions?: RequestOptions) =>
+        request<ModelsListOutput>(
+          {
+            method: "GET",
+            path: `/api/model`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [503, 401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    providers: {
+      list: (input?: ProvidersListInput, requestOptions?: RequestOptions) =>
+        request<ProvidersListOutput>(
+          {
+            method: "GET",
+            path: `/api/provider`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [503, 401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      get: (input: ProvidersGetInput, requestOptions?: RequestOptions) =>
+        request<ProvidersGetOutput>(
+          {
+            method: "GET",
+            path: `/api/provider/${encodeURIComponent(input.providerID)}`,
+            query: { location: input.location },
+            successStatus: 200,
+            declaredStatuses: [404, 503, 401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    integrations: {
+      list: (input?: IntegrationsListInput, requestOptions?: RequestOptions) =>
+        request<IntegrationsListOutput>(
+          {
+            method: "GET",
+            path: `/api/integration`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      get: (input: IntegrationsGetInput, requestOptions?: RequestOptions) =>
+        request<IntegrationsGetOutput>(
+          {
+            method: "GET",
+            path: `/api/integration/${encodeURIComponent(input.integrationID)}`,
+            query: { location: input.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      connectKey: (input: IntegrationsConnectKeyInput, requestOptions?: RequestOptions) =>
+        request<IntegrationsConnectKeyOutput>(
+          {
+            method: "POST",
+            path: `/api/integration/${encodeURIComponent(input.integrationID)}/connect/key`,
+            query: { location: input.location },
+            body: { key: input.key, label: input.label },
+            successStatus: 204,
+            declaredStatuses: [400, 401],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      connectOauth: (input: IntegrationsConnectOauthInput, requestOptions?: RequestOptions) =>
+        request<IntegrationsConnectOauthOutput>(
+          {
+            method: "POST",
+            path: `/api/integration/${encodeURIComponent(input.integrationID)}/connect/oauth`,
+            query: { location: input.location },
+            body: { methodID: input.methodID, inputs: input.inputs, label: input.label },
+            successStatus: 200,
+            declaredStatuses: [400, 401],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      attemptStatus: (input: IntegrationsAttemptStatusInput, requestOptions?: RequestOptions) =>
+        request<IntegrationsAttemptStatusOutput>(
+          {
+            method: "GET",
+            path: `/api/integration/attempt/${encodeURIComponent(input.attemptID)}`,
+            query: { location: input.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      attemptComplete: (input: IntegrationsAttemptCompleteInput, requestOptions?: RequestOptions) =>
+        request<IntegrationsAttemptCompleteOutput>(
+          {
+            method: "POST",
+            path: `/api/integration/attempt/${encodeURIComponent(input.attemptID)}/complete`,
+            query: { location: input.location },
+            body: { code: input.code },
+            successStatus: 204,
+            declaredStatuses: [400, 401],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      attemptCancel: (input: IntegrationsAttemptCancelInput, requestOptions?: RequestOptions) =>
+        request<IntegrationsAttemptCancelOutput>(
+          {
+            method: "DELETE",
+            path: `/api/integration/attempt/${encodeURIComponent(input.attemptID)}`,
+            query: { location: input.location },
+            successStatus: 204,
+            declaredStatuses: [401, 400],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    credentials: {
+      update: (input: CredentialsUpdateInput, requestOptions?: RequestOptions) =>
+        request<CredentialsUpdateOutput>(
+          {
+            method: "PATCH",
+            path: `/api/credential/${encodeURIComponent(input.credentialID)}`,
+            query: { location: input.location },
+            body: { label: input.label },
+            successStatus: 204,
+            declaredStatuses: [401, 400],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      remove: (input: CredentialsRemoveInput, requestOptions?: RequestOptions) =>
+        request<CredentialsRemoveOutput>(
+          {
+            method: "DELETE",
+            path: `/api/credential/${encodeURIComponent(input.credentialID)}`,
+            query: { location: input.location },
+            successStatus: 204,
+            declaredStatuses: [401, 400],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    permissions: {
+      listRequests: (input?: PermissionsListRequestsInput, requestOptions?: RequestOptions) =>
+        request<PermissionsListRequestsOutput>(
+          {
+            method: "GET",
+            path: `/api/permission/request`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      listSaved: (input?: PermissionsListSavedInput, requestOptions?: RequestOptions) =>
+        request<{ readonly data: PermissionsListSavedOutput }>(
+          {
+            method: "GET",
+            path: `/api/permission/saved`,
+            query: { projectID: input?.projectID },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ).then((value) => value.data),
+      removeSaved: (input: PermissionsRemoveSavedInput, requestOptions?: RequestOptions) =>
+        request<PermissionsRemoveSavedOutput>(
+          {
+            method: "DELETE",
+            path: `/api/permission/saved/${encodeURIComponent(input.id)}`,
+            successStatus: 204,
+            declaredStatuses: [401, 400],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      create: (input: PermissionsCreateInput, requestOptions?: RequestOptions) =>
+        request<{ readonly data: PermissionsCreateOutput }>(
+          {
+            method: "POST",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/permission`,
+            body: {
+              id: input.id,
+              action: input.action,
+              resources: input.resources,
+              save: input.save,
+              metadata: input.metadata,
+              source: input.source,
+              agent: input.agent,
+            },
+            successStatus: 200,
+            declaredStatuses: [404, 400, 401],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ).then((value) => value.data),
+      list: (input: PermissionsListInput, requestOptions?: RequestOptions) =>
+        request<{ readonly data: PermissionsListOutput }>(
+          {
+            method: "GET",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/permission`,
+            successStatus: 200,
+            declaredStatuses: [404, 400, 401],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ).then((value) => value.data),
+      get: (input: PermissionsGetInput, requestOptions?: RequestOptions) =>
+        request<{ readonly data: PermissionsGetOutput }>(
+          {
+            method: "GET",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/permission/${encodeURIComponent(input.requestID)}`,
+            successStatus: 200,
+            declaredStatuses: [404, 400, 401],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ).then((value) => value.data),
+      reply: (input: PermissionsReplyInput, requestOptions?: RequestOptions) =>
+        request<PermissionsReplyOutput>(
+          {
+            method: "POST",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/permission/${encodeURIComponent(input.requestID)}/reply`,
+            body: { reply: input.reply, message: input.message },
+            successStatus: 204,
+            declaredStatuses: [404, 400, 401],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    files: {
+      read: (input?: FilesReadInput, requestOptions?: RequestOptions) =>
+        request<FilesReadOutput>(
+          {
+            method: "GET",
+            path: `/api/fs/read/*`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: true,
+          },
+          requestOptions,
+        ),
+      list: (input?: FilesListInput, requestOptions?: RequestOptions) =>
+        request<FilesListOutput>(
+          {
+            method: "GET",
+            path: `/api/fs/list`,
+            query: { location: input?.location, path: input?.path },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      find: (input: FilesFindInput, requestOptions?: RequestOptions) =>
+        request<FilesFindOutput>(
+          {
+            method: "GET",
+            path: `/api/fs/find`,
+            query: { location: input.location, query: input.query, type: input.type, limit: input.limit },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    commands: {
+      list: (input?: CommandsListInput, requestOptions?: RequestOptions) =>
+        request<CommandsListOutput>(
+          {
+            method: "GET",
+            path: `/api/command`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    skills: {
+      list: (input?: SkillsListInput, requestOptions?: RequestOptions) =>
+        request<SkillsListOutput>(
+          {
+            method: "GET",
+            path: `/api/skill`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    events: {
+      subscribe: (requestOptions?: RequestOptions) =>
+        request<EventsSubscribeOutput>(
+          {
+            method: "GET",
+            path: `/api/event`,
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    ptys: {
+      list: (input?: PtysListInput, requestOptions?: RequestOptions) =>
+        request<PtysListOutput>(
+          {
+            method: "GET",
+            path: `/api/pty`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      create: (input?: PtysCreateInput, requestOptions?: RequestOptions) =>
+        request<PtysCreateOutput>(
+          {
+            method: "POST",
+            path: `/api/pty`,
+            query: { location: input?.location },
+            body: { command: input?.command, args: input?.args, cwd: input?.cwd, title: input?.title, env: input?.env },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      get: (input: PtysGetInput, requestOptions?: RequestOptions) =>
+        request<PtysGetOutput>(
+          {
+            method: "GET",
+            path: `/api/pty/${encodeURIComponent(input.ptyID)}`,
+            query: { location: input.location },
+            successStatus: 200,
+            declaredStatuses: [404, 401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      update: (input: PtysUpdateInput, requestOptions?: RequestOptions) =>
+        request<PtysUpdateOutput>(
+          {
+            method: "PUT",
+            path: `/api/pty/${encodeURIComponent(input.ptyID)}`,
+            query: { location: input.location },
+            body: { title: input.title, size: input.size },
+            successStatus: 200,
+            declaredStatuses: [404, 401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      remove: (input: PtysRemoveInput, requestOptions?: RequestOptions) =>
+        request<PtysRemoveOutput>(
+          {
+            method: "DELETE",
+            path: `/api/pty/${encodeURIComponent(input.ptyID)}`,
+            query: { location: input.location },
+            successStatus: 204,
+            declaredStatuses: [404, 401, 400],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      connectToken: (input: PtysConnectTokenInput, requestOptions?: RequestOptions) =>
+        request<PtysConnectTokenOutput>(
+          {
+            method: "POST",
+            path: `/api/pty/${encodeURIComponent(input.ptyID)}/connect-token`,
+            query: { location: input.location },
+            successStatus: 200,
+            declaredStatuses: [403, 404, 401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      connect: (input: PtysConnectInput, requestOptions?: RequestOptions) =>
+        request<PtysConnectOutput>(
+          {
+            method: "GET",
+            path: `/api/pty/${encodeURIComponent(input.ptyID)}/connect`,
+            successStatus: 200,
+            declaredStatuses: [403, 404, 401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    questions: {
+      listRequests: (input?: QuestionsListRequestsInput, requestOptions?: RequestOptions) =>
+        request<QuestionsListRequestsOutput>(
+          {
+            method: "GET",
+            path: `/api/question/request`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      list: (input: QuestionsListInput, requestOptions?: RequestOptions) =>
+        request<{ readonly data: QuestionsListOutput }>(
+          {
+            method: "GET",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/question`,
+            successStatus: 200,
+            declaredStatuses: [404, 400, 401],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ).then((value) => value.data),
+      reply: (input: QuestionsReplyInput, requestOptions?: RequestOptions) =>
+        request<QuestionsReplyOutput>(
+          {
+            method: "POST",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/question/${encodeURIComponent(input.requestID)}/reply`,
+            body: { answers: input.answers },
+            successStatus: 204,
+            declaredStatuses: [404, 400, 401],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      reject: (input: QuestionsRejectInput, requestOptions?: RequestOptions) =>
+        request<QuestionsRejectOutput>(
+          {
+            method: "POST",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/question/${encodeURIComponent(input.requestID)}/reject`,
+            successStatus: 204,
+            declaredStatuses: [404, 400, 401],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    references: {
+      list: (input?: ReferencesListInput, requestOptions?: RequestOptions) =>
+        request<ReferencesListOutput>(
+          {
+            method: "GET",
+            path: `/api/reference`,
+            query: { location: input?.location },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+    },
+    projectCopies: {
+      create: (input: ProjectCopiesCreateInput, requestOptions?: RequestOptions) =>
+        request<ProjectCopiesCreateOutput>(
+          {
+            method: "POST",
+            path: `/experimental/project/${encodeURIComponent(input.projectID)}/copy`,
+            query: { location: input.location },
+            body: { strategy: input.strategy, directory: input.directory, name: input.name },
+            successStatus: 200,
+            declaredStatuses: [400, 401],
+            empty: false,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      remove: (input: ProjectCopiesRemoveInput, requestOptions?: RequestOptions) =>
+        request<ProjectCopiesRemoveOutput>(
+          {
+            method: "DELETE",
+            path: `/experimental/project/${encodeURIComponent(input.projectID)}/copy`,
+            query: { location: input.location },
+            body: { directory: input.directory, force: input.force },
+            successStatus: 204,
+            declaredStatuses: [400, 401],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
+      refresh: (input: ProjectCopiesRefreshInput, requestOptions?: RequestOptions) =>
+        request<ProjectCopiesRefreshOutput>(
+          {
+            method: "POST",
+            path: `/experimental/project/${encodeURIComponent(input.projectID)}/copy/refresh`,
+            query: { location: input.location },
+            successStatus: 204,
+            declaredStatuses: [400, 401],
+            empty: true,
+            binary: false,
+          },
+          requestOptions,
+        ),
     },
   }
 }

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -6,9 +6,9 @@ export type JsonValue =
   | ReadonlyArray<JsonValue>
   | { readonly [key: string]: JsonValue }
 
-export type InvalidCursorError = { readonly _tag: "InvalidCursorError"; readonly message: string }
-export const isInvalidCursorError = (value: unknown): value is InvalidCursorError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "InvalidCursorError"
+export type UnauthorizedError = { readonly _tag: "UnauthorizedError"; readonly message: string }
+export const isUnauthorizedError = (value: unknown): value is UnauthorizedError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "UnauthorizedError"
 
 export type InvalidRequestError = {
   readonly _tag: "InvalidRequestError"
@@ -17,11 +17,11 @@ export type InvalidRequestError = {
   readonly field?: string | undefined
 }
 export const isInvalidRequestError = (value: unknown): value is InvalidRequestError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "InvalidRequestError"
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "InvalidRequestError"
 
-export type UnauthorizedError = { readonly _tag: "UnauthorizedError"; readonly message: string }
-export const isUnauthorizedError = (value: unknown): value is UnauthorizedError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "UnauthorizedError"
+export type InvalidCursorError = { readonly _tag: "InvalidCursorError"; readonly message: string }
+export const isInvalidCursorError = (value: unknown): value is InvalidCursorError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "InvalidCursorError"
 
 export type SessionNotFoundError = {
   readonly _tag: "SessionNotFoundError"
@@ -29,7 +29,7 @@ export type SessionNotFoundError = {
   readonly message: string
 }
 export const isSessionNotFoundError = (value: unknown): value is SessionNotFoundError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "SessionNotFoundError"
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "SessionNotFoundError"
 
 export type ConflictError = {
   readonly _tag: "ConflictError"
@@ -37,7 +37,7 @@ export type ConflictError = {
   readonly resource?: string | undefined
 }
 export const isConflictError = (value: unknown): value is ConflictError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "ConflictError"
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "ConflictError"
 
 export type ServiceUnavailableError = {
   readonly _tag: "ServiceUnavailableError"
@@ -45,7 +45,7 @@ export type ServiceUnavailableError = {
   readonly service?: string | undefined
 }
 export const isServiceUnavailableError = (value: unknown): value is ServiceUnavailableError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "ServiceUnavailableError"
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "ServiceUnavailableError"
 
 export type MessageNotFoundError = {
   readonly _tag: "MessageNotFoundError"
@@ -54,7 +54,7 @@ export type MessageNotFoundError = {
   readonly message: string
 }
 export const isMessageNotFoundError = (value: unknown): value is MessageNotFoundError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "MessageNotFoundError"
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "MessageNotFoundError"
 
 export type UnknownError = {
   readonly _tag: "UnknownError"
@@ -62,7 +62,93 @@ export type UnknownError = {
   readonly ref?: string | undefined
 }
 export const isUnknownError = (value: unknown): value is UnknownError =>
-  typeof value === "object" && value !== null && "_tag" in value && value._tag === "UnknownError"
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "UnknownError"
+
+export type ProviderNotFoundError = {
+  readonly _tag: "ProviderNotFoundError"
+  readonly providerID: string
+  readonly message: string
+}
+export const isProviderNotFoundError = (value: unknown): value is ProviderNotFoundError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "ProviderNotFoundError"
+
+export type PermissionNotFoundError = {
+  readonly _tag: "PermissionNotFoundError"
+  readonly requestID: string
+  readonly message: string
+}
+export const isPermissionNotFoundError = (value: unknown): value is PermissionNotFoundError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "PermissionNotFoundError"
+
+export type PtyNotFoundError = { readonly _tag: "PtyNotFoundError"; readonly ptyID: string; readonly message: string }
+export const isPtyNotFoundError = (value: unknown): value is PtyNotFoundError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "PtyNotFoundError"
+
+export type ForbiddenError = { readonly _tag: "ForbiddenError"; readonly message: string }
+export const isForbiddenError = (value: unknown): value is ForbiddenError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "ForbiddenError"
+
+export type QuestionNotFoundError = {
+  readonly _tag: "QuestionNotFoundError"
+  readonly requestID: string
+  readonly message: string
+}
+export const isQuestionNotFoundError = (value: unknown): value is QuestionNotFoundError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "QuestionNotFoundError"
+
+export type ProjectCopyError = {
+  readonly name: "ProjectCopyError"
+  readonly data: { readonly message: string; readonly forceRequired?: boolean | undefined }
+}
+export const isProjectCopyError = (value: unknown): value is ProjectCopyError =>
+  typeof value === "object" && value !== null && "name" in value && value["name"] === "ProjectCopyError"
+
+export type HealthGetOutput = { readonly healthy: true }
+
+export type LocationGetInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type LocationGetOutput = {
+  readonly directory: string
+  readonly workspaceID?: string
+  readonly project: { readonly id: string; readonly directory: string }
+}
+
+export type AgentsListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type AgentsListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
+    readonly request: {
+      readonly headers: { readonly [x: string]: string }
+      readonly body: { readonly [x: string]: JsonValue }
+    }
+    readonly system?: string
+    readonly description?: string
+    readonly mode: "subagent" | "primary" | "all"
+    readonly hidden: boolean
+    readonly color?: string | "primary" | "secondary" | "accent" | "success" | "warning" | "error" | "info"
+    readonly steps?: number
+    readonly permissions: ReadonlyArray<{
+      readonly action: string
+      readonly resource: string
+      readonly effect: "allow" | "deny" | "ask"
+    }>
+  }>
+}
 
 export type SessionsListInput = {
   readonly workspace?: {
@@ -1208,3 +1294,2320 @@ export type SessionsMessageOutput = {
         readonly time: { readonly created: number }
       }
 }["data"]
+
+export type MessagesListInput = {
+  readonly sessionID: { readonly sessionID: string }["sessionID"]
+  readonly limit?: {
+    readonly limit?: string | undefined
+    readonly order?: "asc" | "desc" | undefined
+    readonly cursor?: string | undefined
+  }["limit"]
+  readonly order?: {
+    readonly limit?: string | undefined
+    readonly order?: "asc" | "desc" | undefined
+    readonly cursor?: string | undefined
+  }["order"]
+  readonly cursor?: {
+    readonly limit?: string | undefined
+    readonly order?: "asc" | "desc" | undefined
+    readonly cursor?: string | undefined
+  }["cursor"]
+}
+
+export type MessagesListOutput = {
+  readonly data: ReadonlyArray<
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly type: "agent-switched"
+        readonly agent: string
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly type: "model-switched"
+        readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly text: string
+        readonly files?: ReadonlyArray<{
+          readonly uri: string
+          readonly mime: string
+          readonly name?: string
+          readonly description?: string
+          readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+        }>
+        readonly agents?: ReadonlyArray<{
+          readonly name: string
+          readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+        }>
+        readonly type: "user"
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly sessionID: string
+        readonly text: string
+        readonly type: "synthetic"
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+        readonly type: "system"
+        readonly text: string
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number; readonly completed?: number }
+        readonly type: "shell"
+        readonly callID: string
+        readonly command: string
+        readonly output: string
+      }
+    | {
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number; readonly completed?: number }
+        readonly type: "assistant"
+        readonly agent: string
+        readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+        readonly content: ReadonlyArray<
+          | { readonly type: "text"; readonly id: string; readonly text: string }
+          | {
+              readonly type: "reasoning"
+              readonly id: string
+              readonly text: string
+              readonly providerMetadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+              readonly time?: { readonly created: number; readonly completed?: number }
+            }
+          | {
+              readonly type: "tool"
+              readonly id: string
+              readonly name: string
+              readonly provider?: {
+                readonly executed: boolean
+                readonly metadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+                readonly resultMetadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+              }
+              readonly state:
+                | { readonly status: "pending"; readonly input: string }
+                | {
+                    readonly status: "running"
+                    readonly input: { readonly [x: string]: JsonValue }
+                    readonly structured: { readonly [x: string]: JsonValue }
+                    readonly content: ReadonlyArray<
+                      | { readonly type: "text"; readonly text: string }
+                      | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+                    >
+                  }
+                | {
+                    readonly status: "completed"
+                    readonly input: { readonly [x: string]: JsonValue }
+                    readonly attachments?: ReadonlyArray<{
+                      readonly uri: string
+                      readonly mime: string
+                      readonly name?: string
+                      readonly description?: string
+                      readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+                    }>
+                    readonly content: ReadonlyArray<
+                      | { readonly type: "text"; readonly text: string }
+                      | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+                    >
+                    readonly outputPaths?: ReadonlyArray<string>
+                    readonly structured: { readonly [x: string]: JsonValue }
+                    readonly result?: JsonValue
+                  }
+                | {
+                    readonly status: "error"
+                    readonly input: { readonly [x: string]: JsonValue }
+                    readonly content: ReadonlyArray<
+                      | { readonly type: "text"; readonly text: string }
+                      | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+                    >
+                    readonly structured: { readonly [x: string]: JsonValue }
+                    readonly error: { readonly type: "unknown"; readonly message: string }
+                    readonly result?: JsonValue
+                  }
+              readonly time: {
+                readonly created: number
+                readonly ran?: number
+                readonly completed?: number
+                readonly pruned?: number
+              }
+            }
+        >
+        readonly snapshot?: { readonly start?: string; readonly end?: string; readonly files?: ReadonlyArray<string> }
+        readonly finish?: string
+        readonly cost?: number
+        readonly tokens?: {
+          readonly input: number
+          readonly output: number
+          readonly reasoning: number
+          readonly cache: { readonly read: number; readonly write: number }
+        }
+        readonly error?: { readonly type: "unknown"; readonly message: string }
+      }
+    | {
+        readonly type: "compaction"
+        readonly reason: "auto" | "manual"
+        readonly summary: string
+        readonly recent: string
+        readonly id: string
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly time: { readonly created: number }
+      }
+  >
+  readonly cursor: { readonly previous?: string | null; readonly next?: string | null }
+}
+
+export type ModelsListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type ModelsListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly providerID: string
+    readonly family?: string
+    readonly name: string
+    readonly api:
+      | {
+          readonly id: string
+          readonly type: "aisdk"
+          readonly package: string
+          readonly url?: string
+          readonly settings?: { readonly [x: string]: JsonValue }
+        }
+      | {
+          readonly id: string
+          readonly type: "native"
+          readonly url?: string
+          readonly settings: { readonly [x: string]: JsonValue }
+        }
+    readonly capabilities: {
+      readonly tools: boolean
+      readonly input: ReadonlyArray<string>
+      readonly output: ReadonlyArray<string>
+    }
+    readonly request: {
+      readonly headers: { readonly [x: string]: string }
+      readonly body: { readonly [x: string]: JsonValue }
+      readonly variant?: string
+    }
+    readonly variants: ReadonlyArray<{
+      readonly id: string
+      readonly headers: { readonly [x: string]: string }
+      readonly body: { readonly [x: string]: JsonValue }
+    }>
+    readonly time: { readonly released: number }
+    readonly cost: ReadonlyArray<{
+      readonly tier?: { readonly type: "context"; readonly size: number }
+      readonly input: number
+      readonly output: number
+      readonly cache: { readonly read: number; readonly write: number }
+    }>
+    readonly status: "alpha" | "beta" | "deprecated" | "active"
+    readonly enabled: boolean
+    readonly limit: { readonly context: number; readonly input?: number; readonly output: number }
+  }>
+}
+
+export type ProvidersListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type ProvidersListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly integrationID?: string
+    readonly name: string
+    readonly disabled?: boolean
+    readonly api:
+      | {
+          readonly type: "aisdk"
+          readonly package: string
+          readonly url?: string
+          readonly settings?: { readonly [x: string]: JsonValue }
+        }
+      | { readonly type: "native"; readonly url?: string; readonly settings: { readonly [x: string]: JsonValue } }
+    readonly request: {
+      readonly headers: { readonly [x: string]: string }
+      readonly body: { readonly [x: string]: JsonValue }
+    }
+  }>
+}
+
+export type ProvidersGetInput = {
+  readonly providerID: { readonly providerID: string }["providerID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type ProvidersGetOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: {
+    readonly id: string
+    readonly integrationID?: string
+    readonly name: string
+    readonly disabled?: boolean
+    readonly api:
+      | {
+          readonly type: "aisdk"
+          readonly package: string
+          readonly url?: string
+          readonly settings?: { readonly [x: string]: JsonValue }
+        }
+      | { readonly type: "native"; readonly url?: string; readonly settings: { readonly [x: string]: JsonValue } }
+    readonly request: {
+      readonly headers: { readonly [x: string]: string }
+      readonly body: { readonly [x: string]: JsonValue }
+    }
+  }
+}
+
+export type IntegrationsListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type IntegrationsListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly name: string
+    readonly methods: ReadonlyArray<
+      | {
+          readonly id: string
+          readonly type: "oauth"
+          readonly label: string
+          readonly prompts?: ReadonlyArray<
+            | {
+                readonly type: "text"
+                readonly key: string
+                readonly message: string
+                readonly placeholder?: string
+                readonly when?: { readonly key: string; readonly op: "eq" | "neq"; readonly value: string }
+              }
+            | {
+                readonly type: "select"
+                readonly key: string
+                readonly message: string
+                readonly options: ReadonlyArray<{
+                  readonly label: string
+                  readonly value: string
+                  readonly hint?: string
+                }>
+                readonly when?: { readonly key: string; readonly op: "eq" | "neq"; readonly value: string }
+              }
+          >
+        }
+      | { readonly type: "key"; readonly label?: string }
+      | { readonly type: "env"; readonly names: ReadonlyArray<string> }
+    >
+    readonly connections: ReadonlyArray<
+      | { readonly type: "credential"; readonly id: string; readonly label: string }
+      | { readonly type: "env"; readonly name: string }
+    >
+  }>
+}
+
+export type IntegrationsGetInput = {
+  readonly integrationID: { readonly integrationID: string }["integrationID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type IntegrationsGetOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: {
+    readonly id: string
+    readonly name: string
+    readonly methods: ReadonlyArray<
+      | {
+          readonly id: string
+          readonly type: "oauth"
+          readonly label: string
+          readonly prompts?: ReadonlyArray<
+            | {
+                readonly type: "text"
+                readonly key: string
+                readonly message: string
+                readonly placeholder?: string
+                readonly when?: { readonly key: string; readonly op: "eq" | "neq"; readonly value: string }
+              }
+            | {
+                readonly type: "select"
+                readonly key: string
+                readonly message: string
+                readonly options: ReadonlyArray<{
+                  readonly label: string
+                  readonly value: string
+                  readonly hint?: string
+                }>
+                readonly when?: { readonly key: string; readonly op: "eq" | "neq"; readonly value: string }
+              }
+          >
+        }
+      | { readonly type: "key"; readonly label?: string }
+      | { readonly type: "env"; readonly names: ReadonlyArray<string> }
+    >
+    readonly connections: ReadonlyArray<
+      | { readonly type: "credential"; readonly id: string; readonly label: string }
+      | { readonly type: "env"; readonly name: string }
+    >
+  } | null
+}
+
+export type IntegrationsConnectKeyInput = {
+  readonly integrationID: { readonly integrationID: string }["integrationID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly key: { readonly key: string; readonly label?: string | undefined }["key"]
+  readonly label?: { readonly key: string; readonly label?: string | undefined }["label"]
+}
+
+export type IntegrationsConnectKeyOutput = void
+
+export type IntegrationsConnectOauthInput = {
+  readonly integrationID: { readonly integrationID: string }["integrationID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly methodID: {
+    readonly methodID: string
+    readonly inputs: { readonly [x: string]: string }
+    readonly label?: string | undefined
+  }["methodID"]
+  readonly inputs: {
+    readonly methodID: string
+    readonly inputs: { readonly [x: string]: string }
+    readonly label?: string | undefined
+  }["inputs"]
+  readonly label?: {
+    readonly methodID: string
+    readonly inputs: { readonly [x: string]: string }
+    readonly label?: string | undefined
+  }["label"]
+}
+
+export type IntegrationsConnectOauthOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: {
+    readonly attemptID: string
+    readonly url: string
+    readonly instructions: string
+    readonly mode: "auto" | "code"
+    readonly time: {
+      readonly created: number | "Infinity" | "-Infinity" | "NaN"
+      readonly expires: number | "Infinity" | "-Infinity" | "NaN"
+    }
+  }
+}
+
+export type IntegrationsAttemptStatusInput = {
+  readonly attemptID: { readonly attemptID: string }["attemptID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type IntegrationsAttemptStatusOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data:
+    | {
+        readonly status: "pending"
+        readonly time: {
+          readonly created: number | "Infinity" | "-Infinity" | "NaN"
+          readonly expires: number | "Infinity" | "-Infinity" | "NaN"
+        }
+      }
+    | {
+        readonly status: "complete"
+        readonly time: {
+          readonly created: number | "Infinity" | "-Infinity" | "NaN"
+          readonly expires: number | "Infinity" | "-Infinity" | "NaN"
+        }
+      }
+    | {
+        readonly status: "failed"
+        readonly message: string
+        readonly time: {
+          readonly created: number | "Infinity" | "-Infinity" | "NaN"
+          readonly expires: number | "Infinity" | "-Infinity" | "NaN"
+        }
+      }
+    | {
+        readonly status: "expired"
+        readonly time: {
+          readonly created: number | "Infinity" | "-Infinity" | "NaN"
+          readonly expires: number | "Infinity" | "-Infinity" | "NaN"
+        }
+      }
+}
+
+export type IntegrationsAttemptCompleteInput = {
+  readonly attemptID: { readonly attemptID: string }["attemptID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly code?: { readonly code?: string | undefined }["code"]
+}
+
+export type IntegrationsAttemptCompleteOutput = void
+
+export type IntegrationsAttemptCancelInput = {
+  readonly attemptID: { readonly attemptID: string }["attemptID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type IntegrationsAttemptCancelOutput = void
+
+export type CredentialsUpdateInput = {
+  readonly credentialID: { readonly credentialID: string }["credentialID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly label: { readonly label: string }["label"]
+}
+
+export type CredentialsUpdateOutput = void
+
+export type CredentialsRemoveInput = {
+  readonly credentialID: { readonly credentialID: string }["credentialID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type CredentialsRemoveOutput = void
+
+export type PermissionsListRequestsInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type PermissionsListRequestsOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly sessionID: string
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+  }>
+}
+
+export type PermissionsListSavedInput = {
+  readonly projectID?: { readonly projectID?: string | undefined }["projectID"]
+}
+
+export type PermissionsListSavedOutput = {
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly projectID: string
+    readonly action: string
+    readonly resource: string
+  }>
+}["data"]
+
+export type PermissionsRemoveSavedInput = { readonly id: { readonly id: string }["id"] }
+
+export type PermissionsRemoveSavedOutput = void
+
+export type PermissionsCreateInput = {
+  readonly sessionID: { readonly sessionID: string }["sessionID"]
+  readonly id?: {
+    readonly id?: string | null
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+    readonly agent?: string | null
+  }["id"]
+  readonly action: {
+    readonly id?: string | null
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+    readonly agent?: string | null
+  }["action"]
+  readonly resources: {
+    readonly id?: string | null
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+    readonly agent?: string | null
+  }["resources"]
+  readonly save?: {
+    readonly id?: string | null
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+    readonly agent?: string | null
+  }["save"]
+  readonly metadata?: {
+    readonly id?: string | null
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+    readonly agent?: string | null
+  }["metadata"]
+  readonly source?: {
+    readonly id?: string | null
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+    readonly agent?: string | null
+  }["source"]
+  readonly agent?: {
+    readonly id?: string | null
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+    readonly agent?: string | null
+  }["agent"]
+}
+
+export type PermissionsCreateOutput = {
+  readonly data: { readonly id: string; readonly effect: "allow" | "deny" | "ask" }
+}["data"]
+
+export type PermissionsListInput = { readonly sessionID: { readonly sessionID: string }["sessionID"] }
+
+export type PermissionsListOutput = {
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly sessionID: string
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+  }>
+}["data"]
+
+export type PermissionsGetInput = {
+  readonly sessionID: { readonly sessionID: string; readonly requestID: string }["sessionID"]
+  readonly requestID: { readonly sessionID: string; readonly requestID: string }["requestID"]
+}
+
+export type PermissionsGetOutput = {
+  readonly data: {
+    readonly id: string
+    readonly sessionID: string
+    readonly action: string
+    readonly resources: ReadonlyArray<string>
+    readonly save?: ReadonlyArray<string>
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+  }
+}["data"]
+
+export type PermissionsReplyInput = {
+  readonly sessionID: { readonly sessionID: string; readonly requestID: string }["sessionID"]
+  readonly requestID: { readonly sessionID: string; readonly requestID: string }["requestID"]
+  readonly reply: { readonly reply: "once" | "always" | "reject"; readonly message?: string | undefined }["reply"]
+  readonly message?: { readonly reply: "once" | "always" | "reject"; readonly message?: string | undefined }["message"]
+}
+
+export type PermissionsReplyOutput = void
+
+export type FilesReadInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type FilesReadOutput = globalThis.Uint8Array
+
+export type FilesListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+    readonly path?: string | undefined
+  }["location"]
+  readonly path?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+    readonly path?: string | undefined
+  }["path"]
+}
+
+export type FilesListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{ readonly path: string; readonly type: "file" | "directory" }>
+}
+
+export type FilesFindInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+    readonly query: string
+    readonly type?: "file" | "directory"
+    readonly limit?: string | undefined
+  }["location"]
+  readonly query: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+    readonly query: string
+    readonly type?: "file" | "directory"
+    readonly limit?: string | undefined
+  }["query"]
+  readonly type?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+    readonly query: string
+    readonly type?: "file" | "directory"
+    readonly limit?: string | undefined
+  }["type"]
+  readonly limit?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+    readonly query: string
+    readonly type?: "file" | "directory"
+    readonly limit?: string | undefined
+  }["limit"]
+}
+
+export type FilesFindOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{ readonly path: string; readonly type: "file" | "directory" }>
+}
+
+export type CommandsListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type CommandsListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly name: string
+    readonly template: string
+    readonly description?: string
+    readonly agent?: string
+    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
+    readonly subtask?: boolean
+  }>
+}
+
+export type SkillsListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type SkillsListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly name: string
+    readonly description?: string
+    readonly slash?: boolean
+    readonly location: string
+    readonly content: string
+  }>
+}
+
+export type EventsSubscribeOutput =
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "models-dev.refreshed"
+      readonly data: {}
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "integration.updated"
+      readonly data: {}
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "integration.connection.updated"
+      readonly data: { readonly integrationID: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "catalog.updated"
+      readonly data: {}
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.created"
+      readonly data: {
+        readonly sessionID: string
+        readonly info: {
+          readonly id: string
+          readonly slug: string
+          readonly projectID: string
+          readonly workspaceID?: string
+          readonly directory: string
+          readonly path?: string
+          readonly parentID?: string
+          readonly summary?: {
+            readonly additions: number
+            readonly deletions: number
+            readonly files: number
+            readonly diffs?: ReadonlyArray<{
+              readonly file?: string
+              readonly patch?: string
+              readonly additions: number
+              readonly deletions: number
+              readonly status?: "added" | "deleted" | "modified"
+            }>
+          }
+          readonly cost?: number
+          readonly tokens?: {
+            readonly input: number
+            readonly output: number
+            readonly reasoning: number
+            readonly cache: { readonly read: number; readonly write: number }
+          }
+          readonly share?: { readonly url: string }
+          readonly title: string
+          readonly agent?: string
+          readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
+          readonly version: string
+          readonly metadata?: { readonly [x: string]: any }
+          readonly time: {
+            readonly created: number
+            readonly updated: number
+            readonly compacting?: number
+            readonly archived?: number
+          }
+          readonly permission?: ReadonlyArray<{
+            readonly permission: string
+            readonly pattern: string
+            readonly action: "allow" | "deny" | "ask"
+          }>
+          readonly revert?: {
+            readonly messageID: string
+            readonly partID?: string
+            readonly snapshot?: string
+            readonly diff?: string
+          }
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.updated"
+      readonly data: {
+        readonly sessionID: string
+        readonly info: {
+          readonly id: string
+          readonly slug: string
+          readonly projectID: string
+          readonly workspaceID?: string
+          readonly directory: string
+          readonly path?: string
+          readonly parentID?: string
+          readonly summary?: {
+            readonly additions: number
+            readonly deletions: number
+            readonly files: number
+            readonly diffs?: ReadonlyArray<{
+              readonly file?: string
+              readonly patch?: string
+              readonly additions: number
+              readonly deletions: number
+              readonly status?: "added" | "deleted" | "modified"
+            }>
+          }
+          readonly cost?: number
+          readonly tokens?: {
+            readonly input: number
+            readonly output: number
+            readonly reasoning: number
+            readonly cache: { readonly read: number; readonly write: number }
+          }
+          readonly share?: { readonly url: string }
+          readonly title: string
+          readonly agent?: string
+          readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
+          readonly version: string
+          readonly metadata?: { readonly [x: string]: any }
+          readonly time: {
+            readonly created: number
+            readonly updated: number
+            readonly compacting?: number
+            readonly archived?: number
+          }
+          readonly permission?: ReadonlyArray<{
+            readonly permission: string
+            readonly pattern: string
+            readonly action: "allow" | "deny" | "ask"
+          }>
+          readonly revert?: {
+            readonly messageID: string
+            readonly partID?: string
+            readonly snapshot?: string
+            readonly diff?: string
+          }
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.deleted"
+      readonly data: {
+        readonly sessionID: string
+        readonly info: {
+          readonly id: string
+          readonly slug: string
+          readonly projectID: string
+          readonly workspaceID?: string
+          readonly directory: string
+          readonly path?: string
+          readonly parentID?: string
+          readonly summary?: {
+            readonly additions: number
+            readonly deletions: number
+            readonly files: number
+            readonly diffs?: ReadonlyArray<{
+              readonly file?: string
+              readonly patch?: string
+              readonly additions: number
+              readonly deletions: number
+              readonly status?: "added" | "deleted" | "modified"
+            }>
+          }
+          readonly cost?: number
+          readonly tokens?: {
+            readonly input: number
+            readonly output: number
+            readonly reasoning: number
+            readonly cache: { readonly read: number; readonly write: number }
+          }
+          readonly share?: { readonly url: string }
+          readonly title: string
+          readonly agent?: string
+          readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string }
+          readonly version: string
+          readonly metadata?: { readonly [x: string]: any }
+          readonly time: {
+            readonly created: number
+            readonly updated: number
+            readonly compacting?: number
+            readonly archived?: number
+          }
+          readonly permission?: ReadonlyArray<{
+            readonly permission: string
+            readonly pattern: string
+            readonly action: "allow" | "deny" | "ask"
+          }>
+          readonly revert?: {
+            readonly messageID: string
+            readonly partID?: string
+            readonly snapshot?: string
+            readonly diff?: string
+          }
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "message.updated"
+      readonly data: {
+        readonly sessionID: string
+        readonly info:
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly role: "user"
+              readonly time: { readonly created: number }
+              readonly format?:
+                | (
+                    | { readonly type: "text" }
+                    | {
+                        readonly type: "json_schema"
+                        readonly schema: { readonly [x: string]: any }
+                        readonly retryCount?: number | null | null
+                      }
+                  )
+                | null
+              readonly summary?: {
+                readonly title?: string | null
+                readonly body?: string | null
+                readonly diffs: ReadonlyArray<{
+                  readonly file?: string
+                  readonly patch?: string
+                  readonly additions: number
+                  readonly deletions: number
+                  readonly status?: "added" | "deleted" | "modified"
+                }>
+              } | null
+              readonly agent: string
+              readonly model: {
+                readonly providerID: string
+                readonly modelID: string
+                readonly variant?: string | null
+              }
+              readonly system?: string | null
+              readonly tools?: { readonly [x: string]: boolean } | null
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly role: "assistant"
+              readonly time: { readonly created: number; readonly completed?: number | null }
+              readonly error?:
+                | {
+                    readonly name: "ProviderAuthError"
+                    readonly data: { readonly providerID: string; readonly message: string }
+                  }
+                | {
+                    readonly name: "UnknownError"
+                    readonly data: { readonly message: string; readonly ref?: string | null }
+                  }
+                | { readonly name: "MessageOutputLengthError"; readonly data: {} }
+                | { readonly name: "MessageAbortedError"; readonly data: { readonly message: string } }
+                | {
+                    readonly name: "StructuredOutputError"
+                    readonly data: { readonly message: string; readonly retries: number }
+                  }
+                | {
+                    readonly name: "ContextOverflowError"
+                    readonly data: { readonly message: string; readonly responseBody?: string | null }
+                  }
+                | { readonly name: "ContentFilterError"; readonly data: { readonly message: string } }
+                | {
+                    readonly name: "APIError"
+                    readonly data: {
+                      readonly message: string
+                      readonly statusCode?: number | null
+                      readonly isRetryable: boolean
+                      readonly responseHeaders?: { readonly [x: string]: string } | null
+                      readonly responseBody?: string | null
+                      readonly metadata?: { readonly [x: string]: string } | null
+                    }
+                  }
+                | null
+              readonly parentID: string
+              readonly modelID: string
+              readonly providerID: string
+              readonly mode: string
+              readonly agent: string
+              readonly path: { readonly cwd: string; readonly root: string }
+              readonly summary?: boolean | null
+              readonly cost: number
+              readonly tokens: {
+                readonly total?: number | null
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
+              readonly structured?: any | null
+              readonly variant?: string | null
+              readonly finish?: string | null
+            }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "message.removed"
+      readonly data: { readonly sessionID: string; readonly messageID: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "message.part.updated"
+      readonly data: {
+        readonly sessionID: string
+        readonly part:
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "text"
+              readonly text: string
+              readonly synthetic?: boolean | null
+              readonly ignored?: boolean | null
+              readonly time?: { readonly start: number; readonly end?: number | null } | null
+              readonly metadata?: { readonly [x: string]: any } | null
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "subtask"
+              readonly prompt: string
+              readonly description: string
+              readonly agent: string
+              readonly model?: { readonly providerID: string; readonly modelID: string } | null
+              readonly command?: string | null
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "reasoning"
+              readonly text: string
+              readonly metadata?: { readonly [x: string]: any } | null
+              readonly time: { readonly start: number; readonly end?: number | null }
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "file"
+              readonly mime: string
+              readonly filename?: string | null
+              readonly url: string
+              readonly source?:
+                | (
+                    | {
+                        readonly text: { readonly value: string; readonly start: number; readonly end: number }
+                        readonly type: "file"
+                        readonly path: string
+                      }
+                    | {
+                        readonly text: { readonly value: string; readonly start: number; readonly end: number }
+                        readonly type: "symbol"
+                        readonly path: string
+                        readonly range: {
+                          readonly start: { readonly line: number; readonly character: number }
+                          readonly end: { readonly line: number; readonly character: number }
+                        }
+                        readonly name: string
+                        readonly kind: number
+                      }
+                    | {
+                        readonly text: { readonly value: string; readonly start: number; readonly end: number }
+                        readonly type: "resource"
+                        readonly clientName: string
+                        readonly uri: string
+                      }
+                  )
+                | null
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "tool"
+              readonly callID: string
+              readonly tool: string
+              readonly state:
+                | { readonly status: "pending"; readonly input: { readonly [x: string]: any }; readonly raw: string }
+                | {
+                    readonly status: "running"
+                    readonly input: { readonly [x: string]: any }
+                    readonly title?: string | null
+                    readonly metadata?: { readonly [x: string]: any } | null
+                    readonly time: { readonly start: number }
+                  }
+                | {
+                    readonly status: "completed"
+                    readonly input: { readonly [x: string]: any }
+                    readonly output: string
+                    readonly title: string
+                    readonly metadata: { readonly [x: string]: any }
+                    readonly time: { readonly start: number; readonly end: number; readonly compacted?: number | null }
+                    readonly attachments?: ReadonlyArray<{
+                      readonly id: string
+                      readonly sessionID: string
+                      readonly messageID: string
+                      readonly type: "file"
+                      readonly mime: string
+                      readonly filename?: string | null
+                      readonly url: string
+                      readonly source?:
+                        | (
+                            | {
+                                readonly text: { readonly value: string; readonly start: number; readonly end: number }
+                                readonly type: "file"
+                                readonly path: string
+                              }
+                            | {
+                                readonly text: { readonly value: string; readonly start: number; readonly end: number }
+                                readonly type: "symbol"
+                                readonly path: string
+                                readonly range: {
+                                  readonly start: { readonly line: number; readonly character: number }
+                                  readonly end: { readonly line: number; readonly character: number }
+                                }
+                                readonly name: string
+                                readonly kind: number
+                              }
+                            | {
+                                readonly text: { readonly value: string; readonly start: number; readonly end: number }
+                                readonly type: "resource"
+                                readonly clientName: string
+                                readonly uri: string
+                              }
+                          )
+                        | null
+                    }> | null
+                  }
+                | {
+                    readonly status: "error"
+                    readonly input: { readonly [x: string]: any }
+                    readonly error: string
+                    readonly metadata?: { readonly [x: string]: any } | null
+                    readonly time: { readonly start: number; readonly end: number }
+                  }
+              readonly metadata?: { readonly [x: string]: any } | null
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "step-start"
+              readonly snapshot?: string | null
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "step-finish"
+              readonly reason: string
+              readonly snapshot?: string | null
+              readonly cost: number
+              readonly tokens: {
+                readonly total?: number | null
+                readonly input: number
+                readonly output: number
+                readonly reasoning: number
+                readonly cache: { readonly read: number; readonly write: number }
+              }
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "snapshot"
+              readonly snapshot: string
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "patch"
+              readonly hash: string
+              readonly files: ReadonlyArray<string>
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "agent"
+              readonly name: string
+              readonly source?: { readonly value: string; readonly start: number; readonly end: number } | null
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "retry"
+              readonly attempt: number
+              readonly error: {
+                readonly name: "APIError"
+                readonly data: {
+                  readonly message: string
+                  readonly statusCode?: number | null
+                  readonly isRetryable: boolean
+                  readonly responseHeaders?: { readonly [x: string]: string } | null
+                  readonly responseBody?: string | null
+                  readonly metadata?: { readonly [x: string]: string } | null
+                }
+              }
+              readonly time: { readonly created: number }
+            }
+          | {
+              readonly id: string
+              readonly sessionID: string
+              readonly messageID: string
+              readonly type: "compaction"
+              readonly auto: boolean
+              readonly overflow?: boolean | null
+              readonly tail_start_id?: string | null
+            }
+        readonly time: number
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "message.part.removed"
+      readonly data: { readonly sessionID: string; readonly messageID: string; readonly partID: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.agent.switched"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly agent: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.model.switched"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.moved"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly location: { readonly directory: string; readonly workspaceID?: string }
+        readonly subdirectory?: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.prompted"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly prompt: {
+          readonly text: string
+          readonly files?: ReadonlyArray<{
+            readonly uri: string
+            readonly mime: string
+            readonly name?: string
+            readonly description?: string
+            readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+          }>
+          readonly agents?: ReadonlyArray<{
+            readonly name: string
+            readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+          }>
+        }
+        readonly delivery: "steer" | "queue"
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.prompt.admitted"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly prompt: {
+          readonly text: string
+          readonly files?: ReadonlyArray<{
+            readonly uri: string
+            readonly mime: string
+            readonly name?: string
+            readonly description?: string
+            readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+          }>
+          readonly agents?: ReadonlyArray<{
+            readonly name: string
+            readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+          }>
+        }
+        readonly delivery: "steer" | "queue"
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.context.updated"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly text: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.synthetic"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly text: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.shell.started"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly callID: string
+        readonly command: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.shell.ended"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly callID: string
+        readonly output: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.step.started"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly agent: string
+        readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+        readonly snapshot?: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.step.ended"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly finish: string
+        readonly cost: number
+        readonly tokens: {
+          readonly input: number
+          readonly output: number
+          readonly reasoning: number
+          readonly cache: { readonly read: number; readonly write: number }
+        }
+        readonly snapshot?: string
+        readonly files?: ReadonlyArray<string>
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.step.failed"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly error: { readonly type: "unknown"; readonly message: string }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.text.started"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly textID: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.text.delta"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly textID: string
+        readonly delta: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.text.ended"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly textID: string
+        readonly text: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.reasoning.started"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly reasoningID: string
+        readonly providerMetadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.reasoning.delta"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly reasoningID: string
+        readonly delta: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.reasoning.ended"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly reasoningID: string
+        readonly text: string
+        readonly providerMetadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.tool.input.started"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly callID: string
+        readonly name: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.tool.input.delta"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly callID: string
+        readonly delta: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.tool.input.ended"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly callID: string
+        readonly text: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.tool.called"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly callID: string
+        readonly tool: string
+        readonly input: { readonly [x: string]: JsonValue }
+        readonly provider: {
+          readonly executed: boolean
+          readonly metadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.tool.progress"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly callID: string
+        readonly structured: { readonly [x: string]: JsonValue }
+        readonly content: ReadonlyArray<
+          | { readonly type: "text"; readonly text: string }
+          | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+        >
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.tool.success"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly callID: string
+        readonly structured: { readonly [x: string]: JsonValue }
+        readonly content: ReadonlyArray<
+          | { readonly type: "text"; readonly text: string }
+          | { readonly type: "file"; readonly uri: string; readonly mime: string; readonly name?: string }
+        >
+        readonly outputPaths?: ReadonlyArray<string>
+        readonly result?: JsonValue
+        readonly provider: {
+          readonly executed: boolean
+          readonly metadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.tool.failed"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly assistantMessageID: string
+        readonly callID: string
+        readonly error: { readonly type: "unknown"; readonly message: string }
+        readonly result?: JsonValue
+        readonly provider: {
+          readonly executed: boolean
+          readonly metadata?: { readonly [x: string]: { readonly [x: string]: JsonValue } }
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.retried"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly attempt: number
+        readonly error: {
+          readonly message: string
+          readonly statusCode?: number
+          readonly isRetryable: boolean
+          readonly responseHeaders?: { readonly [x: string]: string }
+          readonly responseBody?: string
+          readonly metadata?: { readonly [x: string]: string }
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.compaction.started"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly reason: "auto" | "manual"
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.compaction.delta"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly text: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.compaction.ended"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly messageID: string
+        readonly reason: "auto" | "manual"
+        readonly text: string
+        readonly recent: string
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.revert.staged"
+      readonly data: {
+        readonly timestamp: number
+        readonly sessionID: string
+        readonly revert: {
+          readonly messageID: string
+          readonly partID?: string
+          readonly snapshot?: string
+          readonly diff?: string
+          readonly files?: ReadonlyArray<{
+            readonly path: string
+            readonly status: "added" | "modified" | "deleted"
+            readonly additions: number
+            readonly deletions: number
+            readonly patch: string
+          }>
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.revert.cleared"
+      readonly data: { readonly timestamp: number; readonly sessionID: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "session.next.revert.committed"
+      readonly data: { readonly timestamp: number; readonly sessionID: string; readonly messageID: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "file.edited"
+      readonly data: { readonly file: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "reference.updated"
+      readonly data: {}
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "permission.v2.asked"
+      readonly data: {
+        readonly id: string
+        readonly sessionID: string
+        readonly action: string
+        readonly resources: ReadonlyArray<string>
+        readonly save?: ReadonlyArray<string>
+        readonly metadata?: { readonly [x: string]: JsonValue }
+        readonly source?: { readonly type: "tool"; readonly messageID: string; readonly callID: string }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "permission.v2.replied"
+      readonly data: {
+        readonly sessionID: string
+        readonly requestID: string
+        readonly reply: "once" | "always" | "reject"
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "plugin.added"
+      readonly data: { readonly id: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "project.directories.updated"
+      readonly data: { readonly projectID: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "file.watcher.updated"
+      readonly data: { readonly file: string; readonly event: "add" | "change" | "unlink" }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "pty.created"
+      readonly data: {
+        readonly info: {
+          readonly id: string
+          readonly title: string
+          readonly command: string
+          readonly args: ReadonlyArray<string>
+          readonly cwd: string
+          readonly status: "running" | "exited"
+          readonly pid: number
+          readonly exitCode?: number
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "pty.updated"
+      readonly data: {
+        readonly info: {
+          readonly id: string
+          readonly title: string
+          readonly command: string
+          readonly args: ReadonlyArray<string>
+          readonly cwd: string
+          readonly status: "running" | "exited"
+          readonly pid: number
+          readonly exitCode?: number
+        }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "pty.exited"
+      readonly data: { readonly id: string; readonly exitCode: number }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "pty.deleted"
+      readonly data: { readonly id: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "question.v2.asked"
+      readonly data: {
+        readonly id: string
+        readonly sessionID: string
+        readonly questions: ReadonlyArray<{
+          readonly question: string
+          readonly header: string
+          readonly options: ReadonlyArray<{ readonly label: string; readonly description: string }>
+          readonly multiple?: boolean
+          readonly custom?: boolean
+        }>
+        readonly tool?: { readonly messageID: string; readonly callID: string }
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "question.v2.replied"
+      readonly data: {
+        readonly sessionID: string
+        readonly requestID: string
+        readonly answers: ReadonlyArray<ReadonlyArray<string>>
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "question.v2.rejected"
+      readonly data: { readonly sessionID: string; readonly requestID: string }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "todo.updated"
+      readonly data: {
+        readonly sessionID: string
+        readonly todos: ReadonlyArray<{ readonly content: string; readonly status: string; readonly priority: string }>
+      }
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: JsonValue } | null
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number } | null
+      readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+      readonly type: "server.connected"
+      readonly data: {}
+    }
+
+export type PtysListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type PtysListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly title: string
+    readonly command: string
+    readonly args: ReadonlyArray<string>
+    readonly cwd: string
+    readonly status: "running" | "exited"
+    readonly pid: number
+    readonly exitCode?: number
+  }>
+}
+
+export type PtysCreateInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly command?: {
+    readonly command?: string
+    readonly args?: ReadonlyArray<string>
+    readonly cwd?: string
+    readonly title?: string
+    readonly env?: { readonly [x: string]: string }
+  }["command"]
+  readonly args?: {
+    readonly command?: string
+    readonly args?: ReadonlyArray<string>
+    readonly cwd?: string
+    readonly title?: string
+    readonly env?: { readonly [x: string]: string }
+  }["args"]
+  readonly cwd?: {
+    readonly command?: string
+    readonly args?: ReadonlyArray<string>
+    readonly cwd?: string
+    readonly title?: string
+    readonly env?: { readonly [x: string]: string }
+  }["cwd"]
+  readonly title?: {
+    readonly command?: string
+    readonly args?: ReadonlyArray<string>
+    readonly cwd?: string
+    readonly title?: string
+    readonly env?: { readonly [x: string]: string }
+  }["title"]
+  readonly env?: {
+    readonly command?: string
+    readonly args?: ReadonlyArray<string>
+    readonly cwd?: string
+    readonly title?: string
+    readonly env?: { readonly [x: string]: string }
+  }["env"]
+}
+
+export type PtysCreateOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: {
+    readonly id: string
+    readonly title: string
+    readonly command: string
+    readonly args: ReadonlyArray<string>
+    readonly cwd: string
+    readonly status: "running" | "exited"
+    readonly pid: number
+    readonly exitCode?: number
+  }
+}
+
+export type PtysGetInput = {
+  readonly ptyID: { readonly ptyID: string }["ptyID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type PtysGetOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: {
+    readonly id: string
+    readonly title: string
+    readonly command: string
+    readonly args: ReadonlyArray<string>
+    readonly cwd: string
+    readonly status: "running" | "exited"
+    readonly pid: number
+    readonly exitCode?: number
+  }
+}
+
+export type PtysUpdateInput = {
+  readonly ptyID: { readonly ptyID: string }["ptyID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly title?: {
+    readonly title?: string
+    readonly size?: { readonly rows: number; readonly cols: number }
+  }["title"]
+  readonly size?: { readonly title?: string; readonly size?: { readonly rows: number; readonly cols: number } }["size"]
+}
+
+export type PtysUpdateOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: {
+    readonly id: string
+    readonly title: string
+    readonly command: string
+    readonly args: ReadonlyArray<string>
+    readonly cwd: string
+    readonly status: "running" | "exited"
+    readonly pid: number
+    readonly exitCode?: number
+  }
+}
+
+export type PtysRemoveInput = {
+  readonly ptyID: { readonly ptyID: string }["ptyID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type PtysRemoveOutput = void
+
+export type PtysConnectTokenInput = {
+  readonly ptyID: { readonly ptyID: string }["ptyID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type PtysConnectTokenOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: { readonly ticket: string; readonly expires_in: number }
+}
+
+export type PtysConnectInput = { readonly ptyID: { readonly ptyID: string }["ptyID"] }
+
+export type PtysConnectOutput = boolean
+
+export type QuestionsListRequestsInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type QuestionsListRequestsOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly sessionID: string
+    readonly questions: ReadonlyArray<{
+      readonly question: string
+      readonly header: string
+      readonly options: ReadonlyArray<{ readonly label: string; readonly description: string }>
+      readonly multiple?: boolean
+      readonly custom?: boolean
+    }>
+    readonly tool?: { readonly messageID: string; readonly callID: string }
+  }>
+}
+
+export type QuestionsListInput = { readonly sessionID: { readonly sessionID: string }["sessionID"] }
+
+export type QuestionsListOutput = {
+  readonly data: ReadonlyArray<{
+    readonly id: string
+    readonly sessionID: string
+    readonly questions: ReadonlyArray<{
+      readonly question: string
+      readonly header: string
+      readonly options: ReadonlyArray<{ readonly label: string; readonly description: string }>
+      readonly multiple?: boolean
+      readonly custom?: boolean
+    }>
+    readonly tool?: { readonly messageID: string; readonly callID: string }
+  }>
+}["data"]
+
+export type QuestionsReplyInput = {
+  readonly sessionID: { readonly sessionID: string; readonly requestID: string }["sessionID"]
+  readonly requestID: { readonly sessionID: string; readonly requestID: string }["requestID"]
+  readonly answers: { readonly answers: ReadonlyArray<ReadonlyArray<string>> }["answers"]
+}
+
+export type QuestionsReplyOutput = void
+
+export type QuestionsRejectInput = {
+  readonly sessionID: { readonly sessionID: string; readonly requestID: string }["sessionID"]
+  readonly requestID: { readonly sessionID: string; readonly requestID: string }["requestID"]
+}
+
+export type QuestionsRejectOutput = void
+
+export type ReferencesListInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type ReferencesListOutput = {
+  readonly location: {
+    readonly directory: string
+    readonly workspaceID?: string
+    readonly project: { readonly id: string; readonly directory: string }
+  }
+  readonly data: ReadonlyArray<{
+    readonly name: string
+    readonly path: string
+    readonly description?: string
+    readonly hidden?: boolean
+    readonly source:
+      | { readonly type: "local"; readonly path: string; readonly description?: string; readonly hidden?: boolean }
+      | {
+          readonly type: "git"
+          readonly repository: string
+          readonly branch?: string
+          readonly description?: string
+          readonly hidden?: boolean
+        }
+  }>
+}
+
+export type ProjectCopiesCreateInput = {
+  readonly projectID: { readonly projectID: string }["projectID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly strategy: { readonly strategy: string; readonly directory: string; readonly name?: string }["strategy"]
+  readonly directory: { readonly strategy: string; readonly directory: string; readonly name?: string }["directory"]
+  readonly name?: { readonly strategy: string; readonly directory: string; readonly name?: string }["name"]
+}
+
+export type ProjectCopiesCreateOutput = { readonly directory: string }
+
+export type ProjectCopiesRemoveInput = {
+  readonly projectID: { readonly projectID: string }["projectID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly directory: { readonly directory: string; readonly force: boolean }["directory"]
+  readonly force: { readonly directory: string; readonly force: boolean }["force"]
+}
+
+export type ProjectCopiesRemoveOutput = void
+
+export type ProjectCopiesRefreshInput = {
+  readonly projectID: { readonly projectID: string }["projectID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type ProjectCopiesRefreshOutput = void

--- a/packages/client/test/contract-identity.test.ts
+++ b/packages/client/test/contract-identity.test.ts
@@ -19,8 +19,7 @@ import { SessionMessage } from "@opencode-ai/schema/session-message"
 import { Workspace } from "@opencode-ai/schema/workspace"
 import { Api } from "@opencode-ai/server/api"
 import { compile, emitPromise } from "@opencode-ai/httpapi-codegen"
-import { HttpApi } from "effect/unstable/httpapi"
-import { SessionGroup } from "../src/contract"
+import { Api as ClientApi, endpointNames, groupNames } from "../src/contract"
 
 test("Core and Server reuse the authoritative Schema and Protocol values", () => {
   expect(AgentV2.ID).toBe(Agent.ID)
@@ -31,17 +30,16 @@ test("Core and Server reuse the authoritative Schema and Protocol values", () =>
   expect(CoreSessionMessage.Message).toBe(SessionMessage.Message)
   expect(CorePrompt).toBe(Prompt)
   expect(Api.groups["server.session"].identifier).toBe("server.session")
-  expect(SessionGroup.identifier).toBe(Api.groups["server.session"].identifier)
+  expect(Object.keys(ClientApi.groups)).toEqual(Object.keys(Api.groups))
   expect(Session.ID.create()).toStartWith("ses_")
   expect(Project.ID.global).toBe("global")
   expect(Provider.ID.anthropic).toBe("anthropic")
   expect(Workspace.ID.create()).toStartWith("wrk_")
 })
 
-test("client and Server Session contracts generate identically", () => {
-  const options = { groupNames: { "server.session": "sessions" } }
-  const server = compile(HttpApi.make("server").add(Api.groups["server.session"]), options)
-  const client = compile(HttpApi.make("client").add(SessionGroup), options)
+test("client and Server contracts generate identically", () => {
+  const server = compile(Api, { groupNames, endpointNames })
+  const client = compile(ClientApi, { groupNames, endpointNames })
 
   expect(emitPromise(client)).toEqual(emitPromise(server))
 })

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -1,6 +1,50 @@
 import { expect, test } from "bun:test"
 import { isUnauthorizedError, OpenCode } from "../src"
 
+test("exposes every authoritative API group", () => {
+  const client = OpenCode.make({ baseUrl: "http://localhost:3000" })
+
+  expect(Object.keys(client)).toEqual([
+    "health",
+    "location",
+    "agents",
+    "sessions",
+    "messages",
+    "models",
+    "providers",
+    "integrations",
+    "credentials",
+    "permissions",
+    "files",
+    "commands",
+    "skills",
+    "events",
+    "ptys",
+    "questions",
+    "references",
+    "projectCopies",
+  ])
+  expect(Object.keys(client.messages)).toEqual(["list"])
+  expect(Object.keys(client.integrations)).toEqual([
+    "list",
+    "get",
+    "connectKey",
+    "connectOauth",
+    "attemptStatus",
+    "attemptComplete",
+    "attemptCancel",
+  ])
+  expect(Object.keys(client.permissions)).toEqual([
+    "listRequests",
+    "listSaved",
+    "removeSaved",
+    "create",
+    "list",
+    "get",
+    "reply",
+  ])
+})
+
 test("sessions.get returns the wire projection", async () => {
   const client = OpenCode.make({
     baseUrl: "http://localhost:3000",

--- a/packages/httpapi-codegen/src/index.ts
+++ b/packages/httpapi-codegen/src/index.ts
@@ -75,7 +75,10 @@ const manifestName = ".httpapi-codegen.json"
 
 export function compile<Id extends string, Groups extends HttpApiGroup.Any>(
   api: HttpApi.HttpApi<Id, Groups>,
-  options?: { readonly groupNames?: Readonly<Record<string, string>> },
+  options?: {
+    readonly groupNames?: Readonly<Record<string, string>>
+    readonly endpointNames?: Readonly<Record<string, string>>
+  },
 ): Contract {
   const endpoints: Array<Endpoint> = []
   const portable = new Map<SchemaAST.AST, boolean>()
@@ -150,7 +153,7 @@ export function compile<Id extends string, Groups extends HttpApiGroup.Any>(
         effectPortable,
         operation: {
           group: groupName,
-          name: clientEndpointName(endpoint.name),
+          name: options?.endpointNames?.[endpoint.name] ?? clientEndpointName(endpoint.name),
           input: inputs.map(({ name, source }) => ({ name, source })),
           inputMode: inputs.length === 0 ? "none" : inputs.every((field) => field.optional) ? "optional" : "required",
           success: isStreamSchema(success.schema)
@@ -245,7 +248,13 @@ export function emitPromise(contract: Contract): Output {
       },
       {
         path: "client.ts",
-        content: renderPromiseClient(groups).replace("let next: ReadableStreamReadResult<Uint8Array>", "let next"),
+        content: renderPromiseClient(groups)
+          .replace("readonly empty: boolean\n}", "readonly empty: boolean\n  readonly binary: boolean\n}")
+          .replace(
+            "return await json(response) as A",
+            'if (descriptor.binary) {\n      try {\n        return new Uint8Array(await response.arrayBuffer()) as A\n      } catch (cause) {\n        throw new ClientError("Transport", { cause })\n      }\n    }\n    return await json(response) as A',
+          )
+          .replace("let next: ReadableStreamReadResult<Uint8Array>", "let next"),
       },
       {
         path: "index.ts",
@@ -277,13 +286,13 @@ function assertPromiseEndpoint(endpoint: Endpoint) {
     }
   } else if (
     !HttpApiSchema.isNoContent(success.ast) &&
-    (resolveHttpApiEncoding(success.ast)?._tag ?? "Json") !== "Json"
+    !["Json", "Uint8Array"].includes(resolveHttpApiEncoding(success.ast)?._tag ?? "Json")
   ) {
     throw new GenerationError({ reason: `Unsupported Promise success encoding: ${name}` })
   }
   for (const error of endpoint.errors) {
-    if (taggedErrorFields(error) === undefined) {
-      throw new GenerationError({ reason: `Promise error must be tagged: ${name}` })
+    if (declaredErrorFields(error) === undefined) {
+      throw new GenerationError({ reason: `Promise error must have a literal discriminator: ${name}` })
     }
     if ((resolveHttpApiEncoding(error.ast)?._tag ?? "Json") !== "Json") {
       throw new GenerationError({ reason: `Unsupported Promise error encoding: ${name}` })
@@ -422,7 +431,7 @@ function renderPromiseTypes(groups: ReadonlyArray<Group>) {
     groups.flatMap((group) =>
       group.endpoints.flatMap((endpoint) =>
         endpoint.errors.flatMap((schema) => {
-          const tagged = taggedErrorFields(schema)
+          const tagged = declaredErrorFields(schema)
           return tagged === undefined ? [] : [[tagged.tag, tagged] as const]
         }),
       ),
@@ -432,7 +441,7 @@ function renderPromiseTypes(groups: ReadonlyArray<Group>) {
     const fields = error.fields
       .map(([name, schema, optional]) => `readonly ${JSON.stringify(name)}${optional ? "?" : ""}: ${typeOf(schema)}`)
       .join("; ")
-    return `export type ${error.identifier} = { readonly _tag: ${JSON.stringify(error.tag)}; ${fields} }\nexport const is${error.identifier} = (value: unknown): value is ${error.identifier} => typeof value === "object" && value !== null && "_tag" in value && value._tag === ${JSON.stringify(error.tag)}`
+    return `export type ${error.identifier} = { readonly ${JSON.stringify(error.key)}: ${JSON.stringify(error.tag)}; ${fields} }\nexport const is${error.identifier} = (value: unknown): value is ${error.identifier} => typeof value === "object" && value !== null && ${JSON.stringify(error.key)} in value && value[${JSON.stringify(error.key)}] === ${JSON.stringify(error.tag)}`
   })
   const operations = groups
     .flatMap((group) =>
@@ -505,7 +514,7 @@ function renderPromiseClient(groups: ReadonlyArray<Group>) {
           endpoint.errors.map((schema) => resolveHttpApiStatus(schema.ast)).filter((status) => status !== undefined),
         ),
       ]
-      const descriptor = `{ method: ${JSON.stringify(endpoint.endpoint.method)}, path: ${path}${parts.length === 0 ? "" : `, ${parts.join(", ")}`}, successStatus: ${resolveHttpApiStatus(endpoint.successes[0].ast) ?? 200}, declaredStatuses: [${declaredStatuses.join(", ")}], empty: ${endpoint.operation.success === "void"} }`
+      const descriptor = `{ method: ${JSON.stringify(endpoint.endpoint.method)}, path: ${path}${parts.length === 0 ? "" : `, ${parts.join(", ")}`}, successStatus: ${resolveHttpApiStatus(endpoint.successes[0].ast) ?? 200}, declaredStatuses: [${declaredStatuses.join(", ")}], empty: ${endpoint.operation.success === "void"}, binary: ${resolveHttpApiEncoding(endpoint.successes[0].ast)?._tag === "Uint8Array"} }`
       if (endpoint.operation.success === "stream") {
         const success = endpoint.successes[0]
         if (!isStreamSchema(success) || success._tag !== "StreamSse" || success.sseMode !== "data") {
@@ -556,9 +565,12 @@ function structuralType(schema: Schema.Top) {
   )
   const expand = (type: string, seen = new Set<string>()): string => {
     for (const [reference, value] of references) {
-      if (!type.includes(reference)) continue
-      if (seen.has(reference)) throw new GenerationError({ reason: "Recursive Promise types are not implemented" })
-      type = type.replaceAll(reference, `(${expand(value, new Set([...seen, reference]))})`)
+      const pattern = `(?<![A-Za-z0-9_$.'"])${reference.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![A-Za-z0-9_$.'"])`
+      if (!new RegExp(pattern).test(type)) continue
+      if (seen.has(reference)) {
+        throw new GenerationError({ reason: `Recursive Promise types are not implemented: ${reference}` })
+      }
+      type = type.replace(new RegExp(pattern, "g"), `(${expand(value, new Set([...seen, reference]))})`)
     }
     return type
   }
@@ -921,18 +933,26 @@ function serializable(value: unknown): boolean {
 }
 
 function taggedErrorFields(schema: Schema.Top) {
+  const fields = declaredErrorFields(schema)
+  return fields?.key === "_tag" ? fields : undefined
+}
+
+function declaredErrorFields(schema: Schema.Top) {
   if (!SchemaAST.isDeclaration(schema.ast) || schema.ast.annotations?.["~effect/Schema/Class"] === undefined) {
     return undefined
   }
   const fields = schema.ast.typeParameters[0]
   if (!SchemaAST.isObjects(fields) || fields.indexSignatures.length > 0) return undefined
-  const tag = fields.propertySignatures.find((field) => field.name === "_tag")?.type
+  const key = fields.propertySignatures.find((field) => field.name === "_tag" || field.name === "name")?.name
+  if (key !== "_tag" && key !== "name") return undefined
+  const tag = fields.propertySignatures.find((field) => field.name === key)?.type
   if (tag === undefined || !SchemaAST.isLiteral(tag) || typeof tag.literal !== "string") return undefined
   return {
+    key,
     tag: tag.literal,
     identifier: SchemaAST.resolveIdentifier(schema.ast) ?? tag.literal,
     fields: fields.propertySignatures.flatMap((field) =>
-      field.name === "_tag" || typeof field.name !== "string"
+      field.name === key || typeof field.name !== "string"
         ? []
         : [[field.name, Schema.make(field.type), SchemaAST.isOptional(field.type)] as const],
     ),

--- a/packages/httpapi-codegen/test/generate.test.ts
+++ b/packages/httpapi-codegen/test/generate.test.ts
@@ -151,6 +151,19 @@ describe("HttpApiCodegen.generate", () => {
     expect(effect).toContain('raw["session.get"]')
   })
 
+  test("supports explicit public endpoint names", () => {
+    const source = HttpApi.make("test").add(
+      HttpApiGroup.make("server.permission")
+        .add(HttpApiEndpoint.get("permission.request.list", "/request", { success: Schema.String }))
+        .add(HttpApiEndpoint.get("session.permission.list", "/session", { success: Schema.String })),
+    )
+    const contract = compileContract(source, {
+      endpointNames: { "permission.request.list": "listRequests" },
+    })
+
+    expect(contract.groups[0]?.endpoints.map((endpoint) => endpoint.operation.name)).toEqual(["listRequests", "list"])
+  })
+
   test("preserves optional keys in Promise error types", () => {
     class OptionalError extends Schema.TaggedErrorClass<OptionalError>()(
       "OptionalError",
@@ -164,6 +177,22 @@ describe("HttpApiCodegen.generate", () => {
     expect(output.files.find((file) => file.path === "types.ts")?.content).toContain(
       'readonly "message": string; readonly "detail"?: string | undefined',
     )
+  })
+
+  test("supports name-discriminated Promise errors", () => {
+    class NamedError extends Schema.ErrorClass<NamedError>("NamedError")(
+      { name: Schema.Literal("NamedError"), message: Schema.String },
+      { httpApiStatus: 400 },
+    ) {}
+    const output = emitPromise(
+      compileContract(
+        api(HttpApiEndpoint.get("get", "/session", { success: Schema.NumberFromString, error: NamedError })),
+      ),
+    )
+    const types = output.files.find((file) => file.path === "types.ts")?.content
+
+    expect(types).toContain('readonly "name": "NamedError"')
+    expect(types).toContain('"name" in value && value["name"] === "NamedError"')
   })
 
   test("erases brands from Promise wire types", () => {
@@ -197,6 +226,26 @@ describe("HttpApiCodegen.generate", () => {
 
     expect(output.files.find((file) => file.path === "types.ts")?.content).toContain(
       'export type SessionGetOutput = ({ readonly "data": ({ readonly "value": string }) })["data"]',
+    )
+  })
+
+  test("expands Promise references only at identifier boundaries", () => {
+    const Session = Schema.Struct({ name: Schema.Literal("Session"), id: Schema.String }).annotate({
+      identifier: "Session",
+    })
+    const SessionID = Schema.String.annotate({ identifier: "SessionID" })
+    const output = emitPromise(
+      compileContract(
+        api(
+          HttpApiEndpoint.get("get", "/session", {
+            success: Schema.Struct({ session: Session, sessionID: SessionID }),
+          }),
+        ),
+      ),
+    )
+
+    expect(output.files.find((file) => file.path === "types.ts")?.content).toContain(
+      'readonly "session": ({ readonly "name": "Session", readonly "id": string })',
     )
   })
 
@@ -258,6 +307,32 @@ describe("HttpApiCodegen.generate", () => {
         ),
       ),
     ).toThrow("Unsupported Promise stream: session.events")
+  })
+
+  test("executes an emitted binary Promise response", async () => {
+    const output = emitPromise(
+      compileContract(
+        api(
+          HttpApiEndpoint.get("read", "/file", {
+            success: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+          }),
+        ),
+      ),
+    )
+    const directory = await mkdtemp(join(tmpdir(), "opencode-httpapi-codegen-"))
+
+    try {
+      await Promise.all(output.files.map((file) => Bun.write(join(directory, file.path), file.content)))
+      const generated = await import(`${join(directory, "index.ts")}?t=${crypto.randomUUID()}`)
+      const client = generated.OpenCode.make({
+        baseUrl: "https://example.com",
+        fetch: async () => new Response(new Uint8Array([1, 2, 3])),
+      })
+
+      expect(await client.session.read()).toEqual(new Uint8Array([1, 2, 3]))
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 
   test("executes an emitted Promise GET through fetch", async () => {


### PR DESCRIPTION
## Summary

- generate Promise and Effect clients from every authoritative Server `HttpApi` group
- define stable public group and endpoint names for the expanded client surface
- extend codegen for explicit endpoint names, buffered binary responses, name-discriminated errors, and safe schema reference expansion
- preserve the zero-Effect Promise entrypoint and full Server/Protocol contract identity checks

## Verification

- `bun typecheck` in `packages/httpapi-codegen`
- `bun run test -- generate.test.ts` in `packages/httpapi-codegen` (57 passed)
- `bun typecheck` in `packages/client`
- `bun run test` in `packages/client` (10 passed)
- `bun run check:generated` in `packages/client`
- file-scoped Prettier and oxlint checks
- repository push hook: full monorepo typecheck (29 tasks passed)

This PR only expands the generated client and its generator support. It does not migrate the TUI or remove the legacy SDK client.