### PR TITLE
fix(task): auto-update parent todo when subagent completes

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -8,6 +8,7 @@ import { SessionID, MessageID } from "../session/schema"
 import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
+import { Todo } from "../session/todo"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
 import { Effect, Exit, Schema, Scope } from "effect"
@@ -78,6 +79,44 @@ function renderOutput(input: {
   ].join("\n")
 }
 
+const TODO_UPDATE_FAILED =
+  "[!] Automatic todo update failed. If you were tracking this in your todo list, please mark it as completed manually."
+
+function completeMatchingParentTodo(input: {
+  parentID: SessionID
+  description: string
+  text: string
+  todo: Todo.Interface
+}) {
+  return Effect.gen(function* () {
+    const exit = yield* markMatchingParentTodoComplete(input).pipe(Effect.exit)
+    if (Exit.isSuccess(exit)) return input.text
+    if (input.text.length === 0) return TODO_UPDATE_FAILED
+    return [input.text, TODO_UPDATE_FAILED].join("\n\n")
+  })
+}
+
+function markMatchingParentTodoComplete(input: { parentID: SessionID; description: string; todo: Todo.Interface }) {
+  return Effect.gen(function* () {
+    const description = normalizeTodoText(input.description)
+    if (description.length === 0) return
+    const todos = yield* input.todo.get(input.parentID)
+    const updated = todos.map((todo) => {
+      if (todo.status !== "pending" && todo.status !== "in_progress") return todo
+      const content = normalizeTodoText(todo.content)
+      if (content.length === 0) return todo
+      if (!content.includes(description) && !description.includes(content)) return todo
+      return { ...todo, status: "completed" as const }
+    })
+    if (updated.every((todo, index) => todo.status === todos[index]?.status)) return
+    yield* input.todo.update({ sessionID: input.parentID, todos: updated })
+  })
+}
+
+function normalizeTodoText(value: string) {
+  return value.toLowerCase().replace(/\s+/g, " ").trim()
+}
+
 export const TaskTool = Tool.define(
   id,
   Effect.gen(function* () {
@@ -85,6 +124,7 @@ export const TaskTool = Tool.define(
     const background = yield* BackgroundJob.Service
     const config = yield* Config.Service
     const sessions = yield* Session.Service
+    const todo = yield* Todo.Service
     const scope = yield* Scope.Scope
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
@@ -231,8 +271,19 @@ export const TaskTool = Tool.define(
       const notify = Effect.fn("TaskTool.notifyBackgroundResult")(function* (jobID: string) {
         yield* background.wait({ id: jobID }).pipe(
           Effect.flatMap((result) => {
-            if (result.info?.status === "completed") return inject("completed", result.info.output ?? "")
-            if (result.info?.status === "error") return inject("error", result.info.error ?? "")
+            const info = result.info
+            if (info?.status === "completed") {
+              return Effect.gen(function* () {
+                const text = yield* completeMatchingParentTodo({
+                  parentID: ctx.sessionID,
+                  description: params.description,
+                  text: info.output ?? "",
+                  todo,
+                })
+                yield* inject("completed", text)
+              })
+            }
+            if (info?.status === "error") return inject("error", info.error ?? "")
             return Effect.void
           }),
           Effect.forkIn(scope, { startImmediately: true }),
@@ -313,10 +364,16 @@ export const TaskTool = Tool.define(
             if (result?.metadata?.background === true) return backgroundResult()
             if (result?.status === "error") return yield* Effect.fail(new Error(result.error ?? "Task failed"))
             if (result?.status === "cancelled") return yield* Effect.fail(new Error("Task cancelled"))
+            const text = yield* completeMatchingParentTodo({
+              parentID: ctx.sessionID,
+              description: params.description,
+              text: result?.output ?? "",
+              todo,
+            })
             return {
               title: params.description,
               metadata,
-              output: renderOutput({ sessionID: nextSession.id, state: "completed", text: result?.output ?? "" }),
+              output: renderOutput({ sessionID: nextSession.id, state: "completed", text }),
             }
           }),
         (_, exit) =>

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -11,6 +11,7 @@ import { Config } from "@/config/config"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Session } from "@/session/session"
+import { Todo } from "@/session/todo"
 import type { SessionPrompt } from "../../src/session/prompt"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionRunState } from "@/session/run-state"
@@ -47,6 +48,7 @@ const layer = (flags: Partial<RuntimeFlags.Info> = {}) =>
       SessionRunState.node,
       SessionStatus.node,
       Truncate.node,
+      Todo.node,
       ToolRegistry.node,
       Database.node,
       RuntimeFlags.node,
@@ -388,6 +390,45 @@ describe("tool.task", () => {
     }),
   )
 
+  it.instance("execute marks the matching parent todo completed when the subagent completes", () =>
+    Effect.gen(function* () {
+      const todos = yield* Todo.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      yield* todos.update({
+        sessionID: chat.id,
+        todos: [
+          { content: "Create hello.txt file", status: "pending", priority: "high" },
+          { content: "Run tests", status: "pending", priority: "medium" },
+        ],
+      })
+
+      yield* def.execute(
+        {
+          description: "Create hello.txt",
+          prompt: "Create hello.txt in the workspace",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps: stubOps() },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(yield* todos.get(chat.id)).toEqual([
+        { content: "Create hello.txt file", status: "completed", priority: "high" },
+        { content: "Run tests", status: "pending", priority: "medium" },
+      ])
+    }),
+  )
+
   it.instance(
     "execute shapes child permissions for task, todowrite, and primary tools",
     () =>
@@ -695,6 +736,59 @@ describe("tool.task", () => {
       expect(waited.timedOut).toBe(false)
       expect(waited.info?.status).toBe("completed")
       expect(waited.info?.output).toBe("background done")
+    }),
+  )
+
+  background.instance("background completion marks the matching parent todo completed", () =>
+    Effect.gen(function* () {
+      const todos = yield* Todo.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const injected = defer<SessionPrompt.PromptInput>()
+      yield* todos.update({
+        sessionID: chat.id,
+        todos: [
+          { content: "Create hello.txt file", status: "pending", priority: "high" },
+          { content: "Run tests", status: "pending", priority: "medium" },
+        ],
+      })
+
+      yield* def.execute(
+        {
+          description: "Create hello.txt",
+          prompt: "Create hello.txt in the workspace",
+          subagent_type: "general",
+          background: true,
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {
+            promptOps: {
+              ...stubOps({ text: "background done" }),
+              prompt: (input) => {
+                if (input.sessionID === chat.id) {
+                  injected.resolve(input)
+                  return Effect.succeed(reply(input, "injected"))
+                }
+                return Effect.succeed(reply(input, "background done"))
+              },
+            } satisfies TaskPromptOps,
+          },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      yield* Effect.promise(() => injected.promise)
+      expect(yield* todos.get(chat.id)).toEqual([
+        { content: "Create hello.txt file", status: "completed", priority: "high" },
+        { content: "Run tests", status: "pending", priority: "medium" },
+      ])
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #12938

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a task subagent completes, the parent session can keep a matching todo item stuck as pending or in progress. This updates the task tool so completed foreground and background subagent runs mark the matching parent todo as completed.

The update is best-effort. If the todo update fails, the task output includes a short note so the parent agent can update the todo manually.

### How did you verify your code works?

- `bun test test/tool/task.test.ts`
- `bun typecheck`
- `bun lint`
- pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
