### PR TITLE
fix(tui): search files inside reference directory with @alias/

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -493,8 +493,16 @@ export function Autocomplete(props: {
     const nonFileOptions: AutocompleteOption[] =
       store.visible === "@" ? [...referenceAliasesValue, ...agentsValue, ...mcpResources()] : [...commandsValue]
 
+    const refMatch = referenceMatch()
+    const bareSlash = refMatch && searchValue === refMatch.name + "/"
     if (!searchValue) {
       return [...nonFileOptions, ...fileOptions]
+    }
+    if (bareSlash) {
+      const aliasOption = referenceAliasesValue.filter(
+        (item) => item.display === `@${refMatch!.name}`
+      )
+      return [...aliasOption, ...fileOptions]
     }
 
     if (files.loading && prev && prev.length > 0) {

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -317,15 +317,23 @@ export function Autocomplete(props: {
     () => ({ query: search(), location: location() }),
     async (input) => {
       if (!store.visible || store.visible === "/") return []
-      if (referenceMatch()) return []
       const { lineRange, baseQuery } = extractLineRange(input.query ?? "")
+
+      const ref = referenceMatch()
+      let searchQuery = baseQuery
+      const searchDir = ref?.path ?? input.location?.directory
+      if (ref) {
+        const slash = baseQuery.indexOf("/")
+        if (slash === -1) return []
+        searchQuery = baseQuery.slice(slash + 1)
+      }
 
       // Get files from SDK
       const result = await sdk.client.v2.fs.find({
-        query: baseQuery,
+        query: searchQuery,
         limit: "20",
         location: {
-          directory: input.location?.directory,
+          directory: searchDir,
           workspace: input.location?.workspaceID ?? project.workspace.current(),
         },
       })
@@ -336,24 +344,23 @@ export function Autocomplete(props: {
       // score, filename bonus, etc. are already factored in).
       if (!result.error && result.data) {
         const width = props.anchor().width - 4
-        options.push(
-          ...result.data.data.map((item): AutocompleteOption => {
-            const { filename, part } = createFilePart(
-              item,
-              path.join(result.data.location.directory, item.path),
-              lineRange,
-            )
-            return {
-              display: Locale.truncateMiddle(filename, width),
-              value: filename,
-              isDirectory: item.type === "directory",
-              path: item.path,
-              onSelect: () => {
-                insertPart(filename, part)
-              },
-            }
-          }),
-        )
+        for (const item of result.data.data) {
+          const filePath = path.join(result.data.location.directory, item.path)
+          const { part } = createFilePart(item, filePath, lineRange)
+          const displayName = ref ? `${ref.name}/${item.path}` : part.filename
+          options.push({
+            display: Locale.truncateMiddle(displayName, width),
+            value: displayName,
+            isDirectory: item.type === "directory",
+            path: item.path,
+            onSelect: () => {
+              insertPart(displayName, {
+                ...part,
+                filename: displayName,
+              })
+            },
+          })
+        }
       }
 
       return options
@@ -475,15 +482,10 @@ export function Autocomplete(props: {
 
   const options = createMemo((prev: AutocompleteOption[] | undefined) => {
     const filesValue = files()
-    const referenceMatchValue = referenceMatch()
     const agentsValue = agents()
     const referenceAliasesValue = referenceAliases()
     const commandsValue = commands()
     const searchValue = search()
-
-    if (store.visible === "@" && referenceMatchValue) {
-      return referenceAliasesValue.filter((item) => item.display === `@${referenceMatchValue.name}`)
-    }
 
     // Files come from fff already fuzzy ranked and filtered
     // it shouldn't be additionally sorted by fuzzysort as it will loose the results


### PR DESCRIPTION
### Issue for this PR

Closes #34106

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Configured references (like `@docs`) can't search files inside the reference directory — typing `@docs/xxx` shows "No matching results". The @ autocomplete was skipping file search entirely whenever a reference alias matched.

This PR removes the early return, and when the user has typed / after a reference alias, scopes the file search to the reference directory (via the existing fs.find API). `@docs` without / still attaches the reference root as before.

This behavior is described in the references documentation ([docs: References](https://opencode.ai/docs/en/references/#use-references)) but was not yet implemented.

### How did you verify your code works?

Configured "docs": "./packages/web/src/content/docs" in opencode.jsonc and ran bun dev . to test:

- `@docs` → alias shown, selecting attaches the reference root directory
- `@docs/` with typed characters → file results from within the reference
- `@docs/references` → fuzzy-searches `references.mdx`
- `@packages/` normal file search → unchanged
- `@agent` names and /commands → unaffected

### Screenshots / recordings

https://github.com/user-attachments/assets/95069aeb-3fef-48b8-8676-36efeb29247e

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR