### PR TITLE
fix(tui): register `prompt.skills` keybinds

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -567,6 +567,7 @@ export function Prompt(props: PromptProps) {
       "prompt.stash",
       "prompt.stash.pop",
       "prompt.stash.list",
+      "prompt.skills",
       "session.interrupt",
       "workspace.set",
       "session.move",


### PR DESCRIPTION
### Issue for this PR

Closes #30322
Closes #29148 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

issue:
The prompt component never registers `prompt.skills` in its prompt.palette binding layer. This means even if a user sets a custom shortcut in `tui.json`, the keymap has no binding to match against in that scope, so the shortcut does nothing.

fix:
Added `prompt.skills` to the `tuiConfig.keybinds.gather("prompt.palette", [...])` in the prompt component

### How did you verify your code works?

1. Manually tested by adding `keybinds.prompt_skills` to local `tui.json`, ran `opencode`, and pressed keybind
2. Ran `bun typecheck`

### Screenshots / recordings

#### before
<img width="1728" height="1084" alt="before" src="https://github.com/user-attachments/assets/8832398b-2ae7-4c5b-9966-0e954ef6da21" />

#### after
<img width="1728" height="1084" alt="after" src="https://github.com/user-attachments/assets/0a975a75-853f-4e75-94b5-9435e121122d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
