### PR TITLE
fix(core): migrate legacy local databases

### DIFF
--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -50,16 +50,33 @@ export function applyOnly(db: Database, input: Migration[]) {
     )
     if (completed.size === 0) {
       // Existing installs used Drizzle's migration journal. Seed the new
-      // journal once so TypeScript migrations don't replay old SQL.
+      // journal once so TypeScript migrations don't replay old SQL. Drizzle's
+      // SQLite journal used to store only id/hash/created_at, so fall back to
+      // the row count when migration names are not available.
       if (
         yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${"__drizzle_migrations"}`)
       ) {
-        yield* db.run(sql`
-          INSERT OR IGNORE INTO ${sql.identifier("migration")} (id, time_completed)
-          SELECT name, ${Date.now()}
-          FROM ${sql.identifier("__drizzle_migrations")}
-          WHERE name IS NOT NULL
-        `)
+        const columns = new Set(
+          (yield* db.all<{ name: string }>(sql`PRAGMA table_info("__drizzle_migrations")`)).map((row) => row.name),
+        )
+        if (columns.has("name")) {
+          yield* db.run(sql`
+            INSERT OR IGNORE INTO ${sql.identifier("migration")} (id, time_completed)
+            SELECT name, ${Date.now()}
+            FROM ${sql.identifier("__drizzle_migrations")}
+            WHERE name IS NOT NULL
+          `)
+        } else {
+          const count =
+            (yield* db.get<{ count: number }>(
+              sql`SELECT COUNT(*) as count FROM ${sql.identifier("__drizzle_migrations")}`,
+            ))?.count ?? 0
+          yield* Effect.forEach(input.slice(0, count), (migration) =>
+            db.run(
+              sql`INSERT OR IGNORE INTO ${sql.identifier("migration")} (id, time_completed) VALUES (${migration.id}, ${Date.now()})`,
+            ),
+          )
+        }
         completed = new Set(
           (yield* db.all<{ id: string }>(sql`SELECT id FROM ${sql.identifier("migration")}`)).map((row) => row.id),
         )

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -109,6 +109,37 @@ describe("DatabaseMigration", () => {
     ).rejects.toThrow("Database is not empty and has no session table")
   })
 
+  test("seeds unnamed Drizzle journal entries by migration order", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.transaction((tx) =>
+          Effect.forEach(migrations.slice(0, 3), (migration) => migration.up(tx), { discard: true }),
+        )
+        yield* db.run(sql`
+          CREATE TABLE "__drizzle_migrations" (
+            id SERIAL PRIMARY KEY,
+            hash text NOT NULL,
+            created_at numeric
+          )
+        `)
+        yield* Effect.forEach([1, 2, 3], (createdAt) =>
+          db.run(sql`INSERT INTO "__drizzle_migrations" (hash, created_at) VALUES ('', ${createdAt})`),
+        )
+
+        yield* DatabaseMigration.apply(db)
+
+        expect(yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'workspace'`)).toEqual({
+          name: "workspace",
+        })
+        expect(yield* db.get(sql`SELECT count(*) as count FROM migration`)).toEqual({ count: migrations.length })
+        expect(yield* db.all(sql`SELECT id FROM migration ORDER BY id LIMIT 3`)).toEqual(
+          migrations.slice(0, 3).map((migration) => ({ id: migration.id })),
+        )
+      }),
+    )
+  })
+
   test("backfills existing Context Epoch rows to the build agent", async () => {
     await run(
       Effect.gen(function* () {

--- a/packages/opencode/src/bus/global.ts
+++ b/packages/opencode/src/bus/global.ts
@@ -8,14 +8,26 @@ export type GlobalEvent = {
   payload: any
 }
 
-class GlobalBusEmitter extends EventEmitter<{
-  event: [GlobalEvent]
-}> {
-  override emit(eventName: "event", event: GlobalEvent): boolean {
+class GlobalBusEmitter {
+  private emitter = new EventEmitter<{
+    event: [GlobalEvent]
+  }>()
+
+  emit(eventName: "event", event: GlobalEvent) {
     if (event.payload && typeof event.payload === "object" && !("id" in event.payload)) {
       event.payload.id = event.payload.syncEvent?.id ?? Identifier.create("evt", "ascending")
     }
-    return super.emit(eventName, event)
+    return this.emitter.emit(eventName, event)
+  }
+
+  on(eventName: "event", listener: (event: GlobalEvent) => void) {
+    this.emitter.on(eventName, listener)
+    return this
+  }
+
+  off(eventName: "event", listener: (event: GlobalEvent) => void) {
+    this.emitter.off(eventName, listener)
+    return this
   }
 }
 

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,5 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, ne, sql } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
 import { ProjectDirectoryTable, ProjectTable } from "@opencode-ai/core/project/sql"
 import { ProjectDirectories } from "@opencode-ai/core/project/directories"
@@ -219,6 +219,13 @@ export const layer = Layer.effect(
       // Phase 2: upsert
       const projectID = ProjectV2.ID.make(data.id)
       yield* migrateProjectId(data.previous ? ProjectV2.ID.make(data.previous) : undefined, projectID)
+      const legacy = yield* db
+        .select({ id: ProjectTable.id })
+        .from(ProjectTable)
+        .where(and(eq(ProjectTable.worktree, AbsolutePath.make(worktree)), ne(ProjectTable.id, projectID)))
+        .all()
+        .pipe(Effect.orDie)
+      for (const item of legacy) yield* migrateProjectId(ProjectV2.ID.make(item.id), projectID)
       const row = yield* db.select().from(ProjectTable).where(eq(ProjectTable.id, projectID)).get().pipe(Effect.orDie)
       const existing = row
         ? fromRow(row)

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -241,6 +241,46 @@ describe("Project.fromDirectory", () => {
       ).toBe(remoteID)
     }),
   )
+
+  it.live("migrates uncached root project data by matching worktree", () =>
+    Effect.gen(function* () {
+      const { db } = yield* Database.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      const projects = yield* Project.Service
+      const rootResult = yield* projects.fromDirectory(tmp)
+      const rootProject = rootResult.project
+      const remoteID = remoteProjectID("github.com/acme/uncached")
+      const sessionID = crypto.randomUUID() as SessionID
+
+      yield* Effect.promise(() => Bun.file(path.join(tmp, ".git", "opencode")).delete()).pipe(Effect.ignore)
+      yield* db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: rootProject.id,
+          slug: sessionID,
+          directory: tmp,
+          title: "test",
+          version: "0.0.0-test",
+          time_created: Date.now(),
+          time_updated: Date.now(),
+        })
+        .run()
+        .pipe(Effect.orDie)
+      yield* Effect.promise(() => $`git remote add origin git@github.com:acme/uncached.git`.cwd(tmp).quiet())
+
+      const result = yield* projects.fromDirectory(tmp)
+
+      expect(result.project.id).toBe(remoteID)
+      expect(
+        yield* db.select().from(ProjectTable).where(eq(ProjectTable.id, rootProject.id)).get().pipe(Effect.orDie),
+      ).toBeUndefined()
+      expect(
+        (yield* db.select().from(SessionTable).where(eq(SessionTable.id, sessionID)).get().pipe(Effect.orDie))
+          ?.project_id,
+      ).toBe(remoteID)
+    }),
+  )
 })
 
 describe("Project.fromDirectory git failure paths", () => {


### PR DESCRIPTION
  ### Issue for this PR

   Closes #33887, closes #32361, closes #28013, closes #33828

 ### Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Refactor / code improvement
 - [ ] Documentation

 ### What does this PR do?

   Fixes two legacy local database migration issues.

   Older databases can have a Drizzle journal table named `__drizzle_migrations` with only `id`, `hash`, and `created_at`. The migration bridge expected a `name` column, so startup
 failed with `no such column: name`. In the full TUI this looked like a blank hang because the screen was already cleared.

   Older sessions can also be attached to a previous project ID. Current code may resolve the same repo from its normalized git remote, while old rows used a root-commit project ID.
 If there is no cached `.git/opencode` ID, the app creates a new project row and `/sessions` appears empty.

   This PR handles both cases during migration:
   - seed the new `migration` table from old Drizzle journal row count when migration names are unavailable
   - migrate existing project/session/workspace rows with the same worktree into the currently resolved project ID
   - update `GlobalBus` to avoid a typed `EventEmitter.emit` override that fails current typecheck

   ### How did you verify your code works?

   - `bun test test/database-migration.test.ts -t "seeds unnamed Drizzle journal entries"`
   - `bun test test/project/project.test.ts -t "migrates uncached root project data"`
   - `bun typecheck` from `packages/core`
   - `bun typecheck` from `packages/opencode`
   - Tested a rebuilt local binary against an affected database: startup works and `/sessions` shows old sessions again.

 ### Screenshots / recordings

 N/A

 ### Checklist

 - [x] I have tested my changes locally
 - [x] I have not included unrelated changes in this PR
