### PR TITLE
fix(opencode): connect disabled MCP after auth

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -945,7 +945,7 @@ export const layer = Layer.effect(
 
       const mcpConfig = yield* requireMcpConfig(mcpName)
 
-      return yield* createAndStore(mcpName, mcpConfig)
+      return yield* createAndStore(mcpName, { ...mcpConfig, enabled: true })
     })
 
     const removeAuth = Effect.fn("MCP.removeAuth")(function* (mcpName: string) {

--- a/packages/opencode/test/mcp/oauth-auto-connect.test.ts
+++ b/packages/opencode/test/mcp/oauth-auto-connect.test.ts
@@ -299,6 +299,34 @@ mcpTest.instance(
 )
 
 mcpTest.instance(
+  "finishAuth() connects an OAuth server configured as disabled",
+  () =>
+    Effect.gen(function* () {
+      yield* Effect.addFinalizer(() => Effect.promise(() => McpOAuthCallback.stop()).pipe(Effect.ignore))
+      const mcp = yield* MCP.Service
+      const name = "test-disabled-auth-success"
+
+      expect((yield* mcp.startAuth(name)).authorizationUrl).toContain("https://auth.example.com/authorize")
+      connectSucceedsImmediately = true
+
+      expect((yield* mcp.finishAuth(name, "valid-code")).status).toBe("connected")
+      const status = yield* mcp.status()
+      expect(status[name]?.status).toBe("connected")
+    }),
+  {
+    config: {
+      mcp: {
+        "test-disabled-auth-success": {
+          type: "remote",
+          url: "https://example.com/mcp",
+          enabled: false,
+        },
+      },
+    },
+  },
+)
+
+mcpTest.instance(
   "auth status only reports credentials stored for the configured server URL",
   () =>
     Effect.gen(function* () {


### PR DESCRIPTION
Fixes #33915

Summary:
- Connect after OAuth with `enabled` forced on for the current run.
- Cover disabled OAuth MCP configs in the auth regression test.

Test:
- `npx --yes bun@1.3.14 test test/mcp/oauth-auto-connect.test.ts --timeout 30000`
- `npx --yes bun@1.3.14 run typecheck`
- `npx --yes bun@1.3.14 x prettier --check packages/opencode/src/mcp/index.ts packages/opencode/test/mcp/oauth-auto-connect.test.ts`