### PR TITLE
feat(session): configurable retry max delay cap

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -163,6 +163,14 @@ export const Info = Schema.Struct({
       }),
     }),
   ),
+  retry: Schema.optional(
+    Schema.Struct({
+      max_delay_ms: Schema.optional(PositiveInt).annotate({
+        description:
+          "Maximum retry delay in milliseconds when a provider returns retryable errors. When omitted, retries fall back to the runtime timer limit (2147483647 ms).",
+      }),
+    }),
+  ).annotate({ description: "Retry behavior configuration" }),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -628,7 +628,9 @@ export const layer = Layer.effect(
           messageID: input.assistantMessage.id,
         })
         ctx.needsCompaction = false
-        ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        const cfg = yield* config.get()
+        ctx.shouldBreak = cfg.experimental?.continue_loop_on_deny !== true
+        const retryMaxDelayMs = cfg.retry?.max_delay_ms
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -659,6 +661,7 @@ export const layer = Layer.effect(
               SessionRetry.policy({
                 provider: input.model.providerID,
                 parse,
+                maxDelayMs: retryMaxDelayMs,
                 set: (info) => {
                   return status.set(ctx.sessionID, {
                     type: "retry",

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -28,11 +28,12 @@ export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 
-function cap(ms: number) {
-  return Math.min(ms, RETRY_MAX_DELAY)
+function cap(ms: number, maxDelayMs = RETRY_MAX_DELAY) {
+  return Math.min(ms, maxDelayMs)
 }
 
-export function delay(attempt: number, error?: SessionV1.APIError) {
+export function delay(attempt: number, error?: SessionV1.APIError, maxDelayMs?: number) {
+  const maxDelay = maxDelayMs ?? RETRY_MAX_DELAY
   if (error) {
     const headers = error.data.responseHeaders
     if (headers) {
@@ -40,7 +41,7 @@ export function delay(attempt: number, error?: SessionV1.APIError) {
       if (retryAfterMs) {
         const parsedMs = Number.parseFloat(retryAfterMs)
         if (!Number.isNaN(parsedMs)) {
-          return cap(parsedMs)
+          return cap(parsedMs, maxDelay)
         }
       }
 
@@ -49,20 +50,23 @@ export function delay(attempt: number, error?: SessionV1.APIError) {
         const parsedSeconds = Number.parseFloat(retryAfter)
         if (!Number.isNaN(parsedSeconds)) {
           // convert seconds to milliseconds
-          return cap(Math.ceil(parsedSeconds * 1000))
+          return cap(Math.ceil(parsedSeconds * 1000), maxDelay)
         }
         // Try parsing as HTTP date format
         const parsed = Date.parse(retryAfter) - Date.now()
         if (!Number.isNaN(parsed) && parsed > 0) {
-          return cap(Math.ceil(parsed))
+          return cap(Math.ceil(parsed), maxDelay)
         }
       }
 
-      return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1))
+      return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), maxDelay)
     }
   }
 
-  return cap(Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS))
+  return cap(
+    Math.min(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1), RETRY_MAX_DELAY_NO_HEADERS),
+    maxDelay,
+  )
 }
 
 export function retryable(error: Err, provider: string) {
@@ -177,6 +181,7 @@ export function policy(opts: {
   provider: string
   parse: (error: unknown) => Err
   set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
+  maxDelayMs?: number
 }) {
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
@@ -184,7 +189,7 @@ export function policy(opts: {
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
-        const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
+        const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined, opts.maxDelayMs)
         const now = yield* Clock.currentTimeMillis
         yield* opts.set({
           attempt: meta.attempt,

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -87,6 +87,25 @@ describe("session.retry.delay", () => {
     expect(SessionRetry.delay(1, error)).toBe(SessionRetry.RETRY_MAX_DELAY)
   })
 
+  test("caps header delays to configured max delay", () => {
+    const error = apiError({ "retry-after-ms": "700000" })
+    expect(SessionRetry.delay(1, error, 60000)).toBe(60000)
+
+    const secondsError = apiError({ "retry-after": "120" })
+    expect(SessionRetry.delay(1, secondsError, 60000)).toBe(60000)
+  })
+
+  test("configured max delay also caps exponential fallback without headers", () => {
+    const error = apiError()
+    const delays = Array.from({ length: 10 }, (_, index) => SessionRetry.delay(index + 1, error, 5000))
+    expect(delays).toStrictEqual([2000, 4000, 5000, 5000, 5000, 5000, 5000, 5000, 5000, 5000])
+  })
+
+  test("configured max delay does not raise the default no-headers cap", () => {
+    const error = apiError()
+    expect(SessionRetry.delay(10, error, 60000)).toBe(30000)
+  })
+
   it.instance("policy updates retry status and increments attempts", () =>
     Effect.gen(function* () {
       const sessionID = SessionID.make("session-retry-test")


### PR DESCRIPTION
Add retry.max_delay_ms config option. When set, it caps both provider retry-after hints and the exponential backoff fallback. If unset, the existing runtime timer limit (2147483647 ms) remains the default.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some remote returns very large unreasonable delay time, thus make the client wait for severay days before the next calling.
I wish there be a config for handling such situation

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
