### PR TITLE
fix(tui): defer question mode push while dialog is open

### DIFF
--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -1,11 +1,12 @@
 import { createStore } from "solid-js/store"
-import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, onCleanup, Show } from "solid-js"
 import { useRenderer } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../ui/border"
+import { useDialog } from "../../ui/dialog"
 import { useTuiConfig } from "../../config"
 import { useBindings, useOpencodeModeStack } from "../../keymap"
 
@@ -125,7 +126,10 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     pick(opt.label)
   }
 
-  onMount(() => {
+  const dialog = useDialog()
+
+  createEffect(() => {
+    if (dialog.stack.length > 0) return
     const popMode = modeStack.push(QUESTION_MODE)
     onCleanup(popMode)
   })


### PR DESCRIPTION
### Issue for this PR

Closes #29999 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Simpler version of #30000 and I feel like #30000 should be considered first

When a dialog is open and the agent asks a question, the question widget captures keyboard even though the dialog is visually on top — user presses keys expecting dialog interaction but the hidden question widget consumes them.

`QuestionPrompt` now pushes its `"question"` mode in a `createEffect` gated on `dialog.stack.length === 0` instead of unconditionally on `onMount`. When a dialog is open the mode is not pushed, so keyboard stays with the dialog. When the dialog closes the effect re-runs, pushes `"question"`, and the already-rendered question becomes interactive immediately.

Follows the same pattern already used by autocomplete (`prompt/autocomplete.tsx:109-113`).

https://github.com/anomalyco/opencode/blob/2caa016fe1f3d8533e38e8d92fda73ce5c93082d/packages/tui/src/component/prompt/autocomplete.tsx#L109-L113

### How did you verify your code works?

Typecheck passes. Existing keymap mode stack tests in `test/keymap.test.tsx` pass.

### Screenshots / recordings

Before:

https://github.com/user-attachments/assets/9340b50b-017d-4b75-9ccf-a070bfe712e8

After:

https://github.com/user-attachments/assets/98176f18-7515-4e70-aced-417c330bdc17

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
