### PR TITLE
feat(tui): add permission_fullscreen_default option

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -62,6 +62,9 @@ export const Info = Schema.Struct({
   scroll_speed: Schema.optional(ScrollSpeed).annotate({ description: "TUI scroll speed" }),
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
+  permission_fullscreen_default: Schema.optional(Schema.Boolean).annotate({
+    description: "Open the permission prompt in fullscreen by default",
+  }),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
 })
 export type Info = Schema.Schema.Type<typeof Info>

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -536,7 +536,7 @@ function Prompt<const T extends Record<string, string>>(props: {
   const keys = Object.keys(props.options) as (keyof T)[]
   const [store, setStore] = createStore({
     selected: keys[0],
-    expanded: false,
+    expanded: !!(props.fullscreen && tuiConfig.permission_fullscreen_default),
   })
   const narrow = createMemo(() => dimensions().width < 80)
   const fullscreenHint = useCommandShortcut("permission.prompt.fullscreen")


### PR DESCRIPTION
### Issue for this PR

Closes #12334

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `permission_fullscreen_default` option to `tui.json`. When it's `true`, the permission prompt opens in the fullscreen view instead of collapsed, so you don't have to toggle fullscreen on every prompt. Defaults to `false`, so behaviour is unchanged unless you opt in.

It's gated on `props.fullscreen`, so it only affects prompts that already support the fullscreen toggle. I added the field to the `Info` schema in `config/index.tsx`; `resolve()` already spreads `...input`, so it flows through to the resolved config and the generated `tui.json` schema without extra wiring. The only behaviour change is the initial value of `store.expanded` in `permission.tsx`.

#12334 requested this and was closed by the stale bot with no implementation.

### How did you verify your code works?

Built locally, set `permission_fullscreen_default: true` in `tui.json`, and triggered an edit permission prompt — it opens fullscreen. Unset / `false` opens collapsed as before. Also confirmed the generated `tui.json` schema includes the new key.

### Screenshots / recordings

No visual change beyond the existing fullscreen permission view opening by default. Can add a recording if that's preferred.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
