### PR TITLE
fix(tui): prevent model/agent reset on Prompt remount

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -136,6 +136,7 @@ function formatEditorContext(selection: EditorSelection) {
 }
 
 let stashed: { prompt: PromptInfo; cursor: number } | undefined
+let syncedSessionID: string | undefined
 
 export function Prompt(props: PromptProps) {
   let input: TextareaRenderable
@@ -304,7 +305,6 @@ export function Prompt(props: PromptProps) {
   )
 
   // Initialize agent/model/variant from last user message when session changes
-  let syncedSessionID: string | undefined
   createEffect(() => {
     const sessionID = props.sessionID
     const msg = lastUserMessage()


### PR DESCRIPTION
### Issue for this PR

Closes #34207

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moving `syncedSessionID` from component closure to module level. This variable guards against re-syncing model/agent from `lastUserMessage()` on Prompt remount — when a question or permission dialog appears, the Prompt unmounts and remounts, which previously reset the guard and triggered an unwanted sync, overwriting any manual model selection.

### How did you verify your code works?

1. Open session and trigger the agent to trigger question
2. While the agent is still running,  switch model from A to B
3. Question appears, and after answering, the model stays B

### Screenshots / recordings

https://github.com/user-attachments/assets/29464e14-9195-439e-bfc9-83da269dc39e

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
