### PR TITLE
chore(llm): fix misleading comment on RESPECTS_INLINE_HINTS

### DIFF
--- a/packages/llm/src/cache-policy.ts
+++ b/packages/llm/src/cache-policy.ts
@@ -36,9 +36,9 @@ const resolve = (policy: CachePolicy | undefined): CachePolicyObject => {
   return policy
 }
 
-// Protocols whose wire format ignores inline cache markers (OpenAI's implicit
-// prefix caching, Gemini's implicit + out-of-band CachedContent). Skip the
-// whole policy pass for these — emitting hints would be harmless but pointless.
+// Protocols whose wire format supports inline cache markers. Only these receive
+// the policy pass; others (OpenAI's implicit prefix caching, Gemini's implicit
+// + out-of-band CachedContent) don't use inline hints, so the pass is skipped.
 const RESPECTS_INLINE_HINTS = new Set(["anthropic-messages", "bedrock-converse"])
 
 const makeHint = (ttlSeconds: number | undefined): CacheHint =>


### PR DESCRIPTION
The comment above `RESPECTS_INLINE_HINTS` described protocols that
*ignore* inline cache markers (OpenAI, Gemini) while the set actually
contains protocols that *support* them (`anthropic-messages`,
`bedrock-converse`).

This caused a readability trap: the comment and the variable name
pointed in opposite directions.

No logic change — comment only.

Fixes #34134