### PR TITLE
chore(llm): fix misleading comment on RESPECTS_INLINE_HINTS

### DIFF
--- a/packages/llm/src/cache-policy.ts
+++ b/packages/llm/src/cache-policy.ts
@@ -36,9 +36,9 @@ const resolve = (policy: CachePolicy | undefined): CachePolicyObject => {
   return policy
 }
 
-// Protocols whose wire format ignores inline cache markers (OpenAI's implicit
-// prefix caching, Gemini's implicit + out-of-band CachedContent). Skip the
-// whole policy pass for these — emitting hints would be harmless but pointless.
+// Protocols whose wire format supports inline cache markers. Only these receive
+// the policy pass; others (OpenAI's implicit prefix caching, Gemini's implicit
+// + out-of-band CachedContent) don't use inline hints, so the pass is skipped.
 const RESPECTS_INLINE_HINTS = new Set(["anthropic-messages", "bedrock-converse"])
 
 const makeHint = (ttlSeconds: number | undefined): CacheHint =>


### PR DESCRIPTION
### Issue for this PR

Closes #34134

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The comment above `RESPECTS_INLINE_HINTS` said "Protocols whose wire format ignores inline cache markers" and listed OpenAI/Gemini as examples — but the set actually holds the protocols that *support* inline hints (anthropic-messages, bedrock-converse). Comment and variable name pointed in opposite directions, which is a trap for anyone adding a new route ID.

Fixed the comment to match what the set actually contains. No logic change.

### How did you verify your code works?

Comment-only change, no runtime behavior modified. Verified by reading the usage at line 100: `if (!RESPECTS_INLINE_HINTS.has(...)) return request` — the logic is correct, only the comment was wrong.

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR