### PR TITLE
test(core): cover app node builder graphs

### DIFF
--- a/packages/core/src/effect/app-node-builder.ts
+++ b/packages/core/src/effect/app-node-builder.ts
@@ -21,4 +21,4 @@ export function build<A, E>(root: LayerNode.Node<A, E, any>, replacements?: read
   return LayerNode.compile(app, replacementMap)
 }
 
-export * as NodeBuild from "./app-node-builder"
+export * as AppNodeBuilder from "./app-node-builder"

--- a/packages/core/test/effect/layer-node/node-build.test.ts
+++ b/packages/core/test/effect/layer-node/node-build.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { Context, Effect, Layer, LayerMap, Option } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Node } from "@opencode-ai/core/effect/app-node"
-import { NodeBuild } from "@opencode-ai/core/effect/app-node-builder"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
 import type { LocationError, LocationServices } from "@opencode-ai/core/location-services"
@@ -22,7 +22,7 @@ describe("node build", () => {
       layer: Layer.succeed(Result, Result.of({ value: "plain" })),
       deps: [],
     })
-    const layer = NodeBuild.build(LayerNode.group([result]))
+    const layer = AppNodeBuilder.build(result)
     const program = Effect.gen(function* () {
       expect(Option.isNone(yield* Effect.serviceOption(LocationServiceMap.Service))).toBe(true)
       return (yield* Result).value
@@ -64,7 +64,7 @@ describe("node build", () => {
     const map = Node.makeGlobalNode({ service: LocationServiceMap.Service, layer: mapLayer, deps: [b] })
     const graph = LayerNode.bind(LayerNode.group([a]), LocationServiceMap.node, map)
 
-    expect(() => NodeBuild.build(graph)).toThrow("Cycle detected in layer tree")
+    expect(() => AppNodeBuilder.build(graph)).toThrow("Cycle detected in layer tree")
   })
 
   test("shares top-level project with location services", async () => {
@@ -81,7 +81,7 @@ describe("node build", () => {
         })
       }),
     )
-    const layer = NodeBuild.build(LayerNode.group([Project.node, LocationServiceMap.node]), [
+    const layer = AppNodeBuilder.build(LayerNode.group([Project.node, LocationServiceMap.node]), [
       LayerNode.replace(Project.layer, projectLayer),
     ])
     const ref = Location.Ref.make({ directory: AbsolutePath.make(tmp.path) })
@@ -112,7 +112,7 @@ describe("node build", () => {
       ),
       deps: [value],
     })
-    const serviceLayer = NodeBuild.build(LayerNode.group([result]))
+    const serviceLayer = AppNodeBuilder.build(result)
     const program = Effect.gen(function* () {
       expect(Option.isNone(yield* Effect.serviceOption(LocationServiceMap.Service))).toBe(true)
       return (yield* Result).value

--- a/packages/core/test/project-directories.test.ts
+++ b/packages/core/test/project-directories.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect } from "bun:test"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import { Database } from "@opencode-ai/core/database/database"
-import { EventV2 } from "@opencode-ai/core/event"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectDirectories } from "@opencode-ai/core/project/directories"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(Layer.mergeAll(Database.defaultLayer, EventV2.defaultLayer, ProjectDirectories.defaultLayer))
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Database.node, ProjectDirectories.node])))
 
 const projectID = Project.ID.make("project-directories")
 const directory = AbsolutePath.make("/tmp/project-directories")

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -2,18 +2,15 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Schema } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { ProjectV2 } from "@opencode-ai/core/project"
-import { Database } from "@opencode-ai/core/database/database"
-import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Git } from "@opencode-ai/core/git"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Hash } from "@opencode-ai/core/util/hash"
-import { ProjectDirectories } from "@opencode-ai/core/project/directories"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(Layer.mergeAll(ProjectV2.defaultLayer, Database.defaultLayer, ProjectDirectories.defaultLayer))
+const it = testEffect(AppNodeBuilder.build(ProjectV2.node))
 
 function remoteID(remote: string) {
   return ProjectV2.ID.make(Hash.fast(`git-remote:${remote}`))

--- a/packages/core/test/question.test.ts
+++ b/packages/core/test/question.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect } from "bun:test"
 import { Context, Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect"
-import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { EventV2 } from "@opencode-ai/core/event"
 import { QuestionV2 } from "@opencode-ai/core/question"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { testEffect } from "./lib/effect"
 
-const questions = QuestionV2.layer.pipe(Layer.provide(EventV2.defaultLayer))
-const it = testEffect(Layer.mergeAll(Database.defaultLayer, EventV2.defaultLayer, questions))
+const questions = AppNodeBuilder.build(LayerNode.group([EventV2.node, QuestionV2.node]))
+const it = testEffect(questions)
 
 const sessionID = SessionV2.ID.make("ses_question_test")
 const question: QuestionV2.Info = {

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -1,7 +1,7 @@
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
-import { NodeBuild } from "@opencode-ai/core/effect/app-node-builder"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Credential } from "@opencode-ai/core/credential"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
@@ -49,7 +49,7 @@ export function createEmbeddedRoutes() {
 }
 
 function makeRoutes<AuthError, AuthServices>(auth: Layer.Layer<ServerAuth.Config, AuthError, AuthServices>) {
-  const serviceLayer = NodeBuild.build(
+  const serviceLayer = AppNodeBuilder.build(
     LayerNode.bind(applicationServices, SessionExecution.node, SessionExecutionLocal.node),
   )
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds coverage and cleanup around the app node builder and moves a few core tests onto the node graph system.

- Renames the app node builder namespace export to `AppNodeBuilder` and updates callers.
- Adds tests proving `AppNodeBuilder.build` skips `LocationServiceMap` when the graph does not require it.
- Adds a cycle test for graphs that bind a custom location service map back into global dependencies.
- Verifies a top-level Project dependency is shared with location services instead of acquired twice.
- Converts several core tests from manual `defaultLayer` composition to `AppNodeBuilder.build(...)`.
- Updates the standalone server route composition to use the renamed `AppNodeBuilder` import.

### How did you verify your code works?

- `bun turbo typecheck` via the pre-push hook
- `bun typecheck` in `packages/core`
- `bun test test/effect/layer-node/node-build.test.ts` in `packages/core`
- `bun test test/project.test.ts test/project-directories.test.ts test/question.test.ts` in `packages/core`

### Screenshots / recordings

N/A - no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._