### PR TITLE
refactor(core): move session test to nodes

### DIFF
--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect } from "bun:test"
-import { DateTime, Effect, Layer, Schema } from "effect"
+import { DateTime, Effect, Schema } from "effect"
 import { asc, eq } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { makeGlobalNode } from "@opencode-ai/core/effect/app-node"
 import { EventV2 } from "@opencode-ai/core/event"
 import { EventTable } from "@opencode-ai/core/event/sql"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -10,7 +13,6 @@ import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
-import { locationServiceMapLayer } from "@opencode-ai/core/location-services"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionMessage } from "@opencode-ai/core/session/message"
 import { Prompt } from "@opencode-ai/core/session/prompt"
@@ -18,12 +20,18 @@ import { SessionMessageUpdater } from "@opencode-ai/core/session/message-updater
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionInput } from "@opencode-ai/core/session/input"
-import { SessionStore } from "@opencode-ai/core/session/store"
 import { SessionInputTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
 import { testEffect } from "./lib/effect"
 import { Snapshot } from "@opencode-ai/core/snapshot"
 
-const it = testEffect(Layer.mergeAll(Database.defaultLayer, EventV2.defaultLayer, SessionProjector.defaultLayer))
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Database.node, EventV2.node, SessionProjector.node])))
+const sessionsLayer = AppNodeBuilder.build(
+  LayerNode.bind(
+    SessionV2.node,
+    SessionExecution.node,
+    makeGlobalNode({ service: SessionExecution.Service, layer: SessionExecution.noopLayer, deps: [] }),
+  ),
+)
 const sessionID = SessionV2.ID.make("ses_projector_test")
 const created = DateTime.makeUnsafe(0)
 const model = { id: ModelV2.ID.make("model"), providerID: ProviderV2.ID.make("provider") }
@@ -162,16 +170,7 @@ describe("SessionProjector", () => {
         (yield* sessions.context(sessionID)).map((message) => (message.type === "user" ? message.text : message.type)),
       ).toEqual(["first", "second"])
     }).pipe(
-      Effect.provide(
-        SessionV2.layer.pipe(
-          Layer.provide(locationServiceMapLayer),
-          Layer.provide(EventV2.defaultLayer),
-          Layer.provide(Database.defaultLayer),
-          Layer.provide(Project.defaultLayer),
-          Layer.provide(SessionStore.defaultLayer),
-          Layer.provide(SessionExecution.noopLayer),
-        ),
-      ),
+      Effect.provide(sessionsLayer),
     ),
   )
 

--- a/packages/core/test/session-todo.test.ts
+++ b/packages/core/test/session-todo.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect } from "bun:test"
 import { asc } from "drizzle-orm"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { Database } from "@opencode-ai/core/database/database"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
@@ -11,7 +13,7 @@ import { SessionTable, TodoTable } from "@opencode-ai/core/session/sql"
 import { SessionTodo } from "@opencode-ai/core/session/todo"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(Layer.mergeAll(Database.defaultLayer, EventV2.defaultLayer, SessionTodo.defaultLayer))
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Database.node, EventV2.node, SessionTodo.node])))
 const sessionID = SessionV2.ID.make("ses_todo_test")
 
 const setup = Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves several core tests from hand-written `defaultLayer` composition to the new app node graph builder.

- Converts project, project directory, question, session projector, and session todo tests to use `AppNodeBuilder.build(...)` where appropriate.
- Keeps direct test dependencies explicit by adding dependency nodes as graph roots when tests yield those services directly.
- Replaces the manual `SessionV2.layer` setup in the session projector test with a node graph that binds `SessionExecution.node` to a noop execution node.
- Renames app node builder usage to `AppNodeBuilder.build(...)` for clarity.
- Leaves specialized local layer overrides in place where tests intentionally exercise a narrow layer boundary.

### How did you verify your code works?

- `bun typecheck` in `packages/core`
- `bun test test/project.test.ts test/project-directories.test.ts test/question.test.ts test/session-projector.test.ts test/session-todo.test.ts` in `packages/core`

### Screenshots / recordings

N/A - no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._