### PR TITLE
feat(tui): add tool_output_expanded_default option

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -63,6 +63,9 @@ export const Info = Schema.Struct({
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  tool_output_expanded_default: Schema.optional(Schema.Boolean).annotate({
+    description: "Expand tool/command output by default instead of collapsing it",
+  }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1789,7 +1789,7 @@ function GenericTool(props: ToolProps) {
   const { theme } = useTheme()
   const ctx = use()
   const output = createMemo(() => props.output?.trim() ?? "")
-  const [expanded, setExpanded] = createSignal(false)
+  const [expanded, setExpanded] = createSignal(ctx.tui.tool_output_expanded_default ?? false)
   const maxLines = 3
   const maxChars = createMemo(() => maxLines * Math.max(20, ctx.width - 6))
   const collapsed = createMemo(() => collapseToolOutput(output(), maxLines, maxChars()))
@@ -2039,7 +2039,7 @@ function Shell(props: ToolProps) {
   const ctx = use()
   const isRunning = createMemo(() => props.part.state.status === "running")
   const output = createMemo(() => stripAnsi(stringValue(props.metadata.output)?.trim() ?? ""))
-  const [expanded, setExpanded] = createSignal(false)
+  const [expanded, setExpanded] = createSignal(ctx.tui.tool_output_expanded_default ?? false)
   const maxLines = 10
   const maxChars = createMemo(() => maxLines * Math.max(20, ctx.width - 6))
   const collapsed = createMemo(() => collapseToolOutput(output(), maxLines, maxChars()))


### PR DESCRIPTION
### Issue for this PR

No existing issue — small, self-contained TUI config addition.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `tool_output_expanded_default` option to `tui.json`. When `true`, tool and shell-command output renders expanded by default instead of collapsing to a few lines behind "Click to expand". Defaults to `false`, so behaviour is unchanged unless you opt in.

It sets the initial value of the existing `expanded` signal in the two output renderers — `GenericTool` (`maxLines` 3) and `Shell` (`maxLines` 10) in `routes/session/index.tsx` — from `ctx.tui.tool_output_expanded_default` instead of hardcoding `false`. The field is added to the `Info` schema in `config/index.tsx`; `resolve()` already spreads `...input`, so it flows through with no extra wiring. The "Click to expand" / "Click to collapse" toggle still works. Reasoning blocks are unaffected — this only touches tool/command output.

### How did you verify your code works?

Built locally, set `tool_output_expanded_default: true` in `tui.json`, and ran shell commands with long output — they render expanded. Unset / `false` collapses as before. Also confirmed the generated `tui.json` schema includes the new key.

### Screenshots / recordings

No new UI — the existing expanded output view, just shown by default. Can add a recording if preferred.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
