### PR TITLE
refactor(core): move more tests to nodes

### DIFF
--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -6,9 +6,10 @@ import { Effect, Exit, Stream } from "effect"
 import type * as PlatformError from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { testEffect } from "../lib/effect"
 
-const live = CrossSpawnSpawner.defaultLayer
+const live = LayerNode.compile(CrossSpawnSpawner.node)
 const fx = testEffect(live)
 
 function js(code: string, opts?: ChildProcess.CommandOptions) {

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -2,12 +2,13 @@ import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
-const it = testEffect(Ripgrep.defaultLayer)
+const it = testEffect(LayerNode.compile(Ripgrep.node))
 
 const withTmp = <A, E, R>(f: (directory: AbsolutePath) => Effect.Effect<A, E, R>) =>
   Effect.acquireRelease(

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -3,13 +3,14 @@ import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Git } from "@opencode-ai/core/git"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { branch, commit, gitRemote } from "./fixture/git"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(Git.defaultLayer)
+const it = testEffect(LayerNode.compile(Git.node))
 
 describe("Git", () => {
   it.live("clones a remote and reads checkout metadata", () =>

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect } from "bun:test"
-import { Duration, Effect, Exit, Fiber, Layer, Scope, Stream } from "effect"
+import { Duration, Effect, Exit, Fiber, Scope, Stream } from "effect"
 import * as TestClock from "effect/testing/TestClock"
-import { Integration } from "@opencode-ai/core/integration"
 import { Credential } from "@opencode-ai/core/credential"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { EventV2 } from "@opencode-ai/core/event"
+import { Integration } from "@opencode-ai/core/integration"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(
-  Integration.locationLayer.pipe(Layer.provideMerge(Credential.defaultLayer), Layer.provideMerge(EventV2.defaultLayer)),
-)
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Integration.node, Credential.node, EventV2.node])))
 
 describe("Integration", () => {
   it.effect("registers integrations through the editor", () =>

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -2,10 +2,10 @@ import fs from "fs/promises"
 import path from "path"
 import { describe, expect } from "bun:test"
 import { Effect, Exit, Layer } from "effect"
+import { makeLocationNode } from "@opencode-ai/core/effect/app-node"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FileSystem } from "@opencode-ai/core/filesystem"
-import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Location } from "@opencode-ai/core/location"
-import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { location } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
@@ -13,13 +13,15 @@ import { it } from "./lib/effect"
 
 const provide = (directory: string) =>
   Effect.provide(
-    FileSystem.layer.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          FSUtil.defaultLayer,
-          Ripgrep.defaultLayer,
-          Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
-        ),
+    LayerNode.compile(
+      LayerNode.bind(
+        FileSystem.node,
+        Location.node,
+        makeLocationNode({
+          service: Location.Service,
+          layer: Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
+          deps: [],
+        }),
       ),
     ),
   )

--- a/packages/core/test/location-mutation.test.ts
+++ b/packages/core/test/location-mutation.test.ts
@@ -2,7 +2,8 @@ import fs from "fs/promises"
 import path from "path"
 import { describe, expect, test } from "bun:test"
 import { Effect, Layer, Schema } from "effect"
-import { FSUtil } from "@opencode-ai/core/fs-util"
+import { makeLocationNode } from "@opencode-ai/core/effect/app-node"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Location } from "@opencode-ai/core/location"
 import { LocationMutation } from "@opencode-ai/core/location-mutation"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -12,12 +13,15 @@ import { it } from "./lib/effect"
 
 function provide(directory: string) {
   return Effect.provide(
-    LocationMutation.layer.pipe(
-      Layer.provide(
-        Layer.mergeAll(
-          FSUtil.defaultLayer,
-          Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
-        ),
+    LayerNode.compile(
+      LayerNode.bind(
+        LocationMutation.node,
+        Location.node,
+        makeLocationNode({
+          service: Location.Service,
+          layer: Layer.succeed(Location.Service, Location.Service.of(location({ directory: AbsolutePath.make(directory) }))),
+          deps: [],
+        }),
       ),
     ),
   )

--- a/packages/core/test/plugin/skill.test.ts
+++ b/packages/core/test/plugin/skill.test.ts
@@ -1,20 +1,12 @@
 import { describe, expect } from "bun:test"
-import { Effect, Layer } from "effect"
-import { AgentV2 } from "@opencode-ai/core/agent"
-import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Effect } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
 import { SkillV2 } from "@opencode-ai/core/skill"
-import { SkillDiscovery } from "@opencode-ai/core/skill/discovery"
 import { testEffect } from "../lib/effect"
 import { host } from "./host"
 
-const it = testEffect(
-  SkillV2.layer.pipe(
-    Layer.provide(FSUtil.defaultLayer),
-    Layer.provide(SkillDiscovery.defaultLayer),
-    Layer.provideMerge(AgentV2.locationLayer),
-  ),
-)
+const it = testEffect(AppNodeBuilder.build(SkillV2.node))
 
 describe("SkillPlugin.Plugin", () => {
   it.effect("registers the built-in customize-opencode skill", () =>

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -2,12 +2,13 @@ import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Effect } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { RelativePath } from "@opencode-ai/core/schema"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(Ripgrep.defaultLayer)
+const it = testEffect(LayerNode.compile(Ripgrep.node))
 
 describe("Ripgrep", () => {
   it.live("keeps ignored files out of catch-all find results", () =>

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -3,6 +3,8 @@ import path from "path"
 import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SkillV2 } from "@opencode-ai/core/skill"
@@ -22,11 +24,7 @@ const discovery = Layer.succeed(
   }),
 )
 const it = testEffect(
-  SkillV2.layer.pipe(
-    Layer.provide(discovery),
-    Layer.provide(FSUtil.defaultLayer),
-    Layer.provideMerge(AgentV2.locationLayer),
-  ),
+  AppNodeBuilder.build(LayerNode.group([SkillV2.node, AgentV2.node]), [LayerNode.replace(SkillDiscovery.layer, discovery)]),
 )
 
 function write(directory: string, name: string, description: string) {

--- a/packages/core/test/system-context/builtins.test.ts
+++ b/packages/core/test/system-context/builtins.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import * as TestClock from "effect/testing/TestClock"
+import { makeLocationNode } from "@opencode-ai/core/effect/app-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Location } from "@opencode-ai/core/location"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
@@ -25,12 +28,14 @@ const locationLayer = Layer.succeed(
     ),
   ),
 )
+const locationNode = makeLocationNode({ service: Location.Service, layer: locationLayer, deps: [] })
+const builtInsNode = LayerNode.bind(
+  LayerNode.group([SystemContextBuiltIns.node, SystemContextRegistry.node]),
+  Location.node,
+  locationNode,
+)
 const it = testEffect(
-  SystemContextBuiltIns.locationLayer.pipe(
-    Layer.provide(FSUtil.defaultLayer),
-    Layer.provide(Global.layerWith({ config: "/global" })),
-    Layer.provide(locationLayer),
-  ),
+  AppNodeBuilder.build(builtInsNode, [LayerNode.replace(Global.layer, Global.layerWith({ config: "/global" }))]),
 )
 const instructionFS = Layer.effect(
   FSUtil.Service,
@@ -43,13 +48,12 @@ const instructionFS = Layer.effect(
       }),
     ),
   ),
-).pipe(Layer.provide(FSUtil.defaultLayer))
+).pipe(Layer.provide(LayerNode.compile(FSUtil.node)))
 const itWithInstructions = testEffect(
-  SystemContextBuiltIns.locationLayer.pipe(
-    Layer.provide(instructionFS),
-    Layer.provide(Global.layerWith({ config: "/global" })),
-    Layer.provide(locationLayer),
-  ),
+  AppNodeBuilder.build(builtInsNode, [
+    LayerNode.replace(FSUtil.layer, instructionFS),
+    LayerNode.replace(Global.layer, Global.layerWith({ config: "/global" })),
+  ]),
 )
 
 describe("SystemContextBuiltIns", () => {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves ten more core tests from manual `defaultLayer` composition to the node graph system.

- Uses `LayerNode.compile(...)` for direct global service test environments.
- Uses `AppNodeBuilder.build(...)` for app/location-scoped graphs.
- Keeps directly-yielded transitive services as explicit graph roots.
- Binds synthetic `Location.node` implementations in location-focused tests instead of composing ad hoc default layers.
- Uses `LayerNode.replace(...)` for test-specific layer overrides.

### How did you verify your code works?

- `bun test "test/ripgrep.test.ts" "test/filesystem/search.test.ts" "test/git.test.ts" "test/effect/cross-spawn-spawner.test.ts" "test/integration.test.ts" "test/location-filesystem.test.ts" "test/location-mutation.test.ts" "test/skill.test.ts" "test/plugin/skill.test.ts" "test/system-context/builtins.test.ts"` in `packages/core`
- `bun typecheck` in `packages/core`
- Pre-push `bun turbo typecheck`

### Screenshots / recordings

N/A - no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._