### PR TITLE
fix(app): transition draft project updates

### DIFF
--- a/packages/app/src/context/tabs.tsx
+++ b/packages/app/src/context/tabs.tsx
@@ -173,10 +173,12 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
         })
       },
       updateDraft(draftID: string, draft: Partial<Omit<DraftTab, "type" | "draftID">>) {
-        setStore(
-          (tab) => tab.type === "draft" && tab.draftID === draftID,
-          produce((tab) => Object.assign(tab, draft)),
-        )
+        void startTransition(() => {
+          setStore(
+            (tab) => tab.type === "draft" && tab.draftID === draftID,
+            produce((tab) => Object.assign(tab, draft)),
+          )
+        })
       },
       promoteDraft(draftID: string, session: Omit<SessionTab, "type">) {
         // Keep the replacement and navigation atomic so /new-session never renders


### PR DESCRIPTION
Summary:
- Wrap draft tab updates in Solid startTransition so /new-session project switches avoid urgent suspense fallback flicker.

Tests:
- bun typecheck (packages/app)
- pre-push bun turbo typecheck