### PR TITLE
fix(app): resolve sandbox project edits

### DIFF
--- a/packages/app/src/context/global-sync/utils.test.ts
+++ b/packages/app/src/context/global-sync/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { Agent } from "@opencode-ai/sdk/v2/client"
-import { directoryKey, normalizeAgentList } from "./utils"
+import { directoryKey, findProjectMetadata, normalizeAgentList } from "./utils"
 
 const agent = (name = "build") =>
   ({
@@ -48,5 +48,13 @@ describe("directoryKey", () => {
     expect(String(directoryKey("C:/Repos/sst/opencode/"))).toBe("C:/Repos/sst/opencode")
     expect(String(directoryKey("C:/"))).toBe("C:/")
     expect(String(directoryKey("/"))).toBe("/")
+  })
+})
+
+describe("findProjectMetadata", () => {
+  test("matches sandbox directories to their root project", () => {
+    const project = { id: "project", worktree: "/repo", sandboxes: ["/repo-worktree"] }
+
+    expect(findProjectMetadata([project], { worktree: "/repo-worktree" })).toBe(project)
   })
 })

--- a/packages/app/src/context/global-sync/utils.ts
+++ b/packages/app/src/context/global-sync/utils.ts
@@ -49,3 +49,12 @@ export function sanitizeProject(project: Project) {
     },
   }
 }
+
+export function findProjectMetadata<T extends { id?: string; worktree: string; sandboxes?: string[] }>(
+  projects: T[],
+  input: { projectID?: string; worktree: string },
+) {
+  const byID = input.projectID ? projects.find((project) => project.id === input.projectID) : undefined
+  if (byID) return byID
+  return projects.find((project) => project.worktree === input.worktree || project.sandboxes?.includes(input.worktree))
+}

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -5,6 +5,7 @@ import { createServerProjects, ServerConnection, useServer } from "./server"
 import { useServerHealth } from "@/utils/server-health"
 import { createServerSdkContext } from "./server-sdk"
 import { createServerSyncContext } from "./server-sync"
+import { findProjectMetadata } from "./global-sync/utils"
 import { getOwner } from "solid-js/web"
 import { QueryClient } from "@tanstack/solid-query"
 import type { ServerScope } from "@/utils/server-scope"
@@ -111,10 +112,10 @@ function createServerCtx(
 
   function enrich(project: { worktree: string; expanded: boolean }) {
     const [childStore] = sync.child(project.worktree, { bootstrap: false })
-    const projectID = childStore.project
-    const metadata = projectID
-      ? sync.data.project.find((x) => x.id === projectID)
-      : sync.data.project.find((x) => x.worktree === project.worktree)
+    const metadata = findProjectMetadata(sync.data.project, {
+      projectID: childStore.project,
+      worktree: project.worktree,
+    })
 
     // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
     // Without this, different subdirectories of the same git repo would share the same

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -18,6 +18,7 @@ import { migrateLegacySessionStateKeys, ServerScope, SessionStateKey } from "@/u
 import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout-helpers"
 import { requireServerKey } from "@/utils/session-route"
 import { type DraftTab, useTabs } from "./tabs"
+import { findProjectMetadata } from "./global-sync/utils"
 
 export { createSessionKeyReader, ensureSessionKey, pruneSessionKeys }
 
@@ -430,10 +431,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
     function enrich(project: { worktree: string; expanded: boolean }) {
       const [childStore] = serverSync().child(project.worktree, { bootstrap: false })
-      const projectID = childStore.project
-      const metadata = projectID
-        ? serverSync().data.project.find((x) => x.id === projectID)
-        : serverSync().data.project.find((x) => x.worktree === project.worktree)
+      const metadata = findProjectMetadata(serverSync().data.project, {
+        projectID: childStore.project,
+        worktree: project.worktree,
+      })
 
       // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
       // Without this, different subdirectories of the same git repo would share the same


### PR DESCRIPTION
## Summary
- Match project metadata by project ID, worktree, or sandbox membership before edit actions decide whether to call project.update
- Share lookup between global and layout project enrichment paths
- Add regression coverage for sandbox directories

## Testing
- bun test src/context/global-sync/utils.test.ts
- bun typecheck
- bun turbo typecheck (push hook)