### PR TITLE
docs: clarify 'opencode auth' describes AI providers, not MCP servers

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -213,7 +213,7 @@ export function resolvePluginProviders(input: {
 export const ProvidersCommand = cmd({
   command: "providers",
   aliases: ["auth"],
-  describe: "manage AI providers and credentials",
+  describe: "manage AI providers and credentials (Claude, OpenAI, etc.)",
   builder: (yargs) =>
     yargs.command(ProvidersListCommand).command(ProvidersLoginCommand).command(ProvidersLogoutCommand).demandCommand(),
   async handler() {},


### PR DESCRIPTION
Fixes #34259

## Changes

Updates the help text for the providers command to explicitly mention that it manages AI providers like Claude and OpenAI.

## Why

When running opencode mcp auth, users would see help text saying manage AI providers and credentials without clarifying that this was for AI providers specifically. Since there's also opencode mcp auth for MCP server authentication, the distinction was confusing.

## Testing

The help text now reads: manage AI providers and credentials (Claude, OpenAI, etc.)

This makes it immediately clear which command manages what type of authentication.