### PR TITLE
fix(core): send max-steps message as user role, not assistant prefill

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -208,7 +208,7 @@ const layer = Layer.effect(
         system: [agent.info?.system, system.baseline]
           .filter((part): part is string => part !== undefined && part.length > 0)
           .map(SystemPart.make),
-        messages: [...toLLMMessages(context, model), ...(isLastStep ? [Message.assistant(MAX_STEPS_PROMPT)] : [])],
+        messages: [...toLLMMessages(context, model), ...(isLastStep ? [Message.user(MAX_STEPS_PROMPT)] : [])],
         tools: toolMaterialization?.definitions ?? [],
         toolChoice: isLastStep ? "none" : undefined,
       })

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2987,7 +2987,7 @@ describe("SessionRunnerLLM", () => {
       expect(requests[1]?.toolChoice).toMatchObject({ type: "none" })
       expect(requests[1]?.tools).toEqual([])
       expect(requests[1]?.messages.at(-1)).toMatchObject({
-        role: "assistant",
+        role: "user",
         content: [{ type: "text", text: expect.stringContaining("MAXIMUM STEPS REACHED") }],
       })
       expect(executions).toEqual(["done"])

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1278,7 +1278,7 @@ const layer = Layer.effect(
               system,
               messages: [
                 ...modelMsgs,
-                ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS_PROMPT }] : []),
+                ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS_PROMPT }] : []),
               ],
               tools,
               model,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -514,6 +514,38 @@ it.instance("loop calls LLM and returns assistant message", () =>
   }),
 )
 
+it.instance("loop sends max steps instruction as a user message", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      agent: { build: { steps: 1 } },
+    }))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.text("world")
+
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const hits = yield* llm.hits
+    expect(hits).toHaveLength(1)
+    const messages = hits[0]?.body.messages
+    expect(messages).toBeArray()
+    if (!Array.isArray(messages)) return
+    const maxSteps = messages.find(
+      (message) => JSON.stringify(message).includes("CRITICAL - MAXIMUM STEPS REACHED"),
+    )
+    expect(maxSteps).toMatchObject({ role: "user" })
+  }),
+  30_000,
+)
+
 withMcpInstructions.instance(
   "loop includes MCP instructions in model system context",
   () =>


### PR DESCRIPTION
### Issue for this PR

Closes #32548

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an agent hits its step cap, opencode appends a "MAXIMUM STEPS REACHED" notice to the request with `role: "assistant"`. Providers treat a trailing assistant message as a prefill — something the model should continue, not instructions to follow. So instead of summarizing its work, the model just emits a stop token and the turn ends empty. On Claude with thinking enabled it's worse: the request 400s, because you can't prefill an assistant turn that's supposed to start with a thinking block.

The notice is an instruction, so it belongs in a user message. Changing the role to `"user"` makes the model read it as instructions and actually produce the summary.

Two call sites, both changed:

- `packages/opencode/src/session/prompt.ts` (V1)
- `packages/core/src/session/runner/llm.ts` (V2)

### How did you verify your code works?

- `packages/opencode/test/session/prompt.test.ts` — added `loop sends max steps instruction as a user message`. 57 pass.
- `packages/core/test/session-runner.test.ts` — the existing `forces a text response on an agent's configured final step` test asserted `role: "assistant"`, which locked the bug in. Updated to `"user"`. 80 pass.
- `bun turbo typecheck` — 29/29.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Related

- #32546 — alternative approach, gates the message behind a config flag.
- #36970 — duplicate V1-only fix by @rguliyev, closed in favor of this one. Their regression test is folded in here.
