### PR TITLE
fix(provider): expose xhigh instead of max for GLM-5.2 on OpenAI-compatible

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -688,9 +688,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     }
   }
   if (glm52 && model.api.npm === "@ai-sdk/openai-compatible") {
+    // GLM-5.2's native top tier is `max`, but `max` is not a member of the
+    // OpenAI `reasoning_effort` enum (none/minimal/low/medium/high/xhigh).
+    // OpenAI-compatible upstreams that follow the OpenAI spec (e.g. hyper,
+    // Cloudflare AI Gateway, OpenRouter passthrough) reject `reasoning_effort:
+    // "max"` with a 400. Expose `xhigh` instead and let the gateway translate
+    // it to GLM's native `max`, mirroring the OpenRouter branch above.
     return {
       high: { reasoningEffort: "high" },
-      max: { reasoningEffort: "max" },
+      xhigh: { reasoningEffort: "xhigh" },
     }
   }
   if (glm52 && model.api.npm === "@ai-sdk/anthropic") {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2914,7 +2914,7 @@ describe("ProviderTransform.variants", () => {
     })
     expect(ProviderTransform.variants(model)).toEqual({
       high: { reasoningEffort: "high" },
-      max: { reasoningEffort: "max" },
+      xhigh: { reasoningEffort: "xhigh" },
     })
   })
 
@@ -2930,7 +2930,7 @@ describe("ProviderTransform.variants", () => {
       })
       expect(ProviderTransform.variants(model)).toEqual({
         high: { reasoningEffort: "high" },
-        max: { reasoningEffort: "max" },
+        xhigh: { reasoningEffort: "xhigh" },
       })
     }
   })
@@ -2946,7 +2946,7 @@ describe("ProviderTransform.variants", () => {
     })
     expect(ProviderTransform.variants(model)).toEqual({
       high: { reasoningEffort: "high" },
-      max: { reasoningEffort: "max" },
+      xhigh: { reasoningEffort: "xhigh" },
     })
   })
 


### PR DESCRIPTION
## Summary

GLM-5.2's native top reasoning tier is `max`, but `max` is **not** a member of the OpenAI `reasoning_effort` enum (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`). The OpenAI-compatible branch of `variants()` exposed `max` directly, which breaks spec-compliant OpenAI-compatible upstreams and hides the actually-selectable top tier in the TUI.

## Problem

For `glm-5.2` + `@ai-sdk/openai-compatible`, `variants()` returned:

```ts
{ high: { reasoningEffort: "high" }, max: { reasoningEffort: "max" } }
```

This causes two issues for OpenAI-compatible upstreams that follow the OpenAI spec (e.g. `hyper`, Cloudflare AI Gateway, OpenRouter passthrough):

1. **400 from the upstream** when the user picks the top tier — `reasoning_effort: "max"` is rejected because `max` isn't in the OpenAI enum.
2. **The TUI variant switcher only shows `high` and `max`** — the `xhigh` tier (which the user can actually select without errors) is hidden, so users can't switch to it even if their config initialises with `@xhigh`.

For context, the OpenRouter branch right above already does the right thing:

```ts
// OpenRouter maps xhigh to GLM-5.2's native max effort.
return { high: { reasoning: { effort: "high" } }, xhigh: { reasoning: { effort: "xhigh" } } }
```

## Fix

Mirror the OpenRouter branch for `@ai-sdk/openai-compatible`: expose `high` and `xhigh`, and let the gateway translate `xhigh` to GLM's native `max` when needed.

```ts
if (glm52 && model.api.npm === "@ai-sdk/openai-compatible") {
  return {
    high: { reasoningEffort: "high" },
    xhigh: { reasoningEffort: "xhigh" },
  }
}
```

The Anthropic-compatible branch (`@ai-sdk/anthropic`) is left untouched — Anthropic's `effort` field does accept `max` natively (see `anthropicAdaptiveEfforts` in the same file), so that branch is correct as-is.

## Verification

- `bun test test/provider/transform.test.ts` — 275 pass, 0 fail
- `bun run typecheck` — clean
- `oxlint` on changed files — 0 errors (pre-existing warnings unchanged)

## Notes

- Native GLM providers (e.g. `zhipuai` directly via `@ai-sdk/anthropic`) still expose `max` because the Anthropic SDK accepts it — this PR only changes the OpenAI-compatible path.
- This is a behaviour fix, not a feature add: the `xhigh` tier was already supposed to be reachable (the OpenRouter branch confirms the intent), the OpenAI-compatible branch just had the wrong key.

Closes #34278