### PR TITLE
feat(tui): add /usage command for token and cost usage

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -38,6 +38,7 @@ import { DataProvider } from "./context/data"
 import { LocationProvider } from "./context/location"
 import { LocalProvider, useLocal } from "./context/local"
 import { DialogModel } from "./component/dialog-model"
+import { DialogUsage } from "./component/dialog-usage"
 import { useConnected } from "./component/use-connected"
 import { DialogMcp } from "./component/dialog-mcp"
 import { DialogStatus } from "./component/dialog-status"
@@ -628,6 +629,17 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         slashAliases: ["mo"],
         run: () => {
           dialog.replace(() => <DialogModel />)
+        },
+      },
+      {
+        name: "usage.show",
+        title: "Usage",
+        suggested: true,
+        category: "Session",
+        slashName: "usage",
+        slashAliases: ["cost"],
+        run: () => {
+          dialog.replace(() => <DialogUsage />)
         },
       },
       {

--- a/packages/tui/src/component/dialog-usage.tsx
+++ b/packages/tui/src/component/dialog-usage.tsx
@@ -1,0 +1,213 @@
+import { TextAttributes } from "@opentui/core"
+import { For, Show, createMemo, createResource } from "solid-js"
+import { useTheme } from "../context/theme"
+import { useDialog } from "../ui/dialog"
+import { useSDK } from "../context/sdk"
+import { useBindings } from "../keymap"
+
+type SessionRow = {
+  cost?: number
+  tokens?: {
+    input?: number
+    output?: number
+    reasoning?: number
+    cache?: { read?: number; write?: number }
+  }
+  model?: { id: string; providerID: string }
+  time: { updated: number }
+}
+
+type Bucket = {
+  sessions: number
+  input: number
+  output: number
+  cache: number
+  cost: number
+}
+
+type ModelBucket = {
+  model: string
+  tokens: number
+  cost: number
+}
+
+type WindowRow = Bucket & { label: string }
+
+type Report = {
+  totalSessions: number
+  windows: WindowRow[]
+  models: ModelBucket[]
+}
+
+function emptyBucket(): Bucket {
+  return { sessions: 0, input: 0, output: 0, cache: 0, cost: 0 }
+}
+
+function formatNumber(num: number): string {
+  if (num >= 1_000_000) return (num / 1_000_000).toFixed(1) + "M"
+  if (num >= 1_000) return (num / 1_000).toFixed(1) + "K"
+  return num.toString()
+}
+
+// Local midnight, start of this week (Monday) and start of this month.
+function windowStarts() {
+  const now = new Date()
+  const today = new Date(now)
+  today.setHours(0, 0, 0, 0)
+  const week = new Date(today)
+  // getDay() is 0 (Sun) to 6 (Sat); shift so Monday is the first day.
+  week.setDate(week.getDate() - ((today.getDay() + 6) % 7))
+  const month = new Date(now.getFullYear(), now.getMonth(), 1)
+  return { today: today.getTime(), week: week.getTime(), month: month.getTime() }
+}
+
+// Aggregate cost and tokens from the client session list. This mirrors the
+// numbers behind `opencode stats`, but only for the sessions returned here.
+function buildReport(sessions: SessionRow[]): Report {
+  const starts = windowStarts()
+  const windows: WindowRow[] = [
+    { label: "Today", ...emptyBucket() },
+    { label: "This Week", ...emptyBucket() },
+    { label: "This Month", ...emptyBucket() },
+    { label: "All Time", ...emptyBucket() },
+  ]
+  const models = new Map<string, ModelBucket>()
+
+  function add(bucket: Bucket, input: number, output: number, cache: number, cost: number) {
+    bucket.sessions += 1
+    bucket.input += input
+    bucket.output += output
+    bucket.cache += cache
+    bucket.cost += cost
+  }
+
+  for (const session of sessions) {
+    const cost = session.cost ?? 0
+    const tokens = session.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } }
+    const input = tokens.input ?? 0
+    const output = (tokens.output ?? 0) + (tokens.reasoning ?? 0)
+    const cache = (tokens.cache?.read ?? 0) + (tokens.cache?.write ?? 0)
+    const updated = session.time.updated
+
+    if (updated >= starts.today) add(windows[0], input, output, cache, cost)
+    if (updated >= starts.week) add(windows[1], input, output, cache, cost)
+    if (updated >= starts.month) add(windows[2], input, output, cache, cost)
+    add(windows[3], input, output, cache, cost)
+
+    const key = session.model ? `${session.model.providerID}/${session.model.id}` : "unknown"
+    let entry = models.get(key)
+    if (!entry) {
+      entry = { model: key, tokens: 0, cost: 0 }
+      models.set(key, entry)
+    }
+    entry.tokens += input + output + cache
+    entry.cost += cost
+  }
+
+  return {
+    totalSessions: sessions.length,
+    windows,
+    models: [...models.values()].sort((a, b) => b.cost - a.cost).slice(0, 6),
+  }
+}
+
+function windowRow(label: string, sessions: string, input: string, output: string, cache: string, cost: string) {
+  return (
+    label.padEnd(10) +
+    sessions.padStart(5) +
+    input.padStart(8) +
+    output.padStart(8) +
+    cache.padStart(8) +
+    cost.padStart(9)
+  )
+}
+
+function modelRow(model: string, tokens: string, cost: string) {
+  const name = model.length > 28 ? model.slice(0, 27) + "..." : model
+  return name.padEnd(28) + tokens.padStart(9) + cost.padStart(11)
+}
+
+export function DialogUsage() {
+  const dialog = useDialog()
+  const sdk = useSDK()
+  const { theme } = useTheme()
+
+  useBindings(() => ({
+    bindings: [
+      {
+        key: "return",
+        desc: "Close usage",
+        group: "Dialog",
+        cmd: () => dialog.clear(),
+      },
+    ],
+  }))
+
+  const [sessions] = createResource(async () => {
+    // Scope to the current project and cap the row count to keep this snappy.
+    const result = await sdk.client.session.list({ scope: "project", limit: 1000 })
+    return result.data ?? []
+  })
+
+  const report = createMemo(() => {
+    const list = sessions()
+    if (!list) return undefined
+    return buildReport(list)
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          Usage
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+      <text fg={theme.textMuted}>Token and cost usage for the current project.</text>
+      <Show when={!sessions.loading} fallback={<text fg={theme.textMuted}>Loading usage...</text>}>
+        <Show when={sessions.error}>
+          <text fg={theme.textMuted}>Could not load usage.</text>
+        </Show>
+        <Show when={report()}>
+          {(value) => (
+            <Show when={value().totalSessions > 0} fallback={<text fg={theme.textMuted}>No usage recorded yet.</text>}>
+              <box gap={1}>
+                <box>
+                  <text fg={theme.textMuted}>{windowRow("Period", "Sess", "Input", "Output", "Cache", "Cost")}</text>
+                  <For each={value().windows}>
+                    {(row) => (
+                      <text fg={theme.text}>
+                        {windowRow(
+                          row.label,
+                          row.sessions.toString(),
+                          formatNumber(row.input),
+                          formatNumber(row.output),
+                          formatNumber(row.cache),
+                          "$" + row.cost.toFixed(2),
+                        )}
+                      </text>
+                    )}
+                  </For>
+                </box>
+                <Show when={value().models.length > 0}>
+                  <box>
+                    <text fg={theme.textMuted}>{modelRow("Model", "Tokens", "Cost")}</text>
+                    <For each={value().models}>
+                      {(model) => (
+                        <text fg={theme.text}>
+                          {modelRow(model.model, formatNumber(model.tokens), "$" + model.cost.toFixed(4))}
+                        </text>
+                      )}
+                    </For>
+                  </box>
+                </Show>
+              </box>
+            </Show>
+          )}
+        </Show>
+      </Show>
+    </box>
+  )
+}


### PR DESCRIPTION
### Issue for this PR

Related to #9281

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `/usage` command (alias `/cost`) to the TUI. It pulls the session list from the SDK client, sums cost and tokens into Today / This Week / This Month / All Time buckets plus a per-model breakdown, and shows them in a dialog. The numbers are the same ones `opencode stats` already computes, just surfaced in the TUI. It is one new dialog component plus one command registration in `app.tsx`, all inside the TUI package.

I first wrote this as a plugin, then read the codebase and it looked small enough to do natively. Please treat it as a proposal: happy to change scope or approach, or fold it into the discussion in #9281.

Known limitation: the client `session.list` is scoped to the current project, whereas `opencode stats` reads every session from the DB. I can wire it to a server side aggregation if you would prefer all projects.

### How did you verify your code works?

- Ran it in the TUI; `/usage` opens the dialog and renders correctly (screenshot below).
- `bun install`, then `bun run typecheck` in `packages/tui`: passes, no errors.
- `oxlint` on the new file: clean. `app.tsx` shows only pre-existing warnings (confirmed unchanged via `git stash`).
- prettier applied to both changed files; pre-push checks passed.

### Screenshots / recordings

<img width="856" alt="/usage dialog in the TUI" src="https://github.com/user-attachments/assets/13ffa39f-51dc-4c33-a361-cbf5dd37502e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
