### PR TITLE
fix(provider): expose xhigh instead of max for GLM-5.2 on OpenAI-compatible

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -688,9 +688,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     }
   }
   if (glm52 && model.api.npm === "@ai-sdk/openai-compatible") {
+    // GLM-5.2's native top tier is `max`, but `max` is not a member of the
+    // OpenAI `reasoning_effort` enum (none/minimal/low/medium/high/xhigh).
+    // OpenAI-compatible upstreams that follow the OpenAI spec (e.g. hyper,
+    // Cloudflare AI Gateway, OpenRouter passthrough) reject `reasoning_effort:
+    // "max"` with a 400. Expose `xhigh` instead and let the gateway translate
+    // it to GLM's native `max`, mirroring the OpenRouter branch above.
     return {
       high: { reasoningEffort: "high" },
-      max: { reasoningEffort: "max" },
+      xhigh: { reasoningEffort: "xhigh" },
     }
   }
   if (glm52 && model.api.npm === "@ai-sdk/anthropic") {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2914,7 +2914,7 @@ describe("ProviderTransform.variants", () => {
     })
     expect(ProviderTransform.variants(model)).toEqual({
       high: { reasoningEffort: "high" },
-      max: { reasoningEffort: "max" },
+      xhigh: { reasoningEffort: "xhigh" },
     })
   })
 
@@ -2930,7 +2930,7 @@ describe("ProviderTransform.variants", () => {
       })
       expect(ProviderTransform.variants(model)).toEqual({
         high: { reasoningEffort: "high" },
-        max: { reasoningEffort: "max" },
+        xhigh: { reasoningEffort: "xhigh" },
       })
     }
   })
@@ -2946,7 +2946,7 @@ describe("ProviderTransform.variants", () => {
     })
     expect(ProviderTransform.variants(model)).toEqual({
       high: { reasoningEffort: "high" },
-      max: { reasoningEffort: "max" },
+      xhigh: { reasoningEffort: "xhigh" },
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #34278

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GLM-5.2's native top reasoning tier is called `max`, but `max` is not in the OpenAI `reasoning_effort` enum (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`). The OpenAI-compatible branch of `variants()` was exposing `max` directly, which:

- gets 400'd by spec-compliant upstreams (hyper, Cloudflare AI Gateway, OpenRouter passthrough) that reject `reasoning_effort: "max"`,
- hides the actually-selectable `xhigh` tier from the TUI switcher.

The sibling OpenRouter branch already does the right thing (exposes `xhigh`, gateway translates to native `max`). This PR mirrors that for `@ai-sdk/openai-compatible`. The Anthropic branch is left alone since `@ai-sdk/anthropic` accepts `max` natively.

### How did you verify your code works?

```
$ bun test test/provider/transform.test.ts
275 pass, 0 fail, 523 expect() calls

$ bun run typecheck
(tsgo --noEmit, clean)

$ oxlint packages/opencode/src/provider/transform.ts packages/opencode/test/provider/transform.test.ts
0 errors (143 pre-existing warnings unchanged)
```

Updated the three existing GLM-5.2 openai-compatible tests to expect `xhigh` instead of `max`.

### Screenshots / recordings

N/A (no UI change — the variant list is rendered from the map this PR fixes).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
