### PR TITLE
fix(app): disable empty server chevron

### DIFF
--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -657,35 +657,33 @@ function HomeServerRow(props: {
         disabled={!healthy()}
         onClick={() => props.focusServer(props.server)}
       >
-        <Show when={healthy()}>
-          <span
-            data-action="home-server-collapse"
-            class="inline-flex -ml-0.5 -mr-1.5 size-5 shrink-0 items-center justify-center rounded-[4px] text-v2-icon-icon-muted"
-            classList={{
-              "hover:bg-v2-overlay-simple-overlay-hover": canToggle(),
-              "cursor-default opacity-40": !canToggle(),
-            }}
-            aria-label={
-              props.collapsed ? props.language.t("home.server.expand") : props.language.t("home.server.collapse")
-            }
-            aria-disabled={!canToggle()}
-            aria-expanded={canToggle() ? !props.collapsed : undefined}
-            onClick={(event) => {
-              event.preventDefault()
-              event.stopPropagation()
-              if (!canToggle()) return
-              props.toggleCollapsed()
-            }}
-            onPointerDown={(event) => event.preventDefault()}
-          >
-            <IconV2
-              name="chevron-down"
-              size="small"
-              class="transition-transform duration-150 ease-in-out"
-              style={{ transform: `rotate(${props.collapsed ? -90 : 0}deg)` }}
-            />
-          </span>
-        </Show>
+        <span
+          data-action="home-server-collapse"
+          class="inline-flex -ml-0.5 -mr-1.5 size-5 shrink-0 items-center justify-center rounded-[4px] text-v2-icon-icon-muted"
+          classList={{
+            "hover:bg-v2-overlay-simple-overlay-hover": canToggle(),
+            "cursor-default opacity-40": !canToggle(),
+          }}
+          aria-label={
+            props.collapsed ? props.language.t("home.server.expand") : props.language.t("home.server.collapse")
+          }
+          aria-disabled={!canToggle()}
+          aria-expanded={canToggle() ? !props.collapsed : undefined}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            if (!canToggle()) return
+            props.toggleCollapsed()
+          }}
+          onPointerDown={(event) => event.preventDefault()}
+        >
+          <IconV2
+            name="chevron-down"
+            size="small"
+            class="transition-transform duration-150 ease-in-out"
+            style={{ transform: `rotate(${props.collapsed ? -90 : 0}deg)` }}
+          />
+        </span>
         <div class="flex size-4 shrink-0 items-center justify-center -mr-0.5">
           <ServerHealthIndicator health={props.health} />
         </div>

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -649,6 +649,7 @@ function HomeServerRow(props: {
   language: ReturnType<typeof useLanguage>
 }) {
   const [state, setState] = createStore({ menuOpen: false })
+  const canToggle = () => props.healthy && props.hasProjects
   return (
     <div class="group/server relative flex h-7 min-w-0 items-center rounded-[6px]">
       <button
@@ -658,17 +659,23 @@ function HomeServerRow(props: {
         disabled={!props.healthy}
         onClick={() => props.focusServer(props.server)}
       >
-        <Show when={props.healthy && props.hasProjects}>
+        <Show when={props.healthy}>
           <span
             data-action="home-server-collapse"
-            class="inline-flex -ml-0.5 -mr-1.5 size-5 shrink-0 items-center justify-center rounded-[4px] text-v2-icon-icon-muted hover:bg-v2-overlay-simple-overlay-hover"
+            class="inline-flex -ml-0.5 -mr-1.5 size-5 shrink-0 items-center justify-center rounded-[4px] text-v2-icon-icon-muted"
+            classList={{
+              "hover:bg-v2-overlay-simple-overlay-hover": canToggle(),
+              "cursor-default opacity-40": !canToggle(),
+            }}
             aria-label={
               props.collapsed ? props.language.t("home.server.expand") : props.language.t("home.server.collapse")
             }
-            aria-expanded={!props.collapsed}
+            aria-disabled={!canToggle()}
+            aria-expanded={canToggle() ? !props.collapsed : undefined}
             onClick={(event) => {
               event.preventDefault()
               event.stopPropagation()
+              if (!canToggle()) return
               props.toggleCollapsed()
             }}
             onPointerDown={(event) => event.preventDefault()}

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -568,6 +568,8 @@ function HomeProjectColumn(props: {
             const key = ServerConnection.key(item)
             const healthy = () => !!global.servers.health[key]?.healthy
             const serverCtx = global.ensureServerCtx(item)
+            const projects = () => serverCtx.projects.list()
+            const hasProjects = () => projects().length > 0
             const collapsed = () => !!state().collapsed[key]
             return (
               <div class="flex max-h-[min(572px,calc(100vh_-_300px))] min-w-0 flex-col gap-1 overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
@@ -575,6 +577,7 @@ function HomeProjectColumn(props: {
                   server={item}
                   selected={props.selected.server === key && !props.selected.directory}
                   healthy={healthy()}
+                  hasProjects={hasProjects()}
                   collapsed={collapsed()}
                   health={global.servers.health[key]}
                   controller={controller}
@@ -584,9 +587,9 @@ function HomeProjectColumn(props: {
                   toggleCollapsed={() => setState("collapsed", key, !state().collapsed[key])}
                   language={props.language}
                 />
-                <Show when={healthy() && !collapsed()}>
+                <Show when={healthy() && hasProjects() && !collapsed()}>
                   <div class="mx-3 h-px bg-v2-border-border-base" />
-                  <HomeProjectList {...props} server={item} projects={serverCtx.projects.list()} />
+                  <HomeProjectList {...props} server={item} projects={projects()} />
                 </Show>
               </div>
             )
@@ -635,6 +638,7 @@ function HomeServerRow(props: {
   server: ServerConnection.Any
   selected: boolean
   healthy: boolean
+  hasProjects: boolean
   collapsed: boolean
   health: ServerHealth | undefined
   controller: ReturnType<typeof useServerManagementController>
@@ -654,7 +658,7 @@ function HomeServerRow(props: {
         disabled={!props.healthy}
         onClick={() => props.focusServer(props.server)}
       >
-        <Show when={props.healthy}>
+        <Show when={props.healthy && props.hasProjects}>
           <span
             data-action="home-server-collapse"
             class="inline-flex -ml-0.5 -mr-1.5 size-5 shrink-0 items-center justify-center rounded-[4px] text-v2-icon-icon-muted hover:bg-v2-overlay-simple-overlay-hover"

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -576,8 +576,6 @@ function HomeProjectColumn(props: {
                 <HomeServerRow
                   server={item}
                   selected={props.selected.server === key && !props.selected.directory}
-                  healthy={healthy()}
-                  hasProjects={hasProjects()}
                   collapsed={collapsed()}
                   health={global.servers.health[key]}
                   controller={controller}
@@ -637,8 +635,6 @@ function HomeUtilityNav(props: {
 function HomeServerRow(props: {
   server: ServerConnection.Any
   selected: boolean
-  healthy: boolean
-  hasProjects: boolean
   collapsed: boolean
   health: ServerHealth | undefined
   controller: ReturnType<typeof useServerManagementController>
@@ -648,18 +644,20 @@ function HomeServerRow(props: {
   toggleCollapsed: () => void
   language: ReturnType<typeof useLanguage>
 }) {
+  const global = useGlobal()
   const [state, setState] = createStore({ menuOpen: false })
-  const canToggle = () => props.healthy && props.hasProjects
+  const healthy = () => !!props.health?.healthy
+  const canToggle = () => healthy() && global.ensureServerCtx(props.server).projects.list().length > 0
   return (
     <div class="group/server relative flex h-7 min-w-0 items-center rounded-[6px]">
       <button
         type="button"
         class={`${HOME_PROJECT_NAV_ROW} pr-16 disabled:opacity-60`}
         data-selected={props.selected ? "" : undefined}
-        disabled={!props.healthy}
+        disabled={!healthy()}
         onClick={() => props.focusServer(props.server)}
       >
-        <Show when={props.healthy}>
+        <Show when={healthy()}>
           <span
             data-action="home-server-collapse"
             class="inline-flex -ml-0.5 -mr-1.5 size-5 shrink-0 items-center justify-center rounded-[4px] text-v2-icon-icon-muted"


### PR DESCRIPTION
### Issue for this PR

Closes #34291

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Disable expanding / collapsing when given server has 0 added projects 
Also add chevron rendering for offline servers

### How did you verify your code works?

Add a server and have no added projects

### Screenshots / recordings

Render and disable chevron on offline servers 

<img width="323" height="146" alt="image" src="https://github.com/user-attachments/assets/a3eff161-13f5-4b77-8611-fc899988a15c" />

Disable when no projects are added 

<img width="359" height="134" alt="image" src="https://github.com/user-attachments/assets/799f37e9-27b7-424b-9cc1-8fcdd2db623e" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR