### PR TITLE
fix(desktop): avoid destroyed window permission checks

### DIFF
--- a/packages/desktop/src/main/windows.ts
+++ b/packages/desktop/src/main/windows.ts
@@ -354,16 +354,18 @@ function addDocumentPolicy(response: Response, file: string) {
 }
 
 function allowRendererPermissions(win: BrowserWindow) {
+  const webContentsId = win.webContents.id
+
   win.webContents.session.setPermissionRequestHandler((webContents, permission, callback, details) => {
     callback(
       rendererPermissions.has(permission) &&
         isTrustedRendererUrl(details.requestingUrl) &&
-        webContents.id === win.webContents.id,
+        webContents.id === webContentsId,
     )
   })
   win.webContents.session.setPermissionCheckHandler((webContents, permission, requestingOrigin, details) => {
     if (!rendererPermissions.has(permission)) return false
-    if (webContents && webContents.id !== win.webContents.id) return false
+    if (webContents && webContents.id !== webContentsId) return false
     return isTrustedRendererUrl(details.requestingUrl) || isTrustedRendererUrl(requestingOrigin)
   })
 }


### PR DESCRIPTION
## Summary
- Capture the window webContents ID before registering permission handlers
- Compare against the captured ID so shared session callbacks do not touch a destroyed BrowserWindow

## Testing
- bun typecheck (packages/desktop)
- bun test src/main (packages/desktop)
- pre-push: bun turbo typecheck