### PR TITLE
feat(tui,app): insert absolute path when dragging unsupported file

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -61,6 +61,19 @@ export function createPromptAttachmentsCore(input: PromptAttachmentsCoreInput) {
     if (!target) return false
     const mime = await attachmentMime(file)
     if (!mime) {
+      // File extension/mime is not natively supported (e.g. docx, pptx).
+      // Instead of rejecting with a toast, insert the file's absolute path
+      // (when running in Electron/desktop) so the agent can read it on demand.
+      // In browser-only mode we have no access to the absolute path, so we
+      // fall back to the previous warn-toast behavior.
+      const absolutePath = input.getPathForFile?.(file)
+      if (absolutePath) {
+        target.prompt.set(
+          [...target.prompt.current(), { type: "file", path: absolutePath, content: "@" + absolutePath, start: 0, end: 0 }],
+          target.cursor,
+        )
+        return true
+      }
       if (toast) input.warn?.()
       return false
     }

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -12,6 +12,7 @@ import type { CommandContext } from "@opentui/keymap"
 import { createEffect, createMemo, onMount, createSignal, onCleanup, on, Show, Switch, Match } from "solid-js"
 import "opentui-spinner/solid"
 import path from "path"
+import { existsSync } from "fs"
 import { fileURLToPath } from "url"
 import { useLocal } from "../../context/local"
 import { Flag } from "@opencode-ai/core/flag/flag"
@@ -371,7 +372,20 @@ export function Prompt(props: PromptProps) {
           ctx.event.preventDefault()
           ctx.event.stopPropagation()
           const content = await clipboard.read?.()
-          if (content?.mime.startsWith("image/")) {
+          if (!content) {
+            // Surface the failure rather than swallowing it — users previously
+            // could not tell why Ctrl+V did nothing on Windows hosts where
+            // `Get-Clipboard` or `clipboardy` fail silently.
+            toast.show({
+              variant: "error",
+              title: "Paste failed",
+              message:
+                "Clipboard is empty or unreadable. On Windows, verify PowerShell can run Get-Clipboard / Clipboard::GetText.",
+              duration: 6000,
+            })
+            return
+          }
+          if (content.mime.startsWith("image/")) {
             await pasteAttachment({
               filename: "clipboard",
               mime: content.mime,
@@ -379,7 +393,7 @@ export function Prompt(props: PromptProps) {
             })
             return
           }
-          if (content?.mime === "text/plain") {
+          if (content.mime === "text/plain") {
             await pasteInputText(content.data)
           }
         },
@@ -1194,6 +1208,19 @@ export function Prompt(props: PromptProps) {
           mime: attachment.mime,
           content: Buffer.from(attachment.content).toString("base64"),
         })
+        return
+      }
+      // File exists on disk but its extension/mime is not natively supported
+      // (e.g. docx, pptx, directories). Insert the absolute path as text so the
+      // agent can read it on demand, instead of letting it get folded into a
+      // [Pasted ~N lines] summary or dropped silently.
+      if (attachment === undefined && existsSync(filepath)) {
+        input.insertText(filepath)
+        setTimeout(() => {
+          if (!input || input.isDestroyed) return
+          input.getLayoutNode().markDirty()
+          renderer.requestRender()
+        }, 0)
         return
       }
     }


### PR DESCRIPTION
Three small, complementary fixes that share a theme: when the user pastes or drops something the native pipeline can't handle natively, give them (or the agent) a path they can act on, instead of a silent failure.

## Web — packages/app/src/components/prompt-input/attachments.ts

Dragging a file with an unsupported MIME/extension (e.g. .docx, .pptx) into the web prompt input used to reject it with a warn toast and silently drop the file reference. The agent had no way to know the file even existed.

When running under Electron, input.getPathForFile(file) exposes the absolute path. Use it to insert a file part whose content starts with '@' so the agent can read the file on demand via its existing tools. Pure-browser deployments (where getPathForFile is undefined) fall back to the original warn-toast behavior.

## TUI — packages/tui/src/component/prompt/index.tsx

### Drag-and-drop (pasteInputText)

When the user pastes a filepath that readLocalAttachment returns undefined for (i.e. not SVG, image, or PDF), the existing flow falls through to a [Pasted ~N lines] summary for long content. A typical Windows path like 'C:\Users\me\Documents\project-notes.docx' can be long enough to trigger that summary, hiding the actual path.

Add an early-exit branch: if attachment === undefined but existsSync(filepath) is true, insertText(filepath) and bail out, bypassing the paste-summary fold. The agent still sees the path, just not wrapped in a placeholder.

### Ctrl+V (prompt.paste handler)

When clipboard.read() returned undefined (e.g. Get-Clipboard / clipboardy failing silently on Windows hosts), all the ?.-checks short-circuited and the function returned silently. Users had no way to tell whether the keystroke was received, the clipboard was empty, or the OS-side reader was broken.

Replace the implicit fallthrough with an explicit error toast. The subsequent branches drop the now-redundant ?. since content is proven non-null.

## Compatibility

- Web: guarded by if (absolutePath); browser-only behavior unchanged.
- TUI drag-drop: only activates when pastedContent parses as a non-URL local path AND existsSync returns true. URL paste and plain-text paste flows are untouched.
- TUI Ctrl+V: additive; only adds user feedback on the failure path. Happy-path text/image paste unchanged.

Refs: #13800, #12595, #18104, #26283, #32851, #18771 (Windows paste cluster), #31470 (CJK mojibake through ConPTY — orthogonal, not addressed here).

Tested: portable Windows desktop build (Win11, Windows Terminal + cmd.exe).
- Dragging a .docx into web prompt → inserts '@C:\path\file.docx' as a file part.
- Pasting a long Windows path into TUI → inserts the path verbatim, no [Pasted ~N lines] summary.
- Ctrl+V with empty/broken clipboard → red toast explaining the failure.
- Happy-path image drag, text paste, and URL paste unchanged.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
