### PR TITLE
fix(opencode): detect mime type for --file attachments in local mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -382,7 +382,7 @@ export const RunCommand = effectCmd({
           const mime = !args.attach
             ? isDirectory
               ? "application/x-directory"
-              : "text/plain"
+              : detected
             : content && text !== undefined && Buffer.from(text, "utf8").equals(content)
               ? "text/plain"
               : detected


### PR DESCRIPTION
### Issue for this PR

Closes #34318

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In local mode the --file flag hardcodes mime to text/plain for all non-directory files. FSUtil.mimeType is already called on the line above but the result is never used. This means PNGs and JPEGs are routed through the Read-tool text path in session/prompt.ts:830, producing garbled UTF-8 output instead of base64 data: URLs.

The fix uses the already-computed FSUtil.mimeType result instead of the text/plain literal.

### How did you verify your code works?

Traced the full pipeline: run.ts:382-385 sets mime, session/prompt.ts:811 uses part.mime directly without re-detection, prompt.ts:830 branches on mime === text/plain to the Read-tool path instead of the base64 image path at line 949. Confirmed FSUtil.mimeType returns correct types via extension lookup (image/png, image/jpeg, etc.).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR