### PR TITLE
fix(opencode): gate thinking/reasoning provider options on model capabilities

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1097,19 +1097,21 @@ export function options(input: {
     result["usage"] = {
       include: true,
     }
-    if (input.model.api.id.includes("gemini-3")) {
+    if (input.model.api.id.includes("gemini-3") && input.model.capabilities.reasoning) {
       result["reasoning"] = { effort: "high" }
     }
   }
 
   if (
-    input.model.providerID === "baseten" ||
-    (input.model.providerID === "opencode" && ["kimi-k2-thinking", "glm-4.6"].includes(input.model.api.id))
+    input.model.capabilities.reasoning &&
+    (input.model.providerID === "baseten" ||
+    (input.model.providerID === "opencode" && ["kimi-k2-thinking", "glm-4.6"].includes(input.model.api.id)))
   ) {
     result["chat_template_args"] = { enable_thinking: true }
   }
 
   if (
+    input.model.capabilities.reasoning &&
     ["zai", "zhipuai"].some((id) => input.model.providerID.includes(id)) &&
     input.model.api.npm === "@ai-sdk/openai-compatible"
   ) {
@@ -1137,12 +1139,13 @@ export function options(input: {
   const modelId = input.model.api.id.toLowerCase()
 
   // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
-  if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
+  if (input.model.capabilities.reasoning && modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
     result["thinking"] = { type: "adaptive" }
   }
 
   // Enable thinking by default for kimi models using anthropic SDK
   if (
+    input.model.capabilities.reasoning &&
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
     (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))
   ) {
@@ -1166,13 +1169,13 @@ export function options(input: {
     result["enable_thinking"] = true
   }
 
-  if (input.model.api.npm === "@ai-sdk/azure" && input.model.api.id.includes("gpt-5.5")) {
+  if (input.model.capabilities.reasoning && input.model.api.npm === "@ai-sdk/azure" && input.model.api.id.includes("gpt-5.5")) {
     result["reasoningSummary"] = "auto"
     return result
   }
 
   if (input.model.api.id.includes("gpt-5") && !input.model.api.id.includes("gpt-5-chat")) {
-    if (!input.model.api.id.includes("gpt-5-pro")) {
+    if (input.model.capabilities.reasoning && !input.model.api.id.includes("gpt-5-pro")) {
       result["reasoningEffort"] = "medium"
       if (
         input.model.api.npm === "@ai-sdk/openai" ||
@@ -1200,8 +1203,10 @@ export function options(input: {
 
     if (input.model.providerID.startsWith("opencode")) {
       result["promptCacheKey"] = input.sessionID
-      result["include"] = INCLUDE_ENCRYPTED_REASONING
-      result["reasoningSummary"] = "auto"
+      if (input.model.capabilities.reasoning) {
+        result["include"] = INCLUDE_ENCRYPTED_REASONING
+        result["reasoningSummary"] = "auto"
+      }
     }
   }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -514,6 +514,54 @@ describe("ProviderTransform.options - gpt-5 reasoningEffort", () => {
   })
 })
 
+describe("ProviderTransform.options - gates thinking on capabilities.reasoning", () => {
+  const sessionID = "test-session-123"
+
+  const nonReasoningModel = (overrides: Record<string, any> = {}) =>
+    ({
+      id: "test/no-reasoning",
+      providerID: "test",
+      api: { id: "no-reasoning", url: "https://api.test.com", npm: "@ai-sdk/openai-compatible", ...overrides.api },
+      capabilities: { reasoning: false },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      limit: { context: 128000, output: 4096 },
+      status: "active",
+      options: {},
+      headers: {},
+      ...overrides,
+    }) as any
+
+  test("zai/zhipuai non-reasoning model skips thinking", () => {
+    const result = ProviderTransform.options({
+      model: nonReasoningModel({ id: "zai/non-reasoning", providerID: "zai" }),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.thinking).toBeUndefined()
+  })
+
+  test("minimax-m3 anthropic non-reasoning model skips thinking", () => {
+    const result = ProviderTransform.options({
+      model: nonReasoningModel({ api: { id: "minimax-m3", url: "...", npm: "@ai-sdk/anthropic" } }),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.thinking).toBeUndefined()
+  })
+
+  test("gpt-5 non-reasoning model skips reasoning params but keeps textVerbosity", () => {
+    const result = ProviderTransform.options({
+      model: nonReasoningModel({ id: "azure/gpt-5.2", providerID: "azure", api: { id: "gpt-5.2", url: "...", npm: "@ai-sdk/azure" } }),
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.reasoningSummary).toBeUndefined()
+    expect(result.include).toBeUndefined()
+    expect(result.textVerbosity).toBe("low")
+  })
+})
+
 describe("ProviderTransform.options - gateway", () => {
   const sessionID = "test-session-123"
 


### PR DESCRIPTION
### Issue for this PR

Closes #34323

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Seven branches in ProviderTransform.options() injected thinking/reasoning params based solely on provider ID or model ID matching, ignoring model.capabilities.reasoning. Only Google and alibaba-cn already gated correctly.

This gates every remaining branch on capabilities.reasoning following the established pattern. For the gpt-5 family block reasoningEffort, reasoningSummary, and include are gated while textVerbosity and promptCacheKey are left ungated since they are not reasoning-specific.

### How did you verify your code works?

All existing tests set capabilities.reasoning: true on their model fixtures and remain unchanged. Added three tests that create non-reasoning models and verify thinking/reasoning params are absent: zai/zhipuai skips thinking, minimax-m3 skips thinking, gpt-5 skips reasoningEffort/reasoningSummary/include but keeps textVerbosity.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR