### PR TITLE
chore(github): pin actions/cache v4 to commit SHA

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Cache opencode
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: ~/.opencode/bin
         key: opencode-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}


### PR DESCRIPTION
### Issue for this PR

Closes #16041

### Type of change

* [ ] Bug fix
* [ ] New feature
* [x] Refactor / code improvement
* [ ] Documentation

### What does this PR do?

Pins the `actions/cache` dependency in `github/action.yml` to a specific v4 commit SHA instead of the mutable `v4` tag.

This improves supply-chain security while keeping the action on the existing v4 major version.

### How did you verify your code works?

Not run locally because this is a GitHub Actions metadata-only change.

Verified that the change only replaces the `actions/cache@v4` reference with a v4 commit SHA in `github/action.yml`.

### Screenshots / recordings

N/A

### Checklist

* [ ] I have tested my changes locally
* [x] I have not included unrelated changes in this PR

*If you do not follow this template your PR will be automatically rejected.*

