### PR TITLE
feat(core): optional plugin gate in PermissionV2 for allow→ask

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -1,7 +1,7 @@
 export * as PermissionV2 from "./permission"
 
 import { makeLocationNode } from "./effect/app-node"
-import { Context, Deferred, Effect as EffectRuntime, Layer, Schema } from "effect"
+import { Context, Deferred, Effect as EffectRuntime, Layer, Option, Schema } from "effect"
 import { Permission } from "@opencode-ai/schema/permission"
 import { EventV2 } from "./event"
 import { Location } from "./location"
@@ -100,6 +100,25 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Permission") {}
 
+export interface GateInput {
+  readonly action: string
+  readonly resources: ReadonlyArray<string>
+  readonly sessionID: string
+  readonly metadata: Record<string, unknown>
+}
+
+/**
+ * Optional gate: lets a plugin adjust a resolved permission effect before it is
+ * enforced — e.g. downgrade a would-auto-approve `allow` to `ask` (prompt the
+ * human) or `deny`, or upgrade an `ask` to `allow`. Hard `deny` rules are not
+ * routed through it. Consumed via `Effect.serviceOption`, so it is a no-op
+ * unless an implementation is provided (PermissionV2 keeps no hard dependency).
+ */
+export class Gate extends Context.Service<
+  Gate,
+  { readonly adjust: (input: GateInput, effect: Permission.Effect) => EffectRuntime.Effect<Permission.Effect> }
+>()("@opencode/v2/Permission/Gate") {}
+
 interface Pending {
   readonly request: Request
   readonly agent?: AgentV2.ID
@@ -158,7 +177,15 @@ export const layer = Layer.effect(
       const all = [...rules, ...(yield* savedRules())]
       const effects = input.resources.map((resource) => evaluate(input.action, resource, all).effect)
       const effect: Permission.Effect = effects.includes("deny") ? "deny" : effects.includes("ask") ? "ask" : "allow"
-      return { effect, rules: all }
+      // optional plugin gate: may tighten an allow→ask/deny or loosen an ask→allow
+      const gate = yield* EffectRuntime.serviceOption(Gate)
+      const adjusted = Option.isSome(gate)
+        ? yield* gate.value.adjust(
+            { action: input.action, resources: input.resources, sessionID: input.sessionID, metadata: input.metadata ?? {} },
+            effect,
+          )
+        : effect
+      return { effect: adjusted, rules: all }
     })
 
     function request(input: AssertInput): Request {


### PR DESCRIPTION
### Issue for this PR

Implements the consultation point requested in #34327.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`PermissionV2` is where every tool (bash, edit, webfetch, read, …) resolves a
permission to `allow`/`ask`/`deny`. A plugin today can only observe a tool call
via `tool.execute.before`, which runs after permission resolution and can deny
only by throwing — there's no way for a plugin to turn a *would-auto-approve*
call into an interactive prompt.

This adds an optional `Gate` service that `evaluateInput` consults right after the
effect resolves (and only on the non-hard-deny path). A provider can downgrade an
`allow` to `ask`/`deny`, or upgrade an `ask` to `allow`. It's read via
`Effect.serviceOption`, so `PermissionV2` keeps **no hard dependency** on it and
the behavior is unchanged when nothing provides a `Gate` (the common case). The
service is defined in core and consumed in core; a host wires a provider.

Scope note: this is intentionally just the core hook point. Wiring a concrete
provider — e.g. one backed by the already-declared `permission.ask` plugin hook —
into `PermissionV2`'s location-scoped runtime touches the location-service
composition, so I've left that out for maintainer guidance rather than guess at
the layering. Happy to follow up with the provider once the approach is agreed.

Motivation: I maintain an external OGR guardrails plugin that evaluates tool calls
against agent-configured rules; today it can only block (via `tool.execute.before`)
and a first-class `ask` from a plugin would let it request human confirmation.

### How did you verify your code works?

`tsgo --noEmit` is clean for `@opencode-ai/core`. The change is additive and
no-op without a registered `Gate` (verified the `serviceOption` path leaves the
existing effect untouched). No existing behavior changes.

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR