### PR TITLE
refactor(tui): share sidebar section header

### DIFF
--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -261,6 +261,7 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       DialogConfirm: () => null,
       DialogPrompt: () => null,
       DialogSelect: () => null,
+      SidebarSection: () => null,
       Slot: () => null,
       Prompt: () => null,
       toast: () => {},

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -223,6 +223,13 @@ export type TuiPromptProps = {
   }
 }
 
+export type TuiSidebarSectionProps = {
+  title: string
+  collapsible?: boolean
+  collapsedSummary?: JSX.Element
+  children: JSX.Element
+}
+
 export type TuiToast = {
   variant?: "info" | "success" | "warning" | "error"
   title?: string
@@ -602,6 +609,7 @@ export type TuiPluginApi = {
     DialogConfirm: (props: TuiDialogConfirmProps) => JSX.Element
     DialogPrompt: (props: TuiDialogPromptProps) => JSX.Element
     DialogSelect: <Value = unknown>(props: TuiDialogSelectProps<Value>) => JSX.Element
+    SidebarSection: (props: TuiSidebarSectionProps) => JSX.Element
     Slot: <Name extends string>(props: TuiSlotProps<Name>) => JSX.Element | null
     Prompt: (props: TuiPromptProps) => JSX.Element
     toast: (input: TuiToast) => void

--- a/packages/tui/src/component/sidebar-section.tsx
+++ b/packages/tui/src/component/sidebar-section.tsx
@@ -1,0 +1,28 @@
+import type { JSX } from "solid-js"
+import { Show, createSignal } from "solid-js"
+import { useTheme } from "../context/theme"
+
+export function SidebarSection(props: {
+  title: string
+  collapsible?: boolean
+  collapsedSummary?: JSX.Element
+  children: JSX.Element
+}) {
+  const [open, setOpen] = createSignal(true)
+  const theme = useTheme()
+
+  return (
+    <box>
+      <box flexDirection="row" gap={1} onMouseDown={() => props.collapsible && setOpen((value) => !value)}>
+        <Show when={props.collapsible}>
+          <text fg={theme.theme.text}>{open() ? "▼" : "▶"}</text>
+        </Show>
+        <text fg={theme.theme.text}>
+          <b>{props.title}</b>
+          <Show when={props.collapsible && !open()}>{props.collapsedSummary}</Show>
+        </text>
+      </box>
+      <Show when={!props.collapsible || open()}>{props.children}</Show>
+    </box>
+  )
+}

--- a/packages/tui/src/feature-plugins/sidebar/files.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/files.tsx
@@ -1,6 +1,7 @@
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createMemo, For, Show, createSignal } from "solid-js"
+import { createMemo, For, Show } from "solid-js"
+import { SidebarSection } from "../../component/sidebar-section"
 import { Locale } from "../../util/locale"
 
 const id = "internal:sidebar-files"
@@ -12,41 +13,30 @@ function changeCountWidth(item: { additions: number; deletions: number }) {
 }
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
-  const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
   const list = createMemo(() => props.api.state.session.diff(props.session_id))
 
   return (
     <Show when={list().length > 0}>
-      <box>
-        <box flexDirection="row" gap={1} onMouseDown={() => list().length > 2 && setOpen((x) => !x)}>
-          <Show when={list().length > 2}>
-            <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
-          </Show>
-          <text fg={theme().text}>
-            <b>Modified Files</b>
-          </text>
-        </box>
-        <Show when={list().length <= 2 || open()}>
-          <For each={list()}>
-            {(item) => (
-              <box flexDirection="row" gap={1} justifyContent="space-between">
-                <text fg={theme().textMuted} wrapMode="none">
-                  {Locale.truncateLeft(item.file, Math.max(2, 36 - changeCountWidth(item)))}
-                </text>
-                <box flexDirection="row" gap={1} flexShrink={0}>
-                  <Show when={item.additions}>
-                    <text fg={theme().diffAdded}>+{item.additions}</text>
-                  </Show>
-                  <Show when={item.deletions}>
-                    <text fg={theme().diffRemoved}>-{item.deletions}</text>
-                  </Show>
-                </box>
+      <SidebarSection title="Modified Files" collapsible={list().length > 2}>
+        <For each={list()}>
+          {(item) => (
+            <box flexDirection="row" gap={1} justifyContent="space-between">
+              <text fg={theme().textMuted} wrapMode="none">
+                {Locale.truncateLeft(item.file, Math.max(2, 36 - changeCountWidth(item)))}
+              </text>
+              <box flexDirection="row" gap={1} flexShrink={0}>
+                <Show when={item.additions}>
+                  <text fg={theme().diffAdded}>+{item.additions}</text>
+                </Show>
+                <Show when={item.deletions}>
+                  <text fg={theme().diffRemoved}>-{item.deletions}</text>
+                </Show>
               </box>
-            )}
-          </For>
-        </Show>
-      </box>
+            </box>
+          )}
+        </For>
+      </SidebarSection>
     </Show>
   )
 }

--- a/packages/tui/src/feature-plugins/sidebar/lsp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/lsp.tsx
@@ -1,48 +1,38 @@
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createMemo, For, Show, createSignal } from "solid-js"
+import { createMemo, For, Show } from "solid-js"
+import { SidebarSection } from "../../component/sidebar-section"
 
 const id = "internal:sidebar-lsp"
 
 function View(props: { api: TuiPluginApi }) {
-  const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
   const list = createMemo(() => props.api.state.lsp())
   const off = createMemo(() => !props.api.state.config.lsp)
 
   return (
-    <box>
-      <box flexDirection="row" gap={1} onMouseDown={() => list().length > 2 && setOpen((x) => !x)}>
-        <Show when={list().length > 2}>
-          <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
-        </Show>
-        <text fg={theme().text}>
-          <b>LSP</b>
-        </text>
-      </box>
-      <Show when={list().length <= 2 || open()}>
-        <Show when={list().length === 0}>
-          <text fg={theme().textMuted}>{off() ? "LSPs are disabled" : "LSPs will activate as files are read"}</text>
-        </Show>
-        <For each={list()}>
-          {(item) => (
-            <box flexDirection="row" gap={1}>
-              <text
-                flexShrink={0}
-                style={{
-                  fg: item.status === "connected" ? theme().success : theme().error,
-                }}
-              >
-                •
-              </text>
-              <text fg={theme().textMuted}>
-                {item.id} {item.root}
-              </text>
-            </box>
-          )}
-        </For>
+    <SidebarSection title="LSP" collapsible={list().length > 2}>
+      <Show when={list().length === 0}>
+        <text fg={theme().textMuted}>{off() ? "LSPs are disabled" : "LSPs will activate as files are read"}</text>
       </Show>
-    </box>
+      <For each={list()}>
+        {(item) => (
+          <box flexDirection="row" gap={1}>
+            <text
+              flexShrink={0}
+              style={{
+                fg: item.status === "connected" ? theme().success : theme().error,
+              }}
+            >
+              •
+            </text>
+            <text fg={theme().textMuted}>
+              {item.id} {item.root}
+            </text>
+          </box>
+        )}
+      </For>
+    </SidebarSection>
   )
 }
 

--- a/packages/tui/src/feature-plugins/sidebar/mcp.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/mcp.tsx
@@ -1,11 +1,11 @@
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createMemo, For, Match, Show, Switch, createSignal } from "solid-js"
+import { createMemo, For, Match, Show, Switch } from "solid-js"
+import { SidebarSection } from "../../component/sidebar-section"
 
 const id = "internal:sidebar-mcp"
 
 function View(props: { api: TuiPluginApi }) {
-  const [open, setOpen] = createSignal(true)
   const theme = () => props.api.theme.current
   const list = createMemo(() => props.api.state.mcp())
   const on = createMemo(() => list().filter((item) => item.status === "connected").length)
@@ -28,52 +28,45 @@ function View(props: { api: TuiPluginApi }) {
 
   return (
     <Show when={list().length > 0}>
-      <box>
-        <box flexDirection="row" gap={1} onMouseDown={() => list().length > 2 && setOpen((x) => !x)}>
-          <Show when={list().length > 2}>
-            <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
-          </Show>
-          <text fg={theme().text}>
-            <b>MCP</b>
-            <Show when={!open()}>
-              <span style={{ fg: theme().textMuted }}>
-                {" "}
-                ({on()} active{bad() > 0 ? `, ${bad()} error${bad() > 1 ? "s" : ""}` : ""})
-              </span>
-            </Show>
-          </text>
-        </box>
-        <Show when={list().length <= 2 || open()}>
-          <For each={list()}>
-            {(item) => (
-              <box flexDirection="row" gap={1}>
-                <text
-                  flexShrink={0}
-                  style={{
-                    fg: dot(item.status),
-                  }}
-                >
-                  •
-                </text>
-                <text fg={theme().text} wrapMode="word">
-                  {item.name}{" "}
-                  <span style={{ fg: theme().textMuted }}>
-                    <Switch fallback={item.status}>
-                      <Match when={item.status === "connected"}>Connected</Match>
-                      <Match when={item.status === "failed"}>
-                        <i>{item.error}</i>
-                      </Match>
-                      <Match when={item.status === "disabled"}>Disabled</Match>
-                      <Match when={item.status === "needs_auth"}>Needs auth</Match>
-                      <Match when={item.status === "needs_client_registration"}>Needs client ID</Match>
-                    </Switch>
-                  </span>
-                </text>
-              </box>
-            )}
-          </For>
-        </Show>
-      </box>
+      <SidebarSection
+        title="MCP"
+        collapsible={list().length > 2}
+        collapsedSummary={
+          <span style={{ fg: theme().textMuted }}>
+            {" "}
+            ({on()} active{bad() > 0 ? `, ${bad()} error${bad() > 1 ? "s" : ""}` : ""})
+          </span>
+        }
+      >
+        <For each={list()}>
+          {(item) => (
+            <box flexDirection="row" gap={1}>
+              <text
+                flexShrink={0}
+                style={{
+                  fg: dot(item.status),
+                }}
+              >
+                •
+              </text>
+              <text fg={theme().text} wrapMode="word">
+                {item.name}{" "}
+                <span style={{ fg: theme().textMuted }}>
+                  <Switch fallback={item.status}>
+                    <Match when={item.status === "connected"}>Connected</Match>
+                    <Match when={item.status === "failed"}>
+                      <i>{item.error}</i>
+                    </Match>
+                    <Match when={item.status === "disabled"}>Disabled</Match>
+                    <Match when={item.status === "needs_auth"}>Needs auth</Match>
+                    <Match when={item.status === "needs_client_registration"}>Needs client ID</Match>
+                  </Switch>
+                </span>
+              </text>
+            </box>
+          )}
+        </For>
+      </SidebarSection>
     </Show>
   )
 }

--- a/packages/tui/src/feature-plugins/sidebar/todo.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/todo.tsx
@@ -1,31 +1,20 @@
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
-import { createMemo, For, Show, createSignal } from "solid-js"
+import { createMemo, For, Show } from "solid-js"
 import { TodoItem } from "../../component/todo-item"
+import { SidebarSection } from "../../component/sidebar-section"
 
 const id = "internal:sidebar-todo"
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
-  const [open, setOpen] = createSignal(true)
-  const theme = () => props.api.theme.current
   const list = createMemo(() => props.api.state.session.todo(props.session_id))
   const show = createMemo(() => list().length > 0 && list().some((item) => item.status !== "completed"))
 
   return (
     <Show when={show()}>
-      <box>
-        <box flexDirection="row" gap={1} onMouseDown={() => list().length > 2 && setOpen((x) => !x)}>
-          <Show when={list().length > 2}>
-            <text fg={theme().text}>{open() ? "▼" : "▶"}</text>
-          </Show>
-          <text fg={theme().text}>
-            <b>Todo</b>
-          </text>
-        </box>
-        <Show when={list().length <= 2 || open()}>
-          <For each={list()}>{(item) => <TodoItem status={item.status} content={item.content} />}</For>
-        </Show>
-      </box>
+      <SidebarSection title="Todo" collapsible={list().length > 2}>
+        <For each={list()}>{(item) => <TodoItem status={item.status} content={item.content} />}</For>
+      </SidebarSection>
     </Show>
   )
 }

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -13,6 +13,7 @@ import { DialogConfirm } from "../ui/dialog-confirm"
 import { DialogPrompt } from "../ui/dialog-prompt"
 import { DialogSelect, type DialogSelectOption as SelectOption } from "../ui/dialog-select"
 import { Prompt } from "../component/prompt"
+import { SidebarSection } from "../component/sidebar-section"
 import type { useToast } from "../ui/toast"
 import * as Keymap from "../keymap"
 import { createCommandShim } from "./command-shim"
@@ -235,6 +236,9 @@ export function createTuiApiAdapters(input: Input): Omit<TuiPluginApi, "lifecycl
             current={props.current}
           />
         )
+      },
+      SidebarSection(props) {
+        return <SidebarSection {...props} />
       },
       Slot<Name extends string>(props: TuiSlotProps<Name>) {
         return <input.Slot {...props} />


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a shared TUI sidebar section component and exposes it to TUI plugins as `api.ui.SidebarSection`. This keeps built-in sidebar panel headers consistent and gives external TUI plugins the same header/collapse pattern used by sections like MCP, Todo, LSP, and Modified Files.

The built-in MCP, Todo, LSP, and Modified Files sidebar panels now use the shared component, preserving their existing behavior while removing repeated header/collapse markup.

### How did you verify your code works?

- `bun typecheck` in `packages/plugin`
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/tui`
- `bun test ./test/plugin/slots.test.tsx ./test/app-lifecycle.test.tsx` in `packages/tui`
- `prettier --check` on touched files
- `bun run lint` from repo root: 0 errors, existing warnings only
- pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

No screenshot included. This is a shared component/API refactor that preserves existing sidebar visuals.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR