### PR TITLE
fix(core): commit staged revert before admitting new prompt

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -370,7 +370,11 @@ export const layer = Layer.effect(
       prompt: Effect.fn("V2Session.prompt")((input) =>
         Effect.uninterruptible(
           Effect.gen(function* () {
-            yield* result.get(input.sessionID)
+            const session = yield* result.get(input.sessionID)
+            // A staged revert must be committed before admitting new input so the prompt
+            // continues from the reverted boundary rather than stale post-boundary history.
+            if (session.revert)
+              yield* SessionRevert.commit(session).pipe(Effect.provideService(EventV2.Service, events))
             const prompt = resolvePrompt(input.prompt)
             const messageID = input.id ?? SessionMessage.ID.create()
             const delivery = input.delivery ?? "steer"

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect } from "bun:test"
-import { DateTime, Effect, Fiber, Layer, Stream } from "effect"
+import { DateTime, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { eq } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
 import { EventV2 } from "@opencode-ai/core/event"
 import { EventTable } from "@opencode-ai/core/event/sql"
 import { SessionEvent } from "@opencode-ai/core/session/event"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -110,6 +112,21 @@ const eventCount = (type: string) =>
       ),
   )
 
+const encodeMessage = Schema.encodeSync(SessionMessage.Message)
+const assistantRow = (id: SessionMessage.ID, seq: number) => {
+  const { id: _, type, ...data } = encodeMessage(
+    SessionMessage.Assistant.make({
+      id,
+      type: "assistant",
+      agent: "build",
+      model: { id: ModelV2.ID.make("model"), providerID: ProviderV2.ID.make("provider") },
+      content: [],
+      time: { created: DateTime.makeUnsafe(0) },
+    }),
+  )
+  return { id, session_id: sessionID, type, seq, time_created: 0, data }
+}
+
 describe("SessionV2.prompt", () => {
   it.effect("exposes the execution registry", () =>
     Effect.gen(function* () {
@@ -198,6 +215,39 @@ describe("SessionV2.prompt", () => {
       expect(yield* session.messages({ sessionID })).toMatchObject([
         { id: message.id, type: "user", text: "Fix the failing tests", system: "Per-request override" },
       ])
+    }),
+  )
+
+  it.effect("commits a staged revert before admitting a new prompt", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const events = yield* EventV2.Service
+      const { db } = yield* Database.Service
+
+      const boundary = yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "boundary" }),
+        resume: false,
+      })
+      yield* SessionInput.promoteSteers(db, events, sessionID, Number.MAX_SAFE_INTEGER)
+      const stale = SessionMessage.ID.make("msg_stale_assistant")
+      yield* db.insert(SessionMessageTable).values(assistantRow(stale, 100)).run().pipe(Effect.orDie)
+      yield* events.publish(SessionEvent.RevertEvent.Staged, {
+        sessionID,
+        timestamp: yield* DateTime.now,
+        revert: { messageID: boundary.id, files: [] },
+      })
+      expect((yield* session.get(sessionID)).revert?.messageID).toBe(boundary.id)
+
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "after revert" }), resume: false })
+
+      expect((yield* session.get(sessionID)).revert).toBeUndefined()
+      expect(
+        (yield* db.select({ id: SessionMessageTable.id }).from(SessionMessageTable).all().pipe(Effect.orDie)).map(
+          (row) => row.id,
+        ),
+      ).not.toContain(stale)
     }),
   )
 


### PR DESCRIPTION
When a session has a staged revert and a new user prompt is sent, core now commits the revert first so the prompt continues from the reverted boundary rather than stale post-boundary history.

## Problem

A staged revert in V2 marks a boundary message but doesn't delete the post-boundary history until committed. If a new prompt was admitted while a revert was staged, the prompt would continue on top of history the user intended to discard. This matches v1 behavior, where `SessionPrompt` calls `revert.cleanup(session)` at the start of a prompt when `session.revert` is set.

## Fix

In `SessionV2.prompt`, if a revert is staged, commit it before admitting the new durable input:

```ts
const session = yield* result.get(input.sessionID)
if (session.revert)
  yield* SessionRevert.commit(session).pipe(Effect.provideService(EventV2.Service, events))
```

Event projectors run synchronously and transactionally inside `commitDurableEvent`, so the `RevertEvent.Committed` projection deletes the post-boundary `session_message` and `session_input` rows and resets the context epoch before `SessionInput.admit` assigns a sequence to the new prompt. The new input lands cleanly above the reverted boundary.

## Test

Added `commits a staged revert before admitting a new prompt` to `session-prompt.test.ts`: stages a revert with a stale post-boundary assistant message, sends a new prompt, and asserts the revert is cleared and the stale message is deleted.

All prompt and projector tests pass. `shell` and `skill` remain stubbed in V2 and should apply the same guard when implemented.