### PR TITLE
fix(mcp): clarify debug oauth probe

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -761,7 +761,7 @@ export const McpDebugCommand = effectCmd({
         }
 
         if (response.status === 401) {
-          prompts.log.warn("Server returned 401 Unauthorized")
+          prompts.log.info("Initial unauthenticated check returned 401, so this server requires OAuth")
 
           // Try to discover OAuth metadata
           const oauthConfig = typeof serverConfig.oauth === "object" ? serverConfig.oauth : undefined


### PR DESCRIPTION
## Summary
- report the unauthenticated MCP debug 401 as expected OAuth protection instead of a warning
- keep the raw HTTP status and `WWW-Authenticate` details visible for debugging

Closes #31746

## Test plan
- `bun typecheck` from `packages/opencode`