### PR TITLE
feat(sdk-next): let embedders contribute plugins via opencode.plugin

### DIFF
--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -31,6 +31,7 @@ import { AgentPlugin } from "./agent"
 import { CommandPlugin } from "./command"
 import { ModelsDevPlugin } from "./models-dev"
 import { ProviderPlugins } from "./provider"
+import { SdkPlugins } from "./sdk"
 import { SkillPlugin } from "./skill"
 import { VariantPlugin } from "./variant"
 
@@ -65,6 +66,7 @@ const layer = Layer.effectDiscard(
     const catalog = yield* Catalog.Service
     const commands = yield* CommandV2.Service
     const plugin = yield* PluginV2.Service
+    const sdkPlugins = yield* SdkPlugins.Service
     const integration = yield* Integration.Service
     const agents = yield* AgentV2.Service
     const config = yield* Config.Service
@@ -119,6 +121,8 @@ const layer = Layer.effectDiscard(
         yield* add(ConfigExternalPlugin.Plugin)
         yield* add(ConfigProviderPlugin.Plugin)
         yield* add(VariantPlugin.Plugin)
+        // Embedder-contributed plugins are added last so they layer over config.
+        for (const plugin of sdkPlugins.all()) yield* add(plugin)
       }),
     ).pipe(Effect.withSpan("PluginInternal.boot"), Effect.forkScoped({ startImmediately: true }))
   }),
@@ -151,5 +155,6 @@ export const node = makeLocationNode({
     httpClient,
     SkillV2.node,
     Reference.node,
+    SdkPlugins.node,
   ],
 })

--- a/packages/core/src/plugin/sdk.ts
+++ b/packages/core/src/plugin/sdk.ts
@@ -1,0 +1,37 @@
+export * as SdkPlugins from "./sdk"
+
+import type { Plugin } from "@opencode-ai/plugin/v2/effect"
+import { Context, Effect, Layer } from "effect"
+import { makeGlobalNode } from "../effect/app-node"
+
+/**
+ * Holds the plugins an embedder (the `@opencode-ai/sdk-next` host) contributes,
+ * so `PluginInternal` can add them on every Location boot through the ordinary
+ * `ctx.plugin.add` seam — the same path `ConfigExternalPlugin` uses for plugins
+ * discovered from config. A plugin registered after a Location has booted only
+ * applies to Locations booted afterward, matching config-plugin timing;
+ * embedders register at startup before creating Sessions.
+ *
+ * State lives in this global-node service (like `ApplicationTools`) rather than
+ * module scope, so the list belongs to one embedded instance and is disposed
+ * with it instead of leaking across `OpenCode.create` calls.
+ */
+export interface Interface {
+  readonly register: (plugin: Plugin) => Effect.Effect<void>
+  readonly all: () => readonly Plugin[]
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SdkPlugins") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.sync(() => {
+    const plugins: Plugin[] = []
+    return Service.of({
+      register: (plugin) => Effect.sync(() => void plugins.push(plugin)),
+      all: () => plugins,
+    })
+  }),
+)
+
+export const node = makeGlobalNode({ service: Service, layer, deps: [] })

--- a/packages/sdk-next/src/opencode.ts
+++ b/packages/sdk-next/src/opencode.ts
@@ -1,5 +1,6 @@
 import { OpenCode } from "@opencode-ai/client/effect"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { ApplicationTools } from "@opencode-ai/core/tool/application-tools"
 import { createEmbeddedRoutes } from "@opencode-ai/server/routes"
 import { Context, Effect, Layer, Scope } from "effect"
@@ -9,11 +10,12 @@ export const create = Effect.fn("OpenCode.create")(function* () {
   const scope = yield* Scope.Scope
   const memoMap = yield* Layer.makeMemoMap
   const context = yield* Layer.buildWithMemoMap(
-    Layer.merge(ApplicationTools.layer, PermissionSaved.defaultLayer),
+    Layer.mergeAll(ApplicationTools.layer, PermissionSaved.defaultLayer, SdkPlugins.layer),
     memoMap,
     scope,
   )
   const tools = Context.get(context, ApplicationTools.Service)
+  const plugins = Context.get(context, SdkPlugins.Service)
   const permissions = Context.get(context, PermissionSaved.Service)
   const web = yield* Effect.acquireRelease(
     Effect.sync(() =>
@@ -37,6 +39,12 @@ export const create = Effect.fn("OpenCode.create")(function* () {
   return {
     ...client,
     tools: { register: tools.register },
+    // The embedded host contributes plugins through the ordinary discovery flow:
+    // each plugin's `effect` runs inside every Location with the real
+    // `PluginContext`, so `ctx.agent.transform` and every other hook behave exactly
+    // as they do for a config-discovered plugin. Define agent profiles here at
+    // startup, then select one per Session with `sessions.create({ agent })`.
+    plugin: plugins.register,
   }
 })
 


### PR DESCRIPTION
## What

Adds `opencode.plugin(definition)` to the embedded SDK so an embedder can contribute plugins through the **ordinary discovery flow** instead of a bespoke side channel.

```ts
yield* opencode.plugin({
  id: "my-agent",
  effect: (ctx) =>
    ctx.agent.transform((draft) => {
      draft.update("my-discord", (a) => { a.system = DISCORD_PERSONA; a.mode = "primary" })
      draft.update("my-slack", (a) => { a.system = SLACK_PERSONA; a.mode = "primary" })
    }),
})
// then select per Session:
yield* opencode.sessions.create({ agent: "my-discord" })
```

## Why

The embedded SDK exposes `tools.register`, but there was no way to set an agent's **system prompt / persona** or otherwise use the plugin hook API from an embedding application. Agents are configured by plugins via `ctx.agent.transform`, but that hook only existed inside the in-process plugin flow.

Rather than invent a one-off `agent.transform` SDK method (which would be both narrow and, done naively, a silent no-op — `AgentV2` is location-scoped, so pulling it eagerly in the SDK mutates an instance the runner never reads), this makes the embedder a first-class plugin contributor. Inside a registered plugin's `effect`, the embedder gets the **real per-Location `PluginContext`** — `agent`, `command`, `skill`, `reference`, `catalog`, `integration`, `plugin` — with real return values, exactly like a config-discovered plugin.

## How

- **`packages/core/src/plugin/sdk.ts`** (new): `SdkPlugins`, a global-node service holding the embedder-registered plugin list. `register` appends; `all` reads. Modeled on `ApplicationTools` so the list is scoped to one embedded instance and disposed with it (not a module global that would leak across `OpenCode.create` calls).
- **`packages/core/src/plugin/internal.ts`**: `PluginInternal` reads `SdkPlugins.Service` and adds each registered plugin **last** in the boot batch (so embedder plugins layer over config), through the same `ctx.plugin.add` seam `ConfigExternalPlugin` uses. `PluginInternal.node` gains the `SdkPlugins.node` dep.
- **`packages/sdk-next/src/opencode.ts`**: merges `SdkPlugins.layer`, pulls the service from the instance context, and surfaces `plugin: plugins.register` next to `tools.register`.

## Notes / limitations

- A plugin registered **after** a Location has already booted applies only to Locations booted afterward (Locations cache and boot lazily). This matches config-plugin timing — register at startup before creating Sessions.
- This does **not** yet replace `tools.register` / retire `ApplicationTools`. There is no `ctx.tool` plugin hook today, so registering tools via `opencode.plugin` requires first adding a `tool` hook to `PluginContext` — a separate follow-up.

## Testing

- `turbo typecheck` for `@opencode-ai/core` and `@opencode-ai/sdk-next` pass (and the full pre-push typecheck: 29/29).
- The pre-existing `sdk-next` runtime tests that fail in a bare sandbox (no SQLite / no model) fail identically on `v2` without this change; this PR does not regress them. A full end-to-end "transform reaches the runner" test needs the DB+model harness.