### PR TITLE
fix(core): remove per-prompt system option

### DIFF
--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -412,7 +412,6 @@ export type SessionsPromptInput = {
         readonly name: string
         readonly source?: { readonly start: number; readonly end: number; readonly text: string }
       }>
-      readonly system?: string
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
@@ -431,7 +430,6 @@ export type SessionsPromptInput = {
         readonly name: string
         readonly source?: { readonly start: number; readonly end: number; readonly text: string }
       }>
-      readonly system?: string
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
@@ -450,7 +448,6 @@ export type SessionsPromptInput = {
         readonly name: string
         readonly source?: { readonly start: number; readonly end: number; readonly text: string }
       }>
-      readonly system?: string
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
@@ -469,7 +466,6 @@ export type SessionsPromptInput = {
         readonly name: string
         readonly source?: { readonly start: number; readonly end: number; readonly text: string }
       }>
-      readonly system?: string
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
@@ -494,7 +490,6 @@ export type SessionsPromptOutput = {
         readonly name: string
         readonly source?: { readonly start: number; readonly end: number; readonly text: string }
       }>
-      readonly system?: string
     }
     readonly delivery: "steer" | "queue"
     readonly timeCreated: number
@@ -574,7 +569,6 @@ export type SessionsContextOutput = {
           readonly name: string
           readonly source?: { readonly start: number; readonly end: number; readonly text: string }
         }>
-        readonly system?: string
         readonly type: "user"
       }
     | {
@@ -775,7 +769,6 @@ export type SessionsHistoryOutput = {
               readonly name: string
               readonly source?: { readonly start: number; readonly end: number; readonly text: string }
             }>
-            readonly system?: string
           }
           readonly delivery: "steer" | "queue"
         }
@@ -803,7 +796,6 @@ export type SessionsHistoryOutput = {
               readonly name: string
               readonly source?: { readonly start: number; readonly end: number; readonly text: string }
             }>
-            readonly system?: string
           }
           readonly delivery: "steer" | "queue"
         }
@@ -1243,7 +1235,6 @@ export type SessionsEventsOutput =
             readonly name: string
             readonly source?: { readonly start: number; readonly end: number; readonly text: string }
           }>
-          readonly system?: string
         }
         readonly delivery: "steer" | "queue"
       }
@@ -1271,7 +1262,6 @@ export type SessionsEventsOutput =
             readonly name: string
             readonly source?: { readonly start: number; readonly end: number; readonly text: string }
           }>
-          readonly system?: string
         }
         readonly delivery: "steer" | "queue"
       }
@@ -1673,7 +1663,6 @@ export type SessionsMessageOutput = {
           readonly name: string
           readonly source?: { readonly start: number; readonly end: number; readonly text: string }
         }>
-        readonly system?: string
         readonly type: "user"
       }
     | {
@@ -1846,7 +1835,6 @@ export type MessagesListOutput = {
           readonly name: string
           readonly source?: { readonly start: number; readonly end: number; readonly text: string }
         }>
-        readonly system?: string
         readonly type: "user"
       }
     | {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -509,7 +509,6 @@ const resolvePrompt = (input: PromptInput.Prompt) =>
   Prompt.make({
     text: input.text,
     agents: input.agents,
-    system: input.system,
     files: input.files?.map((file) => {
       const dataMime = file.uri.match(/^data:([^;,]+)[;,]/i)?.[1]
       const target = URL.canParse(file.uri) ? new URL(file.uri).pathname : (file.name ?? file.uri)

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -133,7 +133,6 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
             text: event.data.prompt.text,
             files: event.data.prompt.files,
             agents: event.data.prompt.agents,
-            system: event.data.prompt.system,
             time: { created: event.data.timestamp },
           }),
         )

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -193,16 +193,13 @@ export const layer = Layer.effect(
       const model = yield* models.resolve(session)
       const entries = yield* SessionHistory.entriesForRunner(db, session.id, system.baselineSeq)
       const context = entries.map((entry) => entry.message)
-      // Mirror V1 (session/llm/request.ts): append the current turn's per-request system string after the
-      // agent prompt and durable baseline. The current turn's user prompt is the latest user message in context.
-      const turnSystem = context.findLast((message) => message.type === "user")?.system
       const isLastStep = agent.info?.steps !== undefined && currentStep >= agent.info.steps
       const toolMaterialization = isLastStep ? undefined : yield* tools.materialize(agent.info?.permissions)
       const promptCacheKey = /^ses_[0-9a-f]{64}$/.test(session.id) ? session.id.slice(4) : session.id
       const request = LLM.request({
         model,
         providerOptions: { openai: { promptCacheKey } },
-        system: [agent.info?.system ? agent.info.system : SessionRunnerSystemPrompt.provider(model), system.baseline, turnSystem]
+        system: [agent.info?.system ? agent.info.system : SessionRunnerSystemPrompt.provider(model), system.baseline]
           .filter((part): part is string => part !== undefined && part.length > 0)
           .map(SystemPart.make),
         messages: [...toLLMMessages(context, model), ...(isLastStep ? [Message.assistant(MAX_STEPS_PROMPT)] : [])],

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -191,33 +191,6 @@ describe("SessionV2.prompt", () => {
     }),
   )
 
-  it.effect("preserves an optional per-request system string through admission and projection", () =>
-    Effect.gen(function* () {
-      yield* setup
-      const { db } = yield* Database.Service
-      const session = yield* SessionV2.Service
-      const events = yield* EventV2.Service
-
-      const message = yield* session.prompt({
-        sessionID,
-        prompt: Prompt.make({ text: "Fix the failing tests", system: "Per-request override" }),
-        resume: false,
-      })
-
-      expect(message.prompt.system).toBe("Per-request override")
-      expect(yield* admitted(message.id)).toMatchObject({
-        id: message.id,
-        prompt: { text: "Fix the failing tests", system: "Per-request override" },
-      })
-
-      yield* SessionInput.promoteSteers(db, events, sessionID, Number.MAX_SAFE_INTEGER)
-
-      expect(yield* session.messages({ sessionID })).toMatchObject([
-        { id: message.id, type: "user", text: "Fix the failing tests", system: "Per-request override" },
-      ])
-    }),
-  )
-
   it.effect("commits a staged revert before admitting a new prompt", () =>
     Effect.gen(function* () {
       yield* setup

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -894,36 +894,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("appends the per-request prompt system after the agent prompt and durable baseline", () =>
-    Effect.gen(function* () {
-      yield* setup
-      const agent = yield* AgentV2.Service
-      yield* agent.transform((editor) =>
-        editor.update(AgentV2.ID.make("build"), (agent) => {
-          agent.system = "Build agent instructions"
-          agent.mode = "primary"
-        }),
-      )
-      const session = yield* SessionV2.Service
-      yield* session.prompt({
-        sessionID,
-        prompt: Prompt.make({ text: "First", system: "Per-request override" }),
-        resume: false,
-      })
-
-      requests.length = 0
-      response = fragmentFixture("text", "text-system", ["Done"]).completeEvents
-      yield* session.resume(sessionID)
-
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual([
-        "Build agent instructions",
-        "Initial context",
-        "Per-request override",
-      ])
-    }),
-  )
-
-  it.effect("omits the per-request system part when the prompt has no system string", () =>
+  it.effect("uses only the agent prompt and durable baseline as system parts", () =>
     Effect.gen(function* () {
       yield* setup
       const agent = yield* AgentV2.Service

--- a/packages/schema/src/prompt-input.ts
+++ b/packages/schema/src/prompt-input.ts
@@ -23,5 +23,4 @@ export const Prompt = Schema.Struct({
   text: Schema.String,
   files: Schema.Array(FileAttachment).pipe(optional),
   agents: Schema.Array(AgentAttachment).pipe(optional),
-  system: Schema.String.pipe(optional),
 }).annotate({ identifier: "PromptInput" })

--- a/packages/schema/src/prompt.ts
+++ b/packages/schema/src/prompt.ts
@@ -42,18 +42,16 @@ export const Prompt = Schema.Struct({
   text: Schema.String,
   files: Schema.Array(FileAttachment).pipe(optional),
   agents: Schema.Array(AgentAttachment).pipe(optional),
-  system: Schema.String.pipe(optional),
 })
   .annotate({ identifier: "Prompt" })
   .pipe(
     statics((schema) => ({
       equivalence: Schema.toEquivalence(schema),
-      fromUserMessage: (input: Pick<Prompt, "text" | "files" | "agents" | "system">) =>
+      fromUserMessage: (input: Pick<Prompt, "text" | "files" | "agents">) =>
         schema.make({
           text: input.text,
           ...(input.files === undefined ? {} : { files: input.files }),
           ...(input.agents === undefined ? {} : { agents: input.agents }),
-          ...(input.system === undefined ? {} : { system: input.system }),
         }),
     })),
   )

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -47,7 +47,6 @@ export const User = Schema.Struct({
   text: Prompt.fields.text,
   files: Prompt.fields.files,
   agents: Prompt.fields.agents,
-  system: Prompt.fields.system,
   type: Schema.Literal("user"),
 }).annotate({ identifier: "Session.Message.User" })
 


### PR DESCRIPTION
## Summary

- Remove the prompt-level `system` option from the V2 `Prompt` / `PromptInput` schemas and generated client types.
- Stop projecting prompt `system` onto user messages.
- Stop appending prompt `system` into the runner's LLM system parts.
- Remove the tests that locked in per-prompt system behavior and keep the agent + durable baseline assertion.

## Test

- `bun test test/session-prompt.test.ts test/session-runner.test.ts --timeout 30000` from `packages/core`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/client typecheck`
- `bun run --cwd packages/sdk-next typecheck`
- pre-push hook: `bun turbo typecheck`
