### PR TITLE
docs: add iFlow Search MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -509,3 +509,37 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### iFlow Search
+
+Add the [iFlow Search MCP server](https://www.npmjs.com/package/@iflow-ai/search-mcp) to search the web, search images, and fetch the readable content of a page. This is a community/third-party MCP stdio server published as `@iflow-ai/search-mcp` and listed in the [MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.zhengyanglsun/iflow-search`.
+
+```json title="opencode.json" {4-10}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "iflow_search": {
+      "type": "local",
+      "command": ["npx", "-y", "@iflow-ai/search-mcp"],
+      "environment": {
+        "IFLOW_MCP_CLIENT": "opencode"
+      },
+      "enabled": true
+    }
+  }
+}
+```
+
+The server reads its iFlow API credential from the `IFLOW_API_KEY` environment variable of its own process. Provide it through the shell or secret manager that launches OpenCode rather than embedding it in `opencode.json`:
+
+```bash
+export IFLOW_API_KEY=YOUR_IFLOW_API_KEY
+```
+
+Once configured, three tools become available: `iflow_web_search`, `iflow_image_search`, and `iflow_web_fetch`. You can reference the server by its name in prompts.
+
+```txt "use iflow_search"
+Find recent posts about MCP stdio transports. use iflow_search
+```


### PR DESCRIPTION
### Issue for this PR

Closes #

_(no tracking issue; community contribution. Originally submitted as #29365, which was auto-closed by the monthly cleanup bot rather than a maintainer decision. Resubmitting unchanged content from the same branch `zhengyanglsun:docs/iflow-search-mcp`, HEAD `5dda69db`.)_

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a single docs example for `iFlow Search` as an MCP stdio server in `packages/web/src/content/docs/mcp-servers.mdx`, mirroring the existing format used by other community MCP server entries on the same page (e.g. `github-mcp`, `gh_grep`).

Why it works:
- The MCP server (`@iflow-ai/search-mcp`) is already published to npm and registered in the public MCP Registry as `io.github.zhengyanglsun/iflow-search`, so the snippet only references stable external endpoints.
- The `opencode.json` snippet follows the existing schema documented on the same page; no OpenCode core code is touched.
- Credentials are handled via the `IFLOW_API_KEY` environment variable read by the MCP server process, as recommended by the page's existing examples — nothing is embedded in `opencode.json`.

Scope: docs-only, single-file, +35/-0 lines under `packages/web/`. No runtime code, no dependencies, no build/CI changes.

### How did you verify your code works?

- Locally rendered the docs site with the new section and confirmed it appears under "MCP Servers" with correct anchor and code highlighting.
- Verified the `opencode.json` snippet by configuring OpenCode against `@iflow-ai/search-mcp@latest` and confirming the three tools (`iflow_web_search`, `iflow_image_search`, `iflow_web_fetch`) appear in the tool list and respond to a sample prompt.
- Confirmed the npm package and MCP Registry entry referenced in the docs both resolve.

### Screenshots / recordings

_Docs-only text addition; no UI screenshot. If maintainers want a rendered preview, I can attach one — just let me know._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR