### PR TITLE
fix: bound compaction request size

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -352,6 +352,13 @@ export const layer = Layer.effect(
         stripMedia: true,
         toolOutputMaxChars: TOOL_OUTPUT_MAX_CHARS,
       })
+      let compactMessages = [
+        ...modelMessages,
+        {
+          role: "user" as const,
+          content: [{ type: "text" as const, text: nextPrompt }],
+        },
+      ]
       const ctx = yield* InstanceState.context
       const msg: SessionV1.Assistant = {
         id: MessageID.ascending(),
@@ -380,6 +387,32 @@ export const layer = Layer.effect(
         },
       }
       yield* session.updateMessage(msg)
+      const compactLimit = usable({ cfg, model, outputTokenMax: flags.outputTokenMax })
+      let compactSize = Token.estimate(JSON.stringify(compactMessages))
+      let dropped = 0
+      while (compactLimit > 0 && compactSize >= compactLimit && compactMessages.length > 1) {
+        compactMessages = compactMessages.slice(1)
+        compactSize = Token.estimate(JSON.stringify(compactMessages))
+        dropped++
+      }
+      if (dropped > 0) {
+        yield* Effect.logWarning("dropped oldest messages from compaction request", {
+          "session.id": input.sessionID,
+          messageID: msg.id,
+          dropped,
+          compactSize,
+          compactLimit,
+        })
+      }
+      if (compactLimit > 0 && compactSize >= compactLimit) {
+        msg.error = new SessionV1.ContextOverflowError({
+          message: "Conversation history too large to compact - compaction request exceeds model context limit",
+        }).toObject()
+        msg.finish = "error"
+        msg.time.completed = Date.now()
+        yield* session.updateMessage(msg)
+        return "stop"
+      }
       const processor = yield* processors.create({
         assistantMessage: msg,
         sessionID: input.sessionID,
@@ -391,13 +424,7 @@ export const layer = Layer.effect(
         sessionID: input.sessionID,
         tools: {},
         system: [],
-        messages: [
-          ...modelMessages,
-          {
-            role: "user",
-            content: [{ type: "text", text: nextPrompt }],
-          },
-        ],
+        messages: compactMessages,
         model,
       })
 


### PR DESCRIPTION
### Issue for this PR

Related to anomalyco/opencode#15556

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This adds a final size guard before sending a compaction request to the provider.

In some very large sessions, the selected history plus the compaction prompt can still exceed the model's usable context window. When that happens, opencode may ask the provider to summarize a request that is already too large, and the provider returns a context limit error.

The change estimates the compact request size before calling the model. If it is too large, it drops the oldest messages from the compaction request until it fits. If even the final compaction prompt cannot fit, it records a local context overflow error and stops instead of sending a request that is expected to fail.

### How did you verify your code works?

- Ran `bun run --cwd packages/opencode typecheck`
- Ran `git diff --check`
- Tested opencode against DashScope-compatible models:
  - `kimi-k2.6`: short prompt passed, low-budget long-context compaction pressure test passed
  - `MiniMax-M2.5`: short prompt passed, low-budget long-context compaction pressure test passed

### Screenshots / recordings

N/A, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR