### PR TITLE
fix(opencode): preserve shell command variant

### DIFF
--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -1248,6 +1248,7 @@ function createLayer(input: StreamInput) {
                                 sessionID: input.sessionID,
                                 agent,
                                 model: next.model,
+                                variant: next.variant,
                                 command: next.prompt.text,
                               },
                               { signal: turn.signal, throwOnError: true },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -467,13 +467,32 @@ export const layer = Layer.effect(
               throw error
             }
             const model = input.model ?? agent.model ?? (yield* currentModel(input.sessionID))
+            const variant = input.variant
             const userMsg: SessionV1.User = {
               id: input.messageID ?? MessageID.ascending(),
               sessionID: input.sessionID,
               time: { created: Date.now() },
               role: "user",
               agent: input.agent,
-              model: { providerID: model.providerID, modelID: model.modelID },
+              model: { providerID: model.providerID, modelID: model.modelID, variant },
+            }
+            const current = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
+            if (
+              current.agent !== userMsg.agent ||
+              current.model?.providerID !== userMsg.model.providerID ||
+              current.model?.id !== userMsg.model.modelID ||
+              (current.model?.variant === "default" ? undefined : current.model?.variant) !== userMsg.model.variant
+            ) {
+              yield* sessions.setAgentModel({
+                sessionID: input.sessionID,
+                agent: userMsg.agent,
+                model: {
+                  id: userMsg.model.modelID,
+                  providerID: userMsg.model.providerID,
+                  variant: userMsg.model.variant ?? "default",
+                },
+                time: userMsg.time.created,
+              })
             }
             yield* sessions.updateMessage(userMsg)
             const userPart: SessionV1.Part = {
@@ -1562,6 +1581,7 @@ export const ShellInput = Schema.Struct({
   messageID: Schema.optional(MessageID),
   agent: Schema.String,
   model: Schema.optional(ModelRef),
+  variant: Schema.optional(Schema.String),
   command: Schema.String,
 })
 export type ShellInput = Schema.Schema.Type<typeof ShellInput>

--- a/packages/opencode/test/cli/run/stream.transport.test.ts
+++ b/packages/opencode/test/cli/run/stream.transport.test.ts
@@ -420,6 +420,7 @@ function sdk(
     subscribe?: OpencodeClient["event"]["subscribe"]
     globalEvent?: OpencodeClient["global"]["event"]
     promptAsync?: OpencodeClient["session"]["promptAsync"]
+    shell?: OpencodeClient["session"]["shell"]
     status?: OpencodeClient["session"]["status"]
     messages?: OpencodeClient["session"]["messages"]
     children?: OpencodeClient["session"]["children"]
@@ -433,6 +434,8 @@ function sdk(
   const globalEvent: OpencodeClient["global"]["event"] =
     input.globalEvent ?? (() => globalSse(input.globalStream ?? wrapGlobalStream(input.stream ?? emptyStream())))
   const promptAsync: OpencodeClient["session"]["promptAsync"] = input.promptAsync ?? (() => ok(undefined))
+  const shell: OpencodeClient["session"]["shell"] =
+    input.shell ?? (() => ok(assistantMessage({ sessionID: "session-1", id: "msg-shell", parts: [] })))
   const status: OpencodeClient["session"]["status"] = input.status ?? (() => ok({}))
   const messages: OpencodeClient["session"]["messages"] = input.messages ?? (() => ok([]))
   const children: OpencodeClient["session"]["children"] = input.children ?? (() => ok([]))
@@ -442,6 +445,7 @@ function sdk(
   spyOn(client.event, "subscribe").mockImplementation(subscribe)
   spyOn(client.global, "event").mockImplementation(globalEvent)
   spyOn(client.session, "promptAsync").mockImplementation(promptAsync)
+  spyOn(client.session, "shell").mockImplementation(shell)
   spyOn(client.session, "status").mockImplementation(status)
   spyOn(client.session, "messages").mockImplementation(messages)
   spyOn(client.session, "children").mockImplementation(children)
@@ -452,6 +456,44 @@ function sdk(
 }
 
 describe("run stream transport", () => {
+  test("passes active variant to direct shell requests", async () => {
+    const ui = footer()
+    let request: Parameters<OpencodeClient["session"]["shell"]>[0] | undefined
+    const transport = await createSessionTransport({
+      sdk: sdk({
+        shell: async (next) => {
+          request = next
+          return ok(assistantMessage({ sessionID: "session-1", id: "msg-shell", parts: [] }))
+        },
+      }),
+      sessionID: "session-1",
+      thinking: true,
+      limits: () => ({}),
+      footer: ui.api,
+    })
+
+    try {
+      await transport.runPromptTurn({
+        agent: "build",
+        model: { providerID: "openai", modelID: "gpt-5" },
+        variant: "high",
+        prompt: { text: "pwd", parts: [], mode: "shell" },
+        files: [],
+        includeFiles: false,
+      })
+
+      expect(request).toMatchObject({
+        sessionID: "session-1",
+        agent: "build",
+        model: { providerID: "openai", modelID: "gpt-5" },
+        variant: "high",
+        command: "pwd",
+      })
+    } finally {
+      await transport.close()
+    }
+  })
+
   test("does not replay persisted main-session history during bootstrap by default", async () => {
     const src = eventFeed()
     const ui = footer()

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1548,6 +1548,38 @@ unixNoLLMServer(
 )
 
 unixNoLLMServer(
+  "shell preserves the selected model variant",
+  () =>
+    Effect.gen(function* () {
+      const { prompt, run, sessions, chat } = yield* boot()
+      yield* prompt.shell({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        variant: "high",
+        command: "printf variant",
+      })
+
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const user = messages.find((message) => message.info.role === "user")
+      if (!user || user.info.role !== "user") throw new Error("expected shell user message")
+
+      expect(user.info.model).toMatchObject({
+        providerID: ref.providerID,
+        modelID: ref.modelID,
+        variant: "high",
+      })
+      expect((yield* sessions.get(chat.id)).model).toMatchObject({
+        providerID: ref.providerID,
+        id: ref.modelID,
+        variant: "high",
+      })
+      yield* run.assertNotBusy(chat.id)
+    }),
+  { config: cfg },
+)
+
+unixNoLLMServer(
   "shell uses configured shell over env shell",
   () =>
     withSh(() =>

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -4221,6 +4221,7 @@ export class Session2 extends HeyApiClient {
         providerID: string
         modelID: string
       }
+      variant?: string
       command?: string
     },
     options?: Options<never, ThrowOnError>,
@@ -4236,6 +4237,7 @@ export class Session2 extends HeyApiClient {
             { in: "body", key: "messageID" },
             { in: "body", key: "agent" },
             { in: "body", key: "model" },
+            { in: "body", key: "variant" },
             { in: "body", key: "command" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -10242,6 +10242,7 @@ export type SessionShellData = {
       providerID: string
       modelID: string
     }
+    variant?: string
     command: string
   }
   path: {


### PR DESCRIPTION
## Summary

- Thread the active model variant through direct `!cmd` shell requests so shell mode preserves the selected thinking effort.
- Persist the selected variant on shell-created user messages and the session model state.
- Regenerate the JS SDK v2 shell payload types for the new `variant` field.

Fixes #34399.

## Testing

- `bun run generate` from `packages/client`
- `./packages/sdk/js/script/build.ts`
- `bun typecheck` from `packages/opencode`
- `bun typecheck` from `packages/client`
- `bun test test/cli/run/stream.transport.test.ts` from `packages/opencode`
- `bun test test/session/prompt.test.ts --timeout 30000` from `packages/opencode`
- `git diff --check`
- `bun run script/build.ts --single --skip-install` from `packages/opencode`
  - smoke test passed: `dist/opencode-darwin-arm64/bin/opencode --version` -> `0.0.0-shell-thinking-202606291024`
- pre-push hook: `bun turbo typecheck`

## Screenshot proof

Pending manual capture from the local binary:

1. Run `packages/opencode/dist/opencode-darwin-arm64/bin/opencode --mini .` from the repo root.
2. Select a model with variants and press `Ctrl+T` until the footer shows a non-default variant such as `high`.
3. Capture the footer before running a shell command: the model label should include the selected variant.
4. Type `!pwd` and press Enter.
5. After the shell command finishes and the prompt returns, capture the footer again: the same selected variant should still be shown.
