### PR TITLE
fix(llm): narrow raw overlays

### DIFF
--- a/packages/llm/src/route/transport/http.ts
+++ b/packages/llm/src/route/transport/http.ts
@@ -28,9 +28,56 @@ const applyQuery = (url: string, query: Record<string, string> | undefined) => {
   return next.toString()
 }
 
+const PROTOCOL_BODY_ROOTS = new Set([
+  "content",
+  "contents",
+  "frequencyPenalty",
+  "frequency_penalty",
+  "generationConfig",
+  "inferenceConfig",
+  "input",
+  "maxTokens",
+  "max_tokens",
+  "messages",
+  "model",
+  "presencePenalty",
+  "presence_penalty",
+  "responseFormat",
+  "response_format",
+  "seed",
+  "stop",
+  "stopSequences",
+  "stop_sequences",
+  "stream",
+  "streamOptions",
+  "stream_options",
+  "system",
+  "systemInstruction",
+  "system_instruction",
+  "temperature",
+  "thinking",
+  "toolChoice",
+  "toolConfig",
+  "tool_choice",
+  "tool_config",
+  "tools",
+  "topK",
+  "topP",
+  "top_k",
+  "top_p",
+])
+
+const validateBodyOverlay = (body: Record<string, unknown>) => {
+  const invalidKeys = Object.keys(body).filter((key) => PROTOCOL_BODY_ROOTS.has(key))
+  if (invalidKeys.length === 0) return undefined
+  return ProviderShared.invalidRequest(`http.body cannot overlay protocol-owned field(s): ${invalidKeys.join(", ")}`)
+}
+
 const bodyWithOverlay = <Body>(body: Body, request: LLMRequest, encodeBody: (body: Body) => string) =>
   Effect.gen(function* () {
     if (request.http?.body === undefined) return { jsonBody: body, bodyText: encodeBody(body) }
+    const error = validateBodyOverlay(request.http.body)
+    if (error) return yield* error
     if (ProviderShared.isRecord(body)) {
       const overlaid = mergeJsonRecords(body, request.http.body) ?? {}
       return { jsonBody: overlaid, bodyText: ProviderShared.encodeJson(overlaid) }

--- a/packages/llm/src/route/transport/http.ts
+++ b/packages/llm/src/route/transport/http.ts
@@ -28,7 +28,7 @@ const applyQuery = (url: string, query: Record<string, string> | undefined) => {
   return next.toString()
 }
 
-const PROTOCOL_BODY_ROOTS = new Set([
+const PROTOCOL_BODY_OVERLAY_DENYLIST = new Set([
   "content",
   "contents",
   "frequencyPenalty",
@@ -67,17 +67,17 @@ const PROTOCOL_BODY_ROOTS = new Set([
   "top_p",
 ])
 
-const validateBodyOverlay = (body: Record<string, unknown>) => {
-  const invalidKeys = Object.keys(body).filter((key) => PROTOCOL_BODY_ROOTS.has(key))
-  if (invalidKeys.length === 0) return undefined
-  return ProviderShared.invalidRequest(`http.body cannot overlay protocol-owned field(s): ${invalidKeys.join(", ")}`)
-}
+const forbiddenBodyOverlayKeys = (body: Record<string, unknown>) =>
+  Object.keys(body).filter((key) => PROTOCOL_BODY_OVERLAY_DENYLIST.has(key))
 
 const bodyWithOverlay = <Body>(body: Body, request: LLMRequest, encodeBody: (body: Body) => string) =>
   Effect.gen(function* () {
     if (request.http?.body === undefined) return { jsonBody: body, bodyText: encodeBody(body) }
-    const error = validateBodyOverlay(request.http.body)
-    if (error) return yield* error
+    const forbiddenKeys = forbiddenBodyOverlayKeys(request.http.body)
+    if (forbiddenKeys.length > 0)
+      return yield* ProviderShared.invalidRequest(
+        `http.body cannot overlay protocol-owned field(s): ${forbiddenKeys.join(", ")}`,
+      )
     if (ProviderShared.isRecord(body)) {
       const overlaid = mergeJsonRecords(body, request.http.body) ?? {}
       return { jsonBody: overlaid, bodyText: ProviderShared.encodeJson(overlaid) }

--- a/packages/llm/test/prepare.test.ts
+++ b/packages/llm/test/prepare.test.ts
@@ -117,11 +117,9 @@ describe("request option precedence", () => {
         dynamicResponse((input) =>
           Effect.gen(function* () {
             const web = yield* HttpClientRequest.toWeb(input.request).pipe(Effect.orDie)
-            const url = new URL(web.url)
-            expect(url.searchParams.get("route")).toBe("1")
-            expect(url.searchParams.get("model")).toBe("1")
-            expect(url.searchParams.get("request")).toBe("1")
-            expect(url.searchParams.get("shared")).toBe("model")
+            expect(web.url).toBe(
+              "https://api.openai.test/v1/chat/completions?route=1&shared=model&model=1&request=1",
+            )
             expect(web.headers.get("authorization")).toBe("Bearer fresh-key")
             expect(web.headers.get("x-route")).toBe("route")
             expect(web.headers.get("x-model")).toBe("model")
@@ -138,6 +136,24 @@ describe("request option precedence", () => {
         ),
       ),
     ),
+  )
+
+  it.effect("rejects raw body overlays for protocol-owned roots", () =>
+    Effect.gen(function* () {
+      const model = OpenAIChat.route
+        .with({ endpoint: { baseURL: "https://api.openai.test/v1/" }, auth: Auth.bearer("test") })
+        .model({ id: "gpt-4o-mini" })
+      const error = yield* LLMClient.prepare(
+        LLM.request({
+          model,
+          prompt: "Say hello.",
+          http: { body: { model: "gpt-5", messages: [], tools: [] } },
+        }),
+      ).pipe(Effect.flip)
+
+      expect(error.reason).toMatchObject({ _tag: "InvalidRequest" })
+      expect(error.message).toContain("http.body cannot overlay protocol-owned field(s): model, messages, tools")
+    }),
   )
 
   it.effect("uses model output limits after route limits and before call maxTokens", () =>

--- a/packages/llm/test/prepare.test.ts
+++ b/packages/llm/test/prepare.test.ts
@@ -151,8 +151,10 @@ describe("request option precedence", () => {
         }),
       ).pipe(Effect.flip)
 
-      expect(error.reason).toMatchObject({ _tag: "InvalidRequest" })
-      expect(error.message).toContain("http.body cannot overlay protocol-owned field(s): model, messages, tools")
+      expect(error.reason).toMatchObject({
+        _tag: "InvalidRequest",
+        message: "http.body cannot overlay protocol-owned field(s): model, messages, tools",
+      })
     }),
   )
 


### PR DESCRIPTION
## Summary
- reject raw http.body overlays that target protocol-owned body roots like model, messages, tools, system, generation, and streaming fields
- keep raw overlays available for non-protocol provider fields
- tighten prepare coverage for deterministic query order, auth winning over header overlays, and local invalid-request failures

## Tests
- cd packages/llm && bun typecheck
- cd packages/llm && bun test
- pre-push hook passed: bun turbo typecheck (29/29 tasks)

## Note
- local worktree has an unrelated unstaged formatting change in packages/llm/src/schema/options.ts; it is not part of this PR