### PR TITLE
fix(desktop): preserve selected model during session promotion

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -80,6 +80,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const [store, setStore] = createStore<{
       current?: string
       draft?: State
+      promoting?: State
       last?: {
         type: "agent" | "model" | "variant"
         agent?: string
@@ -123,7 +124,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const scope = createMemo<State | undefined>(() => {
       const session = id()
-      if (!session) return store.draft
+      if (!session) return store.draft ?? store.promoting
       return saved.session[session] ?? handoff.get(handoffKey(serverSDK().scope, sdk().directory, session))
     })
 
@@ -136,11 +137,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       if (!next) return
       if (saved.session[session] !== undefined) {
         handoff.delete(key)
+        setStore("promoting", undefined)
         return
       }
 
       setSaved("session", session, clone(next))
       handoff.delete(key)
+      setStore("promoting", undefined)
     })
 
     const configuredModel = () => {
@@ -373,19 +376,19 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       agent,
       session: {
         reset() {
-          setStore("draft", undefined)
+          setStore({ draft: undefined, promoting: undefined })
         },
         promote(dir: string, session: string) {
           const next = clone(snapshot())
           if (!next) return
+          const key = handoffKey(serverSDK().scope, dir, session)
+          handoff.set(key, next)
 
           if (dir === sdk().directory) {
             setSaved("session", session, next)
-            setStore("draft", undefined)
-            return
           }
 
-          handoff.set(handoffKey(serverSDK().scope, dir, session), next)
+          setStore("promoting", next)
           setStore("draft", undefined)
         },
         restore(msg: { sessionID: string; agent: string; model: ModelKey }) {


### PR DESCRIPTION
### Issue for this PR

Closes #34466

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a composer model picker flicker when submitting a new session with a non-default model selected.

During new-session promotion, the local draft model selection was cleared before the routed session state became available. That left the picker with no scoped selection for a moment, so it fell back to the configured default model, then switched back once the promoted session selection was restored.

This keeps the promoted model selection in an in-memory handoff state until the session route consumes it, so the picker continues showing the selected model throughout the transition.

### How did you verify your code works?

- `bun run typecheck` from `packages/app`
- `bun test src/components/prompt-input/submit.test.ts` from `packages/app`

### Screenshots / recordings

**Before**

https://github.com/user-attachments/assets/328dfac1-bd5c-4a27-9848-c965733fd6a6

**After**

https://github.com/user-attachments/assets/bda99edf-257f-4298-b66e-2beca04087aa

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR