### PR TITLE
feat(tui): auto-enter edit mode when typing on 'Type your own answer'

### DIFF
--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-js"
-import { useRenderer } from "@opentui/solid"
+import { useKeyboard, useRenderer } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
@@ -22,6 +22,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
   const tabs = createMemo(() => (single() ? 1 : questions().length + 1)) // questions + confirm tab (no confirm for single select)
   const [tabHover, setTabHover] = createSignal<number | "confirm" | null>(null)
+  const [pending, setPending] = createSignal<string | null>(null)
   const [store, setStore] = createStore({
     tab: 0,
     answers: [] as QuestionAnswer[],
@@ -285,6 +286,17 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     }
   })
 
+  useKeyboard((evt) => {
+    if (store.editing || confirm() || !other()) return
+    if (evt.ctrl || evt.meta || evt.option) return
+    if (evt.name === "space" || (evt.name.length === 1 && !"hjkl".includes(evt.name))) {
+      evt.preventDefault()
+      evt.stopPropagation()
+      setPending(evt.sequence)
+      setStore("editing", true)
+    }
+  })
+
   return (
     <box
       backgroundColor={theme.backgroundPanel}
@@ -431,6 +443,11 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                           queueMicrotask(() => {
                             val.focus()
                             val.gotoLineEnd()
+                            const ch = pending()
+                            if (ch) {
+                              val.insertText(ch)
+                              setPending(null)
+                            }
                           })
                         }}
                         initialValue={input()}


### PR DESCRIPTION
## What

When "Type your own answer" is the selected option in the Question prompt, pressing any printable character now immediately enters edit mode and inserts that character — no need to press Enter first.

## Why

Navigating to "Type your own answer" already signals intent to type. Forcing an extra Enter keypress before typing is friction. This removes it.

Closes #34476

## How

- Added a `useKeyboard` handler in `QuestionPrompt` that fires before the keymap bindings (global listeners run before renderable/internal handlers in opentui's `InternalKeyHandler`).
- When `other()` is true (the custom option is highlighted) and the key is a printable character (single-char name, not `hjkl` which are navigation keys, no ctrl/meta/option), it calls `preventDefault` + `stopPropagation` to prevent digit-quick-select and other bindings from firing, stores the character in a `pending` signal, and sets `store.editing = true`.
- The textarea `ref` callback (which already runs `focus()` + `gotoLineEnd()` in a `queueMicrotask`) now also inserts the pending character via `insertText` and clears the signal.

Navigation keys (↑↓/jk, h/l, tab, Enter, Esc) are unaffected — they have multi-char names or are explicitly excluded by `!"hjkl".includes(evt.name)`.

## Verification

- `bun run typecheck` in `packages/tui` — no new errors (the pre-existing `traits` type error on `TextareaRenderable` exists on `upstream/dev` already).
- Manually: trigger a question with `custom: true`, navigate to "Type your own answer", start typing — the first character appears in the textarea immediately.