### PR TITLE
fix(tui): truncateMiddle returns the whole string when maxLength is 1 or 2

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -75,7 +75,7 @@ export function truncateMiddle(str: string, maxLength: number = 35): string {
   const keepStart = Math.ceil((maxLength - ellipsis.length) / 2)
   const keepEnd = Math.floor((maxLength - ellipsis.length) / 2)
 
-  return str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)
+  return str.slice(0, keepStart) + ellipsis + (keepEnd > 0 ? str.slice(-keepEnd) : "")
 }
 
 export function pluralize(count: number, singular: string, plural: string): string {

--- a/packages/tui/test/util/locale.test.ts
+++ b/packages/tui/test/util/locale.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { truncateMiddle } from "../../src/util/locale"
+
+describe("util.locale", () => {
+  describe("truncateMiddle", () => {
+    test("never exceeds maxLength at small widths", () => {
+      expect(truncateMiddle("hello-world", 1)).toBe("…")
+      expect(truncateMiddle("hello-world", 2)).toBe("h…")
+    })
+
+    test("truncates in the middle for larger widths", () => {
+      expect(truncateMiddle("hello-world", 3)).toBe("h…d")
+      expect(truncateMiddle("abcdefghij", 5)).toBe("ab…ij")
+    })
+
+    test("returns the string unchanged when it fits", () => {
+      expect(truncateMiddle("short", 35)).toBe("short")
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #20880

### Type of change

- [x] Bug fix

### What does this PR do?

`truncateMiddle` (`packages/tui/src/util/locale.ts`) returns the whole string when `maxLength` is 1 or 2. At those widths `keepEnd` is 0, and `str.slice(-0)` slices from index 0 (returns everything) instead of nothing — so the result is longer than the input, and the run splash detail line overflows on very narrow terminals. The fix skips the end slice when `keepEnd` is 0.

### How did you verify your code works?

Added `packages/tui/test/util/locale.test.ts`: `truncateMiddle("hello-world", 1)` now returns `"…"` and `(..., 2)` returns `"h…"`; widths >= 3 are unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
