### PR TITLE
refactor(opencode): use layer nodes in plugin tests

### DIFF
--- a/packages/opencode/test/plugin/auth-override.test.ts
+++ b/packages/opencode/test/plugin/auth-override.test.ts
@@ -2,46 +2,39 @@ import { describe, expect, test } from "bun:test"
 import path from "path"
 import { pathToFileURL } from "url"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { provideInstance, TestInstance, tmpdirScoped } from "../fixture/fixture"
 import { ProviderAuth } from "@/provider/auth"
 
-import { Plugin } from "@/plugin"
 import { RuntimeFlags } from "@/effect/runtime-flags"
-import { Auth } from "@/auth"
-import { EventV2Bridge } from "@/event-v2-bridge"
 import { TestConfig } from "../fixture/config"
 import { testEffect } from "../lib/effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { ProviderV2 } from "@opencode-ai/core/provider"
+import { Config } from "@/config/config"
 
 const it = testEffect(LayerNode.compile(LayerNode.group([CrossSpawnSpawner.node, FSUtil.node])))
 
-function layer(directory: string, plugins: string[]) {
-  return ProviderAuth.layer.pipe(
-    Layer.provide(Auth.defaultLayer),
-    Layer.provide(
-      Plugin.layer.pipe(
-        Layer.provide(EventV2Bridge.defaultLayer),
-        Layer.provide(RuntimeFlags.layer()),
-        Layer.provide(
-          TestConfig.layer({
-            get: () =>
-              Effect.succeed({
-                plugin: plugins,
-                plugin_origins: plugins.map((plugin) => ({
-                  spec: plugin,
-                  source: path.join(directory, "opencode.json"),
-                  scope: "local" as const,
-                })),
-              }),
-            directories: () => Effect.succeed([directory]),
+function providerAuthLayer(directory: string, plugins: string[]) {
+  return LayerNode.compile(ProviderAuth.node, [
+    [
+      Config.node,
+      TestConfig.layer({
+        get: () =>
+          Effect.succeed({
+            plugin: plugins,
+            plugin_origins: plugins.map((plugin) => ({
+              spec: plugin,
+              source: path.join(directory, "opencode.json"),
+              scope: "local" as const,
+            })),
           }),
-        ),
-      ),
-    ),
-  )
+        directories: () => Effect.succeed([directory]),
+      }),
+    ],
+    [RuntimeFlags.node, RuntimeFlags.layer()],
+  ])
 }
 
 describe("plugin.auth-override", () => {
@@ -74,10 +67,10 @@ describe("plugin.auth-override", () => {
 
         const plain = yield* tmpdirScoped({ git: true })
         const plugin = pathToFileURL(path.join(pluginDir, "custom-copilot-auth.ts")).href
-        const methods = yield* ProviderAuth.use.methods().pipe(Effect.provide(layer(tmp.directory, [plugin])))
+        const methods = yield* ProviderAuth.use.methods().pipe(Effect.provide(providerAuthLayer(tmp.directory, [plugin])))
         const plainMethods = yield* ProviderAuth.use
           .methods()
-          .pipe(Effect.provide(layer(plain, [])), provideInstance(plain))
+          .pipe(Effect.provide(providerAuthLayer(plain, [])), provideInstance(plain))
 
         const copilot = methods[ProviderV2.ID.make("github-copilot")]
         expect(copilot).toBeDefined()

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -6,13 +6,13 @@ import path from "path"
 import { pathToFileURL } from "url"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Config } from "@/config/config"
 import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
 const { Plugin } = await import("../../src/plugin/index")
 const { PluginLoader } = await import("../../src/plugin/loader")
 const { readPackageThemes } = await import("../../src/plugin/shared")
-const { EventV2Bridge } = await import("../../src/event-v2-bridge")
 const { Npm } = await import("@opencode-ai/core/npm")
 const { TestConfig } = await import("../fixture/config")
 const { RuntimeFlags } = await import("../../src/effect/runtime-flags")
@@ -48,10 +48,9 @@ function load(dir: string, flags?: Parameters<typeof RuntimeFlags.layer>[0]) {
       yield* plugin.list()
     }).pipe(
       Effect.provide(
-        Plugin.layer.pipe(
-          Layer.provide(EventV2Bridge.defaultLayer),
-          Layer.provide(RuntimeFlags.layer({ disableDefaultPlugins: true, ...flags })),
-          Layer.provide(
+        LayerNode.compile(Plugin.node, [
+          [
+            Config.node,
             TestConfig.layer({
               get: () =>
                 Effect.succeed({
@@ -60,8 +59,9 @@ function load(dir: string, flags?: Parameters<typeof RuntimeFlags.layer>[0]) {
                 }),
               directories: () => Effect.succeed([dir]),
             }),
-          ),
-        ),
+          ],
+          [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true, ...flags })],
+        ]),
       ),
       provideInstance(dir),
     )


### PR DESCRIPTION
## Summary
- switch plugin loader shared test helpers to compile Plugin.node with config/runtime replacements
- switch provider auth override helpers to compile ProviderAuth.node with test config replacements

## Testing
- git diff --check -- packages/opencode/test/plugin/loader-shared.test.ts packages/opencode/test/plugin/auth-override.test.ts
- bun test test/plugin/loader-shared.test.ts (blocked: preload not found "@opentui/solid/preload")
- bun test test/plugin/auth-override.test.ts (blocked: preload not found "@opentui/solid/preload")
- bun typecheck (blocked: tsgo: command not found)