### PR TITLE
fix(tui): surface provider error in assistant footer

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1147,15 +1147,32 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
     props.message.time.completed ? props.message.time.completed - props.message.time.created : 0,
   )
   return (
-    <box paddingLeft={3}>
-      <text>
-        <span style={{ fg: local.agent.color(props.message.agent) }}>{Locale.titlecase(props.message.agent)}</span>
-        <span style={{ fg: theme.textMuted }}> · {model()}</span>
-        <Show when={duration()}>
-          <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
-        </Show>
-      </text>
-    </box>
+    <>
+      <Show when={props.message.error}>
+        <box
+          border={["left"]}
+          paddingTop={1}
+          paddingBottom={1}
+          paddingLeft={2}
+          backgroundColor={theme.backgroundPanel}
+          customBorderChars={SplitBorder.customBorderChars}
+          borderColor={theme.error}
+        >
+          <text fg={theme.textMuted}>{errorMessage(props.message.error)}</text>
+        </box>
+      </Show>
+      <box paddingLeft={3} marginTop={props.message.error ? 1 : 0}>
+        <text>
+          <span style={{ fg: props.message.error ? theme.textMuted : local.agent.color(props.message.agent) }}>
+            {Locale.titlecase(props.message.agent)}
+          </span>
+          <span style={{ fg: theme.textMuted }}> · {model()}</span>
+          <Show when={duration()}>
+            <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
+          </Show>
+        </text>
+      </box>
+    </>
   )
 }
 


### PR DESCRIPTION
## Problem

When a V2 provider turn fails (e.g. a `401` auth error), the session ends with a failed empty assistant message. Core propagates this correctly:

- `session.next.step.failed` is published and projected onto the assistant message as `message.error` / `finish: "error"`.
- The TUI data layer in `context/data.tsx` stores `message.error`.

But the active TUI timeline renders failed empty assistant turns through `AssistantFooter` (via the `assistant-footer` row in `rows.ts`), and `AssistantFooter` only displayed agent/model/duration. The error text was dropped, so prompts appeared to do nothing with no visible error.

## Fix

`AssistantFooter` now renders `props.message.error` in the same red error panel style used by `AssistantMessage`, with the agent label muted in the error case. A top margin is added before the metadata line only when an error is present, so the error panel and the model/agent footer stay visually separated.

## Verification

- `bun typecheck` from `packages/tui`.
- Verified live via `termctrl`: sent a prompt to `meta/muse-spark` with no valid credential and confirmed the `HTTP 401` provider error now renders in the timeline.