### PR TITLE
fix(core): sanitize registered tool names

### DIFF
--- a/packages/core/src/tool/application-tools.ts
+++ b/packages/core/src/tool/application-tools.ts
@@ -41,9 +41,8 @@ export const layer = Layer.effect(
 
     return Service.of({
       register: Effect.fn("ApplicationTools.register")(function* (tools) {
-        const entries = Object.entries(tools)
+        const entries = Object.entries(tools).map(([name, tool]) => [Tool.sanitizeName(name), tool] as const)
         if (entries.length === 0) return
-        yield* Effect.forEach(entries, ([name]) => Tool.validateName(name), { discard: true })
         const registrations = entries.map(([name, tool]) => [name, { identity: {}, tool }] as const)
         yield* state.transform((draft) => {
           for (const [name, entry] of registrations) draft.set(name, entry)

--- a/packages/core/src/tool/application-tools.ts
+++ b/packages/core/src/tool/application-tools.ts
@@ -41,7 +41,7 @@ export const layer = Layer.effect(
 
     return Service.of({
       register: Effect.fn("ApplicationTools.register")(function* (tools) {
-        const entries = Object.entries(tools).map(([name, tool]) => [Tool.sanitizeName(name), tool] as const)
+        const entries = Tool.registrationEntries(tools)
         if (entries.length === 0) return
         const registrations = entries.map(([name, tool]) => [name, { identity: {}, tool }] as const)
         yield* state.transform((draft) => {

--- a/packages/core/src/tool/registry.ts
+++ b/packages/core/src/tool/registry.ts
@@ -9,7 +9,7 @@ import { SessionSchema } from "../session/schema"
 import { ToolOutputStore } from "../tool-output-store"
 import { Wildcard } from "../util/wildcard"
 import { ApplicationTools } from "./application-tools"
-import { definition, permission, sanitizeName, settle, type AnyTool, type RegistrationError } from "./tool"
+import { definition, permission, registrationEntries, settle, type AnyTool, type RegistrationError } from "./tool"
 import { Tools } from "./tools"
 import { makeLocationNode } from "../effect/app-node"
 
@@ -83,7 +83,7 @@ const registryLayer = Layer.effect(
 
     return Service.of({
       register: Effect.fn("ToolRegistry.register")(function* (tools) {
-        const entries = Object.entries(tools).map(([name, tool]) => [sanitizeName(name), tool] as const)
+        const entries = registrationEntries(tools)
         if (entries.length === 0) return
         yield* Effect.uninterruptible(
           Effect.gen(function* () {

--- a/packages/core/src/tool/registry.ts
+++ b/packages/core/src/tool/registry.ts
@@ -9,7 +9,7 @@ import { SessionSchema } from "../session/schema"
 import { ToolOutputStore } from "../tool-output-store"
 import { Wildcard } from "../util/wildcard"
 import { ApplicationTools } from "./application-tools"
-import { definition, permission, settle, validateName, type AnyTool, type RegistrationError } from "./tool"
+import { definition, permission, sanitizeName, settle, type AnyTool, type RegistrationError } from "./tool"
 import { Tools } from "./tools"
 import { makeLocationNode } from "../effect/app-node"
 
@@ -83,9 +83,8 @@ const registryLayer = Layer.effect(
 
     return Service.of({
       register: Effect.fn("ToolRegistry.register")(function* (tools) {
-        const entries = Object.entries(tools)
+        const entries = Object.entries(tools).map(([name, tool]) => [sanitizeName(name), tool] as const)
         if (entries.length === 0) return
-        yield* Effect.forEach(entries, ([name]) => validateName(name), { discard: true })
         yield* Effect.uninterruptible(
           Effect.gen(function* () {
             const token = {}

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -136,6 +136,8 @@ export const validateName = (name: string) =>
     ? Effect.void
     : Effect.fail(new RegistrationError({ name, message: `Invalid tool name: ${name}` }))
 
+export const sanitizeName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, "_")
+
 export const withPermission = <Input extends SchemaType<any>, Output extends SchemaType<any>>(
   tool: Definition<Input, Output>,
   permission: string,

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -136,10 +136,8 @@ export const validateName = (name: string) =>
     ? Effect.void
     : Effect.fail(new RegistrationError({ name, message: `Invalid tool name: ${name}` }))
 
-export const sanitizeName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, "_")
-
 export const registrationEntries = (tools: Readonly<Record<string, AnyTool>>) =>
-  Object.entries(tools).map(([name, tool]) => [sanitizeName(name), tool] as const)
+  Object.entries(tools).map(([name, tool]) => [name.replace(/[^a-zA-Z0-9_-]/g, "_"), tool] as const)
 
 export const withPermission = <Input extends SchemaType<any>, Output extends SchemaType<any>>(
   tool: Definition<Input, Output>,

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -138,6 +138,9 @@ export const validateName = (name: string) =>
 
 export const sanitizeName = (name: string) => name.replace(/[^a-zA-Z0-9_-]/g, "_")
 
+export const registrationEntries = (tools: Readonly<Record<string, AnyTool>>) =>
+  Object.entries(tools).map(([name, tool]) => [sanitizeName(name), tool] as const)
+
 export const withPermission = <Input extends SchemaType<any>, Output extends SchemaType<any>>(
   tool: Definition<Input, Output>,
   permission: string,

--- a/packages/core/test/application-tools.test.ts
+++ b/packages/core/test/application-tools.test.ts
@@ -70,17 +70,14 @@ describe("ApplicationTools", () => {
     }),
   )
 
-  it.effect("exposes narrow scoped Location registration and validates names", () =>
+  it.effect("exposes narrow scoped Location registration and sanitizes names", () =>
     Effect.gen(function* () {
       const tools: Tools.Interface = yield* Tools.Service
       const registry = yield* ToolRegistry.Service
       const scope = yield* Scope.make()
 
-      yield* tools.register({ location_tool: contextual([]) }).pipe(Scope.provide(scope))
-      expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["location_tool"])
-      expect(yield* Effect.flip(tools.register({ "invalid name": contextual([]) }))).toBeInstanceOf(
-        Tool.RegistrationError,
-      )
+      yield* tools.register({ "location.tool/search": contextual([]) }).pipe(Scope.provide(scope))
+      expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["location_tool_search"])
 
       yield* Scope.close(scope, Exit.void)
       expect(yield* toolDefinitions(registry)).toEqual([])


### PR DESCRIPTION
Summary:
- sanitize registered core tool names with the existing MCP-style replacement rule
- use sanitized names for both application and location-scoped tool registration
- update the core registration test to assert sanitized model-facing names

Refs #34485

Tests:
- bun test test/application-tools.test.ts
- bun typecheck