### PR TITLE
feat(cli): add auth command to list authenticated providers

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -36,6 +36,7 @@ export const Commands = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCO
       description: "Debugging and troubleshooting tools",
       commands: [Spec.make("agents", { description: "List all agents" })],
     }),
+    Spec.make("auth", { description: "List authenticated providers" }),
     Spec.make("migrate", { description: "Migrate v1 data to v2" }),
     Spec.make("service", {
       description: "Manage the background server",

--- a/packages/cli/src/commands/handlers/auth.ts
+++ b/packages/cli/src/commands/handlers/auth.ts
@@ -1,0 +1,33 @@
+import { EOL } from "os"
+import * as Effect from "effect/Effect"
+import { Commands } from "../commands"
+import { Runtime } from "../../framework/runtime"
+import { Daemon } from "../../services/daemon"
+
+export default Runtime.handler(
+  Commands.commands.auth,
+  Effect.fn("cli.auth")(function* () {
+    const daemon = yield* Daemon.Service
+    const client = yield* daemon.client()
+    const response = yield* Effect.promise(() =>
+      client.v2.integration.list({ location: { directory: process.cwd() } }),
+    )
+    const connected = (response.data?.data ?? [])
+      .filter((integration) => integration.connections.length > 0)
+      .toSorted((a, b) => a.name.localeCompare(b.name))
+    if (connected.length === 0) {
+      process.stdout.write("No authenticated providers" + EOL)
+      return
+    }
+    const width = Math.max(...connected.map((integration) => integration.name.length))
+    const lines = connected.flatMap((integration) =>
+      integration.connections.map(
+        (connection) =>
+          `${integration.name.padEnd(width)}  ${
+            connection.type === "credential" ? `${connection.label} · credential` : `${connection.name} · env`
+          }`,
+      ),
+    )
+    process.stdout.write(lines.join(EOL) + EOL)
+  }),
+)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ const LoggingLayer = Logger.layer(Logging.loggers(), { mergeWithExisting: false 
 const Handlers = Runtime.handlers(Commands, {
   $: () => import("./commands/handlers/default"),
   api: () => import("./commands/handlers/api"),
+  auth: () => import("./commands/handlers/auth"),
   debug: {
     agents: () => import("./commands/handlers/debug/agents"),
   },


### PR DESCRIPTION
## What

Adds a top-level `auth` command to the V2 CLI that lists which providers are currently authenticated.

```
$ opencode auth
Amazon Bedrock  AWS_REGION · env
Google          GEMINI_API_KEY · env
OpenCode        anomaly · credential
```

When nothing is authenticated it prints `No authenticated providers`.

## Why

The V2 CLi (`packages/cli`) had no way to see authenticated providers — the legacy `auth list` / `providers list` command was never ported. V2 already models auth as integrations with `connections`, exposed over the server API (`integration.list`) and used by the TUI's connect-provider flow, but nothing surfaced it on the command line.

## How

Thin handler over the existing typed client, mirroring the `debug agents` handler:

- `client.v2.integration.list({ location: { directory } })`
- Keep only integrations with a non-empty `connections` array (i.e. authenticated).
- Render one line per connection: `credential` connections show their label, `env` connections show the active environment variable name.

No backend or server changes are needed. The command name is intentionally simple and leaves room for future `auth login` / `auth logout` subcommands.

## Verification

- `bun typecheck` from `packages/cli`.
- `bun dev auth` against a real running server lists the connected providers shown above; `bun dev --help` lists the new command.