### PR TITLE
refactor(opencode): use layer nodes in remaining harnesses

### DIFF
--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect } from "bun:test"
 import { ConfigProvider, Effect, Layer } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { RuntimeFlags } from "../../src/effect/runtime-flags"
 import { it } from "../lib/effect"
 
 const fromConfig = (input: Record<string, unknown>) =>
-  RuntimeFlags.defaultLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(input))))
+  AppNodeBuilder.build(RuntimeFlags.node).pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(input))))
 
 const readFlags = RuntimeFlags.Service.useSync((flags) => flags)
 

--- a/packages/opencode/test/session/structured-output-integration.test.ts
+++ b/packages/opencode/test/session/structured-output-integration.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
-import { Effect, Layer } from "effect"
+import { Effect } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Session } from "@/session/session"
 import { SessionPrompt } from "../../src/session/prompt"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -10,7 +12,7 @@ import { testEffect } from "../lib/effect"
 // Skip tests if no API key is available
 const hasApiKey = !!process.env.ANTHROPIC_API_KEY
 const it = testEffect(
-  Layer.mergeAll(SessionPrompt.defaultLayer, Session.defaultLayer).pipe(Layer.provide(Ripgrep.defaultLayer)),
+  AppNodeBuilder.build(LayerNode.group([SessionPrompt.node, Session.node, Ripgrep.node])),
 )
 const live = hasApiKey ? it.instance : it.instance.skip
 


### PR DESCRIPTION
## Summary
- convert remaining direct test harnesses to AppNodeBuilder / LayerNode graphs
- update TUI config and runtime flag tests to avoid defaultLayer exports
- keep test semantics and expectations unchanged

## Testing
- bun typecheck
- bun turbo typecheck (pre-push)

## Stack
1. #34515 refactor(opencode): build runtimes from layer nodes
2. #34516 refactor(opencode): use layer nodes in remaining harnesses
3. #34517 refactor(opencode): remove app service layer exports
4. #34518 refactor(opencode): remove core service layer exports
5. #34519 refactor(opencode): keep plugin pty environment route local

Previous: #34515
Base: node-runtimes
Next: #34517