### PR TITLE
fix(core): clean up mcp stdio descendants

### DIFF
--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -1,6 +1,7 @@
 export * as MCPClient from "./client"
 
 import path from "node:path"
+import { execFile } from "node:child_process"
 import { pathToFileURL } from "node:url"
 import { Client, type ClientOptions } from "@modelcontextprotocol/sdk/client/index.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
@@ -19,6 +20,8 @@ import { InstallationVersion } from "../installation/version"
 
 const DEFAULT_STARTUP_TIMEOUT = 30_000
 const DEFAULT_REQUEST_TIMEOUT = 30_000
+
+type Transport = StdioClientTransport | StreamableHTTPClientTransport
 
 // Some servers advertise tool outputSchemas the SDK's strict validator can't resolve; this drops
 // only that field so a single bad schema doesn't blank out the whole tool list.
@@ -73,7 +76,7 @@ export const connect = Effect.fnUntraced(function* (
   config: typeof ConfigMCP.Server.Type,
   directory: string,
 ) {
-  const transport = yield* Effect.gen(function* () {
+  const transport: Transport = yield* Effect.gen(function* () {
     if (config.type === "local") {
       const [command, ...args] = config.command
       return new StdioClientTransport({
@@ -111,7 +114,7 @@ export const connect = Effect.fnUntraced(function* (
     catch: (error) => error,
   }).pipe(Effect.exit)
   if (Exit.isSuccess(exit)) {
-    yield* Effect.addFinalizer(() => Effect.promise(() => client.close()).pipe(Effect.ignore))
+    yield* Effect.addFinalizer(() => closeClient(transport, client))
     const requestTimeout = config.timeout?.request ?? DEFAULT_REQUEST_TIMEOUT
     return {
       instructions: client.getInstructions()?.trim() || undefined,
@@ -185,12 +188,66 @@ export const connect = Effect.fnUntraced(function* (
     } satisfies Connection
   }
 
-  yield* Effect.promise(() => transport.close()).pipe(Effect.ignore)
+  yield* closeTransport(transport)
   const error = Cause.squash(exit.cause)
   if (error instanceof UnauthorizedError || (error instanceof Error && error.message.includes("OAuth")))
     return yield* new NeedsAuthError({ server })
   return yield* new ConnectError({ server, message: error instanceof Error ? error.message : String(error) })
 })
+
+const closeClient = (transport: Transport, client: Client) =>
+  cleanupStdioDescendants(transport).pipe(Effect.andThen(Effect.promise(() => client.close())), Effect.ignore)
+
+const closeTransport = (transport: Transport) =>
+  cleanupStdioDescendants(transport).pipe(Effect.andThen(Effect.promise(() => transport.close())), Effect.ignore)
+
+const cleanupStdioDescendants = (transport: Transport) =>
+  Effect.gen(function* () {
+    const pid = stdioPid(transport)
+    if (pid === undefined) return
+    yield* Effect.forEach(yield* descendantPids(pid), killPid, { discard: true })
+  })
+
+const stdioPid = (transport: Transport) => {
+  if (!(transport instanceof StdioClientTransport)) return undefined
+  const pid = (transport as { readonly pid?: unknown }).pid
+  return typeof pid === "number" ? pid : undefined
+}
+
+const descendantPids = Effect.fnUntraced(function* (root: number) {
+  if (process.platform === "win32") return []
+  const result: number[] = []
+  const queue = [root]
+  for (let index = 0; index < queue.length; index++) {
+    const parent = queue[index]
+    if (parent === undefined) return result
+    const children = (yield* childPids(parent)).filter((pid) => !result.includes(pid))
+    result.push(...children)
+    queue.push(...children)
+  }
+  return result
+})
+
+const childPids = (pid: number) =>
+  Effect.promise(
+    () =>
+      new Promise<number[]>((resolve) => {
+        execFile("pgrep", ["-P", String(pid)], { encoding: "utf8" }, (_error, stdout) => {
+          resolve(
+            stdout
+              .split("\n")
+              .map((line) => Number.parseInt(line, 10))
+              .filter((pid) => Number.isInteger(pid)),
+          )
+        })
+      }),
+  )
+
+const killPid = (pid: number) =>
+  Effect.try({
+    try: () => process.kill(pid, "SIGTERM"),
+    catch: () => undefined,
+  }).pipe(Effect.ignore)
 
 async function paginate<R extends { nextCursor?: string }, T>(
   list: (cursor: string | undefined) => Promise<R>,

--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -203,6 +203,7 @@ export const connect = Effect.fnUntraced(function* (
   return yield* new ConnectError({ server, message: error instanceof Error ? error.message : String(error) })
 })
 
+// SDK close stops the MCP process, but not child processes it spawned.
 const cleanupStdioDescendants = (transport: Transport) =>
   Effect.gen(function* () {
     if (!(transport instanceof StdioClientTransport)) return

--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -114,7 +114,12 @@ export const connect = Effect.fnUntraced(function* (
     catch: (error) => error,
   }).pipe(Effect.exit)
   if (Exit.isSuccess(exit)) {
-    yield* Effect.addFinalizer(() => closeClient(transport, client))
+    yield* Effect.addFinalizer(() =>
+      cleanupStdioDescendants(transport).pipe(
+        Effect.andThen(Effect.promise(() => client.close())),
+        Effect.ignore,
+      ),
+    )
     const requestTimeout = config.timeout?.request ?? DEFAULT_REQUEST_TIMEOUT
     return {
       instructions: client.getInstructions()?.trim() || undefined,
@@ -188,31 +193,31 @@ export const connect = Effect.fnUntraced(function* (
     } satisfies Connection
   }
 
-  yield* closeTransport(transport)
+  yield* cleanupStdioDescendants(transport).pipe(
+    Effect.andThen(Effect.promise(() => transport.close())),
+    Effect.ignore,
+  )
   const error = Cause.squash(exit.cause)
   if (error instanceof UnauthorizedError || (error instanceof Error && error.message.includes("OAuth")))
     return yield* new NeedsAuthError({ server })
   return yield* new ConnectError({ server, message: error instanceof Error ? error.message : String(error) })
 })
 
-const closeClient = (transport: Transport, client: Client) =>
-  cleanupStdioDescendants(transport).pipe(Effect.andThen(Effect.promise(() => client.close())), Effect.ignore)
-
-const closeTransport = (transport: Transport) =>
-  cleanupStdioDescendants(transport).pipe(Effect.andThen(Effect.promise(() => transport.close())), Effect.ignore)
-
 const cleanupStdioDescendants = (transport: Transport) =>
   Effect.gen(function* () {
-    const pid = stdioPid(transport)
-    if (pid === undefined) return
-    yield* Effect.forEach(yield* descendantPids(pid), killPid, { discard: true })
+    if (!(transport instanceof StdioClientTransport)) return
+    const pid = transport.pid
+    if (typeof pid !== "number") return
+    yield* Effect.forEach(
+      yield* descendantPids(pid),
+      (pid) =>
+        Effect.try({
+          try: () => process.kill(pid, "SIGTERM"),
+          catch: () => undefined,
+        }).pipe(Effect.ignore),
+      { discard: true },
+    )
   })
-
-const stdioPid = (transport: Transport) => {
-  if (!(transport instanceof StdioClientTransport)) return undefined
-  const pid = (transport as { readonly pid?: unknown }).pid
-  return typeof pid === "number" ? pid : undefined
-}
 
 const descendantPids = Effect.fnUntraced(function* (root: number) {
   if (process.platform === "win32") return []
@@ -242,12 +247,6 @@ const childPids = (pid: number) =>
         })
       }),
   )
-
-const killPid = (pid: number) =>
-  Effect.try({
-    try: () => process.kill(pid, "SIGTERM"),
-    catch: () => undefined,
-  }).pipe(Effect.ignore)
 
 async function paginate<R extends { nextCursor?: string }, T>(
   list: (cursor: string | undefined) => Promise<R>,


### PR DESCRIPTION
## Summary
- terminate descendant processes for stdio MCP transports before closing the SDK client or transport
- reuse the cleanup path for failed startup transport teardown
- keep the change scoped to local MCP process cleanup

## Verification
- inspected MCP SDK v1.29.0 StdioClientTransport.close: it only closes/kills the root server process
- confirmed with a local POSIX repro that a child process can survive after its parent is killed
- git diff --check
- bun typecheck could not run because tsgo is not installed in this checkout