### PR TITLE
feat(core): log mcp server messages

### DIFF
--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -11,6 +11,8 @@ import {
   CallToolResultSchema,
   ListRootsRequestSchema,
   ListToolsResultSchema,
+  type LoggingMessageNotification,
+  LoggingMessageNotificationSchema,
   ToolListChangedNotificationSchema,
   ToolSchema,
 } from "@modelcontextprotocol/sdk/types.js"
@@ -54,6 +56,12 @@ export interface CallToolResult {
   readonly content: ReadonlyArray<CallToolContent>
 }
 
+export interface LogMessage {
+  readonly level: LoggingMessageNotification["params"]["level"]
+  readonly logger: LoggingMessageNotification["params"]["logger"]
+  readonly data: LoggingMessageNotification["params"]["data"]
+}
+
 /** Handle over a connected MCP server that keeps the SDK `Client` out of the rest of core. */
 export interface Connection {
   /** Server-supplied usage instructions from the initialize result, if any. */
@@ -66,6 +74,8 @@ export interface Connection {
     readonly args?: Record<string, unknown>
   }) => Effect.Effect<CallToolResult, Error>
   readonly onClose: (callback: () => void) => void
+  /** Registers a callback fired when the server emits an MCP logging notification. */
+  readonly onLog: (callback: (message: LogMessage) => void) => void
   /** Registers a callback fired when the server announces its tool list changed; no-op if unsupported. */
   readonly onToolsChanged: (callback: () => void) => void
 }
@@ -185,6 +195,9 @@ export const connect = Effect.fnUntraced(function* (
         ),
       onClose: (callback) => {
         client.onclose = callback
+      },
+      onLog: (callback) => {
+        client.setNotificationHandler(LoggingMessageNotificationSchema, (notification) => callback(notification.params))
       },
       onToolsChanged: (callback) => {
         if (!client.getServerCapabilities()?.tools?.listChanged) return

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -251,6 +251,7 @@ export const layer = Layer.effect(
         entry.status = { status: "failed", error: "Connection closed" }
         fork(events.publish(McpEvent.ToolsChanged, { server: name }).pipe(Effect.ignore))
       })
+      connection.onLog((message) => fork(serverLog(name, message).pipe(Effect.ignore)))
       connection.onToolsChanged(() => {
         fork(
           refreshTools(name, entry, connection).pipe(
@@ -259,6 +260,24 @@ export const layer = Layer.effect(
           ),
         )
       })
+    }
+
+    const serverLog = (server: ServerName, message: MCPClient.LogMessage) => {
+      const fields = { server, logger: message.logger, level: message.level, data: message.data }
+      switch (message.level) {
+        case "debug":
+          return Effect.logDebug("MCP server log", fields)
+        case "info":
+        case "notice":
+          return Effect.logInfo("MCP server log", fields)
+        case "warning":
+          return Effect.logWarning("MCP server log", fields)
+        case "error":
+        case "critical":
+        case "alert":
+        case "emergency":
+          return Effect.logError("MCP server log", fields)
+      }
     }
 
     const startServer = (name: ServerName, entry: ServerEntry) =>


### PR DESCRIPTION
## Summary
- expose MCP logging notifications from core MCP connections
- route MCP server log levels through Effect.logDebug/logInfo/logWarning/logError
- include server, logger, level, and data in structured log fields

## Verification
- git diff --check
- inspected MCP SDK v1.29.0 logging notification schema and V1 MCP server log routing
- bun typecheck could not run because tsgo is not installed in this checkout