### PR TITLE
feat(app): add Reveal in Finder context menu

### DIFF
--- a/packages/app/src/components/file-tree.test.ts
+++ b/packages/app/src/components/file-tree.test.ts
@@ -28,6 +28,9 @@ beforeAll(async () => {
       Content: (props: { children?: unknown }) => props.children,
     },
   }))
+  mock.module("@opencode-ai/ui/context-menu", () => ({
+    ContextMenu: (props: { children?: unknown }) => props.children,
+  }))
   mock.module("@opencode-ai/ui/file-icon", () => ({ FileIcon: () => null }))
   mock.module("@opencode-ai/ui/icon", () => ({ Icon: () => null }))
   mock.module("@opencode-ai/ui/tooltip", () => ({ Tooltip: (props: { children?: unknown }) => props.children }))

--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -138,6 +138,7 @@ const FileTreeNode = (
     "classList",
   ])
   const platform = usePlatform()
+  const { onContextMenu: _omit, ...triggerRest } = rest
   const kind = () => visibleKind(local.node, local.kinds, local.marks)
   const active = () => !!kind() && !local.node.ignored
   const color = () => {
@@ -168,11 +169,7 @@ const FileTreeNode = (
           if (event.dataTransfer) event.dataTransfer.effectAllowed = "copy"
           withFileDragImage(event)
         }}
-        onContextMenu={(event: MouseEvent) => {
-          event.preventDefault()
-          event.stopPropagation()
-        }}
-        {...rest}
+        {...triggerRest}
       >
         {local.children}
         <span
@@ -202,11 +199,7 @@ const FileTreeNode = (
         <ContextMenu.Content>
           {canOpenInFinder && (
             <>
-              <ContextMenu.Item
-                onSelect={() => {
-                  void platform.openPath?.(local.node.absolute)
-                }}
-              >
+              <ContextMenu.Item onSelect={() => void platform.openPath?.(local.node.absolute)}>
                 <ContextMenu.ItemLabel>{language.t("fileTree.context.revealInFinder")}</ContextMenu.ItemLabel>
               </ContextMenu.Item>
               <ContextMenu.Separator />

--- a/packages/app/src/components/file-tree.tsx
+++ b/packages/app/src/components/file-tree.tsx
@@ -1,8 +1,11 @@
 import { useFile } from "@/context/file"
 import { encodeFilePath } from "@/context/file/path"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
+import { ContextMenu } from "@opencode-ai/ui/context-menu"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { Icon } from "@opencode-ai/ui/icon"
+import { usePlatform } from "@/context/platform"
+import { useLanguage } from "@/context/language"
 import {
   createEffect,
   createMemo,
@@ -134,6 +137,7 @@ const FileTreeNode = (
     "class",
     "classList",
   ])
+  const platform = usePlatform()
   const kind = () => visibleKind(local.node, local.kinds, local.marks)
   const active = () => !!kind() && !local.node.ignored
   const color = () => {
@@ -141,52 +145,76 @@ const FileTreeNode = (
     if (!value) return
     return kindTextColor(value)
   }
+  const canOpenInFinder = platform.platform === "desktop" && !!platform.openPath
+  const language = useLanguage()
 
   return (
-    <Dynamic
-      component={local.as ?? "div"}
-      classList={{
-        "w-full min-w-0 h-6 flex items-center justify-start gap-x-1.5 rounded-md px-1.5 py-0 text-left hover:bg-surface-raised-base-hover active:bg-surface-base-active transition-colors cursor-pointer": true,
-        "bg-surface-base-active": local.node.path === local.active,
-        ...local.classList,
-        [local.class ?? ""]: !!local.class,
-        [local.nodeClass ?? ""]: !!local.nodeClass,
-      }}
-      style={`padding-left: ${Math.max(0, 8 + local.level * 12 - (local.node.type === "file" ? 24 : 4))}px`}
-      draggable={local.draggable}
-      onDragStart={(event: DragEvent) => {
-        if (!local.draggable) return
-        event.dataTransfer?.setData("text/plain", `file:${local.node.path}`)
-        event.dataTransfer?.setData("text/uri-list", pathToFileUrl(local.node.path))
-        if (event.dataTransfer) event.dataTransfer.effectAllowed = "copy"
-        withFileDragImage(event)
-      }}
-      {...rest}
-    >
-      {local.children}
-      <span
+    <ContextMenu modal={false}>
+      <ContextMenu.Trigger
+        as={local.as ?? "div"}
         classList={{
-          "flex-1 min-w-0 text-12-medium whitespace-nowrap truncate": true,
-          "text-text-weaker": local.node.ignored,
-          "text-text-weak": !local.node.ignored && !active(),
+          "w-full min-w-0 h-6 flex items-center justify-start gap-x-1.5 rounded-md px-1.5 py-0 text-left hover:bg-surface-raised-base-hover active:bg-surface-base-active transition-colors cursor-pointer": true,
+          "bg-surface-base-active": local.node.path === local.active,
+          ...local.classList,
+          [local.class ?? ""]: !!local.class,
+          [local.nodeClass ?? ""]: !!local.nodeClass,
         }}
-        style={active() ? color() : undefined}
+        style={`padding-left: ${Math.max(0, 8 + local.level * 12 - (local.node.type === "file" ? 24 : 4))}px`}
+        draggable={local.draggable}
+        onDragStart={(event: DragEvent) => {
+          if (!local.draggable) return
+          event.dataTransfer?.setData("text/plain", `file:${local.node.path}`)
+          event.dataTransfer?.setData("text/uri-list", pathToFileUrl(local.node.path))
+          if (event.dataTransfer) event.dataTransfer.effectAllowed = "copy"
+          withFileDragImage(event)
+        }}
+        onContextMenu={(event: MouseEvent) => {
+          event.preventDefault()
+          event.stopPropagation()
+        }}
+        {...rest}
       >
-        {local.node.name}
-      </span>
-      {(() => {
-        const value = kind()
-        if (!value) return null
-        if (local.node.type === "file") {
-          return (
-            <span class="shrink-0 w-4 text-center text-12-medium" style={kindTextColor(value)}>
-              {kindLabel(value)}
-            </span>
-          )
-        }
-        return <div class="shrink-0 size-1.5 mr-1.5 rounded-full" style={kindDotColor(value)} />
-      })()}
-    </Dynamic>
+        {local.children}
+        <span
+          classList={{
+            "flex-1 min-w-0 text-12-medium whitespace-nowrap truncate": true,
+            "text-text-weaker": local.node.ignored,
+            "text-text-weak": !local.node.ignored && !active(),
+          }}
+          style={active() ? color() : undefined}
+        >
+          {local.node.name}
+        </span>
+        {(() => {
+          const value = kind()
+          if (!value) return null
+          if (local.node.type === "file") {
+            return (
+              <span class="shrink-0 w-4 text-center text-12-medium" style={kindTextColor(value)}>
+                {kindLabel(value)}
+              </span>
+            )
+          }
+          return <div class="shrink-0 size-1.5 mr-1.5 rounded-full" style={kindDotColor(value)} />
+        })()}
+      </ContextMenu.Trigger>
+      <ContextMenu.Portal>
+        <ContextMenu.Content>
+          {canOpenInFinder && (
+            <>
+              <ContextMenu.Item
+                onSelect={() => {
+                  void platform.openPath?.(local.node.absolute)
+                }}
+              >
+                <ContextMenu.ItemLabel>{language.t("fileTree.context.revealInFinder")}</ContextMenu.ItemLabel>
+              </ContextMenu.Item>
+              <ContextMenu.Separator />
+            </>
+          )}
+        </ContextMenu.Content>
+      </ContextMenu.Portal>
+    </ContextMenu>
   )
 }
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -624,6 +624,7 @@ export const dict = {
   "session.files.all": "All files",
   "session.files.empty": "No files",
   "session.files.binaryContent": "Binary file (content cannot be displayed)",
+  "fileTree.context.revealInFinder": "Reveal in Finder",
 
   "session.messages.renderEarlier": "Render earlier messages",
   "session.messages.loadingEarlier": "Loading earlier messages...",

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -168,7 +168,12 @@ export function registerIpcHandlers(deps: Deps) {
   })
 
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
-    if (!app) return shell.openPath(path)
+    if (!app)
+      return process.platform === "darwin"
+        ? new Promise<void>((resolve, reject) =>
+            execFile("open", ["--reveal", path], (err) => (err ? reject(err) : resolve())),
+          )
+        : shell.openPath(path)
     await new Promise<void>((resolve, reject) => {
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a right-click "Reveal in Finder" context-menu option to the file tree.

When users right-click on a file or folder in the file tree, they can now open the native file explorer (Finder on macOS) directly to that location using the new "Reveal in Finder" context menu item.

### Changes

**file-tree.tsx**
- Wrapped `FileTreeNode` in `ContextMenu` from `@kobalte/core/context-menu`
- Added platform check: `platform.platform === "desktop" && !!platform.openPath`
- Context menu appears only on desktop platforms (no web support without `platform.openPath`)
- Preserved existing `as` prop behavior for directories (`div`) and files (`button`)
- Added localization via `language.t("fileTree.context.revealInFinder")`

**ipc.ts (desktop/main)**
- Changed macOS implementation from `shell.openPath(path)` to `execFile("open", ["--reveal", path])`
- This ensures Finder opens to reveal the file rather than trying to open it with an app

### How did you verify your code works?

- Typecheck passes (35 packages)
- Unit tests pass (3/3 in file-tree.test.ts with ContextMenu mock added)
- Manual testing: Right-click on file/folder shows context menu; selecting "Reveal in Finder" opens finder

### Screenshots / recordings

N/A - Feature only visible through right-click interaction

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR