### PR TITLE
fix(ui): prevent tool status blank frame

### DIFF
--- a/packages/session-ui/src/components/tool-status-title.tsx
+++ b/packages/session-ui/src/components/tool-status-title.tsx
@@ -59,24 +59,21 @@ export function ToolStatusTitle(props: {
 
   const animate = () => {
     const first = contentWidth(widthRef)
+    const next = props.active
     finish()
+    setState("active", next)
+    if (!first) return
+
     setState("animating", true)
-    setState("active", props.active)
-    const last = contentWidth(props.active ? activeRef : doneRef)
-    if (!first || !last) {
-      finish()
-      return
-    }
-
     setState("width", first)
-    if (first === last) {
-      finishTimer = setTimeout(finish, 600)
-      return
-    }
-
     frame = requestAnimationFrame(() => {
       frame = undefined
-      setState("width", last)
+      const last = contentWidth(next ? activeRef : doneRef)
+      if (!last) {
+        finish()
+        return
+      }
+      if (first !== last) setState("width", last)
       finishTimer = setTimeout(finish, 600)
     })
   }


### PR DESCRIPTION
## Summary
- keep the perf optimization that only mounts both tool status labels during animation
- flip `data-active` synchronously, then defer the target-width measurement to the next frame so the incoming label is mounted/measurable
- preserve the measured-width transition for the Exploring → Explored status title without the blank/drop frame

## Chrome trace benchmark

Setup:
- 1000 timeline status rows on one page
- Chrome trace via CDP
- 4x CPU slowdown
- 5 traced runs per variant
- same isolated real-component harness/CSS/theme across variants

| Variant | Visual | Runs | Main avg | Main median | Max task avg | Max task range | Long tasks avg | Script avg | Style/Layout avg | Paint/Composite avg |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Current dev | ❌ blank/drop frame | 5 | 82488ms | 81526ms | 2695ms | 2327.9–2838.0ms | 198.0 | 1380ms | 5447ms | 34522ms |
| Old correct, pre-perf revert | ✅ correct | 5 | 77271ms | 74614ms | 8700ms | 7820.4–9301.9ms | 174.8 | 5125ms | 5087ms | 28365ms |
| Fixed PR | ✅ correct | 5 | 47638ms | 30071ms | 8029ms | 7913.3–8194.8ms | 59.6 | 6194ms | 4227ms | 16426ms |

Readout:
- Fixed PR restores the visual transition without returning to the old always-mounted behavior.
- Versus old visual-correct behavior: lower main-thread trace time, fewer long tasks, slightly lower max task, lower style/layout, and lower paint/composite.
- Versus current broken dev: fixed has a higher max task because it performs the real target-width measurement/animation work, but lower total main-thread time and fewer long tasks while preserving correctness.

## Validation
- `bun typecheck` from `packages/session-ui`
- push hook full turbo typecheck passed
- recorded isolated real-component harness video for Exploring → Explored after the fix
