### PR TITLE
fix(core): respect OPENCODE_LOG_LEVEL in the stderr logger

### DIFF
--- a/packages/core/src/observability/logging.ts
+++ b/packages/core/src/observability/logging.ts
@@ -1,4 +1,4 @@
-import { Formatter, Logger, type LogLevel } from "effect"
+import { Formatter, Logger, LogLevel } from "effect"
 import path from "path"
 import { Global } from "../global"
 import { runID } from "./shared"
@@ -51,7 +51,14 @@ export function fileLogger(file = path.join(Global.Path.log, "opencode.log"), id
   return Logger.toFile(formatter(id), file, { flag: "a" })
 }
 
-const stderrLogger = Logger.make((options) => process.stderr.write(formatter().log(options) + "\n"))
+export const stderrLogger = Logger.make((options) => {
+  // The minimum-log-level FiberRef set by `observability.ts` is not always
+  // honored by the context that emits these logs (e.g. the worker started by
+  // `opencode github run`), so `OPENCODE_LOG_LEVEL` had no effect on stderr
+  // output. Re-apply the threshold here so the stderr logger always respects it.
+  if (LogLevel.isGreaterThanOrEqualTo(options.logLevel, minimumLogLevel()))
+    process.stderr.write(formatter().log(options) + "\n")
+})
 
 export function minimumLogLevel() {
   const value = process.env.OPENCODE_LOG_LEVEL?.toUpperCase()

--- a/packages/core/test/effect/observability.test.ts
+++ b/packages/core/test/effect/observability.test.ts
@@ -1,10 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, spyOn, test } from "bun:test"
 import { NodeFileSystem } from "@effect/platform-node"
 import { Effect, Layer, Logger } from "effect"
 import fs from "fs/promises"
 import os from "os"
 import path from "path"
-import { fileLogger } from "../../src/observability/logging"
+import { fileLogger, stderrLogger } from "../../src/observability/logging"
 import { resource } from "../../src/observability/otlp"
 
 const otelResourceAttributes = process.env.OTEL_RESOURCE_ATTRIBUTES
@@ -106,4 +106,41 @@ test("file logger flattens nested objects", async () => {
   expect(line).toContain('tags="[\\\"api\\\",\\\"test\\\"]"')
   expect(line).toContain("session.id=session-1")
   expect(line).not.toContain("request={")
+})
+describe("stderr logger", () => {
+  const originalLevel = process.env.OPENCODE_LOG_LEVEL
+  afterEach(() => {
+    if (originalLevel === undefined) delete process.env.OPENCODE_LOG_LEVEL
+    else process.env.OPENCODE_LOG_LEVEL = originalLevel
+  })
+
+  const capture = (level: string) => {
+    process.env.OPENCODE_LOG_LEVEL = level
+    const writes: Array<string> = []
+    const spy = spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString())
+      return true
+    })
+    return Effect.gen(function* () {
+      yield* Effect.logInfo("info-line")
+      yield* Effect.logError("error-line")
+    })
+      .pipe(Effect.provide(Logger.layer([stderrLogger])), Effect.scoped, Effect.runPromise)
+      .then(() => {
+        spy.mockRestore()
+        return writes.join("")
+      })
+  }
+
+  test("drops records below OPENCODE_LOG_LEVEL", async () => {
+    const output = await capture("ERROR")
+    expect(output).not.toContain("info-line")
+    expect(output).toContain("error-line")
+  })
+
+  test("keeps records at or above OPENCODE_LOG_LEVEL", async () => {
+    const output = await capture("INFO")
+    expect(output).toContain("info-line")
+    expect(output).toContain("error-line")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #34550

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`stderrLogger` in `packages/core/src/observability/logging.ts` writes every record straight to stderr with no level check:

```ts
const stderrLogger = Logger.make((options) => process.stderr.write(formatter().log(options) + "\n"))
```

So `OPENCODE_LOG_LEVEL` / `--log-level` have no effect on stderr. This bit me with `opencode github run`: the Actions log fills up with INFO telemetry (`created`, `creating share`, `full sync`, `loop`, `stream`, `tracking`, ...) and there's no way to quiet it — `OPENCODE_LOG_LEVEL=ERROR` did nothing.

The `References.MinimumLogLevel` set in `observability.ts` is supposed to gate this, but the context emitting those logs doesn't honor it (seems like the same problem as #13158, where the level doesn't reach the worker). Instead of chasing that, I made the stderr logger apply the threshold itself with `LogLevel.isGreaterThanOrEqualTo(options.logLevel, minimumLogLevel())` — `minimumLogLevel()` already reads `OPENCODE_LOG_LEVEL`, and this is the pattern Effect's own LogLevel docs use for an "only Error and above" logger. The file logger and runtime gating are untouched.

### How did you verify your code works?

Added two unit tests in `observability.test.ts` that send an INFO and an ERROR through the stderr logger and assert INFO is dropped when `OPENCODE_LOG_LEVEL=ERROR` and kept when it's `INFO`.

- `bun test test/effect/observability.test.ts` → 7 pass, 0 fail
- `bun run typecheck` → clean

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
