### PR TITLE
fix(provider): forward agent temperature for config-defined custom models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1048,7 +1048,9 @@ export namespace Provider {
                 name,
                 providerID: ProviderID.make(providerID),
                 capabilities: {
-                  temperature: model.temperature ?? existingModel?.capabilities.temperature ?? false,
+                  // Config-defined custom models should forward agent-level temperature
+                  // unless the user explicitly disables it for that model.
+                  temperature: model.temperature ?? existingModel?.capabilities.temperature ?? true,
                   reasoning: model.reasoning ?? existingModel?.capabilities.reasoning ?? false,
                   attachment: model.attachment ?? existingModel?.capabilities.attachment ?? false,
                   toolcall: model.tool_call ?? existingModel?.capabilities.toolcall ?? true,

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1263,6 +1263,44 @@ test("completely new provider not in database can be configured", async () => {
   })
 })
 
+test("config-defined custom models allow temperature by default", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          provider: {
+            "brand-new-provider": {
+              name: "Brand New",
+              npm: "@ai-sdk/openai-compatible",
+              env: [],
+              api: "https://new-api.com/v1",
+              models: {
+                "new-model": {
+                  name: "New Model",
+                  tool_call: true,
+                  limit: { context: 32000, output: 8000 },
+                },
+              },
+              options: {
+                apiKey: "new-key",
+              },
+            },
+          },
+        }),
+      )
+    },
+  })
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const model = (await Provider.list())[ProviderID.make("brand-new-provider")].models["new-model"]
+      expect(model.capabilities.temperature).toBe(true)
+    },
+  })
+})
+
 test("disabled_providers and enabled_providers interaction", async () => {
   await using tmp = await tmpdir({
     init: async (dir) => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -385,6 +385,96 @@ describe("session.llm.stream", () => {
     })
   })
 
+  test("sends agent temperature for config-defined custom openai-compatible models by default", async () => {
+    const server = state.server
+    if (!server) {
+      throw new Error("Server not initialized")
+    }
+
+    const request = waitRequest(
+      "/chat/completions",
+      new Response(createChatStream("Hello"), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    )
+
+    await using tmp = await tmpdir({
+      init: async (dir) => {
+        await Bun.write(
+          path.join(dir, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            enabled_providers: ["custom-openai"],
+            provider: {
+              "custom-openai": {
+                name: "Custom OpenAI",
+                npm: "@ai-sdk/openai-compatible",
+                env: [],
+                api: `${server.url.origin}/v1`,
+                options: {
+                  apiKey: "test-key",
+                  baseURL: `${server.url.origin}/v1`,
+                },
+                models: {
+                  "custom-model": {
+                    name: "Custom Model",
+                    limit: { context: 32000, output: 8000 },
+                    tool_call: true,
+                  },
+                },
+              },
+            },
+          }),
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const resolved = await Provider.getModel(ProviderID.make("custom-openai"), ModelID.make("custom-model"))
+        const sessionID = SessionID.make("session-test-custom-temp")
+        const agent = {
+          name: "build",
+          mode: "primary",
+          options: {},
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          temperature: 1,
+        } satisfies Agent.Info
+
+        const user = {
+          id: MessageID.make("user-custom-temp"),
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: agent.name,
+          model: { providerID: ProviderID.make("custom-openai"), modelID: resolved.id },
+          variant: "high",
+        } satisfies MessageV2.User
+
+        const stream = await LLM.stream({
+          user,
+          sessionID,
+          model: resolved,
+          agent,
+          system: ["You are a helpful assistant."],
+          abort: new AbortController().signal,
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {},
+        })
+
+        for await (const _ of stream.fullStream) {
+        }
+
+        const capture = await request
+        const body = capture.body
+        expect(body.model).toBe(resolved.api.id)
+        expect(body.temperature).toBe(1)
+      },
+    })
+  })
+
   test("raw stream abort signal cancels provider response body promptly", async () => {
     const server = state.server
     if (!server) throw new Error("Server not initialized")


### PR DESCRIPTION
### Issue for this PR

Closes #34554

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Config-defined custom models currently default `capabilities.temperature` to `false` when the model entry omits that field. That causes `agent.temperature` to be stripped before the OpenAI-compatible request is built.

This PR defaults custom-model temperature support to enabled unless the config explicitly sets `temperature: false`, and adds regression coverage for both provider merging and the request payload.

### How did you verify your code works?

- `bun test test/provider/provider.test.ts test/session/llm.test.ts`
- `bun run typecheck`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
