### PR TITLE
fix(core): align agent tests with universal default permissions

### DIFF
--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -2714,6 +2714,14 @@ export type EventSubscribeOutput =
   | {
       readonly id: string
       readonly metadata?: { readonly [x: string]: unknown }
+      readonly type: "agent.updated"
+      readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number }
+      readonly location?: { readonly directory: string; readonly workspaceID?: string }
+      readonly data: {}
+    }
+  | {
+      readonly id: string
+      readonly metadata?: { readonly [x: string]: unknown }
       readonly type: "session.created"
       readonly durable?: { readonly aggregateID: string; readonly seq: number; readonly version: number }
       readonly location?: { readonly directory: string; readonly workspaceID?: string }

--- a/packages/core/src/config/plugin/agent.ts
+++ b/packages/core/src/config/plugin/agent.ts
@@ -60,7 +60,6 @@ export const Plugin = define({
         const configuredDefault = Config.latest(documents, "default_agent")
         if (configuredDefault !== undefined) draft.default(AgentV2.ID.make(configuredDefault))
         for (const current of draft.list()) {
-          yield* Effect.log({ msg: "applying permissions", id: current.id, permissions: global })
           draft.update(current.id, (agent) => agent.permissions.push(...global))
         }
 

--- a/packages/core/test/config/agent.test.ts
+++ b/packages/core/test/config/agent.test.ts
@@ -77,6 +77,8 @@ describe("ConfigAgentPlugin.Plugin", () => {
       const buildAgent = yield* agents.get(build)
       if (!buildAgent) throw new Error("expected configured build agent")
       expect(buildAgent.permissions).toEqual([
+        { action: "*", resource: "*", effect: "allow" },
+        { action: "external_directory", resource: "*", effect: "ask" },
         { action: "bash", resource: "*", effect: "allow" },
         { action: "bash", resource: "*", effect: "ask" },
         { action: "read", resource: "*", effect: "allow" },
@@ -94,6 +96,8 @@ describe("ConfigAgentPlugin.Plugin", () => {
         model: { providerID: "openrouter", id: "openai/gpt-5", variant: "high" },
       })
       expect(reviewer.permissions).toEqual([
+        { action: "*", resource: "*", effect: "allow" },
+        { action: "external_directory", resource: "*", effect: "ask" },
         { action: "bash", resource: "*", effect: "ask" },
         { action: "read", resource: "*", effect: "allow" },
         { action: "edit", resource: "*", effect: "deny" },
@@ -101,6 +105,8 @@ describe("ConfigAgentPlugin.Plugin", () => {
       ])
       expect(PermissionV2.evaluate("read", "README.md", reviewer.permissions).effect).toBe("deny")
       expect((yield* agents.get(AgentV2.ID.make("late")))?.permissions).toEqual([
+        { action: "*", resource: "*", effect: "allow" },
+        { action: "external_directory", resource: "*", effect: "ask" },
         { action: "bash", resource: "*", effect: "ask" },
         { action: "read", resource: "*", effect: "allow" },
         { action: "edit", resource: "*", effect: "allow" },
@@ -258,13 +264,21 @@ Use native v2 fields.`,
             system: "Review carefully.",
             description: "Markdown description",
             request: { body: { temperature: 0.5 } },
-            permissions: [{ action: "edit", resource: "*", effect: "deny" }],
+            permissions: [
+              { action: "*", resource: "*", effect: "allow" },
+              { action: "external_directory", resource: "*", effect: "ask" },
+              { action: "edit", resource: "*", effect: "deny" },
+            ],
           })
           expect(yield* agents.get(AgentV2.ID.make("team/helper"))).toMatchObject({ system: "Help the team." })
           expect(yield* agents.get(AgentV2.ID.make("native"))).toMatchObject({
             system: "Use native v2 fields.",
             request: { headers: { "x-agent": "native" }, body: { effort: "high" } },
-            permissions: [{ action: "edit", resource: "*", effect: "deny" }],
+            permissions: [
+              { action: "*", resource: "*", effect: "allow" },
+              { action: "external_directory", resource: "*", effect: "ask" },
+              { action: "edit", resource: "*", effect: "deny" },
+            ],
           })
           expect(yield* agents.get(AgentV2.ID.make("disabled"))).toBeUndefined()
           expect(yield* agents.get(AgentV2.ID.make("plan"))).toMatchObject({ system: "Make a plan.", mode: "primary" })


### PR DESCRIPTION
## Problem

`unit (linux)` and `unit (windows)` on `v2` failed in `@opencode-ai/core`:

```
(fail) ConfigAgentPlugin.Plugin > applies all global permissions before agent-specific permissions
(fail) ConfigAgentPlugin.Plugin > loads legacy file-based agents from config directories
```

Every agent's `permissions` now begins with two baseline entries:

```
{ action: "*", resource: "*", effect: "allow" }
{ action: "external_directory", resource: "*", effect: "ask" }
```

Fixing the tests also unmasked a second, Linux-only failure: `Check generated client` runs after the unit tests, so the failing tests were hiding stale generated SDK output.

## Root cause

`02cb35088 feat(tui): refresh agents after update events` seeded those two baseline permissions into `Agent.Info.empty()` (`packages/schema/src/agent.ts`). Since `agent.ts:61` builds every agent from `Info.empty(id)`, all agents now carry the baseline.

This is correct and matches v1: in `packages/opencode/src/agent/agent.ts` the `defaults` ruleset (including `"*": "allow"` and `external_directory: { "*": "ask" }`) is merged into **every** agent, native and custom alike — even a custom agent configured with only `{ bash: "allow" }` inherits it. The `ConfigAgentPlugin` test expectations simply were not updated to include the baseline.

The same commit also (a) left a stray debug `Effect.log({ msg: "applying permissions", ... })` in `config/plugin/agent.ts`, and (b) added the `agent.updated` protocol event without regenerating the client SDK.

## Fix

- Update the `ConfigAgentPlugin` test expectations to include the universal baseline permissions (the `empty()` defaults are kept as intended behavior).
- Remove the stray debug log.
- Regenerate the client SDK so `generated/types.ts` includes the `agent.updated` event.

No runtime permission behavior is changed.

## Verification

- `bun typecheck` in `packages/core` and `packages/schema`.
- `bun test` in `packages/core`: the `ConfigAgentPlugin` tests pass; full suite green except `Watcher > publishes .git/HEAD events`, a pre-existing macOS-only FSEvents flake that passes on the Linux CI runner.
- `bun run check:generated` in `packages/client` passes.

Rebased onto the latest `v2` (`524ee8fc0`).