### PR TITLE
fix(core): allow embedding modality in provider config

### DIFF
--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -47,9 +47,11 @@ export const Model = Schema.Struct({
   ),
   modalities: Schema.optional(
     Schema.Struct({
-      input: Schema.optional(Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"])))),
+      input: Schema.optional(
+        Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf", "embedding"]))),
+      ),
       output: Schema.optional(
-        Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf"]))),
+        Schema.mutable(Schema.Array(Schema.Literals(["text", "audio", "image", "video", "pdf", "embedding"]))),
       ),
     }),
   ),

--- a/packages/opencode/test/provider/model-status.test.ts
+++ b/packages/opencode/test/provider/model-status.test.ts
@@ -58,4 +58,12 @@ describe("provider model status schemas", () => {
       }).status,
     ).toBe("active")
   })
+
+  test("accepts embedding modality in configured provider models", () => {
+    expect(
+      Schema.decodeUnknownSync(ConfigProviderV1.Model)({
+        modalities: { output: ["embedding"] },
+      }).modalities?.output,
+    ).toEqual(["embedding"])
+  })
 })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1790,8 +1790,8 @@ export type ProviderConfig = {
         output: number
       }
       modalities?: {
-        input?: Array<"text" | "audio" | "image" | "video" | "pdf">
-        output?: Array<"text" | "audio" | "image" | "video" | "pdf">
+        input?: Array<"text" | "audio" | "image" | "video" | "pdf" | "embedding">
+        output?: Array<"text" | "audio" | "image" | "video" | "pdf" | "embedding">
       }
       experimental?: boolean
       status?: "alpha" | "beta" | "deprecated" | "active"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -20896,14 +20896,14 @@
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "enum": ["text", "audio", "image", "video", "pdf"]
+                        "enum": ["text", "audio", "image", "video", "pdf", "embedding"]
                       }
                     },
                     "output": {
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "enum": ["text", "audio", "image", "video", "pdf"]
+                        "enum": ["text", "audio", "image", "video", "pdf", "embedding"]
                       }
                     }
                   },


### PR DESCRIPTION
### Issue for this PR

Closes #34472

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

opencode fails to start when a provider config contains an embedding model. The v1 provider-config schema in `packages/core/src/v1/config/provider.ts` limits each model's `modalities.input`/`output` to a closed literal set — `text | audio | image | video | pdf` — so a model declaring `"modalities": { "output": ["embedding"] }` (for example an embedding model surfaced from a LiteLLM server by the models-discovery plugin) fails to decode and throws on launch.

The fix adds `embedding` to that literal union for both input and output. I scoped it to the config schema on purpose: `models-dev.ts` carries the same union, but the live models.dev API never emits `embedding`, so there's no reason to widen it there. `openapi.json` and the SDK types are regenerated because they're derived from this schema.

### How did you verify your code works?

- Added a regression test in `packages/opencode/test/provider/model-status.test.ts` that decodes a config with `modalities: { output: ["embedding"] }` and asserts it succeeds — it threw before the change.
- `bun typecheck` in `packages/core` is clean.
- `bun test` passes for the provider/config schema tests (`test/config/provider.test.ts`, `test/config/config.test.ts`, `test/provider/model-status.test.ts`).

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
