### PR TITLE
fix: respect agent temperature config when capabilities.temperature is false

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -121,9 +121,8 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
       message: input.user,
     },
     {
-      temperature: input.model.capabilities.temperature
-        ? (input.agent.temperature ?? ProviderTransform.temperature(input.model))
-        : undefined,
+      temperature: input.agent.temperature
+        ?? (input.model.capabilities.temperature ? ProviderTransform.temperature(input.model) : undefined),
       topP: input.agent.topP ?? ProviderTransform.topP(input.model),
       topK: ProviderTransform.topK(input.model),
       maxOutputTokens: ProviderTransform.maxOutputTokens(input.model, input.flags.outputTokenMax),


### PR DESCRIPTION
Fixes #34554. When a model's capabilities.temperature is false (e.g., custom OpenAI-compatible providers), the agent-level temperature config was dropped. Changed precedence: agent.temperature is honored first; model capability check only gates the ProviderTransform fallback.