### PR TITLE
feat(desktop): add hover background to session title and single-click edit

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1357,7 +1357,7 @@ export function MessageTimeline(props: {
               "w-full": true,
               "pb-4": true,
               "pr-3": true,
-              "pl-4": settings.general.newLayoutDesigns(),
+              "pl-2": settings.general.newLayoutDesigns(),
               "pl-2 md:pl-4": !settings.general.newLayoutDesigns(),
               "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered && !settings.general.newLayoutDesigns(),
             }}
@@ -1393,8 +1393,13 @@ export function MessageTimeline(props: {
                       fallback={
                         <h1
                           data-slot="session-title-child"
-                          class="text-14-medium text-text-strong truncate grow-1 min-w-0"
-                          onDblClick={openTitleEditor}
+                          classList={{
+                            "text-14-medium text-text-strong truncate": true,
+                            "w-fit rounded-[6px] px-2 py-1 hover:bg-v2-overlay-simple-overlay-hover":
+                              settings.general.newLayoutDesigns(),
+                            "grow-1 min-w-0": !settings.general.newLayoutDesigns(),
+                          }}
+                          onClick={openTitleEditor}
                         >
                           {childTitle()}
                         </h1>
@@ -1408,10 +1413,10 @@ export function MessageTimeline(props: {
                         value={title.draft}
                         disabled={titleMutation.isPending}
                         classList={{
-                          "text-14-medium text-text-strong grow-1 min-w-0 pl-1 -ml-1": true,
-                          "h-6 leading-4 rounded-[3px] focus:shadow-none focus:outline focus:outline-1 focus:outline-offset-[-1px] focus:outline-v2-border-border-focus":
+                          "text-14-medium text-text-strong grow-1 min-w-0 pl-1 ml-1": true,
+                          "grow-1 min-w-0 pl-1 -ml-1 rounded-[6px]": !settings.general.newLayoutDesigns(),
+                          "rounded-[6px] -ml-2 px-2 py-1 h-6 leading-4 focus:shadow-none focus:outline focus:outline-1 focus:outline-offset-[-1px] focus:outline-v2-border-border-focus":
                             settings.general.newLayoutDesigns(),
-                          "rounded-[6px]": !settings.general.newLayoutDesigns(),
                         }}
                         style={{
                           "--inline-input-shadow": settings.general.newLayoutDesigns()


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] New feature

### What does this PR do?

For new layout designs, improves the session title editing UX:
- Adds an overlay hover background (`hover:bg-v2-overlay-simple-overlay-hover`) on the session title to indicate it's editable
- Changes edit trigger from double-click to single-click (hover background makes affordance clear)
- Uses `w-fit` with `px-2` so the hover bg only covers the text width, not the full container
- Aligns the static h1 and inline-edit `<input>` box model (`px-2`, `-ml-2`, `rounded-[6px]`) to prevent layout shift when entering edit mode
- Reduces left padding from `pl-4` to `pl-2`

### How did you verify your code works?

- `bun turbo typecheck` passes across all packages

### Screenshots / recordings

https://github.com/user-attachments/assets/f3fb7e6c-7481-4804-bbd8-e0985c84c3c9

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR