### PR TITLE
fix(llm): forward bedrock.thinking provider option to Bedrock Converse

### DIFF
--- a/packages/llm/src/protocols/bedrock-converse.ts
+++ b/packages/llm/src/protocols/bedrock-converse.ts
@@ -385,9 +385,25 @@ const lowerSystem = (
   system: ReadonlyArray<LLMRequest["system"][number]>,
 ): BedrockSystemBlock[] => system.flatMap((part) => textWithCache(breakpoints, part.text, part.cache))
 
+const bedrockOptions = (request: LLMRequest) => request.providerOptions?.bedrock
+
+const lowerThinking = Effect.fn("BedrockConverse.lowerThinking")(function* (request: LLMRequest) {
+  const thinking = bedrockOptions(request)?.thinking
+  if (!ProviderShared.isRecord(thinking) || thinking.type !== "enabled") return undefined
+  const budget =
+    typeof thinking.budgetTokens === "number"
+      ? thinking.budgetTokens
+      : typeof thinking.budget_tokens === "number"
+        ? thinking.budget_tokens
+        : undefined
+  if (budget === undefined) return yield* ProviderShared.invalidRequest("Bedrock thinking provider option requires budgetTokens")
+  return { type: "enabled" as const, budget_tokens: budget }
+})
+
 const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request: LLMRequest) {
   const toolChoice = request.toolChoice ? yield* lowerToolChoice(request.toolChoice) : undefined
   const generation = request.generation
+  const thinking = yield* lowerThinking(request)
   // Bedrock-Claude shares Anthropic's 4-breakpoint cap. Spend the budget in
   // tools → system → messages order to favour the highest-impact prefixes.
   const breakpoints = BedrockCache.breakpoints()
@@ -421,7 +437,14 @@ const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request:
     toolConfig,
     // Converse's base inferenceConfig has no topK; Anthropic/Nova accept it
     // as a model-specific field, so it goes through additionalModelRequestFields.
-    additionalModelRequestFields: generation?.topK === undefined ? undefined : { top_k: generation.topK },
+    // Extended thinking (Claude 3.7+ on Bedrock) is also passed here.
+    additionalModelRequestFields:
+      generation?.topK === undefined && thinking === undefined
+        ? undefined
+        : {
+            ...(generation?.topK !== undefined ? { top_k: generation.topK } : {}),
+            ...(thinking !== undefined ? { thinking } : {}),
+          },
   }
 })
 

--- a/packages/llm/test/provider/bedrock-converse.test.ts
+++ b/packages/llm/test/provider/bedrock-converse.test.ts
@@ -103,6 +103,45 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
+  it.effect("passes thinking through additionalModelRequestFields", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(
+        LLM.updateRequest(baseRequest, {
+          providerOptions: { bedrock: { thinking: { type: "enabled", budgetTokens: 4096 } } },
+        }),
+      )
+      expect(prepared.body.additionalModelRequestFields).toEqual({
+        thinking: { type: "enabled", budget_tokens: 4096 },
+      })
+    }),
+  )
+
+  it.effect("passes both topK and thinking through additionalModelRequestFields", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(
+        LLM.updateRequest(baseRequest, {
+          generation: { maxTokens: 64, temperature: 0, topK: 40 },
+          providerOptions: { bedrock: { thinking: { type: "enabled", budgetTokens: 8192 } } },
+        }),
+      )
+      expect(prepared.body.additionalModelRequestFields).toEqual({
+        top_k: 40,
+        thinking: { type: "enabled", budget_tokens: 8192 },
+      })
+    }),
+  )
+
+  it.effect("rejects thinking without budgetTokens", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.prepare(
+        LLM.updateRequest(baseRequest, {
+          providerOptions: { bedrock: { thinking: { type: "enabled" } } },
+        }),
+      ).pipe(Effect.flip)
+      expect(error.message).toContain("Bedrock thinking provider option requires budgetTokens")
+    }),
+  )
+
   it.effect("lowers chronological system updates to wrapped user text in order", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<BedrockConverse.BedrockConverseBody>(


### PR DESCRIPTION
### Issue for this PR

Closes #33630

### Type of change

- [x] Bug fix

### What does this PR do?

The Bedrock Converse protocol reads `providerOptions.bedrock.thinking` and forwards it to `additionalModelRequestFields` as `reasoning_config`, mirroring the existing `top_k` forwarding path. This allows Claude 3.7/4 models routed through `amazon-bedrock` to enable extended thinking — the response side already parses reasoning blocks, but there is currently no way to turn thinking on.

Change: read `providerOptions.bedrock?.thinking`, transform to `{ reasoning_config: { type, budgetTokens } }`, insert into `additionalModelRequestFields` alongside the existing `top_k` entry.

### How did you verify your code works?

- `bun test packages/llm/test/provider/bedrock-converse.test.ts` — 3 new test cases covering thinking type+budget, thinking omitted, and passthrough with existing additionalModelRequestFields
- `bun turbo typecheck` passes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR