### PR TITLE
feat(app): hide separators around active tabs

### DIFF
--- a/packages/app/src/components/titlebar-tab-nav.css
+++ b/packages/app/src/components/titlebar-tab-nav.css
@@ -21,7 +21,7 @@
   position: relative;
 }
 
-[data-titlebar-tab-slot]:not(:first-child)::before {
+[data-titlebar-tab-slot]:not(:first-child):not([data-active="true"])::before {
   content: "";
   position: absolute;
   top: 8px;
@@ -30,6 +30,10 @@
   height: 12px;
   border-radius: 9999px;
   background: var(--v2-background-bg-layer-02);
+}
+
+[data-titlebar-tab-slot][data-active="true"] + [data-titlebar-tab-slot]::before {
+  display: none;
 }
 
 [data-titlebar-tab] [data-slot="tab-close"]::before {

--- a/packages/app/src/components/titlebar-tab-strip.tsx
+++ b/packages/app/src/components/titlebar-tab-strip.tsx
@@ -85,6 +85,7 @@ function SessionTabSlot(props: {
       ref={sortable.ref}
       data-titlebar-tab-slot
       data-tab-key={props.id}
+      data-active={props.active()}
       class="relative flex w-56 min-w-7 max-w-56 flex-shrink"
       classList={{ hidden: !session() }}
     >
@@ -140,6 +141,7 @@ function DraftTabSlot(props: {
       ref={sortable.ref}
       data-titlebar-tab-slot
       data-tab-key={props.id}
+      data-active={props.active()}
       class="relative flex w-56 min-w-7 max-w-56 flex-shrink"
     >
       <DraftTabItem


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Titlebar tab separators were shown on both sides of the active tab. This marks each titlebar tab slot with its active state and updates the separator selectors so separators render only between two inactive tab slots.

### How did you verify your code works?

- `bun typecheck` from `packages/app`
- Push hook ran `bun turbo typecheck` successfully

### Screenshots / recordings

https://github.com/user-attachments/assets/601e3799-ed87-41b7-87cd-1c80dac18614

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._