### PR TITLE
fix(llm): inject _noop tool for all providers when messages contain tool history

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -157,11 +157,9 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
     for (const key of Object.keys(tools)) tools[key] = { ...tools[key], strict: false }
   }
   if (
-    input.model.providerID.includes("github-copilot") &&
     Object.keys(tools).length === 0 &&
     hasToolCalls(input.messages)
   ) {
-    // Copilot needs a tools field when replaying prior tool calls, even if no tools are currently enabled.
     tools["_noop"] = aiTool({
       description: "Do not call this tool. It exists only for API compatibility and must never be invoked.",
       inputSchema: jsonSchema({


### PR DESCRIPTION
### Issue for this PR

Closes #34089

### Type of change

- [x] Bug fix

### What does this PR do?

The _noop tool injection in request.ts has a provider guard that only runs for github-copilot. However, when tool_use messages are present in history, the AI SDK requires a tool list to be non-empty. Without _noop, providers without native tool support fail to process conversations that contain prior tool interactions.

This removes the provider guard so _noop is injected unconditionally when messages contain tool history.

### How did you verify your code works?

- Ran full test suite: 52/52 passing
- Typecheck: bun run typecheck passes cleanly

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR