### PR TITLE
fix(cli): write error message to stderr before showing help

### DIFF
--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -108,6 +108,7 @@ const cli = yargs(args)
       msg?.startsWith("Invalid values:")
     ) {
       if (err) throw err
+      if (msg) process.stderr.write(msg + "\n")
       cli.showHelp(show)
     }
     if (err) throw err


### PR DESCRIPTION
### Issue for this PR

Closes #29390

### Type of change

- [x] Bug fix

### What does this PR do?

When the user passes an unknown argument or invalid value, the .fail() handler calls cli.showHelp() but never writes the error message to stderr. This makes `opencode --unknown-flag` silently show help output identical to `opencode --help`, leaving the user unaware of the error.

This adds `process.stderr.write(msg + "\n")` before showing help so the user sees what went wrong.

### How did you verify your code works?

- Typecheck: bun run typecheck passes cleanly (full monorepo 29/29)
- Manual verification: error conditions remain unchanged, msg is now written to stderr

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR