### PR TITLE
fix(patch): normalize Unicode NFC/NFD differences in apply_patch

### DIFF
--- a/packages/opencode/src/patch/index.ts
+++ b/packages/opencode/src/patch/index.ts
@@ -480,7 +480,16 @@ function seekSequence(lines: string[], pattern: string[], startIndex: number, eo
     (a, b) => normalizeUnicode(a.trim()) === normalizeUnicode(b.trim()),
     eof,
   )
-  return normalized
+  if (normalized !== -1) return normalized
+
+  // Pass 5: NFC normalized (canonical composition, e.g. combining accents)
+  return tryMatch(
+    lines,
+    pattern,
+    startIndex,
+    (a, b) => a.trim().normalize("NFC") === b.trim().normalize("NFC"),
+    eof,
+  )
 }
 
 function generateUnifiedDiff(oldContent: string, newContent: string): string {

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -526,4 +526,25 @@ EOF`
       expect(yield* readText(target)).toBe(`He said "hi"\nsome${emDash}dash\nend\n`)
     }),
   )
+
+  it.instance("matches with NFC/NFD Unicode differences", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx } = makeCtx()
+      const target = path.join(test.directory, "nfc-nfd.txt")
+      // e with acute accent in NFD form (e + combining acute)
+      const nfd = "re\u0301sume\u0301"
+      // Same word in NFC form (single codepoint precomposed)
+      const nfc = "r\u00E9sum\u00E9"
+      // File uses NFD form
+      yield* writeText(target, `before\n${nfd}\nafter\n`)
+
+      // Patch uses NFC form — should match via NFC normalized pass
+      const patchText = `*** Begin Patch\n*** Update File: nfc-nfd.txt\n@@\n-${nfc}\n+caf\u00E9\n*** End Patch`
+
+      yield* execute({ patchText }, ctx)
+      // Result uses the replacement from the patch (NFC)
+      expect(yield* readText(target)).toBe(`before\ncaf\u00E9\nafter\n`)
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31651

### Type of change

- [x] Bug fix

### What does this PR do?

When a file contains NFD Unicode (e.g., macOS-generated combining accents) and the patch uses NFC precomposed characters (or vice versa), the existing seek passes (exact, rstrip, trim, normalizeUnicode) all fail to match.

This adds a 5th NFC normalization pass that canonicalizes both sides with normalize("NFC") before comparison, so r\u0065\u0301sum\u0065\u0301 (NFD) matches r\u00E9sum\u00E9 (NFC).

### How did you verify your code works?

- Added test case with NFD/NFC mismatch: 28/28 passing
- All existing apply_patch tests continue to pass
- Typecheck: bun run typecheck passes cleanly

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR