### PR TITLE
fix(app): enable -webkit-app-region drag on titlebar for macOS

### DIFF
--- a/packages/app/src/components/titlebar-tab-strip.tsx
+++ b/packages/app/src/components/titlebar-tab-strip.tsx
@@ -212,7 +212,7 @@ export function TitlebarTabStrip(props: {
     <div data-slot="titlebar-tabs" class="relative min-w-0">
       <div
         data-slot="titlebar-tabs-scroll"
-        class="flex min-w-0 flex-row items-center gap-1.5 overflow-x-auto no-scrollbar [app-region:no-drag]"
+        class="flex min-w-0 flex-row items-center gap-1.5 overflow-x-auto no-scrollbar [-webkit-app-region:no-drag]"
         ref={scrollRef}
       >
         <DragDropProvider

--- a/packages/app/src/components/titlebar.css
+++ b/packages/app/src/components/titlebar.css
@@ -6,6 +6,19 @@
   outline: none;
 }
 
+/* Enable native window drag for Electron on macOS */
+header {
+  -webkit-app-region: drag;
+}
+
+header button,
+header a,
+header input,
+header [role="button"],
+header [role="menuitem"] {
+  -webkit-app-region: no-drag;
+}
+
 [data-slot="titlebar-v2"]
   [data-component="icon-button-v2"][data-variant="ghost-muted"]:is(:focus-visible, [data-state="focus"]):not(
     :disabled


### PR DESCRIPTION
### Issue for this PR

Closes #34573

### Type of change

- [x] Bug fix

### What does this PR do?

The titlebar uses Tauri's data-tauri-drag-region attribute and the non-standard CSS app-region property, neither of which works in Electron. On macOS the titlebar is completely undraggable.

This adds -webkit-app-region: drag to the header element and no-drag to interactive children (buttons, inputs, etc.) for proper Electron frameless window dragging. Also fixes the tab strip to use the standard -webkit-app-region: no-drag property instead of the non-standard app-region.

### How did you verify your code works?

- Typecheck: bun run typecheck passes cleanly
- CSS-only change, no runtime logic affected

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR