### PR TITLE
feat(desktop): polish inline session title editing

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -736,8 +736,9 @@ export function MessageTimeline(props: {
     if (!sessionID() || parentID()) return
     setTitle({ editing: true, draft: titleLabel() ?? "" })
     requestAnimationFrame(() => {
-      titleRef?.focus()
-      titleRef?.select()
+      if (!titleRef) return
+      titleRef.focus()
+      titleRef.select()
     })
   }
 
@@ -1369,7 +1370,7 @@ export function MessageTimeline(props: {
                   "pr-3": !settings.general.newLayoutDesigns(),
                 }}
               >
-                <div class="flex items-center min-w-0 grow-1">
+                <div class="flex items-center min-w-0 flex-1 w-full">
                   <Show when={parentID()}>
                     <button
                       type="button"
@@ -1413,9 +1414,9 @@ export function MessageTimeline(props: {
                         value={title.draft}
                         disabled={titleMutation.isPending}
                         classList={{
-                          "text-14-medium text-text-strong grow-1 min-w-0 pl-1 ml-1": true,
-                          "grow-1 min-w-0 pl-1 -ml-1 rounded-[6px]": !settings.general.newLayoutDesigns(),
-                          "rounded-[6px] -ml-2 px-2 py-1 h-6 leading-4 focus:shadow-none focus:outline focus:outline-1 focus:outline-offset-[-1px] focus:outline-v2-border-border-focus":
+                          "text-14-medium text-text-strong block": true,
+                          "w-full flex-1 grow-1 min-w-0 pl-1 -ml-1 rounded-[6px]": !settings.general.newLayoutDesigns(),
+                          "field-sizing-content self-start rounded-[6px] px-2 py-1 ":
                             settings.general.newLayoutDesigns(),
                         }}
                         style={{


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Polishes the inline session title editor in the desktop session detail view. The title row now gives the inline input the expected width, keeps click-to-edit selecting the title text, and removes the focused outline styling so the active state matches the intended title treatment.

### How did you verify your code works?

- `bun typecheck` from `packages/app`
- Pre-push `bun turbo typecheck`

### Screenshots / recordings

https://github.com/user-attachments/assets/8ecf08b5-9dfc-44a3-9652-88fa482fd826

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR