### PR TITLE
fix(app): wait for settings persistence before rendering app tree

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -554,7 +554,7 @@ export function AppInterface(props: {
       <GlobalProvider>
         <SettingsProvider>
           <ConnectionGate disableHealthCheck={props.disableHealthCheck} startup={props.startup}>
-            <Show when={useSettings().general.newLayoutDesigns().toString()} keyed>
+            <Show when={useSettings().ready()} keyed>
               <Dynamic
                 component={props.router ?? Router}
                 root={(routerProps) => (


### PR DESCRIPTION
### Issue for this PR

Closes #34507

### Type of change

- [x] Bug fix

### What does this PR do?

The outer Show gate in AppInterface used `newLayoutDesigns().toString()` to gate the app tree.  This converts a boolean to a string — JS treats both "true" and "false" as truthy — so the gate was permanently open and never served its intended purpose of waiting for settings availability.

Replace it with the `ready()` signal from the settings context, which tracks whether the persisted settings have finished loading from storage.  The `keyed` attribute ensures a clean re-mount when settings become ready.

### How did you verify your code works?

- Full typecheck: `bun run typecheck` (35 packages, 29/29 successful)
- App test suite: 491/491 passing
- The `ready` signal from `persisted()` already gates the `createSimpleContext` provider internally (`isAsync ? initialValue=false : initialValue=true`)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR