### PR TITLE
fix(app): don't render session UI until model selection persistence is ready

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -55,6 +55,7 @@ const clone = (value: State | undefined) => {
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
+  gate: true,
   init: () => {
     const params = useParams()
     const sdk = useSDK()
@@ -372,6 +373,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const result = {
       slug: createMemo(() => base64Encode(sdk().directory)),
+      get ready() {
+        return models.ready() && savedReady()
+      },
       model,
       agent,
       session: {


### PR DESCRIPTION
### Issue for this PR

Closes #34575

### Type of change

- [x] Bug fix

### What does this PR do?

The LocalProvider initializes a persisted store for model selections per session, but the async readiness signal from `persisted()` was discarded in destructuring.  Because `init.ready` was undefined, the provider gate allowed children to render immediately, and `scope()` would read empty `saved.session` during the load gap, falling back to the agent default model — causing an apparent reset.

Changes:
- Capture the `persistedReady` signal (4th element of `persisted()` return tuple)
- Expose a combined `ready` getter that gates on both model list readiness AND persistence readiness
- Add `gate: true` to the `createSimpleContext` config so the gate actually blocks rendering until ready

### How did you verify your code works?

- Full typecheck: `bun run typecheck` (35 packages, 29/29 successful)
- App test suite: 491/491 passing
- The `gate: true` flag is now required by the TypeScript conditional type (`T extends { ready: unknown } ? { gate: boolean } : ...`)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR