### PR TITLE
refactor(core): route aggregate layers through nodes

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -9,6 +9,7 @@ import { Global } from "./global"
 import { EffectFlock } from "./util/effect-flock"
 import { makeGlobalNode } from "./effect/app-node"
 import { filesystem } from "./effect/app-node-platform"
+import { LayerNode } from "./effect/layer-node"
 import { makeRuntime } from "./effect/runtime"
 import { NpmConfig } from "./npm-config"
 
@@ -259,7 +260,7 @@ export const node = makeGlobalNode({
   deps: [FSUtil.node, Global.node, filesystem, EffectFlock.node],
 })
 
-const { runPromise } = makeRuntime(Service, defaultLayer)
+const { runPromise } = makeRuntime(Service, LayerNode.compile(node))
 
 export async function install(...args: Parameters<Interface["install"]>) {
   return runPromise((svc) => svc.install(...args))

--- a/packages/core/src/tool-output-store.ts
+++ b/packages/core/src/tool-output-store.ts
@@ -206,6 +206,8 @@ export const cleanupLayer = Layer.effectDiscard(
   }),
 )
 
-export const defaultCleanupLayer = Layer.merge(defaultLayer, cleanupLayer.pipe(Layer.provide(defaultLayer)))
-
-export const cleanupNode = makeGlobalNode({ name: "tool-output-cleanup", layer: defaultCleanupLayer, deps: [] })
+export const cleanupNode = makeGlobalNode({
+  name: "tool-output-cleanup",
+  layer: Layer.merge(layer, cleanupLayer.pipe(Layer.provide(layer))),
+  deps: [FSUtil.node, Global.node],
+})


### PR DESCRIPTION
## Summary
- route built-in tool and system-context aggregate composition through node dependencies
- update core Npm runtime helper and tool-output cleanup node to avoid default layer bundles
- keep Observability.layer and sqlite layer factories as explicit exceptions

## Testing
- bun typecheck
- bun turbo typecheck (pre-push)

## Stack
1. #34621 refactor(core): route aggregate layers through nodes
2. #34622 refactor(core): remove tool layer exports
3. #34623 refactor(core): remove session layer exports
4. #34624 refactor(core): remove infrastructure layer exports
5. #34625 refactor(core): remove domain layer exports

Base: dev
Next: #34622