### PR TITLE
refactor(core): remove tool layer exports

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -9,6 +9,7 @@ import { Global } from "./global"
 import { EffectFlock } from "./util/effect-flock"
 import { makeGlobalNode } from "./effect/app-node"
 import { filesystem } from "./effect/app-node-platform"
+import { LayerNode } from "./effect/layer-node"
 import { makeRuntime } from "./effect/runtime"
 import { NpmConfig } from "./npm-config"
 
@@ -259,7 +260,7 @@ export const node = makeGlobalNode({
   deps: [FSUtil.node, Global.node, filesystem, EffectFlock.node],
 })
 
-const { runPromise } = makeRuntime(Service, defaultLayer)
+const { runPromise } = makeRuntime(Service, LayerNode.compile(node))
 
 export async function install(...args: Parameters<Interface["install"]>) {
   return runPromise((svc) => svc.install(...args))

--- a/packages/core/src/tool-output-store.ts
+++ b/packages/core/src/tool-output-store.ts
@@ -109,7 +109,7 @@ const lineCount = (text: string) => {
   return count
 }
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
@@ -191,8 +191,6 @@ export const layer = Layer.effect(
     return Service.of({ limits, bound, cleanup })
   }),
 )
-
-export const defaultLayer = layer.pipe(Layer.provide(FSUtil.defaultLayer), Layer.provide(Global.defaultLayer))
 
 export const node = makeLocationNode({ service: Service, layer, deps: [FSUtil.node, Global.node, Config.node] })
 

--- a/packages/core/src/tool-output-store.ts
+++ b/packages/core/src/tool-output-store.ts
@@ -206,6 +206,8 @@ export const cleanupLayer = Layer.effectDiscard(
   }),
 )
 
-export const defaultCleanupLayer = Layer.merge(defaultLayer, cleanupLayer.pipe(Layer.provide(defaultLayer)))
-
-export const cleanupNode = makeGlobalNode({ name: "tool-output-cleanup", layer: defaultCleanupLayer, deps: [] })
+export const cleanupNode = makeGlobalNode({
+  name: "tool-output-cleanup",
+  layer: Layer.merge(layer, cleanupLayer.pipe(Layer.provide(layer))),
+  deps: [FSUtil.node, Global.node],
+})

--- a/packages/core/src/tool/application-tools.ts
+++ b/packages/core/src/tool/application-tools.ts
@@ -27,7 +27,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ApplicationTools") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const state = State.create<Data, Draft>({

--- a/packages/core/src/tool/apply-patch.ts
+++ b/packages/core/src/tool/apply-patch.ts
@@ -56,7 +56,7 @@ type Prepared =
       readonly after: string
     })
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const mutation = yield* LocationMutation.Service

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -90,7 +90,7 @@ const externalCommandDirectories = (command: string, cwd: string) => {
   return [...directories]
 }
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const mutation = yield* LocationMutation.Service

--- a/packages/core/src/tool/builtins.ts
+++ b/packages/core/src/tool/builtins.ts
@@ -29,21 +29,6 @@ import { WriteTool } from "./write"
  * repo_clone, repo_overview, plan_exit, and Rune/code mode. Keep MCP and plugin
  * transforms separate from this static built-in list.
  */
-export const locationLayer = Layer.mergeAll(
-  ApplyPatchTool.layer,
-  BashTool.layer,
-  EditTool.layer,
-  GlobTool.layer,
-  GrepTool.layer,
-  QuestionTool.layer,
-  ReadTool.layer.pipe(Layer.provide(ReadToolFileSystem.layer)),
-  SkillTool.layer,
-  TodoWriteTool.layer,
-  WebFetchTool.layer,
-  WebSearchTool.layer.pipe(Layer.provide(WebSearchTool.defaultConfigLayer)),
-  WriteTool.layer,
-)
-
 export const node = makeLocationNode({
   name: "built-in-tools",
   layer: Layer.empty,
@@ -55,6 +40,7 @@ export const node = makeLocationNode({
     GrepTool.node,
     QuestionTool.node,
     ReadTool.node,
+    ReadToolFileSystem.node,
     SkillTool.node,
     TodoWriteTool.node,
     WebFetchTool.node,

--- a/packages/core/src/tool/builtins.ts
+++ b/packages/core/src/tool/builtins.ts
@@ -9,7 +9,6 @@ import { GlobTool } from "./glob"
 import { GrepTool } from "./grep"
 import { QuestionTool } from "./question"
 import { ReadTool } from "./read"
-import { ReadToolFileSystem } from "./read-filesystem"
 import { SkillTool } from "./skill"
 import { TodoWriteTool } from "./todowrite"
 import { WebFetchTool } from "./webfetch"
@@ -40,7 +39,6 @@ export const node = makeLocationNode({
     GrepTool.node,
     QuestionTool.node,
     ReadTool.node,
-    ReadToolFileSystem.node,
     SkillTool.node,
     TodoWriteTool.node,
     WebFetchTool.node,

--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -87,7 +87,7 @@ export const toModelOutput = (output: Output, oldString: string, newString: stri
 // TODO: Add snapshots / undo after design exists.
 // TODO: Add LSP notification and diagnostics after V2 LSP runtime exists.
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const mutation = yield* LocationMutation.Service

--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -35,7 +35,7 @@ export const toModelOutput = (output: ModelOutput) => {
 }
 
 /** Glob leaf that defaults its filesystem root to the active Location. */
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const ripgrep = yield* Ripgrep.Service

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -50,7 +50,7 @@ export const toModelOutput = (output: ModelOutput) => {
 }
 
 /** Grep leaf that defaults its filesystem root to the active Location. */
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const fs = yield* FSUtil.Service

--- a/packages/core/src/tool/question.ts
+++ b/packages/core/src/tool/question.ts
@@ -44,7 +44,7 @@ export const toModelOutput = (
   return `User has answered your questions: ${formatted}. You can now continue with the user's answers in mind.`
 }
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const question = yield* QuestionV2.Service

--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -351,7 +351,7 @@ export const list = Effect.fn("ReadTool.list")(function* (fs: FSUtil.Interface, 
   return new ListPage({ entries: selected, truncated, ...(truncated ? { next: offset + selected.length } : {}) })
 })
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service

--- a/packages/core/src/tool/read.ts
+++ b/packages/core/src/tool/read.ts
@@ -27,7 +27,7 @@ const LocationInput = Schema.Struct({
 const Input = LocationInput
 const Output = Schema.Union([FileSystem.Content, ReadToolFileSystem.TextPage, ReadToolFileSystem.ListPage])
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const reader = yield* ReadToolFileSystem.Service

--- a/packages/core/src/tool/registry.ts
+++ b/packages/core/src/tool/registry.ts
@@ -124,7 +124,7 @@ const registryLayer = Layer.effect(
   }),
 )
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Tools.Service,
   Service.use((registry) => Effect.succeed(Tools.Service.of({ register: registry.register }))),
 ).pipe(Layer.provideMerge(registryLayer))
@@ -133,11 +133,6 @@ function whollyDisabled(action: string, rules: PermissionV2.Ruleset) {
   const rule = rules.findLast((rule) => Wildcard.match(action, rule.action))
   return rule?.resource === "*" && rule.effect === "deny"
 }
-
-export const defaultLayer = layer.pipe(
-  Layer.provide(ApplicationTools.layer),
-  Layer.provide(ToolOutputStore.defaultLayer),
-)
 
 export const node = makeLocationNode({
   service: Service,

--- a/packages/core/src/tool/skill.ts
+++ b/packages/core/src/tool/skill.ts
@@ -54,7 +54,7 @@ export const toModelOutput = (skill: SkillV2.Info, files: ReadonlyArray<string>)
 const unableToLoad = (name: string, error?: unknown) =>
   new ToolFailure({ message: `Unable to load skill ${name}`, error })
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const fs = yield* FSUtil.Service

--- a/packages/core/src/tool/todowrite.ts
+++ b/packages/core/src/tool/todowrite.ts
@@ -22,7 +22,7 @@ export type Output = typeof Output.Type
 
 export const toModelOutput = (output: Output) => JSON.stringify(output.todos, null, 2)
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const todos = yield* SessionTodo.Service

--- a/packages/core/src/tool/webfetch.ts
+++ b/packages/core/src/tool/webfetch.ts
@@ -115,7 +115,7 @@ const convert = (content: string, contentType: string, format: Format) => {
   return content
 }
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const http = yield* HttpClient.HttpClient

--- a/packages/core/src/tool/websearch.ts
+++ b/packages/core/src/tool/websearch.ts
@@ -189,7 +189,7 @@ const Output = Schema.Struct({
   text: Schema.String,
 })
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const http = yield* HttpClient.HttpClient

--- a/packages/core/src/tool/write.ts
+++ b/packages/core/src/tool/write.ts
@@ -44,7 +44,7 @@ export const toModelOutput = (output: Output) =>
 // TODO: Add snapshots / undo after design exists.
 // TODO: Add LSP notification and diagnostics after V2 LSP runtime exists.
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const mutation = yield* LocationMutation.Service

--- a/packages/sdk-next/src/opencode.ts
+++ b/packages/sdk-next/src/opencode.ts
@@ -1,4 +1,6 @@
 import { OpenCode } from "@opencode-ai/client/effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { ApplicationTools } from "@opencode-ai/core/tool/application-tools"
 import { createEmbeddedRoutes } from "@opencode-ai/server/routes"
@@ -9,7 +11,7 @@ export const create = Effect.fn("OpenCode.create")(function* () {
   const scope = yield* Scope.Scope
   const memoMap = yield* Layer.makeMemoMap
   const context = yield* Layer.buildWithMemoMap(
-    Layer.merge(ApplicationTools.layer, PermissionSaved.defaultLayer),
+    AppNodeBuilder.build(LayerNode.group([ApplicationTools.node, PermissionSaved.node])),
     memoMap,
     scope,
   )


### PR DESCRIPTION
## Summary
- make core built-in tool implementation layers private
- remove tool registry/tool output default layer exports
- keep tool behavior wired through existing node graph

## Testing
- bun typecheck
- bun turbo typecheck (pre-push)

## Stack
1. #34621 refactor(core): route aggregate layers through nodes
2. #34622 refactor(core): remove tool layer exports
3. #34623 refactor(core): remove session layer exports
4. #34624 refactor(core): remove infrastructure layer exports
5. #34625 refactor(core): remove domain layer exports

Previous: #34621
Base: core-node-consumers
Next: #34623