### PR TITLE
refactor(core): remove session layer exports

### DIFF
--- a/packages/core/src/control-plane/move-session.ts
+++ b/packages/core/src/control-plane/move-session.ts
@@ -66,7 +66,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ControlPlaneMoveSession") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const git = yield* Git.Service
@@ -139,13 +139,6 @@ export const layer = Layer.effect(
 
     return Service.of({ moveSession })
   }),
-)
-
-export const defaultLayer = layer.pipe(
-  Layer.provide(Git.defaultLayer),
-  Layer.provide(EventV2.defaultLayer),
-  Layer.provide(ProjectV2.defaultLayer),
-  Layer.provide(SessionStore.defaultLayer),
 )
 
 export const node = makeGlobalNode({

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -181,7 +181,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Session") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const database = yield* Database.Service
@@ -455,15 +455,6 @@ export const layer = Layer.effect(
 
     return result
   }),
-)
-
-export const defaultLayer = layer.pipe(
-  Layer.provide(SessionStore.defaultLayer),
-  Layer.provide(SessionProjector.defaultLayer),
-  Layer.provide(EventV2.defaultLayer),
-  Layer.provide(Database.defaultLayer),
-  Layer.provide(ProjectV2.defaultLayer),
-  Layer.orDie,
 )
 
 const resolvePrompt = (input: PromptInput.Prompt) =>

--- a/packages/core/src/session/execution/local.ts
+++ b/packages/core/src/session/execution/local.ts
@@ -8,7 +8,7 @@ import { SessionStore } from "../store"
 import { SessionExecution } from "../execution"
 
 /** Current-process routing for implicit-local Locations. Future remote placement belongs here. */
-export const layer = Layer.effect(
+const layer = Layer.effect(
   SessionExecution.Service,
   Effect.gen(function* () {
     const store = yield* SessionStore.Service
@@ -36,8 +36,6 @@ export const layer = Layer.effect(
     })
   }),
 )
-
-export const defaultLayer = layer.pipe(Layer.provide(SessionStore.defaultLayer))
 
 export const node = makeGlobalNode({
   service: SessionExecution.Service,

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -208,7 +208,7 @@ function insertMessage(db: DatabaseService, event: SessionEvent.Event, message: 
     .pipe(Effect.orDie)
 }
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const events = yield* EventV2.Service
     const { db } = yield* Database.Service
@@ -455,5 +455,4 @@ export const layer = Layer.effectDiscard(
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(EventV2.defaultLayer), Layer.provide(Database.defaultLayer))
 export const node = makeGlobalNode({ name: "session-projector", layer, deps: [EventV2.node, Database.node] })

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -89,7 +89,7 @@ import { llmClient } from "../../effect/app-node-platform"
  * explicit loop starts the next provider turn after local settlement. Configured agent step limits bound the loop.
  */
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2.Service
@@ -405,8 +405,6 @@ export const layer = Layer.effect(
     })
   }),
 )
-
-export const defaultLayer = layer
 
 export const node = makeLocationNode({
   service: Service,

--- a/packages/core/src/session/store.ts
+++ b/packages/core/src/session/store.ts
@@ -25,7 +25,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SessionStore") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const { db } = yield* Database.Service
@@ -59,7 +59,5 @@ export const layer = Layer.effect(
     })
   }),
 )
-
-export const defaultLayer = layer.pipe(Layer.provide(Database.defaultLayer))
 
 export const node = makeGlobalNode({ service: Service, layer, deps: [Database.node] })

--- a/packages/core/src/session/todo.ts
+++ b/packages/core/src/session/todo.ts
@@ -23,7 +23,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SessionTodo") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const { db } = yield* Database.Service
@@ -74,7 +74,5 @@ export const layer = Layer.effect(
     return Service.of({ update, get })
   }),
 )
-
-export const defaultLayer = layer.pipe(Layer.provide(EventV2.defaultLayer), Layer.provide(Database.defaultLayer))
 
 export const node = makeLocationNode({ service: Service, layer, deps: [EventV2.node, Database.node] })

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -52,6 +52,7 @@ import { Worktree } from "@/worktree"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
 import { Database } from "@opencode-ai/core/database/database"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
 import { EventV2 } from "@opencode-ai/core/event"
@@ -64,6 +65,7 @@ import { PtyTicket } from "@opencode-ai/core/pty/ticket"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionV2 } from "@opencode-ai/core/session"
+import { SessionExecution } from "@opencode-ai/core/session/execution"
 import * as SessionExecutionLocal from "@opencode-ai/core/session/execution/local"
 import { lazy } from "@/util/lazy"
 import { CorsConfig, isAllowedCorsOrigin, type CorsOptions } from "@opencode-ai/server/cors"
@@ -285,7 +287,7 @@ export function createRoutes(
       corsVaryFix,
       fenceLayer,
       cors(corsOptions),
-      MoveSession.defaultLayer,
+      AppNodeBuilder.build(MoveSession.node),
       HttpServer.layerServices,
     ]),
     Layer.provide(Layer.succeed(CorsConfig)(corsOptions)),
@@ -295,8 +297,7 @@ export function createRoutes(
     Layer.provide(locationLayer),
     Layer.provide(PtyEnvironment.layer),
     Layer.provide(
-      SessionV2.defaultLayer.pipe(
-        Layer.provide(SessionExecutionLocal.defaultLayer),
+      AppNodeBuilder.build(SessionV2.node, [[SessionExecution.node, SessionExecutionLocal.node]]).pipe(
         Layer.provide(locationServiceMapLayer),
       ),
     ),


### PR DESCRIPTION
## Summary
- make core session-related implementation layers private
- remove session store/projector/execution default layer exports
- update move-session composition to use node dependencies

## Testing
- bun typecheck
- bun turbo typecheck (pre-push)

## Stack
1. #34621 refactor(core): route aggregate layers through nodes
2. #34622 refactor(core): remove tool layer exports
3. #34623 refactor(core): remove session layer exports
4. #34624 refactor(core): remove infrastructure layer exports
5. #34625 refactor(core): remove domain layer exports

Previous: #34622
Base: core-tool-layers
Next: #34624