### PR TITLE
refactor(core): remove domain layer exports

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -42,7 +42,7 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Agent") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const state = State.create<Data, Draft>({

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -233,5 +233,3 @@ export const locationLayer = Layer.effect(
 )
 
 export const node = makeLocationNode({ service: Service, layer: locationLayer, deps: [] })
-
-export const defaultLayer = locationLayer

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -61,7 +61,7 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Catalog") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2.Service

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -26,7 +26,7 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Command") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.sync(() => {
     const state = State.create<Data, Draft>({

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -132,7 +132,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Config") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -636,4 +636,3 @@ export const layerWith = (options?: LayerOptions) =>
 
 const layer = layerWith()
 export const node = makeGlobalNode({ service: Service, layer: layer, deps: [Database.node] })
-

--- a/packages/core/src/file-mutation.ts
+++ b/packages/core/src/file-mutation.ts
@@ -71,7 +71,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/v2
  * write under the same process-local lock so cooperating OpenCode mutations do
  * not overwrite changes made from the same stale content.
  */
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service

--- a/packages/core/src/image.ts
+++ b/packages/core/src/image.ts
@@ -44,7 +44,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Image") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const config = yield* Config.Service

--- a/packages/core/src/instruction-context.ts
+++ b/packages/core/src/instruction-context.ts
@@ -19,7 +19,7 @@ class File extends Schema.Class<File>("InstructionContext.File")({
 const Files = Schema.Array(File)
 const key = SystemContext.Key.make("core/instructions")
 
-export const layer = Layer.effectDiscard(
+const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service

--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -76,7 +76,7 @@ interface ResolvedPath {
 
 const slash = (value: string) => value.replaceAll("\\", "/")
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service

--- a/packages/core/src/location.ts
+++ b/packages/core/src/location.ts
@@ -16,7 +16,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Lo
 
 export const node = LayerNode.unbound(Service, tags.values.location)
 
-export const layer = (ref: Ref) =>
+const layer = (ref: Ref) =>
   Layer.effect(
     Service,
     Effect.gen(function* () {

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -106,7 +106,7 @@ interface Pending {
   readonly deferred: Deferred.Deferred<void, RejectedError | CorrectedError>
 }
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   EffectRuntime.gen(function* () {
     const events = yield* EventV2.Service

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -28,7 +28,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Plugin") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2.Service

--- a/packages/core/src/policy.ts
+++ b/packages/core/src/policy.ts
@@ -22,7 +22,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Policy") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   EffectRuntime.gen(function* () {
     let statements: Info[] = []

--- a/packages/core/src/project/copy.ts
+++ b/packages/core/src/project/copy.ts
@@ -125,7 +125,7 @@ export const refreshAfterBoot = Effect.gen(function* () {
   )
 })
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service

--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -89,7 +89,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Pty") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2.Service

--- a/packages/core/src/pty/ticket.ts
+++ b/packages/core/src/pty/ticket.ts
@@ -51,7 +51,6 @@ export const make = (ttl: Duration.Input = DEFAULT_TTL) =>
     })
   })
 
-export const layer = Layer.effect(Service, make())
+const layer = Layer.effect(Service, make())
 
-export const defaultLayer = layer
 export const node = makeGlobalNode({ service: Service, layer: layer, deps: [] })

--- a/packages/core/src/question.ts
+++ b/packages/core/src/question.ts
@@ -72,7 +72,7 @@ interface Pending {
  * layer once per embedded Location so replies cannot settle another Location's
  * deferred request.
  */
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2.Service

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -40,7 +40,7 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Reference") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const global = yield* Global.Service

--- a/packages/core/src/reference/guidance.ts
+++ b/packages/core/src/reference/guidance.ts
@@ -31,7 +31,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/ReferenceGuidance") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const references = yield* Reference.Service

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -53,7 +53,7 @@ export interface Interface extends State.Transformable<Draft> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Skill") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const discovery = yield* SkillDiscovery.Service

--- a/packages/core/src/skill/guidance.ts
+++ b/packages/core/src/skill/guidance.ts
@@ -37,7 +37,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SkillGuidance") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const skills = yield* SkillV2.Service

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -83,7 +83,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/Snapshot") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const config = yield* Config.Service

--- a/packages/core/src/system-context/builtins.ts
+++ b/packages/core/src/system-context/builtins.ts
@@ -43,14 +43,8 @@ const builtIns = Layer.effectDiscard(
   }),
 )
 
-export const layer = Layer.mergeAll(builtIns, InstructionContext.layer).pipe(
-  Layer.provideMerge(SystemContextRegistry.layer),
-)
-
-export const locationLayer = layer
-
 export const node = makeLocationNode({
   name: "system-context-builtins",
-  layer,
+  layer: builtIns,
   deps: [Location.node, SystemContextRegistry.node, InstructionContext.node, FSUtil.node, Global.node],
 })

--- a/packages/core/src/system-context/registry.ts
+++ b/packages/core/src/system-context/registry.ts
@@ -16,7 +16,7 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SystemContextRegistry") {}
 
-export const layer = Layer.effect(
+const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const entries = yield* Ref.make<ReadonlyArray<Entry>>([])

--- a/packages/opencode/src/control-plane/workspace.ts
+++ b/packages/opencode/src/control-plane/workspace.ts
@@ -31,8 +31,8 @@ import { waitEvent } from "./util"
 import { WorkspaceRef } from "@/effect/instance-ref"
 import { Vcs } from "@/project/vcs"
 import { InstanceStore } from "@/project/instance-store"
-import { InstanceBootstrap } from "@/project/bootstrap"
 import { WorkspaceAdapterRuntime } from "./workspace-adapter-runtime"
+import { AppNodeBuilderV1 } from "@/effect/app-node-builder-v1"
 import { WorkspaceEvent } from "@opencode-ai/schema/workspace-event"
 
 export const Info = Schema.Struct({
@@ -602,9 +602,7 @@ const layer = Layer.effect(
                 fallback: "",
                 response: "text",
               }).pipe(
-                Effect.provide(
-                  LayerNode.compile(InstanceStore.node, [[InstanceStore.bootstrapNode, InstanceBootstrap.node]]),
-                ),
+                Effect.provide(AppNodeBuilderV1.build(InstanceStore.node)),
               )
             : ""
 
@@ -622,9 +620,7 @@ const layer = Layer.effect(
               }),
             fallback: { applied: false },
           }).pipe(
-            Effect.provide(
-              LayerNode.compile(InstanceStore.node, [[InstanceStore.bootstrapNode, InstanceBootstrap.node]]),
-            ),
+            Effect.provide(AppNodeBuilderV1.build(InstanceStore.node)),
           )
         }
 

--- a/packages/opencode/src/effect/app-node-builder-v1.ts
+++ b/packages/opencode/src/effect/app-node-builder-v1.ts
@@ -1,0 +1,12 @@
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { InstanceBootstrap } from "@/project/bootstrap"
+import { InstanceStore } from "@/project/instance-store"
+
+const bootstrapReplacement = [InstanceStore.bootstrapNode, InstanceBootstrap.node] as const
+
+export function build<A, E>(root: LayerNode.Node<A, E, any>, replacements: LayerNode.Replacements = []) {
+  return AppNodeBuilder.build(root, replacements.concat([bootstrapReplacement]))
+}
+
+export * as AppNodeBuilderV1 from "./app-node-builder-v1"

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -38,7 +38,6 @@ import { Command } from "@/command"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
 import { Format } from "@/format"
-import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceStore } from "@/project/instance-store"
 import { Project } from "@/project/project"
 import { Vcs } from "@/project/vcs"
@@ -53,10 +52,10 @@ import { BackgroundJob } from "@/background/job"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { AppNodeBuilderV1 } from "./app-node-builder-v1"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 
-export const AppLayer = AppNodeBuilder.build(
+export const AppLayer = AppNodeBuilderV1.build(
   LayerNode.group([
     Npm.node,
     FSUtil.node,
@@ -107,8 +106,7 @@ export const AppLayer = AppNodeBuilder.build(
     ShareNext.node,
     SessionShare.node,
   ]),
-  [[InstanceStore.bootstrapNode, InstanceBootstrap.node]],
-).pipe(Layer.provideMerge(AppNodeBuilder.build(Ripgrep.node)), Layer.provideMerge(Observability.layer))
+).pipe(Layer.provideMerge(AppNodeBuilderV1.build(Ripgrep.node)), Layer.provideMerge(Observability.layer))
 
 const rt = ManagedRuntime.make(AppLayer, { memoMap })
 type Runtime = Pick<typeof rt, "runSync" | "runPromise" | "runPromiseExit" | "runFork" | "runCallback" | "dispose">

--- a/packages/opencode/src/effect/config-service.ts
+++ b/packages/opencode/src/effect/config-service.ts
@@ -14,9 +14,9 @@ export type Shape<Fields extends ConfigMap> = {
  */
 export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClass<Self, Id, Service> & {
   /** Provide already-parsed config, useful in tests. */
-  readonly layer: (input: Service) => Layer.Layer<Self>
+  readonly configLayer: (input: Service) => Layer.Layer<Self>
   /** Parse config once from the active Effect ConfigProvider and provide the service. */
-  readonly configLayer: Layer.Layer<Self, Config.ConfigError>
+  readonly layer: Layer.Layer<Self, Config.ConfigError>
 }
 
 /**
@@ -35,19 +35,19 @@ export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClas
  *   },
  * ) {}
  *
- * const live = ServerAuthConfig.configLayer
- * const test = ServerAuthConfig.layer({ password: Option.some("secret"), username: "kit" })
+ * const live = ServerAuthConfig.layer
+ * const test = ServerAuthConfig.configLayer({ password: Option.some("secret"), username: "kit" })
  * ```
  */
 export const Service =
   <Self>() =>
   <const Id extends string, const Fields extends ConfigMap>(id: Id, fields: Fields) => {
     class ConfigTag extends Context.Service<Self, Shape<Fields>>()(id) {
-      static layer(input: Shape<Fields>) {
+      static configLayer(input: Shape<Fields>) {
         return Layer.succeed(this, this.of(input))
       }
 
-      static get configLayer() {
+      static get layer() {
         const tag = this
         return Layer.effect(
           tag,

--- a/packages/opencode/src/effect/config-service.ts
+++ b/packages/opencode/src/effect/config-service.ts
@@ -16,7 +16,7 @@ export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClas
   /** Provide already-parsed config, useful in tests. */
   readonly layer: (input: Service) => Layer.Layer<Self>
   /** Parse config once from the active Effect ConfigProvider and provide the service. */
-  readonly defaultLayer: Layer.Layer<Self, Config.ConfigError>
+  readonly configLayer: Layer.Layer<Self, Config.ConfigError>
 }
 
 /**
@@ -35,7 +35,7 @@ export type ServiceClass<Self, Id extends string, Service> = Context.ServiceClas
  *   },
  * ) {}
  *
- * const live = ServerAuthConfig.defaultLayer
+ * const live = ServerAuthConfig.configLayer
  * const test = ServerAuthConfig.layer({ password: Option.some("secret"), username: "kit" })
  * ```
  */
@@ -47,7 +47,7 @@ export const Service =
         return Layer.succeed(this, this.of(input))
       }
 
-      static get defaultLayer() {
+      static get configLayer() {
         const tag = this
         return Layer.effect(
           tag,

--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -57,7 +57,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
 
 export type Info = Context.Service.Shape<typeof Service>
 
-const emptyConfigLayer = Service.configLayer.pipe(
+const emptyConfigLayer = Service.layer.pipe(
   Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({}))),
   Layer.orDie,
 )
@@ -71,7 +71,7 @@ export const layer = (overrides: Partial<Info> = {}) =>
     }),
   ).pipe(Layer.provide(emptyConfigLayer))
 
-export const node = LayerNode.make({ service: Service, layer: Service.configLayer.pipe(Layer.orDie), deps: [] })
+export const node = LayerNode.make({ service: Service, layer: Service.layer.pipe(Layer.orDie), deps: [] })
 
 export * as RuntimeFlags from "./runtime-flags"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"

--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -57,7 +57,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
 
 export type Info = Context.Service.Shape<typeof Service>
 
-const emptyConfigLayer = Service.defaultLayer.pipe(
+const emptyConfigLayer = Service.configLayer.pipe(
   Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({}))),
   Layer.orDie,
 )
@@ -71,7 +71,7 @@ export const layer = (overrides: Partial<Info> = {}) =>
     }),
   ).pipe(Layer.provide(emptyConfigLayer))
 
-export const node = LayerNode.make({ service: Service, layer: Service.defaultLayer.pipe(Layer.orDie), deps: [] })
+export const node = LayerNode.make({ service: Service, layer: Service.configLayer.pipe(Layer.orDie), deps: [] })
 
 export * as RuntimeFlags from "./runtime-flags"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -133,10 +133,10 @@ const cors = (corsOptions?: CorsOptions) =>
 // - ptyConnectApiRoutes: typed WebSocket upgrade route with ticket-aware auth.
 // - instanceApiRoutes: remaining typed instance routes.
 // - uiRoute: raw catch-all fallback; auth is router middleware so public static assets can bypass it.
-const authOnlyRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
-const httpApiAuthLayer = authorizationLayer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
-const ptyConnectHttpApiAuthLayer = ptyConnectAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
-const serverHttpApiAuthLayer = serverAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.defaultLayer))
+const authOnlyRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.configLayer))
+const httpApiAuthLayer = authorizationLayer.pipe(Layer.provide(ServerAuth.Config.configLayer))
+const ptyConnectHttpApiAuthLayer = ptyConnectAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.configLayer))
+const serverHttpApiAuthLayer = serverAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.configLayer))
 const workspaceRoutingLive = workspaceRoutingLayer.pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal))
 const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(
   Layer.provide([controlHandlers, controlPlaneHandlers, globalHandlers]),

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -271,7 +271,8 @@ const app = LayerNode.group([
 export function createRoutes(
   corsOptions?: CorsOptions,
 ): Layer.Layer<never, EffectConfig.ConfigError, RouteRequirements> {
-  const locationServiceMap = buildLocationServiceMap()
+  const locationServiceMapV2 = buildLocationServiceMap()
+
   return Layer.mergeAll(
     rootApiRoutes,
     eventApiRoutes,
@@ -287,7 +288,7 @@ export function createRoutes(
       corsVaryFix,
       fenceLayer,
       cors(corsOptions),
-      AppNodeBuilderV1.build(MoveSession.node, [[LocationServiceMap.node, locationServiceMap]]),
+      AppNodeBuilderV1.build(MoveSession.node, [[LocationServiceMap.node, locationServiceMapV2]]),
       HttpServer.layerServices,
     ]),
     Layer.provide(Layer.succeed(CorsConfig)(corsOptions)),
@@ -298,13 +299,13 @@ export function createRoutes(
     Layer.provide(PtyEnvironment.layer),
     Layer.provide(
       AppNodeBuilderV1.build(SessionV2.node, [
-        [LocationServiceMap.node, locationServiceMap],
+        [LocationServiceMap.node, locationServiceMapV2],
         [SessionExecution.node, SessionExecutionLocal.node],
       ]),
     ),
-    Layer.provide(locationServiceMap),
+    Layer.provide(locationServiceMapV2),
 
-    Layer.provide(AppNodeBuilderV1.build(app, [[LocationServiceMap.node, locationServiceMap]])),
+    Layer.provide(AppNodeBuilderV1.build(app)),
   )
 }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -22,7 +22,6 @@ import { McpAuth } from "@/mcp/auth"
 import { Permission } from "@/permission"
 import { Plugin } from "@/plugin"
 import { PluginPtyEnvironment } from "@/plugin/pty-environment"
-import { InstanceBootstrap } from "@/project/bootstrap"
 import { InstanceStore } from "@/project/instance-store"
 import { Project } from "@/project/project"
 import { Vcs } from "@/project/vcs"
@@ -52,7 +51,7 @@ import { Worktree } from "@/worktree"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
 import { Database } from "@opencode-ai/core/database/database"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { AppNodeBuilderV1 } from "@/effect/app-node-builder-v1"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
 import { EventV2 } from "@opencode-ai/core/event"
@@ -101,7 +100,7 @@ import { sessionHandlers } from "./handlers/session"
 import { syncHandlers } from "./handlers/sync"
 import { tuiHandlers } from "./handlers/tui"
 import { handlers } from "@opencode-ai/server/handlers"
-import { locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { buildLocationServiceMap, LocationServiceMap } from "@opencode-ai/core/location-services"
 import { layer as locationLayer } from "@opencode-ai/server/location"
 import { sessionLocationLayer } from "@opencode-ai/server/middleware/session-location"
 import { PtyEnvironment } from "@opencode-ai/server/pty-environment"
@@ -272,6 +271,7 @@ const app = LayerNode.group([
 export function createRoutes(
   corsOptions?: CorsOptions,
 ): Layer.Layer<never, EffectConfig.ConfigError, RouteRequirements> {
+  const locationServiceMap = buildLocationServiceMap()
   return Layer.mergeAll(
     rootApiRoutes,
     eventApiRoutes,
@@ -287,7 +287,7 @@ export function createRoutes(
       corsVaryFix,
       fenceLayer,
       cors(corsOptions),
-      AppNodeBuilder.build(MoveSession.node),
+      AppNodeBuilderV1.build(MoveSession.node, [[LocationServiceMap.node, locationServiceMap]]),
       HttpServer.layerServices,
     ]),
     Layer.provide(Layer.succeed(CorsConfig)(corsOptions)),
@@ -297,13 +297,14 @@ export function createRoutes(
     Layer.provide(locationLayer),
     Layer.provide(PtyEnvironment.layer),
     Layer.provide(
-      AppNodeBuilder.build(SessionV2.node, [[SessionExecution.node, SessionExecutionLocal.node]]).pipe(
-        Layer.provide(locationServiceMapLayer),
-      ),
+      AppNodeBuilderV1.build(SessionV2.node, [
+        [LocationServiceMap.node, locationServiceMap],
+        [SessionExecution.node, SessionExecutionLocal.node],
+      ]),
     ),
-    Layer.provide(locationServiceMapLayer),
+    Layer.provide(locationServiceMap),
 
-    Layer.provide(LayerNode.compile(app, [[InstanceStore.bootstrapNode, InstanceBootstrap.node]])),
+    Layer.provide(AppNodeBuilderV1.build(app, [[LocationServiceMap.node, locationServiceMap]])),
   )
 }
 

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -133,10 +133,10 @@ const cors = (corsOptions?: CorsOptions) =>
 // - ptyConnectApiRoutes: typed WebSocket upgrade route with ticket-aware auth.
 // - instanceApiRoutes: remaining typed instance routes.
 // - uiRoute: raw catch-all fallback; auth is router middleware so public static assets can bypass it.
-const authOnlyRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.configLayer))
-const httpApiAuthLayer = authorizationLayer.pipe(Layer.provide(ServerAuth.Config.configLayer))
-const ptyConnectHttpApiAuthLayer = ptyConnectAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.configLayer))
-const serverHttpApiAuthLayer = serverAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.configLayer))
+const authOnlyRouterLayer = authorizationRouterMiddleware.layer.pipe(Layer.provide(ServerAuth.Config.layer))
+const httpApiAuthLayer = authorizationLayer.pipe(Layer.provide(ServerAuth.Config.layer))
+const ptyConnectHttpApiAuthLayer = ptyConnectAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.layer))
+const serverHttpApiAuthLayer = serverAuthorizationLayer.pipe(Layer.provide(ServerAuth.Config.layer))
 const workspaceRoutingLive = workspaceRoutingLayer.pipe(Layer.provide(Socket.layerWebSocketConstructorGlobal))
 const rootApiRoutes = HttpApiBuilder.layer(RootHttpApi).pipe(
   Layer.provide([controlHandlers, controlPlaneHandlers, globalHandlers]),

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -1,5 +1,4 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Slug } from "@opencode-ai/core/util/slug"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
@@ -10,7 +9,6 @@ import { Decimal } from "decimal.js"
 import type { ProviderMetadata, Usage } from "@opencode-ai/llm"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Database } from "@opencode-ai/core/database/database"
-import { makeRuntime } from "@opencode-ai/core/effect/runtime"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { SessionV2 } from "@opencode-ai/core/session"
 import * as SessionExecutionLocal from "@opencode-ai/core/session/execution/local"
@@ -46,8 +44,6 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { SessionMessage } from "@opencode-ai/schema/session-message"
-
-const runtime = makeRuntime(Database.Service, AppNodeBuilder.build(Database.node))
 
 const parentTitlePrefix = "New session - "
 const childTitlePrefix = "Child session - "
@@ -1011,76 +1007,6 @@ function listByProject(
       Effect.orDie,
       Effect.map((rows) => rows.map(fromRow)),
     )
-}
-
-export function* listGlobal(input?: {
-  directory?: string
-  roots?: boolean
-  start?: number
-  cursor?: number
-  search?: string
-  limit?: number
-  archived?: boolean
-}) {
-  const conditions: SQL[] = []
-
-  if (input?.directory) {
-    conditions.push(eq(SessionTable.directory, input.directory))
-  }
-  if (input?.roots) {
-    conditions.push(isNull(SessionTable.parent_id))
-  }
-  if (input?.start) {
-    conditions.push(gte(SessionTable.time_updated, input.start))
-  }
-  if (input?.cursor) {
-    conditions.push(lt(SessionTable.time_updated, input.cursor))
-  }
-  if (input?.search) {
-    conditions.push(like(SessionTable.title, `%${input.search}%`))
-  }
-  if (!input?.archived) {
-    conditions.push(isNull(SessionTable.time_archived))
-  }
-
-  const limit = input?.limit ?? 100
-
-  const rows = runtime.runSync(({ db }) => {
-    const query =
-      conditions.length > 0
-        ? db
-            .select()
-            .from(SessionTable)
-            .where(and(...conditions))
-        : db.select().from(SessionTable)
-    return query.orderBy(desc(SessionTable.time_updated), desc(SessionTable.id)).limit(limit).all().pipe(Effect.orDie)
-  })
-
-  const ids = [...new Set(rows.map((row) => row.project_id))]
-  const projects = new Map<string, ProjectInfo>()
-
-  if (ids.length > 0) {
-    const items = runtime.runSync(({ db }) =>
-      db
-        .select({ id: ProjectTable.id, name: ProjectTable.name, worktree: ProjectTable.worktree })
-        .from(ProjectTable)
-        .where(inArray(ProjectTable.id, ids))
-        .all()
-        .pipe(Effect.orDie),
-    )
-    for (const item of items) {
-      projects.set(item.id, {
-        id: item.id,
-        name: item.name ?? undefined,
-        worktree: item.worktree,
-      })
-    }
-  }
-
-  for (const row of rows) {
-    const project = projects.get(row.project_id) ?? null
-    yield { ...fromRow(row), project }
-  }
 }
 
 export const node = LayerNode.make({

--- a/packages/opencode/test/effect/config-service.test.ts
+++ b/packages/opencode/test/effect/config-service.test.ts
@@ -10,12 +10,12 @@ class TestConfig extends ConfigService.Service<TestConfig>()("@test/ConfigServic
 }) {}
 
 const fromConfig = (input: Record<string, unknown>) =>
-  TestConfig.configLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(input))))
+  TestConfig.layer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(input))))
 
 const readConfig = TestConfig.useSync((config) => config)
 
 describe("ConfigService", () => {
-  it.effect("configLayer parses values from the active ConfigProvider", () =>
+  it.effect("layer parses values from the active ConfigProvider", () =>
     Effect.gen(function* () {
       const config = yield* readConfig.pipe(
         Effect.provide(
@@ -33,7 +33,7 @@ describe("ConfigService", () => {
     }),
   )
 
-  it.effect("configLayer applies Effect Config defaults", () =>
+  it.effect("layer applies Effect Config defaults", () =>
     Effect.gen(function* () {
       const config = yield* readConfig.pipe(Effect.provide(fromConfig({ NAME: "kit" })))
 
@@ -47,7 +47,7 @@ describe("ConfigService", () => {
     Effect.gen(function* () {
       const config = yield* readConfig.pipe(
         Effect.provide(
-          TestConfig.layer({
+          TestConfig.configLayer({
             name: "direct",
             token: Option.some("parsed"),
             port: 9000,

--- a/packages/opencode/test/effect/config-service.test.ts
+++ b/packages/opencode/test/effect/config-service.test.ts
@@ -10,12 +10,12 @@ class TestConfig extends ConfigService.Service<TestConfig>()("@test/ConfigServic
 }) {}
 
 const fromConfig = (input: Record<string, unknown>) =>
-  TestConfig.defaultLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(input))))
+  TestConfig.configLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(input))))
 
 const readConfig = TestConfig.useSync((config) => config)
 
 describe("ConfigService", () => {
-  it.effect("defaultLayer parses values from the active ConfigProvider", () =>
+  it.effect("configLayer parses values from the active ConfigProvider", () =>
     Effect.gen(function* () {
       const config = yield* readConfig.pipe(
         Effect.provide(
@@ -33,7 +33,7 @@ describe("ConfigService", () => {
     }),
   )
 
-  it.effect("defaultLayer applies Effect Config defaults", () =>
+  it.effect("configLayer applies Effect Config defaults", () =>
     Effect.gen(function* () {
       const config = yield* readConfig.pipe(Effect.provide(fromConfig({ NAME: "kit" })))
 

--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -10,7 +10,7 @@ const fromConfig = (input: Record<string, unknown>) =>
 const readFlags = RuntimeFlags.Service.useSync((flags) => flags)
 
 describe("RuntimeFlags", () => {
-  it.effect("configLayer defaults autoShare to false", () =>
+  it.effect("layer defaults autoShare to false", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(Effect.provide(fromConfig({})))
 
@@ -18,7 +18,7 @@ describe("RuntimeFlags", () => {
     }),
   )
 
-  it.effect("configLayer parses plugin flags from the active ConfigProvider", () =>
+  it.effect("layer parses plugin flags from the active ConfigProvider", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(
         Effect.provide(
@@ -65,7 +65,7 @@ describe("RuntimeFlags", () => {
     }),
   )
 
-  it.effect("configLayer parses OPENCODE_EXPERIMENTAL_LSP_TY", () =>
+  it.effect("layer parses OPENCODE_EXPERIMENTAL_LSP_TY", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(
         Effect.provide(

--- a/packages/opencode/test/effect/runtime-flags.test.ts
+++ b/packages/opencode/test/effect/runtime-flags.test.ts
@@ -10,7 +10,7 @@ const fromConfig = (input: Record<string, unknown>) =>
 const readFlags = RuntimeFlags.Service.useSync((flags) => flags)
 
 describe("RuntimeFlags", () => {
-  it.effect("defaultLayer defaults autoShare to false", () =>
+  it.effect("configLayer defaults autoShare to false", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(Effect.provide(fromConfig({})))
 
@@ -18,7 +18,7 @@ describe("RuntimeFlags", () => {
     }),
   )
 
-  it.effect("defaultLayer parses plugin flags from the active ConfigProvider", () =>
+  it.effect("configLayer parses plugin flags from the active ConfigProvider", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(
         Effect.provide(
@@ -65,7 +65,7 @@ describe("RuntimeFlags", () => {
     }),
   )
 
-  it.effect("defaultLayer parses OPENCODE_EXPERIMENTAL_LSP_TY", () =>
+  it.effect("configLayer parses OPENCODE_EXPERIMENTAL_LSP_TY", () =>
     Effect.gen(function* () {
       const flags = yield* readFlags.pipe(
         Effect.provide(

--- a/packages/opencode/test/server/httpapi-authorization.test.ts
+++ b/packages/opencode/test/server/httpapi-authorization.test.ts
@@ -56,9 +56,9 @@ const v2ApiLayer = HttpRouter.serve(
   { disableListenLog: true, disableLogger: true },
 ).pipe(Layer.provideMerge(NodeHttpServer.layerTest))
 
-const noAuthLayer = ServerAuth.Config.layer({ password: Option.none(), username: "opencode" })
-const secretLayer = ServerAuth.Config.layer({ password: Option.some("secret"), username: "opencode" })
-const kitSecretLayer = ServerAuth.Config.layer({ password: Option.some("secret"), username: "kit" })
+const noAuthLayer = ServerAuth.Config.configLayer({ password: Option.none(), username: "opencode" })
+const secretLayer = ServerAuth.Config.configLayer({ password: Option.some("secret"), username: "opencode" })
+const kitSecretLayer = ServerAuth.Config.configLayer({ password: Option.some("secret"), username: "kit" })
 
 const it = testEffect(apiLayer.pipe(Layer.provide(noAuthLayer)))
 const itSecret = testEffect(apiLayer.pipe(Layer.provide(secretLayer)))

--- a/packages/opencode/test/server/httpapi-control-plane.test.ts
+++ b/packages/opencode/test/server/httpapi-control-plane.test.ts
@@ -44,7 +44,7 @@ const apiLayer = HttpRouter.serve(
       moveSession: (value) => Ref.set(called, value),
     }),
   ),
-  Layer.provide(ServerAuth.Config.layer({ password: Option.none(), username: "opencode" })),
+  Layer.provide(ServerAuth.Config.configLayer({ password: Option.none(), username: "opencode" })),
 )
 const it = testEffect(apiLayer)
 

--- a/packages/opencode/test/server/httpapi-global.test.ts
+++ b/packages/opencode/test/server/httpapi-global.test.ts
@@ -38,7 +38,7 @@ const apiLayer = HttpRouter.serve(
       upgrade: () => Effect.void,
     }),
   ),
-  Layer.provide(ServerAuth.Config.layer({ password: Option.none(), username: "opencode" })),
+  Layer.provide(ServerAuth.Config.configLayer({ password: Option.none(), username: "opencode" })),
 )
 const it = testEffect(apiLayer)
 

--- a/packages/opencode/test/server/httpapi-ui.test.ts
+++ b/packages/opencode/test/server/httpapi-ui.test.ts
@@ -44,7 +44,7 @@ const fsUtilLayer = AppNodeBuilder.build(FSUtil.node)
 const it = testEffect(Layer.mergeAll(testStateLayer, fsUtilLayer, RuntimeFlags.layer()))
 
 function authConfigLayer(input?: { password?: string; username?: string }) {
-  return ServerAuth.Config.layer({
+  return ServerAuth.Config.configLayer({
     password: input?.password === undefined ? Option.none() : Option.some(input.password),
     username: input?.username ?? "opencode",
   })

--- a/packages/opencode/test/session/llm-native.test.ts
+++ b/packages/opencode/test/session/llm-native.test.ts
@@ -3,6 +3,7 @@ import { LLMEvent, ToolFailure } from "@opencode-ai/llm"
 import { LLMClient, RequestExecutor, WebSocketExecutor, type LLMClientShape } from "@opencode-ai/llm/route"
 import { jsonSchema, tool, type ModelMessage, type Tool } from "ai"
 import { Effect, Fiber, Layer, Stream } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
 import { LLMNative } from "@/session/llm/native-request"
 import { LLMNativeRuntime } from "@/session/llm/native-runtime"
 import type { Provider } from "@/provider/provider"
@@ -73,7 +74,9 @@ const providerInfo: Provider.Info = {
 }
 
 const it = testEffect(
-  LLMClient.layer.pipe(Layer.provide(Layer.mergeAll(RequestExecutor.defaultLayer, WebSocketExecutor.layer))),
+  LLMClient.layer.pipe(
+    Layer.provide(Layer.mergeAll(RequestExecutor.layer.pipe(Layer.provide(FetchHttpClient.layer)), WebSocketExecutor.layer)),
+  ),
 )
 
 function responsesStream(chunks: unknown[]) {


### PR DESCRIPTION
## Summary
- make remaining core domain implementation layers private
- remove final default layer exports from domain modules
- leave only Observability.layer and sqlite layer(config) factories as approved exceptions

## Testing
- bun typecheck
- bun turbo typecheck (pre-push)

## Stack
1. #34621 refactor(core): route aggregate layers through nodes
2. #34622 refactor(core): remove tool layer exports
3. #34623 refactor(core): remove session layer exports
4. #34624 refactor(core): remove infrastructure layer exports
5. #34625 refactor(core): remove domain layer exports

Previous: #34624
Base: core-infra-layers
Next: none