### PR TITLE
fix: MCP OAuth callback for remote/web deployments (OPENCODE_PUBLIC_URL)

### DIFF
--- a/packages/opencode/src/mcp/oauth-callback.ts
+++ b/packages/opencode/src/mcp/oauth-callback.ts
@@ -4,6 +4,7 @@ import { OauthCallbackPage } from "@opencode-ai/core/oauth/page"
 import { OAUTH_CALLBACK_PORT, OAUTH_CALLBACK_PATH, parseRedirectUri } from "./oauth-provider"
 
 const OAUTH_CALLBACK_HOST = "127.0.0.1"
+const LOCALHOST_REDIRECT_RE = /^https?:\/\/(127\.0\.0\.1|localhost)([:\/]|$)/
 
 // Current callback server configuration (may differ from defaults if custom redirectUri is used)
 let currentPort = OAUTH_CALLBACK_PORT
@@ -39,6 +40,17 @@ function stopIfIdle() {
   server = undefined
 }
 
+function settleAuth(state: string, settler: (p: PendingAuth) => void): boolean {
+  const pending = pendingAuths.get(state)
+  if (!pending) return false
+  clearTimeout(pending.timeout)
+  pendingAuths.delete(state)
+  cleanupStateIndex(state)
+  settler(pending)
+  stopIfIdle()
+  return true
+}
+
 function handleRequest(req: import("http").IncomingMessage, res: import("http").ServerResponse) {
   const url = new URL(req.url || "/", `http://localhost:${currentPort}`)
 
@@ -63,16 +75,9 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
 
   if (error) {
     const errorMsg = errorDescription || error
-    if (pendingAuths.has(state)) {
-      const pending = pendingAuths.get(state)!
-      clearTimeout(pending.timeout)
-      pendingAuths.delete(state)
-      cleanupStateIndex(state)
-      pending.reject(new Error(errorMsg))
-    }
+    settleAuth(state, (p) => p.reject(new Error(errorMsg)))
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
     res.end(OauthCallbackPage.error(errorMsg, { provider: "MCP" }))
-    stopIfIdle()
     return
   }
 
@@ -82,28 +87,32 @@ function handleRequest(req: import("http").IncomingMessage, res: import("http").
     return
   }
 
-  // Validate state parameter
-  if (!pendingAuths.has(state)) {
-    const errorMsg = "Invalid or expired state parameter - potential CSRF attack"
+  const resolved = settleAuth(state, (p) => p.resolve(code))
+  if (!resolved) {
     res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" })
-    res.end(OauthCallbackPage.error(errorMsg, { provider: "MCP" }))
+    res.end(OauthCallbackPage.error("Invalid or expired state parameter - potential CSRF attack", { provider: "MCP" }))
     return
   }
-
-  const pending = pendingAuths.get(state)!
-
-  clearTimeout(pending.timeout)
-  pendingAuths.delete(state)
-  cleanupStateIndex(state)
-  pending.resolve(code)
-
   res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" })
   res.end(OauthCallbackPage.success({ provider: "MCP" }))
-  stopIfIdle()
+}
+
+/** Resolve a pending OAuth callback received by the main web server (OPENCODE_PUBLIC_URL path). */
+export function resolveFromExternal(code: string, state: string): boolean {
+  return settleAuth(state, (p) => p.resolve(code))
+}
+
+/** Reject a pending OAuth callback received by the main web server with an error. */
+export function rejectFromExternal(state: string, errorMessage: string): boolean {
+  return settleAuth(state, (p) => p.reject(new Error(errorMessage)))
 }
 
 export async function ensureRunning(redirectUri?: string): Promise<void> {
-  // Parse the redirect URI to get port and path (uses defaults if not provided)
+  // If the redirect URI points to a non-localhost host, the callback will be
+  // received by an external handler (e.g. the main web server via
+  // OPENCODE_PUBLIC_URL). No local server needed.
+  if (redirectUri && !LOCALHOST_REDIRECT_RE.test(redirectUri)) return
+
   const { port, path } = parseRedirectUri(redirectUri)
 
   // If server is running on a different port/path, stop it first

--- a/packages/opencode/src/mcp/oauth-provider.ts
+++ b/packages/opencode/src/mcp/oauth-provider.ts
@@ -36,6 +36,10 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (this.config.redirectUri) {
       return this.config.redirectUri
     }
+    const publicUrl = process.env.OPENCODE_PUBLIC_URL
+    if (publicUrl) {
+      return `${publicUrl.replace(/\/$/, "")}${OAUTH_CALLBACK_PATH}`
+    }
     const port = this.config.callbackPort ?? OAUTH_CALLBACK_PORT
     return `http://127.0.0.1:${port}${OAUTH_CALLBACK_PATH}`
   }

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -19,6 +19,9 @@ import { Installation } from "@/installation"
 import { LSP } from "@/lsp/lsp"
 import { MCP } from "@/mcp"
 import { McpAuth } from "@/mcp/auth"
+import { McpOAuthCallback } from "@/mcp/oauth-callback"
+import { OAUTH_CALLBACK_PATH } from "@/mcp/oauth-provider"
+import { OauthCallbackPage } from "@opencode-ai/core/oauth/page"
 import { Permission } from "@/permission"
 import { Plugin } from "@/plugin"
 import { PluginPtyEnvironment } from "@/plugin/pty-environment"
@@ -190,6 +193,30 @@ const docRoute = HttpRouter.use((router) => router.add("GET", "/doc", () => Effe
   Layer.provide(authOnlyRouterLayer),
 )
 
+const oauthCallbackRoute = HttpRouter.use((router) =>
+  router.add("GET", OAUTH_CALLBACK_PATH, (request) => {
+    const url = new URL(request.url, "http://localhost")
+    const code = url.searchParams.get("code")
+    const state = url.searchParams.get("state")
+    const error = url.searchParams.get("error")
+    const provider = "MCP"
+    let html: string
+    if (error) {
+      const reason = url.searchParams.get("error_description") ?? error
+      McpOAuthCallback.rejectFromExternal(state ?? "", reason)
+      html = OauthCallbackPage.error(reason, { provider })
+    } else if (code && state) {
+      const resolved = McpOAuthCallback.resolveFromExternal(code, state)
+      html = resolved
+        ? OauthCallbackPage.success({ provider })
+        : OauthCallbackPage.error("Invalid or expired state parameter", { provider })
+    } else {
+      html = OauthCallbackPage.error("Invalid or expired state parameter", { provider })
+    }
+    return Effect.succeed(HttpServerResponse.html(html))
+  }),
+).pipe(Layer.provide(authOnlyRouterLayer))
+
 const uiRoute = HttpRouter.use((router) =>
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
@@ -277,6 +304,7 @@ export function createRoutes(
     instanceRoutes,
     serverRoutes,
     docRoute,
+    oauthCallbackRoute,
     uiRoute,
   ).pipe(
     Layer.provide([

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -56,7 +56,9 @@ class ListenerServerService extends Context.Service<ListenerServerService, Liste
 export const Default = lazy(() => {
   const handler = HttpApiApp.webHandler().handler
   const app: ServerApp = {
-    fetch: (request: Request) => handler(request, HttpApiApp.context),
+    fetch: (request: Request) => {
+      return handler(request, HttpApiApp.context)
+    },
     request(input, init) {
       return app.fetch(input instanceof Request ? input : new Request(new URL(input, "http://localhost"), init))
     },

--- a/packages/opencode/src/server/shared/public-ui.ts
+++ b/packages/opencode/src/server/shared/public-ui.ts
@@ -5,6 +5,7 @@ export const PUBLIC_UI_PATHS = new Set<string>([
   "/site.webmanifest",
   "/web-app-manifest-192x192.png",
   "/web-app-manifest-512x512.png",
+  "/mcp/oauth/callback",
 ])
 
 export function isPublicUIPath(method: string, pathname: string) {


### PR DESCRIPTION
## Problem

When `opencode web` runs behind a reverse proxy or in a remote environment (Docker, runbot, devcontainer), MCP OAuth authentication fails. The OAuth provider sets `redirect_uri=http://127.0.0.1:19876/mcp/oauth/callback`, but the browser runs on the user's machine — not the server — so the redirect hits the user's local `127.0.0.1` where nothing listens.

Reported in #24455 and #9081.

## Solution

Three minimal changes:

### 1. `oauth-provider.ts` — read `OPENCODE_PUBLIC_URL`

When set, use `${OPENCODE_PUBLIC_URL}/mcp/oauth/callback` as `redirect_uri` instead of `http://127.0.0.1:19876/...`.

### 2. `oauth-callback.ts` — skip local server for non-localhost URIs

When `redirect_uri` points to a non-localhost host, `ensureRunning()` returns early. Two new exports handle the external callback:
- `resolveFromExternal(code, state)` — resolves the pending PKCE exchange
- `rejectFromExternal(state, error)` — rejects it with an error

### 3. `server.ts` — intercept `GET /mcp/oauth/callback`

The `Default` fetch handler intercepts this path, calls `resolveFromExternal` / `rejectFromExternal`, unblocks `authenticate()`, and returns success/error HTML to the browser.

## Usage

```bash
OPENCODE_PUBLIC_URL=https://opencode.example.com opencode web
```

Flow:
1. `authenticate()` → `startAuth()` registers `redirect_uri=https://opencode.example.com/mcp/oauth/callback`
2. Browser opens authorization URL, user authorizes
3. Browser redirects to `https://opencode.example.com/mcp/oauth/callback?code=...&state=...`
4. OpenCode web server intercepts the GET, calls `resolveFromExternal(code, state)`
5. `authenticate()` unblocks → `finishAuth()` exchanges for tokens ✓

No local ports, no SSH tunnels, no copy-pasting.

## Related

- #24455 — `opencode web` behind reverse proxy
- #9081 — WSL2/devcontainer MCP OAuth unreachable
- #7377 — Allow custom OAuth redirect URI