### PR TITLE
feat(desktop): make error view draggable

### DIFF
--- a/packages/app/src/pages/error.tsx
+++ b/packages/app/src/pages/error.tsx
@@ -276,7 +276,10 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
   }
 
   return (
-    <div class="relative flex-1 h-screen w-screen min-h-0 flex flex-col items-center justify-center bg-background-base font-sans">
+    <div
+      class="relative flex-1 h-screen w-screen min-h-0 flex flex-col items-center justify-center bg-background-base font-sans"
+      data-tauri-drag-region
+    >
       <div class="w-2/3 max-w-3xl flex flex-col items-center justify-center gap-8">
         <Logo class="w-58.5 opacity-12 shrink-0" />
         <div class="flex flex-col items-center gap-2 text-center">


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the desktop error screen a native drag region so the window can still be moved when the app renders the fatal error view. The shared drag-region CSS already excludes buttons, links, inputs, textareas, selects, and other interactive controls, so error actions and text selection/copy behavior remain usable.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/app`
- Pushed branch successfully; pre-push hook ran `bun turbo typecheck`

### Screenshots / recordings

Not included.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR