### PR TITLE
test(opencode): update help snapshots

### DIFF
--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -76,39 +76,47 @@ Positionals:
   message  message to send                                                     [array] [default: []]
 
 Options:
-  -h, --help                          show help                                            [boolean]
-  -v, --version                       show version number                                  [boolean]
-      --print-logs                    print logs to stderr                                 [boolean]
-      --log-level                     log level [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
-      --pure                          run without external plugins                         [boolean]
-      --command                       the command to run, use message for args              [string]
-  -c, --continue                      continue the last session                            [boolean]
-  -s, --session                       session id to continue                                [string]
-      --fork                          fork the session before continuing (requires --continue or
-                                      --session)                                           [boolean]
-      --share                         share the session                                    [boolean]
-  -m, --model                         model to use in the format of provider/model          [string]
-      --agent                         agent to use                                          [string]
-      --format                        format: default (formatted) or json (raw JSON events)
+  -h, --help                                          show help                            [boolean]
+  -v, --version                                       show version number                  [boolean]
+      --print-logs                                    print logs to stderr                 [boolean]
+      --log-level                                     log level
+                                                [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
+      --pure                                          run without external plugins         [boolean]
+      --command                                       the command to run, use message for args
+                                                                                            [string]
+  -c, --continue                                      continue the last session            [boolean]
+  -s, --session                                       session id to continue                [string]
+      --fork                                          fork the session before continuing (requires
+                                                      --continue or --session)             [boolean]
+      --share                                         share the session                    [boolean]
+  -m, --model                                         model to use in the format of provider/model
+                                                                                            [string]
+      --agent                                         agent to use                          [string]
+      --format                                        format: default (formatted) or json (raw JSON
+                                                      events)
                                           [string] [choices: "default", "json"] [default: "default"]
-  -f, --file                          file(s) to attach to message                           [array]
-      --title                         title for the session (uses truncated prompt if no value
-                                      provided)                                             [string]
-      --attach                        attach to a running opencode server (e.g.,
-                                      http://localhost:4096)                                [string]
-  -p, --password                      basic auth password (defaults to OPENCODE_SERVER_PASSWORD)
+  -f, --file                                          file(s) to attach to message           [array]
+      --title                                         title for the session (uses truncated prompt
+                                                      if no value provided)                 [string]
+      --attach                                        attach to a running opencode server (e.g.,
+                                                      http://localhost:4096)                [string]
+  -p, --password                                      basic auth password (defaults to
+                                                      OPENCODE_SERVER_PASSWORD)             [string]
+  -u, --username                                      basic auth username (defaults to
+                                                      OPENCODE_SERVER_USERNAME or 'opencode')
                                                                                             [string]
-  -u, --username                      basic auth username (defaults to OPENCODE_SERVER_USERNAME or
-                                      'opencode')                                           [string]
-      --dir                           directory to run in, path on remote server if attaching
-                                                                                            [string]
-      --port                          port for the local server (defaults to random port if no value
-                                      provided)                                             [number]
-      --variant                       model variant (provider-specific reasoning effort, e.g., high,
-                                      max, minimal)                                         [string]
-      --thinking                      show thinking blocks                                 [boolean]
-      --dangerously-skip-permissions  auto-approve permissions that are not explicitly denied
-                                      (dangerous!)                        [boolean] [default: false]"
+      --dir                                           directory to run in, path on remote server if
+                                                      attaching                             [string]
+      --port                                          port for the local server (defaults to random
+                                                      port if no value provided)            [number]
+      --variant                                       model variant (provider-specific reasoning
+                                                      effort, e.g., high, max, minimal)     [string]
+      --thinking                                      show thinking blocks                 [boolean]
+  -i, --interactive                                   run in direct interactive split-footer mode
+                                                                          [boolean] [default: false]
+      --auto, --yolo, --dangerously-skip-permissions  auto-approve permissions that are not
+                                                      explicitly denied (dangerous!)
+                                                                          [boolean] [default: false]"
 `;
 
 exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode debug --help 1`] = `


### PR DESCRIPTION
## Summary
- update CLI help snapshots for current top-level help output
- capture the interactive flag and permission aliases in the snapshot

## Testing
- bun test test/cli/help/help-snapshots.test.ts
- bun turbo typecheck