### PR TITLE
fix(auth): validate OPENCODE_AUTH_CONTENT against Auth.Info schema

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -56,10 +56,18 @@ const layer = Layer.effect(
     const decode = Schema.decodeUnknownOption(Info)
 
     const all = Effect.fn("Auth.all")(function* () {
-      if (process.env.OPENCODE_AUTH_CONTENT) {
-        try {
-          return JSON.parse(process.env.OPENCODE_AUTH_CONTENT)
-        } catch (err) {}
+      const env = process.env.OPENCODE_AUTH_CONTENT
+      if (env) {
+        const parsed = yield* Effect.try({
+          try: () => JSON.parse(env),
+          catch: (cause) => new AuthError({ message: "OPENCODE_AUTH_CONTENT is not valid JSON", cause }),
+        })
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return yield* Effect.fail(new AuthError({ message: "OPENCODE_AUTH_CONTENT must be a JSON object" }))
+        }
+        return Record.filterMap(parsed as Record<string, unknown>, (value) =>
+          Result.fromOption(decode(value), () => undefined),
+        )
       }
 
       const data = (yield* fsys.readJson(file).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Effect } from "effect"
-import { Auth } from "../../src/auth"
+import { Cause, Effect, Exit } from "effect"
+import { Auth, AuthError } from "../../src/auth"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(LayerNode.compile(Auth.node))
+
+// Tracks and restores the previous value of OPENCODE_AUTH_CONTENT so a test
+// (or sibling tests) cannot leak state across runs.
+function withAuthContent<A, E, R>(self: Effect.Effect<A, E, R>, value: string | undefined): Effect.Effect<A, E, R> {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = process.env.OPENCODE_AUTH_CONTENT
+      if (value === undefined) delete process.env.OPENCODE_AUTH_CONTENT
+      else process.env.OPENCODE_AUTH_CONTENT = value
+      return previous
+    }),
+    () => self,
+    (previous) =>
+      Effect.sync(() => {
+        if (previous === undefined) delete process.env.OPENCODE_AUTH_CONTENT
+        else process.env.OPENCODE_AUTH_CONTENT = previous
+      }),
+  )
+}
 
 describe("Auth", () => {
   it.instance("set normalizes trailing slashes in keys", () =>
@@ -71,5 +90,108 @@ describe("Auth", () => {
       const after = yield* auth.all()
       expect(after["anthropic"]).toBeUndefined()
     }),
+  )
+
+  // Regression: #34075 — env-var path previously bypassed schema validation
+  // and silently swallowed JSON parse errors, so malformed OPENCODE_AUTH_CONTENT
+  // fell through to file-based auth and invalid entries reached downstream
+  // code that switches on info.type. The fix applies the same
+  // Record.filterMap(decode) validation that the file path already uses, and
+  // surfaces parse errors as AuthError.
+  it.instance("all() returns valid entries from OPENCODE_AUTH_CONTENT (env-var path)", () =>
+    withAuthContent(
+      Effect.gen(function* () {
+        const auth = yield* Auth.Service
+        const env = JSON.stringify({
+          anthropic: { type: "api", key: "sk-test-anthropic" },
+          openai: { type: "wellknown", key: "K", token: "T" },
+        })
+        const data = yield* withAuthContent(auth.all(), env)
+        expect(data["anthropic"]).toEqual({ type: "api", key: "sk-test-anthropic" })
+        expect(data["openai"]).toEqual({ type: "wellknown", key: "K", token: "T" })
+      }),
+      undefined,
+    ),
+  )
+
+  it.instance("all() filters out entries whose type is not a valid Auth.Info schema", () =>
+    withAuthContent(
+      Effect.gen(function* () {
+        const auth = yield* Auth.Service
+        const env = JSON.stringify({
+          good: { type: "api", key: "valid" },
+          bad: { type: "unknown_type", key: "x" },
+          missingType: { key: "no-type" },
+          notAnObject: "string-value",
+          numberValue: 42,
+          nullValue: null,
+        })
+        const data = yield* withAuthContent(auth.all(), env)
+        expect(data["good"]).toEqual({ type: "api", key: "valid" })
+        expect(data["bad"]).toBeUndefined()
+        expect(data["missingType"]).toBeUndefined()
+        expect(data["notAnObject"]).toBeUndefined()
+        expect(data["numberValue"]).toBeUndefined()
+        expect(data["nullValue"]).toBeUndefined()
+      }),
+      undefined,
+    ),
+  )
+
+  it.instance("all() surfaces malformed JSON in OPENCODE_AUTH_CONTENT as AuthError", () =>
+    withAuthContent(
+      Effect.gen(function* () {
+        const auth = yield* Auth.Service
+        const exit = yield* withAuthContent(auth.all(), "{not valid json").pipe(Effect.exit)
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          const squashed = Cause.squash(exit.cause)
+          expect(squashed).toBeInstanceOf(AuthError)
+          expect((squashed as AuthError).message).toMatch(/OPENCODE_AUTH_CONTENT/)
+        }
+      }),
+      undefined,
+    ),
+  )
+
+  it.instance("all() surfaces non-object top-level JSON in OPENCODE_AUTH_CONTENT as AuthError", () =>
+    withAuthContent(
+      Effect.gen(function* () {
+        const auth = yield* Auth.Service
+        // top-level array is valid JSON but cannot be Record<string, Info>
+        const exit = yield* withAuthContent(auth.all(), "[1,2,3]").pipe(Effect.exit)
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          const squashed = Cause.squash(exit.cause)
+          expect(squashed).toBeInstanceOf(AuthError)
+        }
+      }),
+      undefined,
+    ),
+  )
+
+  it.instance("all() preserves file-path behavior when OPENCODE_AUTH_CONTENT is empty", () =>
+    withAuthContent(
+      Effect.gen(function* () {
+        const auth = yield* Auth.Service
+        yield* auth.set("file-only", { type: "api", key: "sk-from-file" })
+        const data = yield* withAuthContent(auth.all(), "")
+        // empty string is falsy → falls through to file path
+        expect(data["file-only"]).toEqual({ type: "api", key: "sk-from-file" })
+      }),
+      undefined,
+    ),
+  )
+
+  it.instance("all() preserves file-path behavior when OPENCODE_AUTH_CONTENT is unset", () =>
+    withAuthContent(
+      Effect.gen(function* () {
+        const auth = yield* Auth.Service
+        yield* auth.set("file-only", { type: "api", key: "sk-from-file" })
+        const data = yield* withAuthContent(auth.all(), undefined)
+        expect(data["file-only"]).toEqual({ type: "api", key: "sk-from-file" })
+      }),
+      undefined,
+    ),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #34075

### Type of change

- [x] Bug fix

### What does this PR do?

In `packages/opencode/src/auth/index.ts` `Auth.all()`, the env-var path of `OPENCODE_AUTH_CONTENT` returned `JSON.parse(...)` directly, bypassing the `Record.filterMap(decode)` schema validation that the file-based path applies. The empty `catch` block silently swallowed JSON parse errors, so a malformed env var fell through to file-based auth even though the user had explicitly set it.

Two consequences:

1. Invalid entries (unknown `type`, missing `type`, non-object values) reached downstream provider code that switches on `info.type` (e.g. `provider/auth.ts:167`).
2. A typo in the env var silently inverted precedence — file auth overrode the user's explicit env var.

The fix:

- Replaces the bare `try/catch` with `Effect.try({ try, catch })` to surface parse errors as `AuthError`.
- Rejects non-object top-level JSON (arrays, primitives, null) with `AuthError`.
- Applies the same `Record.filterMap(decode)` validation that the file path already uses, so invalid entries are silently filtered (matching existing file-path behavior) but parse/type errors surface loudly.

The file-path branch is untouched.

### How did you verify your code works?

```bash
cd packages/opencode
bun typecheck                              # 29 successful, 0 failed
bun test ./test/auth/                      # 10 pass, 0 fail, 24 expect()
bun test ./test/auth/ ./test/provider/header-timeout.test.ts \
         ./test/provider/digitalocean.test.ts \
         ./test/control-plane/ \
         ./test/cli/acp/initialize-auth.test.ts \
         ./test/server/auth.test.ts \
         ./test/mcp/auth.test.ts
                                          # 66 pass, 0 fail, 199 expect()
```

The 6 new regression tests in `test/auth/auth.test.ts` reproduce both bugs against the unmodified code (3 of 6 fail before the fix), and verify that empty/unset env vars still fall through to the file path. The cross-cluster run covers every other consumer of `Auth` (provider, control-plane, server, MCP, CLI/ACP) and confirms no regressions.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR