### PR TITLE
refactor: remove remaining default layer aliases

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,7 +25,7 @@ const Handlers = Runtime.handlers(Commands, {
 })
 
 Runtime.run(Commands, Handlers, { version: "local" }).pipe(
-  Effect.provide(Daemon.defaultLayer),
+  Effect.provide(Daemon.layer),
   Effect.provide(NodeServices.layer),
   Effect.scoped,
   NodeRuntime.runMain,

--- a/packages/cli/src/services/daemon.ts
+++ b/packages/cli/src/services/daemon.ts
@@ -189,6 +189,4 @@ export const layer = Layer.effect(
   }),
 )
 
-export const defaultLayer = layer
-
 export * as Daemon from "./daemon"

--- a/packages/llm/example/tutorial.ts
+++ b/packages/llm/example/tutorial.ts
@@ -238,7 +238,7 @@ const inspectFakeProvider = Effect.gen(function* () {
 // Provide the LLM runtime and the HTTP request executor once. Keep one path
 // enabled at a time so the tutorial can demonstrate generate, prepare, stream,
 // or tool-loop behavior without spending tokens on every example.
-const requestExecutorLayer = RequestExecutor.defaultLayer
+const requestExecutorLayer = RequestExecutor.fetchLayer
 const llmDeps = Layer.mergeAll(requestExecutorLayer, WebSocketExecutor.layer)
 const llmClientLayer = LLMClient.layer.pipe(Layer.provide(llmDeps))
 

--- a/packages/llm/src/route/executor.ts
+++ b/packages/llm/src/route/executor.ts
@@ -380,6 +380,6 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient> = Layer.e
   }),
 )
 
-export const defaultLayer = layer.pipe(Layer.provide(FetchHttpClient.layer))
+export const fetchLayer = layer.pipe(Layer.provide(FetchHttpClient.layer))
 
 export * as RequestExecutor from "./executor"

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -18,11 +18,11 @@ export type Info = {
 }
 
 export class Config extends Context.Service<Config, Info>()("@opencode/ServerAuthConfig") {
-  static layer(input: Info) {
+  static configLayer(input: Info) {
     return Layer.succeed(this, this.of(input))
   }
 
-  static get defaultLayer() {
+  static get layer() {
     return Layer.effect(
       this,
       Effect.gen(function* () {

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -39,13 +39,13 @@ const applicationServices = LayerNode.group([
 export function createRoutes(password?: string) {
   return makeRoutes(
     password
-      ? ServerAuth.Config.layer({ username: "opencode", password: Option.some(password) })
-      : ServerAuth.Config.defaultLayer,
+      ? ServerAuth.Config.configLayer({ username: "opencode", password: Option.some(password) })
+      : ServerAuth.Config.layer,
   )
 }
 
 export function createEmbeddedRoutes() {
-  return makeRoutes(ServerAuth.Config.layer({ username: "opencode", password: Option.none() }))
+  return makeRoutes(ServerAuth.Config.configLayer({ username: "opencode", password: Option.none() }))
 }
 
 function makeRoutes<AuthError, AuthServices>(auth: Layer.Layer<ServerAuth.Config, AuthError, AuthServices>) {


### PR DESCRIPTION
## Summary
- remove the remaining repo-wide `defaultLayer` aliases/usages outside the core/opencode cleanup
- rename server auth config helpers to `layer` / `configLayer` to match opencode config helpers
- use explicit request executor HTTP composition in the LLM tutorial

## Testing
- `bun typecheck`

Stacked on #34625.