### PR TITLE
fix(core): load scoped instructions from read

### DIFF
--- a/packages/core/src/instruction-context.ts
+++ b/packages/core/src/instruction-context.ts
@@ -1,7 +1,7 @@
 export * as InstructionContext from "./instruction-context"
 
-import { Array, Effect, Layer, Schema } from "effect"
-import { isAbsolute, join, relative, sep } from "path"
+import { Array, Context, Effect, Layer, Schema } from "effect"
+import { dirname, isAbsolute, join, relative, sep } from "path"
 import { FSUtil } from "./fs-util"
 import { Flag } from "./flag/flag"
 import { Global } from "./global"
@@ -11,22 +11,36 @@ import { SystemContext } from "./system-context/index"
 import { SystemContextRegistry } from "./system-context/registry"
 import { makeLocationNode } from "./effect/app-node"
 
-class File extends Schema.Class<File>("InstructionContext.File")({
+export class InstructionFile extends Schema.Class<InstructionFile>("InstructionContext.File")({
   path: AbsolutePath,
   content: Schema.String,
 }) {}
 
-const Files = Schema.Array(File)
+const Files = Schema.Array(InstructionFile)
 const key = SystemContext.Key.make("core/instructions")
+const targets = ["AGENTS.md"]
 
-const layer = Layer.effectDiscard(
+export interface Interface {
+  readonly load: () => Effect.Effect<SystemContext.SystemContext>
+  readonly resolveForPath: (input: {
+    readonly path: AbsolutePath
+    readonly kind: "file" | "directory"
+    readonly sessionID: string
+  }) => Effect.Effect<readonly InstructionFile[], FSUtil.Error>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/InstructionContext") {}
+
+const serviceLayer = Layer.effect(
+  Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
     const global = yield* Global.Service
     const location = yield* Location.Service
-    const registry = yield* SystemContextRegistry.Service
+    // ponytail: process-local dedupe; move to durable session context when scoped instructions leave the read tool.
+    const claims = new Map<string, Set<string>>()
 
-    const source = (value: ReadonlyArray<File> | SystemContext.Unavailable) =>
+    const source = (value: ReadonlyArray<InstructionFile> | SystemContext.Unavailable) =>
       SystemContext.make({
         key,
         codec: Schema.toCodecJson(Files),
@@ -37,23 +51,23 @@ const layer = Layer.effectDiscard(
         removed: () => "Previously loaded instructions no longer apply.",
       })
 
-    const observe = Effect.fn("InstructionContext.observe")(function* () {
+    const ambientPaths = Effect.fn("InstructionContext.ambientPaths")(function* () {
       const start = FSUtil.resolve(location.directory)
       const stop = FSUtil.resolve(location.project.directory)
-      const fromProject = relative(stop, start)
-      const insideProject =
-        fromProject === "" || (fromProject !== ".." && !fromProject.startsWith(`..${sep}`) && !isAbsolute(fromProject))
       const discovered = new Set(
-        (Flag.OPENCODE_DISABLE_PROJECT_CONFIG || !insideProject
+        (Flag.OPENCODE_DISABLE_PROJECT_CONFIG || !insideProject(start, stop)
           ? []
           : yield* fs.up({
-              targets: ["AGENTS.md"],
+              targets,
               start,
               stop,
             })
         ).map(FSUtil.resolve),
       )
-      const paths = Array.dedupe([FSUtil.resolve(join(global.config, "AGENTS.md")), ...discovered])
+      return Array.dedupe([FSUtil.resolve(join(global.config, "AGENTS.md")), ...discovered])
+    })
+
+    const readFiles = Effect.fn("InstructionContext.readFiles")(function* (paths: readonly string[]) {
       const files = yield* Effect.forEach(
         paths,
         (path) =>
@@ -61,19 +75,25 @@ const layer = Layer.effectDiscard(
             .readFileStringSafe(path)
             .pipe(
               Effect.map((content) =>
-                content === undefined ? undefined : new File({ path: AbsolutePath.make(path), content }),
+                content === undefined ? undefined : new InstructionFile({ path: AbsolutePath.make(path), content }),
               ),
             ),
         { concurrency: "unbounded" },
       )
-      if (files.some((file, index) => file === undefined && discovered.has(paths[index])))
-        return SystemContext.unavailable
-      return files.filter((file): file is File => file !== undefined)
+      return files
     })
 
-    yield* registry.register({
-      key,
-      load: observe().pipe(
+    const observe = Effect.fn("InstructionContext.observe")(function* () {
+      const paths = yield* ambientPaths()
+      const discovered = new Set(paths.filter((path) => path !== FSUtil.resolve(join(global.config, "AGENTS.md"))))
+      const files = yield* readFiles(paths)
+      if (files.some((file, index) => file === undefined && discovered.has(paths[index])))
+        return SystemContext.unavailable
+      return files.filter((file): file is InstructionFile => file !== undefined)
+    })
+
+    const load = Effect.fn("InstructionContext.load")(function* () {
+      return yield* observe().pipe(
         Effect.map((files) =>
           files === SystemContext.unavailable
             ? source(files)
@@ -83,10 +103,49 @@ const layer = Layer.effectDiscard(
         ),
         Effect.catch(() => Effect.succeed(source(SystemContext.unavailable))),
         Effect.catchDefect(() => Effect.succeed(source(SystemContext.unavailable))),
-      ),
+      )
+    })
+
+    const resolveForPath = Effect.fn("InstructionContext.resolveForPath")(function* (input: {
+      readonly path: AbsolutePath
+      readonly kind: "file" | "directory"
+      readonly sessionID: string
+    }) {
+      if (Flag.OPENCODE_DISABLE_PROJECT_CONFIG) return []
+      const target = FSUtil.resolve(input.path)
+      const start = input.kind === "directory" ? target : dirname(target)
+      const stop = FSUtil.resolve(location.project.directory)
+      if (!insideProject(start, stop)) return []
+
+      const ambient = new Set(yield* ambientPaths())
+      const paths = Array.dedupe((yield* fs.up({ targets, start, stop })).map(FSUtil.resolve)).filter(
+        (path) => path !== target && !ambient.has(path),
+      )
+      const delivered = claims.get(input.sessionID) ?? new Set<string>()
+      claims.set(input.sessionID, delivered)
+      const fresh = paths.filter((path) => !delivered.has(path))
+      const files = (yield* readFiles(fresh)).filter((file): file is InstructionFile => file !== undefined)
+      for (const file of files) delivered.add(file.path)
+      return files
+    })
+
+    return Service.of({ load, resolveForPath })
+  }),
+)
+
+const registrationLayer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const registry = yield* SystemContextRegistry.Service
+    const service = yield* Service
+
+    yield* registry.register({
+      key,
+      load: service.load(),
     })
   }),
 )
+
+export const layer = registrationLayer.pipe(Layer.provideMerge(serviceLayer))
 
 export const node = makeLocationNode({
   name: "instruction-context",
@@ -94,6 +153,11 @@ export const node = makeLocationNode({
   deps: [FSUtil.node, Global.node, Location.node, SystemContextRegistry.node],
 })
 
-function render(files: ReadonlyArray<File>) {
+function render(files: ReadonlyArray<InstructionFile>) {
   return files.map((file) => `Instructions from: ${file.path}\n${file.content}`).join("\n\n")
+}
+
+function insideProject(start: string, stop: string) {
+  const fromProject = relative(stop, start)
+  return fromProject === "" || (fromProject !== ".." && !fromProject.startsWith(`..${sep}`) && !isAbsolute(fromProject))
 }

--- a/packages/core/src/tool/read.ts
+++ b/packages/core/src/tool/read.ts
@@ -5,6 +5,7 @@ import { Effect, Layer, Schema } from "effect"
 import { makeLocationNode } from "../effect/app-node"
 import { FileSystem } from "../filesystem"
 import { Image } from "../image"
+import { InstructionContext } from "../instruction-context"
 import { LocationMutation } from "../location-mutation"
 import { PermissionV2 } from "../permission"
 import { AbsolutePath } from "../schema"
@@ -33,7 +34,43 @@ const layer = Layer.effectDiscard(
     const reader = yield* ReadToolFileSystem.Service
     const mutation = yield* LocationMutation.Service
     const image = yield* Image.Service
+    const instructions = yield* InstructionContext.Service
     const permission = yield* PermissionV2.Service
+
+    const imageOutput = (input: Schema.Schema.Type<typeof Input>, output: typeof Output.Encoded): Tool.Content[] => {
+      if (!("encoding" in output) || output.encoding !== "base64" || !SUPPORTED_IMAGE_MIMES.has(output.mime)) return []
+      return [
+        { type: "text", text: "Image read successfully" },
+        { type: "file", data: output.content, mime: output.mime, name: input.path },
+      ]
+    }
+
+    const textOutput = (output: typeof Output.Encoded) => {
+      return JSON.stringify(output)
+    }
+
+    const modelOutput = Effect.fn("ReadTool.modelOutput")(function* (
+      input: Schema.Schema.Type<typeof Input>,
+      output: typeof Output.Encoded,
+      context: Tool.Context,
+    ) {
+      const media = imageOutput(input, output)
+      const target = yield* mutation.resolve({ path: input.path, kind: "directory" }).pipe(Effect.catch(() => Effect.void))
+      if (!target) return media
+
+      const loaded = yield* instructions
+        .resolveForPath({
+          path: AbsolutePath.make(target.canonical),
+          kind: "entries" in output ? "directory" : "file",
+          sessionID: context.sessionID,
+        })
+        .pipe(Effect.catch(() => Effect.succeed([])))
+      if (loaded.length === 0) return media
+
+      const reminder = `<system-reminder>\n${loaded.map((file) => `Instructions from: ${file.path}\n${file.content}`).join("\n\n")}\n</system-reminder>`
+      if (media.length > 0) return [{ type: "text" as const, text: reminder }, ...media]
+      return [{ type: "text" as const, text: `${reminder}\n\n${textOutput(output)}` }]
+    })
 
     yield* tools
       .register({
@@ -42,14 +79,7 @@ const layer = Layer.effectDiscard(
             "Read a text file or supported image, page through a large UTF-8 text file by line offset, or list a directory page. Relative paths resolve from the current location; absolute paths inside it are accepted, while external absolute paths require external_directory approval.",
           input: Input,
           output: Output,
-          toModelOutput: ({ input, output }) => {
-            if (!("encoding" in output) || output.encoding !== "base64" || !SUPPORTED_IMAGE_MIMES.has(output.mime))
-              return []
-            return [
-              { type: "text", text: "Image read successfully" },
-              { type: "file", data: output.content, mime: output.mime, name: input.path },
-            ]
-          },
+          toModelOutputEffect: ({ input, output, context }) => modelOutput(input, output, context),
           execute: (input, context) => {
             return Effect.gen(function* () {
               const source = {
@@ -113,5 +143,12 @@ const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "tool/read",
   layer,
-  deps: [ToolRegistry.node, ReadToolFileSystem.node, LocationMutation.node, Image.node, PermissionV2.node],
+  deps: [
+    ToolRegistry.node,
+    ReadToolFileSystem.node,
+    LocationMutation.node,
+    Image.node,
+    InstructionContext.node,
+    PermissionV2.node,
+  ],
 })

--- a/packages/core/src/tool/tool.ts
+++ b/packages/core/src/tool/tool.ts
@@ -58,6 +58,11 @@ type Config<
     readonly input: Schema.Schema.Type<Input>
     readonly output: Output["Encoded"]
   }) => ReadonlyArray<Content>
+  readonly toModelOutputEffect?: (input: {
+    readonly input: Schema.Schema.Type<Input>
+    readonly output: Output["Encoded"]
+    readonly context: Context
+  }) => Effect.Effect<ReadonlyArray<Content>, ToolFailure>
 }
 
 type Runtime = {
@@ -110,20 +115,30 @@ export function make<
                 ),
               ),
             ),
-            Effect.map(({ output, structured }) => ({
-              structured,
-              content:
-                config.toModelOutput?.({ input, output }).map((part) =>
-                  part.type === "text"
-                    ? { type: "text" as const, text: part.text }
-                    : {
-                        type: "file" as const,
-                        uri: `data:${part.mime};base64,${part.data}`,
-                        mime: part.mime,
-                        name: part.name,
-                      },
-                ) ?? (typeof output === "string" ? [{ type: "text" as const, text: output }] : []),
-            })),
+            Effect.flatMap(({ output, structured }) =>
+              (config.toModelOutputEffect
+                ? config.toModelOutputEffect({ input, output, context })
+                : Effect.succeed(config.toModelOutput?.({ input, output }) ?? [])).pipe(
+                Effect.map((content) => ({
+                  structured,
+                  content:
+                    content.length > 0
+                      ? content.map((part) =>
+                          part.type === "text"
+                            ? { type: "text" as const, text: part.text }
+                            : {
+                                type: "file" as const,
+                                uri: `data:${part.mime};base64,${part.data}`,
+                                mime: part.mime,
+                                name: part.name,
+                              },
+                        )
+                      : typeof output === "string"
+                        ? [{ type: "text" as const, text: output }]
+                        : [],
+                })),
+              ),
+            ),
           ),
         ),
       ),

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { Effect, Exit, Layer, PlatformError } from "effect"
 import { Config } from "@opencode-ai/core/config"
@@ -194,6 +195,44 @@ describe("ReadTool", () => {
         },
       ])
     }),
+  )
+
+  it.effect("includes scoped AGENTS.md instructions in model-visible read output", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => fs.mkdtemp(path.join(process.cwd(), ".tmp-read-instructions-"))),
+      (dir) => Effect.promise(() => fs.rm(dir, { recursive: true, force: true })),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const file = path.join(dir, "subdir", "nested", "file.ts")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(path.dirname(file), { recursive: true })
+            await fs.writeFile(path.join(dir, "subdir", "AGENTS.md"), "Use subdir rules.")
+          })
+          const registry = yield* ToolRegistry.Service
+
+          const settled = yield* settleTool(registry, {
+            sessionID,
+            ...toolIdentity,
+            call: {
+              type: "tool-call",
+              id: "call-read-scoped-instructions",
+              name: "read",
+              input: { path: path.relative(process.cwd(), file) },
+            },
+          })
+
+          expect(settled.output?.structured).toEqual(readResult)
+          const content = settled.output?.content[0]
+          expect(content?.type).toBe("text")
+          if (content?.type !== "text") return
+          expect(content.text.startsWith("<system-reminder>")).toBe(true)
+          expect(content.text).toContain(
+            `<system-reminder>\nInstructions from: ${path.join(dir, "subdir", "AGENTS.md")}\nUse subdir rules.\n</system-reminder>`,
+          )
+        }),
+      ),
+    ),
   )
 
   it.effect("asks for external_directory approval before reading an external absolute path", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #34341

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V2 read tools now resolve newly applicable nested `AGENTS.md` files for the path being read and prepend those instructions to the model-visible tool output as a system reminder.

The structured read result stays unchanged. Delivered instruction files are deduped per session so repeated reads do not keep re-sending the same file.

### How did you verify your code works?

- `cd packages/core && bun test test/tool-read.test.ts --timeout 30000`
- `cd packages/core && bun test test/instruction-context.test.ts --timeout 30000`
- `cd packages/core && bun test test/tool-webfetch.test.ts test/tool-write.test.ts test/tool-bash.test.ts --timeout 30000`
- `cd packages/core && bun typecheck`

### Screenshots / recordings

Not applicable; this change has no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
