### PR TITLE
docs(ecosystem): add Loop Engineering to Projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -62,6 +62,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | Name                                                                                       | Description                                                      |
 | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
 | [kimaki](https://github.com/remorses/kimaki)                                               | Discord bot to control OpenCode sessions, built on the SDK       |
+| [Loop Engineering](https://github.com/cobusgreyling/loop-engineering)                      | Production loop patterns for headless `opencode run` + cron — daily triage, PR babysitter, CI sweeper; `loop-init --tool opencode` + Loop Ready score |
 | [opencode.nvim](https://github.com/NickvanDyke/opencode.nvim)                              | Neovim plugin for editor-aware prompts, built on the API         |
 | [portal](https://github.com/hosenur/portal)                                                | Mobile-first web UI for OpenCode over Tailscale/VPN              |
 | [opencode plugin template](https://github.com/zenobi-us/opencode-plugin-template/)         | Template for building OpenCode plugins                           |


### PR DESCRIPTION
## Summary

Adds [Loop Engineering](https://github.com/cobusgreyling/loop-engineering) to the **Projects** table on the [Ecosystem](https://opencode.ai/docs/ecosystem/) docs page.

Loop Engineering is a tool-agnostic reference for **production agent loops** — scheduling, triage, `STATE.md`, worktree isolation, maker/checker verifier split, and a Loop Ready score (`loop-audit`).

### Why it fits OpenCode users

Many OpenCode users run **headless** via `opencode run` + cron/systemd (complements plugins like `opencode-scheduler`). Loop Engineering documents that shape explicitly for OpenCode:

- Starter: `npx @cobusgreyling/loop-init . --pattern daily-triage --tool opencode`
- Examples: https://github.com/cobusgreyling/loop-engineering/tree/main/examples/opencode
- Community PR: https://github.com/cobusgreyling/loop-engineering/pull/98 (@ulises-jeremias)

### Quick start (copy-paste)

```bash
npx @cobusgreyling/loop-init . --pattern daily-triage --tool opencode
opencode run "Run loop-triage. Read STATE.md first. No auto-fix in week one." --agent loop-triage
npx @cobusgreyling/loop-audit . --badge
```

Happy to shorten the description line if you prefer a tighter table entry.

---

*Submitted per the ecosystem page note: "Want to add your OpenCode related project to this list? Submit a PR."*