### PR TITLE
fix(llm): suppress lone `</think>` chunk at reasoning→tool boundary

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -421,7 +421,17 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
 
     if (delta?.content) {
       lifecycle = Lifecycle.reasoningEnd(lifecycle, events, "reasoning-0")
-      lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
+      // Suppress a lone closing reasoning marker (</think> / </thinking>) at the
+      // reasoning→tool boundary — some OpenAI-compatible proxies (OmniRoute +
+      // Kimi Coding) emit it as a separate content chunk between
+      // reasoning_content and tool_calls. Treat it as a reasoning boundary
+      // artifact, not user-visible assistant text. Only suppresses when
+      // reasoning is currently active; outside that boundary the marker is
+      // ordinary text and must be preserved. See #34126.
+      const isLoneClosingMarker = /^\s*<\/(?:think|thinking)>\s*$/.test(delta.content)
+      if (!(isLoneClosingMarker && state.lifecycle.reasoning.has("reasoning-0"))) {
+        lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
+      }
     }
 
     if (toolDeltas.length) lifecycle = Lifecycle.reasoningEnd(lifecycle, events, "reasoning-0")

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -552,6 +552,126 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  // Regression: #34126 — a standalone `</think>` chunk that some
+  // OpenAI-compatible proxies (OmniRoute + Kimi Coding) emit at the
+  // reasoning→tool boundary must not become persisted assistant text.
+  // Currently the parser emits a `text-delta` for any `delta.content`,
+  // including the lone closing marker, which downstream `processor.ts`
+  // turns into a regular text part and `message-v2.ts` replays into the
+  // next request.
+  it.effect("drops standalone `</think>` chunk emitted between reasoning and tool_calls", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        { choices: [{ delta: { reasoning_content: "thinking" }, finish_reason: null }] },
+        { choices: [{ delta: { content: "</think>" }, finish_reason: null }] },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_1",
+                    type: "function",
+                    function: { name: "lookup", arguments: '{"query":"weather"}' },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        { choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+      )
+
+      const response = yield* LLMClient.generate(
+        LLM.updateRequest(request, {
+          tools: [{ name: "lookup", description: "Lookup data", inputSchema: { type: "object" } }],
+        }),
+      ).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.reasoning).toBe("thinking")
+      expect(response.text).toBe("")
+      expect(response.toolCalls).toHaveLength(1)
+      expect(response.toolCalls[0]?.name).toBe("lookup")
+      // No text-delta should be emitted for the dropped closing marker.
+      expect(response.events.filter(LLMEvent.is.textDelta)).toEqual([])
+    }),
+  )
+
+  it.effect("drops standalone `</thinking>` chunk between reasoning and tool_calls", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        { choices: [{ delta: { reasoning_content: "thinking" }, finish_reason: null }] },
+        { choices: [{ delta: { content: "</thinking>" }, finish_reason: null }] },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_1",
+                    type: "function",
+                    function: { name: "lookup", arguments: "{}" },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        { choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+      )
+
+      const response = yield* LLMClient.generate(
+        LLM.updateRequest(request, {
+          tools: [{ name: "lookup", description: "Lookup data", inputSchema: { type: "object" } }],
+        }),
+      ).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.reasoning).toBe("thinking")
+      expect(response.text).toBe("")
+      expect(response.toolCalls).toHaveLength(1)
+    }),
+  )
+
+  it.effect("preserves `</think>` as ordinary text when reasoning was never active", () =>
+    Effect.gen(function* () {
+      // Defensive: if `</think>` appears without preceding reasoning_content
+      // it must remain user-visible text (e.g. model literally wrote it as
+      // a tag, or it's part of a larger string).
+      const body = sseEvents(
+        deltaChunk({ role: "assistant", content: "before " }),
+        deltaChunk({ content: "</think>" }),
+        deltaChunk({}, "stop"),
+      )
+
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.text).toBe("before </think>")
+      expect(response.reasoning).toBe("")
+    }),
+  )
+
+  it.effect("preserves `</think>` embedded in larger content even after reasoning", () =>
+    Effect.gen(function* () {
+      // `</think>` is a CLOSING marker, but only when it's a *lone*
+      // boundary marker. If it appears inside a larger content string,
+      // it must be preserved.
+      const body = sseEvents(
+        { choices: [{ delta: { reasoning_content: "thinking" }, finish_reason: null }] },
+        { choices: [{ delta: { content: "ok here's the answer </think> done" }, finish_reason: null }] },
+        { choices: [{ delta: {}, finish_reason: "stop" }] },
+      )
+
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.reasoning).toBe("thinking")
+      expect(response.text).toBe("ok here's the answer </think> done")
+    }),
+  )
+
   it.effect("assembles streamed tool call input", () =>
     Effect.gen(function* () {
       const body = sseEvents(


### PR DESCRIPTION
### Issue for this PR

Closes #34126

### Type of change

- [x] Bug fix

### What does this PR do?

In `packages/llm/src/protocols/openai-chat.ts` `step()`, the parser emitted a `text-delta` event unconditionally for any `delta.content`, including a lone closing reasoning marker (`</think>` / `</thinking>`) emitted as a separate content chunk between `reasoning_content` and `tool_calls`. Some OpenAI-compatible proxies (OmniRoute + Kimi Coding in the reporter's repro) produce this stream shape, and the stray text-delta was then persisted as a normal text part by `session/processor.ts` and replayed into the next model request.

The fix adds a narrow conditional: when `delta.content` is exactly a lone closing marker (allowing surrounding whitespace) AND a reasoning block is currently active, skip the `text-delta` emission while still emitting `reasoningEnd`. This is precisely the boundary-only behavior your second comment proposed — narrower than #11439 and unrelated to #19548.

`/^\s*<\/(?:think|thinking)>\s*$/` matches both `</think>` and `</thinking>` but does NOT match the marker embedded in larger content like `"ok here's the answer </think> done"`. The `state.lifecycle.reasoning.has("reasoning-0")` guard ensures the suppression only fires in the actual reasoning→tool transition; `</think>` written as ordinary text without preceding reasoning remains user-visible.

### Coverage

The fix is local to `openai-chat.ts` `step()`, but transitively covers:

- `openai-compatible-chat.ts` — reuses `OpenAIChat.protocol` end-to-end → covers DeepSeek, Groq, Cerebras, Fireworks, Baseten, DeepInfra, TogetherAI, xAI, Zhipu/ZAI, MiniMax, OmniRoute
- `openrouter.ts` — does `stream: OpenAIChat.protocol.stream` (reuses the entire streaming state machine) → covers GLM-5.2 and other models proxied through OpenRouter

Other parsers (`openai-responses`, `anthropic-messages`, `bedrock-converse`, `gemini`) are structurally immune because their API contracts separate reasoning from text at the event-type or field-name level, not by interleaving both fields in a single delta.

### How did you verify your code works?

```bash
cd packages/llm
bun test ./test/provider/openai-chat.test.ts
# 31 pass, 0 fail, 53 expect() calls

bun test ./test/
# 300 pass, 30 skip, 0 fail, 674 expect() calls across 29 test files
```

`bun typecheck` (workspace-wide via turbo): 29/29 packages successful.

Four new tests in `test/provider/openai-chat.test.ts`:

| # | Test | Status |
|---|------|--------|
| 1 | drops standalone `</think>` chunk emitted between reasoning and tool_calls | TDD: failed before fix (`Expected: "", Received: "</think>"`), passes after |
| 2 | drops standalone `</thinking>` chunk between reasoning and tool_calls | TDD: failed before fix (`Expected: "", Received: "</thinking>"`), passes after |
| 3 | preserves `</think>` as ordinary text when reasoning was never active | No-regression — passes before AND after fix |
| 4 | preserves `</think>` embedded in larger content even after reasoning | No-regression — passes before AND after fix |

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR