### PR TITLE
feat(app,tui): slash picker on any line and multi-command prompts

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1064,7 +1064,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     if (!shellMode) {
       const atMatch = rawText.substring(0, cursorPosition).match(/@(\S*)$/)
-      const slashMatch = rawText.match(/^\/(\S*)$/)
+      // Match `/` at the start of any line (not mid-line, to avoid false-triggering on file paths)
+      const slashMatch = rawText.substring(0, cursorPosition).match(/(?:^|\n)\/(\S*)$/)
 
       if (atMatch) {
         atOnInput(atMatch[1])

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -800,10 +800,33 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     const images = imageAttachments()
 
     if (cmd.type === "custom") {
-      const text = `/${cmd.trigger} `
-      setEditorText(text)
-      prompt.set([{ type: "text", content: text, start: 0, end: text.length }, ...images], text.length)
-      focusEditorEnd()
+      const replacement = `/${cmd.trigger} `
+      const triggerOffset = store.slashTriggerOffset
+      const cursorOffset = getCursorPosition(editorRef)
+
+      // If the slash was at position 0 and there is nothing else in the editor,
+      // use the fast path that replaces the whole content.
+      if (triggerOffset === 0 && promptLength(prompt.current().filter((p) => p.type !== "image")) === cursorOffset) {
+        setEditorText(replacement)
+        prompt.set([{ type: "text", content: replacement, start: 0, end: replacement.length }, ...images], replacement.length)
+        focusEditorEnd()
+        return
+      }
+
+      // Multi-command path: replace only the `/filter` token on this line,
+      // keeping any other content (previous lines / commands) intact.
+      const rawParts = prompt.current()
+      const fullText = rawParts.map((p) => ("content" in p ? p.content : "")).join("")
+      const before = fullText.slice(0, triggerOffset)
+      const after = fullText.slice(cursorOffset) // skip the partial filter the user typed
+      const newText = before + replacement + after
+      setEditorText(newText)
+      const newCursor = before.length + replacement.length
+      prompt.set([{ type: "text", content: newText, start: 0, end: newText.length }, ...images], newCursor)
+      requestAnimationFrame(() => {
+        editorRef.focus()
+        setCursorPosition(editorRef, newCursor)
+      })
       return
     }
 
@@ -1071,6 +1094,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
         atOnInput(atMatch[1])
         setStore("popover", "at")
       } else if (slashMatch) {
+        // Compute the character offset of the `/` within rawText so handleSlashSelect
+        // can replace only that token rather than the whole editor content.
+        const matchStart = slashMatch.index ?? 0
+        const slashOffset = matchStart + (slashMatch[0].startsWith("\n") ? 1 : 0)
+        setStore("slashTriggerOffset", slashOffset)
         slashOnInput(slashMatch[1])
         setStore("popover", "slash")
       } else {

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -457,6 +457,56 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       return
     }
 
+    // Multi-command: if every non-empty line starts with a known slash command,
+    // fire them sequentially rather than treating the text as a plain prompt.
+    const lines = text.split("\n").map((l) => l.trim()).filter(Boolean)
+    const commandLines = lines.filter((l) => l.startsWith("/"))
+    const isAllCommands = lines.length > 0 && commandLines.length === lines.length
+
+    if (isAllCommands) {
+      const knownCommands = commandLines.map((line) => {
+        const [head, ...rest] = line.split(" ")
+        const name = head.slice(1)
+        const cmd = sync().data.command.find((c) => c.name === name)
+        return cmd ? { name, args: rest.join(" "), cmd } : null
+      })
+
+      // Only proceed if every line resolved to a known command
+      if (knownCommands.every(Boolean)) {
+        clearInput()
+        const fireSequentially = async (index: number): Promise<void> => {
+          if (index >= knownCommands.length) return
+          const item = knownCommands[index]!
+          await client.session.command({
+            sessionID: session.id,
+            command: item.name,
+            arguments: item.args,
+            agent,
+            model: `${model.providerID}/${model.modelID}`,
+            variant,
+            parts: images.map((attachment) => ({
+              id: Identifier.ascending("part"),
+              type: "file" as const,
+              mime: attachment.mime,
+              url: attachment.dataUrl,
+              filename: attachment.filename,
+            })),
+          })
+          await fireSequentially(index + 1)
+        }
+        fireSequentially(0).catch((err) => {
+          showToast({
+            title: language.t("prompt.toast.commandSendFailed.title"),
+            description: formatServerError(err, language.t, language.t("common.requestFailed")),
+          })
+          restoreInput()
+        })
+        return
+      }
+    }
+
+    // Single-command fast path (kept for backward compat and the case where
+    // the line is a command mixed with other non-command text).
     if (text.startsWith("/")) {
       const [cmdName, ...args] = text.split(" ")
       const commandName = cmdName.slice(1)

--- a/packages/app/src/components/prompt-input/transient-state.ts
+++ b/packages/app/src/components/prompt-input/transient-state.ts
@@ -4,6 +4,10 @@ import type { PromptHistoryEntry } from "./history"
 
 export type PromptInputTransientState = {
   popover: "at" | "slash" | null
+  // Offset of the `/` character that opened the slash picker, within the raw editor text.
+  // Used by handleSlashSelect to replace only the typed `/filter` with the chosen command
+  // instead of nuking the entire editor — required for multi-command prompts.
+  slashTriggerOffset: number
   historyIndex: number
   savedPrompt: PromptHistoryEntry | null
   placeholder: number
@@ -16,6 +20,7 @@ export type PromptInputTransientState = {
 function resetPromptInputTransientState(setStore: SetStoreFunction<PromptInputTransientState>) {
   setStore({
     popover: null,
+    slashTriggerOffset: 0,
     historyIndex: -1,
     savedPrompt: null,
     draggingType: null,
@@ -28,6 +33,7 @@ function resetPromptInputTransientState(setStore: SetStoreFunction<PromptInputTr
 export function createPromptInputTransientState(identity: Accessor<unknown>, placeholder: number) {
   const [store, setStore] = createStore<PromptInputTransientState>({
     popover: null,
+    slashTriggerOffset: 0,
     historyIndex: -1,
     savedPrompt: null,
     placeholder,

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -680,8 +680,8 @@ export function Autocomplete(props: {
             props.input().cursorOffset <= store.index ||
             // There is a space between the trigger and the cursor
             props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/) ||
-            // "/<command>" is not the sole content
-            (store.visible === "/" && value.match(/^\S+\s+\S+\s*$/))
+            // "/<command> <arg>" — user has finished selecting a command and started typing args
+            (store.visible === "/" && value.slice(store.index).match(/^\S+\s+\S+/))
           ) {
             hide()
           }
@@ -692,10 +692,14 @@ export function Autocomplete(props: {
         const offset = props.input().cursorOffset
         if (offset === 0) return
 
-        // Check for "/" at position 0 - reopen slash commands
-        if (value.startsWith("/") && !value.slice(0, offset).match(/\s/)) {
+        // Check for "/" at the start of the current line — trigger slash commands.
+        // Using lastIndexOf("\n") finds the start of the current line so that "/" mid-sentence
+        // (e.g. inside a file path like "/Users/foo") does NOT trigger the picker.
+        const lineStart = value.lastIndexOf("\n", offset - 1) + 1
+        const lineUpToCursor = value.slice(lineStart, offset)
+        if (lineUpToCursor.startsWith("/") && !lineUpToCursor.slice(1).match(/\s/)) {
           show("/")
-          setStore("index", 0)
+          setStore("index", lineStart)
           return
         }
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem**

The slash command picker (`/`) only opened when `/` was the very first character of the entire input (position 0). The regex was `rawText.match(/^\/(\S*)$/)` — anchored to the whole string. This made two things impossible:

1. Typing context text on one line and a slash command on the next line
2. Composing multiple slash commands in a single prompt

**Changes**

*Fix: picker triggers at the start of any line (web + TUI)*

Web UI (`prompt-input.tsx`): changed the regex from a whole-string anchor to a cursor-aware line-start match that mirrors the existing `@` trigger:
```ts
// before
const slashMatch = rawText.match(/^\/(\S*)$/)
// after
const slashMatch = rawText.substring(0, cursorPosition).match(/(?:^|\n)\/(\S*)$/)
```

TUI (`autocomplete.tsx`): replaced `value.startsWith('/')` with a `lastIndexOf('\n')` line-start computation. `store.index` is now set to `lineStart` so the filter and hide logic work correctly on any line.

*Feature: multi-command prompts*

Each slash command goes on its own line. The picker opens per-line. On submit, if every non-empty line is a known custom command they fire sequentially.

`transient-state.ts`: added `slashTriggerOffset: number` to record where the `/` was in the editor text.

`handleSlashSelect` in `prompt-input.tsx`: previously called `setEditorText(text)` which replaced the entire editor. Now splices only the `/filter` token at `slashTriggerOffset`, keeping the rest of the editor intact.

`submit.ts`: added a multi-command path before the existing single-command check. Parses all lines, verifies each resolves to a known command, fires them sequentially. Single-command and plain-prompt paths are fully unchanged.

*Path collision handling*

`/Users/foo/bar` mid-sentence does not trigger the picker. The rule is `/` must be the first non-whitespace character on its line — matching how Notion, Linear, and Slack handle slash commands.

### How did you verify your code works?

- Ran the app dev server (`packages/app` vite dev against the running opencode backend on port 4096)
- Confirmed `/` on an empty input opens the picker (existing behaviour unchanged)
- Confirmed typing context text, pressing Shift+Enter, then typing `/` opens the picker on the second line
- Confirmed selecting a command on line 2 inserts it there without clearing line 1
- Confirmed typing `/update-docs` on line 1, Shift+Enter, `/code-review` on line 2, then Enter fires both commands sequentially
- Confirmed `/Users/foo/bar` mid-sentence does not open the picker

### Screenshots / recordings

_UI change — picker now opens on the second line after context text on the first line._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR