### PR TITLE
fix(tui): skip compaction summary when computing usage counter

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -260,7 +260,9 @@ export function Prompt(props: PromptProps) {
     if (!props.sessionID) return
     const session = sync.session.get(props.sessionID)
     const msg = sync.data.message[props.sessionID] ?? []
-    const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
+    const last = msg.findLast(
+      (item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0 && !item.summary,
+    )
     if (!last) return
 
     const tokens =


### PR DESCRIPTION
### Issue for this PR

Refs #23962 (the `/compact` half only)
And Fixes #30930 
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After `/compact`, the token count in the prompt footer stays on the pre-compaction number instead of dropping.

Cause: the `usage` memo in `packages/tui/src/component/prompt/index.tsx` uses `findLast` to pick the last assistant message with `tokens.output > 0`. After compaction that's the summary message itself — its `tokens.input` is the full pre-compaction history sent to the summarizer, so the counter latches on that.

Fix: add `!item.summary` to the predicate. The summary is skipped; the counter falls through to the last real assistant turn.

Caveat: there's still a window between "compaction complete" and "next real turn" where the counter shows the last pre-compaction turn's value instead of the true post-compaction size. Closing that would require reacting to `Event.Compacted` in the TUI sync layer — not doing that here.

### How did you verify your code works?

Built from this branch, ran against a real session with ~651K pre-compaction context.

- Without the fix: counter would jump to 523K (the summary's total) and stay there.
- With the fix: counter held at the last real turn (~651K) through summary generation, then dropped to 43K when the next assistant response landed.

### Screenshots / recordings

Not applicable — the UI change is a number in the footer updating correctly instead of staying stale.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR