### PR TITLE
feat(app): go home on session delete

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -813,10 +813,6 @@ export function MessageTimeline(props: {
     const session = sync().session.get(sessionID)
     if (!session) return false
 
-    const sessions = (sync().data.session ?? []).filter((s) => !s.parentID && !s.time?.archived)
-    const index = sessions.findIndex((s) => s.id === sessionID)
-    const nextSession = index === -1 ? undefined : (sessions[index + 1] ?? sessions[index - 1])
-
     const result = await sdk()
       .client.session.delete({ sessionID })
       .then((x) => x.data)
@@ -858,7 +854,13 @@ export function MessageTimeline(props: {
       }
     }
 
-    navigateAfterSessionRemoval(sessionID, session.parentID, nextSession?.id)
+    const nextSession = params.serverKey
+      ? undefined
+      : (() => {
+          const sessions = (sync().data.session ?? []).filter((s) => !s.parentID && !s.time?.archived)
+          const index = sessions.findIndex((s) => s.id === sessionID)
+          return index === -1 ? undefined : (sessions[index + 1] ?? sessions[index - 1])
+        })()
 
     sync().set(
       produce((draft) => {
@@ -869,7 +871,21 @@ export function MessageTimeline(props: {
     for (const id of removed) {
       sync().session.evict(id)
     }
+    if (params.serverKey) {
+      notifySessionTabsRemoved({
+        server: requireServerKey(params.serverKey),
+        directory: sdk().directory,
+        sessionIDs: [...removed],
+      })
+      if (params.id === sessionID) {
+        if (session.parentID) navigate(sessionHref(requireServerKey(params.serverKey), session.parentID))
+        else navigate("/")
+      }
+      return true
+    }
+
     notifySessionTabsRemoved({ directory: sdk().directory, sessionIDs: [...removed] })
+    navigateAfterSessionRemoval(sessionID, session.parentID, nextSession?.id)
     return true
   }
 


### PR DESCRIPTION
### Issue for this PR
N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When a session is deleted, go home instead of opening the next session under that project.

### How did you verify your code works?
- Ran the app locally and verified the updated UI manually
- Ran type checks locally (`bun turbo typecheck`)

### Screenshots / recordings
N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
