### PR TITLE
fix(plugin): log server plugin load and skip failures

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -185,11 +185,15 @@ const layer = Layer.effect(
             kind: "server",
             report: {
               start(candidate) {},
-              missing(candidate, _retry, message) {},
+              missing(candidate, _retry, message) {
+                bridge.fork(Effect.logWarning("skipped plugin", { spec: candidate.plan.spec, message }))
+              },
               error(candidate, _retry, stage, error, resolved) {
                 const spec = candidate.plan.spec
                 const cause = error instanceof Error ? (error.cause ?? error) : error
                 const message = stage === "load" ? errorMessage(error) : errorMessage(cause)
+
+                bridge.fork(Effect.logError("failed to load plugin", { spec, message, stage, target: resolved?.target }))
 
                 if (stage === "install") {
                   const parsed = parsePluginSpecifier(spec)


### PR DESCRIPTION
### Issue for this PR

Closes #34742

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Server plugin failures were nearly invisible: load/install/compatibility/entry errors only surfaced as session events, and a missing entrypoint was dropped with a no-op missing reporter. A file:// plugin whose module throws at import time (e.g. a top-level readFileSync of a missing asset) therefore looked like it was silently ignored.

This logs skipped plugins (Effect.logWarning) and load errors (Effect.logError, with stage and target) through the effect logger so failures are visible on stderr. No behavior change beyond logging.

### How did you verify your code works?

Diagnosed against a file:// oh-my-opencode plugin that failed to import because its Nix package was missing dist/skills/**/SKILL.md; the plugin loader itself resolved the entrypoint correctly.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
