### PR TITLE
feat(tui): show session status in prompt area

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -259,6 +259,11 @@ export function Prompt(props: PromptProps) {
   const usage = createMemo(() => {
     if (!props.sessionID) return
     const session = sync.session.get(props.sessionID)
+
+    const mcpList = Object.values(sync.data.mcp)
+    const lspList = sync.data.lsp
+    const title = session?.title
+
     const msg = sync.data.message[props.sessionID] ?? []
     const last = msg.findLast((item): item is AssistantMessage => item.role === "assistant" && item.tokens.output > 0)
     if (!last) return
@@ -270,9 +275,26 @@ export function Prompt(props: PromptProps) {
     const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
     const cost = session?.cost ?? 0
+
+    const mcpConnected = mcpList.filter((x) => x.status === "connected").length
+    const mcpHasError = mcpList.some((x) => x.status === "failed")
+
+    const lspConnected = lspList.filter((x) => x.status === "connected").length
+
+    const branch = sync.data.vcs?.branch
+    const directory = session?.directory ? session.directory.split("/").pop() : undefined
+
     return {
+      title,
       context: pct ? `${Locale.number(tokens)} (${pct})` : Locale.number(tokens),
       cost: cost > 0 ? money.format(cost) : undefined,
+      mcpConnected,
+      mcpHasError,
+      mcpTotal: mcpList.length,
+      lspConnected,
+      lspTotal: lspList.length,
+      branch,
+      directory,
     }
   })
 
@@ -1648,11 +1670,32 @@ export function Prompt(props: PromptProps) {
                 <Match when={store.mode === "normal"}>
                   <Switch>
                     <Match when={usage()}>
-                      {(item) => (
-                        <text fg={theme.textMuted} wrapMode="none">
-                          {[item().context, item().cost].filter(Boolean).join(" · ")}
-                        </text>
-                      )}
+                      {(item) => {
+                        const parts: string[] = []
+                        const title = item().title
+                        if (title) parts.push(title)
+                        const ctx = item().context
+                        if (ctx) parts.push(ctx)
+                        const cost = item().cost
+                        if (cost) parts.push(cost)
+                        if (item().mcpTotal > 0) {
+                          const dot = item().mcpHasError ? "⊙" : (item().mcpConnected > 0 ? "⊙" : "⊙")
+                          parts.push(`${dot} ${item().mcpConnected}/${item().mcpTotal} MCP`)
+                        }
+                        if (item().lspTotal > 0) {
+                          parts.push(`• ${item().lspConnected}/${item().lspTotal} LSP`)
+                        }
+                        const branch = item().branch
+                        const directory = item().directory
+                        if (directory || branch) {
+                          parts.push([directory, branch].filter(Boolean).join(":"))
+                        }
+                        return (
+                          <text fg={theme.textMuted} wrapMode="none">
+                            {parts.join(" · ")}
+                          </text>
+                        )
+                      }}
                     </Match>
                     <Match when={true}>
                       <text fg={theme.text}>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1679,7 +1679,7 @@ export function Prompt(props: PromptProps) {
                         const cost = item().cost
                         if (cost) parts.push(cost)
                         if (item().mcpTotal > 0) {
-                          const dot = item().mcpHasError ? "⊙" : (item().mcpConnected > 0 ? "⊙" : "⊙")
+                          const dot = item().mcpHasError ? "⊙" : (item().mcpConnected > 0 ? "●" : "○")
                           parts.push(`${dot} ${item().mcpConnected}/${item().mcpTotal} MCP`)
                         }
                         if (item().lspTotal > 0) {


### PR DESCRIPTION
### Issue for this PR

Closes #25262

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the sidebar is hidden, session info (tokens, cost, MCP, LSP, branch, directory) is no longer visible. This adds that info to the existing status line in the prompt input area.

The `usage` memo in `packages/tui/src/component/prompt/index.tsx` is extended to read MCP, LSP, VCS, and session data, and renders them inline alongside the existing token/cost display. The MCP/LSP reads are moved before the early return so reactivity is properly tracked.

**Before:**
`12,345 (5%) · /bin/zsh.00`

**After:**
`My Session · 12,345 (5%) · /bin/zsh.00 · ● 2/2 MCP · • 1/1 LSP · test-project:main`

MCP dot characters are visually distinct: ● connected, ○ disconnected, ⊙ error.

### How did you verify your code works?

- Built the TUI locally and verified the status line renders correctly with sidebar both visible and hidden
- Tested with MCP servers connected/disconnected/failed states
- Tested with LSP servers connected/disconnected states
- Verified token/cost display unchanged when MCP/LSP are not configured
- Verified branch and directory display when in a git repo
- `bun run typecheck` passes (29/29)
- `bun run --cwd packages/tui test` passes (191 pass, 0 fail)

### Screenshots / recordings

N/A — terminal UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR