### PR TITLE
fix(tui): pass live process env to the TUI worker

### DIFF
--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -207,7 +207,11 @@ export const TuiThreadCommand = cmd({
       }
       const cwd = Filesystem.resolve(process.cwd())
 
-      const worker = new Worker(file)
+      // Pass the current process env to the worker. Bun (and Node worker_threads without SHARE_ENV) snapshot
+      // a worker's env at PROCESS START, so an env var set programmatically before the TUI launches — e.g.
+      // OPENCODE_CONFIG_DIR or an augmented PATH from a wrapper/launcher — is otherwise absent in this worker,
+      // which runs the server: env-derived config and PATH-resolved LSP spawns then silently break.
+      const worker = new Worker(file, { env: { ...process.env } } as WorkerOptions)
       const client = Rpc.client<typeof rpc>(worker)
       const reload = () => {
         client.call("reload", undefined).catch(() => {})


### PR DESCRIPTION
### Problem

`cli/cmd/tui.ts` creates the TUI's server worker with `new Worker(file)` and no `env`. Bun (and Node `worker_threads` without `SHARE_ENV`) initialize a worker's `process.env` from a snapshot taken at **process start**, so any environment variable set *programmatically* before the TUI launches is missing inside the worker.

Because that worker runs the server (config resolution, LSP spawns, etc.), anything env-derived silently breaks in the TUI while working everywhere else:
- config loaded via `OPENCODE_CONFIG_DIR` isn't seen inside the worker;
- LSP servers that resolve by name off a runtime-augmented `PATH` fail to spawn.

This bites any wrapper/launcher that sets env at runtime before handing off to the opencode entry (verified on Windows with Bun: a worker created after `process.env.X = …` still reports `X` as undefined; passing `{ env }` fixes it).

### Fix

```ts
const worker = new Worker(file, { env: { ...process.env } } as WorkerOptions)
```

Low-risk: the worker now inherits the current env instead of a stale start-time snapshot (a superset of the previous behavior).