### PR TITLE
docs: add LongCat provider

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1449,6 +1449,35 @@ In this example:
 
 ---
 
+### LongCat
+
+To use LongCat-2.0 from LongCat (Meituan):
+
+1. Head over to the [LongCat platform](https://longcat.chat/platform), create an account, and create an API key.
+
+2. Run the `/connect` command and search for **LongCat**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your LongCat API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select _LongCat-2.0_.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### Moonshot AI
 
 To use Kimi K2 from Moonshot AI:


### PR DESCRIPTION
### Issue for this PR

Closes # N/A — small docs addition (new provider entry).

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a **LongCat** entry to the providers list, alphabetically between LM Studio and Moonshot AI. LongCat (Meituan) is an OpenAI-compatible provider serving `LongCat-2.0`. It uses the same `/connect` → `/models` flow as the other standard providers because the model data comes from models.dev.

Depends on the models.dev entry (anomalyco/models.dev#2967) so `/connect` can find LongCat.

### How did you verify your code works?

Configured LongCat as a standalone provider in `opencode.json` (npm `@ai-sdk/openai-compatible`, baseURL `https://api.longcat.chat/openai`, model `LongCat-2.0`) and confirmed it connects and responds. The steps in the docs match LongCat's official opencode config.

### Screenshots / recordings

N/A — text-only docs change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR