### PR TITLE
fix: surface shell stderr output

### DIFF
--- a/packages/core/src/tool/shell.ts
+++ b/packages/core/src/tool/shell.ts
@@ -136,7 +136,7 @@ export const Plugin = {
     yield* ctx.tool
       .register({
         [name]: Tool.make({
-          description: `Execute one shell command string with the host user's filesystem, process, and network authority. The active Location is the default working directory. Relative workdir values resolve from that Location. External workdir values require external_directory approval; best-effort command-argument path warnings are advisory only. Timeout values are milliseconds (default: ${DEFAULT_TIMEOUT_MS}; maximum: ${MAX_TIMEOUT_MS}). Uses the configured shell when set; otherwise uses /bin/sh on POSIX and COMSPEC or cmd.exe on Windows. Background mode (background=true) launches the command asynchronously and returns immediately; you are notified when it finishes.`,
+          description: `Execute one shell command string with the host user's filesystem, process, and network authority. The active Location is the default working directory. Relative workdir values resolve from that Location. External workdir values require external_directory approval; best-effort command-argument path warnings are advisory only. Stdout and stderr are captured together in output. Timeout values are milliseconds (default: ${DEFAULT_TIMEOUT_MS}; maximum: ${MAX_TIMEOUT_MS}). Uses the configured shell when set; otherwise uses /bin/sh on POSIX and COMSPEC or cmd.exe on Windows. Background mode (background=true) launches the command asynchronously and returns immediately; you are notified when it finishes.`,
           input: Input,
           output: Output,
           structured: StructuredOutput,

--- a/packages/core/src/tool/shell.ts
+++ b/packages/core/src/tool/shell.ts
@@ -136,7 +136,7 @@ export const Plugin = {
     yield* ctx.tool
       .register({
         [name]: Tool.make({
-          description: `Execute one shell command string with the host user's filesystem, process, and network authority. The active Location is the default working directory. Relative workdir values resolve from that Location. External workdir values require external_directory approval; best-effort command-argument path warnings are advisory only. Stdout and stderr are captured together in output. Timeout values are milliseconds (default: ${DEFAULT_TIMEOUT_MS}; maximum: ${MAX_TIMEOUT_MS}). Uses the configured shell when set; otherwise uses /bin/sh on POSIX and COMSPEC or cmd.exe on Windows. Background mode (background=true) launches the command asynchronously and returns immediately; you are notified when it finishes.`,
+          description: `Execute one shell command string with the host user's filesystem, process, and network authority. The active Location is the default working directory. Relative workdir values resolve from that Location. External workdir values require external_directory approval; best-effort command-argument path warnings are advisory only. Timeout values are milliseconds (default: ${DEFAULT_TIMEOUT_MS}; maximum: ${MAX_TIMEOUT_MS}). Uses the configured shell when set; otherwise uses /bin/sh on POSIX and COMSPEC or cmd.exe on Windows. Background mode (background=true) launches the command asynchronously and returns immediately; you are notified when it finishes.`,
           input: Input,
           output: Output,
           structured: StructuredOutput,

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -148,6 +148,12 @@ const call = (input: typeof ShellTool.Input.Type, id = "call-shell") => ({
 const isWindows = process.platform === "win32"
 const cwdCommand = isWindows ? "(Get-Location).Path; Start-Sleep -Milliseconds 100" : "pwd"
 const helloCommand = isWindows ? "[Console]::Out.Write('hello'); Start-Sleep -Milliseconds 100" : "printf hello"
+const stderrCommand = isWindows
+  ? "[Console]::Error.Write('stderr only'); Start-Sleep -Milliseconds 100"
+  : "printf 'stderr only' >&2"
+const mixedOutputCommand = isWindows
+  ? "[Console]::Out.Write('stdout'); Start-Sleep -Milliseconds 50; [Console]::Error.Write('stderr'); Start-Sleep -Milliseconds 100"
+  : "printf stdout; sleep 0.05; printf stderr >&2"
 const idleCommand = isWindows ? "Start-Sleep -Seconds 60" : "sleep 60"
 const bodyExitCommand = isWindows
   ? "[Console]::Out.Write('body'); Start-Sleep -Milliseconds 100; exit 7"
@@ -224,6 +230,29 @@ describe("ShellTool", () => {
               }),
             ),
           ),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+    ),
+  )
+
+  it.live("captures stderr-only and mixed stdout/stderr output", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        return withSession(tmp.path, (registry) =>
+          Effect.gen(function* () {
+            const stderr = yield* settleTool(registry, call({ command: stderrCommand }, "call-stderr"))
+            expect(stderr.output?.structured).toMatchObject({ exit: 0, truncated: false })
+            expect(stderr.output?.content[0]).toEqual({ type: "text", text: "stderr only" })
+
+            const mixed = yield* settleTool(registry, call({ command: mixedOutputCommand }, "call-mixed"))
+            expect(mixed.output?.structured).toMatchObject({ exit: 0, truncated: false })
+            const output = mixed.output?.content[0]?.type === "text" ? mixed.output.content[0].text : ""
+            expect(output).toContain("stdout")
+            expect(output).toContain("stderr")
+          }),
         )
       },
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1687,6 +1687,7 @@ function ToolPart(props: { part: SessionMessageAssistantTool }) {
     if (ctx.showDetails()) return false
     if (runningShell()) return false
     if (props.part.state.status !== "completed") return false
+    if (display() === "shell") return false
     return true
   })
 


### PR DESCRIPTION
## summary
- add shell tool coverage for stderr-only and mixed stdout/stderr output
- keep completed shell output visible in the TUI when tool details are hidden

Closes #34493

## testing
- bun test test/tool-shell.test.ts (packages/core)
- bun typecheck (packages/core)
- bun typecheck (packages/tui)
- bun test test/cli/tui/session-rows.test.ts test/cli/tui/collapse-tool-output.test.ts test/cli/tui/inline-tool-wrap-snapshot.test.tsx (packages/tui)