### PR TITLE
feat(tui): optionally keep model groups organized while searching

### DIFF
--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -889,6 +889,22 @@ it.instance("missing tui.json - silently treated as empty (ENOENT path)", () =>
       const config = yield* getTuiConfig(test.directory)
       expect(config).toBeDefined()
       expect(config.theme).toBeUndefined()
+      expect(config.model_picker.group_search_results).toBe(false)
+    }),
+  ),
+)
+
+it.instance("resolves model_picker.group_search_results from tui.json", () =>
+  withCleanState(
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const test = yield* TestInstance
+      yield* fs.writeJson(path.join(test.directory, "tui.json"), {
+        model_picker: { group_search_results: true },
+      })
+
+      const config = yield* getTuiConfig(test.directory)
+      expect(config.model_picker.group_search_results).toBe(true)
     }),
   ),
 )

--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -8,12 +8,14 @@ import { DialogVariant } from "./dialog-variant"
 import * as fuzzysort from "fuzzysort"
 import { useConnected } from "./use-connected"
 import { useSync } from "../context/sync"
+import { useTuiConfig } from "../config"
 
 export function DialogModel(props: { providerID?: string }) {
   const local = useLocal()
   const sync = useSync()
   const dialog = useDialog()
   const [query, setQuery] = createSignal("")
+  const tuiConfig = useTuiConfig()
 
   const connected = useConnected()
   const providers = createDialogProviderOptions()
@@ -22,7 +24,7 @@ export function DialogModel(props: { providerID?: string }) {
 
   const options = createMemo(() => {
     const needle = query().trim()
-    const showSections = showExtra() && needle.length === 0
+    const showSections = showExtra() && (needle.length === 0 || tuiConfig.model_picker.group_search_results)
     const favorites = connected() ? local.model.favorite() : []
     const recents = local.model.recent()
 
@@ -117,6 +119,17 @@ export function DialogModel(props: { providerID?: string }) {
       : []
 
     if (needle) {
+      if (tuiConfig.model_picker.group_search_results) {
+        return [
+          ...fuzzysort.go(needle, favoriteOptions, { keys: ["title", "description"] }).map((x) => x.obj),
+          ...fuzzysort.go(needle, recentOptions, { keys: ["title", "description"] }).map((x) => x.obj),
+          ...sortModelOptions(
+            fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
+            false,
+          ),
+          ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
+        ]
+      }
       return [
         ...sortModelOptions(
           fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
@@ -175,7 +188,7 @@ export function DialogModel(props: { providerID?: string }) {
         },
       ]}
       onFilter={setQuery}
-      flat={true}
+      flat={!tuiConfig.model_picker.group_search_results}
       skipFilter={true}
       title={title()}
       current={local.model.current()}

--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -1,7 +1,7 @@
 import { createMemo, createSignal } from "solid-js"
 import { useLocal } from "../context/local"
 import { map, pipe, flatMap, entries, filter, sortBy, take } from "remeda"
-import { DialogSelect } from "../ui/dialog-select"
+import { DialogSelect, type DialogSelectOption } from "../ui/dialog-select"
 import { useDialog } from "../ui/dialog"
 import { createDialogProviderOptions, DialogProvider } from "./dialog-provider"
 import { DialogVariant } from "./dialog-variant"
@@ -9,6 +9,11 @@ import * as fuzzysort from "fuzzysort"
 import { useConnected } from "./use-connected"
 import { useSync } from "../context/sync"
 import { useTuiConfig } from "../config"
+import type { Provider } from "@opencode-ai/sdk/v2"
+
+type ModelReference = { providerID: string; modelID: string }
+
+type ModelPickerOption = DialogSelectOption<ModelReference | string> & { key?: ModelReference }
 
 export function DialogModel(props: { providerID?: string }) {
   const local = useLocal()
@@ -20,126 +25,18 @@ export function DialogModel(props: { providerID?: string }) {
   const connected = useConnected()
   const providers = createDialogProviderOptions()
 
-  const showExtra = createMemo(() => connected() && !props.providerID)
-
   const options = createMemo(() => {
-    const needle = query().trim()
-    const showSections = showExtra() && (needle.length === 0 || tuiConfig.model_picker.group_search_results)
-    const favorites = connected() ? local.model.favorite() : []
-    const recents = local.model.recent()
-
-    function toOptions(items: typeof favorites, category: string) {
-      if (!showSections) return []
-      return items.flatMap((item) => {
-        const provider = sync.data.provider.find((provider) => provider.id === item.providerID)
-        if (!provider) return []
-        const model = provider.models[item.modelID]
-        if (!model) return []
-        return [
-          {
-            key: item,
-            value: { providerID: provider.id, modelID: model.id },
-            title: model.name ?? item.modelID,
-            description: provider.name,
-            category,
-            disabled: provider.id === "opencode" && model.id.includes("-nano"),
-            footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
-            onSelect: () => {
-              onSelect(provider.id, model.id)
-            },
-          },
-        ]
-      })
-    }
-
-    const favoriteOptions = toOptions(favorites, "Favorites")
-    const recentOptions = toOptions(
-      recents.filter(
-        (item) => !favorites.some((fav) => fav.providerID === item.providerID && fav.modelID === item.modelID),
-      ),
-      "Recent",
-    )
-
-    const providerOptions = pipe(
-      sync.data.provider,
-      sortBy(
-        (provider) => provider.id !== "opencode",
-        (provider) => provider.name,
-      ),
-      flatMap((provider) =>
-        pipe(
-          provider.models,
-          entries(),
-          filter(([_, info]) => info.status !== "deprecated"),
-          filter(([_, info]) => (props.providerID ? info.providerID === props.providerID : true)),
-          map(([model, info]) => ({
-            value: { providerID: provider.id, modelID: model },
-            title: info.name ?? model,
-            releaseDate: info.release_date,
-            description: favorites.some((item) => item.providerID === provider.id && item.modelID === model)
-              ? "(Favorite)"
-              : undefined,
-            category: connected() ? provider.name : undefined,
-            disabled: provider.id === "opencode" && model.includes("-nano"),
-            footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
-            onSelect() {
-              onSelect(provider.id, model)
-            },
-          })),
-          filter((option) => {
-            if (!showSections) return true
-            if (
-              favorites.some(
-                (item) => item.providerID === option.value.providerID && item.modelID === option.value.modelID,
-              )
-            )
-              return false
-            if (
-              recents.some(
-                (item) => item.providerID === option.value.providerID && item.modelID === option.value.modelID,
-              )
-            )
-              return false
-            return true
-          }),
-          (options) => sortModelOptions(options, props.providerID !== undefined),
-        ),
-      ),
-    )
-
-    const popularProviders = !connected()
-      ? pipe(
-          providers(),
-          map((option) => ({
-            ...option,
-            category: "Popular providers",
-          })),
-          take(6),
-        )
-      : []
-
-    if (needle) {
-      if (tuiConfig.model_picker.group_search_results) {
-        return [
-          ...fuzzysort.go(needle, favoriteOptions, { keys: ["title", "description"] }).map((x) => x.obj),
-          ...fuzzysort.go(needle, recentOptions, { keys: ["title", "description"] }).map((x) => x.obj),
-          ...sortModelOptions(
-            fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
-            false,
-          ),
-          ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
-        ]
-      }
-      return [
-        ...sortModelOptions(
-          fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
-          false,
-        ),
-        ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
-      ]
-    }
-
-    return [...favoriteOptions, ...recentOptions, ...providerOptions, ...popularProviders]
+    return createModelPickerOptions({
+      query: query(),
+      connected: connected(),
+      providerID: props.providerID,
+      groupSearchResults: tuiConfig.model_picker.group_search_results,
+      providers: sync.data.provider,
+      favorites: connected() ? local.model.favorite() : [],
+      recents: local.model.recent(),
+      popularProviders: providers(),
+      onSelect,
+    })
   })
 
   const provider = createMemo(() =>
@@ -194,6 +91,134 @@ export function DialogModel(props: { providerID?: string }) {
       current={local.model.current()}
     />
   )
+}
+
+export function createModelPickerOptions(input: {
+  query: string
+  connected: boolean
+  providerID?: string
+  groupSearchResults: boolean
+  providers: Provider[]
+  favorites: ModelReference[]
+  recents: ModelReference[]
+  popularProviders: ModelPickerOption[]
+  onSelect: (providerID: string, modelID: string) => void
+}) {
+  const needle = input.query.trim()
+  const showSections = input.connected && !input.providerID && (needle.length === 0 || input.groupSearchResults)
+
+  function toOptions(items: ModelReference[], category: string): ModelPickerOption[] {
+    if (!showSections) return []
+    return items.flatMap((item) => {
+      const provider = input.providers.find((provider) => provider.id === item.providerID)
+      if (!provider) return []
+      const model = provider.models[item.modelID]
+      if (!model) return []
+      return [
+        {
+          key: item,
+          value: { providerID: provider.id, modelID: model.id },
+          title: model.name ?? item.modelID,
+          description: provider.name,
+          category,
+          disabled: provider.id === "opencode" && model.id.includes("-nano"),
+          footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+          onSelect: () => {
+            input.onSelect(provider.id, model.id)
+          },
+        },
+      ]
+    })
+  }
+
+  const favoriteOptions = toOptions(input.favorites, "Favorites")
+  const recentOptions = toOptions(
+    input.recents.filter(
+      (item) => !input.favorites.some((fav) => fav.providerID === item.providerID && fav.modelID === item.modelID),
+    ),
+    "Recent",
+  )
+
+  const providerOptions = pipe(
+    input.providers,
+    sortBy(
+      (provider) => provider.id !== "opencode",
+      (provider) => provider.name,
+    ),
+    flatMap((provider) =>
+      pipe(
+        provider.models,
+        entries(),
+        filter(([_, info]) => info.status !== "deprecated"),
+        filter(([_, info]) => (input.providerID ? info.providerID === input.providerID : true)),
+        map(([model, info]) => ({
+          value: { providerID: provider.id, modelID: model },
+          title: info.name ?? model,
+          releaseDate: info.release_date,
+          description: input.favorites.some((item) => item.providerID === provider.id && item.modelID === model)
+            ? "(Favorite)"
+            : undefined,
+          category: input.connected ? provider.name : undefined,
+          disabled: provider.id === "opencode" && model.includes("-nano"),
+          footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+          onSelect() {
+            input.onSelect(provider.id, model)
+          },
+        })),
+        filter((option) => {
+          if (!showSections) return true
+          if (
+            input.favorites.some(
+              (item) => item.providerID === option.value.providerID && item.modelID === option.value.modelID,
+            )
+          )
+            return false
+          if (
+            input.recents.some(
+              (item) => item.providerID === option.value.providerID && item.modelID === option.value.modelID,
+            )
+          )
+            return false
+          return true
+        }),
+        (options) => sortModelOptions(options, input.providerID !== undefined),
+      ),
+    ),
+  )
+
+  const popularProviders = !input.connected
+    ? pipe(
+        input.popularProviders,
+        map((option) => ({
+          ...option,
+          category: "Popular providers",
+        })),
+        take(6),
+      )
+    : []
+
+  if (needle) {
+    if (input.groupSearchResults) {
+      return [
+        ...fuzzysort.go(needle, favoriteOptions, { keys: ["title", "description"] }).map((x) => x.obj),
+        ...fuzzysort.go(needle, recentOptions, { keys: ["title", "description"] }).map((x) => x.obj),
+        ...sortModelOptions(
+          fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
+          false,
+        ),
+        ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
+      ]
+    }
+    return [
+      ...sortModelOptions(
+        fuzzysort.go(needle, providerOptions, { keys: ["title", "category"] }).map((x) => x.obj),
+        false,
+      ),
+      ...fuzzysort.go(needle, popularProviders, { keys: ["title"] }).map((x) => x.obj),
+    ]
+  }
+
+  return [...favoriteOptions, ...recentOptions, ...providerOptions, ...popularProviders]
 }
 
 export function sortModelOptions<T extends { footer?: string; releaseDate: string | number; title: string }>(

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -50,6 +50,12 @@ export const Prompt = Schema.Struct({
   }),
 }).annotate({ description: "Prompt size settings" })
 
+export const ModelPicker = Schema.Struct({
+  group_search_results: Schema.optional(Schema.Boolean).annotate({
+    description: "Keep Favorites, Recent, and provider groups while searching models",
+  }),
+}).annotate({ description: "Model picker settings" })
+
 export const Info = Schema.Struct({
   $schema: Schema.optional(Schema.String),
   theme: Schema.optional(Schema.String),
@@ -63,10 +69,11 @@ export const Info = Schema.Struct({
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  model_picker: Schema.optional(ModelPicker),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
-export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse"> & {
+export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse" | "model_picker"> & {
   attention: {
     enabled: boolean
     notifications: boolean
@@ -78,6 +85,9 @@ export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | 
   keybinds: TuiKeybind.BindingLookupView
   leader_timeout: number
   mouse: boolean
+  model_picker: {
+    group_search_results: boolean
+  }
 }
 
 export const ResolveOptions = Schema.Struct({
@@ -113,6 +123,9 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
     }),
     leader_timeout: input.leader_timeout ?? LeaderTimeoutDefault,
     mouse: input.mouse ?? true,
+    model_picker: {
+      group_search_results: input.model_picker?.group_search_results ?? false,
+    },
   }
 }
 

--- a/packages/tui/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/model-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { sortModelOptions } from "../../../../src/component/dialog-model"
+import type { Model, Provider } from "@opencode-ai/sdk/v2"
+import { createModelPickerOptions, sortModelOptions } from "../../../../src/component/dialog-model"
 
 describe("sortModelOptions", () => {
   test("orders provider-scoped model choices by newest release first", () => {
@@ -30,3 +31,135 @@ describe("sortModelOptions", () => {
     expect(sorted.map((model) => model.title)).toEqual(["Free new", "Free old", "GLM 5.2", "GLM 5.1", "GLM 5"])
   })
 })
+
+describe("createModelPickerOptions", () => {
+  test("keeps search data flat by default", () => {
+    const options = createModelPickerOptions({
+      query: "claude",
+      connected: true,
+      groupSearchResults: false,
+      providers: modelProviders,
+      favorites: [{ providerID: "anthropic", modelID: "claude-sonnet" }],
+      recents: [{ providerID: "anthropic", modelID: "claude-haiku" }],
+      popularProviders: [],
+      onSelect: () => {},
+    })
+
+    expect(options.map((option) => [option.category, option.title])).toEqual([
+      ["Anthropic", "Claude Opus"],
+      ["Anthropic", "Claude Haiku"],
+      ["Anthropic", "Claude Sonnet"],
+    ])
+    expect(options.some((option) => option.category === "Favorites" || option.category === "Recent")).toBe(false)
+  })
+
+  test("keeps favorites and recents grouped while searching", () => {
+    const options = createModelPickerOptions({
+      query: "claude",
+      connected: true,
+      groupSearchResults: true,
+      providers: modelProviders,
+      favorites: [{ providerID: "anthropic", modelID: "claude-sonnet" }],
+      recents: [
+        { providerID: "anthropic", modelID: "claude-sonnet" },
+        { providerID: "anthropic", modelID: "claude-haiku" },
+      ],
+      popularProviders: [],
+      onSelect: () => {},
+    })
+
+    expect(options.map((option) => [option.category, option.title])).toEqual([
+      ["Favorites", "Claude Sonnet"],
+      ["Recent", "Claude Haiku"],
+      ["Anthropic", "Claude Opus"],
+    ])
+  })
+
+  test("matches provider names during grouped search", () => {
+    const options = createModelPickerOptions({
+      query: "anthropic",
+      connected: true,
+      groupSearchResults: true,
+      providers: modelProviders,
+      favorites: [{ providerID: "anthropic", modelID: "claude-sonnet" }],
+      recents: [{ providerID: "anthropic", modelID: "claude-haiku" }],
+      popularProviders: [],
+      onSelect: () => {},
+    })
+
+    expect(options.map((option) => [option.category, option.title])).toEqual([
+      ["Favorites", "Claude Sonnet"],
+      ["Recent", "Claude Haiku"],
+      ["Anthropic", "Claude Opus"],
+    ])
+  })
+})
+
+const modelProviders = [
+  provider("anthropic", "Anthropic", [
+    model("anthropic", "claude-sonnet", "Claude Sonnet", "2026-01-01"),
+    model("anthropic", "claude-haiku", "Claude Haiku", "2026-01-02"),
+    model("anthropic", "claude-opus", "Claude Opus", "2026-01-03"),
+  ]),
+]
+
+function provider(id: string, name: string, models: Model[]): Provider {
+  return {
+    id,
+    name,
+    source: "api",
+    env: [],
+    options: {},
+    models: Object.fromEntries(models.map((model) => [model.id, model])),
+  }
+}
+
+function model(providerID: string, id: string, name: string, releaseDate: string): Model {
+  return {
+    id,
+    providerID,
+    api: {
+      id: "test",
+      url: "https://example.com",
+      npm: "test",
+    },
+    name,
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        pdf: false,
+      },
+      output: {
+        text: true,
+        audio: false,
+        image: false,
+        video: false,
+        pdf: false,
+      },
+      interleaved: false,
+    },
+    cost: {
+      input: 1,
+      output: 1,
+      cache: {
+        read: 1,
+        write: 1,
+      },
+    },
+    limit: {
+      context: 200000,
+      output: 8192,
+    },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: releaseDate,
+  }
+}

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -370,6 +370,9 @@ You can customize TUI behavior through `tui.json` (or `tui.jsonc`).
   },
   "diff_style": "auto",
   "mouse": true,
+  "model_picker": {
+    "group_search_results": false
+  },
   "attention": {
     "enabled": true,
     "notifications": true,
@@ -396,6 +399,7 @@ This is separate from `opencode.json`, which configures server/runtime behavior.
 - `scroll_speed` - Controls how fast the TUI scrolls when using scroll commands (minimum: `0.001`, supports decimal values). Defaults to `3`. **Note: This is ignored if `scroll_acceleration.enabled` is set to `true`.**
 - `diff_style` - Controls diff rendering. `"auto"` adapts to terminal width, `"stacked"` always shows a single-column layout.
 - `mouse` - Enable or disable mouse capture in the TUI (default: `true`). When disabled, the terminal's native mouse selection/scrolling behavior is preserved.
+- `model_picker.group_search_results` - Keep Favorites, Recent, and provider groups while searching models. Defaults to `false`.
 - `attention` - Configures TUI desktop notifications and sounds. Disabled by default.
 
 Use `OPENCODE_TUI_CONFIG` to load a custom TUI config path.


### PR DESCRIPTION
### Issue for this PR

- Closes #12289

### Type of change

- [x] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `model_picker.group_search_results` option in `tui.json` that allows to preserve model grouping (favorites, recent, by provider) when searching models in TUI. Defaults to `false` which reproduces behavior before the PR.

PR includes implementation, tests, docs.

Grouping was previously working, but a fix for another issue related to model picker broke it.

Timeline:
- Dec 2025
  - Issue #5254 reported favorites/recents disappearing during model search.
  - PR #6053 fixed this by filtering each section separately and keeping section order.
- Jan 2026
  - Issue #7366 reported favorite/recent models were not searchable by provider name.
  - PR #7429 fixed provider-name search by switching search to a flat provider list, which intentionally removed grouped favorites/recents while searching.



**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
Implemented tests, ran TUI with configuration option set to: `true`, `false`, without option set.

### Screenshots / recordings

<img width="838" height="694" alt="image" src="https://github.com/user-attachments/assets/faf5f740-bfc6-4f60-acce-34955ff7c682" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._