### PR TITLE
fix(tui): show queued prompt admissions

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -621,7 +621,13 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               (await sdk.api.message.list({ sessionID, limit: 200, order: "desc" })).data,
             ).toReversed()
             const liveByID = new Map(live.map((message) => [message.id, message]))
-            const messages = [...loaded.map((message) => liveByID.get(message.id) ?? message), ...live]
+            const messages = [
+              ...loaded.map((message) => {
+                if (message.type === "user") return message
+                return liveByID.get(message.id) ?? message
+              }),
+              ...live,
+            ]
               .filter((message, index, messages) => messages.findIndex((item) => item.id === message.id) === index)
               .toSorted((a, b) => a.time.created - b.time.created)
             messageIndex.set(sessionID, new Map(messages.map((message, index) => [message.id, index])))

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -226,7 +226,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               text: event.data.prompt.text,
               files: event.data.prompt.files,
               agents: event.data.prompt.agents,
-              metadata: event.data.delivery === "queue" ? { queued: true } : undefined,
+              metadata: { queued: true },
               time: { created: event.data.timestamp },
             })
           })

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -194,6 +194,19 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         case "session.next.prompted": {
           setStore("session", "status", event.data.sessionID, "running")
           message.update(event.data.sessionID, (draft, index) => {
+            const position = index.get(event.data.messageID)
+            const existing = position === undefined ? undefined : draft[position]
+            if (existing?.type === "user") {
+              existing.text = event.data.prompt.text
+              existing.files = event.data.prompt.files
+              existing.agents = event.data.prompt.agents
+              existing.time.created = event.data.timestamp
+              if (existing.metadata?.queued === true) {
+                delete existing.metadata.queued
+                if (Object.keys(existing.metadata).length === 0) existing.metadata = undefined
+              }
+              return
+            }
             message.append(draft, index, {
               id: event.data.messageID,
               type: "user",
@@ -206,6 +219,17 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           break
         }
         case "session.next.prompt.admitted":
+          message.update(event.data.sessionID, (draft, index) => {
+            message.append(draft, index, {
+              id: event.data.messageID,
+              type: "user",
+              text: event.data.prompt.text,
+              files: event.data.prompt.files,
+              agents: event.data.prompt.agents,
+              metadata: event.data.delivery === "queue" ? { queued: true } : undefined,
+              time: { created: event.data.timestamp },
+            })
+          })
           break
         case "session.next.context.updated":
           message.update(event.data.sessionID, (draft, index) => {
@@ -590,12 +614,12 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             return position === undefined ? undefined : messages?.[position]
           },
           async refresh(sessionID: string) {
+            const live = [...(store.session.message[sessionID] ?? [])]
             setStore("session", "message", sessionID, [])
             messageIndex.set(sessionID, new Map())
             const loaded = mutable(
               (await sdk.api.message.list({ sessionID, limit: 200, order: "desc" })).data,
             ).toReversed()
-            const live = store.session.message[sessionID] ?? []
             const liveByID = new Map(live.map((message) => [message.id, message]))
             const messages = [...loaded.map((message) => liveByID.get(message.id) ?? message), ...live]
               .filter((message, index, messages) => messages.findIndex((item) => item.id === message.id) === index)

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -620,15 +620,15 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             const loaded = mutable(
               (await sdk.api.message.list({ sessionID, limit: 200, order: "desc" })).data,
             ).toReversed()
+            const loadedIDs = new Set(loaded.map((message) => message.id))
             const liveByID = new Map(live.map((message) => [message.id, message]))
             const messages = [
               ...loaded.map((message) => {
                 if (message.type === "user") return message
                 return liveByID.get(message.id) ?? message
               }),
-              ...live,
+              ...live.filter((message) => !loadedIDs.has(message.id)),
             ]
-              .filter((message, index, messages) => messages.findIndex((item) => item.id === message.id) === index)
               .toSorted((a, b) => a.time.created - b.time.created)
             messageIndex.set(sessionID, new Map(messages.map((message, index) => [message.id, index])))
             setStore("session", "message", sessionID, messages)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1353,6 +1353,9 @@ function UserMessage(props: { message: SessionMessageUser }) {
           flexShrink={0}
         >
           <text fg={theme.text}>{props.message.text}</text>
+          <Show when={props.message.metadata?.queued === true}>
+            <text fg={theme.warning}>Queued</text>
+          </Show>
           <Show when={files().length}>
             <box
               flexDirection="row"

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1354,7 +1354,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
         >
           <text fg={theme.text}>{props.message.text}</text>
           <Show when={props.message.metadata?.queued === true}>
-            <text fg={theme.warning}>Queued</text>
+            <text fg={theme.textMuted}>queued</text>
           </Show>
           <Show when={files().length}>
             <box

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -22,7 +22,7 @@ import { useData } from "../../context/data"
 import { SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { Spinner } from "../../component/spinner"
-import { createSyntaxStyleMemo, generateSubtleSyntax, useTheme } from "../../context/theme"
+import { createSyntaxStyleMemo, generateSubtleSyntax, selectedForeground, useTheme } from "../../context/theme"
 import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA } from "@opentui/core"
 import { Prompt, type PromptRef } from "../../component/prompt"
 import type {
@@ -1324,6 +1324,9 @@ function UserMessage(props: { message: SessionMessageUser }) {
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
   const color = createMemo(() => local.agent.color(useData().session.get(ctx.sessionID)?.agent ?? "build"))
+  const queued = createMemo(() => props.message.metadata?.queued === true)
+  const queuedFg = createMemo(() => selectedForeground(theme, color()))
+  const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())
   const dialog = useDialog()
   const renderer = useRenderer()
 
@@ -1353,13 +1356,10 @@ function UserMessage(props: { message: SessionMessageUser }) {
           flexShrink={0}
         >
           <text fg={theme.text}>{props.message.text}</text>
-          <Show when={props.message.metadata?.queued === true}>
-            <text fg={theme.textMuted}>queued</text>
-          </Show>
           <Show when={files().length}>
             <box
               flexDirection="row"
-              paddingBottom={ctx.showTimestamps() ? 1 : 0}
+              paddingBottom={metadataVisible() ? 1 : 0}
               paddingTop={1}
               gap={1}
               flexWrap="wrap"
@@ -1382,9 +1382,18 @@ function UserMessage(props: { message: SessionMessageUser }) {
               </For>
             </box>
           </Show>
-          <Show when={ctx.showTimestamps()}>
+          <Show
+            when={queued()}
+            fallback={
+              <Show when={ctx.showTimestamps()}>
+                <text fg={theme.textMuted}>
+                  <span style={{ fg: theme.textMuted }}>{Locale.todayTimeOrDateTime(props.message.time.created)}</span>
+                </text>
+              </Show>
+            }
+          >
             <text fg={theme.textMuted}>
-              <span style={{ fg: theme.textMuted }}>{Locale.todayTimeOrDateTime(props.message.time.created)}</span>
+              <span style={{ bg: color(), fg: queuedFg(), bold: true }}> QUEUED </span>
             </text>
           </Show>
         </box>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1319,11 +1319,12 @@ function RevertMessage(props: {
 
 function UserMessage(props: { message: SessionMessageUser }) {
   const ctx = use()
+  const data = useData()
   const local = useLocal()
   const files = createMemo(() => props.message.files ?? [])
   const { theme } = useTheme()
   const [hover, setHover] = createSignal(false)
-  const color = createMemo(() => local.agent.color(useData().session.get(ctx.sessionID)?.agent ?? "build"))
+  const color = createMemo(() => local.agent.color(data.session.get(ctx.sessionID)?.agent ?? "build"))
   const queued = createMemo(() => props.message.metadata?.queued === true)
   const queuedFg = createMemo(() => selectedForeground(theme, color()))
   const metadataVisible = createMemo(() => queued() || ctx.showTimestamps())

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -116,6 +116,7 @@ export function createSessionRows(sessionID: Accessor<string>) {
     if (event.data.sessionID === sessionID()) appendMessage(event.data.messageID)
   }
   const subscriptions = [
+    data.on("session.next.prompt.admitted", message),
     data.on("session.next.prompted", message),
     data.on("session.next.context.updated", message),
     data.on("session.next.synthetic", message),

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -778,7 +778,7 @@ test("settles pending tools when a live failure arrives", async () => {
   }
 })
 
-test("renders admitted prompts immediately and clears queued marker when promoted", async () => {
+test("renders admitted prompts immediately with queued marker and clears when promoted", async () => {
   const events = createEventStream()
   const calls = createFetch(undefined, events)
   let sync!: ReturnType<typeof useData>
@@ -817,7 +817,7 @@ test("renders admitted prompts immediately and clears queued marker when promote
         messageID: "msg_user_1",
         timestamp: 0,
         prompt: { text: "hello" },
-        delivery: "queue",
+        delivery: "steer",
       },
     })
     await wait(() => sync.session.message.list("session-1")?.length === 1)
@@ -832,7 +832,7 @@ test("renders admitted prompts immediately and clears queued marker when promote
         messageID: "msg_user_1",
         timestamp: 0,
         prompt: { text: "hello" },
-        delivery: "queue",
+        delivery: "steer",
       },
     })
 

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -780,7 +780,13 @@ test("settles pending tools when a live failure arrives", async () => {
 
 test("renders admitted prompts immediately with queued marker and clears when promoted", async () => {
   const events = createEventStream()
-  const calls = createFetch(undefined, events)
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/session/session-1/message")
+      return json({
+        data: [{ id: "msg_user_1", type: "user", text: "hello", time: { created: 0 } }],
+        cursor: {},
+      })
+  }, events)
   let sync!: ReturnType<typeof useData>
   let ready!: () => void
   const mounted = new Promise<void>((resolve) => {
@@ -824,6 +830,9 @@ test("renders admitted prompts immediately with queued marker and clears when pr
     const admitted = sync.session.message.list("session-1")?.[0]
     expect(admitted).toMatchObject({ id: "msg_user_1", type: "user", text: "hello", metadata: { queued: true } })
 
+    await sync.session.message.refresh("session-1")
+    expect(sync.session.message.list("session-1")?.[0]?.metadata?.queued).toBeUndefined()
+
     emitEvent(events, {
       id: "evt_prompted_1",
       type: "session.next.prompted",
@@ -836,7 +845,7 @@ test("renders admitted prompts immediately with queued marker and clears when pr
       },
     })
 
-    await wait(() => sync.session.message.list("session-1")?.[0]?.metadata?.queued !== true)
+    await wait(() => received.at(-1) === "session.next.prompted")
     expect(received.slice(-2)).toEqual(["session.next.prompt.admitted", "session.next.prompted"])
     unsubscribe()
     const message = sync.session.message.list("session-1")?.[0]

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -780,10 +780,12 @@ test("settles pending tools when a live failure arrives", async () => {
 
 test("renders admitted prompts immediately with queued marker and clears when promoted", async () => {
   const events = createEventStream()
+  const sessionID = "session-1"
+  const messageID = "msg_user_1"
   const calls = createFetch((url) => {
-    if (url.pathname === "/api/session/session-1/message")
+    if (url.pathname === `/api/session/${sessionID}/message`)
       return json({
-        data: [{ id: "msg_user_1", type: "user", text: "hello", time: { created: 0 } }],
+        data: [{ id: messageID, type: "user", text: "hello", time: { created: 0 } }],
         cursor: {},
       })
   }, events)
@@ -819,26 +821,26 @@ test("renders admitted prompts immediately with queued marker and clears when pr
       id: "evt_admitted_1",
       type: "session.next.prompt.admitted",
       data: {
-        sessionID: "session-1",
-        messageID: "msg_user_1",
+        sessionID,
+        messageID,
         timestamp: 0,
         prompt: { text: "hello" },
         delivery: "steer",
       },
     })
-    await wait(() => sync.session.message.list("session-1")?.length === 1)
-    const admitted = sync.session.message.list("session-1")?.[0]
-    expect(admitted).toMatchObject({ id: "msg_user_1", type: "user", text: "hello", metadata: { queued: true } })
+    await wait(() => sync.session.message.list(sessionID)?.length === 1)
+    const admitted = sync.session.message.list(sessionID)?.[0]
+    expect(admitted).toMatchObject({ id: messageID, type: "user", text: "hello", metadata: { queued: true } })
 
-    await sync.session.message.refresh("session-1")
-    expect(sync.session.message.list("session-1")?.[0]?.metadata?.queued).toBeUndefined()
+    await sync.session.message.refresh(sessionID)
+    expect(sync.session.message.list(sessionID)?.[0]?.metadata?.queued).toBeUndefined()
 
     emitEvent(events, {
       id: "evt_prompted_1",
       type: "session.next.prompted",
       data: {
-        sessionID: "session-1",
-        messageID: "msg_user_1",
+        sessionID,
+        messageID,
         timestamp: 0,
         prompt: { text: "hello" },
         delivery: "steer",
@@ -848,15 +850,15 @@ test("renders admitted prompts immediately with queued marker and clears when pr
     await wait(() => received.at(-1) === "session.next.prompted")
     expect(received.slice(-2)).toEqual(["session.next.prompt.admitted", "session.next.prompted"])
     unsubscribe()
-    const message = sync.session.message.list("session-1")?.[0]
+    const message = sync.session.message.list(sessionID)?.[0]
     expect(message?.type).toBe("user")
     if (message?.type !== "user") return
-    expect(message).toMatchObject({ id: "msg_user_1", text: "hello" })
+    expect(message).toMatchObject({ id: messageID, text: "hello" })
     expect(message.metadata?.queued).toBeUndefined()
-    expect(sync.session.message.ids("session-1")).toEqual(["msg_user_1"])
+    expect(sync.session.message.ids(sessionID)).toEqual([messageID])
     expect(sync.session.message.ids("missing")).toEqual([])
-    expect(sync.session.message.get("session-1", "msg_user_1")).toBe(message)
-    expect(sync.session.message.get("session-1", "missing")).toBeUndefined()
+    expect(sync.session.message.get(sessionID, messageID)).toBe(message)
+    expect(sync.session.message.get(sessionID, "missing")).toBeUndefined()
     expect(received).toHaveLength(3)
   } finally {
     app.renderer.destroy()

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -778,7 +778,7 @@ test("settles pending tools when a live failure arrives", async () => {
   }
 })
 
-test("renders admitted prompts only after they become model-visible", async () => {
+test("renders admitted prompts immediately and clears queued marker when promoted", async () => {
   const events = createEventStream()
   const calls = createFetch(undefined, events)
   let sync!: ReturnType<typeof useData>
@@ -817,10 +817,12 @@ test("renders admitted prompts only after they become model-visible", async () =
         messageID: "msg_user_1",
         timestamp: 0,
         prompt: { text: "hello" },
-        delivery: "steer",
+        delivery: "queue",
       },
     })
-    expect(sync.session.message.list("session-1") ?? []).toEqual([])
+    await wait(() => sync.session.message.list("session-1")?.length === 1)
+    const admitted = sync.session.message.list("session-1")?.[0]
+    expect(admitted).toMatchObject({ id: "msg_user_1", type: "user", text: "hello", metadata: { queued: true } })
 
     emitEvent(events, {
       id: "evt_prompted_1",
@@ -830,17 +832,18 @@ test("renders admitted prompts only after they become model-visible", async () =
         messageID: "msg_user_1",
         timestamp: 0,
         prompt: { text: "hello" },
-        delivery: "steer",
+        delivery: "queue",
       },
     })
 
-    await wait(() => sync.session.message.list("session-1")?.length === 1)
+    await wait(() => sync.session.message.list("session-1")?.[0]?.metadata?.queued !== true)
     expect(received.slice(-2)).toEqual(["session.next.prompt.admitted", "session.next.prompted"])
     unsubscribe()
     const message = sync.session.message.list("session-1")?.[0]
     expect(message?.type).toBe("user")
     if (message?.type !== "user") return
     expect(message).toMatchObject({ id: "msg_user_1", text: "hello" })
+    expect(message.metadata?.queued).toBeUndefined()
     expect(sync.session.message.ids("session-1")).toEqual(["msg_user_1"])
     expect(sync.session.message.ids("missing")).toEqual([])
     expect(sync.session.message.get("session-1", "msg_user_1")).toBe(message)


### PR DESCRIPTION
## summary
- render admitted prompts in the V2 TUI as soon as the server accepts them
- mark queue-delivered admitted prompts as queued until they are promoted
- keep live admitted prompts through message refreshes

Closes #34766

## testing
- bun test test/cli/tui/data.test.tsx --timeout 30000
- bun test test/cli/tui/session-rows.test.ts --timeout 30000
- bun typecheck
- pre-push: bun turbo typecheck