### PR TITLE
feat(provider): add RFC 8628 device-flow OAuth for custom gateways

### DIFF
--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -112,6 +112,22 @@ export const Info = Schema.Struct({
           description:
             "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
         }),
+        deviceAuthorizationUrl: Schema.optional(Schema.String).annotate({
+          description:
+            "RFC 8628 device-authorization endpoint. When set alongside tokenUrl, this provider uses device-flow OAuth instead of a static API key.",
+        }),
+        tokenUrl: Schema.optional(Schema.String).annotate({
+          description:
+            "RFC 8628 token endpoint. When set alongside deviceAuthorizationUrl, this provider uses device-flow OAuth instead of a static API key.",
+        }),
+        oauthClientId: Schema.optional(Schema.String).annotate({
+          description:
+            "client_id sent in device-authorization and token POSTs. Defaults to \"opencode\". Override if your OAuth server requires a pre-registered client_id.",
+        }),
+        oauthScope: Schema.optional(Schema.String).annotate({
+          description:
+            "OAuth scope string sent in the device-authorization POST. Omitted from the POST body when unset.",
+        }),
       }),
       [Schema.Record(Schema.String, Schema.Any)],
     ),

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -19,6 +19,7 @@ import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cl
 import { AzureAuthPlugin } from "./azure"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
 import { XaiAuthPlugin } from "./xai"
+import { OAuthDeviceProviderPlugin } from "./oauth-device"
 import { SnowflakeCortexAuthPlugin } from "./snowflake-cortex"
 import { Effect, Layer, Context } from "effect"
 import { EffectBridge } from "@/effect/bridge"
@@ -31,6 +32,7 @@ import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
+import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 
 type State = {
   hooks: Hooks[]
@@ -62,7 +64,32 @@ export function experimentalWebSocketsEnabled(input: { enabled: boolean; channel
 }
 
 // Built-in plugins that are directly imported (not installed from npm)
-function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
+function internalPlugins(flags: RuntimeFlags.Info, cfg: ConfigV1.Info): PluginInstance[] {
+  // Config-derived plugins: any user-configured provider whose `options`
+  // declares both `deviceAuthorizationUrl` and `tokenUrl` gets a generic
+  // RFC 8628 device-flow OAuth plugin wired to those endpoints. The
+  // providerId from opencode.json becomes the auth provider id used for
+  // credential storage in auth.json.
+  const configuredOAuthProviders: PluginInstance[] = Object.entries(cfg.provider ?? {})
+    .filter(([, info]) => info?.options?.deviceAuthorizationUrl && info?.options?.tokenUrl)
+    .map(([providerId, info]) => {
+      const options = info!.options!
+      const deviceAuthorizationUrl = options.deviceAuthorizationUrl
+      const tokenUrl = options.tokenUrl
+      const clientId = options.oauthClientId
+      const scope = options.oauthScope
+      const label = info!.name ?? providerId
+      return (input: PluginInput) =>
+        OAuthDeviceProviderPlugin(input, {
+          providerId,
+          label,
+          deviceAuthorizationUrl,
+          tokenUrl,
+          clientId,
+          scope,
+        })
+    })
+
   return [
     // Temporary rollout: pre-release builds use WebSockets by default; releases require explicit opt-in.
     (input) =>
@@ -78,6 +105,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     DigitalOceanAuthPlugin,
     SnowflakeCortexAuthPlugin,
     XaiAuthPlugin,
+    ...configuredOAuthProviders,
   ]
 }
 
@@ -163,7 +191,7 @@ const layer = Layer.effect(
           $: typeof Bun === "undefined" ? undefined : Bun.$,
         }
 
-        for (const plugin of flags.disableDefaultPlugins ? [] : internalPlugins(flags)) {
+        for (const plugin of flags.disableDefaultPlugins ? [] : internalPlugins(flags, cfg)) {
           const init = yield* Effect.tryPromise({
             try: () => plugin(input),
             catch: errorMessage,

--- a/packages/opencode/src/plugin/oauth-device.ts
+++ b/packages/opencode/src/plugin/oauth-device.ts
@@ -1,0 +1,383 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import { OAUTH_DUMMY_KEY } from "../auth"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+
+// Generic RFC 8628 device-flow OAuth plugin. Unlike the xAI plugin (which is
+// the reference implementation this is derived from), this plugin takes its
+// endpoints / client_id / scope from the caller — it makes no assumptions
+// about which OAuth server it is talking to. The intended use is a custom
+// OpenAI-compatible gateway (e.g. an internal litellm-proxy) that exposes
+// RFC 8628 device authorization + token endpoints and needs the same
+// browser-based SSO UX that built-in providers get.
+//
+// There is intentionally no loopback callback server, no PKCE, and no
+// `authorize_code` grant path here — the device flow is the only OAuth
+// method exposed (alongside the standard "Manually enter API Key" fallback).
+// A loopback server is meaningless for headless / VPS / SSH / CI use, and
+// RFC 8628 was designed precisely for those environments.
+
+// Default `client_id` sent in the device-authorization and token POSTs. Some
+// OAuth servers require a pre-registered client_id; users can override this
+// per-provider via `auth.clientId` in their opencode.json.
+const DEFAULT_CLIENT_ID = "opencode"
+
+// RFC 8628 device authorization grant type. Servers MUST accept this exact
+// urn in the `grant_type` field of the token endpoint POST.
+const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+// Bounds for the device-code poll loop. RFC 8628 §3.5 says the server returns
+// `interval` (seconds) but we floor it to avoid hammering and we add the
+// spec's slow_down increment when the server explicitly asks us to back off.
+const DEVICE_CODE_DEFAULT_INTERVAL_MS = 5_000
+const DEVICE_CODE_MIN_INTERVAL_MS = 1_000
+const DEVICE_CODE_SLOW_DOWN_INCREMENT_MS = 5_000
+const DEVICE_CODE_DEFAULT_EXPIRES_MS = 5 * 60 * 1000
+// Extra safety margin added to each poll sleep so a slightly-too-fast client
+// clock doesn't race ahead of the server's polling window.
+const OAUTH_POLLING_SAFETY_MARGIN_MS = 3_000
+
+// Refresh the access token a little before it actually expires so a single
+// long-running tool call doesn't have to recover from a mid-flight 401.
+const ACCESS_TOKEN_REFRESH_SKEW_MS = 120_000
+
+export interface OAuthDeviceProviderOptions {
+  providerId: string
+  label?: string
+  deviceAuthorizationUrl: string
+  tokenUrl: string
+  clientId?: string
+  scope?: string
+}
+
+interface DeviceFlowOptions {
+  deviceAuthorizationUrl: string
+  tokenUrl: string
+  clientId: string
+  scope?: string
+}
+
+interface TokenResponse {
+  access_token: string
+  refresh_token: string
+  id_token?: string
+  token_type?: string
+  expires_in?: number
+  scope?: string
+}
+
+function authHeaders() {
+  return {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+    "User-Agent": `opencode/${InstallationVersion}`,
+  }
+}
+
+// Parse the `exp` claim out of a JWT access_token without verifying the
+// signature. We only use this to decide whether to proactively refresh, never
+// to make trust decisions, so unsigned decode is safe. Returns false for
+// opaque tokens (no JWT shape), which conservatively skips the proactive
+// refresh and lets the 401-on-call path drive the refresh instead.
+export function accessTokenIsExpiring(
+  token: string | undefined,
+  skewMs: number = ACCESS_TOKEN_REFRESH_SKEW_MS,
+): boolean {
+  if (!token || typeof token !== "string") return false
+  const parts = token.split(".")
+  if (parts.length < 2) return false
+  try {
+    let payload = parts[1].replace(/-/g, "+").replace(/_/g, "/")
+    while (payload.length % 4 !== 0) payload += "="
+    const claims = JSON.parse(Buffer.from(payload, "base64").toString("utf8"))
+    if (typeof claims?.exp !== "number") return false
+    return claims.exp * 1000 <= Date.now() + Math.max(0, skewMs)
+  } catch {
+    return false
+  }
+}
+
+export interface DeviceCodeResponse {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete?: string
+  expires_in?: number
+  interval?: number
+}
+
+interface DeviceTokenErrorBody {
+  error?: string
+  error_description?: string
+}
+
+export async function requestDeviceCode(options: DeviceFlowOptions): Promise<DeviceCodeResponse> {
+  const params: Record<string, string> = {
+    client_id: options.clientId,
+  }
+  // Some OAuth servers reject an empty `scope=` form field; only emit it when
+  // the caller actually configured one.
+  if (options.scope) params.scope = options.scope
+  const response = await fetch(options.deviceAuthorizationUrl, {
+    method: "POST",
+    headers: authHeaders(),
+    body: new URLSearchParams(params).toString(),
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "")
+    throw new Error(
+      `OAuth device code request failed for ${options.deviceAuthorizationUrl} (${response.status})${detail ? `: ${detail}` : ""}`,
+    )
+  }
+  const json = (await response.json()) as DeviceCodeResponse
+  if (!json.device_code || !json.user_code || !json.verification_uri) {
+    throw new Error("OAuth device code response is missing device_code / user_code / verification_uri")
+  }
+  return json
+}
+
+// Default sleep used between device-code polls. Test-injectable so we can
+// exercise authorization_pending / slow_down branches without real waits.
+async function defaultSleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+// Normalize a server-supplied seconds value to milliseconds, falling back to
+// the supplied default when the input is missing, non-positive, or not a
+// finite number. Defends the polling loop against garbage like `NaN`, `"NaN"`,
+// `null`, or `-5` from a misbehaving device-code endpoint — without this,
+// a NaN interval would slip through `?? default` (NaN is typeof number),
+// reach `setTimeout(_, NaN)` which is treated as 0, and busy-loop until the
+// hard deadline. Matches the defensive normalization Codex uses for the same
+// field (`parseInt(deviceData.interval) || 5`).
+function positiveSecondsToMs(value: unknown, defaultMs: number): number {
+  const seconds = Number(value)
+  return Number.isFinite(seconds) && seconds > 0 ? seconds * 1000 : defaultMs
+}
+
+export async function pollDeviceCodeToken(
+  device: DeviceCodeResponse,
+  options: DeviceFlowOptions & { sleep?: (ms: number) => Promise<void>; now?: () => number },
+): Promise<TokenResponse> {
+  const sleep = options.sleep ?? defaultSleep
+  const now = options.now ?? (() => Date.now())
+  const expiresInMs = positiveSecondsToMs(device.expires_in, DEVICE_CODE_DEFAULT_EXPIRES_MS)
+  const deadline = now() + expiresInMs
+  let intervalMs = Math.max(
+    positiveSecondsToMs(device.interval, DEVICE_CODE_DEFAULT_INTERVAL_MS),
+    DEVICE_CODE_MIN_INTERVAL_MS,
+  )
+
+  while (now() < deadline) {
+    const response = await fetch(options.tokenUrl, {
+      method: "POST",
+      headers: authHeaders(),
+      body: new URLSearchParams({
+        grant_type: DEVICE_CODE_GRANT_TYPE,
+        client_id: options.clientId,
+        device_code: device.device_code,
+      }).toString(),
+    })
+    if (response.ok) return (await response.json()) as TokenResponse
+
+    const body = (await response.json().catch(() => ({}))) as DeviceTokenErrorBody
+    const remaining = Math.max(0, deadline - now())
+    // RFC 8628 §3.5: authorization_pending = keep polling at the same
+    // interval; slow_down = bump the interval by ≥5s and keep polling.
+    // Anything else is terminal.
+    if (body.error === "authorization_pending") {
+      await sleep(Math.min(intervalMs + OAUTH_POLLING_SAFETY_MARGIN_MS, remaining))
+      continue
+    }
+    if (body.error === "slow_down") {
+      intervalMs += DEVICE_CODE_SLOW_DOWN_INCREMENT_MS
+      await sleep(Math.min(intervalMs + OAUTH_POLLING_SAFETY_MARGIN_MS, remaining))
+      continue
+    }
+    if (body.error === "access_denied" || body.error === "authorization_denied") {
+      throw new Error("OAuth device authorization was denied")
+    }
+    if (body.error === "expired_token") {
+      throw new Error("OAuth device code expired - please re-run login")
+    }
+    const detail = body.error_description ?? body.error ?? ""
+    throw new Error(`OAuth device token exchange failed (${response.status})${detail ? `: ${detail}` : ""}`)
+  }
+  throw new Error("OAuth device authorization timed out")
+}
+
+async function refreshAccessToken(refreshToken: string, options: DeviceFlowOptions): Promise<TokenResponse> {
+  const response = await fetch(options.tokenUrl, {
+    method: "POST",
+    headers: authHeaders(),
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: options.clientId,
+    }).toString(),
+  })
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "")
+    throw new Error(`OAuth token refresh failed (${response.status})${detail ? `: ${detail}` : ""}`)
+  }
+  return response.json() as Promise<TokenResponse>
+}
+
+interface RefreshResult {
+  access: string
+  refresh: string
+  expires: number
+}
+
+// Per-provider single-flight refresh state. Multiple plugin instances (one per
+// configured provider) coexist in the same process; keying the map by
+// providerId ensures instance A's in-flight refresh doesn't collapse
+// instance B's concurrent refresh against a different refresh_token.
+const refreshPromises = new Map<string, Promise<RefreshResult> | undefined>()
+
+export async function OAuthDeviceProviderPlugin(
+  input: PluginInput,
+  options: OAuthDeviceProviderOptions,
+): Promise<Hooks> {
+  const flowOptions: DeviceFlowOptions = {
+    deviceAuthorizationUrl: options.deviceAuthorizationUrl,
+    tokenUrl: options.tokenUrl,
+    clientId: options.clientId ?? DEFAULT_CLIENT_ID,
+    scope: options.scope,
+  }
+  const providerId = options.providerId
+
+  return {
+    auth: {
+      provider: providerId,
+      async loader(getAuth) {
+        const auth = await getAuth()
+        if (auth.type !== "oauth") return {}
+
+        return {
+          // Dummy bearer keeps the AI SDK from bailing on "missing apiKey";
+          // the real OAuth token is injected by the fetch override below.
+          // We intentionally do NOT set baseURL — the user's
+          // `options.baseURL` from their opencode.json provider config must
+          // win, and overriding here would silently route around it.
+          apiKey: OAUTH_DUMMY_KEY,
+          async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
+            let currentAuth = await getAuth()
+            // Auth can flip from oauth to api mid-session (user re-runs
+            // /connect with a pasted key). When that happens, pass the
+            // request through untouched so the AI SDK's own apiKey-based
+            // Authorization header reaches the gateway unmodified.
+            if (currentAuth.type !== "oauth") return fetch(requestInput, init)
+
+            // Refresh either when the stored expires timestamp is within the
+            // skew window, or — for JWT access tokens — when the JWT exp
+            // claim itself is. The stored expires field is best-effort
+            // (servers don't always return expires_in) so the JWT check is
+            // the load-bearing one for tokens that lack a fresh stored
+            // deadline.
+            const expiresSoon =
+              !currentAuth.expires ||
+              currentAuth.expires - Date.now() <= ACCESS_TOKEN_REFRESH_SKEW_MS ||
+              accessTokenIsExpiring(currentAuth.access)
+            if (expiresSoon) {
+              let refreshPromise = refreshPromises.get(providerId)
+              if (!refreshPromise) {
+                const refreshToken = currentAuth.refresh
+                refreshPromise = refreshAccessToken(refreshToken, flowOptions)
+                  .then(async (tokens) => {
+                    const refreshedExpires = Date.now() + (tokens.expires_in ?? 3600) * 1000
+                    const refreshedRefresh = tokens.refresh_token || refreshToken
+                    // Persist the rotated pair as best-effort. The OAuth
+                    // server has already consumed the old refresh_token by
+                    // the time we get here; an auth.set failure leaves the
+                    // on-disk state stale but the in-memory result is still
+                    // valid for this turn. The next live refresh against the
+                    // stale disk state will 4xx and force re-login — a known
+                    // cross-process limitation.
+                    await input.client.auth
+                      .set({
+                        path: { id: providerId },
+                        body: {
+                          type: "oauth",
+                          access: tokens.access_token,
+                          refresh: refreshedRefresh,
+                          expires: refreshedExpires,
+                        },
+                      })
+                      .catch(() => {})
+                    return { access: tokens.access_token, refresh: refreshedRefresh, expires: refreshedExpires }
+                  })
+                  .finally(() => {
+                    refreshPromises.set(providerId, undefined)
+                  })
+                refreshPromises.set(providerId, refreshPromise)
+              }
+              const refreshed = await refreshPromise
+              currentAuth = { ...currentAuth, ...refreshed }
+            }
+
+            // Copy the caller's headers into a fresh Headers (case-insensitive)
+            // so we never mutate the RequestInit the AI SDK may reuse on retry.
+            // Headers.set overwrites case-insensitively, which kills the dummy
+            // bearer the AI SDK injected from apiKey in a single line.
+            const headers = new Headers(requestInput instanceof Request ? requestInput.headers : undefined)
+            if (init?.headers) {
+              const entries =
+                init.headers instanceof Headers
+                  ? init.headers.entries()
+                  : Array.isArray(init.headers)
+                    ? init.headers
+                    : Object.entries(init.headers as Record<string, string | undefined>)
+              for (const [key, value] of entries) {
+                if (value !== undefined) headers.set(key, String(value))
+              }
+            }
+            headers.set("authorization", `Bearer ${currentAuth.access}`)
+            headers.set("User-Agent", `opencode/${InstallationVersion}`)
+
+            return fetch(requestInput, { ...init, headers })
+          },
+        }
+      },
+      methods: [
+        {
+          // RFC 8628 device-code flow. The CLI prints a verification URL
+          // and a short user_code that the user enters in a browser on any
+          // device. No loopback callback server runs on the CLI host, so
+          // this works on VPS / SSH / Docker / CI / WSL / any environment
+          // where 127.0.0.1 isn't reachable from the user's browser.
+          // Defends the only attack surface (the polling loop) with the
+          // standard authorization_pending / slow_down backoff and a hard
+          // deadline from the server's `expires_in`.
+          label: options.label ?? `${providerId} OAuth (Device Flow)`,
+          type: "oauth",
+          authorize: async () => {
+            const device = await requestDeviceCode(flowOptions)
+            const browserUrl = device.verification_uri_complete ?? device.verification_uri
+            return {
+              url: browserUrl,
+              instructions: `Open ${device.verification_uri} on any device and enter code: ${device.user_code}`,
+              method: "auto" as const,
+              callback: async () => {
+                try {
+                  const tokens = await pollDeviceCodeToken(device, flowOptions)
+                  return {
+                    type: "success" as const,
+                    refresh: tokens.refresh_token,
+                    access: tokens.access_token,
+                    expires: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+                  }
+                } catch {
+                  return { type: "failed" as const }
+                }
+              },
+            }
+          },
+        },
+        {
+          label: "Manually enter API Key",
+          type: "api",
+        },
+      ],
+    },
+  }
+}

--- a/packages/opencode/test/plugin/oauth-device.test.ts
+++ b/packages/opencode/test/plugin/oauth-device.test.ts
@@ -1,0 +1,606 @@
+import { describe, expect, test } from "bun:test"
+import {
+  accessTokenIsExpiring,
+  OAuthDeviceProviderPlugin,
+  pollDeviceCodeToken,
+  requestDeviceCode,
+} from "../../src/plugin/oauth-device"
+import { OAUTH_DUMMY_KEY } from "../../src/auth"
+import type { PluginInput } from "@opencode-ai/plugin"
+
+function makeJwt(payload: object): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url")
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url")
+  return `${header}.${body}.sig`
+}
+
+function makeInput(opts?: { failSet?: boolean }) {
+  const setCalls: Array<Record<string, unknown>> = []
+  return {
+    input: {
+      client: {
+        auth: {
+          set: async (req: Record<string, unknown>) => {
+            setCalls.push(req)
+            if (opts?.failSet) throw new Error("auth.set boom")
+          },
+        },
+      },
+    } as unknown as PluginInput,
+    setCalls,
+  }
+}
+
+function makeServer(handler: (request: Request, url: URL) => Response | Promise<Response>) {
+  return Bun.serve({
+    port: 0,
+    fetch: (request) => handler(request, new URL(request.url)),
+  })
+}
+
+function deviceFlowOptions(server: ReturnType<typeof Bun.serve>) {
+  return {
+    deviceAuthorizationUrl: new URL("/oauth/device_authorization", server.url).toString(),
+    tokenUrl: new URL("/oauth/token", server.url).toString(),
+  }
+}
+
+describe("plugin.oauth-device", () => {
+  describe("accessTokenIsExpiring", () => {
+    test("returns true for an already-expired JWT", () => {
+      expect(accessTokenIsExpiring(makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 }), 0)).toBe(true)
+    })
+
+    test("returns false for a fresh JWT outside the skew window", () => {
+      expect(accessTokenIsExpiring(makeJwt({ exp: Math.floor(Date.now() / 1000) + 3600 }), 0)).toBe(false)
+    })
+
+    test("honors the skew window", () => {
+      const nearExpiry = makeJwt({ exp: Math.floor(Date.now() / 1000) + 30 })
+      expect(accessTokenIsExpiring(nearExpiry, 60_000)).toBe(true)
+      expect(accessTokenIsExpiring(nearExpiry, 0)).toBe(false)
+    })
+
+    test("clamps negative skew to zero rather than refusing to refresh", () => {
+      expect(accessTokenIsExpiring(makeJwt({ exp: Math.floor(Date.now() / 1000) - 1 }), -60_000)).toBe(true)
+    })
+
+    test("returns false for opaque and malformed tokens", () => {
+      expect(accessTokenIsExpiring("opaque-token-no-dots", 0)).toBe(false)
+      expect(accessTokenIsExpiring("", 0)).toBe(false)
+      expect(accessTokenIsExpiring(undefined, 0)).toBe(false)
+      expect(accessTokenIsExpiring(makeJwt({ sub: "user-1" }), 0)).toBe(false)
+      expect(accessTokenIsExpiring(makeJwt({ exp: "1234" }), 0)).toBe(false)
+      expect(accessTokenIsExpiring("header.!!!not-valid-base64-or-json!!!.sig", 0)).toBe(false)
+    })
+  })
+
+  describe("requestDeviceCode", () => {
+    test("posts form body with default client_id=opencode and omits scope when unset", async () => {
+      let capturedBody = ""
+      using server = makeServer(async (request, url) => {
+        if (url.pathname === "/missing") return Response.json({ device_code: "x" })
+        if (url.pathname === "/error") return new Response("rate limited", { status: 429 })
+        expect(request.method).toBe("POST")
+        expect(request.headers.get("content-type")).toBe("application/x-www-form-urlencoded")
+        expect(request.headers.get("accept")).toBe("application/json")
+        expect(request.headers.get("user-agent")).toMatch(/^opencode\//)
+        capturedBody = await request.text()
+        return Response.json({
+          device_code: "DC",
+          user_code: "UC",
+          verification_uri: "https://gateway.example/device",
+        })
+      })
+
+      await requestDeviceCode({
+        ...deviceFlowOptions(server),
+        clientId: "opencode",
+      })
+      const parsed = new URLSearchParams(capturedBody)
+      expect(parsed.get("client_id")).toBe("opencode")
+      expect(parsed.has("scope")).toBe(false)
+
+      await expect(
+        requestDeviceCode({
+          deviceAuthorizationUrl: new URL("/error", server.url).toString(),
+          tokenUrl: new URL("/oauth/token", server.url).toString(),
+          clientId: "opencode",
+        }),
+      ).rejects.toThrow(/429.*rate limited/)
+      await expect(
+        requestDeviceCode({
+          deviceAuthorizationUrl: new URL("/missing", server.url).toString(),
+          tokenUrl: new URL("/oauth/token", server.url).toString(),
+          clientId: "opencode",
+        }),
+      ).rejects.toThrow(/missing device_code/)
+    })
+
+    test("includes scope when set in options", async () => {
+      let capturedBody = ""
+      using server = makeServer(async (request) => {
+        capturedBody = await request.text()
+        return Response.json({
+          device_code: "DC",
+          user_code: "UC",
+          verification_uri: "https://gateway.example/device",
+        })
+      })
+      await requestDeviceCode({
+        ...deviceFlowOptions(server),
+        clientId: "my-client",
+        scope: "openid profile email offline_access",
+      })
+      const parsed = new URLSearchParams(capturedBody)
+      expect(parsed.get("client_id")).toBe("my-client")
+      expect(parsed.get("scope")).toBe("openid profile email offline_access")
+    })
+
+    test("accepts a custom clientId", async () => {
+      let capturedBody = ""
+      using server = makeServer(async (request) => {
+        capturedBody = await request.text()
+        return Response.json({
+          device_code: "DC",
+          user_code: "UC",
+          verification_uri: "https://gateway.example/device",
+        })
+      })
+      await requestDeviceCode({
+        ...deviceFlowOptions(server),
+        clientId: "custom-gateway-client",
+      })
+      const parsed = new URLSearchParams(capturedBody)
+      expect(parsed.get("client_id")).toBe("custom-gateway-client")
+    })
+  })
+
+  describe("pollDeviceCodeToken", () => {
+    test("resolves on success and posts the device-code grant", async () => {
+      let tokenCalls = 0
+      using server = makeServer(async (request) => {
+        tokenCalls++
+        expect(request.headers.get("content-type")).toBe("application/x-www-form-urlencoded")
+        const body = new URLSearchParams(await request.text())
+        expect(body.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:device_code")
+        expect(body.get("device_code")).toBe("DC-1")
+        expect(body.get("client_id")).toBe("opencode")
+        return Response.json({ access_token: "AT", refresh_token: "RT", expires_in: 3600 })
+      })
+
+      const tokens = await pollDeviceCodeToken(
+        { device_code: "DC-1", user_code: "UC", verification_uri: "https://gateway.example/device", interval: 1, expires_in: 600 },
+        {
+          sleep: async () => {},
+          ...deviceFlowOptions(server),
+          clientId: "opencode",
+        },
+      )
+      expect(tokens.access_token).toBe("AT")
+      expect(tokens.refresh_token).toBe("RT")
+      expect(tokenCalls).toBe(1)
+    })
+
+    test("honors authorization_pending and slow_down", async () => {
+      let n = 0
+      using server = makeServer(() => {
+        n++
+        if (n === 1) return Response.json({ error: "authorization_pending" }, { status: 400 })
+        if (n === 2) return Response.json({ error: "slow_down" }, { status: 400 })
+        return Response.json({ access_token: "AT", refresh_token: "RT", expires_in: 3600 })
+      })
+      const sleeps: number[] = []
+      const tokens = await pollDeviceCodeToken(
+        { device_code: "DC", user_code: "UC", verification_uri: "https://gateway.example/device", interval: 5, expires_in: 600 },
+        {
+          sleep: async (ms) => void sleeps.push(ms),
+          ...deviceFlowOptions(server),
+          clientId: "opencode",
+        },
+      )
+      expect(tokens.access_token).toBe("AT")
+      expect(n).toBe(3)
+      expect(sleeps).toEqual([8_000, 13_000])
+    })
+
+    test("handles terminal errors and timeout", async () => {
+      for (const [body, error] of [
+        [{ error: "access_denied" }, /authorization was denied/],
+        [{ error: "expired_token" }, /device code expired/],
+        [{ error: "server_error", error_description: "oops" }, /500.*oops/],
+      ] as const) {
+        using server = makeServer(() => Response.json(body, { status: 500 }))
+        await expect(
+          pollDeviceCodeToken(
+            {
+              device_code: "DC",
+              user_code: "UC",
+              verification_uri: "https://gateway.example/device",
+              interval: 1,
+              expires_in: 600,
+            },
+            {
+              sleep: async () => {},
+              ...deviceFlowOptions(server),
+              clientId: "opencode",
+            },
+          ),
+        ).rejects.toThrow(error)
+      }
+
+      using pending = makeServer(() => Response.json({ error: "authorization_pending" }, { status: 400 }))
+      let tick = 0
+      await expect(
+        pollDeviceCodeToken(
+          { device_code: "DC", user_code: "UC", verification_uri: "https://gateway.example/device", interval: 1, expires_in: 1 },
+          {
+            sleep: async () => {},
+            now: () => 1_000_000 + tick++ * 600,
+            ...deviceFlowOptions(pending),
+            clientId: "opencode",
+          },
+        ),
+      ).rejects.toThrow(/timed out/)
+    })
+
+    test("normalizes bad interval and expires_in values", async () => {
+      const badIntervals: Array<unknown> = [Number.NaN, "NaN", "garbage", -5, null, 0]
+      for (const bad of badIntervals) {
+        let n = 0
+        using server = makeServer(() => {
+          n++
+          if (n === 1) return Response.json({ error: "authorization_pending" }, { status: 400 })
+          return Response.json({ access_token: "AT", refresh_token: "RT", expires_in: 3600 })
+        })
+        const sleeps: number[] = []
+        await pollDeviceCodeToken(
+          {
+            device_code: "DC",
+            user_code: "UC",
+            verification_uri: "https://gateway.example/device",
+            interval: bad as number,
+            expires_in: 600,
+          },
+          {
+            sleep: async (ms) => void sleeps.push(ms),
+            ...deviceFlowOptions(server),
+            clientId: "opencode",
+          },
+        )
+        expect(sleeps[0]).toBe(8_000)
+      }
+
+      for (const bad of [Number.NaN, "NaN", "garbage", -5, null, 0]) {
+        using server = makeServer(() => Response.json({ access_token: "AT", refresh_token: "RT", expires_in: 3600 }))
+        expect(
+          (
+            await pollDeviceCodeToken(
+              {
+                device_code: "DC",
+                user_code: "UC",
+                verification_uri: "https://gateway.example/device",
+                interval: 1,
+                expires_in: bad as number,
+              },
+              {
+                sleep: async () => {},
+                ...deviceFlowOptions(server),
+                clientId: "opencode",
+              },
+            )
+          ).access_token,
+        ).toBe("AT")
+      }
+    })
+  })
+
+  describe("loader", () => {
+    test("returns no options unless stored auth is oauth and exposes methods in order", async () => {
+      const hooks = await OAuthDeviceProviderPlugin({} as PluginInput, {
+        providerId: "litellm-proxy",
+        deviceAuthorizationUrl: "https://gateway.example/oauth/device_authorization",
+        tokenUrl: "https://gateway.example/oauth/token",
+      })
+      expect(await hooks.auth!.loader!(async () => ({ type: "api", key: "sk-test" }), {} as any)).toEqual({})
+      expect(hooks.auth!.methods.map((m) => [m.type, m.label])).toEqual([
+        ["oauth", "litellm-proxy OAuth (Device Flow)"],
+        ["api", "Manually enter API Key"],
+      ])
+    })
+
+    test("uses options.label when provided", async () => {
+      const hooks = await OAuthDeviceProviderPlugin({} as PluginInput, {
+        providerId: "litellm-proxy",
+        label: "LiteLLM Proxy",
+        deviceAuthorizationUrl: "https://gateway.example/oauth/device_authorization",
+        tokenUrl: "https://gateway.example/oauth/token",
+      })
+      expect(hooks.auth!.methods[0].label).toBe("LiteLLM Proxy")
+    })
+
+    test("replaces the dummy bearer and does not set baseURL", async () => {
+      const { input } = makeInput()
+      const captured: Headers[] = []
+      using server = makeServer((request) => {
+        captured.push(request.headers)
+        return new Response("{}", { status: 200 })
+      })
+      const hooks = await OAuthDeviceProviderPlugin(input, {
+        providerId: "litellm-proxy",
+        ...deviceFlowOptions(server),
+      })
+      const opts = await hooks.auth!.loader!(
+        async () => ({ type: "oauth", access: "live-token", refresh: "rt", expires: Date.now() + 3600_000 }),
+        {} as any,
+      )
+      expect(opts.apiKey).toBe(OAUTH_DUMMY_KEY)
+      expect(opts.baseURL).toBeUndefined()
+
+      await opts.fetch!(new URL("/chat/completions", server.url), {
+        headers: { Authorization: `Bearer ${OAUTH_DUMMY_KEY}`, "x-keep": "yes" },
+      })
+
+      expect(captured[0].get("authorization")).toBe("Bearer live-token")
+      expect(captured[0].get("x-keep")).toBe("yes")
+      expect(captured[0].get("user-agent")).toMatch(/^opencode\//)
+    })
+
+    test("falls through to plain fetch when stored auth flips from oauth to api", async () => {
+      const { input } = makeInput()
+      const captured: Headers[] = []
+      using server = makeServer((request) => {
+        captured.push(request.headers)
+        return new Response("{}", { status: 200 })
+      })
+      let firstCall = true
+      const hooks = await OAuthDeviceProviderPlugin(input, {
+        providerId: "litellm-proxy",
+        ...deviceFlowOptions(server),
+      })
+      const opts = await hooks.auth!.loader!(async () => {
+        if (firstCall) {
+          firstCall = false
+          return { type: "oauth", access: "tok", refresh: "rt", expires: Date.now() + 3600_000 }
+        }
+        return { type: "api", key: "sk-new" }
+      }, {} as any)
+
+      await opts.fetch!(new URL("/chat/completions", server.url), {
+        headers: { Authorization: "Bearer sk-from-aisdk", "x-keep": "v" },
+      })
+      expect(captured[0].get("authorization")).toBe("Bearer sk-from-aisdk")
+      expect(captured[0].get("x-keep")).toBe("v")
+    })
+
+    test("refreshes proactively, persists rotated token, and sets Bearer header", async () => {
+      const { input, setCalls } = makeInput()
+      let tokenRequests = 0
+      const apiRequests: Headers[] = []
+      using server = makeServer(async (request, url) => {
+        if (url.pathname === "/oauth/token") {
+          tokenRequests++
+          const body = await request.text()
+          expect(body).toContain("refresh_token=rt-old")
+          expect(body).toContain("client_id=opencode")
+          await new Promise((resolve) => setTimeout(resolve, 30))
+          return Response.json({ access_token: "new-access", refresh_token: "rt-new", expires_in: 3600 })
+        }
+        apiRequests.push(request.headers)
+        return new Response("{}", { status: 200 })
+      })
+      const hooks = await OAuthDeviceProviderPlugin(input, {
+        providerId: "litellm-proxy",
+        ...deviceFlowOptions(server),
+      })
+      const opts = await hooks.auth!.loader!(
+        async () => ({ type: "oauth" as const, access: "old", refresh: "rt-old", expires: 0 }),
+        {} as any,
+      )
+
+      await opts.fetch!(new URL("/chat/completions", server.url), { headers: {} })
+
+      expect(tokenRequests).toBe(1)
+      expect(apiRequests.map((headers) => headers.get("authorization"))).toEqual(["Bearer new-access"])
+      expect(setCalls).toHaveLength(1)
+      expect(setCalls[0].path).toEqual({ id: "litellm-proxy" })
+      expect((setCalls[0].body as any).type).toBe("oauth")
+      expect((setCalls[0].body as any).access).toBe("new-access")
+      expect((setCalls[0].body as any).refresh).toBe("rt-new")
+    })
+
+    test("deduplicates concurrent refreshes within a loader instance", async () => {
+      const { input, setCalls } = makeInput()
+      let tokenRequests = 0
+      using server = makeServer(async (request, url) => {
+        if (url.pathname === "/oauth/token") {
+          tokenRequests++
+          await new Promise((resolve) => setTimeout(resolve, 30))
+          return Response.json({ access_token: "new-access", refresh_token: "rt-new", expires_in: 3600 })
+        }
+        return new Response("{}", { status: 200 })
+      })
+      const opts = await (
+        await OAuthDeviceProviderPlugin(input, {
+          providerId: "litellm-proxy",
+          ...deviceFlowOptions(server),
+        })
+      ).auth!.loader!(async () => ({ type: "oauth" as const, access: "old", refresh: "rt-old", expires: 0 }), {} as any)
+
+      await Promise.all([
+        opts.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
+        opts.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
+      ])
+
+      expect(tokenRequests).toBe(1)
+      expect(setCalls).toHaveLength(1)
+    })
+
+    test("does not share refresh single-flight across provider instances", async () => {
+      const { input } = makeInput()
+      const tokenRequests: string[] = []
+      using server = makeServer(async (request, url) => {
+        if (url.pathname === "/oauth/token") {
+          const refreshToken = new URLSearchParams(await request.text()).get("refresh_token")!
+          tokenRequests.push(refreshToken)
+          await new Promise((resolve) => setTimeout(resolve, 20))
+          return Response.json({
+            access_token: `access-${refreshToken}`,
+            refresh_token: `next-${refreshToken}`,
+            expires_in: 3600,
+          })
+        }
+        return new Response("{}", { status: 200 })
+      })
+      const first = await (
+        await OAuthDeviceProviderPlugin(input, {
+          providerId: "gateway-a",
+          ...deviceFlowOptions(server),
+        })
+      ).auth!.loader!(async () => ({ type: "oauth" as const, access: "old-a", refresh: "rt-a", expires: 0 }), {} as any)
+      const second = await (
+        await OAuthDeviceProviderPlugin(input, {
+          providerId: "gateway-b",
+          ...deviceFlowOptions(server),
+        })
+      ).auth!.loader!(async () => ({ type: "oauth" as const, access: "old-b", refresh: "rt-b", expires: 0 }), {} as any)
+
+      await Promise.all([
+        first.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
+        second.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
+      ])
+
+      expect(tokenRequests.sort()).toEqual(["rt-a", "rt-b"])
+    })
+
+    test("handles refresh response without refresh_token (reuses old) and persistence failure", async () => {
+      const { input, setCalls } = makeInput({ failSet: true })
+      const captured: Headers[] = []
+      using server = makeServer((request, url) => {
+        if (url.pathname === "/oauth/token") return Response.json({ access_token: "new-access", expires_in: 3600 })
+        captured.push(request.headers)
+        return new Response("{}", { status: 200 })
+      })
+      const opts = await (
+        await OAuthDeviceProviderPlugin(input, {
+          providerId: "litellm-proxy",
+          ...deviceFlowOptions(server),
+        })
+      ).auth!.loader!(async () => ({ type: "oauth" as const, access: "old", refresh: "rt-old", expires: 0 }), {} as any)
+
+      const resp = await opts.fetch!(new URL("/chat/completions", server.url), { headers: {} })
+      expect(resp.status).toBe(200)
+      expect(captured[0].get("authorization")).toBe("Bearer new-access")
+      expect(setCalls).toHaveLength(1)
+      expect((setCalls[0].body as any).refresh).toBe("rt-old")
+    })
+
+    test("skips refresh when both stored and JWT expiry are fresh", async () => {
+      const { input, setCalls } = makeInput()
+      let tokenRequests = 0
+      using server = makeServer((_, url) => {
+        if (url.pathname === "/oauth/token") {
+          tokenRequests++
+          return Response.json({ access_token: "new-access", refresh_token: "rt-new", expires_in: 3600 })
+        }
+        return new Response("{}", { status: 200 })
+      })
+      const fresh = await (
+        await OAuthDeviceProviderPlugin(input, {
+          providerId: "litellm-proxy",
+          ...deviceFlowOptions(server),
+        })
+      ).auth!.loader!(
+        async () => ({
+          type: "oauth",
+          access: makeJwt({ exp: Math.floor(Date.now() / 1000) + 24 * 3600 }),
+          refresh: "rt",
+          expires: Date.now() + 24 * 3600 * 1000,
+        }),
+        {} as any,
+      )
+      await fresh.fetch!(new URL("/chat/completions", server.url), { headers: {} })
+      expect(tokenRequests).toBe(0)
+      expect(setCalls).toHaveLength(0)
+    })
+  })
+
+  describe("device code authorize", () => {
+    test("advertises verification URL + user code and returns success on callback", async () => {
+      using server = makeServer((_, url) => {
+        if (url.pathname === "/oauth/device_authorization") {
+          return Response.json({
+            device_code: "DEVICE-1",
+            user_code: "ABCD-1234",
+            verification_uri: "https://gateway.example/device",
+            verification_uri_complete: "https://gateway.example/device?user_code=ABCD-1234",
+            expires_in: 600,
+            interval: 5,
+          })
+        }
+        if (url.pathname === "/oauth/token") {
+          return Response.json({ access_token: "AT", refresh_token: "RT", expires_in: 3600 })
+        }
+        return new Response("unexpected request", { status: 500 })
+      })
+      const hooks = await OAuthDeviceProviderPlugin({} as PluginInput, {
+        providerId: "litellm-proxy",
+        ...deviceFlowOptions(server),
+      })
+      const oauthMethod = hooks.auth!.methods.find(
+        (m): m is Extract<typeof m, { type: "oauth" }> => m.type === "oauth",
+      )!
+      const result = await oauthMethod.authorize!()
+
+      expect(result.method).toBe("auto")
+      expect(result.url).toBe("https://gateway.example/device?user_code=ABCD-1234")
+      expect(result.instructions).toContain("https://gateway.example/device")
+      expect(result.instructions).toContain("ABCD-1234")
+      expect(await (result as any).callback()).toMatchObject({ type: "success", refresh: "RT", access: "AT" })
+    })
+
+    test("falls back to verification_uri when verification_uri_complete is absent", async () => {
+      using server = makeServer((_, url) => {
+        if (url.pathname === "/oauth/device_authorization") {
+          return Response.json({
+            device_code: "DEVICE-2",
+            user_code: "WXYZ-9876",
+            verification_uri: "https://gateway.example/device",
+          })
+        }
+        return new Response("unexpected request", { status: 500 })
+      })
+      const hooks = await OAuthDeviceProviderPlugin({} as PluginInput, {
+        providerId: "litellm-proxy",
+        ...deviceFlowOptions(server),
+      })
+      const oauthMethod = hooks.auth!.methods.find(
+        (m): m is Extract<typeof m, { type: "oauth" }> => m.type === "oauth",
+      )!
+      expect((await oauthMethod.authorize!()).url).toBe("https://gateway.example/device")
+    })
+
+    test("authorize callback returns failed when polling errors", async () => {
+      using server = makeServer((_, url) => {
+        if (url.pathname === "/oauth/device_authorization") {
+          return Response.json({
+            device_code: "DC",
+            user_code: "UC",
+            verification_uri: "https://gateway.example/device",
+            interval: 0,
+            expires_in: 600,
+          })
+        }
+        return Response.json({ error: "access_denied" }, { status: 400 })
+      })
+      const hooks = await OAuthDeviceProviderPlugin({} as PluginInput, {
+        providerId: "litellm-proxy",
+        ...deviceFlowOptions(server),
+      })
+      const oauthMethod = hooks.auth!.methods.find(
+        (m): m is Extract<typeof m, { type: "oauth" }> => m.type === "oauth",
+      )!
+      expect(await ((await oauthMethod.authorize!()) as any).callback()).toEqual({ type: "failed" })
+    })
+  })
+})

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2486,6 +2486,51 @@ The `limit` fields allow OpenCode to understand how much context you have left. 
 
 ---
 
+## Custom OAuth (device flow)
+
+If your custom OpenAI-compatible gateway exposes [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) device-flow OAuth endpoints, opencode can drive the same browser-based SSO UX that built-in providers (xAI, Copilot) get. This is the headless / VPS / SSH / CI path: opencode prints a verification URL and a short user code, the user opens the URL on any device with a browser, types the code, and opencode long-polls the token endpoint until authorization completes. No loopback callback server is started on the CLI host, so this works in every environment where `127.0.0.1` isn't reachable from the user's browser.
+
+Configure the OAuth endpoints inside the provider's `options` block alongside `baseURL`. When both `deviceAuthorizationUrl` and `tokenUrl` are present, opencode automatically registers a device-flow plugin for that provider and exposes it in the `/connect` command. Refresh tokens are persisted to `auth.json` and rotated proactively before each request — you do not need to re-authorize on every run.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "litellm-proxy": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LiteLLM Proxy",
+      "options": {
+        "baseURL": "https://litellm-proxy.d.shared.int/v1",
+        "deviceAuthorizationUrl": "https://litellm-proxy.d.shared.int/oauth/device_authorization",
+        "tokenUrl": "https://litellm-proxy.d.shared.int/oauth/token"
+      },
+      "models": {
+        "glm-5.2": {
+          "name": "GLM 5.2"
+        }
+      }
+    }
+  }
+}
+```
+
+Optional fields (also under `options`):
+
+- **oauthClientId**: `client_id` sent in the device-authorization and token POSTs. Defaults to `opencode`. Override this if your OAuth server requires a pre-registered client_id.
+- **oauthScope**: OAuth scope string sent in the device-authorization POST. Omitted entirely from the POST body when unset (some servers reject an empty `scope=` form field).
+
+##### Requirements for your OAuth server
+
+- Must expose `deviceAuthorizationUrl` and `tokenUrl` per [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628).
+- The device-authorization endpoint MUST return `device_code`, `user_code`, and `verification_uri` (RFC 8628 §3.2).
+- The token endpoint MUST accept `grant_type=urn:ietf:params:oauth:grant-type:device_code` and return `access_token` + `refresh_token` (RFC 8628 §3.4-3.5).
+- Must accept `client_id=opencode` (or whatever you configured in `options.oauthClientId`).
+- Must issue refresh tokens so opencode can rotate the access token proactively without re-prompting the user.
+- `token_type` SHOULD be `Bearer`. The access token is sent to your gateway as `Authorization: Bearer <access>`.
+- The token endpoint MUST handle the standard RFC 8628 error responses: `authorization_pending`, `slow_down`, `access_denied`, and `expired_token`.
+
+---
+
 ## Troubleshooting
 
 If you are having trouble with configuring a provider, check the following:


### PR DESCRIPTION
### Issue for this PR

Closes # (no associated issue — opening as a feature contribution per CONTRIBUTING.md)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a generic RFC 8628 device-flow OAuth provider type so any custom OpenAI-compatible gateway can expose browser-based SSO with the same UX as built-in providers (xAI, Copilot).

Users declare `deviceAuthorizationUrl` + `tokenUrl` under a provider's `options` block in `opencode.json`. opencode detects these and auto-registers a device-flow plugin for that provider — no CLI changes, no per-gateway code.

```json
{
  "provider": {
    "my-gateway": {
      "npm": "@ai-sdk/openai-compatible",
      "options": {
        "baseURL": "https://my-gateway.example.com/v1",
        "deviceAuthorizationUrl": "https://my-gateway.example.com/oauth/device_authorization",
        "tokenUrl": "https://my-gateway.example.com/oauth/token"
      }
    }
  }
}
```

Optional: `options.oauthClientId` (default `"opencode"`), `options.oauthScope` (omitted from POST body when unset).

Implementation:

- New `packages/opencode/src/plugin/oauth-device.ts` — parameterized factory `OAuthDeviceProviderPlugin` porting device-code + refresh logic from `xai.ts`. Proactive refresh with 120s skew, single-flight per provider instance via module-level `refreshPromises` map, rotated tokens persisted to `auth.json` via `input.client.auth.set`.
- `packages/opencode/src/plugin/index.ts` — `internalPlugins()` now takes `cfg` and derives one plugin instance per config entry that has both `deviceAuthorizationUrl` and `tokenUrl`.
- `packages/core/src/v1/config/provider.ts` — four optional fields on `options`: `deviceAuthorizationUrl`, `tokenUrl`, `oauthClientId`, `oauthScope`.
- `packages/web/src/content/docs/providers.mdx` — new "Custom OAuth (device flow)" section.

Requirements on the OAuth server side: standard RFC 8628 endpoints (`device_authorization` returns `device_code`/`user_code`/`verification_uri`; token endpoint accepts `grant_type=urn:ietf:params:oauth:grant-type:device_code`, handles `authorization_pending`/`slow_down`/`access_denied`/`expired_token`, returns `access_token` + `refresh_token`). `token_type` SHOULD be `Bearer`.

### How did you verify your code works?

- `cd packages/opencode && bun test test/plugin/oauth-device.test.ts` — 24/24 pass. Covers `requestDeviceCode` (default client_id, custom client_id, scope omission, error surfacing), `pollDeviceCodeToken` (success, `slow_down`/`authorization_pending` backoff, terminal errors, timeout, NaN-interval defense), and loader behavior (non-oauth passthrough, dummy bearer injection, header override, auth-type flip, proactive refresh + persistence, single-flight dedup, cross-instance isolation).
- `cd packages/opencode && bun test test/plugin/xai.test.ts` — 26/26 pass (regression).
- `bun turbo typecheck --force --filter=@opencode-ai/core --filter=@opencode-ai/server` — clean.
- End-to-end smoke against an internal LiteLLM gateway exposing RFC 8628 endpoints: `opencode auth login` completes the browser flow, access token is injected as `Authorization: Bearer …` on gateway requests, proactive refresh fires before expiry, and chat completions succeed.

### Screenshots / recordings

N/A — no UI changes. Login flow reuses the existing device-flow picker.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR