### PR TITLE
fix(stats): include locale header in vary

### DIFF
--- a/packages/console/app/src/lib/stats-proxy.ts
+++ b/packages/console/app/src/lib/stats-proxy.ts
@@ -39,7 +39,7 @@ export async function statsProxy(evt: APIEvent) {
   headers.delete("content-encoding")
   headers.delete("content-length")
   headers.delete("etag")
-  appendVary(headers, "Accept-Language", "Cookie")
+  appendVary(headers, "Accept-Language", "Cookie", LOCALE_HEADER)
 
   return new Response(rewriteStatsHtml(await response.text()), {
     status: response.status,
@@ -78,7 +78,7 @@ function redirectToLocalizedData(request: Request, url: URL, locale: ReturnType<
     Location: next.toString(),
   })
   headers.append("set-cookie", cookie(locale))
-  appendVary(headers, "Accept-Language", "Cookie")
+  appendVary(headers, "Accept-Language", "Cookie", LOCALE_HEADER)
 
   return new Response(null, {
     status: 308,

--- a/packages/stats/app/src/context/language.tsx
+++ b/packages/stats/app/src/context/language.tsx
@@ -4,8 +4,10 @@ import { createStore } from "solid-js/store"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import {
   LOCALES,
+  cookie,
   detectFromLanguages,
   dir,
+  fromPathname,
   label,
   localeFromCookieHeader,
   localeFromRequest,
@@ -19,11 +21,16 @@ function initial() {
   const event = getRequestEvent()
   if (event) return localeFromRequest(event.request)
 
+  if (typeof window === "object") {
+    const fromPath = fromPathname(window.location.pathname)
+    if (fromPath) return fromPath
+  }
+
   if (typeof document === "object") {
-    const fromDom = parseLocale(document.documentElement.dataset.locale)
-    if (fromDom) return fromDom
     const fromCookie = localeFromCookieHeader(document.cookie)
     if (fromCookie) return fromCookie
+    const fromDom = parseLocale(document.documentElement.dataset.locale)
+    if (fromDom) return fromDom
   }
 
   if (typeof navigator !== "object") return "en" satisfies Locale
@@ -55,6 +62,8 @@ export const { use: useLanguage, provider: LanguageProvider } = createSimpleCont
       },
       setLocale(next: Locale) {
         setStore("locale", next)
+        if (typeof document !== "object") return
+        document.cookie = cookie(next)
       },
     }
   },

--- a/packages/stats/app/src/routes/stats-cache.ts
+++ b/packages/stats/app/src/routes/stats-cache.ts
@@ -1,10 +1,12 @@
+import { LOCALE_HEADER } from "../lib/language"
+
 const statsPageCacheControl = "public, max-age=60, s-maxage=300, stale-while-revalidate=86400"
 
 export function setStatsPageCacheHeaders(headers: Headers | undefined) {
   if (!headers) return
 
   headers.set("Cache-Control", statsPageCacheControl)
-  appendVary(headers, "Accept-Language", "Cookie")
+  appendVary(headers, "Accept-Language", "Cookie", LOCALE_HEADER)
 }
 
 function appendVary(headers: Headers, ...values: string[]) {


### PR DESCRIPTION
## Summary
- include `LOCALE_HEADER` in stats proxy and page cache `Vary` headers
- prefer pathname locale detection on the client and persist locale changes to `document.cookie`
- keep initial locale resolution aligned across request, path, cookie, and DOM sources

## Testing
- Not run (not requested)