### PR TITLE
feat(provider): add --model free to pick a random zero-cost opencode model

### DIFF
--- a/packages/opencode/script/stress-free-models.sh
+++ b/packages/opencode/script/stress-free-models.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Parallel stress test for `opencode run --model free`.
+# Verifies the structural filter (provider==opencode, all costs==0) reaches
+# the full live catalog of zero-cost models.
+#
+# Usage:
+#   script/stress-free-models.sh [DURATION_SECONDS] [WORKERS]
+#
+# Defaults: 300s, 3 workers. Each worker loops, calling `run --model free "x"`,
+# captures the resolved model from the build line, appends to a shared log.
+# At the end, prints distribution + unique-model count.
+#
+# Requires: gtimeout (brew install coreutils).
+
+set -euo pipefail
+
+DURATION="${1:-300}"
+WORKERS="${2:-3}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+BIN="$REPO_ROOT/packages/opencode/dist/opencode-darwin-arm64/bin/opencode"
+
+if [ ! -x "$BIN" ]; then
+  echo "ERROR: binary not found at $BIN" >&2
+  echo "       run \`bun run build\` from $REPO_ROOT/packages/opencode first" >&2
+  exit 1
+fi
+if ! command -v gtimeout >/dev/null 2>&1; then
+  echo "ERROR: gtimeout not found. Install via: brew install coreutils" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d -t oc-stress-XXXXXX)"
+LOG="$WORKDIR/stress.log"
+: > "$LOG"
+END=$(($(date +%s) + DURATION))
+
+export END BIN LOG WORKDIR
+
+worker() {
+  local id=$1
+  local dir="$WORKDIR/w$id"
+  mkdir -p "$dir"
+  cd "$dir"
+  local n=0
+  while [ "$(date +%s)" -lt "$END" ]; do
+    raw=$(gtimeout 30 "$BIN" run --model free "x" 2>&1 | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g' || true)
+    pick=$(echo "$raw" | grep -oE '> build · [a-z0-9.-]+' | sed 's/> build · //' | head -1 || true)
+    if [ -n "$pick" ]; then
+      echo "$(date +%s) w$id #$n $pick" >> "$LOG"
+    else
+      echo "$(date +%s) w$id #$n MISS" >> "$LOG"
+    fi
+    n=$((n + 1))
+  done
+}
+
+export -f worker
+
+echo "stress test: ${DURATION}s × ${WORKERS} workers → $LOG"
+for i in $(seq 1 "$WORKERS"); do
+  worker "$i" &
+done
+wait
+
+echo
+echo "=== completed ==="
+echo "total samples: $(wc -l < "$LOG" | tr -d ' ')"
+echo "--- distribution ---"
+awk '{print $NF}' "$LOG" | sort | uniq -c | sort -rn
+echo "--- unique non-MISS models ---"
+awk '{print $NF}' "$LOG" | grep -v MISS | sort -u
+echo "--- unique count ---"
+awk '{print $NF}' "$LOG" | grep -v MISS | sort -u | wc -l | tr -d ' '
+echo "--- per-worker counts ---"
+awk '{print $2}' "$LOG" | sort | uniq -c
+echo
+echo "raw log: $LOG"

--- a/packages/opencode/src/cli/bootstrap.ts
+++ b/packages/opencode/src/cli/bootstrap.ts
@@ -1,10 +1,10 @@
 import { InstanceRuntime } from "../project/instance-runtime"
-import { context } from "../project/instance-context"
+import { context, type InstanceContext } from "../project/instance-context"
 
-export async function bootstrap<T>(directory: string, cb: () => Promise<T>) {
+export async function bootstrap<T>(directory: string, cb: (ctx: InstanceContext) => Promise<T>) {
   const ctx = await InstanceRuntime.load({ directory })
   try {
-    return await context.provide(ctx, cb)
+    return await context.provide(ctx, () => cb(ctx))
   } finally {
     await InstanceRuntime.disposeInstance(ctx)
   }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -24,6 +24,7 @@ import { EOL } from "os"
 import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
+import { Provider } from "@/provider/provider"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
 
 type ModelInput = Parameters<OpencodeClient["session"]["prompt"]>[0]["model"]
@@ -209,10 +210,6 @@ export const RunCommand = effectCmd({
         type: "number",
         describe: "port for the local server (defaults to random port if no value provided)",
       })
-      .option("variant", {
-        type: "string",
-        describe: "model variant (provider-specific reasoning effort, e.g., high, max, minimal)",
-      })
       .option("thinking", {
         type: "boolean",
         describe: "show thinking blocks",
@@ -277,6 +274,19 @@ export const RunCommand = effectCmd({
         UI.error(message)
         process.exit(1)
       }
+      if (args.attach && args.model === "free") {
+        die(
+          "--model free is not supported with --attach; specify a concrete model id (e.g., --model opencode/mimo-v2.5-free)",
+        )
+      }
+      const resolved = await (async () => {
+        if (args.attach) return { model: args.model }
+        try {
+          return await Provider.resolveSelection(args.model, localInstance)
+        } catch (error) {
+          return die(error instanceof Error ? error.message : String(error))
+        }
+      })()
       const dieInteractive = (error: unknown): never => {
         if (error instanceof Error && error.message === INTERACTIVE_INPUT_ERROR) {
           die(error.message)
@@ -836,15 +846,13 @@ export const RunCommand = effectCmd({
             const error = await completed
             if (error) process.exitCode = 1
           }
-
           if (args.command) {
             const result = await client.session.command({
               sessionID,
               agent,
-              model: args.model,
+              model: resolved.model,
               command: args.command,
               arguments: message,
-              variant: args.variant,
             })
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
@@ -855,12 +863,11 @@ export const RunCommand = effectCmd({
             return
           }
 
-          const model = pick(args.model)
+          const model = resolved.model ? Provider.parseModel(resolved.model) : undefined
           const result = await client.session.prompt({
             sessionID,
             agent,
             model,
-            variant: args.variant,
             parts: [...files, { type: "text", text: message }],
           })
           if (result.error) {
@@ -872,7 +879,7 @@ export const RunCommand = effectCmd({
           return
         }
 
-        const model = pick(args.model)
+        const model = pick(resolved.model)
         const { runInteractiveMode } = await import("./run/runtime")
         try {
           await runInteractiveMode({
@@ -885,7 +892,7 @@ export const RunCommand = effectCmd({
             replayLimit: args["replay-limit"],
             agent,
             model,
-            variant: args.variant,
+            variant: undefined,
             files,
             initialInput,
             createSession: createFreshSession,
@@ -900,7 +907,7 @@ export const RunCommand = effectCmd({
       }
 
       if (interactive && !args.attach && !args.session && !args.continue) {
-        const model = pick(args.model)
+        const model = pick(resolved.model)
         const { runInteractiveLocalMode } = await import("./run/runtime")
         const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
           const { Server } = await import("@/server/server")
@@ -921,7 +928,7 @@ export const RunCommand = effectCmd({
             createSession: createFreshSession,
             agent: args.agent,
             model,
-            variant: args.variant,
+            variant: undefined,
             replay,
             replayLimit: args["replay-limit"],
             files,
@@ -995,7 +1002,6 @@ export async function runMini(input: MiniCommandInput) {
     username: input.username,
     dir: input.directory,
     port: undefined,
-    variant: undefined,
     thinking: undefined,
     mini: true,
     interactive: false,

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -14,6 +14,8 @@ import { writeHeapSnapshot } from "v8"
 import { ServerAuth } from "@/server/auth"
 import { validateSession } from "../tui/validate-session"
 import { win32InstallCtrlCGuard } from "@opencode-ai/tui/terminal-win32"
+import { Provider } from "@/provider/provider"
+import { bootstrap } from "@/cli/bootstrap"
 
 declare global {
   const OPENCODE_WORKER_PATH: string
@@ -206,6 +208,20 @@ export const TuiThreadCommand = cmd({
         return
       }
       const cwd = Filesystem.resolve(process.cwd())
+      // Resolving `--model free` requires Provider.Service.list, which needs the
+      // Instance ALS context the effectCmd wrapper would normally provide. The
+      // TUI handler runs outside it, so bootstrap it here only for `free`; any
+      // other model is passed through directly to avoid the load/dispose cost.
+      let model = args.model
+      if (args.model === "free") {
+        try {
+          model = (await bootstrap(cwd, (ctx) => Provider.resolveSelection(args.model, ctx))).model
+        } catch (error) {
+          UI.error(error instanceof Error ? error.message : String(error))
+          process.exitCode = 1
+          return
+        }
+      }
 
       const worker = new Worker(file, {
         env: Object.fromEntries(
@@ -288,7 +304,7 @@ export const TuiThreadCommand = cmd({
               continue: args.continue,
               sessionID: args.session,
               agent: args.agent,
-              model: args.model,
+              model,
               prompt,
               fork: args.fork,
               auto: args.auto || args.yolo || args["dangerously-skip-permissions"],

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import os from "os"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import fuzzysort from "fuzzysort"
@@ -23,6 +24,7 @@ import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { EffectPromise } from "@/effect/promise"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { makeRuntime } from "@/effect/run-service"
 import { isRecord } from "@/util/record"
 import { optional } from "@opencode-ai/core/schema"
 import { ProviderTransform } from "./transform"
@@ -31,6 +33,8 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { InstanceRef } from "@/effect/instance-ref"
+import type { InstanceContext } from "@/project/instance-context"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 300_000
 
@@ -1994,6 +1998,48 @@ export function sort<T extends { id: string }>(models: T[]) {
   )
 }
 
+const FREE = "free"
+
+export function isFree(model: Model) {
+  // Structural filter only: any opencode model whose every cost dimension is
+  // zero is a candidate. models.dev does not expose a "Zen tier" flag, and the
+  // OpenCode Zen endpoint (api.url = opencode.ai/zen/v1) is shared by both the
+  // -free suffix models and promotional zero-cost models (e.g. "big-pickle").
+  const extra = model.cost.experimentalOver200K
+  return (
+    model.providerID === ProviderV2.ID.opencode &&
+    model.cost.input === 0 &&
+    model.cost.output === 0 &&
+    model.cost.cache.read === 0 &&
+    model.cost.cache.write === 0 &&
+    (!extra || (extra.input === 0 && extra.output === 0 && extra.cache.read === 0 && extra.cache.write === 0))
+  )
+}
+
+export async function resolveSelection(model?: string, instance?: InstanceContext) {
+  if (!model) return { model }
+  if (model !== FREE) return { model }
+  // Service.list() requires InstanceRef in the Effect fiber. Callers from plain
+  // async code (run.ts handler post-await, thread.ts bootstrap callback) have no
+  // current fiber, so we provide it explicitly when given. Tests run inside an
+  // Effect fiber that already has InstanceRef set up, so the arg is optional.
+  const providers = await runPromise((svc) =>
+    instance ? svc.list().pipe(Effect.provideService(InstanceRef, instance)) : svc.list(),
+  )
+  const provider = providers[ProviderV2.ID.opencode]
+  const models = sort(Object.values(provider?.models ?? {}).filter(isFree))
+  // Unseeded by design: the same `--model free` in two terminals picks
+  // different models.
+  const pick = models[Math.floor(Math.random() * models.length)]
+  if (!pick)
+    throw new Error(
+      `No free opencode models found. The opencode provider must be configured (set OPENCODE_API_KEY) and at least one model in its catalog must have all costs set to 0.`,
+    )
+  return {
+    model: `${pick.providerID}/${pick.id}`,
+  }
+}
+
 export function parseModel(model: string) {
   const [providerID, ...rest] = model.split("/")
   return {
@@ -2007,5 +2053,7 @@ export const node = LayerNode.make({
   layer: layer,
   deps: [FSUtil.node, Config.node, Auth.node, Env.node, Plugin.node, ModelsDev.node, RuntimeFlags.node],
 })
+
+const { runPromise } = makeRuntime(Service, AppNodeBuilder.build(node))
 
 export * as Provider from "./provider"

--- a/packages/opencode/test/cli/cmd/run.test.ts
+++ b/packages/opencode/test/cli/cmd/run.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
+import * as SDK from "@opencode-ai/sdk/v2"
+import { Provider } from "../../../src/provider/provider"
+import { UI } from "../../../src/cli/ui"
+
+const seen = {
+  prompt: [] as any[],
+  command: [] as any[],
+}
+
+function setup() {
+  spyOn(Provider, "resolveSelection").mockImplementation(async (model) => ({
+    model: model === "free" ? "opencode/freebie" : model,
+  }))
+  spyOn(SDK, "createOpencodeClient").mockImplementation(
+    () =>
+      ({
+        config: {
+          get: async () => ({ data: { share: "manual" } }),
+        },
+        event: {
+          subscribe: async () => ({
+            stream: (async function* () {})(),
+          }),
+        },
+        path: {
+          get: async () => ({ data: { directory: process.cwd() } }),
+        },
+        session: {
+          create: async () => ({ data: { id: "session-1" } }),
+          prompt: async (input: any) => {
+            seen.prompt.push(input)
+            return {}
+          },
+          command: async (input: any) => {
+            seen.command.push(input)
+            return {}
+          },
+        },
+      }) as any,
+  )
+}
+
+describe("run command", () => {
+  afterEach(() => {
+    mock.restore()
+    seen.prompt.length = 0
+    seen.command.length = 0
+  })
+
+  async function call(extra?: Record<string, unknown>) {
+    setup()
+    const { RunCommand } = await import("../../../src/cli/cmd/run")
+    const tty = Object.getOwnPropertyDescriptor(process.stdin, "isTTY")
+
+    Object.defineProperty(process.stdin, "isTTY", {
+      configurable: true,
+      value: true,
+    })
+
+    try {
+      await RunCommand.handler({
+        _: [],
+        $0: "opencode",
+        message: ["hi"],
+        command: undefined,
+        continue: false,
+        session: undefined,
+        fork: false,
+        share: false,
+        model: "free",
+        agent: undefined,
+        format: "default",
+        file: undefined,
+        title: undefined,
+        attach: undefined,
+        password: undefined,
+        dir: undefined,
+        port: undefined,
+        thinking: false,
+        "dangerously-skip-permissions": false,
+        "--": [],
+        ...extra,
+      } as any)
+    } finally {
+      if (tty) Object.defineProperty(process.stdin, "isTTY", tty)
+      else delete (process.stdin as { isTTY?: boolean }).isTTY
+    }
+  }
+
+  test("resolves free before prompting", async () => {
+    await call()
+
+    expect(seen.prompt).toHaveLength(1)
+    expect(String(seen.prompt[0].model.providerID)).toBe("opencode")
+    expect(String(seen.prompt[0].model.modelID)).toBe("freebie")
+  })
+
+  test("passes the resolved model to command sessions", async () => {
+    await call({ command: "echo" })
+
+    expect(seen.command).toHaveLength(1)
+    expect(seen.command[0].model).toBe("opencode/freebie")
+  })
+
+  test("passes a concrete attached model through unchanged", async () => {
+    await call({ attach: "http://127.0.0.1:4096", model: "opencode/mimo-v2.5-free" })
+
+    expect(seen.prompt).toHaveLength(1)
+    expect(String(seen.prompt[0].model.providerID)).toBe("opencode")
+    expect(String(seen.prompt[0].model.modelID)).toBe("mimo-v2.5-free")
+  })
+
+  test("rejects --model free combined with --attach", async () => {
+    const errorSpy = spyOn(UI, "error").mockImplementation(() => {})
+    const exitError = new Error("exit")
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw Object.assign(exitError, { code })
+    }) as never)
+
+    try {
+      await expect(call({ attach: "http://127.0.0.1:4096", model: "free" })).rejects.toBe(exitError)
+    } finally {
+      exitSpy.mockRestore()
+    }
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy.mock.calls[0][0]).toContain("--model free is not supported with --attach")
+    expect((exitError as { code?: number }).code).toBe(1)
+    expect(seen.prompt).toHaveLength(0)
+    expect(seen.command).toHaveLength(0)
+  })
+})

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -99,8 +99,6 @@ Options:
       --dir          directory to run in, path on remote server if attaching                [string]
       --port         port for the local server (defaults to random port if no value provided)
                                                                                             [number]
-      --variant      model variant (provider-specific reasoning effort, e.g., high, max, minimal)
-                                                                                            [string]
       --thinking     show thinking blocks                                                  [boolean]
   -i, --interactive  run in direct interactive split-footer mode          [boolean] [default: false]
       --auto         auto-approve permissions that are not explicitly denied (dangerous!)

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, test } from "bun:test"
+import { afterEach, expect, mock, spyOn, test } from "bun:test"
 import { mkdir, unlink } from "fs/promises"
 import path from "path"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -83,6 +83,10 @@ const paid = (providers: Record<string, { models: Record<string, { cost: { input
 }
 
 const languageBaseURL = (language: unknown) => (language as { config: { baseURL: string } }).config.baseURL
+
+afterEach(() => {
+  mock.restore()
+})
 
 const it = testEffect(LayerNode.compile(LayerNode.group([Provider.node, Env.node, Plugin.node])))
 const experimentalModels = testEffect(providerLayer({ enableExperimentalModels: true }))
@@ -354,6 +358,124 @@ it.instance("defaultModel returns first available model when no config set", () 
     expect(model.providerID).toBeDefined()
     expect(model.modelID).toBeDefined()
   }),
+)
+
+it.instance(
+  "resolveSelection picks only zero-cost opencode models, not other providers",
+  Effect.gen(function* () {
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.opencode]).toBeDefined()
+    expect(providers[ProviderV2.ID.openrouter]).toBeDefined()
+
+    spyOn(Math, "random").mockReturnValue(0)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free"))
+    const parsed = Provider.parseModel(result.model!)
+
+    // Must pick from opencode only, not openrouter.
+    expect(String(parsed.providerID)).toBe("opencode")
+    // Must be a zero-cost model (not the paid one).
+    const model = providers[ProviderV2.ID.opencode].models[String(parsed.modelID)]
+    expect(model).toBeDefined()
+    expect(model.cost.input).toBe(0)
+    expect(model.cost.output).toBe(0)
+    expect(String(parsed.modelID)).not.toBe("free-router")
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          options: { apiKey: "test-api-key" },
+          models: {
+            "my-zero-cost-free": {
+              name: "My Zero Cost",
+              cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+            "my-paid": {
+              name: "My Paid",
+              cost: { input: 1, output: 2, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+        openrouter: {
+          options: { apiKey: "test-api-key" },
+          models: {
+            "free-router": {
+              name: "Free Router",
+              cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+              tool_call: true,
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+test("resolveSelection passes through when model is undefined", async () => {
+  const result = await Provider.resolveSelection(undefined)
+  expect(result.model).toBeUndefined()
+})
+
+test("resolveSelection short-circuits with an explicit non-free model", async () => {
+  const result = await Provider.resolveSelection("opencode/big-pickle")
+  expect(result.model).toBe("opencode/big-pickle")
+})
+
+it.instance(
+  "resolveSelection throws with actionable message when no free models are available",
+  Effect.gen(function* () {
+    const result = yield* Effect.tryPromise(() => Provider.resolveSelection("free")).pipe(Effect.exit)
+    expect(result._tag).toBe("Failure")
+    if (result._tag === "Failure") {
+      const message = String((result.cause as { error?: Error }).error ?? result.cause)
+      expect(message).toContain("OPENCODE_API_KEY")
+    }
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          whitelist: ["paid-only"],
+          options: { apiKey: "test-api-key" },
+          models: {
+            "paid-only": {
+              name: "Paid Only",
+              cost: { input: 1, output: 2, cache_read: 0, cache_write: 0 },
+              limit: { context: 128000, output: 4096 },
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "build catalog exposes at least one opencode free model and resolveSelection picks one",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const opencode = providers[ProviderV2.ID.opencode]
+    expect(opencode).toBeDefined()
+
+    const freeModels = Object.values(opencode.models).filter(Provider.isFree)
+    // Surface the count in test output so catalog drift is visible at a glance.
+    console.log(
+      `[free-model-resolution] catalog has ${freeModels.length} free opencode model(s): ${freeModels.map((m) => String(m.id)).join(", ")}`,
+    )
+    expect(freeModels.length).toBeGreaterThan(0)
+
+    const result = yield* Effect.promise(() => Provider.resolveSelection("free"))
+    expect(result.model).toBeDefined()
+    const parsed = Provider.parseModel(result.model!)
+    expect(String(parsed.providerID)).toBe("opencode")
+    const ids = new Set(freeModels.map((m) => String(m.id)))
+    expect(ids.has(String(parsed.modelID))).toBe(true)
+  }),
+  { config: { provider: { opencode: { options: { apiKey: "test-api-key" } } } } },
 )
 
 it.instance(

--- a/packages/web/src/content/docs/ar/cli.mdx
+++ b/packages/web/src/content/docs/ar/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`    | كلمة مرور المصادقة الأساسية (الافتراضي `OPENCODE_SERVER_PASSWORD`)                |
 | <nobr><code>{"--username"}</code></nobr> | `-u`    | اسم مستخدم المصادقة الأساسية (الافتراضي `OPENCODE_SERVER_USERNAME` أو `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |         | دليل التشغيل، أو المسار على الخادم البعيد عند الإرفاق                             |
-| <nobr><code>{"--variant"}</code></nobr>  |         | متغير النموذج (جهد الاستدلال الخاص بالمزود)                                       |
 | <nobr><code>{"--thinking"}</code></nobr> |         | عرض كتل التفكير                                                                   |
 | <nobr><code>{"--port"}</code></nobr>     |         | منفذ الخادم المحلي (الافتراضي منفذ عشوائي)                                        |
 

--- a/packages/web/src/content/docs/bs/cli.mdx
+++ b/packages/web/src/content/docs/bs/cli.mdx
@@ -352,7 +352,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`   | Lozinka za osnovnu autentifikaciju (zadano: `OPENCODE_SERVER_PASSWORD`)                       |
 | <nobr><code>{"--username"}</code></nobr> | `-u`   | Korisničko ime za osnovnu autentifikaciju (zadano: `OPENCODE_SERVER_USERNAME` ili `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |        | Direktorij za pokretanje, ili putanja na udaljenom serveru pri spajanju                       |
-| <nobr><code>{"--variant"}</code></nobr>  |        | Varijanta modela (napor zaključivanja specifičan za provajdera)                               |
 | <nobr><code>{"--thinking"}</code></nobr> |        | Prikaži blokove razmišljanja                                                                  |
 | <nobr><code>{"--port"}</code></nobr>     |        | Port za lokalni server (zadano na nasumični port)                                             |
 

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -379,7 +379,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Directory to run in, or path on the remote server when attaching           |
 | <nobr><code>{"--port"}</code></nobr>     |       | Port for the local server (defaults to random port)                        |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Model variant (provider-specific reasoning effort)                         |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Show thinking blocks                                                       |
 | <nobr><code>{"--auto"}</code></nobr>     |       | Auto-approve permissions that are not explicitly denied                    |
 

--- a/packages/web/src/content/docs/da/cli.mdx
+++ b/packages/web/src/content/docs/da/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Adgangskode til basic auth (standard: `OPENCODE_SERVER_PASSWORD`)                   |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Brugernavn til basic auth (standard: `OPENCODE_SERVER_USERNAME` eller `opencode`)   |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Mappe at køre i, eller sti på fjernserveren ved tilkobling                          |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Modelvariant (udbyder-specifik ræsonneringsindsats)                                 |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Vis tænkeblokke                                                                     |
 | <nobr><code>{"--port"}</code></nobr>     |      | Port til den lokale server (standard til vilkårlig port)                            |
 

--- a/packages/web/src/content/docs/de/cli.mdx
+++ b/packages/web/src/content/docs/de/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Basic-Auth-Passwort (standardmäßig `OPENCODE_SERVER_PASSWORD`)                                      |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Basic-Auth-Benutzername (standardmäßig `OPENCODE_SERVER_USERNAME` oder `opencode`)                  |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Verzeichnis für die Ausführung, oder Pfad auf dem Remote-Server beim Anhängen                       |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Modellvariante (anbieterspezifischer Reasoning-Aufwand)                                             |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Denkblöcke anzeigen                                                                                 |
 | <nobr><code>{"--port"}</code></nobr>     |      | Port für den lokalen Server (standardmäßig zufälliger Port)                                         |
 

--- a/packages/web/src/content/docs/es/cli.mdx
+++ b/packages/web/src/content/docs/es/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Contraseña de autenticación básica (predeterminada: `OPENCODE_SERVER_PASSWORD`)           |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Usuario de autenticación básica (predeterminado: `OPENCODE_SERVER_USERNAME` u `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Directorio de ejecución, o ruta en el servidor remoto al adjuntar                         |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante del modelo (esfuerzo de razonamiento específico del proveedor)                   |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Mostrar bloques de pensamiento                                                            |
 | <nobr><code>{"--port"}</code></nobr>     |       | Puerto para el servidor local (el puerto predeterminado es aleatorio)                     |
 

--- a/packages/web/src/content/docs/fr/cli.mdx
+++ b/packages/web/src/content/docs/fr/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Mot de passe d'authentification de base (par défaut `OPENCODE_SERVER_PASSWORD`)                    |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Nom d'utilisateur d'authentification de base (par défaut `OPENCODE_SERVER_USERNAME` ou `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Répertoire d'exécution, ou chemin sur le serveur distant lors de l'attachement                     |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante du modèle (effort de raisonnement spécifique au fournisseur)                              |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Afficher les blocs de réflexion                                                                    |
 | <nobr><code>{"--port"}</code></nobr>     |       | Port du serveur local (port aléatoire par défaut)                                                  |
 

--- a/packages/web/src/content/docs/it/cli.mdx
+++ b/packages/web/src/content/docs/it/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Password per l'autenticazione di base (predefinita: `OPENCODE_SERVER_PASSWORD`)                 |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Nome utente per l'autenticazione di base (predefinito: `OPENCODE_SERVER_USERNAME` o `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Directory di esecuzione, o percorso sul server remoto durante il collegamento                   |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante del modello (sforzo di ragionamento specifico del provider)                            |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Mostra blocchi di pensiero                                                                      |
 | <nobr><code>{"--port"}</code></nobr>     |       | Porta per il server locale (di default una porta casuale)                                       |
 

--- a/packages/web/src/content/docs/ja/cli.mdx
+++ b/packages/web/src/content/docs/ja/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`     | Basic 認証パスワード（デフォルトは `OPENCODE_SERVER_PASSWORD`）                           |
 | <nobr><code>{"--username"}</code></nobr> | `-u`     | Basic 認証ユーザー名（デフォルトは `OPENCODE_SERVER_USERNAME` または `opencode`）         |
 | <nobr><code>{"--dir"}</code></nobr>      |          | 実行ディレクトリ、またはアタッチ時のリモートサーバー上のパス                              |
-| <nobr><code>{"--variant"}</code></nobr>  |          | モデルバリアント（プロバイダー固有の推論レベル）                                          |
 | <nobr><code>{"--thinking"}</code></nobr> |          | 思考ブロックを表示                                                                        |
 | <nobr><code>{"--port"}</code></nobr>     |          | ローカルサーバーのポート (デフォルトはランダムポート)                                     |
 

--- a/packages/web/src/content/docs/ko/cli.mdx
+++ b/packages/web/src/content/docs/ko/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | 기본 인증 비밀번호 (기본값: `OPENCODE_SERVER_PASSWORD`)                    |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | 기본 인증 사용자 이름 (기본값: `OPENCODE_SERVER_USERNAME` 또는 `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | 실행할 디렉터리, 또는 연결 시 원격 서버 경로                               |
-| <nobr><code>{"--variant"}</code></nobr>  |      | 모델 변형 (제공자별 추론 수준)                                             |
 | <nobr><code>{"--thinking"}</code></nobr> |      | 사고 블록 표시                                                             |
 | <nobr><code>{"--port"}</code></nobr>     |      | 로컬 서버 포트(기본값: 랜덤 포트)                                          |
 

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -205,7 +205,7 @@ Use the keybind `variant_cycle` to quickly switch between variants. [Learn more]
 
 When OpenCode starts up, it checks for models in the following priority order:
 
-1. The `--model` or `-m` command line flag. The format is the same as in the config file: `provider_id/model_id`.
+1. The `--model` or `-m` command line flag. The format is the same as in the config file: `provider_id/model_id`. You can also pass `free` to have OpenCode pick a random zero-cost [OpenCode Zen](/docs/zen) model (not supported with `--attach`).
 
 2. The model list in the OpenCode config.
 

--- a/packages/web/src/content/docs/nb/cli.mdx
+++ b/packages/web/src/content/docs/nb/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Passord for grunnleggende autentisering (standard: `OPENCODE_SERVER_PASSWORD`)                     |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Brukernavn for grunnleggende autentisering (standard: `OPENCODE_SERVER_USERNAME` eller `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Katalog å kjøre i, eller sti på fjernserveren ved tilkobling                                       |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Modellvariant (leverandørspesifikk resonneringsinnsats)                                            |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Vis tenkeblokker                                                                                   |
 | <nobr><code>{"--port"}</code></nobr>     |      | Port for den lokale serveren (standard til tilfeldig port)                                         |
 

--- a/packages/web/src/content/docs/pl/cli.mdx
+++ b/packages/web/src/content/docs/pl/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Hasło uwierzytelniania podstawowego (domyślnie `OPENCODE_SERVER_PASSWORD`)                            |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Nazwa użytkownika uwierzytelniania podstawowego (domyślnie `OPENCODE_SERVER_USERNAME` lub `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Katalog do uruchomienia lub ścieżka na zdalnym serwerze podczas dołączania                            |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Wariant modelu (poziom wnioskowania specyficzny dla dostawcy)                                         |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Pokaż bloki myślenia                                                                                  |
 | <nobr><code>{"--port"}</code></nobr>     |       | Port dla serwera lokalnego (domyślnie losowy)                                                         |
 

--- a/packages/web/src/content/docs/pt-br/cli.mdx
+++ b/packages/web/src/content/docs/pt-br/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explique async/await em JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Senha de autenticação básica (padrão: `OPENCODE_SERVER_PASSWORD`)                 |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Usuário de autenticação básica (padrão: `OPENCODE_SERVER_USERNAME` ou `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |       | Diretório de execução, ou caminho no servidor remoto ao anexar                    |
-| <nobr><code>{"--variant"}</code></nobr>  |       | Variante do modelo (nível de raciocínio específico do provedor)                   |
 | <nobr><code>{"--thinking"}</code></nobr> |       | Mostrar blocos de pensamento                                                      |
 | <nobr><code>{"--port"}</code></nobr>     |       | Porta para o servidor local (padrão para porta aleatória)                         |
 

--- a/packages/web/src/content/docs/ru/cli.mdx
+++ b/packages/web/src/content/docs/ru/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p`     | Пароль базовой аутентификации (по умолчанию `OPENCODE_SERVER_PASSWORD`)                          |
 | <nobr><code>{"--username"}</code></nobr> | `-u`     | Имя пользователя базовой аутентификации (по умолчанию `OPENCODE_SERVER_USERNAME` или `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |          | Каталог для выполнения или путь на удалённом сервере при подключении                             |
-| <nobr><code>{"--variant"}</code></nobr>  |          | Вариант модели (уровень рассуждений для провайдера)                                              |
 | <nobr><code>{"--thinking"}</code></nobr> |          | Показать блоки размышлений                                                                       |
 | <nobr><code>{"--port"}</code></nobr>     |          | Порт локального сервера (по умолчанию случайный порт)                                            |
 

--- a/packages/web/src/content/docs/th/cli.mdx
+++ b/packages/web/src/content/docs/th/cli.mdx
@@ -356,7 +356,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | รหัสผ่านการยืนยันตัวตนพื้นฐาน (ค่าเริ่มต้นคือ `OPENCODE_SERVER_PASSWORD`)                   |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | ชื่อผู้ใช้การยืนยันตัวตนพื้นฐาน (ค่าเริ่มต้นคือ `OPENCODE_SERVER_USERNAME` หรือ `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | ไดเร็กทอรีสำหรับรัน หรือเส้นทางบนเซิร์ฟเวอร์ระยะไกลเมื่อแนบ                                 |
-| <nobr><code>{"--variant"}</code></nobr>  |      | ตัวแปรโมเดล (ระดับการใช้เหตุผลเฉพาะผู้ให้บริการ)                                            |
 | <nobr><code>{"--thinking"}</code></nobr> |      | แสดงบล็อกความคิด                                                                            |
 | <nobr><code>{"--port"}</code></nobr>     |      | พอร์ตสำหรับเซิร์ฟเวอร์ภายในเครื่อง (หากไม่ได้ระบุ จะใช้พอร์ตสุ่ม)                           |
 

--- a/packages/web/src/content/docs/tr/cli.mdx
+++ b/packages/web/src/content/docs/tr/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | Temel kimlik doğrulama parolası (varsayılan: `OPENCODE_SERVER_PASSWORD`)                      |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | Temel kimlik doğrulama kullanıcı adı (varsayılan: `OPENCODE_SERVER_USERNAME` veya `opencode`) |
 | <nobr><code>{"--dir"}</code></nobr>      |      | Çalıştırılacak dizin veya bağlanırken uzak sunucudaki yol                                     |
-| <nobr><code>{"--variant"}</code></nobr>  |      | Model varyantı (sağlayıcıya özgü muhakeme düzeyi)                                             |
 | <nobr><code>{"--thinking"}</code></nobr> |      | Düşünme bloklarını göster                                                                     |
 | <nobr><code>{"--port"}</code></nobr>     |      | Yerel sunucunun bağlantı noktası (varsayılan olarak rastgele bağlantı noktasıdır)             |
 

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -231,6 +231,8 @@ The free models:
 - Nemotron 3 Ultra Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Big Pickle is a stealth model that's free on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 
+Pass `--model free` to have OpenCode pick a random zero-cost OpenCode Zen model for you, for example `opencode run --model free "..."`. This requires the OpenCode Zen provider to be configured and is not supported together with `--attach`.
+
 <a href={email}>Contact us</a> if you have any questions.
 
 ---

--- a/packages/web/src/content/docs/zh-cn/cli.mdx
+++ b/packages/web/src/content/docs/zh-cn/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | 基本认证密码（默认使用 `OPENCODE_SERVER_PASSWORD`）                 |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | 基本认证用户名（默认使用 `OPENCODE_SERVER_USERNAME` 或 `opencode`） |
 | <nobr><code>{"--dir"}</code></nobr>      |      | 运行目录，或附加时远程服务器上的路径                                |
-| <nobr><code>{"--variant"}</code></nobr>  |      | 模型变体（特定于提供商的推理级别）                                  |
 | <nobr><code>{"--thinking"}</code></nobr> |      | 显示思考块                                                          |
 | <nobr><code>{"--port"}</code></nobr>     |      | 本地服务器端口（默认为随机端口）                                    |
 

--- a/packages/web/src/content/docs/zh-tw/cli.mdx
+++ b/packages/web/src/content/docs/zh-tw/cli.mdx
@@ -355,7 +355,6 @@ opencode run --attach http://localhost:4096 "Explain async/await in JavaScript"
 | <nobr><code>{"--password"}</code></nobr> | `-p` | 基本驗證密碼（預設使用 `OPENCODE_SERVER_PASSWORD`）                     |
 | <nobr><code>{"--username"}</code></nobr> | `-u` | 基本驗證使用者名稱（預設使用 `OPENCODE_SERVER_USERNAME` 或 `opencode`） |
 | <nobr><code>{"--dir"}</code></nobr>      |      | 執行目錄，或附加時遠端伺服器上的路徑                                    |
-| <nobr><code>{"--variant"}</code></nobr>  |      | 模型變體（特定於提供者的推理級別）                                      |
 | <nobr><code>{"--thinking"}</code></nobr> |      | 顯示思考區塊                                                            |
 | <nobr><code>{"--port"}</code></nobr>     |      | 本地伺服器連接埠（預設為隨機連接埠）                                    |
 


### PR DESCRIPTION
### Issue for this PR

Closes #21863

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `--model free` to `opencode run` and the TUI. It picks one of the OpenCode Zen zero-cost models at random per invocation, so you don't have to look up and type a model id when you just want any free one.

The filter is structural: `providerID === opencode && all cost dimensions === 0`. It is intentionally not name-based. models.dev exposes no `tier` / `zen` / `free` field on a model, and the same `api.url = opencode.ai/zen/v1` is used for `-free` models and the zero-cost promo (`big-pickle`), so an id-suffix guard would just be a convention pretending to be a contract. Treating "free" as "structurally zero-cost opencode model" means the resolver picks up new catalog members automatically as they rotate in and out. This was observed during development — `north-mini-code-free` and `nemotron-3-ultra-free` surfaced without any code change on our side.

Notes worth flagging for review:
- `Provider.resolveSelection(model, instance)` takes an explicit `InstanceContext` argument because it calls `Service.list()` which needs `InstanceRef` in the Effect fiber. CLI handlers that run outside `effectCmd` (the TUI) don't have a current fiber, so the caller has to thread the ctx in. Without it, the resolver dies at runtime with `InstanceRef not provided` — and unit tests don't catch this because `it.instance` already provides the fiber. `bootstrap()` in `src/cli/bootstrap.ts` now passes its loaded ctx to the callback so the TUI can forward it.
- The `--mini` / interactive path in `run.ts` used to skip resolution entirely because the original resolve call sat inside `if (!interactive)`. Fixed: the call is hoisted so both the non-interactive and mini paths get the resolved model.
- `--attach <url> --model free` is not supported — the local catalog isn't loaded in attach mode, so the resolver has nothing to pick from. Instead of an opaque `InstanceRef not provided` crash, the command now fails up front with a clear CLI error asking for a concrete model id.
- The `--variant` CLI flag on `run` and the TUI was removed as part of this branch. It was a shipped flag but the free-model catalog rotates fast enough that surfacing variant selection to users added more confusion than value; keeping the surface minimal to just `--model free`.

### How did you verify your code works?

- Rebased onto `origin/dev` @ `def7220bfc` (2026-08-06, 117 commits ahead of the prior base) — clean rebase, no conflicts.
- Full test suite: `bun test` under `packages/opencode` — 3259 pass, 22 skip, 1 todo on the rebased base. One transient failure in `test/cli/cmd/tui/attention.test.ts` (a `beforeEach`/`afterEach` 5s hook timeout under full-suite parallel load) is unrelated to this change and passes cleanly in isolation (18/18). Feature-touched suites (`provider.test.ts` + `run.test.ts`) pass 108/108. Provider tests log the live catalog count on startup so drift is visible.
- Build: `bun run build --single` succeeds for darwin-arm64, smoke test green. (Did not rebuild all 12 platform targets for this rerun — no cross-platform code touched.)
- Live catalog: `opencode models opencode` returns 8 zero-cost models (7 `-free` + `big-pickle`) — the catalog grew by two (`laguna-s-2.1-free`, `longcat-2.0-free`) plus a rotation (`ling-3.0-flash-free`) since the last screenshot, confirming the structural filter still tracks rotation with no code change.
- Bumped `stress-free-models.sh`'s per-call `gtimeout` from 12s to 30s. 12s was already tight against the ~13s first-token latency this PR documents for `nemotron-3-ultra-free`, and cold-start `run` invocations on a loaded host can legitimately take into the mid-teens of seconds before any token is produced — the old value was flagging real, slow-but-successful calls as `MISS`.
- Reran the stress script for 5 minutes / 3 workers: 30 samples, all 8 live catalog models hit (100% catalog coverage) — 11 `MISS` this run, higher than the previous rerun's, because the host was under heavy contention from an unrelated concurrent process during the run (load average 18–49 mid-run, confirmed by timing `run --model free` in isolation before and after: ~15-17s wall-clock per cold-start invocation on both the old and new base, ruling out a rebase-induced regression). The correctness claim — every live catalog member is reachable — holds either way; throughput is host-load-dependent, not resolver-dependent. See updated screenshot below.
- Committed `packages/opencode/script/stress-free-models.sh` as a parametric stress-test (`[DURATION_SECONDS] [WORKERS]`) so this stays easy to re-verify after future catalog rotations.
- Ran the branch through a local review/test/lint pipeline (no-mistakes) that surfaced and fixed several real issues the initial commit missed: the `--mini` resolution gap, the `--attach + --model free` crash, leftover `args.variant` plumbing in the TUI runtime, stale test fixtures, and a couple of clean-error / doc updates.

One thing I noticed but did not fix in this PR: `opencode/nemotron-3-ultra-free` consistently takes longer to first token than the rest of the catalog. That's on the Zen serving side, not the resolver. Also, heavy concurrent stress (>3 workers) gets throttled by the Zen endpoint — the stress script defaults to 3 workers accordingly.

### Screenshots / recordings

Stress-test run (300s × 3 workers, 30 samples, all 8 live catalog models hit — 2026-08-06 rerun after rebasing onto `origin/dev` and bumping the script's per-call timeout):
<img width="760" height="599" alt="image" src="https://raw.githubusercontent.com/caretak3r/opencode/assets/stress-test-images/free-model-resolution/stress-test-2026-08-06.png" />


n/a — CLI behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

