### PR TITLE
fix: normalize Windows paths in session directory SQL queries

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -52,6 +52,8 @@ export type RevertState = Revert.State
 
 export { ListAnchor }
 
+const dbDir = (dir: string) => (process.platform === "win32" ? dir.replaceAll("\\", "/") : dir)
+
 const ListInputBase = {
   workspaceID: WorkspaceV2.ID.pipe(Schema.optional),
   search: Schema.String.pipe(Schema.optional),
@@ -271,7 +273,7 @@ const layer = Layer.effect(
         const order = direction === "previous" ? (requestedOrder === "asc" ? "desc" : "asc") : requestedOrder
         const sortColumn = SessionTable.time_created
         const conditions: SQL[] = []
-        if ("directory" in input) conditions.push(eq(SessionTable.directory, input.directory))
+        if ("directory" in input) conditions.push(eq(SessionTable.directory, dbDir(input.directory)))
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
         if ("project" in input) conditions.push(eq(SessionTable.project_id, input.project))
         if (input.search) conditions.push(like(SessionTable.title, `%${input.search}%`))

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -23,6 +23,8 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Project } from "@opencode-ai/schema/project"
 
+const dbDir = (dir: string) => (process.platform === "win32" ? dir.replaceAll("\\", "/") : dir)
+
 export const Info = Project.Info
 export type Info = Types.DeepMutable<Schema.Schema.Type<typeof Info>>
 
@@ -292,7 +294,7 @@ const layer = Layer.effect(
         yield* db
           .update(SessionTable)
           .set({ project_id: projectID })
-          .where(and(eq(SessionTable.project_id, ProjectV2.ID.global), eq(SessionTable.directory, data.directory)))
+          .where(and(eq(SessionTable.project_id, ProjectV2.ID.global), eq(SessionTable.directory, dbDir(data.directory))))
           .run()
           .pipe(Effect.orDie)
       }

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -556,7 +556,7 @@ const layer: Layer.Layer<
 
     const listGlobal = Effect.fn("Session.listGlobal")(function* (input?: GlobalListInput) {
       const conditions: SQL[] = []
-      if (input?.directory) conditions.push(eq(SessionTable.directory, input.directory))
+      if (input?.directory) conditions.push(eq(SessionTable.directory, dbDir(input.directory)))
       if (input?.roots) conditions.push(isNull(SessionTable.parent_id))
       if (input?.start) conditions.push(gte(SessionTable.time_updated, input.start))
       if (input?.cursor) conditions.push(lt(SessionTable.time_updated, input.cursor))
@@ -954,6 +954,8 @@ const cancelBackgroundJobs = Effect.fn("Session.cancelBackgroundJobs")(function*
   )
 })
 
+const dbDir = (dir: string) => (process.platform === "win32" ? dir.replaceAll("\\", "/") : dir)
+
 function listByProject(
   db: Database.Interface["db"],
   input: ListInput & {
@@ -975,13 +977,13 @@ function listByProject(
 
       conditions.push(
         input.directory
-          ? or(...conds, and(isNull(SessionTable.path), eq(SessionTable.directory, input.directory))!)!
+          ? or(...conds, and(isNull(SessionTable.path), eq(SessionTable.directory, dbDir(input.directory)))!)!
           : or(...conds)!,
       )
     }
   } else if (input.scope !== "project") {
     if (input.directory) {
-      conditions.push(eq(SessionTable.directory, input.directory))
+      conditions.push(eq(SessionTable.directory, dbDir(input.directory)))
     }
   }
   if (input.roots) {


### PR DESCRIPTION
### What does this PR do?

Fixes path separator mismatch on Windows where `SessionTable.directory` stores paths in POSIX format (`D:/Workspace`) but query parameters arrive with backslashes (`D:\Workspace`), causing SQLite exact-match to fail and session lists to appear empty.

Added `dbDir()` normalization (`\\ -> /` on win32 only) to all 5 `eq(SessionTable.directory, ...)` call sites across 3 files:

- `packages/core/src/session.ts` — `V2Session.list`
- `packages/opencode/src/session/session.ts` — `listGlobal`, `listByProject` (2x)
- `packages/opencode/src/project/project.ts` — project migration query

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you verify your code works?

- Built `packages/opencode` successfully (bun run build)
- Ran core test suite: 1058/1060 pass (2 pre-existing failures unrelated)
- No TypeScript errors in modified files
- Changes are Windows-only (`process.platform === "win32"` guard)

### Checklist

- [x] I have tested my changes locally
- [x] I have included no unrelated changes

### Issue for this PR

Fixes #30374
