### PR TITLE
docs: add Composio MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,52 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### Composio
+
+Add the [Composio MCP server](https://composio.dev) to connect agents to 1000+ apps with managed auth and tool-calling (Gmail, Slack, GitHub, Linear).
+
+```json title="opencode.json" {4-8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "composio": {
+      "type": "remote",
+      "url": "https://connect.composio.dev/mcp",
+      "oauth": {}
+    }
+  }
+}
+```
+
+After adding the configuration, authenticate with Composio:
+
+```bash
+opencode mcp auth composio
+```
+
+This will open a browser window to complete the OAuth flow and connect OpenCode to your Composio account.
+
+Once authenticated, you can use Composio tools in your prompts to work with your apps. You'll be asked to connect an app the first time you use it.
+
+Prompts can chain tools across several apps in one go. A few examples:
+
+```txt "use composio"
+Create a Linear issue for the bug in this file, assign it to me, and set it to high priority. use composio
+```
+
+```txt "use composio"
+Summarize the changes on this branch and post the summary to #eng-updates in Slack. use composio
+```
+
+```txt "use composio"
+Find this week's Sentry alert emails in Gmail and turn them into a triage checklist in Notion. use composio
+```
+
+To have the agent reach for Composio by default, add something like this to your [AGENTS.md](/docs/rules/).
+
+```md title="AGENTS.md"
+When a task reaches outside the codebase — email, chat, issues, docs, or calendars — handle it directly with `composio` tools instead of handing it back to me.
+```


### PR DESCRIPTION
### Issue for this PR

N/A — small docs addition, no linked issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a Composio section to the Examples list on the MCP servers docs page, in the same format as the Sentry entry. Composio is a hosted remote MCP server (`https://connect.composio.dev/mcp`) that connects agents to 1000+ apps with managed auth and tool-calling (Gmail, Slack, GitHub, Linear). The entry covers the `opencode.json` config, authenticating with `opencode mcp auth composio`, a few example prompts, and an AGENTS.md rule.

It works the same way as the existing Sentry example: the server returns 401 with OAuth metadata, and opencode's automatic OAuth (dynamic client registration) handles the rest — no client credentials needed.

Disclosure: I work at Composio.

### How did you verify your code works?

Fresh install of opencode 1.17.13, pasted the exact config block from this PR into a test project's `opencode.json`, ran `opencode mcp auth composio`, completed the browser OAuth flow, and `opencode mcp list` shows `✓ composio connected (OAuth)`. Also ran `opencode mcp debug composio` to confirm the 401 + OAuth discovery flow works as the docs describe.

### Screenshots / recordings

N/A — docs-only change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR