### PR TITLE
fix(agent): remove alphabetical sort to preserve insertion order for primary agents

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -318,10 +318,7 @@ const layer = Layer.effect(
           return pipe(
             agents,
             values(),
-            sortBy(
-              [(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "build"), "desc"],
-              [(x) => x.name, "asc"],
-            ),
+            sortBy([(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "build"), "desc"]),
           )
         })
 


### PR DESCRIPTION
Closes #7372

## Changes
Removes the secondary sort criterion `[(x) => x.name, "asc"]` from `Agent.list()`.

The alphabetical sort was reordering user-defined primary agents into unexpected positions (e.g., "Home" sorting before "plan" since `h < p`). Removing it restores the natural insertion order: built-in agents first (build, plan), then user-defined agents in config declaration order.

## How I Verified
- Inspected the source: `packages/opencode/src/agent/agent.ts` — the `list()` function now sorts only by the default agent priority, falling back to Record insertion order for the rest.
- Tab cycling in the TUI now follows: Build -> Plan -> Home (user-defined agent).