### PR TITLE
fix(app): add file tree toggle to new session header

### DIFF
--- a/packages/app/src/components/session/session-header-actions.test.ts
+++ b/packages/app/src/components/session/session-header-actions.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test"
+import { shouldShowSessionHeaderFileTreeAction } from "./session-header-actions"
+
+describe("shouldShowSessionHeaderFileTreeAction", () => {
+  test("shows the header action when the desktop file tree feature is visible", () => {
+    expect(shouldShowSessionHeaderFileTreeAction({ desktop: true, visible: true })).toBe(true)
+  })
+
+  test("hides the header action on mobile or when the feature is hidden", () => {
+    expect(shouldShowSessionHeaderFileTreeAction({ desktop: false, visible: true })).toBe(false)
+    expect(shouldShowSessionHeaderFileTreeAction({ desktop: true, visible: false })).toBe(false)
+  })
+})

--- a/packages/app/src/components/session/session-header-actions.ts
+++ b/packages/app/src/components/session/session-header-actions.ts
@@ -1,0 +1,3 @@
+export function shouldShowSessionHeaderFileTreeAction(input: { desktop: boolean; visible: boolean }) {
+  return input.desktop && input.visible
+}

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -31,6 +31,7 @@ import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { reviewTooltipKeybind } from "../command-tooltip-keybind"
+import { shouldShowSessionHeaderFileTreeAction } from "./session-header-actions"
 
 const OPEN_APPS = [
   "vscode",
@@ -244,6 +245,14 @@ export function SessionHeader() {
     reviewVisible: isDesktop(),
     reviewOpened: view().reviewPanel.opened(),
     onReviewToggle: () => view().reviewPanel.toggle(),
+    fileTreeLabel: language.t("command.fileTree.toggle"),
+    fileTreeKeybind: command.keybindParts("fileTree.toggle"),
+    fileTreeVisible: shouldShowSessionHeaderFileTreeAction({
+      desktop: isDesktop(),
+      visible: settings.visibility.fileTree(),
+    }),
+    fileTreeOpened: layout.fileTree.opened(),
+    onFileTreeToggle: () => layout.fileTree.toggle(),
   }))
 
   const selectApp = (app: OpenApp) => {
@@ -527,11 +536,14 @@ type SessionHeaderV2ActionsState = {
   reviewVisible: boolean
   reviewOpened: boolean
   onReviewToggle: () => void
+  fileTreeLabel: string
+  fileTreeKeybind: string[]
+  fileTreeVisible: boolean
+  fileTreeOpened: boolean
+  onFileTreeToggle: () => void
 }
 
 function SessionHeaderV2Actions(props: { state: SessionHeaderV2ActionsState }) {
-  const language = useLanguage()
-
   return (
     <div class="flex items-center gap-2">
       <Show when={props.state.statusVisible}>
@@ -563,6 +575,33 @@ function SessionHeaderV2Actions(props: { state: SessionHeaderV2ActionsState }) {
             aria-expanded={props.state.reviewOpened}
             aria-controls="review-panel"
             icon={<IconV2 name="sidebar-right" />}
+          />
+        </TooltipV2>
+      </Show>
+      <Show when={props.state.fileTreeVisible}>
+        <TooltipV2
+          class="shrink-0"
+          placement="bottom"
+          value={
+            <>
+              {props.state.fileTreeLabel}
+              <Show when={props.state.fileTreeKeybind.length > 0}>
+                <KeybindV2 keys={props.state.fileTreeKeybind} variant="neutral" />
+              </Show>
+            </>
+          }
+        >
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="!w-9 shrink-0"
+            state={props.state.fileTreeOpened ? "pressed" : undefined}
+            onClick={props.state.onFileTreeToggle}
+            aria-label={props.state.fileTreeLabel}
+            aria-expanded={props.state.fileTreeOpened}
+            aria-controls="file-tree-panel"
+            icon={<IconV2 name="folder" />}
           />
         </TooltipV2>
       </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #29951

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the missing File Tree button to the new desktop session header.

The old header already had a file tree toggle, and the file tree panel already opens from `layout.fileTree`. The new header only rendered review/status actions, so enabling File Tree in settings could still leave no visible button to open it.

This PR wires the new header button to the existing file tree label, shortcut, open state, and toggle action.

### How did you verify your code works?

- `cd packages/app && npm exec --yes --package=bun@1.3.14 -- bun test --preload ./happydom.ts ./src/components/session/session-header-actions.test.ts ./src/pages/session/helpers.test.ts ./src/components/command-tooltip-keybind.test.ts`
- `cd packages/app && npm exec --yes --package=bun@1.3.14 -- bun typecheck`
- `cd packages/app && git diff --check`
- Started desktop dev app locally and confirmed the app launches.

### Screenshots / recordings

Not attached.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
