### PR TITLE
fix(tui): fix @file autocomplete on home screen

### DIFF
--- a/packages/cli/src/tui.ts
+++ b/packages/cli/src/tui.ts
@@ -15,22 +15,32 @@ export function runTui(transport: Transport, args: Args, reload?: () => Promise<
   let disposeSlots: (() => void) | undefined
   return Effect.gen(function* () {
     const options = { baseUrl: transport.url, headers: transport.headers }
-    const api = OpenCode.make(options)
-    const directory = yield* Effect.tryPromise(() => api.file.list({ location: { directory: process.cwd() } })).pipe(
+    const bootstrap = OpenCode.make(options)
+    const directory = yield* Effect.tryPromise(() =>
+      bootstrap.file.list({ location: { directory: process.cwd() } }),
+    ).pipe(
       Effect.map((response) => response.location.directory),
       Effect.catch(() =>
-        Effect.tryPromise(() => api.location.get()).pipe(Effect.map((response) => response.directory)),
+        Effect.tryPromise(() => bootstrap.location.get()).pipe(Effect.map((response) => response.directory)),
       ),
     )
+    // Scope api requests to the resolved directory so calls without an explicit
+    // location (e.g. home screen file autocomplete) don't fall back to the
+    // daemon's cwd. Explicit location query params still take precedence.
+    const withDirectory = (headers: RequestInit["headers"]) => {
+      const next = new Headers(headers)
+      next.set("x-opencode-directory", encodeURIComponent(directory))
+      return next
+    }
     return yield* run({
       client: createOpencodeClient({ ...options, directory }),
-      api,
+      api: OpenCode.make({ baseUrl: transport.url, headers: withDirectory(transport.headers) }),
       reload: reload
         ? async () => {
             const next = await reload()
             return {
               client: createOpencodeClient({ baseUrl: next.url, headers: next.headers, directory }),
-              api: OpenCode.make({ baseUrl: next.url, headers: next.headers }),
+              api: OpenCode.make({ baseUrl: next.url, headers: withDirectory(next.headers) }),
             }
           }
         : undefined,


### PR DESCRIPTION
## Bug

On the V2 TUI home screen (fresh start, no session), typing `@pac` in the prompt shows "No matching items". Inside a session the same autocomplete works.

The home screen renders `<Prompt>` under the top-level `LocationProvider` in `packages/tui/src/app.tsx`, which has no `location` prop, so `useLocation()` returns `undefined`. Autocomplete then calls `sdk.api.file.find(...)` with an undefined `location.directory`, the generated client drops the query param, and the server falls back to `process.cwd()` (`packages/server/src/location.ts`). Since the server is a detached reused daemon (`packages/cli/src/services/daemon.ts`), its cwd is not the user's project, so file search runs against the wrong tree.

## Fix

`packages/cli/src/tui.ts` already resolves the project `directory` at startup and threads it into `sdk.client` via `createOpencodeClient({ ..., directory })` — but not into `sdk.api`. This change also constructs `sdk.api` (and its `reload` counterpart) with an `x-opencode-directory` header carrying the resolved directory, matching how `sdk.client` works.

The server's location middleware prefers explicit `location[directory]` query params over the header, so any `sdk.api` call that passes an explicit location (e.g. the session route, which wraps the prompt in `<LocationProvider location={session().location}>`) is unaffected. Calls that omit a location — home screen file autocomplete, and any other pre-session `sdk.api` call — now default to the project directory instead of the daemon's cwd.

Verified against a running server: `/api/fs/find` with no directory param returns results from the header directory, and an explicit `location[directory]` query param still takes precedence over the header.

Other home-screen mention types (agents, commands, skills) come from `data.location.*` lists which already fall back to a default location resolved from the TUI's cwd, so they were not broken.

`bun typecheck` passes in `packages/cli` and `packages/tui`. (`packages/cli` has one pre-existing failure in `test/standalone.test.ts` that also fails on the base branch, unrelated to this change.)

Fixes #34825