### PR TITLE
feat(tui): add configurable sidebar width

### DIFF
--- a/packages/opencode/src/config/tui-migrate.ts
+++ b/packages/opencode/src/config/tui-migrate.ts
@@ -15,6 +15,7 @@ const decodeRecord = Schema.decodeUnknownOption(Schema.Record(Schema.String, Sch
 const decodeScrollSpeed = Schema.decodeUnknownOption(TuiConfig.ScrollSpeed)
 const decodeScrollAcceleration = Schema.decodeUnknownOption(TuiConfig.ScrollAcceleration)
 const decodeDiffStyle = Schema.decodeUnknownOption(TuiConfig.DiffStyle)
+const decodeSidebar = Schema.decodeUnknownOption(TuiConfig.Sidebar)
 
 interface MigrateInput {
   cwd: string
@@ -72,16 +73,19 @@ function normalizeTui(data: Record<string, unknown>):
       scroll_speed: number | undefined
       scroll_acceleration: { enabled: boolean } | undefined
       diff_style: "auto" | "stacked" | undefined
+      sidebar: { width?: number } | undefined
     }
   | undefined {
   const parsed = {
     scroll_speed: Option.getOrUndefined(decodeScrollSpeed(data.scroll_speed)),
     scroll_acceleration: Option.getOrUndefined(decodeScrollAcceleration(data.scroll_acceleration)),
     diff_style: Option.getOrUndefined(decodeDiffStyle(data.diff_style)),
+    sidebar: Option.getOrUndefined(decodeSidebar(data.sidebar)),
   }
   return parsed.scroll_speed === undefined &&
     parsed.diff_style === undefined &&
-    parsed.scroll_acceleration === undefined
+    parsed.scroll_acceleration === undefined &&
+    parsed.sidebar === undefined
     ? undefined
     : parsed
 }

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -197,17 +197,19 @@ it.instance("migrates tui-specific keys from opencode.json when tui.json does no
       const source = path.join(test.directory, "opencode.json")
       yield* fs.writeJson(source, {
         theme: "migrated-theme",
-        tui: { scroll_speed: 5 },
+        tui: { scroll_speed: 5, sidebar: { width: 50 } },
         keybinds: { app_exit: "ctrl+q" },
       })
 
       const config = yield* getTuiConfig(test.directory)
       expect(config.theme).toBe("migrated-theme")
       expect(config.scroll_speed).toBe(5)
+      expect(config.sidebar.width).toBe(50)
       expect(config.keybinds.get("app.exit")?.[0]?.key).toBe("ctrl+q")
       expect(JSON.parse(yield* fs.readFileString(path.join(test.directory, "tui.json")))).toMatchObject({
         theme: "migrated-theme",
         scroll_speed: 5,
+        sidebar: { width: 50 },
       })
       const server = JSON.parse(yield* fs.readFileString(source))
       expect(server.theme).toBeUndefined()

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -31,6 +31,15 @@ export const DiffStyle = Schema.Literals(["auto", "stacked"]).annotate({
   description: "Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column",
 })
 
+export const SidebarWidthDefault = 42
+export const SidebarWidthMin = 24
+const MainContentWidthMin = 40
+export const Sidebar = Schema.Struct({
+  width: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))).annotate({
+    description: "Session sidebar width in terminal columns",
+  }),
+}).annotate({ description: "Session sidebar settings" })
+
 export const AttentionSounds = Schema.Record(AttentionSoundName, Schema.optionalKey(Schema.String))
 export type AttentionSoundPaths = Schema.Schema.Type<typeof AttentionSounds>
 export const Attention = Schema.Struct({
@@ -62,11 +71,12 @@ export const Info = Schema.Struct({
   scroll_speed: Schema.optional(ScrollSpeed).annotate({ description: "TUI scroll speed" }),
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
+  sidebar: Schema.optional(Sidebar),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
-export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse"> & {
+export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse" | "sidebar"> & {
   attention: {
     enabled: boolean
     notifications: boolean
@@ -74,6 +84,9 @@ export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | 
     volume: number
     sound_pack: string
     sounds: AttentionSoundPaths
+  }
+  sidebar: {
+    width: number
   }
   keybinds: TuiKeybind.BindingLookupView
   leader_timeout: number
@@ -112,8 +125,20 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
       bindingDefaults: TuiKeybind.bindingDefaults(),
     }),
     leader_timeout: input.leader_timeout ?? LeaderTimeoutDefault,
+    sidebar: {
+      width: input.sidebar?.width ?? SidebarWidthDefault,
+    },
     mouse: input.mouse ?? true,
   }
+}
+
+export function sidebarWidth(config: Pick<Resolved, "sidebar">, terminalWidth?: number) {
+  const configured = Math.max(1, Math.floor(config.sidebar.width || SidebarWidthDefault))
+  if (terminalWidth === undefined) return Math.max(SidebarWidthMin, configured)
+
+  const max = Math.max(1, terminalWidth - MainContentWidthMin - 4)
+  const min = Math.min(SidebarWidthMin, max)
+  return Math.max(min, Math.min(configured, max))
 }
 
 const ConfigContext = createContext<Resolved>()

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -71,7 +71,7 @@ import * as Model from "../../util/model"
 import { formatTranscript } from "../../util/transcript"
 import { sessionEpilogue } from "../../util/presentation"
 import { setPreLayoutSiblingMargin } from "../../util/layout"
-import { useTuiConfig } from "../../config"
+import { sidebarWidth, useTuiConfig } from "../../config"
 import { useClipboard } from "../../context/clipboard"
 import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
 import { getScrollAcceleration } from "../../util/scroll"
@@ -261,6 +261,7 @@ export function Session() {
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)
 
   const wide = createMemo(() => dimensions().width > 120)
+  const sidebarPanelWidth = createMemo(() => sidebarWidth(tuiConfig, dimensions().width))
   const sidebarVisible = createMemo(() => {
     if (session()?.parentID) return false
     if (sidebarOpen()) return true
@@ -268,7 +269,7 @@ export function Session() {
     return false
   })
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? sidebarPanelWidth() : 0) - 4)
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
@@ -1324,7 +1325,7 @@ export function Session() {
           <Show when={sidebarVisible()}>
             <Switch>
               <Match when={wide()}>
-                <Sidebar sessionID={route.sessionID} />
+                <Sidebar sessionID={route.sessionID} width={sidebarPanelWidth()} />
               </Match>
               <Match when={!wide()}>
                 <box
@@ -1336,7 +1337,7 @@ export function Session() {
                   alignItems="flex-end"
                   backgroundColor={RGBA.fromInts(0, 0, 0, 70)}
                 >
-                  <Sidebar sessionID={route.sessionID} />
+                  <Sidebar sessionID={route.sessionID} width={sidebarPanelWidth()} />
                 </box>
               </Match>
             </Switch>

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -9,7 +9,7 @@ import { usePluginRuntime } from "../../plugin/runtime"
 import { getScrollAcceleration } from "../../util/scroll"
 import { WorkspaceLabel } from "../../component/workspace-label"
 
-export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+export function Sidebar(props: { sessionID: string; width: number; overlay?: boolean }) {
   const pluginRuntime = usePluginRuntime()
   const project = useProject()
   const sync = useSync()
@@ -27,7 +27,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     <Show when={session()}>
       <box
         backgroundColor={theme.backgroundPanel}
-        width={42}
+        width={props.width}
         height="100%"
         paddingTop={1}
         paddingBottom={1}

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -273,6 +273,9 @@ Use a dedicated `tui.json` (or `tui.jsonc`) file for TUI-specific settings.
     "enabled": true
   },
   "diff_style": "auto",
+  "sidebar": {
+    "width": 50
+  },
   "mouse": true,
   "attention": {
     "enabled": true,
@@ -286,6 +289,8 @@ Use a dedicated `tui.json` (or `tui.jsonc`) file for TUI-specific settings.
 Use `OPENCODE_TUI_CONFIG` to point to a custom TUI config file.
 
 Set `attention.enabled` to turn on TUI desktop notifications and sounds. See [TUI attention](/docs/tui#attention).
+
+Set `sidebar.width` to customize the session sidebar width. The default is `42` terminal columns.
 
 Legacy `theme`, `keybinds`, and `tui` keys in `opencode.json` are deprecated and automatically migrated when possible.
 

--- a/packages/web/src/content/docs/zh-cn/config.mdx
+++ b/packages/web/src/content/docs/zh-cn/config.mdx
@@ -161,7 +161,10 @@ opencode run "Hello world"
     "scroll_acceleration": {
       "enabled": true
     },
-    "diff_style": "auto"
+    "diff_style": "auto",
+    "sidebar": {
+      "width": 50
+    }
   }
 }
 ```
@@ -171,6 +174,7 @@ opencode run "Hello world"
 - `scroll_acceleration.enabled` - 启用 macOS 风格的滚动加速。**优先于 `scroll_speed`。**
 - `scroll_speed` - 自定义滚动速度倍率（默认值：`3`，最小值：`1`）。如果 `scroll_acceleration.enabled` 为 `true`，则忽略此选项。
 - `diff_style` - 控制差异渲染方式。`"auto"` 根据终端宽度自适应，`"stacked"` 始终显示单列。
+- `sidebar.width` - 自定义会话侧栏宽度，单位是终端列数。默认值为 `42`。
 
 [在此了解更多关于 TUI 的信息](/docs/tui)。
 


### PR DESCRIPTION
### Issue for this PR

Closes #6087

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a TUI config option for the session sidebar width:

```json
{
  "sidebar": {
    "width": 50
  }
}
```

The default remains 42 columns. The session layout and sidebar component now use the same resolved width, and the value is clamped against the terminal width so a large configured value does not consume the full main area.

This also updates legacy TUI config migration so `tui.sidebar.width` from `opencode.json` is preserved when moved into `tui.json`, and documents the option in English and Chinese config docs.

### How did you verify your code works?

- `cd packages/tui && bun run typecheck`
- `cd packages/opencode && bun run typecheck`
- `cd packages/opencode && bun test test/config/tui.test.ts --timeout 30000`
- `bunx prettier --check packages/opencode/src/config/tui-migrate.ts packages/opencode/test/config/tui.test.ts packages/tui/src/config/index.tsx packages/tui/src/routes/session/index.tsx packages/tui/src/routes/session/sidebar.tsx packages/web/src/content/docs/config.mdx packages/web/src/content/docs/zh-cn/config.mdx`
- push hook ran `bun turbo typecheck`: 29 packages successful

### Screenshots / recordings

Not included. This is a config-driven layout change; no visible behavior changes unless `sidebar.width` is configured.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR