### PR TITLE
fix(app): resolve target session lineage outside router transition

### DIFF
--- a/packages/app/e2e/regression/subagent-child-navigation.spec.ts
+++ b/packages/app/e2e/regression/subagent-child-navigation.spec.ts
@@ -12,9 +12,38 @@ const childTitle = "Subagent child session"
 // Child session pages derive their heading from the task part that spawned them.
 const taskDescription = "Inspect child navigation"
 
+type EventPayload = { directory: string; payload: Record<string, unknown> }
+
 test.use({ viewport: { width: 1440, height: 900 } })
 
 test("navigates to a subagent child session missing from the session list", async ({ page }) => {
+  await setup(page)
+  await openChildFromParent(page)
+
+  await expectSessionTitle(page, taskDescription)
+  await expect(page.getByRole("heading", { name: parentTitle })).toHaveCount(0)
+
+  const titlebarRight = page.locator("#opencode-titlebar-right")
+  await expect(titlebarRight.getByRole("button", { name: "Toggle review" })).toHaveCount(1)
+})
+
+test("shows the not found fallback when the viewed session is deleted", async ({ page }) => {
+  const events: EventPayload[] = []
+  await setup(page, () => events.splice(0, 1))
+  await openChildFromParent(page)
+  await expectSessionTitle(page, taskDescription)
+
+  events.push({
+    directory,
+    payload: { type: "session.deleted", properties: { info: childSession() } },
+  })
+
+  await expect(page.getByText("This session cannot be found")).toBeVisible()
+  await expect(page.getByRole("button", { name: "Close Tab" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: taskDescription })).toHaveCount(0)
+})
+
+async function setup(page: Page, events?: () => EventPayload[]) {
   await mockOpenCodeServer(page, {
     directory,
     project: {
@@ -40,6 +69,8 @@ test("navigates to a subagent child session missing from the session list", asyn
     },
     sessions: [session(parentID, parentTitle, 1700000000000), childSession()],
     pageMessages: (sessionID) => ({ items: sessionID === parentID ? parentMessages() : [] }),
+    events,
+    eventRetry: events ? 16 : undefined,
   })
   // The child session resolves via /session/:id but is absent from the /session list,
   // matching a subagent session that has not been loaded into the list cache yet.
@@ -54,7 +85,9 @@ test("navigates to a subagent child session missing from the session list", asyn
       }),
   )
   await configurePage(page)
+}
 
+async function openChildFromParent(page: Page) {
   await page.goto(sessionHref(parentID))
   await expectSessionTitle(page, parentTitle)
 
@@ -63,12 +96,7 @@ test("navigates to a subagent child session missing from the session list", asyn
   await card.click()
 
   await expect(page).toHaveURL(new RegExp(`/server/.+/session/${childID}$`), { timeout: 15_000 })
-  await expectSessionTitle(page, taskDescription)
-  await expect(page.getByRole("heading", { name: parentTitle })).toHaveCount(0)
-
-  const titlebarRight = page.locator("#opencode-titlebar-right")
-  await expect(titlebarRight.getByRole("button", { name: "Toggle review" })).toHaveCount(1)
-})
+}
 
 function session(id: string, title: string, created: number, extra?: Record<string, unknown>) {
   return {

--- a/packages/app/e2e/regression/subagent-child-navigation.spec.ts
+++ b/packages/app/e2e/regression/subagent-child-navigation.spec.ts
@@ -1,0 +1,175 @@
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { expect, test, type Page } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectSessionTitle } from "../utils/waits"
+
+const directory = "C:/OpenCode/SubagentNavigation"
+const projectID = "proj_subagent_navigation"
+const parentID = "ses_subagent_parent"
+const childID = "ses_subagent_child"
+const parentTitle = "Parent session"
+const childTitle = "Subagent child session"
+// Child session pages derive their heading from the task part that spawned them.
+const taskDescription = "Inspect child navigation"
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test("navigates to a subagent child session missing from the session list", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: projectID,
+      worktree: directory,
+      vcs: "git",
+      name: "subagent-navigation",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: {
+      all: [
+        {
+          id: "opencode",
+          name: "OpenCode",
+          models: {
+            "claude-opus-4-6": { id: "claude-opus-4-6", name: "Claude Opus 4.6", limit: { context: 200_000 } },
+          },
+        },
+      ],
+      connected: ["opencode"],
+      default: { providerID: "opencode", modelID: "claude-opus-4-6" },
+    },
+    sessions: [session(parentID, parentTitle, 1700000000000), childSession()],
+    pageMessages: (sessionID) => ({ items: sessionID === parentID ? parentMessages() : [] }),
+  })
+  // The child session resolves via /session/:id but is absent from the /session list,
+  // matching a subagent session that has not been loaded into the list cache yet.
+  await page.route(
+    (url) => url.pathname === "/session" && url.port === (process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"),
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        headers: { "access-control-allow-origin": "*" },
+        body: JSON.stringify([session(parentID, parentTitle, 1700000000000)]),
+      }),
+  )
+  await configurePage(page)
+
+  await page.goto(sessionHref(parentID))
+  await expectSessionTitle(page, parentTitle)
+
+  const card = page.locator(`a[href="${sessionHref(childID)}"]`)
+  await expect(card).toBeVisible()
+  await card.click()
+
+  await expect(page).toHaveURL(new RegExp(`/server/.+/session/${childID}$`), { timeout: 15_000 })
+  await expectSessionTitle(page, taskDescription)
+  await expect(page.getByRole("heading", { name: parentTitle })).toHaveCount(0)
+
+  const titlebarRight = page.locator("#opencode-titlebar-right")
+  await expect(titlebarRight.getByRole("button", { name: "Toggle review" })).toHaveCount(1)
+})
+
+function session(id: string, title: string, created: number, extra?: Record<string, unknown>) {
+  return {
+    id,
+    slug: id,
+    projectID,
+    directory,
+    title,
+    version: "dev",
+    time: { created, updated: created },
+    ...extra,
+  }
+}
+
+function childSession() {
+  return session(childID, childTitle, 1700000001000, { parentID })
+}
+
+function parentMessages() {
+  const userID = "msg_user_0001"
+  const assistantID = "msg_assistant_0001"
+  return [
+    {
+      info: {
+        id: userID,
+        sessionID: parentID,
+        role: "user",
+        time: { created: 1700000000000 },
+        agent: "build",
+        model: { providerID: "opencode", modelID: "claude-opus-4-6" },
+      },
+      parts: [
+        {
+          id: "prt_user_text_0001",
+          sessionID: parentID,
+          messageID: userID,
+          type: "text",
+          text: "Delegate work to a subagent",
+        },
+      ],
+    },
+    {
+      info: {
+        id: assistantID,
+        sessionID: parentID,
+        role: "assistant",
+        time: { created: 1700000001000, completed: 1700000002000 },
+        parentID: userID,
+        modelID: "claude-opus-4-6",
+        providerID: "opencode",
+        mode: "build",
+        agent: "build",
+        path: { cwd: directory, root: directory },
+        cost: 0.01,
+        tokens: { input: 100, output: 200, reasoning: 0, cache: { read: 0, write: 0 } },
+        finish: "stop",
+      },
+      parts: [
+        {
+          id: "prt_tool_task_0001",
+          sessionID: parentID,
+          messageID: assistantID,
+          type: "tool",
+          callID: "call_task_0001",
+          tool: "task",
+          state: {
+            status: "completed",
+            input: { description: taskDescription, subagent_type: "explore" },
+            output: "Subagent finished",
+            title: taskDescription,
+            metadata: { sessionId: childID },
+            time: { start: 1700000001000, end: 1700000002000 },
+          },
+        },
+      ],
+    },
+  ]
+}
+
+async function configurePage(page: Page) {
+  const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+  await page.addInitScript(
+    ({ directory, server, sessionId }) => {
+      localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+      localStorage.setItem(
+        "opencode.global.dat:server",
+        JSON.stringify({
+          projects: { local: [{ worktree: directory, expanded: true }] },
+          lastProject: { local: directory },
+        }),
+      )
+      localStorage.setItem(
+        "opencode.window.browser.dat:tabs",
+        JSON.stringify([{ type: "session", server, sessionId }]),
+      )
+    },
+    { directory, server, sessionId: parentID },
+  )
+}
+
+function sessionHref(sessionID: string) {
+  const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+  return `/server/${base64Encode(server)}/session/${sessionID}`
+}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -11,7 +11,7 @@ import {
   createMemo,
   createEffect,
   createComputed,
-  createResource,
+  createSignal,
   on,
   onMount,
   type ParentProps,
@@ -85,7 +85,7 @@ import { diffs as list } from "@/utils/diffs"
 import { Persist, persisted } from "@/utils/persist"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { formatServerError, isSessionNotFoundError } from "@/utils/server-errors"
-import { legacySessionHref, requireServerKey, selectSessionLineage, sessionHref } from "@/utils/session-route"
+import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/session-route"
 import { useUsageExceededDialogs } from "./session/usage-exceeded-dialogs"
 import { createSessionOwnership } from "./session/session-ownership"
 
@@ -223,17 +223,8 @@ function ResolvedTargetSessionRoute() {
   const params = useParams<{ serverKey: string; id: string }>()
   const settings = useSettings()
   const tabs = useTabs()
-  const sync = useServerSync()
   const serverKey = createMemo(() => requireServerKey(params.serverKey))
-  const cached = createMemo(() => sync().session.lineage.peek(params.id))
-  const [resolved] = createResource(
-    () => {
-      if (cached()) return
-      return { id: params.id, sync: sync() }
-    },
-    ({ id, sync }) => sync.session.lineage.resolve(id),
-  )
-  const current = createMemo(() => selectSessionLineage(params.id, cached(), resolved()))
+  const current = createSessionLineage(() => params.id)
   const directory = createMemo(() => current()?.session.directory)
   const targetDirectory = () => directory()!
 
@@ -262,6 +253,31 @@ function ResolvedTargetSessionRoute() {
       </Show>
     </TargetServerScopedProviders>
   )
+}
+
+// Reactive session lineage for the target session route, read from the sync store.
+// The route keys its consumer to the session ID, so resolution runs once per target.
+// Resolution is imperative rather than a resource on purpose: a resource created here
+// would be created inside the router's navigation transition, and suspending that
+// transition deadlocks the URL commit and double-mounts the session header portals
+// from the transition's shadow render. `lineage.resolve` fills the sync store, which
+// the returned accessor observes; resolve failures rethrow on read so the enclosing
+// SessionRouteErrorBoundary renders the scoped session error.
+function createSessionLineage(sessionID: () => string) {
+  const sync = useServerSync()
+  const cached = createMemo(() => sync().session.lineage.peek(sessionID()))
+  const [failure, setFailure] = createSignal<unknown>()
+  onMount(() => {
+    if (cached()) return
+    sync()
+      .session.lineage.resolve(sessionID())
+      .catch((error) => setFailure(() => error))
+  })
+  return createMemo(() => {
+    const error = failure()
+    if (error) throw error
+    return cached()
+  })
 }
 
 function TargetSessionPage() {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -267,16 +267,27 @@ function createSessionLineage(sessionID: () => string) {
   const sync = useServerSync()
   const cached = createMemo(() => sync().session.lineage.peek(sessionID()))
   const [failure, setFailure] = createSignal<unknown>()
+  const [settled, setSettled] = createSignal(false)
   onMount(() => {
-    if (cached()) return
+    if (cached()) {
+      setSettled(true)
+      return
+    }
     sync()
       .session.lineage.resolve(sessionID())
+      .then(() => setSettled(true))
       .catch((error) => setFailure(() => error))
   })
   return createMemo(() => {
     const error = failure()
     if (error) throw error
-    return cached()
+    const lineage = cached()
+    // The viewed session is pinned and pinned lineages are exempt from cache pruning,
+    // so a lineage missing after settlement means the session (or an ancestor) was
+    // deleted, possibly by another client. Match the resolve error so the boundary
+    // shows the session not found fallback.
+    if (!lineage && settled()) throw new Error(`Session not found: ${sessionID()}`)
+    return lineage
   })
 }
 

--- a/packages/app/src/utils/session-route.test.ts
+++ b/packages/app/src/utils/session-route.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { ServerConnection } from "@/context/server"
-import {
-  legacySessionHref,
-  legacySessionServer,
-  requireServerKey,
-  rootSession,
-  selectSessionLineage,
-  sessionHref,
-} from "./session-route"
+import { legacySessionHref, legacySessionServer, requireServerKey, rootSession, sessionHref } from "./session-route"
 
 describe("session routes", () => {
   test("uses the unique persisted server for a legacy session route", () => {
@@ -74,11 +67,5 @@ describe("session routes", () => {
     }
 
     expect(rootSession(sessions.child, async (id) => sessions[id]!)).rejects.toThrow("Session parent cycle: child")
-  })
-
-  test("ignores a resolved lineage retained from the previous route", () => {
-    const previous = { session: { id: "A" }, root: { id: "A" } }
-
-    expect(selectSessionLineage("B", undefined, previous)).toBeUndefined()
   })
 })

--- a/packages/app/src/utils/session-route.ts
+++ b/packages/app/src/utils/session-route.ts
@@ -27,15 +27,6 @@ export function legacySessionServer(
 
 type SessionParent = { id: string; parentID?: string }
 
-export function selectSessionLineage<T extends { session: { id: string } }>(
-  sessionID: string,
-  cached: T | undefined,
-  resolved: T | undefined,
-) {
-  if (cached?.session.id === sessionID) return cached
-  if (resolved?.session.id === sessionID) return resolved
-}
-
 export async function rootSession<T extends SessionParent>(session: T, get: (sessionID: string) => Promise<T>) {
   const seen = new Set([session.id])
   let current = session


### PR DESCRIPTION
## Summary

Clicking a task/subagent card whose child session is **not in the `/session` list** (but resolvable via `/session/:id`) leaves the app stuck on the parent session: the URL never changes, the parent page stays visible, and the titlebar accumulates duplicate `Status` / `Toggle review` buttons from a second `SessionHeader` portal.

Regression introduced by #34254, still reproducible on latest `dev` (`b3934992d1`) and `beta` (`c441a1cf6c`) — verified by running the repro spec in this PR against both.

## Root cause

#34254 moved target-session resolution into `pages/session.tsx` behind a `<Show keyed>` on `serverKey\0id`. Navigating parent → child now recreates `ResolvedTargetSessionRoute` **inside the solid-router navigation transition**, and its `createResource` read suspends that transition. Two things then go wrong:

1. The resource's source observes `lineage.peek(id)`, and its own fetcher (`lineage.resolve`) writes the result into the sync store via `remember(...)`. The fetch resolving invalidates the resource's own source mid-flight, and the suspended navigation transition never commits — `history.pushState` is never called (verified by hooking it: zero calls after click).
2. The transition's shadow render mounts the child subtree's `SessionHeader` portal into the live `#opencode-titlebar-right` node, then the subtree is created again, leaving two live portals (both belonging to the child, verified with a debug marker).

The pre-#34254 code had the same resource shape, but without the keyed remount the resource was never *created* inside the navigation transition, so the deadlock never triggered.

## Fix

Replace the resource with a `createSessionLineage(sessionID)` primitive that never suspends the router transition:

- the returned accessor reads the sync store reactively (`lineage.peek`) — the store is the single source of truth, matching the sync-layer architecture,
- resolution happens imperatively in `onMount` (runs post-commit, outside the transition), filling the store,
- resolve failures are captured in a signal and rethrown on read, preserving #34254's scoped error behavior exactly: any tracked read throws into `SessionRouteErrorBoundary` (same contract as a failed resource read), so the "session not found → close tab" fallback is unchanged.

The navigation transition now commits atomically: URL updates immediately, the parent frame is disposed, and the child page mounts once when the lineage lands.

`selectSessionLineage` becomes dead code (the store peek is inherently keyed by the route's session ID) and is removed along with its test.

Note: `@tanstack/solid-query` was considered and rejected for this spot — solid-query's `useBaseQuery` is built on `createResource` internally, so it would reintroduce the same transition suspension.

## Repro / test

New `e2e/regression/subagent-child-navigation.spec.ts`: parent session with a `task` tool part pointing at a child session that `/session` omits but `/session/:id` resolves. Asserts the URL commits to the child route, the child page heading renders, the parent heading is gone, and exactly one `Toggle review` button exists in the titlebar.

- fails on base commit, latest `dev`, and latest `beta` (URL stuck on parent, `Toggle review` ×2)
- passes with this fix

## Validation

- `bun typecheck` (packages/app) clean
- `bun run test:unit` (packages/app): 497 pass
- `bunx playwright test` (packages/app, regression + smoke): 23/23 pass
- merge-tree against latest `upstream/dev` is conflict-free
