### PR TITLE
fix(agent): remove alphabetical sort to preserve insertion order for primary agents

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -318,10 +318,7 @@ const layer = Layer.effect(
           return pipe(
             agents,
             values(),
-            sortBy(
-              [(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "build"), "desc"],
-              [(x) => x.name, "asc"],
-            ),
+            sortBy([(x) => (cfg.default_agent ? x.name === cfg.default_agent : x.name === "build"), "desc"]),
           )
         })
 


### PR DESCRIPTION
### Issue for this PR

Closes #7372

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the secondary alphabetical sort from `Agent.list()` so primary agents appear in insertion order (built-in first, then user-defined in config declaration order).

Previously, adding a custom "home" agent caused the TUI tab order to become "build" -> "home" -> "plan" instead of the expected "build" -> "plan" -> "home" because `h < p` alphabetically. Removing the `[(x) => x.name, "asc"]` sort criterion restores the user's intended ordering.

This PR does **not** add an explicit ordering field (e.g. `order: number`) for agents. It simply relies on declaration order in the config, which is the simpler fix and sufficient for the current use case.

### How did you verify your code works?

- Inspected the source: `packages/opencode/src/agent/agent.ts` — `list()` now sorts only by default agent priority, preserving insertion order for the rest.
- Tab cycling in the TUI now follows: Build → Plan → Home.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR