### PR TITLE
fix(opencode): filter session list by resolved instance directory

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
@@ -137,8 +137,6 @@ export const experimentalHandlers = HttpApiBuilder.group(InstanceHttpApi, "exper
 
     const session = Effect.fn("ExperimentalHttpApi.session")(function* (ctx: { query: typeof SessionListQuery.Type }) {
       const limit = ctx.query.limit ?? 100
-      // Filter by the instance directory the routing middleware resolved from
-      // the hint, so equivalent spellings match what create stored.
       const directory = ctx.query.directory ? yield* InstanceState.directory : undefined
       const all = yield* sessions.listGlobal({
         directory,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/experimental.ts
@@ -137,8 +137,11 @@ export const experimentalHandlers = HttpApiBuilder.group(InstanceHttpApi, "exper
 
     const session = Effect.fn("ExperimentalHttpApi.session")(function* (ctx: { query: typeof SessionListQuery.Type }) {
       const limit = ctx.query.limit ?? 100
+      // Filter by the instance directory the routing middleware resolved from
+      // the hint, so equivalent spellings match what create stored.
+      const directory = ctx.query.directory ? yield* InstanceState.directory : undefined
       const all = yield* sessions.listGlobal({
-        directory: ctx.query.directory,
+        directory,
         roots: ctx.query.roots,
         start: ctx.query.start,
         cursor: ctx.query.cursor,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -62,9 +62,6 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const scope = yield* Scope.Scope
 
     const list = Effect.fn("SessionHttpApi.list")(function* (ctx: { query: typeof ListQuery.Type }) {
-      // Workspace routing already resolved the requested directory into the
-      // instance context; filter by that canonical form so equivalent hint
-      // spellings (trailing separators, "/" on Windows) match what create stored.
       const directory = ctx.query.directory ? yield* InstanceState.directory : undefined
       return yield* session.list({
         directory: ctx.query.scope === "project" ? undefined : directory,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -18,6 +18,7 @@ import { MessageID, PartID, SessionID } from "@/session/schema"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Cause, Effect, Option, Schema, Scope } from "effect"
 import * as Stream from "effect/Stream"
+import { InstanceState } from "@/effect/instance-state"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
@@ -61,8 +62,12 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     const scope = yield* Scope.Scope
 
     const list = Effect.fn("SessionHttpApi.list")(function* (ctx: { query: typeof ListQuery.Type }) {
+      // Workspace routing already resolved the requested directory into the
+      // instance context; filter by that canonical form so equivalent hint
+      // spellings (trailing separators, "/" on Windows) match what create stored.
+      const directory = ctx.query.directory ? yield* InstanceState.directory : undefined
       return yield* session.list({
-        directory: ctx.query.scope === "project" ? undefined : ctx.query.directory,
+        directory: ctx.query.scope === "project" ? undefined : directory,
         scope: ctx.query.scope,
         path: ctx.query.path,
         roots: ctx.query.roots,

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -885,10 +885,6 @@ describe("session HttpApi", () => {
     () =>
       Effect.gen(function* () {
         const test = yield* TestInstance
-        // Same directory, different spelling: create resolves the hint before
-        // storing (FSUtil.resolve), so list filters must compare against the
-        // same canonical form. Desktop workspaces persisted as "/" or "C:\"
-        // hit this class of mismatch and show an empty sidebar (#34723).
         const hint = test.directory + path.sep
         const headers = { "x-opencode-directory": hint, "content-type": "application/json" }
         const created = yield* requestJson<Session.Info>(SessionPaths.create, {

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -21,6 +21,7 @@ import { InstanceStore } from "../../src/project/instance-store"
 import { Project } from "../../src/project/project"
 import { HttpApiApp } from "../../src/server/routes/instance/httpapi/server"
 import * as HttpSessionError from "../../src/server/routes/instance/httpapi/handlers/session-errors"
+import { ExperimentalPaths } from "../../src/server/routes/instance/httpapi/groups/experimental"
 import { SessionPaths } from "../../src/server/routes/instance/httpapi/groups/session"
 import { Session } from "@/session/session"
 import { MessageID, PartID, SessionID, type SessionID as SessionIDType } from "../../src/session/schema"
@@ -877,6 +878,34 @@ describe("session HttpApi", () => {
         expect(sessions).not.toContain(pathlessSession.id)
       }),
     { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "lists sessions created through an equivalent directory hint",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        // Same directory, different spelling: create resolves the hint before
+        // storing (FSUtil.resolve), so list filters must compare against the
+        // same canonical form. Desktop workspaces persisted as "/" or "C:\"
+        // hit this class of mismatch and show an empty sidebar (#34723).
+        const hint = test.directory + path.sep
+        const headers = { "x-opencode-directory": hint, "content-type": "application/json" }
+        const created = yield* requestJson<Session.Info>(SessionPaths.create, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ title: "hinted" }),
+        })
+
+        const query = new URLSearchParams({ directory: hint, roots: "true" })
+        const listed = yield* requestJson<Session.Info[]>(`${SessionPaths.list}?${query}`, { headers })
+        expect(listed.map((item) => item.id)).toContain(created.id)
+
+        const globalQuery = new URLSearchParams({ directory: hint })
+        const global = yield* requestJson<Session.Info[]>(`${ExperimentalPaths.session}?${globalQuery}`, { headers })
+        expect(global.map((item) => item.id)).toContain(created.id)
+      }),
+    { git: true, config: { formatter: false, lsp: false, share: "disabled" } },
   )
 
   it.instance(


### PR DESCRIPTION
### What does this PR do?

Fixes the "sessions disappear from the sidebar" bug on Windows desktop (#34723) by making the session list filter use the same canonical directory that session create uses — with **no database or schema changes**.

**Root cause** (reproduced live against latest `dev` with the desktop's exact wire values):

- Session **create** resolves the `x-opencode-directory` hint via `FSUtil.resolve` when the instance boots (`instance-store.ts`), so a hint like `/` or a path with a trailing separator is stored in canonical form (e.g. `/` resolves to `C:\` on Windows and the row stores `C:/`).
- Session **list** passed the raw `ctx.query.directory` string into the exact-match SQL filter. Any hint whose spelling differs from its canonical form (`/`, `C:`, trailing separators, symlinked tmp dirs) creates sessions that the same hint can never list back.

The desktop hits this when a global-project session is opened from Home: `project.worktree ?? session.directory` persists the global worktree sentinel `"/"` as a workspace. That workspace then lists `directory=/` (always `[]`) while creating sessions that resolve to the drive root — so every previous session "disappears" when a new one is created, and restarting doesn't help. This is a directory **value** mismatch; it is unrelated to the `\` vs `/` storage encoding fixed in #29666 (which is working correctly).

**Fix**: the workspace-routing middleware already resolves the requested directory to select the instance. The list handlers now filter by that resolved instance directory instead of re-reading the raw query string, so `list(hint)` always finds `create(hint)` by construction:

- `SessionHttpApi.list` (`GET /session`)
- `ExperimentalHttpApi.session` (`GET /experimental/session`)

Existing databases self-heal: previously invisible rows become listable immediately because only the comparison value changes, not the data.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you verify your code works?

- New HTTP-level test (`lists sessions created through an equivalent directory hint`) exercising the full middleware + handler chain: create via a hint whose canonical form differs (trailing separator), then list with the same hint on both endpoints. Fails on `dev` with `Received: []`, passes with this change.
- Live end-to-end repro on Windows against an isolated server: `POST /session` with `x-opencode-directory: %2F` followed by `GET /session?directory=%2F&roots=true` returned `[]` before this change and returns the created sessions after it; `directory=C%3A%5C` and `directory=C%3A%2F` continue to work.
- `bun test test/server/session-list.test.ts test/server/global-session-list.test.ts test/server/workspace-routing.test.ts test/server/httpapi-instance-context.test.ts test/server/httpapi-query-schema-drift.test.ts` — 50/50 pass.
- `bun typecheck` in `packages/opencode` — clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have included no unrelated changes

### Issue for this PR

Fixes #34723