### PR TITLE
refactor(core): resolve database and websearch config through Effect Config

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -2,9 +2,9 @@ export * as Database from "./database"
 
 import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 import { layer as sqliteLayer } from "#sqlite"
-import { Context, Effect, Layer } from "effect"
+import { Config, Context, Effect, Layer, Option } from "effect"
 import { Global } from "../global"
-import { Flag } from "../flag/flag"
+import { truthy } from "../flag/flag"
 import { isAbsolute, join } from "path"
 import { DatabaseMigration } from "./migration"
 import { InstallationChannel } from "../installation/version"
@@ -40,18 +40,33 @@ export function layerFromPath(filename: string) {
   return layer.pipe(Layer.provide(sqliteLayer({ filename })))
 }
 
-export function path() {
-  if (Flag.OPENCODE_DB) {
-    if (Flag.OPENCODE_DB === ":memory:" || isAbsolute(Flag.OPENCODE_DB)) return Flag.OPENCODE_DB
-    return join(Global.Path.data, Flag.OPENCODE_DB)
+/** One placement rule shared by the config-backed layer and the V1 `path()` helper. */
+export function resolvePath(input: { readonly file: string | undefined; readonly disableChannelDb: boolean }) {
+  if (input.file) {
+    if (input.file === ":memory:" || isAbsolute(input.file)) return input.file
+    return join(Global.Path.data, input.file)
   }
-  if (
-    ["latest", "beta", "prod"].includes(InstallationChannel) ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
-  )
+  if (["latest", "beta", "prod"].includes(InstallationChannel) || input.disableChannelDb)
     return join(Global.Path.data, "opencode.db")
   return join(Global.Path.data, `opencode-${InstallationChannel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
 }
 
-export const node = makeGlobalNode({ service: Service, layer: layerFromPath(path()), deps: [] })
+/** V1 compatibility helper; reads the process environment at call time. */
+export function path() {
+  return resolvePath({
+    file: process.env.OPENCODE_DB,
+    disableChannelDb: truthy("OPENCODE_DISABLE_CHANNEL_DB"),
+  })
+}
+
+// Placement is resolved through Effect Config when the layer is built, not at
+// module import, so tests and tooling can override it with a ConfigProvider.
+const configuredLayer = Layer.unwrap(
+  Effect.gen(function* () {
+    const file = yield* Config.option(Config.string("OPENCODE_DB"))
+    const disableChannelDb = yield* Config.boolean("OPENCODE_DISABLE_CHANNEL_DB").pipe(Config.withDefault(false))
+    return layerFromPath(resolvePath({ file: Option.getOrUndefined(file), disableChannelDb }))
+  }).pipe(Effect.orDie),
+)
+
+export const node = makeGlobalNode({ service: Service, layer: configuredLayer, deps: [] })

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -2,9 +2,9 @@ export * as Database from "./database"
 
 import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 import { layer as sqliteLayer } from "#sqlite"
-import { Config, Context, Effect, Layer, Option } from "effect"
+import { Config, Context, Effect, Layer } from "effect"
 import { Global } from "../global"
-import { truthy } from "../flag/flag"
+import { truthy, truthyConfig } from "../flag/flag"
 import { isAbsolute, join } from "path"
 import { DatabaseMigration } from "./migration"
 import { InstallationChannel } from "../installation/version"
@@ -61,12 +61,14 @@ export function path() {
 
 // Placement is resolved through Effect Config when the layer is built, not at
 // module import, so tests and tooling can override it with a ConfigProvider.
+// truthyConfig shares the `truthy` grammar so this layer and the V1 `path()`
+// helper always agree on the same environment.
 const configuredLayer = Layer.unwrap(
   Effect.gen(function* () {
-    const file = yield* Config.option(Config.string("OPENCODE_DB"))
-    const disableChannelDb = yield* Config.boolean("OPENCODE_DISABLE_CHANNEL_DB").pipe(Config.withDefault(false))
-    return layerFromPath(resolvePath({ file: Option.getOrUndefined(file), disableChannelDb }))
-  }).pipe(Effect.orDie),
-)
+    const file = yield* Config.string("OPENCODE_DB").pipe(Config.withDefault(undefined))
+    const disableChannelDb = yield* truthyConfig("OPENCODE_DISABLE_CHANNEL_DB")
+    return layerFromPath(resolvePath({ file, disableChannelDb }))
+  }),
+).pipe(Layer.orDie)
 
 export const node = makeGlobalNode({ service: Service, layer: configuredLayer, deps: [] })

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -4,7 +4,7 @@ import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 import { layer as sqliteLayer } from "#sqlite"
 import { Config, Context, Effect, Layer } from "effect"
 import { Global } from "../global"
-import { truthy, truthyConfig } from "../flag/flag"
+import { truthyConfig } from "../flag/flag"
 import { isAbsolute, join } from "path"
 import { DatabaseMigration } from "./migration"
 import { InstallationChannel } from "../installation/version"
@@ -40,8 +40,7 @@ export function layerFromPath(filename: string) {
   return layer.pipe(Layer.provide(sqliteLayer({ filename })))
 }
 
-/** One placement rule shared by the config-backed layer and the V1 `path()` helper. */
-export function resolvePath(input: { readonly file: string | undefined; readonly disableChannelDb: boolean }) {
+function resolvePath(input: { readonly file: string | undefined; readonly disableChannelDb: boolean }) {
   if (input.file) {
     if (input.file === ":memory:" || isAbsolute(input.file)) return input.file
     return join(Global.Path.data, input.file)
@@ -51,24 +50,18 @@ export function resolvePath(input: { readonly file: string | undefined; readonly
   return join(Global.Path.data, `opencode-${InstallationChannel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
 }
 
-/** V1 compatibility helper; reads the process environment at call time. */
-export function path() {
-  return resolvePath({
-    file: process.env.OPENCODE_DB,
-    disableChannelDb: truthy("OPENCODE_DISABLE_CHANNEL_DB"),
-  })
-}
+/**
+ * The database placement every consumer shares, resolved through Effect
+ * Config so tests and tooling can override it with a ConfigProvider. Used by
+ * the layer below and by external tooling such as `opencode db`.
+ */
+export const configuredPath = Effect.gen(function* () {
+  const file = yield* Config.string("OPENCODE_DB").pipe(Config.withDefault(undefined))
+  const disableChannelDb = yield* truthyConfig("OPENCODE_DISABLE_CHANNEL_DB")
+  return resolvePath({ file, disableChannelDb })
+}).pipe(Effect.orDie)
 
-// Placement is resolved through Effect Config when the layer is built, not at
-// module import, so tests and tooling can override it with a ConfigProvider.
-// truthyConfig shares the `truthy` grammar so this layer and the V1 `path()`
-// helper always agree on the same environment.
-const configuredLayer = Layer.unwrap(
-  Effect.gen(function* () {
-    const file = yield* Config.string("OPENCODE_DB").pipe(Config.withDefault(undefined))
-    const disableChannelDb = yield* truthyConfig("OPENCODE_DISABLE_CHANNEL_DB")
-    return layerFromPath(resolvePath({ file, disableChannelDb }))
-  }),
-).pipe(Layer.orDie)
+// Placement is resolved when the layer is built, not at module import.
+const configuredLayer = Layer.unwrap(Effect.map(configuredPath, layerFromPath))
 
 export const node = makeGlobalNode({ service: Service, layer: configuredLayer, deps: [] })

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -44,7 +44,6 @@ export const Flag = {
     copy === undefined ? process.platform === "win32" : truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"),
   OPENCODE_MODELS_URL: process.env["OPENCODE_MODELS_URL"],
   OPENCODE_MODELS_PATH: process.env["OPENCODE_MODELS_PATH"],
-  OPENCODE_DB: process.env["OPENCODE_DB"],
 
   OPENCODE_WORKSPACE_ID: process.env["OPENCODE_WORKSPACE_ID"],
   OPENCODE_EXPERIMENTAL_WORKSPACES: enabledByExperimental("OPENCODE_EXPERIMENTAL_WORKSPACES"),

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -1,9 +1,23 @@
 import { Config } from "effect"
 
-export function truthy(key: string) {
-  const value = process.env[key]?.toLowerCase()
-  return value === "true" || value === "1"
+function truthyValue(value: string) {
+  const lower = value.toLowerCase()
+  return lower === "true" || lower === "1"
 }
+
+export function truthy(key: string) {
+  const value = process.env[key]
+  return value !== undefined && truthyValue(value)
+}
+
+/**
+ * The `truthy` grammar read through Effect Config, so layer builds can be
+ * steered by a ConfigProvider. Missing or malformed values are false, exactly
+ * like `truthy`; strict boolean decoding would turn a stray env value into a
+ * startup defect.
+ */
+export const truthyConfig = (name: string) =>
+  Config.string(name).pipe(Config.map(truthyValue), Config.withDefault(false))
 
 const copy = process.env["OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"]
 const fff = process.env["OPENCODE_DISABLE_FFF"]

--- a/packages/core/src/tool/websearch.ts
+++ b/packages/core/src/tool/websearch.ts
@@ -1,11 +1,10 @@
 export * as WebSearchTool from "./websearch"
 
 import { ToolFailure } from "@opencode-ai/llm"
-import { Context, Duration, Effect, Layer, Schema } from "effect"
+import { Config, Context, Duration, Effect, Layer, Option, Redacted, Schema } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { makeLocationNode } from "../effect/app-node"
 import { LayerNodePlatform } from "../effect/app-node-platform"
-import { truthy } from "../flag/flag"
 import { InstallationVersion } from "../installation/version"
 import { PositiveInt } from "../schema"
 import { PermissionV2 } from "../permission"
@@ -69,19 +68,33 @@ export interface Config {
 
 export class ConfigService extends Context.Service<ConfigService, Config>()("@opencode/v2/WebSearchConfig") {}
 
-/** Isolates the retained product environment contract from the generic tool implementation. */
-export const defaultConfigLayer = Layer.sync(ConfigService, () =>
-  ConfigService.of({
-    provider:
-      process.env.OPENCODE_WEBSEARCH_PROVIDER === "exa" || process.env.OPENCODE_WEBSEARCH_PROVIDER === "parallel"
-        ? process.env.OPENCODE_WEBSEARCH_PROVIDER
-        : undefined,
-    enableExa: truthy("OPENCODE_EXPERIMENTAL") || truthy("OPENCODE_ENABLE_EXA") || truthy("OPENCODE_EXPERIMENTAL_EXA"),
-    enableParallel: truthy("OPENCODE_ENABLE_PARALLEL") || truthy("OPENCODE_EXPERIMENTAL_PARALLEL"),
-    exaApiKey: process.env.EXA_API_KEY,
-    parallelApiKey: process.env.PARALLEL_API_KEY,
+const flag = (name: string) => Config.boolean(name).pipe(Config.withDefault(false))
+
+/**
+ * Isolates the retained product environment contract from the generic tool
+ * implementation. Reads through Effect `Config` when the layer is built, so
+ * tests can override values with a `ConfigProvider` instead of mutating
+ * `process.env`. Malformed values fail the layer instead of silently
+ * disabling a provider the user asked for.
+ */
+export const defaultConfigLayer = Layer.effect(
+  ConfigService,
+  Effect.gen(function* () {
+    const provider = yield* Config.option(Config.literals(["exa", "parallel"], "OPENCODE_WEBSEARCH_PROVIDER"))
+    const exaApiKey = yield* Config.option(Config.redacted("EXA_API_KEY"))
+    const parallelApiKey = yield* Config.option(Config.redacted("PARALLEL_API_KEY"))
+    return ConfigService.of({
+      provider: Option.getOrUndefined(provider),
+      enableExa:
+        (yield* flag("OPENCODE_EXPERIMENTAL")) ||
+        (yield* flag("OPENCODE_ENABLE_EXA")) ||
+        (yield* flag("OPENCODE_EXPERIMENTAL_EXA")),
+      enableParallel: (yield* flag("OPENCODE_ENABLE_PARALLEL")) || (yield* flag("OPENCODE_EXPERIMENTAL_PARALLEL")),
+      exaApiKey: Option.getOrUndefined(Option.map(exaApiKey, Redacted.value)),
+      parallelApiKey: Option.getOrUndefined(Option.map(parallelApiKey, Redacted.value)),
+    })
   }),
-)
+).pipe(Layer.orDie)
 
 export const configNode = makeLocationNode({ service: ConfigService, layer: defaultConfigLayer, deps: [] })
 

--- a/packages/core/src/tool/websearch.ts
+++ b/packages/core/src/tool/websearch.ts
@@ -1,10 +1,11 @@
 export * as WebSearchTool from "./websearch"
 
 import { ToolFailure } from "@opencode-ai/llm"
-import { Config, Context, Duration, Effect, Layer, Option, Redacted, Schema } from "effect"
+import { Config, Context, Duration, Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { makeLocationNode } from "../effect/app-node"
 import { LayerNodePlatform } from "../effect/app-node-platform"
+import { truthyConfig } from "../flag/flag"
 import { InstallationVersion } from "../installation/version"
 import { PositiveInt } from "../schema"
 import { PermissionV2 } from "../permission"
@@ -68,30 +69,36 @@ export interface Config {
 
 export class ConfigService extends Context.Service<ConfigService, Config>()("@opencode/v2/WebSearchConfig") {}
 
-const flag = (name: string) => Config.boolean(name).pipe(Config.withDefault(false))
-
 /**
  * Isolates the retained product environment contract from the generic tool
  * implementation. Reads through Effect `Config` when the layer is built, so
  * tests can override values with a `ConfigProvider` instead of mutating
- * `process.env`. Malformed values fail the layer instead of silently
- * disabling a provider the user asked for.
+ * `process.env`. Parsing keeps the legacy lenient grammar: missing or
+ * malformed values disable rather than fail, because this layer builds at
+ * Location boot where a defect would surface as opaque session failures.
  */
 export const defaultConfigLayer = Layer.effect(
   ConfigService,
   Effect.gen(function* () {
-    const provider = yield* Config.option(Config.literals(["exa", "parallel"], "OPENCODE_WEBSEARCH_PROVIDER"))
-    const exaApiKey = yield* Config.option(Config.redacted("EXA_API_KEY"))
-    const parallelApiKey = yield* Config.option(Config.redacted("PARALLEL_API_KEY"))
+    const env = yield* Config.all({
+      provider: Config.string("OPENCODE_WEBSEARCH_PROVIDER").pipe(Config.withDefault(undefined)),
+      experimental: truthyConfig("OPENCODE_EXPERIMENTAL"),
+      enableExa: truthyConfig("OPENCODE_ENABLE_EXA"),
+      experimentalExa: truthyConfig("OPENCODE_EXPERIMENTAL_EXA"),
+      enableParallel: truthyConfig("OPENCODE_ENABLE_PARALLEL"),
+      experimentalParallel: truthyConfig("OPENCODE_EXPERIMENTAL_PARALLEL"),
+      exaApiKey: Config.string("EXA_API_KEY").pipe(Config.withDefault(undefined)),
+      parallelApiKey: Config.string("PARALLEL_API_KEY").pipe(Config.withDefault(undefined)),
+    })
+    const provider = env.provider !== undefined && Schema.is(Provider)(env.provider) ? env.provider : undefined
+    if (env.provider !== undefined && provider === undefined)
+      yield* Effect.logWarning("ignoring invalid OPENCODE_WEBSEARCH_PROVIDER", { value: env.provider })
     return ConfigService.of({
-      provider: Option.getOrUndefined(provider),
-      enableExa:
-        (yield* flag("OPENCODE_EXPERIMENTAL")) ||
-        (yield* flag("OPENCODE_ENABLE_EXA")) ||
-        (yield* flag("OPENCODE_EXPERIMENTAL_EXA")),
-      enableParallel: (yield* flag("OPENCODE_ENABLE_PARALLEL")) || (yield* flag("OPENCODE_EXPERIMENTAL_PARALLEL")),
-      exaApiKey: Option.getOrUndefined(Option.map(exaApiKey, Redacted.value)),
-      parallelApiKey: Option.getOrUndefined(Option.map(parallelApiKey, Redacted.value)),
+      provider,
+      enableExa: env.experimental || env.enableExa || env.experimentalExa,
+      enableParallel: env.enableParallel || env.experimentalParallel,
+      exaApiKey: env.exaApiKey,
+      parallelApiKey: env.parallelApiKey,
     })
   }),
 ).pipe(Layer.orDie)

--- a/packages/core/test/database-path.test.ts
+++ b/packages/core/test/database-path.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { ConfigProvider, Effect, Layer } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { Global } from "@opencode-ai/core/global"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { tmpdir } from "./fixture/tmpdir"
+
+describe("Database placement", () => {
+  test("resolves explicit files, relative names, and the channel default", () => {
+    expect(Database.resolvePath({ file: ":memory:", disableChannelDb: false })).toBe(":memory:")
+    expect(Database.resolvePath({ file: "/tmp/explicit.db", disableChannelDb: false })).toBe("/tmp/explicit.db")
+    expect(Database.resolvePath({ file: "relative.db", disableChannelDb: false })).toBe(
+      path.join(Global.Path.data, "relative.db"),
+    )
+    expect(Database.resolvePath({ file: undefined, disableChannelDb: true })).toBe(
+      path.join(Global.Path.data, "opencode.db"),
+    )
+  })
+
+  test("reads placement from the active ConfigProvider when the layer is built", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "config-seam.sqlite")
+
+    // The preload sets OPENCODE_DB=":memory:" in the process environment, so a
+    // database appearing at this path proves the layer reads through the
+    // replaced ConfigProvider rather than the environment snapshot.
+    await Effect.runPromise(
+      Layer.build(
+        LayerNode.compile(LayerNode.group([Database.node])).pipe(
+          Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({ OPENCODE_DB: file }))),
+        ),
+      ).pipe(Effect.scoped, Effect.asVoid),
+    )
+
+    expect(await Bun.file(file).exists()).toBe(true)
+  })
+})

--- a/packages/core/test/database-path.test.ts
+++ b/packages/core/test/database-path.test.ts
@@ -6,16 +6,15 @@ import { Global } from "@opencode-ai/core/global"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { tmpdir } from "./fixture/tmpdir"
 
+const resolve = (env: Record<string, string>) =>
+  Effect.runPromise(Effect.provide(Database.configuredPath, ConfigProvider.layer(ConfigProvider.fromUnknown(env))))
+
 describe("Database placement", () => {
-  test("resolves explicit files, relative names, and the channel default", () => {
-    expect(Database.resolvePath({ file: ":memory:", disableChannelDb: false })).toBe(":memory:")
-    expect(Database.resolvePath({ file: "/tmp/explicit.db", disableChannelDb: false })).toBe("/tmp/explicit.db")
-    expect(Database.resolvePath({ file: "relative.db", disableChannelDb: false })).toBe(
-      path.join(Global.Path.data, "relative.db"),
-    )
-    expect(Database.resolvePath({ file: undefined, disableChannelDb: true })).toBe(
-      path.join(Global.Path.data, "opencode.db"),
-    )
+  test("resolves explicit files, relative names, and the channel default", async () => {
+    expect(await resolve({ OPENCODE_DB: ":memory:" })).toBe(":memory:")
+    expect(await resolve({ OPENCODE_DB: "/tmp/explicit.db" })).toBe("/tmp/explicit.db")
+    expect(await resolve({ OPENCODE_DB: "relative.db" })).toBe(path.join(Global.Path.data, "relative.db"))
+    expect(await resolve({ OPENCODE_DISABLE_CHANNEL_DB: "true" })).toBe(path.join(Global.Path.data, "opencode.db"))
   })
 
   test("reads placement from the active ConfigProvider when the layer is built", async () => {

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test"
-import { Effect, Layer, Schema } from "effect"
+import { ConfigProvider, Effect, Exit, Layer, Schema } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -44,6 +44,52 @@ describe("WebSearchTool provider selection", () => {
 
   test("prefers Exa when only its explicit flag is enabled", () => {
     expect(WebSearchTool.selectProvider(sessionID, { enableExa: true, enableParallel: false })).toBe("exa")
+  })
+})
+
+const readDefaultConfig = (env: Record<string, string>) =>
+  Effect.gen(function* () {
+    return yield* WebSearchTool.ConfigService
+  }).pipe(
+    Effect.provide(
+      WebSearchTool.defaultConfigLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(env)))),
+    ),
+  )
+
+describe("WebSearchTool default config", () => {
+  test("decodes an empty environment to defaults", async () => {
+    expect(await Effect.runPromise(readDefaultConfig({}))).toEqual({
+      provider: undefined,
+      enableExa: false,
+      enableParallel: false,
+      exaApiKey: undefined,
+      parallelApiKey: undefined,
+    })
+  })
+
+  test("decodes provider, truthy flags, and credentials from the active ConfigProvider", async () => {
+    expect(
+      await Effect.runPromise(
+        readDefaultConfig({
+          OPENCODE_WEBSEARCH_PROVIDER: "parallel",
+          OPENCODE_ENABLE_EXA: "1",
+          OPENCODE_EXPERIMENTAL_PARALLEL: "true",
+          EXA_API_KEY: "exa-key",
+          PARALLEL_API_KEY: "parallel-key",
+        }),
+      ),
+    ).toEqual({
+      provider: "parallel",
+      enableExa: true,
+      enableParallel: true,
+      exaApiKey: "exa-key",
+      parallelApiKey: "parallel-key",
+    })
+  })
+
+  test("fails on an invalid provider instead of silently ignoring it", async () => {
+    const exit = await Effect.runPromiseExit(readDefaultConfig({ OPENCODE_WEBSEARCH_PROVIDER: "bing" }))
+    expect(Exit.isFailure(exit)).toBe(true)
   })
 })
 

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test"
-import { ConfigProvider, Effect, Exit, Layer, Schema } from "effect"
+import { ConfigProvider, Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -48,12 +48,9 @@ describe("WebSearchTool provider selection", () => {
 })
 
 const readDefaultConfig = (env: Record<string, string>) =>
-  Effect.gen(function* () {
-    return yield* WebSearchTool.ConfigService
-  }).pipe(
-    Effect.provide(
-      WebSearchTool.defaultConfigLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(env)))),
-    ),
+  Effect.provide(
+    WebSearchTool.ConfigService,
+    WebSearchTool.defaultConfigLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(env)))),
   )
 
 describe("WebSearchTool default config", () => {
@@ -87,9 +84,17 @@ describe("WebSearchTool default config", () => {
     })
   })
 
-  test("fails on an invalid provider instead of silently ignoring it", async () => {
-    const exit = await Effect.runPromiseExit(readDefaultConfig({ OPENCODE_WEBSEARCH_PROVIDER: "bing" }))
-    expect(Exit.isFailure(exit)).toBe(true)
+  test("keeps the legacy lenient truthiness grammar", async () => {
+    const decoded = await Effect.runPromise(
+      readDefaultConfig({ OPENCODE_ENABLE_EXA: "TRUE", OPENCODE_ENABLE_PARALLEL: "banana" }),
+    )
+    expect(decoded.enableExa).toBe(true)
+    expect(decoded.enableParallel).toBe(false)
+  })
+
+  test("ignores an invalid provider instead of failing the Location layer", async () => {
+    const decoded = await Effect.runPromise(readDefaultConfig({ OPENCODE_WEBSEARCH_PROVIDER: "bing" }))
+    expect(decoded.provider).toBeUndefined()
   })
 })
 

--- a/packages/opencode/src/cli/cmd/db.ts
+++ b/packages/opencode/src/cli/cmd/db.ts
@@ -35,7 +35,7 @@ const QueryCommand = effectCmd({
       }
       return
     }
-    const child = spawn("sqlite3", [Database.path()], {
+    const child = spawn("sqlite3", [yield* Database.configuredPath], {
       stdio: "inherit",
     })
     yield* Effect.promise(() => new Promise((resolve) => child.on("close", resolve)))
@@ -47,7 +47,7 @@ const PathCommand = effectCmd({
   describe: "print the database path",
   instance: false,
   handler: Effect.fn("Cli.db.path")(function* () {
-    console.log(Database.path())
+    console.log(yield* Database.configuredPath)
   }),
 })
 

--- a/packages/opencode/test/fixture/db.ts
+++ b/packages/opencode/test/fixture/db.ts
@@ -1,10 +1,11 @@
 import { rm } from "fs/promises"
 import { Database } from "@opencode-ai/core/database/database"
+import { Effect } from "effect"
 import { disposeAllInstances } from "./fixture"
 
 export async function resetDatabase() {
   await disposeAllInstances().catch(() => undefined)
-  const dbPath = Database.path()
+  const dbPath = await Effect.runPromise(Database.configuredPath)
   await rm(dbPath, { force: true }).catch(() => undefined)
   await rm(`${dbPath}-wal`, { force: true }).catch(() => undefined)
   await rm(`${dbPath}-shm`, { force: true }).catch(() => undefined)

--- a/packages/opencode/test/server/httpapi-exercise/environment.ts
+++ b/packages/opencode/test/server/httpapi-exercise/environment.ts
@@ -19,7 +19,6 @@ export const exerciseDatabasePath =
   process.env.OPENCODE_HTTPAPI_EXERCISE_DB ??
   path.join(process.env.TMPDIR ?? "/tmp", `opencode-httpapi-exercise-${process.pid}.db`)
 process.env.OPENCODE_DB = exerciseDatabasePath
-Flag.OPENCODE_DB = exerciseDatabasePath
 
 export const original = {
   OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,

--- a/packages/opencode/test/server/httpapi-exercise/environment.ts
+++ b/packages/opencode/test/server/httpapi-exercise/environment.ts
@@ -18,6 +18,9 @@ const preserveExerciseDatabase = !!process.env.OPENCODE_HTTPAPI_EXERCISE_DB
 export const exerciseDatabasePath =
   process.env.OPENCODE_HTTPAPI_EXERCISE_DB ??
   path.join(process.env.TMPDIR ?? "/tmp", `opencode-httpapi-exercise-${process.pid}.db`)
+// Must run before the first Effect Config read anywhere in the process: the
+// default ConfigProvider snapshots process.env on first use, so a Config read
+// during an earlier module import would freeze the wrong database path.
 process.env.OPENCODE_DB = exerciseDatabasePath
 
 export const original = {

--- a/packages/sdk-next/test/embedded.test.ts
+++ b/packages/sdk-next/test/embedded.test.ts
@@ -1,15 +1,20 @@
-import { expect, test } from "bun:test"
+import { afterAll, expect, test } from "bun:test"
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { Flag } from "@opencode-ai/core/flag/flag"
 import { Deferred, Effect, Latch, Option, Schema, Stream } from "effect"
 import type { OpenCodeEvent } from "../src"
 
+// The database layer resolves OPENCODE_DB through Effect Config, and the
+// default ConfigProvider snapshots the process environment on first use, so
+// database placement is process-wide. Point every embedded host in this file
+// at one shared temporary database before anything builds a runtime.
+const databaseDirectory = await mkdtemp(join(tmpdir(), "opencode-embedded-db-"))
+process.env.OPENCODE_DB = join(databaseDirectory, "opencode.sqlite")
+afterAll(() => rm(databaseDirectory, { recursive: true, force: true }))
+
 test("embedded client uses the real router and handlers", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-"))
-  const database = Flag.OPENCODE_DB
-  Flag.OPENCODE_DB = join(directory, "opencode.sqlite")
   const { AbsolutePath, Agent, Location, Model, OpenCode, Prompt, Provider, Session, Tool } = await import("../src")
   const sessionID = Session.ID.make(`ses_embedded_${crypto.randomUUID()}`)
   const model = Model.Ref.make({ id: Model.ID.make("embedded"), providerID: Provider.ID.make("test") })
@@ -99,15 +104,12 @@ test("embedded client uses the real router and handlers", async () => {
     })
     await Effect.runPromise(Effect.scoped(program))
   } finally {
-    Flag.OPENCODE_DB = database
     await rm(directory, { recursive: true, force: true })
   }
 })
 
 test("Location-owned runner events reach the ready global client", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-events-"))
-  const database = Flag.OPENCODE_DB
-  Flag.OPENCODE_DB = join(directory, "opencode.sqlite")
   const { AbsolutePath, Location, OpenCode, Prompt, Session } = await import("../src")
   const sessionID = Session.ID.make(`ses_embedded_${crypto.randomUUID()}`)
 
@@ -138,15 +140,12 @@ test("Location-owned runner events reach the ready global client", async () => {
     })
     await Effect.runPromise(Effect.scoped(program))
   } finally {
-    Flag.OPENCODE_DB = database
     await rm(directory, { recursive: true, force: true })
   }
 }, 10_000)
 
 test("independent embedded hosts do not share live notifications", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-hosts-"))
-  const database = Flag.OPENCODE_DB
-  Flag.OPENCODE_DB = join(directory, "opencode.sqlite")
   const { AbsolutePath, Agent, Location, OpenCode, Session } = await import("../src")
   const sessionID = Session.ID.make(`ses_embedded_${crypto.randomUUID()}`)
 
@@ -181,15 +180,12 @@ test("independent embedded hosts do not share live notifications", async () => {
     })
     await Effect.runPromise(Effect.scoped(program))
   } finally {
-    Flag.OPENCODE_DB = database
     await rm(directory, { recursive: true, force: true })
   }
 }, 10_000)
 
 test("embedded client is available as a Layer service", async () => {
   const directory = await mkdtemp(join(tmpdir(), "opencode-embedded-layer-"))
-  const database = Flag.OPENCODE_DB
-  Flag.OPENCODE_DB = join(directory, "opencode.sqlite")
   const { AbsolutePath, Location, OpenCode, Session } = await import("../src")
   const sessionID = Session.ID.make(`ses_embedded_${crypto.randomUUID()}`)
 
@@ -206,7 +202,6 @@ test("embedded client is available as a Layer service", async () => {
 
     expect(created.id).toBe(sessionID)
   } finally {
-    Flag.OPENCODE_DB = database
     await rm(directory, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
First slice of moving core runtime config off import-time `process.env` snapshots and onto Effect `Config`, with config ownership distributed to the services that consume it. `ConfigProvider` becomes the single test seam.

## What changed

**WebSearch** (`packages/core/src/tool/websearch.ts`)
- `defaultConfigLayer` decodes one `Config.all({...})` when the layer is built, instead of reading `process.env` directly at module scope.
- Parsing deliberately keeps the **legacy lenient grammar** via a shared `truthyConfig` helper (`truthy`'s case-insensitive `true`/`1`, missing or malformed → `false`). This layer builds at Location boot, where a strict-decode defect would surface as opaque session failures; `OPENCODE_EXPERIMENTAL=TRUE` keeps meaning enabled. An invalid `OPENCODE_WEBSEARCH_PROVIDER` logs a warning and is ignored, matching the old behavior.

**Flag** (`packages/core/src/flag/flag.ts`)
- One truthiness grammar, two readers: `truthy(name)` reads the environment at call time, `truthyConfig(name)` reads the same grammar through Effect `Config` so layer builds can be steered by a `ConfigProvider`.
- `OPENCODE_DB` is removed from the `Flag` snapshot; database config now lives in the database module.

**Database** (`packages/core/src/database/database.ts`)
- Placement was baked at module import (`layerFromPath(path())` evaluated on import, reading the `Flag` env snapshot). There is now exactly one public placement value: `Database.configuredPath`, an Effect that resolves `OPENCODE_DB` / `OPENCODE_DISABLE_CHANNEL_DB` through Effect `Config`. The node layer is `Layer.unwrap(Effect.map(configuredPath, layerFromPath))`, built per runtime instead of per import.
- `Database.path()` is **deleted** rather than kept as a V1 compat shim. Its V1 consumers were already Effect-shaped, so they now yield `configuredPath` directly: `opencode db` / `opencode db path` (`packages/opencode/src/cli/cmd/db.ts`) and the `resetDatabase` test fixture (`packages/opencode/test/fixture/db.ts`). This removes the last skew surface — previously `path()` read the live environment while the layer read the frozen first-use snapshot, so late env mutation could make `opencode db path` disagree with the running app. Now every consumer resolves through the same Config read.

**Tests**
- New `packages/core/test/database-path.test.ts` exercises `configuredPath` through `ConfigProvider.fromUnknown` (explicit `:memory:`, absolute, relative, channel-default cases) and proves the layer seam: the preload sets `OPENCODE_DB=":memory:"` in the environment, and the test shows a provider override wins at layer build.
- `tool-websearch.test.ts` gains decoding tests driven entirely by `ConfigProvider.fromUnknown` — including regression cases for the lenient grammar (`TRUE` enables, `banana` disables, invalid provider ignored).
- `sdk-next/test/embedded.test.ts` previously mutated `Flag.OPENCODE_DB` per test and relied on dynamic import ordering. That was already broken on `dev` locally: the path baked at first import, test 1 deleted its directory in `finally`, and the remaining 3 tests failed with `SQLITE_CANTOPEN`. Since the default `ConfigProvider.fromEnv()` snapshots the process environment on first use, placement is process-wide; the file now points all embedded hosts at one shared temp database up front and cleans it in `afterAll`. All 4 tests pass now (previously 1/4 locally).
- `httpapi-exercise/environment.ts` drops the now-redundant `Flag.OPENCODE_DB` mutation and documents the must-run-before-first-Config-read ordering contract.

## Design notes

- Deliberately **not** a central `RuntimeConfig`/`Flag` service: config values are inputs owned by their consuming services, read once at layer build. `Flag` shrinks by attrition as remaining keys migrate (`OPENCODE_MODELS_*`, OTLP, etc. are follow-ups).
- Lenient vs strict parsing was reviewed explicitly: strict `Config.boolean` would have turned 7 previously-tolerated env values (including uppercase `TRUE`) into startup/Location-boot defects. Strictness may be worth revisiting per-variable, but as an explicit decision — not a side effect of the migration.
- `Config.schema(...)` was evaluated for these call sites and skipped: it shines when reusing an existing domain schema with strict failure semantics, but both call sites here need the lenient legacy grammar (and the provider field needs warn-and-ignore, which `Config.option` can't express since it only swallows missing data). Good candidates for it are future migrations like `OPENCODE_MODELS_URL` as `Config.url`.
- Behavior invariant: two env-driven builds in one process always resolve the same database path, because the default provider's env snapshot is cached process-wide. Only an explicit `ConfigProvider` (see follow-up PR) can differ.
- Considered porting V1's `ConfigService` helper (`packages/opencode/src/effect/config-service.ts`) but skipped it here: both call sites already have a natural home, and the helper's generated test layer wouldn't be used by the existing tests. Worth revisiting once more config-backed services exist in core (it could also unify `ServerAuth.Config` and V1 `RuntimeFlags`).

## Verification

- `bun typecheck` across the workspace (29/29 packages)
- Full `packages/core` suite: 1071 pass / 0 fail
- `packages/sdk-next` suite: 5 pass / 0 fail (embedded tests were 1/4 on clean dev locally)
- `packages/opencode` `script/httpapi-exercise.ts --mode coverage`: 208 pass / 0 fail, plus focused V1 tests using the `resetDatabase` fixture
- oxlint + Prettier on changed files
- Three-agent simplify/safety review pass (reuse, quality, efficiency); findings addressed in follow-up commits