### PR TITLE
fix(opencode): default adaptive Anthropic models to summarized thinking

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1160,6 +1160,21 @@ export function options(input: {
     }
   }
 
+  // Adaptive-only Anthropic models (Fable 5, Opus 4.7+, Sonnet 5) default their
+  // thinking display to "omitted", which streams empty signature-only thinking
+  // blocks. When the model routes its answer into thinking and then calls a tool
+  // (e.g. `question`), no visible text is produced and the turn renders blank.
+  // The reasoning-effort variants in variants() already request
+  // display:"summarized", but variant options only apply when the user selects a
+  // variant. Default it here so the summary is visible even with no variant.
+  if (
+    (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
+    anthropicOmitsThinking(input.model.api.id) &&
+    result["thinking"] === undefined
+  ) {
+    result["thinking"] = { type: "adaptive", display: "summarized" }
+  }
+
   // Enable thinking for reasoning models on alibaba-cn (DashScope).
   // DashScope's OpenAI-compatible API requires `enable_thinking: true` in the request body
   // to return reasoning_content. Without it, models like kimi-k2.5, qwen-plus, qwen3, qwq,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -209,6 +209,56 @@ describe("ProviderTransform.options - minimax m3 thinking", () => {
   })
 })
 
+describe("ProviderTransform.options - adaptive-only anthropic summarized thinking", () => {
+  // Regression: adaptive-only Anthropic models (Fable 5, Opus 4.7+, Sonnet 5)
+  // default their thinking display to "omitted", which streams empty
+  // signature-only thinking blocks. With no variant selected, the summarized
+  // display from variants() never applies, so the model's answer can vanish into
+  // omitted thinking (e.g. it "thinks" then calls the question tool, rendering a
+  // blank turn). options() must default these to display:"summarized".
+  const createModel = (apiId: string, npm: string) =>
+    ({
+      id: apiId,
+      providerID: npm === "@ai-sdk/google-vertex/anthropic" ? "google-vertex-anthropic" : "anthropic",
+      api: {
+        id: apiId,
+        url: "https://api.anthropic.com",
+        npm,
+      },
+      capabilities: { reasoning: true },
+      limit: { output: 64_000 },
+    }) as any
+
+  for (const apiId of ["claude-fable-5", "claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-5"]) {
+    test(`${apiId} defaults to adaptive summarized thinking (anthropic SDK)`, () => {
+      expect(
+        ProviderTransform.options({
+          model: createModel(apiId, "@ai-sdk/anthropic"),
+          sessionID: "test-session-123",
+        }).thinking,
+      ).toEqual({ type: "adaptive", display: "summarized" })
+    })
+  }
+
+  test("applies on the vertex anthropic path too", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("claude-fable-5", "@ai-sdk/google-vertex/anthropic"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toEqual({ type: "adaptive", display: "summarized" })
+  })
+
+  test("does not apply to non-adaptive-only anthropic models (opus 4.5)", () => {
+    expect(
+      ProviderTransform.options({
+        model: createModel("claude-opus-4-5", "@ai-sdk/anthropic"),
+        sessionID: "test-session-123",
+      }).thinking,
+    ).toBeUndefined()
+  })
+})
+
 describe("ProviderTransform.options - google thinkingConfig gating", () => {
   const sessionID = "test-session-123"
 


### PR DESCRIPTION
### Issue for this PR

Closes #31738

### Type of change

- [x] Bug fix

### What does this PR do?

When OpenCode uses a `Default` variant of an adaptive thinking model (like Opus 4.7+, Fable 5, etc) it does not send any options for thinking. Anthropic (on their end) defaults to [`display: "omitted"`](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#controlling-thinking-display) when this happens so users will never see a thinking block, unless they specifically request a thinking variant.

<details>
<summary>source for Claude default claims</summary>

<img width="856" height="435" alt="Adaptive thinking - Claude Platform Docs 2026-07-02 at 9 49 31 AM" src="https://github.com/user-attachments/assets/fcb9190c-2441-4cb6-8649-8594d9416b47" />

</details>

The fix is to send `{ thinking: "adaptive", display: "summary" }` whenever a user selects `Default` variant for these adaptive models. And voila! Thinking blocks are back.

### How did you verify your code works?

Local testing against Fable 5, Opus 4.8, and Opus 4.7 using the following prompt:

```text
Do not write any assistant message text at all. Do not greet me, explain, preface, or summarize. Your entire visible response must be a single tool call and nothing else.

Task: think silently about what one clarifying question would most reduce ambiguity in building a rate limiter, then immediately call the question tool to ask me that one question. The very first thing you emit must be the tool call. No prose before it, no prose after it.
```

I also verified the structure of the messages via debug logging and parsing through the local session DB. The above was verified that way. I can provide more detail if necessary.

### Screenshots / recordings

(audio on to hear the transcript)

https://github.com/user-attachments/assets/7b1f9e85-083f-4a49-b002-3cbee07ff19f

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
