### PR TITLE
test(opencode): cover Windows session list directory spellings

### DIFF
--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -905,6 +905,54 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "lists Windows sessions for equivalent directory spellings",
+    () =>
+      Effect.gen(function* () {
+        if (process.platform !== "win32") return
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory, "content-type": "application/json" }
+        const created = yield* requestJson<Session.Info>(SessionPaths.create, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ title: "windows spelling" }),
+        })
+
+        const forwardSlashes = test.directory.replaceAll("\\", "/")
+        const lowercaseDrive = test.directory.replace(/^[A-Z]:/, (drive) => drive.toLowerCase())
+        const trailingSeparator = `${test.directory}\\`
+        for (const spelling of [forwardSlashes, lowercaseDrive, trailingSeparator]) {
+          const query = new URLSearchParams({ directory: spelling, roots: "true" })
+          const listed = yield* requestJson<Session.Info[]>(`${SessionPaths.list}?${query}`, { headers })
+          expect({ spelling, ids: listed.map((item) => item.id) }).toEqual({ spelling, ids: [created.id] })
+        }
+      }),
+    { git: true, config: { formatter: false, lsp: false, share: "disabled" } },
+    { timeout: 15000 },
+  )
+
+  it.instance(
+    "lists Windows sessions created through the global worktree sentinel",
+    () =>
+      Effect.gen(function* () {
+        if (process.platform !== "win32") return
+        const globalWorktreeSentinel = "/"
+        const headers = { "x-opencode-directory": globalWorktreeSentinel, "content-type": "application/json" }
+        const driveRootSession = yield* requestJson<Session.Info>(SessionPaths.create, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ title: "created at drive root" }),
+        })
+        expect(driveRootSession.directory).toMatch(/^[A-Za-z]:\\$/)
+
+        const query = new URLSearchParams({ directory: globalWorktreeSentinel, roots: "true" })
+        const listed = yield* requestJson<Session.Info[]>(`${SessionPaths.list}?${query}`, { headers })
+        expect(listed.map((item) => item.id)).toContain(driveRootSession.id)
+      }),
+    { git: true, config: { formatter: false, lsp: false, share: "disabled" } },
+    { timeout: 15000 },
+  )
+
+  it.instance(
     "serves paginated message link headers",
     () =>
       Effect.gen(function* () {


### PR DESCRIPTION
### What does this PR do?

Follow-up to #34842 (merged before the test commit was pushed). Adds win32-gated regression tests naming the exact Windows directory spellings from the field reports (#34723, #30374, #31597), exercised through the full HTTP middleware + handler chain:

- `lists Windows sessions for equivalent directory spellings` — creates one session at the instance directory, then lists with `forwardSlashes` (`C:/...`), `lowercaseDrive` (`c:\...`), and `trailingSeparator` (`C:\...\`). The assertion carries the spelling so a failure names the offending form.
- `lists Windows sessions created through the global worktree sentinel` — creates via `x-opencode-directory: /` (the value the desktop persists for global-project workspaces), asserts it stored a real drive root, and lists it back with the same `/` hint. This is the literal #34723 scenario.

Validated TDD-style before #34842 merged: with the handlers reverted to the pre-fix commit, the spellings test fails at `lowercaseDrive` with `Received: []`; with the fix it passes.

Tests are skipped on non-Windows (`process.platform !== "win32"`), matching the platform-gated codec tests in `packages/core/test/database-migration.test.ts`. A 15s `TestOptions` timeout gives the drive-root instance boot headroom on slower Windows machines.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How did you verify your code works?

- `bun test test/server/httpapi-session.test.ts -t "Windows sessions"` on Windows 11 against merged dev — 2 pass.
- Fail-validation against the pre-#34842 handlers reproduced the bug (`lowercaseDrive` -> `[]`).
- `bun typecheck` in `packages/opencode` — clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have included no unrelated changes

### Issue for this PR

Relates to #34723 (fixed by #34842)