### PR TITLE
fix(app): clear original prompt after retarget

### DIFF
--- a/packages/app/src/components/prompt-input/submission-state.ts
+++ b/packages/app/src/components/prompt-input/submission-state.ts
@@ -7,6 +7,7 @@ export function createPromptSubmissionState(input: {
   prompt: Prompt
   context: (ContextItem & { key: string })[]
 }) {
+  const initial = input.target
   let target = input.target
   let cleared: Prompt | undefined
 
@@ -15,6 +16,7 @@ export function createPromptSubmissionState(input: {
     context: input.context,
     target: () => target,
     clear() {
+      if (initial !== target) initial.reset()
       target.reset()
       cleared = target.current()
     },

--- a/packages/app/test-browser/prompt-submission-state.test.ts
+++ b/packages/app/test-browser/prompt-submission-state.test.ts
@@ -38,6 +38,23 @@ describe("prompt submission state", () => {
     expect(session.context.items()[0]).toMatchObject({ type: "file", path: "src/index.ts" })
   })
 
+  test("clears the original first-submit prompt after retargeting", () => {
+    const workspace = createPromptState()
+    const session = createPromptState()
+    workspace.set([{ type: "text", content: "first prompt", start: 0, end: 12 }])
+    const submission = createPromptSubmissionState({
+      target: workspace,
+      prompt: workspace.current(),
+      context: [],
+    })
+
+    submission.retarget(session)
+    submission.clear()
+
+    expect(workspace.current()[0]).toMatchObject({ type: "text", content: "" })
+    expect(session.current()[0]).toMatchObject({ type: "text", content: "" })
+  })
+
   test("does not restore over a prompt edited after submission", () => {
     const target = createPromptState()
     target.set([{ type: "text", content: "submitted", start: 0, end: 9 }])


### PR DESCRIPTION
## Summary
- fixes #34393
- reset the original prompt target when a first-submit prompt is retargeted to a created session
- add regression coverage for clearing the original workspace prompt after retargeting

## Tests
- bun test --conditions=browser --preload ./happydom.ts ./test-browser/prompt-submission-state.test.ts
- bun typecheck
- pre-push: bun turbo typecheck