### PR TITLE
fix: change default dir to current dir instead of home dir due to lim…

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -70,7 +70,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
 
   const home = createMemo(() => sync.data.path.home || fallbackPath()?.home || "")
   const start = createMemo(
-    () => sync.data.path.home || sync.data.path.directory || fallbackPath()?.home || fallbackPath()?.directory,
+    () => sync.data.path.directory || sync.data.path.home || fallbackPath()?.directory || fallbackPath()?.home,
   )
 
   const directories = createDirectorySearch({


### PR DESCRIPTION
In the current version of the web package, in the file (https://github.com/anomalyco/opencode/blob/dev/packages/app/src/components/dialog-select-directory.tsx), it uses/home as the default directory to fetch all the directories under it. But due to the large number of subfiles, folder search.ts (https://github.com/anomalyco/opencode/blob/dev/packages/core/src/filesystem/search.ts) throws a "too many files" error.


Fixes #34675 


So instead of using the /home dir as the default, I have moved the opencode serve dir as the default by simply changing the order. Now by default it looks for the opecode serving project dir, not the /home dir

```{
  ok: false,
  error: "Failed to init file picker: Can not run certain FFF features in a file system root or home directories. Consider smaller per-project directories."
}
```


### #34675 


### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor/code improvement
- [ ] Documentation

### What does this PR do?

What is the issue?
When we start the opencode web command and try to open up the new project from the directory explorer dialog. It doesn't show any file or folder to select. The request fails silently, no error, nothing, just a blank response from the backend.

How did I fix it?
The reason for the blank response is the search.ts file tagged above. It has a function `fff` Which simply doesn't run when the list of subfolders and files is too rich. Infact there is flag to disable beharvious which fixes this issue.`OPENCODE_DISABLE_FFF=1 npm run dev -- serve --port 4096`, but then it reduces the performance. 
To keep up with the performance, I have made a tweak in the directory list dialog. Now, instead of asking for the directories in the /home, it asks for directories and files from the path in which the `opencode web` command was used.



### How did you verify your code works?
By testing it manually locally, as there are no test cases that cover this issue.

### Screenshots / recordings
Working screenshot with no query input in the affected version shows an empty list, which you can check in the issue.
<img width="978" height="639" alt="image" src="https://github.com/user-attachments/assets/d8c20311-7ea4-4454-80bd-af6f5936a33a" />

Searching from the /root or /home dir still works 
<img width="978" height="639" alt="image" src="https://github.com/user-attachments/assets/03f4dc9e-3019-46e6-878c-3c8cff11e614" />




### Checklist

- [x] I have tested my changes locally.
- [x] I have not included unrelated changes in this PR.

