### PR TITLE
fix(opencode): add yieldNow to tool result and truncation loops, debounce MCP notifications

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -451,15 +451,20 @@ const layer = Layer.effect(
       )
 
       if (!client.getServerCapabilities()?.tools) return
+      let debounceTimer: ReturnType<typeof setTimeout> | undefined
       client.setNotificationHandler(ToolListChangedNotificationSchema, async () => {
-        if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
+        if (debounceTimer) clearTimeout(debounceTimer)
+        debounceTimer = setTimeout(async () => {
+          debounceTimer = undefined
+          if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
-        const listed = await bridge.promise(McpCatalog.defs(client, timeout))
-        if (!listed) return
-        if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
+          const listed = await bridge.promise(McpCatalog.defs(client, timeout))
+          if (!listed) return
+          if (s.clients[name] !== client || s.status[name]?.status !== "connected") return
 
-        s.defs[name] = listed
-        await bridge.promise(events.publish(ToolsChanged, { server: name }).pipe(Effect.ignore))
+          s.defs[name] = listed
+          await bridge.promise(events.publish(ToolsChanged, { server: name }).pipe(Effect.ignore))
+        }, 1000)
       })
     }
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -638,7 +638,7 @@ const layer: Layer.Layer<
       Effect.gen(function* () {
         yield* events.publish(SessionV1.Event.PartUpdated, {
           sessionID: part.sessionID,
-          part: structuredClone(part),
+          part,
           time: Date.now(),
         })
         return part

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -418,7 +418,9 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
 
           const textParts: string[] = []
           const attachments: Omit<SessionV1.FilePart, "id" | "sessionID" | "messageID">[] = []
+          let yieldCounter = 0
           for (const contentItem of result.content) {
+            if (++yieldCounter % 50 === 0) yield* Effect.yieldNow
             if (contentItem.type === "text") textParts.push(contentItem.text)
             else if (contentItem.type === "image") {
               attachments.push({

--- a/packages/opencode/src/tool/truncate.ts
+++ b/packages/opencode/src/tool/truncate.ts
@@ -101,6 +101,7 @@ const layer = Layer.effect(
 
       if (direction === "head") {
         for (i = 0; i < lines.length && i < maxLines; i++) {
+          if (i % 100 === 0) yield* Effect.yieldNow
           const size = Buffer.byteLength(lines[i], "utf-8") + (i > 0 ? 1 : 0)
           if (bytes + size > maxBytes) {
             hitBytes = true
@@ -111,6 +112,7 @@ const layer = Layer.effect(
         }
       } else {
         for (i = lines.length - 1; i >= 0 && out.length < maxLines; i--) {
+          if ((lines.length - 1 - i) % 100 === 0) yield* Effect.yieldNow
           const size = Buffer.byteLength(lines[i], "utf-8") + (out.length > 0 ? 1 : 0)
           if (bytes + size > maxBytes) {
             hitBytes = true


### PR DESCRIPTION
### Issue for this PR

Closes #34867

### Type of change

- [x] Bug fix
- [x] Refactor / code improvement

### What does this PR do?

When a model makes many parallel MCP tool calls, the MCP server emits ToolListChangedNotification rapidly. Each notification triggers a full McpCatalog.defs() re-fetch even though tool definitions have not changed, saturating the CPU with redundant work. Adding a 1-second debounce prevents this.

Also, iterating large tool outputs and truncating large text can block the event loop — there were no yieldNow calls in those loops. The yieldNow calls let the Effect runtime process other tasks between iterations.

The structuredClone in PartUpdated was defensive — all callers create fresh objects before passing to updatePart, and downstream consumers never mutate the part after publish (verified by inspecting all subscribers). The share-sync subscriber already clones on its end.

### How did you verify your code works?

- Reviewed downstream PartUpdated consumers (projector, share-sync, github handler, ACP event handler) — none mutate the part after publish
- share-next.ts already does its own structuredClone on the receiving end
- yieldNow pattern is standard Effect practice for preventing blocking in large loops, used elsewhere in the codebase

### Screenshots / recordings

N/A — no UI changes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR