### PR TITLE
fix(opencode): avoid false scoop install detection

### DIFF
--- a/packages/opencode/src/installation/index.ts
+++ b/packages/opencode/src/installation/index.ts
@@ -176,13 +176,17 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
         if (process.execPath.includes(path.join(".local", "bin"))) return "curl" as Method
         const exec = process.execPath.toLowerCase()
 
-        const checks: Array<{ name: Method; command: () => Effect.Effect<string> }> = [
+        type PackageManagerCheck =
+          | { name: Exclude<Method, "curl" | "scoop" | "unknown">; command: () => Effect.Effect<string> }
+          | { name: "scoop" }
+
+        const checks: Array<PackageManagerCheck> = [
           { name: "npm", command: () => text(["npm", "list", "-g", "--depth=0"]) },
           { name: "yarn", command: () => text(["yarn", "global", "list"]) },
           { name: "pnpm", command: () => text(["pnpm", "list", "-g", "--depth=0"]) },
           { name: "bun", command: () => text(["bun", "pm", "ls", "-g"]) },
           { name: "brew", command: () => text(["brew", "list", "--formula", "opencode"]) },
-          { name: "scoop", command: () => text(["scoop", "list", "opencode"]) },
+          { name: "scoop" },
           { name: "choco", command: () => text(["choco", "list", "--limit-output", "opencode"]) },
         ]
 
@@ -195,9 +199,14 @@ const layer: Layer.Layer<Service, never, HttpClient.HttpClient | AppProcess.Serv
         })
 
         for (const check of checks) {
+          if (check.name === "scoop") {
+            const result = yield* run(["scoop", "prefix", "opencode"])
+            if (result.code === 0) return check.name
+            continue
+          }
+
           const output = yield* check.command()
-          const installedName =
-            check.name === "brew" || check.name === "choco" || check.name === "scoop" ? "opencode" : "opencode-ai"
+          const installedName = check.name === "brew" || check.name === "choco" ? "opencode" : "opencode-ai"
           if (output.includes(installedName)) {
             return check.name
           }

--- a/packages/opencode/test/installation/installation.test.ts
+++ b/packages/opencode/test/installation/installation.test.ts
@@ -66,6 +66,26 @@ function testLayer(
   ])
 }
 
+function withExecPath<A, E, R>(execPath: string, effect: Effect.Effect<A, E, R>) {
+  return Effect.suspend(() => {
+    const original = Object.getOwnPropertyDescriptor(process, "execPath")
+    Object.defineProperty(process, "execPath", {
+      configurable: true,
+      enumerable: original?.enumerable ?? true,
+      value: execPath,
+      writable: true,
+    })
+
+    return Effect.gen(function* () {
+      try {
+        return yield* effect
+      } finally {
+        if (original) Object.defineProperty(process, "execPath", original)
+      }
+    })
+  })
+}
+
 describe("installation", () => {
   describe("latest", () => {
     testEffect(testLayer(() => jsonResponse({ tag_name: "v1.2.3" }))).effect(
@@ -178,6 +198,100 @@ describe("installation", () => {
         const result = yield* Installation.use.latest("brew")
         expect(result).toBe("2.1.0")
       }),
+    )
+  })
+
+  describe("method", () => {
+    const scoopNodeExecPath = "C:\\Users\\aquib\\scoop\\apps\\nodejs\\current\\node.exe"
+
+    const reproCalls: Array<{ cmd: string; args: readonly string[] }> = []
+    testEffect(
+      testLayer(
+        () => jsonResponse({}),
+        (cmd, args) => {
+          reproCalls.push({ cmd, args })
+          if (cmd === "scoop" && args[0] === "prefix") {
+            return {
+              code: 1,
+              stdout: "Installed apps matching 'opencode':",
+              stderr: "opencode is not installed",
+            }
+          }
+          if (cmd === "npm") return "opencode-ai@1.2.3"
+          return ""
+        },
+      ),
+    ).effect("does not detect failed scoop prefix output as scoop ownership", () =>
+      withExecPath(
+        scoopNodeExecPath,
+        Effect.gen(function* () {
+          const result = yield* Installation.use.method()
+
+          expect(result).toBe("npm")
+          expect(reproCalls.filter((call) => call.cmd === "scoop").map((call) => call.args)).toEqual([
+            ["prefix", "opencode"],
+          ])
+          expect(reproCalls.some((call) => call.cmd === "scoop" && call.args[0] === "list")).toBe(false)
+        }),
+      ),
+    )
+
+    const positiveCalls: Array<{ cmd: string; args: readonly string[] }> = []
+    testEffect(
+      testLayer(
+        () => jsonResponse({}),
+        (cmd, args) => {
+          positiveCalls.push({ cmd, args })
+          if (cmd === "scoop" && args[0] === "prefix") {
+            return { code: 0, stdout: "C:\\Users\\aquib\\scoop\\apps\\opencode\\current" }
+          }
+          return ""
+        },
+      ),
+    ).effect("detects scoop when scoop prefix succeeds", () =>
+      withExecPath(
+        scoopNodeExecPath,
+        Effect.gen(function* () {
+          const result = yield* Installation.use.method()
+
+          expect(result).toBe("scoop")
+          expect(positiveCalls.filter((call) => call.cmd === "scoop").map((call) => call.args)).toEqual([
+            ["prefix", "opencode"],
+          ])
+          expect(positiveCalls.some((call) => call.cmd === "scoop" && call.args[0] === "list")).toBe(false)
+        }),
+      ),
+    )
+
+    const negativeCalls: Array<{ cmd: string; args: readonly string[] }> = []
+    testEffect(
+      testLayer(
+        () => jsonResponse({}),
+        (cmd, args) => {
+          negativeCalls.push({ cmd, args })
+          if (cmd === "scoop" && args[0] === "prefix") {
+            return {
+              code: 1,
+              stdout: "Installed apps matching 'opencode':",
+              stderr: "opencode is not installed",
+            }
+          }
+          return ""
+        },
+      ),
+    ).effect("returns unknown when failed scoop prefix mentions opencode and no manager owns it", () =>
+      withExecPath(
+        scoopNodeExecPath,
+        Effect.gen(function* () {
+          const result = yield* Installation.use.method()
+
+          expect(result).toBe("unknown")
+          expect(negativeCalls.filter((call) => call.cmd === "scoop").map((call) => call.args)).toEqual([
+            ["prefix", "opencode"],
+          ])
+          expect(negativeCalls.some((call) => call.cmd === "scoop" && call.args[0] === "list")).toBe(false)
+        }),
+      ),
     )
   })
 


### PR DESCRIPTION
### Issue for this PR

Fixes #34734

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode upgrade` can choose `scoop` when Node was installed by Scoop even if opencode itself was installed by npm. The manager checks are sorted by `process.execPath`, and the old Scoop check matched `opencode` inside `scoop list opencode` output even when Scoop only printed its matching header.

This changes only the Scoop ownership check: it now uses `scoop prefix opencode` and treats Scoop as the owner only when that command exits 0. Failed or missing Scoop checks continue to the other managers, so an npm install can still be detected.

### How did you verify your code works?

- `PATH=/tmp/bun-v1.3.14/bun-darwin-aarch64:$PATH bun test test/installation/installation.test.ts --timeout 30000` from `packages/opencode`
- `PATH=/tmp/bun-v1.3.14/bun-darwin-aarch64:$PATH bun run typecheck` from `packages/opencode`
- pre-push hook: `bun turbo typecheck` with Bun 1.3.14 (`29 successful, 29 total`)

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
