### PR TITLE
fix: zen toOaCompatibleRequest reading tool.function.name instead of tool.name

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -199,9 +199,9 @@ export function toOaCompatibleRequest(body: CommonRequest) {
     ? body.tools.map((tool: any) => ({
         type: "function",
         function: {
-          name: tool.name,
-          description: tool.description,
-          parameters: tool.parameters,
+          name: tool.function.name,
+          description: tool.function.description,
+          parameters: tool.function.parameters,
         },
       }))
     : undefined


### PR DESCRIPTION
### Issue for this PR

Closes #34892

### Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor / code improvement
  - [ ] Documentation

  ### What does this PR do?

  `toOaCompatibleRequest()` reads `tool.name` / `tool.description` / `tool.parameters` on `CommonTool[]` inputs, but `CommonTool` stores the tool data under
  `tool.function.*`. This sends `undefined` for all tool fields when converting from Anthropic format to oa-compat upstream providers.

  `fromAnthropicRequest` correctly converts Anthropic tools into `CommonTool`, but `toOaCompatibleRequest` re-reads them from the wrong path.

  ### How did you verify your code works?

  Tested with Anthropic-format requests routed through zen to oa-compat providers. Before fix: `tools[0].function: missing field 'name'` error. After fix:
  tools serialize correctly.

  ### Screenshots / recordings

  _N/A_

  ### Checklist

  - [x] I have tested my changes locally
  - [x] I have not included unrelated changes in this PR