### PR TITLE
fix(provider): respect model limit.output instead of capping at 32k

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1342,8 +1342,10 @@ export function providerOptions(model: Provider.Model, options: { [x: string]: a
   return { [key]: normalized }
 }
 
-export function maxOutputTokens(model: Provider.Model, outputTokenMax = OUTPUT_TOKEN_MAX): number {
-  return Math.min(model.limit.output, outputTokenMax) || outputTokenMax
+export function maxOutputTokens(model: Provider.Model, outputTokenMax?: number): number {
+  const limit = model.limit.output
+  if (limit > 0) return outputTokenMax !== undefined ? Math.min(limit, outputTokenMax) : limit
+  return outputTokenMax ?? OUTPUT_TOKEN_MAX
 }
 
 type JsonRecord = Record<string, unknown>

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -16,7 +16,7 @@ export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outpu
     Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
   return input.model.limit.input
     ? Math.max(0, input.model.limit.input - reserved)
-    : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+    : Math.max(0, context - reserved)
 }
 
 export function isOverflow(input: {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4792,3 +4792,42 @@ describe("ProviderTransform.providerOptions - ai-gateway-provider", () => {
     expect(result).toEqual({ openaiCompatible: { reasoningEffort: "high" } })
   })
 })
+
+describe("ProviderTransform.maxOutputTokens", () => {
+  const model = (output: number) =>
+    ({
+      limit: { context: 200_000, input: undefined, output },
+      capabilities: { toolcall: true, reasoning: false, temperature: true, attachment: false },
+      api: { npm: "@ai-sdk/anthropic" },
+      cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+      options: {},
+    }) as any
+
+  test("respects model limit.output when no env var is set", () => {
+    expect(ProviderTransform.maxOutputTokens(model(131_071))).toBe(131_071)
+  })
+
+  test("caps at env var ceiling when explicitly set below model limit", () => {
+    expect(ProviderTransform.maxOutputTokens(model(131_071), 32_000)).toBe(32_000)
+  })
+
+  test("env var ceiling above model limit has no effect", () => {
+    expect(ProviderTransform.maxOutputTokens(model(131_071), 200_000)).toBe(131_071)
+  })
+
+  test("falls back to OUTPUT_TOKEN_MAX when limit.output is 0 and no env var", () => {
+    expect(ProviderTransform.maxOutputTokens(model(0))).toBe(ProviderTransform.OUTPUT_TOKEN_MAX)
+  })
+
+  test("falls back to env var when limit.output is 0", () => {
+    expect(ProviderTransform.maxOutputTokens(model(0), 64_000)).toBe(64_000)
+  })
+
+  test("falls back to OUTPUT_TOKEN_MAX when limit.output is negative", () => {
+    expect(ProviderTransform.maxOutputTokens(model(-1))).toBe(ProviderTransform.OUTPUT_TOKEN_MAX)
+  })
+
+  test("falls back to OUTPUT_TOKEN_MAX when limit.output is undefined", () => {
+    expect(ProviderTransform.maxOutputTokens(model(undefined as any))).toBe(ProviderTransform.OUTPUT_TOKEN_MAX)
+  })
+})

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -440,12 +440,12 @@ describe("session.compaction.isOverflow", () => {
 
   // ─── Bug reproduction tests ───────────────────────────────────────────
   // These tests demonstrate that when limit.input is set, isOverflow()
-  // does not subtract any headroom for the next model response. This means
+  // does not subtract enough headroom for the next model response. This means
   // compaction only triggers AFTER we've already consumed the full input
   // budget, leaving zero room for the next API call's output tokens.
   //
-  // Compare: without limit.input, usable = context - output (reserves space).
-  // With limit.input, usable = limit.input (reserves nothing).
+  // Compare: without limit.input, usable = context - reserved (reserves space).
+  // With limit.input, usable = limit.input - reserved.
   //
   // Related issues: #10634, #8089, #11086, #12621
   // Open PRs: #6875, #12924
@@ -463,11 +463,11 @@ describe("session.compaction.isOverflow", () => {
         // plus the model needs room to generate output — this WILL overflow.
         const tokens = { input: 180_000, output: 15_000, reasoning: 0, cache: { read: 3_000, write: 0 } }
         // count = 180K + 3K + 15K = 198K
-        // usable = limit.input = 200K (no output subtracted!)
-        // 198K > 200K = false → no compaction triggered
+        // usable = limit.input - reserved = 200K - 20K = 180K
+        // 198K >= 180K = true -> compaction triggered
 
-        // WITHOUT limit.input: usable = 200K - 32K = 168K, and 198K > 168K = true ✓
-        // WITH limit.input: usable = 200K, and 198K > 200K = false ✗
+        // WITHOUT limit.input: usable = 200K - 20K = 180K, and 198K >= 180K = true
+        // WITH limit.input: usable = 200K - 20K = 180K, and 198K >= 180K = true
 
         // With 198K used and only 2K headroom, the next turn will overflow.
         // Compaction MUST trigger here.
@@ -481,14 +481,14 @@ describe("session.compaction.isOverflow", () => {
     provideTmpdirInstance(() =>
       Effect.gen(function* () {
         const compact = yield* SessionCompaction.Service
-        // Same model but without limit.input — uses context - output instead
+        // Same model but without limit.input -- uses context - reserved
         const model = createModel({ context: 200_000, output: 32_000 })
 
         // Same token usage as above
         const tokens = { input: 180_000, output: 15_000, reasoning: 0, cache: { read: 3_000, write: 0 } }
         // count = 198K
-        // usable = context - output = 200K - 32K = 168K
-        // 198K > 168K = true → compaction correctly triggered
+        // usable = context - reserved = 200K - 20K = 180K
+        // 198K >= 180K = true -> compaction correctly triggered
 
         const result = yield* compact.isOverflow({ tokens, model })
         expect(result).toBe(true) // ← Correct: headroom is reserved
@@ -505,15 +505,15 @@ describe("session.compaction.isOverflow", () => {
         const withInputLimit = createModel({ context: 200_000, input: 200_000, output: 32_000 })
         const withoutInputLimit = createModel({ context: 200_000, output: 32_000 })
 
-        // 170K total tokens — well above context-output (168K) but below input limit (200K)
+        // 181K total tokens — above usable (180K) in both paths
         const tokens = { input: 166_000, output: 10_000, reasoning: 0, cache: { read: 5_000, write: 0 } }
 
         const withLimit = yield* compact.isOverflow({ tokens, model: withInputLimit })
         const withoutLimit = yield* compact.isOverflow({ tokens, model: withoutInputLimit })
 
         // Both models have identical real capacity — they should agree:
-        expect(withLimit).toBe(true) // should compact (170K leaves no room for 32K output)
-        expect(withoutLimit).toBe(true) // correctly compacts (170K > 168K)
+        expect(withLimit).toBe(true) // should compact (181K >= 180K leaves little room for output)
+        expect(withoutLimit).toBe(true) // correctly compacts (181K >= 180K)
       }),
     ),
   )

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { usable } from "@/session/overflow"
+import type { Provider } from "@/provider/provider"
+import type { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+
+const COMPACTION_BUFFER = 20_000
+
+const model = (overrides: { context?: number; input?: number; output?: number }): Provider.Model =>
+  ({
+    limit: {
+      context: overrides.context ?? 200_000,
+      input: overrides.input,
+      output: overrides.output ?? 32_000,
+    },
+    capabilities: {
+      toolcall: true,
+      reasoning: false,
+      temperature: true,
+      attachment: false,
+    },
+    api: { npm: "@ai-sdk/anthropic" },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    options: {},
+  }) as Provider.Model
+
+const cfg = (overrides: { reserved?: number; auto?: boolean } = {}): ConfigV1.Info =>
+  ({ compaction: overrides }) as ConfigV1.Info
+
+describe("overflow.usable", () => {
+  test("returns 0 when context is 0", () => {
+    expect(usable({ cfg: cfg(), model: model({ context: 0 }) })).toBe(0)
+  })
+
+  test("uses limit.input path when set", () => {
+    const m = model({ context: 200_000, input: 150_000, output: 32_000 })
+    const reserved = Math.min(COMPACTION_BUFFER, 32_000)
+    expect(usable({ cfg: cfg(), model: m })).toBe(150_000 - reserved)
+  })
+
+  test("uses context - reserved for fallback path without limit.input", () => {
+    const m = model({ context: 200_000, output: 32_000 })
+    const reserved = Math.min(COMPACTION_BUFFER, 32_000)
+    expect(usable({ cfg: cfg(), model: m })).toBe(200_000 - reserved)
+  })
+
+  test("shared-window model with high output does not collapse usable to 0", () => {
+    const m = model({ context: 262_144, output: 262_144 })
+    const reserved = Math.min(COMPACTION_BUFFER, 262_144)
+    expect(usable({ cfg: cfg(), model: m })).toBe(262_144 - reserved)
+  })
+
+  test("respects custom cfg.compaction.reserved", () => {
+    const m = model({ context: 200_000, output: 32_000 })
+    expect(usable({ cfg: cfg({ reserved: 50_000 }), model: m })).toBe(200_000 - 50_000)
+  })
+
+  test("outputTokenMax caps reserved via maxOutputTokens", () => {
+    const m = model({ context: 200_000, output: 131_071 })
+    const reserved = Math.min(COMPACTION_BUFFER, Math.min(131_071, 16_000))
+    expect(usable({ cfg: cfg(), model: m, outputTokenMax: 16_000 })).toBe(200_000 - reserved)
+  })
+
+  test("clamps to 0 when reserved exceeds available context", () => {
+    const m = model({ context: 10_000, output: 32_000 })
+    expect(usable({ cfg: cfg({ reserved: 50_000 }), model: m })).toBe(0)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #29363
Closes #20078
Related: #2949 (closed), #1735 (closed), #32656, #22158, #16971
Prior attempts: #24384 (closed), #29513 (closed), #29679 (closed)
Conflicts with: #32844

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**What is broken:** `maxOutputTokens()` used `Math.min(model.limit.output, OUTPUT_TOKEN_MAX)` which silently capped every model at 32k, regardless of its configured `limit.output`. A user with `limit.output: 131071` still got `max_tokens: 32000` in the API request.

**Expected:** `limit.output` from config should be the primary value sent to the API. The env var `OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` should act as an optional ceiling, not a hard cap.

**Steps to reproduce:** Configure a model with `limit.output` above 32000. Start a session. Observe `max_tokens: 32000` in the API request (or agent stops with `reason: "length"` mid-task).

**Impact:** Reasoning-heavy models (DeepSeek V4, Claude with extended thinking) can exhaust the 32k budget on reasoning tokens, leaving very little headroom for visible output. Three prior PRs (#24384, #29513, #29679) attempted this fix but were closed without merging.

**The fix:**

`maxOutputTokens` now returns `limit.output` directly when no env var is set. When the env var IS set, it applies as `Math.min(limit, envValue)`. This works because `positiveInteger()` in `runtime-flags.ts` returns `undefined` for unset env vars, so we can distinguish "user configured a ceiling" from "default fallback".

`overflow.ts` also needed a change. The fallback path (models without `limit.input`) used `context - maxOutputTokens()` for compaction headroom. With the fix, this would subtract 131k from a 200k context, collapsing `usable` to 69k. For shared-window models like Kimi K2.6 (262k/262k) it would be zero. The fix unifies both paths to use `reserved` (capped at `COMPACTION_BUFFER = 20000`), which the `limit.input` path already used.

Updated comments in `compaction.test.ts` to reflect the unified `reserved` behavior (no logic changes).

**Conflict with PR #32844 (issue #32656):** That PR proposes removing the `COMPACTION_BUFFER` cap to reserve the full `maxOutputTokens`. This was reasonable when `maxOutputTokens` was still capped at 32k. With this fix, it would reserve 131k for Claude and 262k for Kimi K2.6, making `usable = 0` and triggering compaction on every turn. If this PR merges first, #32844 needs rework.

**Why I am unsure:** Several pre-existing test failures in `compaction.test.ts` persist on both original and patched code (verified locally via stash/unstash). I confirmed `overflow()` returns correct values via direct calls, but I do not know why the `SessionCompaction.Service` tests fail. The `COMPACTION_BUFFER = 20000` value may be too low for code-generation sessions (30k+ token responses). Bumping it to 32000 could be a follow-up.

### How did you verify your code works?

- `bun typecheck` from `packages/opencode` - passes
- `bun test test/provider/transform.test.ts` - 295 pass, 0 fail (7 new tests for `maxOutputTokens`)
- `bun test test/session/overflow.test.ts` - 7 pass, 0 fail (new file, direct `usable()` tests)
- `bun test test/session/compaction.test.ts` - pre-existing failures unchanged (verified locally, same failures on original code)
- Direct `isOverflow()` call with test inputs returns expected `true`
- `bun test test/plugin/cloudflare.test.ts` - 4 pass, 0 fail
- `bun test test/session/llm-native.test.ts` - 16 pass, 0 fail
- `bun test test/effect/runtime-flags.test.ts` - 36 pass, 0 fail

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
