### PR TITLE
fix(core): record selected catalog model identity on assistant steps

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -321,12 +321,12 @@ export const layer = Layer.effect(
       compactIfNeeded: compaction.compactIfNeeded,
       compactAfterOverflow: compaction.compactAfterOverflow,
       compactManual: Effect.fn("SessionCompaction.compactManual")(function* (input) {
-        const model = yield* models.resolve(input.session).pipe(Effect.catch(() => Effect.succeed(undefined)))
-        if (!model) return false
+        const resolved = yield* models.resolve(input.session).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        if (!resolved) return false
         return yield* compaction.compactManual({
           sessionID: input.session.id,
           messages: input.messages,
-          model,
+          model: resolved.model,
         })
       }),
     })

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -14,8 +14,6 @@ import { Config } from "../../config"
 import { Database } from "../../database/database"
 import { EventV2 } from "../../event"
 import { Location } from "../../location"
-import { ModelV2 } from "../../model"
-import { ProviderV2 } from "../../provider"
 import { QuestionV2 } from "../../question"
 import { SystemContext } from "../../system-context/index"
 import { SystemContextBuiltIns } from "../../system-context/builtins"
@@ -209,7 +207,8 @@ const layer = Layer.effect(
         }
         if (promoted > 0) currentStep = 1
       }
-      const model = yield* models.resolve(session)
+      const resolved = yield* models.resolve(session)
+      const model = resolved.model
       const entries = yield* SessionHistory.entriesForRunner(db, session.id, checkpoint.baselineSeq)
       const context = entries.map((entry) => entry.message)
       const isLastStep = agent.info?.steps !== undefined && currentStep >= agent.info.steps
@@ -236,11 +235,9 @@ const layer = Layer.effect(
       const publisher = createLLMEventPublisher(events, {
         sessionID: session.id,
         agent: agent.id,
-        model: {
-          id: ModelV2.ID.make(model.id),
-          providerID: ProviderV2.ID.make(model.provider),
-          ...(session.model?.variant === undefined ? {} : { variant: session.model.variant }),
-        },
+        // The selected catalog identity, not model.id: route-level ids are provider API
+        // model ids (for example gpt-5.5-fast resolves to api id gpt-5.5).
+        model: resolved.ref,
         snapshot: startSnapshot,
       })
       const publication = Semaphore.makeUnsafe(1)

--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -72,14 +72,31 @@ export type Error =
   | UnsupportedApiError
   | Integration.AuthorizationError
 
+export interface Resolved {
+  /** Route-level model for provider requests; its id is the provider API model id, which may differ from the catalog id. */
+  readonly model: Model
+  /** Selected catalog identity. Durable records and displays must use this, never the API model id. */
+  readonly ref: ModelV2.Ref
+}
+
 export interface Interface {
-  readonly resolve: (session: SessionSchema.Info) => Effect.Effect<Model, Error>
+  readonly resolve: (session: SessionSchema.Info) => Effect.Effect<Resolved, Error>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SessionRunnerModel") {}
 
 /** Test or embedding seam for supplying a model resolver directly. */
 export const layerWith = (resolve: Interface["resolve"]) => Layer.succeed(Service, Service.of({ resolve }))
+
+/** Builds a Resolved whose catalog identity mirrors the route model. Test or embedding seam. */
+export const resolved = (model: Model, variant?: ModelV2.VariantID): Resolved => ({
+  model,
+  ref: ModelV2.Ref.make({
+    id: ModelV2.ID.make(model.id),
+    providerID: ProviderV2.ID.make(model.provider),
+    ...(variant === undefined ? {} : { variant }),
+  }),
+})
 
 const apiKey = (model: ModelV2.Info, credential?: Credential.Value) => {
   if (credential?.type === "key") return Auth.value(credential.key)
@@ -233,11 +250,19 @@ const layer = Layer.effect(
         const connection = yield* integrations.connection.active(
           provider?.integrationID ?? Integration.ID.make(selected.providerID),
         )
-        return yield* resolve(
+        const model = yield* resolve(
           session,
           selected,
           connection ? yield* integrations.connection.resolve(connection) : undefined,
         )
+        return {
+          model,
+          ref: ModelV2.Ref.make({
+            id: selected.id,
+            providerID: selected.providerID,
+            ...(session.model?.variant === undefined ? {} : { variant: session.model.variant }),
+          }),
+        }
       }),
     })
   }),

--- a/packages/core/src/session/title.ts
+++ b/packages/core/src/session/title.ts
@@ -42,17 +42,17 @@ const make = (dependencies: Dependencies) => {
     if (!firstUser) return
     const agent = yield* dependencies.agents.get(AgentV2.ID.make("title"))
     if (!agent) return
-    const model = yield* (agent.model
+    const resolved = yield* (agent.model
       ? dependencies.models.resolve({ ...session, model: agent.model })
       : dependencies.models.resolve(session)
     ).pipe(Effect.catch(() => Effect.succeed(undefined)))
-    if (!model) return
+    if (!resolved) return
     const chunks: string[] = []
     let failed = false
     const streamed = yield* dependencies.llm
       .stream(
         LLM.request({
-          model,
+          model: resolved.model,
           system: agent.system,
           messages: [Message.user(firstUser.text)],
           tools: [],

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -175,6 +175,58 @@ describe("LocationServiceMap", () => {
     ),
   )
 
+  it.live("preserves the selected catalog identity when the api model id differs", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const location = Location.Ref.make({ directory: AbsolutePath.make(dir.path) })
+          const resolved = yield* Effect.gen(function* () {
+            const catalog = yield* Catalog.Service
+            yield* catalog.transform((editor) => {
+              editor.provider.update(ProviderV2.ID.make("aliased"), (provider) => {
+                provider.api = { type: "aisdk", package: "@ai-sdk/openai", settings: {} }
+              })
+              editor.model.update(ProviderV2.ID.make("aliased"), ModelV2.ID.make("fast"), (model) => {
+                // Catalog id and provider API id intentionally differ, like gpt-5.5-fast -> gpt-5.5.
+                model.api = { ...model.api, id: ModelV2.ID.make("base") }
+                model.variants.push({ id: ModelV2.VariantID.make("high"), settings: {}, headers: {}, body: {} })
+              })
+            })
+            const models = yield* SessionRunnerModel.Service
+            return yield* models.resolve(
+              SessionV2.Info.make({
+                id: SessionV2.ID.make("ses_aliased_model"),
+                projectID: ProjectV2.ID.global,
+                title: "test",
+                model: {
+                  id: ModelV2.ID.make("fast"),
+                  providerID: ProviderV2.ID.make("aliased"),
+                  variant: ModelV2.VariantID.make("high"),
+                },
+                cost: 0,
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                time: { created: DateTime.makeUnsafe(0), updated: DateTime.makeUnsafe(0) },
+                location,
+              }),
+            )
+          }).pipe(Effect.provide(LocationServiceMap.Service.get(location)))
+
+          expect(resolved.ref).toEqual(
+            ModelV2.Ref.make({
+              id: ModelV2.ID.make("fast"),
+              providerID: ProviderV2.ID.make("aliased"),
+              variant: ModelV2.VariantID.make("high"),
+            }),
+          )
+          expect(String(resolved.model.id)).toBe("base")
+        }),
+      ),
+    ),
+  )
+
   it.live("installs public plugins into a location", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/session-compact.test.ts
+++ b/packages/core/test/session-compact.test.ts
@@ -48,7 +48,7 @@ const client = Layer.mock(LLMClient.Service)({
   generate: () => Effect.die("unused"),
 })
 const config = Layer.mock(Config.Service)({ entries: () => Effect.succeed([]) })
-const models = SessionRunnerModel.layerWith(() => Effect.succeed(model))
+const models = SessionRunnerModel.layerWith(() => Effect.succeed(SessionRunnerModel.resolved(model)))
 const locations = Layer.effect(
   LocationServiceMap.Service,
   LayerMap.make(

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -38,7 +38,9 @@ const client = Layer.mock(LLMClient.Service)({
   generate: () => Effect.die("unused"),
 })
 const config = Layer.mock(Config.Service)({ entries: () => Effect.succeed([]) })
-const models = Layer.mock(SessionRunnerModel.Service)({ resolve: () => Effect.succeed(model) })
+const models = Layer.mock(SessionRunnerModel.Service)({
+  resolve: () => Effect.succeed(SessionRunnerModel.resolved(model)),
+})
 const it = testEffect(
   AppNodeBuilder.build(
     LayerNode.group([Database.node, EventV2.node, SessionProjector.node, SessionStore.node, SessionCompaction.node]),

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -72,7 +72,7 @@ const model = OpenAIChat.route
     generation: { maxTokens: 20, temperature: 0 },
   })
   .model({ id: "gpt-4o-mini" })
-const models = SessionRunnerModel.layerWith(() => Effect.succeed(model))
+const models = SessionRunnerModel.layerWith(() => Effect.succeed(SessionRunnerModel.resolved(model)))
 const systemContext = Layer.mock(SystemContextBuiltIns.Service, { load: () => Effect.succeed(SystemContext.empty) })
 const instructionContext = Layer.mock(InstructionContext.Service, { load: () => Effect.succeed(SystemContext.empty) })
 const skillGuidance = Layer.mock(SkillGuidance.Service, { load: () => Effect.succeed(SystemContext.empty) })

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -161,7 +161,14 @@ const echoNode = makeLocationNode({ name: "test/session-runner-tools", layer: ec
 let modelResolveHook = Effect.void
 let currentModel = model
 const models = SessionRunnerModel.layerWith((session) =>
-  modelResolveHook.pipe(Effect.as(session.model?.id === "replacement" ? replacementModel : currentModel)),
+  modelResolveHook.pipe(
+    Effect.as(
+      SessionRunnerModel.resolved(
+        session.model?.id === "replacement" ? replacementModel : currentModel,
+        session.model?.variant,
+      ),
+    ),
+  ),
 )
 const systemContextKey = SystemContext.Key.make("test/context")
 let systemBaseline = "Initial context"

--- a/packages/core/test/session-title.test.ts
+++ b/packages/core/test/session-title.test.ts
@@ -36,7 +36,9 @@ const client = Layer.mock(LLMClient.Service)({
   },
   generate: () => Effect.die("unused"),
 })
-const models = Layer.mock(SessionRunnerModel.Service)({ resolve: () => Effect.succeed(model) })
+const models = Layer.mock(SessionRunnerModel.Service)({
+  resolve: () => Effect.succeed(SessionRunnerModel.resolved(model)),
+})
 const it = testEffect(
   AppNodeBuilder.build(
     LayerNode.group([Database.node, EventV2.node, SessionProjector.node, SessionStore.node, AgentV2.node, SessionTitle.node]),


### PR DESCRIPTION
## Problem

Assistant messages are persisted with the provider API model id instead of the selected catalog model id. For example, with the session on `openai/gpt-5.5-fast` (catalog id `gpt-5.5-fast`, api id `gpt-5.5`), each `session.next.step.started` event and the projected assistant rows record `openai/gpt-5.5`. The TUI assistant footer resolves its display name from the message's model, so it shows "GPT-5.5" even though the session is on "GPT-5.5 Fast" — which also makes real model/variant switch notices look spurious.

Root cause: the runner published the identity of the resolved route-level `Model` (`resolved.api.id`) rather than the catalog selection:

- `SessionRunnerModel` resolves the catalog model into a route model via `route.model({ id: model.api.id })`
- `runner/llm.ts` then published `model.id` / `model.provider` on `Step.Started`

## Fix

Keep the two identities separate:

- `SessionRunnerModel.resolve` now returns `Resolved { model, ref }`: the route-level model for provider requests, plus the selected catalog identity (`Model.Ref`, including the session's variant) for durable records and display.
- The runner publishes `Step.Started` with `resolved.ref`; the API model id stays confined to the LLM request layer.
- `SessionRunnerModel.resolved(model, variant?)` is the seam for tests/embeddings whose catalog identity mirrors the route model.

Existing sessions keep their previously recorded api-id identities; new steps record the catalog identity.

## Tests

- New: `LocationServiceMap > preserves the selected catalog identity when the api model id differs` — seeds a catalog model whose api id differs from its catalog id and asserts `resolve` returns `ref.id = fast` / `model.id = base` with the variant preserved.
- Updated resolver fixtures across runner/compaction/title tests to the `Resolved` shape; all pass.