### PR TITLE
fix(tui): use catalog display name in model switch notices

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1229,10 +1229,11 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
 }
 
 function SessionSwitchMessageV2(props: { message: SessionMessage }) {
+  const ctx = use()
   const { theme } = useTheme()
   const text = () => {
     if (props.message.type === "agent-switched") return `Switched agent to ${props.message.agent}`
-    if (props.message.type === "model-switched") return switchLabel(props.message.model)
+    if (props.message.type === "model-switched") return switchLabel(props.message.model, ctx.models())
     return ""
   }
   return <text fg={theme.textMuted}>{text()}</text>

--- a/packages/tui/src/util/model.ts
+++ b/packages/tui/src/util/model.ts
@@ -31,6 +31,14 @@ export function formatRef(model: { providerID: string; id: string; variant?: str
   return [model.providerID, model.id, model.variant].filter((value) => value !== undefined).join("/")
 }
 
-export function switchLabel(model: { providerID: string; id: string; variant?: string }) {
-  return `Switched model to ${formatRef(model)}`
+export function switchLabel(
+  model: { providerID: string; id: string; variant?: string },
+  models?: readonly { providerID: string; id: string; name: string }[],
+) {
+  const display = models?.find((item) => item.providerID === model.providerID && item.id === model.id)?.name
+  if (display === undefined) return `Switched model to ${formatRef(model)}`
+  // Variant-only switches publish the same model id; without the variant the
+  // notice would look like a redundant model switch.
+  const variant = model.variant && model.variant !== "default" ? ` (${model.variant})` : ""
+  return `Switched model to ${display}${variant}`
 }

--- a/packages/tui/test/util/model.test.ts
+++ b/packages/tui/test/util/model.test.ts
@@ -17,4 +17,21 @@ describe("util.model", () => {
       "Switched model to anthropic/sonnet/thinking",
     )
   })
+
+  test("uses the catalog display name in model switch notices", () => {
+    const models = [
+      { providerID: "openai", id: "gpt-5.5-fast", name: "GPT-5.5 Fast" },
+      { providerID: "anthropic", id: "sonnet", name: "Claude Sonnet" },
+    ]
+    expect(switchLabel({ providerID: "openai", id: "gpt-5.5-fast", variant: "high" }, models)).toBe(
+      "Switched model to GPT-5.5 Fast (high)",
+    )
+    expect(switchLabel({ providerID: "anthropic", id: "sonnet" }, models)).toBe("Switched model to Claude Sonnet")
+    expect(switchLabel({ providerID: "anthropic", id: "sonnet", variant: "default" }, models)).toBe(
+      "Switched model to Claude Sonnet",
+    )
+    expect(switchLabel({ providerID: "removed", id: "gone", variant: "high" }, models)).toBe(
+      "Switched model to removed/gone/high",
+    )
+  })
 })


### PR DESCRIPTION
## Problem

Model switch notices render raw catalog ids instead of the display name used everywhere else:

> Switched model to openai/gpt-5.5-fast/high

#34856 added the variant to the notice (thanks!), but it still doesn't match the assistant footer, which resolves "GPT-5.5 Fast" from the catalog. Since `V2Session.switchModel` dedups on provider + model + variant, these notices are the only signal for variant-only switches, so they should read like the rest of the UI.

## Fix

Extend `switchLabel` to accept the catalog model list and render the display name plus the variant (omitted when unset or `default`):

> Switched model to GPT-5.5 Fast (high)

Falls back to the existing `formatRef` output (`providerID/id/variant`) when the model is no longer in the catalog.

## Tests

- Extended `util.model` tests: display-name rendering, variant suffix, `default` variant omission, and the catalog-miss fallback.