### PR TITLE
fix(opencode): introduce robust multi-line fuzzy matching in edit tool

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -679,6 +679,168 @@ export function trimDiff(diff: string): string {
   return trimmedLines.join("\n")
 }
 
+const FUZZY_MATCH_MIN_LENGTH = 40
+const FUZZY_MATCH_MAX_LINES = 4
+const FUZZY_MATCH_THRESHOLD = 0.74
+const FUZZY_MATCH_MARGIN = 0.08
+
+type FuzzyLineMatch = {
+  start: number
+  end: number
+  line: string
+  score: number
+}
+
+function normalizeForFuzzy(text: string): string {
+  return text
+    .normalize("NFKC")
+    .replace(/[\u2010-\u2015]/g, "-")
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/[`*_]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase()
+}
+
+function tokenSet(text: string): Set<string> {
+  return new Set(
+    normalizeForFuzzy(text)
+      .split(/[^a-z0-9]+/i)
+      .filter((token) => token.length >= 3),
+  )
+}
+
+function jaccardSimilarity(a: string, b: string): number {
+  const left = tokenSet(a)
+  const right = tokenSet(b)
+  if (left.size === 0 || right.size === 0) return 0
+
+  let intersection = 0
+  for (const token of left) {
+    if (right.has(token)) intersection++
+  }
+
+  const union = left.size + right.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+
+function characterSimilarity(a: string, b: string): number {
+  const left = normalizeForFuzzy(a)
+  const right = normalizeForFuzzy(b)
+  const maxLength = Math.max(left.length, right.length)
+  if (maxLength === 0) return 1
+
+  return 1 - levenshtein(left, right) / maxLength
+}
+
+function combinedSimilarity(a: string, b: string): number {
+  return characterSimilarity(a, b) * 0.65 + jaccardSimilarity(a, b) * 0.35
+}
+
+function linePrefix(text: string): string | undefined {
+  return text.trimStart().match(/^([-*+]\s+|\d+\.\s+)/)?.[0]
+}
+
+function findUniqueFuzzyMatch(content: string, oldString: string): FuzzyLineMatch | undefined {
+  const targetLines = oldString.split("\n")
+
+  if (targetLines[targetLines.length - 1] === "") {
+    targetLines.pop()
+  }
+
+  if (targetLines.length === 0) return undefined
+  if (targetLines.length > FUZZY_MATCH_MAX_LINES) return undefined
+
+  const target = targetLines.join("\n").trim()
+  if (normalizeForFuzzy(target).length < FUZZY_MATCH_MIN_LENGTH) return undefined
+
+  const requiredPrefix = linePrefix(targetLines[0] ?? "")
+
+  const rawLines = content.split("\n")
+  const candidates: FuzzyLineMatch[] = []
+
+  let offset = 0
+  const lineStarts: number[] = []
+  const lineEnds: number[] = []
+  const lines: string[] = []
+
+  for (const rawLine of rawLines) {
+    const hasTrailingCR = rawLine.endsWith("\r")
+    const line = hasTrailingCR ? rawLine.slice(0, -1) : rawLine
+
+    lineStarts.push(offset)
+    lineEnds.push(offset + line.length)
+    lines.push(line)
+
+    offset += rawLine.length + 1
+  }
+
+  for (let i = 0; i <= lines.length - targetLines.length; i++) {
+    if (requiredPrefix && !lines[i].trimStart().startsWith(requiredPrefix)) {
+      continue
+    }
+
+    const candidateLines = lines.slice(i, i + targetLines.length)
+    const candidate = candidateLines.join("\n")
+
+    if (!candidate.trim()) continue
+
+    const charScore = characterSimilarity(candidate, target)
+    const tokenScore = jaccardSimilarity(candidate, target)
+    const score = charScore * 0.65 + tokenScore * 0.35
+
+    candidates.push({
+      start: lineStarts[i],
+      end: lineEnds[i + targetLines.length - 1],
+      line: candidate,
+      score,
+    })
+  }
+
+  candidates.sort((a, b) => b.score - a.score)
+
+  const best = candidates[0]
+  if (!best || best.score < FUZZY_MATCH_THRESHOLD) {
+    return undefined
+  }
+
+  const secondScore = candidates[1]?.score ?? 0
+  if (best.score - secondScore < FUZZY_MATCH_MARGIN) {
+    return undefined
+  }
+
+  return best
+}
+
+function nearestLines(content: string, oldString: string, limit = 3): Array<{ line: string; score: number }> {
+  return content
+    .split("\n")
+    .map((rawLine) => {
+      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine
+      return {
+        line,
+        score: combinedSimilarity(line, oldString),
+      }
+    })
+    .filter((candidate) => candidate.line.trim().length > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+}
+
+function oldStringNotFoundError(content: string, oldString: string): Error {
+  const nearest = nearestLines(content, oldString)
+  const hint = nearest.length
+    ? `\n\nClosest candidate lines:\n${nearest
+        .map((candidate) => `- score=${candidate.score.toFixed(2)}: ${candidate.line}`)
+        .join("\n")}`
+    : ""
+
+  return new Error(
+    `Could not find oldString in the file. It must match exactly, including whitespace, indentation, and line endings. No safe unique fuzzy match was found either.${hint}`,
+  )
+}
+
 export function replace(content: string, oldString: string, newString: string, replaceAll = false): string {
   if (oldString === newString) {
     throw new Error("No changes to apply: oldString and newString are identical.")
@@ -705,26 +867,37 @@ export function replace(content: string, oldString: string, newString: string, r
     for (const search of replacer(content, oldString)) {
       const index = content.indexOf(search)
       if (index === -1) continue
+
       notFound = false
+
       if (isDisproportionateMatch(search, oldString)) {
         throw new Error(
           "Refusing replacement because the matched span is much larger than oldString. Re-read the file and provide the full exact oldString for the intended replacement.",
         )
       }
+
       if (replaceAll) {
         return content.replaceAll(search, newString)
       }
+
       const lastIndex = content.lastIndexOf(search)
       if (index !== lastIndex) continue
+
       return content.substring(0, index) + newString + content.substring(index + search.length)
     }
   }
 
-  if (notFound) {
-    throw new Error(
-      "Could not find oldString in the file. It must match exactly, including whitespace, indentation, and line endings.",
-    )
+  if (notFound && !replaceAll) {
+    const fuzzyMatch = findUniqueFuzzyMatch(content, oldString)
+    if (fuzzyMatch) {
+      return content.substring(0, fuzzyMatch.start) + newString + content.substring(fuzzyMatch.end)
+    }
   }
+
+  if (notFound) {
+    throw oldStringNotFoundError(content, oldString)
+  }
+
   throw new Error("Found multiple matches for oldString. Provide more surrounding context to make the match unique.")
 }
 

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -208,6 +208,144 @@ describe("tool.edit", () => {
       }),
     )
 
+    it.instance("fuzzy replaces a unique long single-line markdown bullet", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "pivot-plan.txt")
+
+        const original = [
+          "- unrelated item before",
+          "- ml-research-bench at **15 tasks**, with/without grounding A/B frozen (the novelty — protect it)",
+          "- unrelated item after",
+          "",
+        ].join("\n")
+
+        const oldString =
+          "- ml-research-bench at **15+ tasks**, with/without-grounding A/B frozen (this is the *novelty* — protect it)"
+
+        const newString =
+          "- cost-trajectory on the 100-instance Verified set: **hub-on vs hub-off A/B frozen** (the novelty — protect it)"
+
+        yield* put(filepath, original)
+
+        const result = yield* run({
+          filePath: filepath,
+          oldString,
+          newString,
+        })
+
+        expect(result.output).toContain("Edit applied successfully")
+        expect(yield* load(filepath)).toBe(
+          ["- unrelated item before", newString, "- unrelated item after", ""].join("\n"),
+        )
+      }),
+    )
+
+    it.instance("does not fuzzy replace short single-line strings", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "file.ts")
+        const original = ["return true", ""].join("\n")
+        yield* put(filepath, original)
+
+        expect(
+          (yield* fail({
+            filePath: filepath,
+            oldString: "return false",
+            newString: "return null",
+          })).message,
+        ).toContain("Could not find oldString")
+
+        expect(yield* load(filepath)).toBe(original)
+      }),
+    )
+
+    it.instance("does not fuzzy replace ambiguous similar single-line candidates", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "pivot-plan.txt")
+
+        const original = [
+          "- ml-research-bench at **15 tasks**, with/without grounding A/B frozen (the novelty — protect it)",
+          "- ml-research-bench at **16 tasks**, with/without grounding A/B frozen (the novelty — protect it)",
+          "",
+        ].join("\n")
+
+        yield* put(filepath, original)
+
+        expect(
+          (yield* fail({
+            filePath: filepath,
+            oldString:
+              "- ml-research-bench at **15+ tasks**, with/without-grounding A/B frozen (this is the *novelty* — protect it)",
+            newString:
+              "- cost-trajectory on the 100-instance Verified set: **hub-on vs hub-off A/B frozen** (the novelty — protect it)",
+          })).message,
+        ).toContain("Could not find oldString")
+
+        expect(yield* load(filepath)).toBe(original)
+      }),
+    )
+
+    it.instance("does not use fuzzy fallback with replaceAll", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "pivot-plan.txt")
+
+        const original = [
+          "- ml-research-bench at **15 tasks**, with/without grounding A/B frozen (the novelty — protect it)",
+          "",
+        ].join("\n")
+
+        yield* put(filepath, original)
+
+        expect(
+          (yield* fail({
+            filePath: filepath,
+            oldString:
+              "- ml-research-bench at **15+ tasks**, with/without-grounding A/B frozen (this is the *novelty* — protect it)",
+            newString:
+              "- cost-trajectory on the 100-instance Verified set: **hub-on vs hub-off A/B frozen** (the novelty — protect it)",
+            replaceAll: true,
+          })).message,
+        ).toContain("Could not find oldString")
+
+        expect(yield* load(filepath)).toBe(original)
+      }),
+    )
+
+    it.instance("preserves CRLF when fuzzy replacing a unique single line", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "pivot-plan.txt")
+
+        const original = [
+          "- unrelated item before",
+          "- ml-research-bench at **15 tasks**, with/without grounding A/B frozen (the novelty — protect it)",
+          "- unrelated item after",
+          "",
+        ].join("\r\n")
+
+        const oldString =
+          "- ml-research-bench at **15+ tasks**, with/without-grounding A/B frozen (this is the *novelty* — protect it)"
+
+        const newString =
+          "- cost-trajectory on the 100-instance Verified set: **hub-on vs hub-off A/B frozen** (the novelty — protect it)"
+
+        yield* put(filepath, original)
+
+        yield* run({
+          filePath: filepath,
+          oldString,
+          newString,
+        })
+
+        expect(yield* loadRaw(filepath)).toBe(
+          ["- unrelated item before", newString, "- unrelated item after", ""].join("\r\n"),
+        )
+      }),
+    )
+
     it.instance("rejects loose block-anchor matches and leaves content unchanged", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #34923

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Introduces a robust sliding-window multi-line fuzzy matching approach to the `edit` tool. 

Models like GLM 5.2 often slightly hallucinate whitespaces, indentation, markdown syntax (`*`, `_`), or line breaks when preparing the `oldString` block for file modifications. The new `findUniqueFuzzyMatch` implementation scans the file in candidate blocks matching the expected line count and computes a combined character (Levenshtein) and token (Jaccard) similarity. This allows the tool to safely tolerate minor formatting hallucinations from LLMs, identify the correct target lines, and apply the edit without throwing an exact match error. A safety limit of `FUZZY_MATCH_MAX_LINES = 4` is also added to prevent performance overhead.

### How did you verify your code works?

- Ran the local test suite via `bun test --cwd packages/opencode edit` and all 58 existing unit tests passed successfully.
- Verified that it correctly handles line endings (LF/CRLF), detects ambiguous matches to prevent false positives, and falls back gracefully under strict boundaries.

### Screenshots / recordings

_N/A (This is a core logic change, not a UI change)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR