### PR TITLE
refactor(core): resolve database and websearch config through Effect Config

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -2,9 +2,9 @@ export * as Database from "./database"
 
 import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 import { layer as sqliteLayer } from "#sqlite"
-import { Context, Effect, Layer } from "effect"
+import { Config, Context, Effect, Layer } from "effect"
 import { Global } from "../global"
-import { Flag } from "../flag/flag"
+import { truthyConfig } from "../flag/flag"
 import { isAbsolute, join } from "path"
 import { DatabaseMigration } from "./migration"
 import { InstallationChannel } from "../installation/version"
@@ -40,18 +40,28 @@ export function layerFromPath(filename: string) {
   return layer.pipe(Layer.provide(sqliteLayer({ filename })))
 }
 
-export function path() {
-  if (Flag.OPENCODE_DB) {
-    if (Flag.OPENCODE_DB === ":memory:" || isAbsolute(Flag.OPENCODE_DB)) return Flag.OPENCODE_DB
-    return join(Global.Path.data, Flag.OPENCODE_DB)
+function resolvePath(input: { readonly file: string | undefined; readonly disableChannelDb: boolean }) {
+  if (input.file) {
+    if (input.file === ":memory:" || isAbsolute(input.file)) return input.file
+    return join(Global.Path.data, input.file)
   }
-  if (
-    ["latest", "beta", "prod"].includes(InstallationChannel) ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
-    process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
-  )
+  if (["latest", "beta", "prod"].includes(InstallationChannel) || input.disableChannelDb)
     return join(Global.Path.data, "opencode.db")
   return join(Global.Path.data, `opencode-${InstallationChannel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`)
 }
 
-export const node = makeGlobalNode({ service: Service, layer: layerFromPath(path()), deps: [] })
+/**
+ * The database placement every consumer shares, resolved through Effect
+ * Config so tests and tooling can override it with a ConfigProvider. Used by
+ * the layer below and by external tooling such as `opencode db`.
+ */
+export const configuredPath = Effect.gen(function* () {
+  const file = yield* Config.string("OPENCODE_DB").pipe(Config.withDefault(undefined))
+  const disableChannelDb = yield* truthyConfig("OPENCODE_DISABLE_CHANNEL_DB")
+  return resolvePath({ file, disableChannelDb })
+}).pipe(Effect.orDie)
+
+// Placement is resolved when the layer is built, not at module import.
+const configuredLayer = Layer.unwrap(Effect.map(configuredPath, layerFromPath))
+
+export const node = makeGlobalNode({ service: Service, layer: configuredLayer, deps: [] })

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -1,9 +1,23 @@
 import { Config } from "effect"
 
-export function truthy(key: string) {
-  const value = process.env[key]?.toLowerCase()
-  return value === "true" || value === "1"
+function truthyValue(value: string) {
+  const lower = value.toLowerCase()
+  return lower === "true" || lower === "1"
 }
+
+export function truthy(key: string) {
+  const value = process.env[key]
+  return value !== undefined && truthyValue(value)
+}
+
+/**
+ * The `truthy` grammar read through Effect Config, so layer builds can be
+ * steered by a ConfigProvider. Missing or malformed values are false, exactly
+ * like `truthy`; strict boolean decoding would turn a stray env value into a
+ * startup defect.
+ */
+export const truthyConfig = (name: string) =>
+  Config.string(name).pipe(Config.map(truthyValue), Config.withDefault(false))
 
 const copy = process.env["OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"]
 const fff = process.env["OPENCODE_DISABLE_FFF"]
@@ -39,7 +53,6 @@ export const Flag = {
     copy === undefined ? process.platform === "win32" : truthy("OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT"),
   OPENCODE_MODELS_URL: process.env["OPENCODE_MODELS_URL"],
   OPENCODE_MODELS_PATH: process.env["OPENCODE_MODELS_PATH"],
-  OPENCODE_DB: process.env["OPENCODE_DB"],
 
   OPENCODE_WORKSPACE_ID: process.env["OPENCODE_WORKSPACE_ID"],
   OPENCODE_EXPERIMENTAL_WORKSPACES: enabledByExperimental("OPENCODE_EXPERIMENTAL_WORKSPACES"),

--- a/packages/core/src/tool/websearch.ts
+++ b/packages/core/src/tool/websearch.ts
@@ -1,11 +1,11 @@
 export * as WebSearchTool from "./websearch"
 
 import { ToolFailure } from "@opencode-ai/llm"
-import { Context, Duration, Effect, Layer, Schema } from "effect"
+import { Config, Context, Duration, Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { makeLocationNode } from "../effect/app-node"
 import { LayerNodePlatform } from "../effect/app-node-platform"
-import { truthy } from "../flag/flag"
+import { truthyConfig } from "../flag/flag"
 import { InstallationVersion } from "../installation/version"
 import { PositiveInt } from "../schema"
 import { PermissionV2 } from "../permission"
@@ -69,19 +69,39 @@ export interface Config {
 
 export class ConfigService extends Context.Service<ConfigService, Config>()("@opencode/v2/WebSearchConfig") {}
 
-/** Isolates the retained product environment contract from the generic tool implementation. */
-export const defaultConfigLayer = Layer.sync(ConfigService, () =>
-  ConfigService.of({
-    provider:
-      process.env.OPENCODE_WEBSEARCH_PROVIDER === "exa" || process.env.OPENCODE_WEBSEARCH_PROVIDER === "parallel"
-        ? process.env.OPENCODE_WEBSEARCH_PROVIDER
-        : undefined,
-    enableExa: truthy("OPENCODE_EXPERIMENTAL") || truthy("OPENCODE_ENABLE_EXA") || truthy("OPENCODE_EXPERIMENTAL_EXA"),
-    enableParallel: truthy("OPENCODE_ENABLE_PARALLEL") || truthy("OPENCODE_EXPERIMENTAL_PARALLEL"),
-    exaApiKey: process.env.EXA_API_KEY,
-    parallelApiKey: process.env.PARALLEL_API_KEY,
+/**
+ * Isolates the retained product environment contract from the generic tool
+ * implementation. Reads through Effect `Config` when the layer is built, so
+ * tests can override values with a `ConfigProvider` instead of mutating
+ * `process.env`. Parsing keeps the legacy lenient grammar: missing or
+ * malformed values disable rather than fail, because this layer builds at
+ * Location boot where a defect would surface as opaque session failures.
+ */
+export const defaultConfigLayer = Layer.effect(
+  ConfigService,
+  Effect.gen(function* () {
+    const env = yield* Config.all({
+      provider: Config.string("OPENCODE_WEBSEARCH_PROVIDER").pipe(Config.withDefault(undefined)),
+      experimental: truthyConfig("OPENCODE_EXPERIMENTAL"),
+      enableExa: truthyConfig("OPENCODE_ENABLE_EXA"),
+      experimentalExa: truthyConfig("OPENCODE_EXPERIMENTAL_EXA"),
+      enableParallel: truthyConfig("OPENCODE_ENABLE_PARALLEL"),
+      experimentalParallel: truthyConfig("OPENCODE_EXPERIMENTAL_PARALLEL"),
+      exaApiKey: Config.string("EXA_API_KEY").pipe(Config.withDefault(undefined)),
+      parallelApiKey: Config.string("PARALLEL_API_KEY").pipe(Config.withDefault(undefined)),
+    })
+    const provider = env.provider !== undefined && Schema.is(Provider)(env.provider) ? env.provider : undefined
+    if (env.provider !== undefined && provider === undefined)
+      yield* Effect.logWarning("ignoring invalid OPENCODE_WEBSEARCH_PROVIDER", { value: env.provider })
+    return ConfigService.of({
+      provider,
+      enableExa: env.experimental || env.enableExa || env.experimentalExa,
+      enableParallel: env.enableParallel || env.experimentalParallel,
+      exaApiKey: env.exaApiKey,
+      parallelApiKey: env.parallelApiKey,
+    })
   }),
-)
+).pipe(Layer.orDie)
 
 export const configNode = makeLocationNode({ service: ConfigService, layer: defaultConfigLayer, deps: [] })
 

--- a/packages/core/test/database-path.test.ts
+++ b/packages/core/test/database-path.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import { ConfigProvider, Effect, Layer } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { Global } from "@opencode-ai/core/global"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { tmpdir } from "./fixture/tmpdir"
+
+const resolve = (env: Record<string, string>) =>
+  Effect.runPromise(Effect.provide(Database.configuredPath, ConfigProvider.layer(ConfigProvider.fromUnknown(env))))
+
+describe("Database placement", () => {
+  test("resolves explicit files, relative names, and the channel default", async () => {
+    expect(await resolve({ OPENCODE_DB: ":memory:" })).toBe(":memory:")
+    expect(await resolve({ OPENCODE_DB: "/tmp/explicit.db" })).toBe("/tmp/explicit.db")
+    expect(await resolve({ OPENCODE_DB: "relative.db" })).toBe(path.join(Global.Path.data, "relative.db"))
+    expect(await resolve({ OPENCODE_DISABLE_CHANNEL_DB: "true" })).toBe(path.join(Global.Path.data, "opencode.db"))
+  })
+
+  test("reads placement from the active ConfigProvider when the layer is built", async () => {
+    await using tmp = await tmpdir()
+    const file = path.join(tmp.path, "config-seam.sqlite")
+
+    // The preload sets OPENCODE_DB=":memory:" in the process environment, so a
+    // database appearing at this path proves the layer reads through the
+    // replaced ConfigProvider rather than the environment snapshot.
+    await Effect.runPromise(
+      Layer.build(
+        LayerNode.compile(LayerNode.group([Database.node])).pipe(
+          Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown({ OPENCODE_DB: file }))),
+        ),
+      ).pipe(Effect.scoped, Effect.asVoid),
+    )
+
+    expect(await Bun.file(file).exists()).toBe(true)
+  })
+})

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test"
-import { Effect, Layer, Schema } from "effect"
+import { ConfigProvider, Effect, Layer, Schema } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -44,6 +44,57 @@ describe("WebSearchTool provider selection", () => {
 
   test("prefers Exa when only its explicit flag is enabled", () => {
     expect(WebSearchTool.selectProvider(sessionID, { enableExa: true, enableParallel: false })).toBe("exa")
+  })
+})
+
+const readDefaultConfig = (env: Record<string, string>) =>
+  Effect.provide(
+    WebSearchTool.ConfigService,
+    WebSearchTool.defaultConfigLayer.pipe(Layer.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(env)))),
+  )
+
+describe("WebSearchTool default config", () => {
+  test("decodes an empty environment to defaults", async () => {
+    expect(await Effect.runPromise(readDefaultConfig({}))).toEqual({
+      provider: undefined,
+      enableExa: false,
+      enableParallel: false,
+      exaApiKey: undefined,
+      parallelApiKey: undefined,
+    })
+  })
+
+  test("decodes provider, truthy flags, and credentials from the active ConfigProvider", async () => {
+    expect(
+      await Effect.runPromise(
+        readDefaultConfig({
+          OPENCODE_WEBSEARCH_PROVIDER: "parallel",
+          OPENCODE_ENABLE_EXA: "1",
+          OPENCODE_EXPERIMENTAL_PARALLEL: "true",
+          EXA_API_KEY: "exa-key",
+          PARALLEL_API_KEY: "parallel-key",
+        }),
+      ),
+    ).toEqual({
+      provider: "parallel",
+      enableExa: true,
+      enableParallel: true,
+      exaApiKey: "exa-key",
+      parallelApiKey: "parallel-key",
+    })
+  })
+
+  test("keeps the legacy lenient truthiness grammar", async () => {
+    const decoded = await Effect.runPromise(
+      readDefaultConfig({ OPENCODE_ENABLE_EXA: "TRUE", OPENCODE_ENABLE_PARALLEL: "banana" }),
+    )
+    expect(decoded.enableExa).toBe(true)
+    expect(decoded.enableParallel).toBe(false)
+  })
+
+  test("ignores an invalid provider instead of failing the Location layer", async () => {
+    const decoded = await Effect.runPromise(readDefaultConfig({ OPENCODE_WEBSEARCH_PROVIDER: "bing" }))
+    expect(decoded.provider).toBeUndefined()
   })
 })
 

--- a/packages/opencode/src/cli/cmd/db.ts
+++ b/packages/opencode/src/cli/cmd/db.ts
@@ -35,7 +35,7 @@ const QueryCommand = effectCmd({
       }
       return
     }
-    const child = spawn("sqlite3", [Database.path()], {
+    const child = spawn("sqlite3", [yield* Database.configuredPath], {
       stdio: "inherit",
     })
     yield* Effect.promise(() => new Promise((resolve) => child.on("close", resolve)))
@@ -47,7 +47,7 @@ const PathCommand = effectCmd({
   describe: "print the database path",
   instance: false,
   handler: Effect.fn("Cli.db.path")(function* () {
-    console.log(Database.path())
+    console.log(yield* Database.configuredPath)
   }),
 })
 

--- a/packages/opencode/test/fixture/db.ts
+++ b/packages/opencode/test/fixture/db.ts
@@ -1,10 +1,11 @@
 import { rm } from "fs/promises"
 import { Database } from "@opencode-ai/core/database/database"
+import { Effect } from "effect"
 import { disposeAllInstances } from "./fixture"
 
 export async function resetDatabase() {
   await disposeAllInstances().catch(() => undefined)
-  const dbPath = Database.path()
+  const dbPath = await Effect.runPromise(Database.configuredPath)
   await rm(dbPath, { force: true }).catch(() => undefined)
   await rm(`${dbPath}-wal`, { force: true }).catch(() => undefined)
   await rm(`${dbPath}-shm`, { force: true }).catch(() => undefined)

--- a/packages/opencode/test/server/httpapi-exercise/environment.ts
+++ b/packages/opencode/test/server/httpapi-exercise/environment.ts
@@ -18,8 +18,10 @@ const preserveExerciseDatabase = !!process.env.OPENCODE_HTTPAPI_EXERCISE_DB
 export const exerciseDatabasePath =
   process.env.OPENCODE_HTTPAPI_EXERCISE_DB ??
   path.join(process.env.TMPDIR ?? "/tmp", `opencode-httpapi-exercise-${process.pid}.db`)
+// Must run before the first Effect Config read anywhere in the process: the
+// default ConfigProvider snapshots process.env on first use, so a Config read
+// during an earlier module import would freeze the wrong database path.
 process.env.OPENCODE_DB = exerciseDatabasePath
-Flag.OPENCODE_DB = exerciseDatabasePath
 
 export const original = {
   OPENCODE_SERVER_PASSWORD: Flag.OPENCODE_SERVER_PASSWORD,

--- a/packages/sdk-next/src/opencode.ts
+++ b/packages/sdk-next/src/opencode.ts
@@ -4,17 +4,36 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { createEmbeddedRoutes } from "@opencode-ai/server/routes"
-import { Context, Effect, Layer, Scope } from "effect"
+import { ConfigProvider, Context, Effect, Layer, Scope } from "effect"
 import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http"
 
-export const create = Effect.fn("OpenCode.create")(function* () {
+export interface Options {
+  /**
+   * Replaces the ConfigProvider read while this host's process-global layers
+   * are built, for example the OPENCODE_DB database placement. The default
+   * provider snapshots the process environment on first use, so per-host
+   * configuration must come through this seam rather than env mutation.
+   * Location-scoped layers build lazily outside host construction and still
+   * read the process default. Compose with
+   * ConfigProvider.orElse(ConfigProvider.fromEnv()) to keep environment
+   * fallback.
+   */
+  readonly configProvider?: ConfigProvider.ConfigProvider
+}
+
+export const create = Effect.fn("OpenCode.create")(function* (options?: Options) {
   const scope = yield* Scope.Scope
   const memoMap = yield* Layer.makeMemoMap
+  const configLayer = options?.configProvider === undefined ? undefined : ConfigProvider.layer(options.configProvider)
+  const withConfig = <A, E, R>(layer: Layer.Layer<A, E, R>) =>
+    configLayer === undefined ? layer : layer.pipe(Layer.provide(configLayer))
   const sdkPlugins = SdkPlugins.makeStore()
   const context = yield* Layer.buildWithMemoMap(
-    AppNodeBuilder.build(LayerNode.group([PermissionSaved.node, SdkPlugins.node]), [
-      [SdkPlugins.node, SdkPlugins.layerWithStore(sdkPlugins)],
-    ]),
+    withConfig(
+      AppNodeBuilder.build(LayerNode.group([PermissionSaved.node, SdkPlugins.node]), [
+        [SdkPlugins.node, SdkPlugins.layerWithStore(sdkPlugins)],
+      ]),
+    ),
     memoMap,
     scope,
   )
@@ -23,9 +42,11 @@ export const create = Effect.fn("OpenCode.create")(function* () {
   const web = yield* Effect.acquireRelease(
     Effect.sync(() =>
       HttpRouter.toWebHandler(
-        createEmbeddedRoutes(sdkPlugins).pipe(
-          HttpRouter.provideRequest(Layer.succeed(PermissionSaved.Service, permissions)),
-          Layer.provide(HttpServer.layerServices),
+        withConfig(
+          createEmbeddedRoutes(sdkPlugins).pipe(
+            HttpRouter.provideRequest(Layer.succeed(PermissionSaved.Service, permissions)),
+            Layer.provide(HttpServer.layerServices),
+          ),
         ),
         { disableLogger: true, memoMap },
       ),
@@ -56,4 +77,6 @@ export type Interface = Effect.Success<ReturnType<typeof create>>
 
 export class Service extends Context.Service<Service, Interface>()("@opencode-ai/sdk-next/OpenCode") {}
 
-export const layer = Layer.effect(Service, create())
+export const layerWith = (options: Options) => Layer.effect(Service, create(options))
+
+export const layer = layerWith({})

--- a/packages/sdk-next/test/embedded.test.ts
+++ b/packages/sdk-next/test/embedded.test.ts
@@ -1,11 +1,14 @@
 import { expect } from "bun:test"
-import { Flag } from "@opencode-ai/core/flag/flag"
-import { Deferred, Effect, Latch, Layer, Option, Schema, Stream } from "effect"
+import { ConfigProvider, Deferred, Effect, Latch, Layer, Option, Schema, Stream } from "effect"
+import { join } from "node:path"
 import { testEffect } from "../../core/test/lib/effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import type { OpenCodeEvent } from "../src"
 
-Flag.OPENCODE_DB = ":memory:"
+// Database placement resolves through Effect Config when a host's layers are
+// built. The default ConfigProvider snapshots process.env on first use, so
+// this must run before the first Config read in the process.
+process.env.OPENCODE_DB = ":memory:"
 
 const it = testEffect(Layer.empty)
 type Sdk = typeof import("../src")
@@ -203,4 +206,20 @@ it.live("embedded client is available as a Layer service", () =>
       expect(created.id).toBe(id)
     }).pipe(Effect.provide(fixture.sdk.OpenCode.layer))
   }),
+)
+
+it.live("a host ConfigProvider chooses this host's database placement", () =>
+  withEmbedded("opencode-embedded-config-", (fixture) =>
+    Effect.gen(function* () {
+      // The process env pins OPENCODE_DB to ":memory:" above, so a database
+      // materializing at this path proves the host read the provider instead.
+      const file = join(fixture.directory, "seam.sqlite")
+      const opencode = yield* fixture.sdk.OpenCode.create({
+        configProvider: ConfigProvider.fromUnknown({ OPENCODE_DB: file }),
+      })
+      const created = yield* opencode.sessions.create({ location: location(fixture) })
+      expect(created.id).toBeTruthy()
+      expect(yield* Effect.promise(() => Bun.file(file).exists())).toBe(true)
+    }),
+  ),
 )


### PR DESCRIPTION
Consolidates #34846 and #34920 onto `v2` (they were mistakenly opened against `dev`). Moves core runtime config off import-time `process.env` snapshots and onto Effect `Config`, with config ownership distributed to the services that consume it, plus a `ConfigProvider` seam for embedded hosts. `ConfigProvider` becomes the single test seam.

## What changed

**Database** (`packages/core/src/database/database.ts`)
- Placement was baked at module import (`layerFromPath(path())` evaluated on import, reading the `Flag` env snapshot). There is now exactly one public placement value: `Database.configuredPath`, an Effect that resolves `OPENCODE_DB` / `OPENCODE_DISABLE_CHANNEL_DB` through Effect `Config`. The node layer is `Layer.unwrap(Effect.map(configuredPath, layerFromPath))`, built per runtime instead of per import.
- `Database.path()` is **deleted** rather than kept as a V1 compat shim. Its V1 consumers were already Effect-shaped and now yield `configuredPath` directly: `opencode db` / `opencode db path` and the `resetDatabase` test fixture. This removes a real skew surface — previously `path()` read the live environment while the layer read the frozen first-use snapshot, so late env mutation could make `opencode db path` disagree with the running app.

**Flag** (`packages/core/src/flag/flag.ts`)
- One truthiness grammar, two readers: `truthy(name)` reads the environment at call time, `truthyConfig(name)` reads the same grammar through Effect `Config` so layer builds can be steered by a `ConfigProvider`.
- `OPENCODE_DB` is removed from the `Flag` snapshot; database config now lives in the database module.

**WebSearch** (`packages/core/src/tool/websearch.ts`)
- `defaultConfigLayer` decodes one `Config.all({...})` when the layer is built, instead of reading `process.env` at module scope.
- Parsing deliberately keeps the **legacy lenient grammar** via `truthyConfig` (case-insensitive `true`/`1`, missing or malformed → `false`). This layer builds at Location boot, where a strict-decode defect would surface as opaque session failures; `OPENCODE_EXPERIMENTAL=TRUE` keeps meaning enabled. An invalid `OPENCODE_WEBSEARCH_PROVIDER` logs a warning and is ignored, matching old behavior.

**Embedded host seam** (`packages/sdk-next/src/opencode.ts`)
- The default `ConfigProvider.fromEnv()` snapshots the process environment on first use, so runtime env mutation cannot steer later layer builds. `OpenCode.create(options?)` now accepts a `configProvider`, provided to both the application-node build and the embedded routes layer, so per-host config (like database placement) resolves against it. `OpenCode.layerWith(options)` mirrors it for the layer form.
- Scope is documented precisely: the seam covers the host's process-global layer builds; Location-scoped layers build lazily outside host construction and still read the process default. Replacement semantics are deliberate — compose `ConfigProvider.orElse(ConfigProvider.fromEnv())` for env fallback.

**Tests**
- New `packages/core/test/database-path.test.ts`: exercises `configuredPath` through `ConfigProvider.fromUnknown` (`:memory:`, absolute, relative, channel-default) and proves the layer seam — the preload pins `OPENCODE_DB=":memory:"` in the environment, and a provider override wins at layer build.
- `tool-websearch.test.ts`: decoding tests driven entirely by `ConfigProvider.fromUnknown`, including lenient-grammar regressions (`TRUE` enables, `banana` disables, invalid provider ignored).
- `sdk-next/test/embedded.test.ts`: `Flag.OPENCODE_DB = ":memory:"` becomes `process.env.OPENCODE_DB = ":memory:"` (the Flag entry no longer exists; the env read happens at layer build, after module scope). New test proves a host `configProvider` places the database at a per-host path while the process env says `:memory:`.
- `httpapi-exercise/environment.ts`: drops the redundant `Flag.OPENCODE_DB` mutation and documents the must-run-before-first-Config-read ordering contract.

## Design notes

- Deliberately **not** a central `RuntimeConfig`/`Flag` service: config values are inputs owned by their consuming services, read once at layer build. `Flag` shrinks by attrition as remaining keys migrate (`OPENCODE_MODELS_*`, OTLP, etc. are follow-ups).
- Lenient vs strict parsing was reviewed explicitly (three-agent simplify/safety pass): strict `Config.boolean` would have turned 7 previously-tolerated env values (including uppercase `TRUE`) into startup/Location-boot defects. Strictness may be worth revisiting per-variable, but as an explicit decision — not a side effect of the migration.
- `Config.schema(...)` was evaluated and skipped for these call sites: it fits when reusing a domain schema with strict failure semantics, but both call sites need the lenient legacy grammar, and the provider field needs warn-and-ignore, which `Config.option` can't express (it only swallows missing data). Future migrations like `OPENCODE_MODELS_URL` are better candidates.
- Behavior invariant: two env-driven builds in one process always resolve the same database path, because the default provider's env snapshot is cached process-wide. Only an explicit host `ConfigProvider` can differ, which is the feature.
- Considered hoisting V1's `ConfigService` helper (`packages/opencode/src/effect/config-service.ts`) into core; skipped since both call sites have a natural home. Worth revisiting once more config-backed services exist in core (could also unify `ServerAuth.Config` and V1 `RuntimeFlags`).

## Verification (against `v2`)

- `bun typecheck` in `packages/core`, `packages/sdk-next`, `packages/opencode`
- `packages/core` suite: 1101 pass; the 6 failures (watcher timeouts under full-suite load) reproduce identically on clean `origin/v2` locally and pass in isolation
- `packages/sdk-next` embedded suite: 5 pass / 0 fail (includes the new per-host placement test)
- `packages/opencode` `script/httpapi-exercise.ts --mode coverage`: 209 pass / 0 fail (`missing=15` routes without scenarios is pre-existing on `v2`)
- oxlint + Prettier on changed files