### PR TITLE
refactor(core): mechanism-neutral context entry rendering

### DIFF
--- a/packages/core/src/session/context-entry.ts
+++ b/packages/core/src/session/context-entry.ts
@@ -33,22 +33,20 @@ const renderValue = (value: Schema.Json) => (typeof value === "string" ? value :
 const renderBlock = (key: Key, value: Schema.Json) =>
   [`<context key="${key}">`, renderValue(value), "</context>"].join("\n")
 
+// Rendering stays mechanism-neutral: the model sees session context, not how
+// it was attached. Only chronological updates and removals carry narration.
 const source = (entry: Info) =>
   SystemContext.make({
     key: SystemContext.Key.make(`api/${entry.key}`),
     codec: Schema.toCodecJson(Schema.Json),
     load: Effect.succeed(entry.value),
-    baseline: (value) =>
-      [
-        `An API client attached the following context to this session under "${entry.key}":`,
-        renderBlock(entry.key, value),
-      ].join("\n"),
+    baseline: (value) => renderBlock(entry.key, value),
     update: (_previous, value) =>
       [
-        `The attached context "${entry.key}" changed. This value supersedes the previous one:`,
+        `The context under "${entry.key}" changed and supersedes the previous value:`,
         renderBlock(entry.key, value),
       ].join("\n"),
-    removed: () => `The attached context "${entry.key}" was removed. Disregard it.`,
+    removed: () => `The context under "${entry.key}" no longer applies. Disregard it.`,
   })
 
 const layer = Layer.effect(

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1108,14 +1108,7 @@ describe("SessionRunnerLLM", () => {
       // String values render verbatim inside the tagged block at baseline.
       expect(requests[0]?.system.map((part) => part.text)).toEqual([
         defaultSystem,
-        [
-          "Initial context",
-          "",
-          'An API client attached the following context to this session under "deploy-target":',
-          '<context key="deploy-target">',
-          "production",
-          "</context>",
-        ].join("\n"),
+        ["Initial context", "", '<context key="deploy-target">', "production", "</context>"].join("\n"),
       ])
 
       // Non-string JSON pretty-prints; the change narrates as a System update.
@@ -1128,7 +1121,7 @@ describe("SessionRunnerLLM", () => {
         {
           type: "text",
           text: [
-            'The attached context "deploy-target" changed. This value supersedes the previous one:',
+            'The context under "deploy-target" changed and supersedes the previous value:',
             '<context key="deploy-target">',
             "{",
             '  "region": "us-east-1"',
@@ -1146,7 +1139,7 @@ describe("SessionRunnerLLM", () => {
 
       expect(requests[2]?.messages.map((message) => message.role)).toEqual(["user", "system", "user", "system", "user"])
       expect(requests[2]?.messages.at(-2)?.content).toEqual([
-        { type: "text", text: 'The attached context "deploy-target" was removed. Disregard it.' },
+        { type: "text", text: 'The context under "deploy-target" no longer applies. Disregard it.' },
       ])
       expect(yield* contextEntries.list(sessionID)).toEqual([])
     }),


### PR DESCRIPTION
Follow-up to #34941, from review feedback.

The "An API client attached..." preamble leaked the delivery mechanism into the prompt. The model doesn't need to know how context arrived — it just needs the context, and the `<context key="...">` block is already self-describing.

- baseline: bare tagged block, no preamble
- update: `The context under "<key>" changed and supersedes the previous value:` + block
- removed: `The context under "<key>" no longer applies. Disregard it.`

No wire or schema changes; phrasing is server-owned. A human-readable `description` payload field remains an add-later-compatible option if a real need appears.