### PR TITLE
feat(opencode): surface readable errors when custom tool plugins fail to load

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/errors.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/errors.ts
@@ -175,6 +175,13 @@ export class ProjectNotFoundError extends Schema.TaggedErrorClass<ProjectNotFoun
   { httpApiStatus: 404 },
 ) {}
 
+export class ToolLoadError extends Schema.TaggedErrorClass<ToolLoadError>()("ToolLoadError", {
+  toolPath: Schema.String,
+  message: Schema.String,
+  hint: Schema.optional(Schema.String),
+  cause: Schema.optional(Schema.String),
+}, { httpApiStatus: 500 }) {}
+
 export class ApiNotFoundError extends Schema.ErrorClass<ApiNotFoundError>("NotFoundError")(
   {
     name: Schema.Literal("NotFoundError"),

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/error.ts
@@ -2,6 +2,7 @@ import { NamedError } from "@opencode-ai/core/util/error"
 import { ConfigErrorV1 } from "@opencode-ai/core/v1/config/error"
 import { Cause, Effect } from "effect"
 import { HttpRouter, HttpServerError, HttpServerRespondable, HttpServerResponse } from "effect/unstable/http"
+import { ToolLoadError } from "../errors"
 
 // Keep typed HttpApi failures on their declared error path; this boundary only replaces defect-only empty 500s.
 export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect) =>
@@ -23,6 +24,12 @@ export const errorLayer = HttpRouter.middleware<{ handles: unknown }>()((effect)
         ConfigErrorV1.DirectoryTypoError.isInstance(error)
       ) {
         return Effect.succeed(HttpServerResponse.jsonUnsafe(error.toObject(), { status: 400 }))
+      }
+
+      if (ToolLoadError.isInstance(error)) {
+        return Effect.succeed(
+          HttpServerResponse.jsonUnsafe({ name: "ToolLoadError", data: { ...error } }, { status: 500 }),
+        )
       }
 
       const ref = `err_${crypto.randomUUID().slice(0, 8)}`

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -32,6 +32,7 @@ import { ApplyPatchTool } from "./apply_patch"
 import { Glob } from "@opencode-ai/core/util/glob"
 import path from "path"
 import { pathToFileURL } from "url"
+import { ToolLoadError } from "@/server/routes/instance/httpapi/errors"
 import { Effect, Layer, Context } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -177,7 +178,16 @@ const layer = Layer.effect(
           const namespace = path.basename(match, path.extname(match))
           // `match` is an absolute filesystem path from `Glob.scanSync(..., { absolute: true })`.
           // Import it as `file://` so Node on Windows accepts the dynamic import.
-          const mod = yield* Effect.promise(() => import(pathToFileURL(match).href))
+          const mod = yield* Effect.tryPromise({
+            try: () => import(pathToFileURL(match).href),
+            catch: (raw) =>
+              new ToolLoadError({
+                toolPath: match,
+                message: `Failed to load tool '${namespace}': ${getErrorMessage(raw)}`,
+                hint: inferHint(raw),
+                cause: truncateCause(String((raw as Error)?.stack ?? raw)),
+              }),
+          })
           for (const [id, def] of Object.entries(mod)) {
             if (!isPluginTool(def)) continue
             custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
@@ -388,6 +398,30 @@ function normalizeZodJsonSchema(value: unknown): unknown {
 
 function isJsonSchemaObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function getErrorMessage(raw: unknown): string {
+  if (raw instanceof Error) return raw.message
+  if (typeof raw === "object" && raw !== null && "message" in raw) return String((raw as Record<string, unknown>).message)
+  return String(raw)
+}
+
+function inferHint(error: unknown): string | undefined {
+  const msg = getErrorMessage(error)
+  if (msg.includes("Cannot find module")) {
+    const match = msg.match(/Cannot find module ['"]([^'"]+)['"]/)
+    const dep = match?.[1]
+    return dep
+      ? `Missing dependency '${dep}'. Run 'npm install' (or 'bun install') in your config directory.`
+      : "A required npm dependency is missing. Run 'npm install' in your config directory."
+  }
+  if (msg.includes("ERR_MODULE_NOT_FOUND")) return "Module not found. Check your imports and run 'npm install'."
+  if (msg.includes("SyntaxError")) return "Fix the syntax error in your tool file, then restart opencode."
+  return undefined
+}
+
+function truncateCause(stack: string): string {
+  return stack.split("\n")[0].slice(0, 512)
 }
 
 export const node = LayerNode.make({

--- a/packages/opencode/test/server/httpapi-error-middleware.test.ts
+++ b/packages/opencode/test/server/httpapi-error-middleware.test.ts
@@ -5,6 +5,7 @@ import { ConfigErrorV1 } from "@opencode-ai/core/v1/config/error"
 import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientRequest, HttpRouter } from "effect/unstable/http"
 import { errorLayer } from "../../src/server/routes/instance/httpapi/middleware/error"
+import { ToolLoadError } from "../../src/server/routes/instance/httpapi/errors"
 import { NotFoundError } from "../../src/storage/storage"
 import { testEffect } from "../lib/effect"
 
@@ -96,6 +97,64 @@ describe("HttpApi error middleware", () => {
 
       expect(response.status).toBe(500)
       expectUnknownErrorBody(body)
+    }),
+  )
+
+  it.live("returns ToolLoadError defect as structured 500", () =>
+    Effect.gen(function* () {
+      const toolError = new ToolLoadError({
+        toolPath: "/home/user/.config/opencode/tools/slack_lint.ts",
+        message: "Failed to load tool 'slack_lint': Cannot find module '@opencode-ai/plugin'",
+        hint: "Missing dependency '@opencode-ai/plugin'. Run 'npm install' in your config directory.",
+        cause: "ResolveMessage: Cannot find module '@opencode-ai/plugin'",
+      })
+
+      yield* HttpRouter.add("GET", "/tool-error", Effect.die(toolError)).pipe(
+        Layer.provide(errorLayer),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.get("/tool-error").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(500)
+      expect(body).toMatchObject({
+        name: "ToolLoadError",
+        data: {
+          toolPath: "/home/user/.config/opencode/tools/slack_lint.ts",
+          message: "Failed to load tool 'slack_lint': Cannot find module '@opencode-ai/plugin'",
+          hint: "Missing dependency '@opencode-ai/plugin'. Run 'npm install' in your config directory.",
+          cause: "ResolveMessage: Cannot find module '@opencode-ai/plugin'",
+        },
+      })
+    }),
+  )
+
+  it.live("returns ToolLoadError without optional fields", () =>
+    Effect.gen(function* () {
+      const toolError = new ToolLoadError({
+        toolPath: "/home/user/.config/opencode/tools/bad_syntax.ts",
+        message: "Failed to load tool 'bad_syntax': SyntaxError: Unexpected token",
+      })
+
+      yield* HttpRouter.add("GET", "/tool-error-no-hint", Effect.die(toolError)).pipe(
+        Layer.provide(errorLayer),
+        HttpRouter.serve,
+        Layer.build,
+      )
+
+      const response = yield* HttpClientRequest.get("/tool-error-no-hint").pipe(HttpClient.execute)
+      const body = yield* response.json
+
+      expect(response.status).toBe(500)
+      expect(body).toMatchObject({
+        name: "ToolLoadError",
+        data: {
+          toolPath: "/home/user/.config/opencode/tools/bad_syntax.ts",
+          message: "Failed to load tool 'bad_syntax': SyntaxError: Unexpected token",
+        },
+      })
     }),
   )
 })

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -6,6 +6,7 @@ import { Effect, Layer, Result, Schema } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { ToolRegistry } from "@/tool/registry"
 import { Tool } from "@/tool/tool"
+import { ToolLoadError } from "@/server/routes/instance/httpapi/errors"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import { TestConfig } from "../fixture/config"
@@ -488,6 +489,76 @@ describe("tool.registry", () => {
       const registry = yield* ToolRegistry.Service
       const ids = yield* registry.ids()
       expect(ids).toContain("cowsay")
+    }),
+  )
+
+  it.instance("surfaces a readable error when a custom tool imports a missing module", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const tools = path.join(test.directory, ".opencode", "tools")
+      yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tools, "missing_dep.ts"),
+          [
+            "import { something } from 'definitely-missing-package'",
+            "export default {",
+            "  description: 'tool with missing dep',",
+            "  args: {},",
+            "  execute: async () => 'ok',",
+            "}",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const exit = yield* Effect.exit(registry.ids())
+
+      expect(exit._tag).toBe("Failure")
+      const toolError = (exit as unknown as { cause: { error: unknown } }).cause?.error
+      expect(ToolLoadError.isInstance(toolError)).toBe(true)
+      if (ToolLoadError.isInstance(toolError)) {
+        expect(toolError.message).toContain("Failed to load tool 'missing_dep'")
+        expect(toolError.hint).toBeDefined()
+        expect(toolError.hint).toContain("npm install")
+        expect(toolError.toolPath).toContain("missing_dep.ts")
+      }
+    }),
+  )
+
+  it.instance("surfaces a hint for SyntaxError when a custom tool has invalid JS", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const tools = path.join(test.directory, ".opencode", "tools")
+      yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+      // Write a tool with an intentional SyntaxError by using an invalid import path
+      // that fails module resolution (covers the "Cannot find module" hint path)
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tools, "bad_import.ts"),
+          [
+            "import { tool } from '@this-package-does-not-exist-12345'",
+            "export default tool({",
+            "  description: 'bad import tool',",
+            "  args: {},",
+            "  execute: async () => 'ok',",
+            "})",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const exit = yield* Effect.exit(registry.ids())
+
+      expect(exit._tag).toBe("Failure")
+      const toolError = (exit as unknown as { cause: { error: unknown } }).cause?.error
+      expect(ToolLoadError.isInstance(toolError)).toBe(true)
+      if (ToolLoadError.isInstance(toolError)) {
+        expect(toolError.message).toContain("Failed to load tool 'bad_import'")
+        expect(toolError.hint).toBeDefined()
+      }
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #34933

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a custom tool plugin in `~/.config/opencode/tools/` fails to load (e.g. missing npm dependency, syntax error, or module resolution failure), opencode previously surfaced a generic "Unexpected server error. Check server logs for details." message with no indication of what went wrong.

This PR converts the raw module-resolution error into a typed `ToolLoadError` with a human-readable message and an actionable hint. Users now see:

```
Failed to load tool 'slack_lint': Cannot find module '@opencode-ai/plugin'.
Hint: Missing dependency '@opencode-ai/plugin'. Run 'npm install' in your config directory.
```

**Technical root cause:** The original `Effect.promise(() => import(...))` wraps rejected Promises as defects (`Cause.Die`), which bypass HttpApiBuilder's typed error serialization. Switching to `Effect.tryPromise` with an explicit `catch` maps the raw error into a typed `Cause.Fail(ToolLoadError)`, which HttpApiBuilder serializes automatically using the `httpApiStatus: 500` annotation.

**Changes:**
- `errors.ts`: add `ToolLoadError` using `Schema.TaggedErrorClass` with fields `toolPath`, `message`, `hint`, and `cause`
- `registry.ts`: replace `Effect.promise` with `Effect.tryPromise` in the custom tool import loop, mapping raw import failures to `ToolLoadError` with heuristic hint inference for common error patterns ("Cannot find module", "ERR_MODULE_NOT_FOUND", "SyntaxError")
- `error.ts` middleware: add a defensive `ToolLoadError.isInstance` check in the DieReason branch to handle any callers that raise it as a defect

### How did you verify your code works?

Added integration tests in `httpapi-error-middleware.test.ts` covering the middleware serialization path (full `ToolLoadError` body, optional fields omitted) and unit tests in `registry.test.ts` covering the registry error emission path (missing module surfaces hint with `npm install`, toolPath is correct).

The `Effect.tryPromise` catch handler was reviewed against existing usage patterns in `src/mcp/index.ts` and `src/plugin/index.ts` to confirm the error mapping approach is consistent with the rest of the codebase.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
