### PR TITLE
fix(opencode): turn.idle only when active and ctrl are undefined

### DIFF
--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -248,17 +248,19 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
         return
       } finally {
         draining = undefined
-        emit(
-          {
-            type: "turn.idle",
-            queue: state.queue.length,
-          },
-          {
-            phase: "idle",
-            status: "",
-            queue: state.queue.length,
-          },
-        )
+        if (state.active === undefined && state.ctrl === undefined) {
+          emit(
+            {
+              type: "turn.idle",
+              queue: state.queue.length,
+            },
+            {
+              phase: "idle",
+              status: "",
+              queue: state.queue.length,
+            },
+          )
+        }
       }
 
       finish()

--- a/packages/opencode/test/cli/run/runtime.queue.test.ts
+++ b/packages/opencode/test/cli/run/runtime.queue.test.ts
@@ -478,4 +478,68 @@ describe("run runtime queue", () => {
     ui.submit("one")
     await expect(task).rejects.toThrow("boom")
   })
+  
+  test("emits turn.idle only when session is truly idle", async () => {
+      const ui = footer()
+      let runCalls = 0
+      let wake: (() => void) | undefined
+      const gate = new Promise<void>((resolve) => {
+        wake = resolve
+      })
+  
+      const task = runPromptQueue({
+        footer: ui.api,
+        run: async (input) => {
+          runCalls = 1
+          if (runCalls === 1) {
+            await gate
+          }
+          ui.api.close()
+        },
+      })
+  
+      ui.submit("one")
+      await Promise.resolve()
+      ui.submit("two")
+      await Promise.resolve()
+      
+      const idleEventsBefore = ui.events.filter((event) => event.type === "turn.idle")
+      expect(idleEventsBefore.length).toBe(0)
+      
+      wake?.()
+      await task
+      
+      const idleEventsAfter = ui.events.filter((event) => event.type === "turn.idle")
+      expect(idleEventsAfter.length).toBe(1)
+    })
+  
+    test("does not emit turn.idle when active prompt is running", async () => {
+      const ui = footer()
+      let runCompleted = false
+      let wake: (() => void) | undefined
+      const gate = new Promise<void>((resolve) => {
+        wake = resolve
+      })
+  
+      const task = runPromptQueue({
+        footer: ui.api,
+        run: async () => {
+          await gate
+          runCompleted = true
+          ui.api.close()
+        },
+      })
+  
+      ui.submit("active")
+      await Promise.resolve()
+      
+      const idleEvents = ui.events.filter((event) => event.type === "turn.idle")
+      expect(idleEvents.length).toBe(0)
+      
+      wake?.()
+      await task
+      
+      const idleEventsAfter = ui.events.filter((event) => event.type === "turn.idle")
+      expect(idleEventsAfter.length).toBe(1)
+    })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #26063
I think that closes also #33028 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
<img width="348" height="341" alt="immagine" src="https://github.com/user-attachments/assets/e33388c0-8ae3-4b42-b075-77c10b0f70c2" />


As you can see in this screen I didn't "interrupted" but is happening automatically.

Users experience intermittent "Tool execution aborted" errors with stack=undefined. The error occurs during tool execution, particularly with file editing or command execution.
Various tests with a session with the issue I was able to check that this fix worked. 
In my case a session also resumed asking to edit a file there was this error, but clearly in this way there aren't any subagent or stuff in queue.
I tried with removing the opencode.db file and restarting opencode but using the same session there was again that error. Happens with native tools or plugin tools.

There was various hints that the issue it wasn't the model or provider but the time taking to get the tool from LLM and timeouts but at the end it was an edge cases on checking when the main agent doest' have anything in queue but the tool execution it was stopped without generating any stacktrace.

### How did you verify your code works?

I tested with the same session that wasn't working.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
