### PR TITLE
fix(app): show readable plugin labels

### DIFF
--- a/packages/app/src/components/status-popover-body.test.ts
+++ b/packages/app/src/components/status-popover-body.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { formatPluginName } from "./status-popover-plugin"
+
+describe("formatPluginName", () => {
+  test("keeps registry plugin specs unchanged", () => {
+    expect(formatPluginName("opencode-gemini-auth")).toBe("opencode-gemini-auth")
+    expect(formatPluginName("opencode-foo@1.2.3")).toBe("opencode-foo@1.2.3")
+  })
+
+  test("uses the package name for local package specs", () => {
+    expect(formatPluginName("opencode-usage-audit@file:/Users/alice/plugins/usage-audit")).toBe("opencode-usage-audit")
+    expect(formatPluginName("@scope/usage-audit@file:../plugins/usage-audit")).toBe("@scope/usage-audit")
+  })
+
+  test("uses the file name for local plugin paths", () => {
+    expect(formatPluginName("./plugin/usage-audit.ts")).toBe("usage-audit")
+    expect(formatPluginName("file:///Users/alice/plugin/usage-audit.js")).toBe("usage-audit")
+    expect(formatPluginName("C:\\Users\\alice\\plugin\\usage-audit.ts")).toBe("usage-audit")
+  })
+
+  test("uses the parent directory for local index plugin paths", () => {
+    expect(formatPluginName("./plugin/usage-audit/index.ts")).toBe("usage-audit")
+    expect(formatPluginName("file:///Users/alice/plugin/usage-audit/index.js")).toBe("usage-audit")
+  })
+})

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -16,6 +16,7 @@ import { type ServerHealth } from "@/utils/server-health"
 import { useGlobal } from "@/context/global"
 import { useSettings } from "@/context/settings"
 import { useMcpToggle } from "@/context/mcp"
+import { formatPluginName } from "./status-popover-plugin"
 
 const pluginEmptyMessage = (value: string, file: string): JSXElement => {
   const parts = value.split(file)
@@ -285,7 +286,7 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
   const lspItems = createMemo(() => sync().data.lsp ?? [])
   const lspCount = createMemo(() => lspItems().length)
   const plugins = createMemo(() =>
-    (sync().data.config.plugin ?? []).map((item) => (typeof item === "string" ? item : item[0])),
+    (sync().data.config.plugin ?? []).map((item) => formatPluginName(typeof item === "string" ? item : item[0])),
   )
   const pluginCount = createMemo(() => plugins().length)
   const pluginEmpty = createMemo(() => pluginEmptyMessage(language.t("dialog.plugins.empty"), "opencode.json"))

--- a/packages/app/src/components/status-popover-plugin.ts
+++ b/packages/app/src/components/status-popover-plugin.ts
@@ -1,0 +1,17 @@
+export const formatPluginName = (value: string) => {
+  if (!/^(file:|file:\/\/|\.{1,2}\/|\/|~\/|[A-Za-z]:[\\/])/.test(value)) {
+    const localPackage = value.match(/^(.*)@(file|link|workspace):/)
+    return localPackage?.[1] || value
+  }
+
+  const parts = value
+    .replace(/^file:\/\//, "")
+    .replace(/^file:/, "")
+    .split(/[\\/]/)
+    .filter(Boolean)
+  const name = parts.at(-1)?.replace(/\.[cm]?[jt]sx?$/, "")
+
+  if (!name) return value
+  if (name === "index" && parts.length > 1) return parts.at(-2) ?? value
+  return name
+}


### PR DESCRIPTION
### Issue for this PR

Closes #34953

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Formats plugin labels before rendering them in the status popover.

Local plugins loaded from file URLs now show a readable basename without the extension. Package plugin names are unchanged.

### How did you verify your code works?

- Ran the targeted status popover test in `packages/app`
- Ran `bun typecheck` in `packages/app`
- Ran `bun turbo typecheck` through the pre-push hook

### Screenshots / recordings

Not attached because the broken state exposes a local filesystem path.

Before: `file:///Users/me/.config/opencode/plugin/usage-audit.ts`

After: `usage-audit`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR