### PR TITLE
fix(session): preserve raw running tool state

### DIFF
--- a/packages/opencode/src/cli/cmd/export.ts
+++ b/packages/opencode/src/cli/cmd/export.ts
@@ -104,6 +104,7 @@ function part(part: SessionV1.Part): SessionV1.Part {
               ? {
                   ...part.state,
                   input: data("tool-input", part.id, part.state.input) ?? part.state.input,
+                  raw: part.state.raw === undefined ? undefined : redact("tool-raw", part.id, part.state.raw),
                   title: part.state.title === undefined ? undefined : redact("tool-title", part.id, part.state.title),
                   metadata: data("tool-state-metadata", part.id, part.state.metadata),
                 }
@@ -117,9 +118,11 @@ function part(part: SessionV1.Part): SessionV1.Part {
                     attachments: part.state.attachments?.map(filepart),
                   }
                 : {
-                    ...part.state,
+                    status: "error",
                     input: data("tool-input", part.id, part.state.input) ?? part.state.input,
+                    error: part.state.error,
                     metadata: data("tool-state-metadata", part.id, part.state.metadata),
+                    time: part.state.time,
                   },
       }
     case "patch":
@@ -160,7 +163,7 @@ function part(part: SessionV1.Part): SessionV1.Part {
 
 const partFn = part
 
-function sanitize(data: { info: Session.Info; messages: SessionV1.WithParts[] }) {
+export function sanitize(data: { info: Session.Info; messages: SessionV1.WithParts[] }) {
   return {
     info: {
       ...data.info,

--- a/packages/opencode/src/cli/cmd/run/subagent-data.ts
+++ b/packages/opencode/src/cli/cmd/run/subagent-data.ts
@@ -209,6 +209,7 @@ function compactToolState(part: ToolPart): ToolPart["state"] {
       status: "running",
       input: part.state.input,
       time: part.state.time,
+      ...(part.state.raw !== undefined ? { raw: part.state.raw } : {}),
       ...(part.state.metadata ? { metadata: part.state.metadata } : {}),
       ...(part.state.title ? { title: part.state.title } : {}),
     }

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -319,6 +319,16 @@ const layer = Layer.effect(
 
           case "tool-input-delta":
             yield* ensureToolCall(value)
+            yield* updateToolCall(value.id, (match) => {
+              if (match.state.status !== "pending" && match.state.status !== "running") return match
+              return {
+                ...match,
+                state: {
+                  ...match.state,
+                  raw: (match.state.raw ?? "") + value.text,
+                },
+              }
+            })
             return
 
           case "tool-input-end": {
@@ -332,21 +342,30 @@ const layer = Layer.effect(
             }
             yield* ensureToolCall(value)
             const input = isRecord(value.input) ? value.input : { value: value.input }
-            yield* updateToolCall(value.id, (match) => ({
-              ...match,
-              tool: value.name,
-              state:
-                match.state.status === "running"
-                  ? { ...match.state, input }
-                  : {
-                      status: "running",
-                      input,
-                      time: { start: Date.now() },
-                    },
-              metadata: match.metadata?.providerExecuted
-                ? { ...value.providerMetadata, providerExecuted: true }
-                : value.providerMetadata,
-            }))
+            yield* updateToolCall(value.id, (match) => {
+              if (match.state.status !== "pending" && match.state.status !== "running") return match
+              const start = match.state.status === "running" ? match.state.time.start : Date.now()
+              const raw = match.state.raw
+              return {
+                ...match,
+                tool: value.name,
+                state: {
+                  status: "running",
+                  input,
+                  raw,
+                  time: { start },
+                  ...(match.state.status === "running" && match.state.title !== undefined
+                    ? { title: match.state.title }
+                    : {}),
+                  ...(match.state.status === "running" && match.state.metadata !== undefined
+                    ? { metadata: match.state.metadata }
+                    : {}),
+                },
+                metadata: match.metadata?.providerExecuted
+                  ? { ...value.providerMetadata, providerExecuted: true }
+                  : value.providerMetadata,
+              }
+            })
 
             const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
               Effect.provideService(Database.Service, database),
@@ -581,8 +600,8 @@ const layer = Layer.effect(
           yield* session.updatePart({
             ...part,
             state: {
-              ...part.state,
               status: "error",
+              input: part.state.input,
               error: "Tool execution aborted",
               metadata: { ...metadata, interrupted: true },
               time: { start: "time" in part.state ? part.state.time.start : end, end },

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -63,15 +63,19 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     messages: input.messages,
     metadata: (val) =>
       input.processor.updateToolCall(options.toolCallId, (match) => {
-        if (!["running", "pending"].includes(match.state.status)) return match
+        if (match.state.status !== "pending" && match.state.status !== "running") return match
+        const start = match.state.status === "running" ? match.state.time.start : Date.now()
+        const title = val.title ?? (match.state.status === "running" ? match.state.title : undefined)
+        const metadata = val.metadata ?? (match.state.status === "running" ? match.state.metadata : undefined)
         return {
           ...match,
           state: {
-            title: val.title,
-            metadata: val.metadata,
             status: "running",
             input: args,
-            time: { start: Date.now() },
+            raw: match.state.raw,
+            time: { start },
+            ...(title !== undefined ? { title } : {}),
+            ...(metadata !== undefined ? { metadata } : {}),
           },
         }
       }),

--- a/packages/opencode/test/cli/export.test.ts
+++ b/packages/opencode/test/cli/export.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test"
+import { sanitize } from "../../src/cli/cmd/export"
+
+test("sanitize redacts running tool raw input", () => {
+  const data = {
+    info: {
+      id: "ses_test",
+      title: "Safe title",
+      directory: "C:\\repo",
+      time: { created: 1, updated: 1 },
+    },
+    messages: [
+      {
+        info: {
+          id: "msg_test",
+          sessionID: "ses_test",
+          role: "assistant",
+          agent: "build",
+          mode: "build",
+          path: { cwd: "C:\\repo", root: "C:\\repo" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 }, total: 0 },
+          modelID: "test-model",
+          providerID: "test",
+          time: { created: 1 },
+        },
+        parts: [
+          {
+            id: "part_running",
+            messageID: "msg_test",
+            sessionID: "ses_test",
+            type: "tool",
+            tool: "bash",
+            callID: "call_test",
+            state: {
+              status: "running",
+              input: { command: "Write-Output secret-value" },
+              raw: '{"command":"Write-Output secret-value"}',
+              metadata: { output: "secret-value" },
+              time: { start: 1 },
+            },
+          },
+        ],
+      },
+    ],
+  } as unknown as Parameters<typeof sanitize>[0]
+
+  const result = sanitize(data)
+  const part = result.messages[0]?.parts[0]
+  expect(part?.type).toBe("tool")
+  if (part?.type !== "tool") return
+  expect(part.state.status).toBe("running")
+  if (part.state.status !== "running") return
+  expect(part.state.raw).toBe("[redacted:tool-raw:part_running]")
+  expect(JSON.stringify(result)).not.toContain("secret-value")
+})
+
+test("sanitize drops unexpected error tool raw input", () => {
+  const data = {
+    info: {
+      id: "ses_test",
+      title: "Safe title",
+      directory: "C:\\repo",
+      time: { created: 1, updated: 1 },
+    },
+    messages: [
+      {
+        info: {
+          id: "msg_test",
+          sessionID: "ses_test",
+          role: "assistant",
+          agent: "build",
+          mode: "build",
+          path: { cwd: "C:\\repo", root: "C:\\repo" },
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 }, total: 0 },
+          modelID: "test-model",
+          providerID: "test",
+          time: { created: 1 },
+        },
+        parts: [
+          {
+            id: "part_error",
+            messageID: "msg_test",
+            sessionID: "ses_test",
+            type: "tool",
+            tool: "bash",
+            callID: "call_test",
+            state: {
+              status: "error",
+              input: {},
+              error: "Tool execution aborted",
+              raw: '{"command":"Write-Output raw-secret"}',
+              metadata: { interrupted: true },
+              time: { start: 1, end: 2 },
+            },
+          },
+        ],
+      },
+    ],
+  } as unknown as Parameters<typeof sanitize>[0]
+
+  const result = sanitize(data)
+  const part = result.messages[0]?.parts[0]
+  expect(part?.type).toBe("tool")
+  if (part?.type !== "tool") return
+  expect(part.state.status).toBe("error")
+  if (part.state.status !== "error") return
+  expect("raw" in part.state).toBe(false)
+  expect(JSON.stringify(result)).not.toContain("raw-secret")
+})

--- a/packages/opencode/test/cli/run/subagent-data.test.ts
+++ b/packages/opencode/test/cli/run/subagent-data.test.ts
@@ -417,6 +417,87 @@ describe("run subagent data", () => {
     expect(snapshot.questions).toEqual([])
   })
 
+  test("compacts child tool raw according to tool state", () => {
+    const data = createSubagentData()
+
+    bootstrapSubagentData({
+      data,
+      messages: [taskMessage("child-1", "running")],
+      children: [{ id: "child-1" }],
+      permissions: [],
+      questions: [],
+    })
+
+    const runningRaw = '{"command":"git status --short"}'
+    reduce(data, {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "tool-running",
+          messageID: "msg-assistant-1",
+          sessionID: "child-1",
+          type: "tool",
+          callID: "call-running",
+          tool: "bash",
+          state: {
+            status: "running",
+            input: {
+              command: "git status --short",
+            },
+            raw: runningRaw,
+            time: { start: 1 },
+          },
+        },
+      },
+    })
+
+    const running = snapshotSubagentData(data).details["child-1"]?.commits.find(
+      (commit) => commit.partID === "tool-running",
+    )
+    expect(running?.part?.state.status).toBe("running")
+    if (running?.part?.state.status === "running") {
+      expect(running.part.state.raw).toBe(runningRaw)
+    }
+
+    const errorData = createSubagentData()
+    bootstrapSubagentData({
+      data: errorData,
+      messages: [taskMessage("child-2", "running")],
+      children: [{ id: "child-2" }],
+      permissions: [],
+      questions: [],
+    })
+
+    reduce(errorData, {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "tool-error",
+          messageID: "msg-assistant-2",
+          sessionID: "child-2",
+          type: "tool",
+          callID: "call-error",
+          tool: "bash",
+          state: {
+            status: "error",
+            input: {},
+            error: "Tool execution aborted",
+            raw: '{"command":"Write-Output compact-secret"}',
+            time: { start: 1, end: 2 },
+          },
+        },
+      },
+    })
+
+    const errorCommits = snapshotSubagentData(errorData).details["child-2"]?.commits ?? []
+    const error = errorCommits.find((commit) => commit.partID === "tool-error" && commit.toolState === "error")
+    expect(error?.part?.state.status).toBe("error")
+    if (error?.part?.state.status === "error") {
+      expect("raw" in error.part.state).toBe(false)
+    }
+    expect(JSON.stringify(errorCommits)).not.toContain("compact-secret")
+  })
+
   test("replays bootstrapped child session messages into inspector commits", () => {
     const data = createSubagentData()
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -103,9 +103,22 @@ function defer<T>() {
   return { promise, resolve }
 }
 
+function chatChunk(input: { delta?: Record<string, unknown>; finish?: string }) {
+  return {
+    id: "chatcmpl-test",
+    object: "chat.completion.chunk",
+    choices: [
+      {
+        delta: input.delta ?? {},
+        ...(input.finish ? { finish_reason: input.finish } : {}),
+      },
+    ],
+  }
+}
+
 const waitFor = <A>(check: Effect.Effect<A | undefined>, message: string) =>
   Effect.gen(function* () {
-    const stop = Date.now() + 500
+    const stop = Date.now() + 5_000
     while (Date.now() < stop) {
       const value = yield* check
       if (value !== undefined) return value
@@ -366,6 +379,219 @@ it.live("session.processor effect tests preserve text start time", () =>
         expect(text?.time?.end).toBeDefined()
         if (!text?.time?.start || !text.time.end) return
         expect(text.time.start).toBeLessThan(text.time.end)
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor preserves raw tool input across input deltas", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const database = yield* Database.Service
+        const { processors, session, provider } = yield* boot()
+        const input = {
+          command: "Write-Output pipeline-one",
+          description: "PowerShell pipeline raw state",
+          timeout: 30_000,
+          workdir: dir,
+        }
+        const rawInput = JSON.stringify(input)
+        const split = Math.floor(rawInput.length / 2)
+        const release = defer<void>()
+
+        yield* llm.push(
+          raw({
+            chunks: [
+              chatChunk({ delta: { role: "assistant" } }),
+              chatChunk({
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: "call_raw",
+                      type: "function",
+                      function: { name: "bash", arguments: "" },
+                    },
+                  ],
+                },
+              }),
+              chatChunk({
+                delta: {
+                  tool_calls: [{ index: 0, function: { arguments: rawInput.slice(0, split) } }],
+                },
+              }),
+              chatChunk({
+                delta: {
+                  tool_calls: [{ index: 0, function: { arguments: rawInput.slice(split) } }],
+                },
+              }),
+              chatChunk({ finish: "tool_calls" }),
+            ],
+          }),
+        )
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "hi")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const run = yield* handle
+          .process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+            } satisfies SessionV1.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "hi" }],
+            tools: {
+              bash: tool({
+                description: "Run shell command",
+                inputSchema: z.object({
+                  command: z.string(),
+                  description: z.string(),
+                  timeout: z.number(),
+                  workdir: z.string(),
+                }),
+                execute: async () => {
+                  await release.promise
+                  return { title: "bash", output: "done", metadata: {} }
+                },
+              }),
+            },
+          })
+          .pipe(Effect.forkChild)
+
+        const toolPart = yield* waitFor(
+          MessageV2.parts(msg.id).pipe(
+            Effect.map((parts) =>
+              parts.find(
+                (part): part is SessionV1.ToolPart =>
+                  part.type === "tool" && part.tool === "bash" && part.state.status === "running",
+              ),
+            ),
+            Effect.provideService(Database.Service, database),
+          ),
+          "timed out waiting for running raw tool state",
+        )
+        expect(toolPart.state.status).toBe("running")
+        if (toolPart.state.status !== "running") return
+        expect(toolPart.state.input).toEqual(input)
+        expect(toolPart.state.raw).toBe(rawInput)
+        expect(toolPart.state.time.start).toBeGreaterThan(0)
+
+        release.resolve()
+        const exit = yield* Fiber.await(run)
+        expect(Exit.isSuccess(exit)).toBe(true)
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor drops raw tool input when a running tool aborts on cleanup", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const database = yield* Database.Service
+        const { processors, session, provider } = yield* boot()
+        const input = {
+          command: "Write-Output before-abort",
+          description: "PowerShell pipeline raw state",
+          timeout: 30_000,
+          workdir: dir,
+        }
+        const rawInput = JSON.stringify(input)
+        const release = defer<void>()
+
+        yield* llm.tool("bash", input)
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "abort running raw tool")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const run = yield* handle
+          .process({
+            user: {
+              id: parent.id,
+              sessionID: chat.id,
+              role: "user",
+              time: parent.time,
+              agent: parent.agent,
+              model: { providerID: ref.providerID, modelID: ref.modelID },
+            } satisfies SessionV1.User,
+            sessionID: chat.id,
+            model: mdl,
+            agent: agent(),
+            system: [],
+            messages: [{ role: "user", content: "abort running raw tool" }],
+            tools: {
+              bash: tool({
+                description: "Run shell command",
+                inputSchema: z.object({
+                  command: z.string(),
+                  description: z.string(),
+                  timeout: z.number(),
+                  workdir: z.string(),
+                }),
+                execute: async () => {
+                  await release.promise
+                  return { title: "bash", output: "done", metadata: {} }
+                },
+              }),
+            },
+          })
+          .pipe(Effect.forkChild)
+
+        const running = yield* waitFor(
+          MessageV2.parts(msg.id).pipe(
+            Effect.map((parts) =>
+              parts.find(
+                (part): part is SessionV1.ToolPart =>
+                  part.type === "tool" && part.tool === "bash" && part.state.status === "running",
+              ),
+            ),
+            Effect.provideService(Database.Service, database),
+          ),
+          "timed out waiting for running raw tool state",
+        )
+        expect(running.state.status).toBe("running")
+        if (running.state.status !== "running") return
+        expect(running.state.raw).toBe(rawInput)
+
+        yield* Fiber.interrupt(run)
+        const exit = yield* Fiber.await(run)
+        release.resolve()
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
+        }
+
+        const parts = yield* MessageV2.parts(msg.id)
+        const call = parts.find((part): part is SessionV1.ToolPart => part.type === "tool" && part.tool === "bash")
+        expect(call?.state.status).toBe("error")
+        if (call?.state.status === "error") {
+          expect(call.state.error).toBe("Tool execution aborted")
+          expect("raw" in call.state).toBe(false)
+          expect(call.state.metadata?.interrupted).toBe(true)
+        }
       }),
     { config: (url) => providerCfg(url) },
   ),
@@ -826,6 +1052,7 @@ it.live("session.processor effect tests mark pending tools as aborted on cleanup
         expect(call?.state.status).toBe("error")
         if (call?.state.status === "error") {
           expect(call.state.error).toBe("Tool execution aborted")
+          expect("raw" in call.state).toBe(false)
           expect(call.state.metadata?.interrupted).toBe(true)
           expect(call.state.time.end).toBeDefined()
         }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -50,7 +50,7 @@ import { Truncate } from "@/tool/truncate"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { Format } from "../../src/format"
-import { TestInstance } from "../fixture/fixture"
+import { provideTmpdirServer, TestInstance } from "../fixture/fixture"
 import { awaitWithTimeout, pollWithTimeout, testEffect } from "../lib/effect"
 import { reply, TestLLMServer } from "../lib/llm-server"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -255,6 +255,13 @@ const withMcpInstructions = testEffect(
 )
 const unix = process.platform !== "win32" ? it.instance : it.instance.skip
 const unixNoLLMServer = process.platform !== "win32" ? noLLMServer.instance : noLLMServer.instance.skip
+const win = process.platform === "win32" ? it.live : it.live.skip
+
+function powershell() {
+  const shell = Bun.which("powershell") ?? Bun.which("pwsh")
+  if (!shell) throw new Error("pwsh or powershell is required for PowerShell shell-tool tests")
+  return shell
+}
 
 // Config that registers a custom "test" provider with a "test-model" model
 // so provider model lookup succeeds inside the loop.
@@ -1664,6 +1671,109 @@ unixNoLLMServer(
       }),
     ),
   { config: cfg },
+  30_000,
+)
+
+win(
+  "loop preserves raw tool input while shell tool runs a PowerShell pipeline",
+  () =>
+    provideTmpdirServer(
+      ({ dir, llm }) =>
+        Effect.gen(function* () {
+          const prompt = yield* SessionPrompt.Service
+          const sessions = yield* Session.Service
+          const chat = yield* sessions.create({
+            title: "PowerShell pipeline raw state",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          })
+          yield* prompt.prompt({
+            sessionID: chat.id,
+            agent: "build",
+            noReply: true,
+            parts: [{ type: "text", text: "run powershell pipeline" }],
+          })
+
+          const outDir = path.join(dir, "pipeline-output").replaceAll("'", "''")
+          const releaseFile = path.join(dir, "release-pipeline.txt")
+          const releasePath = releaseFile.replaceAll("'", "''")
+          const command = [
+            `New-Item -ItemType Directory -Path '${outDir}' -Force | Out-Null`,
+            "Write-Output pipeline-one",
+            `while (-not (Test-Path -LiteralPath '${releasePath}')) { Start-Sleep -Milliseconds 100 }`,
+            "Write-Output pipeline-two",
+          ].join("; ")
+          const toolInput = {
+            command,
+            description: "PowerShell pipeline raw state",
+            timeout: 30_000,
+            workdir: dir,
+          }
+          const rawInput = JSON.stringify(toolInput)
+          yield* llm.tool("bash", toolInput)
+          yield* llm.text("done")
+
+          const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+
+          let firstStart: number | undefined
+          const observed = yield* Effect.exit(
+            pollWithTimeout(
+              Effect.gen(function* () {
+                const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+                const tool = msgs
+                  .flatMap((msg) => msg.parts)
+                  .findLast((part): part is SessionV1.ToolPart => part.type === "tool" && part.tool === "bash")
+                if (tool?.state.status === "running") {
+                  expect(tool.state.raw).toBe(rawInput)
+                  const output = String(tool.state.metadata?.output ?? "")
+                  if (output.includes("pipeline-one")) {
+                    firstStart = tool.state.time.start
+                    return true
+                  }
+                }
+                if (tool?.state.status === "completed") {
+                  throw new Error("tool completed before observing running PowerShell pipeline output")
+                }
+                if (tool?.state.status === "error") {
+                  throw new Error(tool.state.error)
+                }
+              }),
+              "timed out waiting for running PowerShell pipeline output",
+              20_000,
+            ),
+          )
+
+          yield* Effect.promise(() => Bun.write(releaseFile, "go"))
+          const exit = yield* Fiber.await(fiber)
+          if (Exit.isFailure(observed)) {
+            return yield* Effect.failCause(observed.cause)
+          }
+          expect(Exit.isSuccess(exit)).toBe(true)
+          if (Exit.isFailure(exit)) return
+
+          const msgs = yield* MessageV2.filterCompactedEffect(chat.id)
+          const tool = msgs
+            .flatMap((msg) => msg.parts)
+            .findLast(
+              (part): part is CompletedToolPart =>
+                part.type === "tool" && part.tool === "bash" && part.state.status === "completed",
+            )
+          expect(tool).toBeDefined()
+          if (!tool) return
+          expect(firstStart).toBeDefined()
+          if (firstStart === undefined) return
+          expect(tool.state.output).toContain("pipeline-one")
+          expect(tool.state.output).toContain("pipeline-two")
+          expect(tool.state.time.start).toBe(firstStart)
+          expect(tool.state.time.end - tool.state.time.start).toBeLessThan(30_000)
+        }),
+      {
+        git: true,
+        config: (url) => ({
+          ...providerCfg(url),
+          shell: powershell(),
+        }),
+      },
+    ),
   30_000,
 )
 

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -266,6 +266,7 @@ export type ToolStatePending = Types.DeepMutable<Schema.Schema.Type<typeof ToolS
 export const ToolStateRunning = Schema.Struct({
   status: Schema.Literal("running"),
   input: Schema.Record(Schema.String, Schema.Any),
+  raw: Schema.optional(Schema.String),
   title: Schema.optional(Schema.String),
   metadata: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
   time: Schema.Struct({

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -247,6 +247,7 @@ export type ToolStateRunning = {
   input: {
     [key: string]: unknown
   }
+  raw?: string
   title?: string
   metadata?: {
     [key: string]: unknown

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -487,6 +487,7 @@ export type ToolStateRunning = {
   input: {
     [key: string]: unknown
   }
+  raw?: string
   title?: string
   metadata?: {
     [key: string]: unknown

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -16722,6 +16722,9 @@
           "input": {
             "type": "object"
           },
+          "raw": {
+            "type": "string"
+          },
           "title": {
             "type": "string"
           },


### PR DESCRIPTION
### Issue for this PR

Fixes #34960.

Related context, but not marked as closing: #29822, #24731, #21489, #27871.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This preserves `raw` tool input while a legacy v1 tool part is still pending/running.

The bug I hit was observed with OpenCode v1.14.28 on Windows PowerShell. My local Mavis wrapper/log observer is not part of OpenCode, but its logs showed the failure shape as a terminal state mismatch: `lastStatus=running` while terminal `status=completed`, followed about 30 minutes later by `session.finish reason=stale`.

Relevant local Mavis log anchors:

- line 151: `[stream-stall] progress ignored without armed state`
- line 190: `lastStatus=running` with `status=completed`
- lines 729-736: `session.finish reason=stale`, `idleMs=1800408`

The local trigger shape was:

```powershell
New-Item -ItemType Directory -Path $env:TEMP\opencode-pipeline-repro -Force | Out-Null
Get-ChildItem $env:TEMP\opencode-pipeline-repro
```

On current `dev`, I reproduced the relevant OpenCode-side state loss with a focused regression test. A clean `origin/dev` worktree at `f52424e05f`, with only the regression test applied, failed because the running tool state had `raw === undefined` while the PowerShell pipeline was still running.

This PR:

- accumulates `tool-input-delta` text into pending/running `raw`
- preserves `raw`, `time.start`, `title`, and `metadata` across pending -> running and running metadata updates
- adds optional `raw?: string` to legacy v1 `ToolStateRunning`
- updates OpenAPI/generated SDK types for that optional field
- redacts running `raw` in sanitized session export
- drops unexpected error-state `raw`
- keeps running `raw` in subagent compaction, while keeping error compaction clean

Generated artifacts were regenerated/checked with:

- `bun dev generate > ../sdk/openapi.json` in `packages/opencode`
- `bun ./packages/sdk/js/script/build.ts` at repo root

The generated SDK/OpenAPI content diff is limited to optional `raw` on `ToolStateRunning`.

### How did you verify your code works?

Environment: Windows. Initial focused verification used Bun `1.3.13`. Before pushing, I upgraded local Bun to `1.3.14` to satisfy the repository pre-push hook (`packageManager: bun@1.3.14`); the hook then ran root `bun typecheck` successfully.

PowerShell regression prefers `powershell.exe`, falling back to `pwsh` only if Windows PowerShell is unavailable. On this machine `powershell` resolves to `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`, `$PSVersionTable.PSVersion` = `5.1.26100.8737`.

Passing locally:

- `bun run typecheck` in `packages/opencode`
- `bun run typecheck` in `packages/sdk/js`
- `bun run typecheck` in `packages/schema`
- root `bun typecheck` via the pre-push hook after upgrading to Bun `1.3.14`
- `bun test test/session/processor-effect.test.ts test/cli/export.test.ts test/cli/run/subagent-data.test.ts --timeout 30000` in `packages/opencode`
  - `25 pass`, `0 fail`, `112 expect() calls`
- `bun test test/session/prompt.test.ts --timeout 30000` in `packages/opencode`
  - `44 pass`, `14 skip`, `0 fail`, `186 expect() calls`
- `git diff --check`

Full-suite note:

- Earlier local Windows `bun test --timeout 30000` in `packages/opencode` exceeded the 604 second command timeout before producing a complete result.
- I am treating that full-suite Windows timeout as unrelated to this PR.
- I am not claiming it as fixed by this PR, not claiming it as a pass, and not using it as evidence for this raw running-tool-state change.

### Screenshots / recordings

N/A; this is a session state handling fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
