### PR TITLE
feat(opencode): inject file in markdown agents

### DIFF
--- a/packages/opencode/src/config/agent.ts
+++ b/packages/opencode/src/config/agent.ts
@@ -7,6 +7,7 @@ import { ConfigAgentV1 } from "@opencode-ai/core/v1/config/agent"
 import { configEntryNameFromPath } from "./entry-name"
 import * as ConfigMarkdown from "./markdown"
 import { ConfigParse } from "./parse"
+import { ConfigVariable } from "./variable"
 
 export async function load(dir: string) {
   const result: Record<string, ConfigAgentV1.Info> = {}
@@ -20,11 +21,16 @@ export async function load(dir: string) {
     if (!md) continue
 
     const name = configEntryNameFromPath(path.relative(dir, item), ["agent/", "agents/"])
+    const prompt = await ConfigVariable.substitute({
+      type: "path",
+      path: item,
+      text: md.content.trim() || String(md.data.prompt ?? ""),
+    })
 
     const config = {
       name,
       ...md.data,
-      prompt: md.content.trim(),
+      prompt,
     }
     result[config.name] = ConfigParse.schema(ConfigAgentV1.Info, config, item)
   }
@@ -42,10 +48,15 @@ export async function loadMode(dir: string) {
     const md = await ConfigMarkdown.parse(item).catch(() => undefined)
     if (!md) continue
 
+    const prompt = await ConfigVariable.substitute({
+      type: "path",
+      path: item,
+      text: md.content.trim() || String(md.data.prompt ?? ""),
+    })
     const config = {
       name: configEntryNameFromPath(path.relative(dir, item), ["mode/", "modes/"]),
       ...md.data,
-      prompt: md.content.trim(),
+      prompt,
     }
     const parsed = Schema.decodeUnknownExit(ConfigAgentV1.Info)(config, { errors: "all", propertyOrder: "original" })
     if (Exit.isSuccess(parsed)) {

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -824,6 +824,41 @@ Nested agent prompt`,
   }),
 )
 
+it.instance("substitutes {file:} tokens in markdown agent body", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, ".opencode", "agents", "python-coder.md"),
+      `---
+mode: subagent
+---
+{file:./skill.txt}`,
+    )
+    yield* FSUtil.use.writeWithDirs(path.join(test.directory, ".opencode", "agents", "skill.txt"), "Loaded from file")
+
+    const config = yield* Config.use.get()
+    expect(config.agent?.["python-coder"]?.prompt).toBe("Loaded from file")
+  }),
+)
+
+it.instance("falls back to frontmatter prompt when body is empty and substitutes {file:} tokens", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* FSUtil.use.writeWithDirs(
+      path.join(test.directory, ".opencode", "agents", "python-coder.md"),
+      `---
+mode: subagent
+prompt: "{file:./skill.txt}"
+---
+`,
+    )
+    yield* FSUtil.use.writeWithDirs(path.join(test.directory, ".opencode", "agents", "skill.txt"), "Frontmatter prompt")
+
+    const config = yield* Config.use.get()
+    expect(config.agent?.["python-coder"]?.prompt).toBe("Frontmatter prompt")
+  }),
+)
+
 it.instance("loads commands from .opencode/command (singular)", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Adresses relevant to #26434
Folks already talking about this
- anomalyco/opencode#26489
- anomalyco/opencode#5092

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- resolve `{file:...}` and `{env:...}` templates for markdown-backed agent prompts using the same substitution path as JSON config
- honor markdown agent body first, but fall back to frontmatter `prompt` when the body is empty
- keep behavior aligned with the earlier frontmatter/env work while fixing the remaining body/template gap

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
- `bun test test/config/config.test.ts` in `packages/opencode`
- `bun typecheck` in `packages/opencode`
- push hook also ran `bun turbo typecheck`

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
