### PR TITLE
feat(V2): add parentID query option to session list endpoint

### DIFF
--- a/packages/client/src/generated-effect/client.ts
+++ b/packages/client/src/generated-effect/client.ts
@@ -45,6 +45,7 @@ type Endpoint4_0Input = {
   readonly limit?: Endpoint4_0Request["query"]["limit"]
   readonly order?: Endpoint4_0Request["query"]["order"]
   readonly search?: Endpoint4_0Request["query"]["search"]
+  readonly parentID?: Endpoint4_0Request["query"]["parentID"]
   readonly directory?: Endpoint4_0Request["query"]["directory"]
   readonly project?: Endpoint4_0Request["query"]["project"]
   readonly subpath?: Endpoint4_0Request["query"]["subpath"]
@@ -57,6 +58,7 @@ const Endpoint4_0 = (raw: RawClient["server.session"]) => (input?: Endpoint4_0In
       limit: input?.["limit"],
       order: input?.["order"],
       search: input?.["search"],
+      parentID: input?.["parentID"],
       directory: input?.["directory"],
       project: input?.["project"],
       subpath: input?.["subpath"],

--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -349,6 +349,7 @@ export function make(options: ClientOptions) {
               limit: input?.["limit"],
               order: input?.["order"],
               search: input?.["search"],
+              parentID: input?.["parentID"],
               directory: input?.["directory"],
               project: input?.["project"],
               subpath: input?.["subpath"],

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -190,6 +190,7 @@ export type SessionListInput = {
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined
@@ -200,6 +201,7 @@ export type SessionListInput = {
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined
@@ -210,6 +212,7 @@ export type SessionListInput = {
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined
@@ -220,16 +223,29 @@ export type SessionListInput = {
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined
     readonly cursor?: string | undefined
   }["search"]
+  readonly parentID?: {
+    readonly workspace?: string | undefined
+    readonly limit?: number | undefined
+    readonly order?: "asc" | "desc" | undefined
+    readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
+    readonly directory?: string | undefined
+    readonly project?: string | undefined
+    readonly subpath?: string | undefined
+    readonly cursor?: string | undefined
+  }["parentID"]
   readonly directory?: {
     readonly workspace?: string | undefined
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined
@@ -240,6 +256,7 @@ export type SessionListInput = {
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined
@@ -250,6 +267,7 @@ export type SessionListInput = {
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined
@@ -260,6 +278,7 @@ export type SessionListInput = {
     readonly limit?: number | undefined
     readonly order?: "asc" | "desc" | undefined
     readonly search?: string | undefined
+    readonly parentID?: string | null | undefined
     readonly directory?: string | undefined
     readonly project?: string | undefined
     readonly subpath?: string | undefined

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -3,7 +3,7 @@ export * from "./session/schema"
 
 import { DateTime, Effect, Layer, Schema, Context, Stream, Scope } from "effect"
 import { ListAnchor } from "@opencode-ai/schema/session"
-import { and, asc, desc, eq, gt, like, lt, or, type SQL } from "drizzle-orm"
+import { and, asc, desc, eq, gt, isNull, like, lt, or, type SQL } from "drizzle-orm"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
 import { ModelV2 } from "./model"
@@ -61,6 +61,7 @@ const ListInputBase = {
   limit: PositiveInt.pipe(Schema.optional),
   order: Schema.Literals(["asc", "desc"]).pipe(Schema.optional),
   anchor: ListAnchor.pipe(Schema.optional),
+  parentID: Schema.Union([SessionSchema.ID, Schema.Null]).pipe(Schema.optional),
 }
 
 const ListDirectoryInput = Schema.Struct({
@@ -331,12 +332,19 @@ const layer = Layer.effect(
         const direction = input.anchor?.direction ?? "next"
         const requestedOrder = input.order ?? "desc"
         const order = direction === "previous" ? (requestedOrder === "asc" ? "desc" : "asc") : requestedOrder
-        const sortColumn = SessionTable.time_created
+        const sortColumn = SessionTable.time_updated
         const conditions: SQL[] = []
         if ("directory" in input) conditions.push(eq(SessionTable.directory, input.directory))
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
         if ("project" in input) conditions.push(eq(SessionTable.project_id, input.project))
         if (input.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
+        if ("parentID" in input) {
+          if (input.parentID === null) {
+            conditions.push(isNull(SessionTable.parent_id))
+          } else if (input.parentID !== undefined) {
+            conditions.push(eq(SessionTable.parent_id, input.parentID))
+          }
+        }
         if (input.anchor) {
           conditions.push(
             order === "asc"

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -124,6 +124,42 @@ describe("SessionV2.create", () => {
     }),
   )
 
+  it.effect("filters roots by updated recency before applying the page limit", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionV2.Service
+      const { db } = yield* Database.Service
+      const staleRoot = yield* session.create({ location, title: "stale root" })
+      const root = yield* session.create({ location, title: "root" })
+      const children = yield* Effect.forEach(Array.from({ length: 60 }), (_, index) =>
+        session.create({ parentID: root.id, title: `child ${index}` }),
+      )
+
+      yield* Effect.forEach(children, (item, index) =>
+        db
+          .update(SessionTable)
+          .set({ time_created: index + 100, time_updated: index + 20_000 })
+          .where(eq(SessionTable.id, item.id))
+          .run(),
+      )
+      yield* db
+        .update(SessionTable)
+        .set({ time_created: 2, time_updated: 5_000 })
+        .where(eq(SessionTable.id, staleRoot.id))
+        .run()
+      yield* db
+        .update(SessionTable)
+        .set({ time_created: 1, time_updated: 10_000 })
+        .where(eq(SessionTable.id, root.id))
+        .run()
+
+      const page = yield* session.list({ directory: location.directory, parentID: null, limit: 1, order: "desc" })
+
+      expect(page.map((item) => item.id)).toEqual([root.id])
+      const childrenPage = yield* session.list({ parentID: root.id })
+      expect(childrenPage.every((item) => item.parentID === root.id)).toBe(true)
+    }),
+  )
+
   it.effect("forks a session by replaying a durable fork event into copied projected rows", () =>
     Effect.gen(function* () {
       const session = yield* SessionV2.Service

--- a/packages/plugin/src/v2/effect/generated/api.ts
+++ b/packages/plugin/src/v2/effect/generated/api.ts
@@ -47,6 +47,7 @@ export type Endpoint4_0Input = {
   readonly limit?: Endpoint4_0Request["query"]["limit"]
   readonly order?: Endpoint4_0Request["query"]["order"]
   readonly search?: Endpoint4_0Request["query"]["search"]
+  readonly parentID?: Endpoint4_0Request["query"]["parentID"]
   readonly directory?: Endpoint4_0Request["query"]["directory"]
   readonly project?: Endpoint4_0Request["query"]["project"]
   readonly subpath?: Endpoint4_0Request["query"]["subpath"]

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -6,7 +6,7 @@ import { SessionContextEntry } from "@opencode-ai/schema/session-context-entry"
 import { Project } from "@opencode-ai/schema/project"
 import { AbsolutePath, NonNegativeInt, PositiveInt, RelativePath, statics } from "@opencode-ai/schema/schema"
 import { Workspace } from "@opencode-ai/schema/workspace"
-import { Context, Effect, Encoding, Result, Schema, Struct } from "effect"
+import { Context, Effect, Encoding, Result, Schema, SchemaGetter, Struct } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import {
   ConflictError,
@@ -34,6 +34,19 @@ const SessionsQueryFields = {
     description: "Session order for the first page. Use desc for newest first or asc for oldest first.",
   }),
   search: Schema.optional(Schema.String),
+  parentID: Schema.Union([
+    Session.ID,
+    Schema.Literal("null").pipe(
+      Schema.decodeTo(Schema.Null, {
+        decode: SchemaGetter.transform(() => null),
+        encode: SchemaGetter.transform(() => "null"),
+      }),
+    ),
+  ])
+    .pipe(Schema.optional)
+    .annotate({
+      description: "Filter by parent session. Use null to return only root sessions.",
+    }),
 }
 
 const SessionsDirectoryQuery = Schema.Struct({

--- a/packages/sdk/js/script/build.ts
+++ b/packages/sdk/js/script/build.ts
@@ -82,7 +82,14 @@ const historyTypesPatched = generatedTypes.replace(
 if (historyTypesPatched === generatedTypes) {
   throw new Error("Session history numeric query patch did not apply")
 }
-await Bun.write("./src/v2/gen/types.gen.ts", historyTypesPatched)
+const sessionListParentTypesPatched = historyTypesPatched.replace(
+  /(export type V2SessionListData = \{[\s\S]*?parentID\?: )string \| ["']null["']/,
+  "$1string | null",
+)
+if (sessionListParentTypesPatched === historyTypesPatched) {
+  throw new Error("Session list parentID type patch did not apply")
+}
+await Bun.write("./src/v2/gen/types.gen.ts", sessionListParentTypesPatched)
 
 const generatedSdk = await Bun.file("./src/v2/gen/sdk.gen.ts").text()
 const historySdkPatched = generatedSdk.replace(
@@ -92,7 +99,28 @@ const historySdkPatched = generatedSdk.replace(
 if (historySdkPatched === generatedSdk) {
   throw new Error("Session history numeric SDK patch did not apply")
 }
-await Bun.write("./src/v2/gen/sdk.gen.ts", historySdkPatched)
+const sessionListParentSdkTypePatched = historySdkPatched.replace(
+  /(Retrieve sessions in the requested order[\s\S]*?parentID\?: )string \| ["']null["']/,
+  "$1string | null",
+)
+if (sessionListParentSdkTypePatched === historySdkPatched) {
+  throw new Error("Session list parentID SDK type patch did not apply")
+}
+const sessionListStart = sessionListParentSdkTypePatched.indexOf("Retrieve sessions in the requested order")
+const sessionListParamsStart = sessionListParentSdkTypePatched.indexOf(
+  "const params = buildClientParams([parameters], [{ args: [",
+  sessionListStart,
+)
+if (sessionListStart === -1 || sessionListParamsStart === -1) {
+  throw new Error("Session list parentID SDK encoding patch did not apply")
+}
+const sessionListParentSdkPatched =
+  sessionListParentSdkTypePatched.slice(0, sessionListParamsStart) +
+  'const params = buildClientParams([{ ...parameters, parentID: parameters?.parentID === null ? "null" : parameters?.parentID }], [{ args: [' +
+  sessionListParentSdkTypePatched.slice(
+    sessionListParamsStart + "const params = buildClientParams([parameters], [{ args: [".length,
+  )
+await Bun.write("./src/v2/gen/sdk.gen.ts", sessionListParentSdkPatched)
 
 // Patch a @hey-api/openapi-ts codegen bug: SseFn incorrectly passes the
 // endpoint's TError into the second generic of ServerSentEventsResult, which

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -181,6 +181,7 @@ import type {
   SessionChildrenResponses,
   SessionCommandErrors,
   SessionCommandResponses,
+  SessionContextEntryKey,
   SessionCreateErrors,
   SessionCreateResponses,
   SessionDeleteErrors,
@@ -351,6 +352,12 @@ import type {
   V2SessionBackgroundResponses,
   V2SessionCompactErrors,
   V2SessionCompactResponses,
+  V2SessionContextEntryListErrors,
+  V2SessionContextEntryListResponses,
+  V2SessionContextEntryPutErrors,
+  V2SessionContextEntryPutResponses,
+  V2SessionContextEntryRemoveErrors,
+  V2SessionContextEntryRemoveResponses,
   V2SessionContextErrors,
   V2SessionContextResponses,
   V2SessionCreateErrors,
@@ -5224,6 +5231,113 @@ export class Revert extends HeyApiClient {
   }
 }
 
+export class Entry extends HeyApiClient {
+  /**
+   * List context entries
+   *
+   * List API-managed context entries attached to the session's system context.
+   */
+  public list<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams([parameters], [{ args: [{ in: "path", key: "sessionID" }] }])
+    return (options?.client ?? this.client).get<
+      V2SessionContextEntryListResponses,
+      V2SessionContextEntryListErrors,
+      ThrowOnError
+    >({
+      url: "/api/session/{sessionID}/context-entry",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Remove context entry
+   *
+   * Remove one context entry; the removal is announced to the model at the next turn boundary.
+   */
+  public remove<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      key: SessionContextEntryKey
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "key" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<
+      V2SessionContextEntryRemoveResponses,
+      V2SessionContextEntryRemoveErrors,
+      ThrowOnError
+    >({
+      url: "/api/session/{sessionID}/context-entry/{key}",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Put context entry
+   *
+   * Attach or replace one durable context entry. The value is rendered into the session's system context; changes announce as updates at the next turn boundary.
+   */
+  public put<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      key: SessionContextEntryKey
+      value?: unknown
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "path", key: "key" },
+            { in: "body", key: "value" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).put<
+      V2SessionContextEntryPutResponses,
+      V2SessionContextEntryPutErrors,
+      ThrowOnError
+    >({
+      url: "/api/session/{sessionID}/context-entry/{key}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+}
+
+export class Context extends HeyApiClient {
+  private _entry?: Entry
+  get entry(): Entry {
+    return (this._entry ??= new Entry({ client: this.client }))
+  }
+}
+
 export class Permission2 extends HeyApiClient {
   /**
    * List session permission requests
@@ -5491,6 +5605,7 @@ export class Session3 extends HeyApiClient {
       limit?: number
       order?: "asc" | "desc"
       search?: string
+      parentID?: string | null
       directory?: string
       project?: string
       subpath?: string
@@ -5499,7 +5614,7 @@ export class Session3 extends HeyApiClient {
     options?: Options<never, ThrowOnError>,
   ) {
     const params = buildClientParams(
-      [parameters],
+      [{ ...parameters, parentID: parameters?.parentID === null ? "null" : parameters?.parentID }],
       [
         {
           args: [
@@ -5507,6 +5622,7 @@ export class Session3 extends HeyApiClient {
             { in: "query", key: "limit" },
             { in: "query", key: "order" },
             { in: "query", key: "search" },
+            { in: "query", key: "parentID" },
             { in: "query", key: "directory" },
             { in: "query", key: "project" },
             { in: "query", key: "subpath" },
@@ -6087,6 +6203,11 @@ export class Session3 extends HeyApiClient {
   private _revert?: Revert
   get revert(): Revert {
     return (this._revert ??= new Revert({ client: this.client }))
+  }
+
+  private _context?: Context
+  get context2(): Context {
+    return (this._context ??= new Context({ client: this.client }))
   }
 
   private _permission?: Permission2

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -4427,6 +4427,13 @@ export type SessionMessage =
   | SessionMessageAssistant
   | SessionMessageCompaction
 
+export type SessionContextEntryKey = string
+
+export type SessionContextEntryInfo = {
+  key: SessionContextEntryKey
+  value: unknown
+}
+
 export type SessionNextAgentSwitched = {
   id: string
   metadata?: {
@@ -11972,6 +11979,10 @@ export type V2SessionListData = {
     limit?: number
     order?: "asc" | "desc"
     search?: string
+    /**
+     * Filter by parent session. Use null to return only root sessions.
+     */
+    parentID?: string | null
     directory?: string
     project?: string
     subpath?: string
@@ -12643,6 +12654,121 @@ export type V2SessionContextResponses = {
 }
 
 export type V2SessionContextResponse = V2SessionContextResponses[keyof V2SessionContextResponses]
+
+export type V2SessionContextEntryListData = {
+  body?: never
+  path: {
+    sessionID: string
+  }
+  query?: never
+  url: "/api/session/{sessionID}/context-entry"
+}
+
+export type V2SessionContextEntryListErrors = {
+  /**
+   * InvalidRequestError
+   */
+  400: InvalidRequestError
+  /**
+   * UnauthorizedError
+   */
+  401: UnauthorizedError
+  /**
+   * SessionNotFoundError
+   */
+  404: SessionNotFoundError
+}
+
+export type V2SessionContextEntryListError = V2SessionContextEntryListErrors[keyof V2SessionContextEntryListErrors]
+
+export type V2SessionContextEntryListResponses = {
+  /**
+   * Success
+   */
+  200: {
+    data: Array<SessionContextEntryInfo>
+  }
+}
+
+export type V2SessionContextEntryListResponse =
+  V2SessionContextEntryListResponses[keyof V2SessionContextEntryListResponses]
+
+export type V2SessionContextEntryRemoveData = {
+  body?: never
+  path: {
+    sessionID: string
+    key: SessionContextEntryKey
+  }
+  query?: never
+  url: "/api/session/{sessionID}/context-entry/{key}"
+}
+
+export type V2SessionContextEntryRemoveErrors = {
+  /**
+   * InvalidRequestError
+   */
+  400: InvalidRequestError
+  /**
+   * UnauthorizedError
+   */
+  401: UnauthorizedError
+  /**
+   * SessionNotFoundError
+   */
+  404: SessionNotFoundError
+}
+
+export type V2SessionContextEntryRemoveError =
+  V2SessionContextEntryRemoveErrors[keyof V2SessionContextEntryRemoveErrors]
+
+export type V2SessionContextEntryRemoveResponses = {
+  /**
+   * <No Content>
+   */
+  204: void
+}
+
+export type V2SessionContextEntryRemoveResponse =
+  V2SessionContextEntryRemoveResponses[keyof V2SessionContextEntryRemoveResponses]
+
+export type V2SessionContextEntryPutData = {
+  body: {
+    value: unknown
+  }
+  path: {
+    sessionID: string
+    key: SessionContextEntryKey
+  }
+  query?: never
+  url: "/api/session/{sessionID}/context-entry/{key}"
+}
+
+export type V2SessionContextEntryPutErrors = {
+  /**
+   * InvalidRequestError
+   */
+  400: InvalidRequestError
+  /**
+   * UnauthorizedError
+   */
+  401: UnauthorizedError
+  /**
+   * SessionNotFoundError
+   */
+  404: SessionNotFoundError
+}
+
+export type V2SessionContextEntryPutError = V2SessionContextEntryPutErrors[keyof V2SessionContextEntryPutErrors]
+
+export type V2SessionContextEntryPutResponses = {
+  /**
+   * <No Content>
+   */
+  204: void
+}
+
+export type V2SessionContextEntryPutResponse =
+  V2SessionContextEntryPutResponses[keyof V2SessionContextEntryPutResponses]
 
 export type V2SessionHistoryData = {
   body?: never

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -48,7 +48,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
                     ...query,
                     anchor: {
                       id: first.id,
-                      time: DateTime.toEpochMillis(first.time.created),
+                      time: DateTime.toEpochMillis(first.time.updated),
                       direction: "previous",
                     },
                   })
@@ -58,7 +58,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
                     ...query,
                     anchor: {
                       id: last.id,
-                      time: DateTime.toEpochMillis(last.time.created),
+                      time: DateTime.toEpochMillis(last.time.updated),
                       direction: "next",
                     },
                   })

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -523,23 +523,33 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
 
   let continued = false
   createEffect(() => {
-    // When using -c, session list is loaded in blocking phase, so we can navigate at "partial"
     if (continued || sync.status === "loading" || !args.continue) return
-    const match = data.session.list().find((session) => !session.parentID)?.id
-    if (match) {
-      continued = true
-      if (args.fork) {
-        void sdk.client.session.fork({ sessionID: match }).then((result) => {
-          if (result.data?.id) {
-            route.navigate({ type: "session", sessionID: result.data.id })
-          } else {
-            toast.show({ message: "Failed to fork session", variant: "error" })
-          }
-        })
-      } else {
+    continued = true
+    const location = data.location.default()
+    void sdk.api.session
+      .list({
+        limit: 1,
+        order: "desc",
+        parentID: null,
+        directory: location.directory,
+        workspace: location.workspaceID,
+      })
+      .then((response) => {
+        const match = response.data[0]?.id
+        if (!match) return
+        if (args.fork) {
+          void sdk.client.session.fork({ sessionID: match }).then((result) => {
+            if (result.data?.id) {
+              route.navigate({ type: "session", sessionID: result.data.id })
+            } else {
+              toast.show({ message: "Failed to fork session", variant: "error" })
+            }
+          })
+          return
+        }
         route.navigate({ type: "session", sessionID: match })
-      }
-    }
+      })
+      .catch(toast.error)
   })
 
   // Handle --session with --fork: wait for sync to be fully complete before forking

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -36,6 +36,7 @@ export function DialogSessionList() {
       search: query,
       limit: 50,
       order: "desc",
+      parentID: null,
       directory: location.directory,
       workspace: location.workspaceID,
     })
@@ -64,11 +65,7 @@ export function DialogSessionList() {
 
   const options = createMemo(() => {
     const today = new Date().toDateString()
-    const sessionMap = new Map(
-      sessions()
-        .filter((session) => !session.parentID)
-        .map((session) => [session.id, session]),
-    )
+    const sessionMap = new Map(sessions().map((session) => [session.id, session]))
     const pinned = local.session.pinned().filter((sessionID) => sessionMap.has(sessionID))
     const pinnedSet = new Set(pinned)
     const slotByID = new Map(local.session.slots().map((sessionID, index) => [sessionID, index + 1]))
@@ -82,17 +79,16 @@ export function DialogSessionList() {
         value: session.id,
         category,
         footer,
-        gutter:
-          data.session.family(session.id).some((id) => data.session.status(id) === "running")
-            ? () => <Spinner />
-            : slot === undefined
-              ? undefined
-              : () => <text fg={theme.accent}>{slot}</text>,
+        gutter: data.session.family(session.id).some((id) => data.session.status(id) === "running")
+          ? () => <Spinner />
+          : slot === undefined
+            ? undefined
+            : () => <text fg={theme.accent}>{slot}</text>,
       }
     }
 
     const remaining = sessions()
-      .filter((session) => !session.parentID && !pinnedSet.has(session.id))
+      .filter((session) => !pinnedSet.has(session.id))
       .map((session) => {
         const date = new Date(session.time.updated).toDateString()
         return option(session, date === today ? "Today" : date)


### PR DESCRIPTION
### Issue for this PR

Closes #34936

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Implements `parentID?: SessionID | null` on the V2 session list endpoint.

Semantics:
- **Omitted `parentID`:** returns all matching sessions, preserving existing behavior.
- **`parentID: null`:** filters in the database with `parent_id IS NULL` before pagination/limit, so root-session callers do not need to over-fetching and filter client-side.
- **`parentID: SessionID`:** filters in the database with `parent_id = SessionID`, allowing callers to list direct child sessions.

This PR also:
- Updates pagination anchors to use `time.updated`, matching the `SessionTable.time_updated` sort column.
- Updates TUI root-session callers, including `--continue` and the session picker search path, to request `parentID: null`.
- Regenerates client and SDK surfaces so callers can pass `parentID?: SessionID | null`.
- Updates the JS SDK generation patch so SDK users can pass `parentID: null`, while HTTP requests encode it as `?parentID=null`.

_Note: The large file count (27 files) is due to running the SDK generator (`./script/generate.ts`) which automatically rebuilt client types, schema types, and SDK definitions across the monorepo to encompass the new query field._

### How did you verify your code works?

- Added regression coverage proving recent child sessions do not hide root sessions when `parentID: null` and a small `limit` are used.
- Added coverage for direct-child listing with `parentID: SessionID`.
- Ran `bun test test/session-create.test.ts` from `packages/core`.
- Ran `bun typecheck` from each changed package: `packages/core`, `packages/protocol`, `packages/server`, `packages/client`, `packages/tui`, `packages/sdk/js`.
- Verified cleanly with `git diff --check`.

### Screenshots / recordings

N/A. This is a core API/query behavior alignment and contract change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
- [x] My code follows the contributing guidelines of this project