### PR TITLE
test(core): make command shell test portable

### DIFF
--- a/packages/core/test/command.test.ts
+++ b/packages/core/test/command.test.ts
@@ -69,7 +69,7 @@ describe("CommandV2", () => {
       const command = yield* CommandV2.Service
       yield* command.transform((editor) => {
         editor.update("review", (command) => {
-          command.template = "Output: !`printf command-output`"
+          command.template = "Output: !`bun -e \"process.stdout.write('command-output')\"`"
         })
       })
 


### PR DESCRIPTION
## Summary
- replace the Unix-only printf fixture in the CommandV2 shell interpolation test with a Bun command available in CI

## Verification
- bun test test/command.test.ts
- bun typecheck

Note: full packages/core test run was attempted locally but unrelated filesystem watcher readiness tests timed out on macOS.