### PR TITLE
fix(process): prevent AbortSignal listener leak on pre-aborted signal

### DIFF
--- a/packages/opencode/src/util/process.ts
+++ b/packages/opencode/src/util/process.ts
@@ -102,8 +102,8 @@ export function spawn(cmd: string[], opts: Options = {}): Child {
   void exited.catch(() => undefined)
 
   if (opts.abort) {
-    opts.abort.addEventListener("abort", abort, { once: true })
     if (opts.abort.aborted) abort()
+    else opts.abort.addEventListener("abort", abort, { once: true })
   }
 
   const child = proc as Child


### PR DESCRIPTION
### Issue for this PR

Closes #34982

### Type of change

- [x] Bug fix

### What does this PR do?

When `spawn()` is called with an already-aborted `AbortSignal`, `addEventListener` installs a listener that will never fire (signal already dispatched `abort`). With `{ once: true }`, it's never auto-removed, leaking the closure which references `proc`, `timer`, `closed`, `opts.kill`.

Fix: check `signal.aborted` before `addEventListener`. If already aborted, call `abort()` directly without registering a listener.

### How did you verify your code works?

Manual repro confirmed: listener count grows without fix, stays flat with fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR