### PR TITLE
fix(persistence): clean stale orphaned temp files before atomic writes

### DIFF
--- a/packages/tui/src/util/persistence.ts
+++ b/packages/tui/src/util/persistence.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { appendFile, mkdir, rename, rm } from "fs/promises"
+import { appendFile, mkdir, readdir, rename, rm } from "fs/promises"
 
 export function readText(filePath: string) {
   return Bun.file(filePath).text()
@@ -19,8 +19,23 @@ export async function appendText(filePath: string, content: string) {
   await appendFile(filePath, content)
 }
 
+async function cleanStaleTempFiles(dir: string, targetName: string) {
+  try {
+    const entries = await readdir(dir)
+    const pattern = `${targetName}.`
+    for (const entry of entries) {
+      if (entry.startsWith(pattern) && entry.endsWith(".tmp")) {
+        await rm(path.join(dir, entry), { force: true }).catch(() => {})
+      }
+    }
+  } catch {
+    // directory doesn't exist yet — nothing to clean
+  }
+}
+
 export async function writeJsonAtomic(filePath: string, value: unknown) {
   await mkdir(path.dirname(filePath), { recursive: true })
+  await cleanStaleTempFiles(path.dirname(filePath), path.basename(filePath))
   const temporary = `${filePath}.${process.pid}.${crypto.randomUUID()}.tmp`
   await Bun.write(temporary, JSON.stringify(value)).catch(async (error) => {
     await rm(temporary, { force: true }).catch(() => undefined)


### PR DESCRIPTION
### Issue for this PR

Closes #34986

### Type of change

- [x] Bug fix

### What does this PR do?

If the process crashes between `Bun.write()` and `rename()` in `writeJsonAtomic`, the temporary `.tmp` file is orphaned on disk. These accumulate over time.

Fix: add `cleanStaleTempFiles()` that removes matching `.tmp` files from the target directory before each atomic write.

### How did you verify your code works?

Code review. The cleanup runs before each write, covering both first-time use and post-crash restart scenarios.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR