### PR TITLE
fix(app): remeasure timeline after message hydration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -87,7 +87,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -135,7 +135,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -171,7 +171,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -198,7 +198,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -220,7 +220,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -244,7 +244,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -264,7 +264,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -357,7 +357,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "effect": "catalog:",
@@ -411,7 +411,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -425,7 +425,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -437,7 +437,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -469,7 +469,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -485,7 +485,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -516,7 +516,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -535,7 +535,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -665,7 +665,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -741,7 +741,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -756,7 +756,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -771,7 +771,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -815,7 +815,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -828,7 +828,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@opencode-ai/stats-core": "workspace:*",
@@ -861,7 +861,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -880,7 +880,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -921,7 +921,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -948,7 +948,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -995,7 +995,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.17.10",
+      "version": "1.17.11",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test"
-import type { OpencodeClient, Session } from "@opencode-ai/sdk/v2/client"
+import { describe, expect, mock, test } from "bun:test"
+import type { Message, OpencodeClient, Part, Session } from "@opencode-ai/sdk/v2/client"
 import { createServerSession } from "./server-session"
 
 const session = (id: string, parentID?: string): Session => ({
@@ -53,6 +53,49 @@ describe("server session", () => {
     expect(ctx.get).toEqual([{ sessionID: "root" }])
     expect(ctx.messages).toEqual([{ sessionID: "root", limit: 2, before: undefined }])
     expect(ctx.store.data.message.root).toEqual([])
+  })
+
+  test("retries transient message hydration failures", async () => {
+    const message: Message = {
+      id: "message",
+      sessionID: "root",
+      role: "user",
+      time: { created: 1 },
+      summary: { diffs: [] },
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude" },
+    }
+    const part: Extract<Part, { type: "text" }> = {
+      id: "part",
+      sessionID: "root",
+      messageID: message.id,
+      type: "text",
+      text: "hello",
+    }
+    const messages = mock(async () => {
+      if (messages.mock.calls.length === 1) {
+        throw new Error("GET /session/root/message -> 503 Service Unavailable", {
+          cause: { status: 503 },
+        })
+      }
+
+      return {
+        data: [{ info: message, parts: [part] }],
+        response: { headers: new Headers() },
+      }
+    })
+    const store = createServerSession({
+      session: {
+        get: mock(async () => ({ data: session("root") })),
+        messages,
+      },
+    } as unknown as OpencodeClient)
+
+    await store.sync("root")
+
+    expect(messages).toHaveBeenCalledTimes(2)
+    expect(store.data.message.root?.map((message) => message.id)).toEqual(["message"])
+    expect(store.data.part.message?.map((part) => part.id)).toEqual(["part"])
   })
 
   test("applies events without a directory store", () => {

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -22,6 +22,7 @@ const SKIP_PARTS = new Set(["patch", "step-start", "step-finish"])
 const initialMessagePageSize = 2
 const historyMessagePageSize = 200
 const sessionInfoLimit = 2_048
+const retryableMessageLoadStatuses = new Set([408, 409, 425, 429, 500, 502, 503, 504])
 
 type OptimisticItem = {
   message: Message
@@ -75,6 +76,24 @@ function merge<T extends { id: string }>(a: readonly T[], b: readonly T[]) {
   return [...items.values()].sort((x, y) => cmp(x.id, y.id))
 }
 
+function isRetryableMessageLoadError(error: unknown) {
+  if (error instanceof Error) {
+    const status = (error.cause as { status?: unknown } | undefined)?.status
+    if (typeof status === "number" && retryableMessageLoadStatuses.has(status)) return true
+    return [
+      "load failed",
+      "network connection was lost",
+      "network request failed",
+      "failed to fetch",
+      "econnreset",
+      "econnrefused",
+      "etimedout",
+      "socket hang up",
+    ].some((message) => error.message.toLowerCase().includes(message))
+  }
+  return false
+}
+
 export function createServerSession(client: OpencodeClient) {
   const [data, setData] = createStore({
     info: {} as Record<string, Session | undefined>,
@@ -92,6 +111,7 @@ export function createServerSession(client: OpencodeClient) {
   })
   const requests = new Map<string, Promise<Session>>()
   const inflight = new Map<string, Promise<void>>()
+  const messageLoads = new Map<string, Promise<void>>()
   const inflightDiff = new Map<string, Promise<void>>()
   const inflightTodo = new Map<string, Promise<void>>()
   const optimistic = new Map<string, Map<string, OptimisticItem>>()
@@ -202,6 +222,7 @@ export function createServerSession(client: OpencodeClient) {
       clearOptimistic(sessionID)
       requests.delete(sessionID)
       inflight.delete(sessionID)
+      messageLoads.delete(sessionID)
       inflightDiff.delete(sessionID)
       inflightTodo.delete(sessionID)
     })
@@ -248,7 +269,9 @@ export function createServerSession(client: OpencodeClient) {
     )
 
   const fetchMessages = async (sessionID: string, limit: number, before?: string) => {
-    const response = await retry(() => client.session.messages({ sessionID, limit, before }))
+    const response = await retry(() => client.session.messages({ sessionID, limit, before }), {
+      retryIf: isRetryableMessageLoadError,
+    })
     const items = (response.data ?? []).filter((item) => !!item?.info?.id)
     return {
       session: items.map((item) => cleanMessage(item.info)).sort((a, b) => cmp(a.id, b.id)),
@@ -262,10 +285,11 @@ export function createServerSession(client: OpencodeClient) {
   }
 
   const loadMessages = async (sessionID: string, limit: number, before?: string, mode?: "replace" | "prepend") => {
-    if (meta.loading[sessionID]) return
+    const pending = messageLoads.get(sessionID)
+    if (pending) return pending
     const generation = generations.get(sessionID) ?? 0
     setMeta("loading", sessionID, true)
-    await fetchMessages(sessionID, limit, before)
+    const request = fetchMessages(sessionID, limit, before)
       .then((page) => {
         if ((generations.get(sessionID) ?? 0) !== generation) return
         const next = mergeOptimisticPage(page, [...(optimistic.get(sessionID)?.values() ?? [])])
@@ -284,8 +308,11 @@ export function createServerSession(client: OpencodeClient) {
         })
       })
       .finally(() => {
+        if (messageLoads.get(sessionID) === request) messageLoads.delete(sessionID)
         if ((generations.get(sessionID) ?? 0) === generation) setMeta("loading", sessionID, false)
       })
+    messageLoads.set(sessionID, request)
+    await request
   }
 
   const sync = (sessionID: string, options?: { force?: boolean; messageLimit?: number }) => {

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -507,11 +507,13 @@ export function MessageTimeline(props: {
   }
 
   let measuredSessionKey = sessionKey()
+  let measuredRowCount = timelineRows().length
   createEffect(() => {
     const key = sessionKey()
-    timelineRows().length
-    if (measuredSessionKey !== key) {
+    const rowCount = timelineRows().length
+    if (measuredSessionKey !== key || measuredRowCount !== rowCount) {
       measuredSessionKey = key
+      measuredRowCount = rowCount
       virtualizer.measure()
     }
     maybeAnchorBottom()
@@ -549,6 +551,10 @@ export function MessageTimeline(props: {
     if (root === listRoot()) return
     setListRoot(root)
     props.setScrollRef(root)
+    requestAnimationFrame(() => {
+      virtualizer.measure()
+      maybeAnchorBottom()
+    })
   }
 
   const handleListWheel = (event: WheelEvent & { currentTarget: HTMLDivElement }) => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "type": "module",
   "license": "MIT",
   "exports": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.17.10",
+  "version": "1.17.11",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Retry transient failures while hydrating session messages so temporary OpenCode proxy/API errors do not leave a session empty.
- Track in-flight message hydration per session so concurrent loads await the same request.
- Remeasure the virtualized message timeline when rows arrive asynchronously or when the scroll root binds.

## Test plan
- `turbo run typecheck --filter=forge-ui --output-logs=errors-only`
- `yarn workspace forge-ui test`
- `diff --check apps/forge-ui/vendor/opencode/packages/app/src/context/server-session.ts apps/forge-ui/vendor/opencode/packages/app/src/context/server-session.test.ts apps/forge-ui/vendor/opencode/packages/app/src/pages/session/timeline/message-timeline.tsx`


Made with [Cursor](https://cursor.com)