### PR TITLE
fix(opencode): CLI queued prompt drain after Esc interrupt

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1811,6 +1811,7 @@ export default function Page() {
     if (!item) return
     if (followupBusy(sessionID)) return
     if (followup.failed[sessionID] === item.id) return
+    if (followup.paused[sessionID]) return
     if (isChildSession()) return
     if (composer.blocked()) return
     if (busy(sessionID)) return
@@ -1957,6 +1958,11 @@ export default function Page() {
             onEditLoaded={clearFollowupEdit}
             shouldQueue={queueEnabled}
             onQueue={queueFollowup}
+            onAbort={() => {
+              const id = params.id
+              if (!id) return
+              setFollowup("paused", id, true)
+            }}
           />
         }
       />

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1811,7 +1811,6 @@ export default function Page() {
     if (!item) return
     if (followupBusy(sessionID)) return
     if (followup.failed[sessionID] === item.id) return
-    if (followup.paused[sessionID]) return
     if (isChildSession()) return
     if (composer.blocked()) return
     if (busy(sessionID)) return
@@ -1958,11 +1957,6 @@ export default function Page() {
             onEditLoaded={clearFollowupEdit}
             shouldQueue={queueEnabled}
             onQueue={queueFollowup}
-            onAbort={() => {
-              const id = params.id
-              if (!id) return
-              setFollowup("paused", id, true)
-            }}
           />
         }
       />

--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -7,6 +7,10 @@
 // The queue also handles /exit, /quit, and /new commands, empty-prompt rejection,
 // and tracks per-turn wall-clock duration for the footer status line.
 //
+// Interrupt (Esc) must abort the active turn's local AbortSignal, not only the
+// server session. Otherwise a queued prompt stays blocked behind a run() that
+// never observes cancellation.
+//
 // Resolves when the footer closes and all in-flight work finishes.
 import * as Locale from "@/util/locale"
 import { MessageID, PartID } from "@/session/schema"
@@ -29,7 +33,7 @@ export type QueueInput = {
   trace?: Trace
   onSend?: (prompt: RunPrompt) => void
   onNewSession?: () => void | Promise<void>
-  bindInterrupt?: (abortActive: () => void) => void
+  bindInterrupt?: (handle: { abortActive: () => void; pendingQueue: () => number }) => void
   run: (prompt: RunPrompt, signal: AbortSignal) => Promise<void>
 }
 
@@ -315,8 +319,11 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
     drain()
   }
 
-  input.bindInterrupt?.(() => {
-    state.ctrl?.abort()
+  input.bindInterrupt?.({
+    abortActive: () => {
+      state.ctrl?.abort()
+    },
+    pendingQueue: () => state.queue.length,
   })
 
   const offPrompt = input.footer.onPrompt((prompt) => {

--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -29,6 +29,7 @@ export type QueueInput = {
   trace?: Trace
   onSend?: (prompt: RunPrompt) => void
   onNewSession?: () => void | Promise<void>
+  bindInterrupt?: (abortActive: () => void) => void
   run: (prompt: RunPrompt, signal: AbortSignal) => Promise<void>
 }
 
@@ -313,6 +314,10 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
     )
     drain()
   }
+
+  input.bindInterrupt?.(() => {
+    state.ctrl?.abort()
+  })
 
   const offPrompt = input.footer.onPrompt((prompt) => {
     submit(prompt)

--- a/packages/opencode/src/cli/cmd/run/runtime.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.ts
@@ -20,7 +20,7 @@ import { resolveModelInfo, resolveRunTuiConfig, resolveSessionInfo } from "./run
 import { createRuntimeLifecycle } from "./runtime.lifecycle"
 import { trace } from "./trace"
 import { cycleVariant, formatModelLabel, resolveSavedVariant, resolveVariant, saveVariant } from "./variant.shared"
-import type { LocalReplayAnchor, LocalReplayRow, RunInput, RunPrompt, RunProvider, StreamCommit } from "./types"
+import type { FooterApi, LocalReplayAnchor, LocalReplayRow, RunInput, RunPrompt, RunProvider, StreamCommit } from "./types"
 
 /** @internal Exported for testing */
 export { pickVariant, resolveVariant } from "./variant.shared"
@@ -120,6 +120,7 @@ type RuntimeState = {
   shown: boolean
   aborting: boolean
   abortActiveTurn?: () => void
+  pendingQueuedCount?: () => number
   model: RunInput["model"]
   providers: RunProvider[]
   variants: string[]
@@ -225,6 +226,8 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
     })
     return state.session
   }
+
+  const interruptFooter: { api?: FooterApi } = {}
 
   const shell = await (deps.createRuntimeLifecycle ?? createRuntimeLifecycle)({
     directory: ctx.directory,
@@ -344,6 +347,16 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
       }
 
       state.aborting = true
+      const pending = state.pendingQueuedCount?.() ?? 0
+      if (pending > 0) {
+        interruptFooter.api?.event({
+          type: "stream.patch",
+          patch: {
+            queue: pending,
+            status: pending === 1 ? "interrupting · 1 queued" : `interrupting · ${pending} queued`,
+          },
+        })
+      }
       state.abortActiveTurn?.()
       void ctx.sdk.session
         .abort({
@@ -366,6 +379,7 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
     },
   })
   const footer = shell.footer
+  interruptFooter.api = footer
   const rememberLocal = (commit: StreamCommit, after?: LocalReplayAnchor) => {
     state.localRows = [...state.localRows, { commit, after }].slice(-LOCAL_REPLAY_ROW_LIMIT)
   }
@@ -548,8 +562,9 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
       footer,
       initialInput: input.initialInput,
       trace: log,
-      bindInterrupt: (abortActive) => {
-        state.abortActiveTurn = abortActive
+      bindInterrupt: (handle) => {
+        state.abortActiveTurn = handle.abortActive
+        state.pendingQueuedCount = handle.pendingQueue
       },
       onSend: (prompt) => {
         state.shown = true

--- a/packages/opencode/src/cli/cmd/run/runtime.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.ts
@@ -119,6 +119,7 @@ function createSessionResolver(fn?: CreateSession) {
 type RuntimeState = {
   shown: boolean
   aborting: boolean
+  abortActiveTurn?: () => void
   model: RunInput["model"]
   providers: RunProvider[]
   variants: string[]
@@ -343,6 +344,7 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
       }
 
       state.aborting = true
+      state.abortActiveTurn?.()
       void ctx.sdk.session
         .abort({
           sessionID: state.sessionID,
@@ -546,6 +548,9 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
       footer,
       initialInput: input.initialInput,
       trace: log,
+      bindInterrupt: (abortActive) => {
+        state.abortActiveTurn = abortActive
+      },
       onSend: (prompt) => {
         state.shown = true
         state.history.push(prompt)

--- a/packages/opencode/test/cli/run/runtime.queue.test.ts
+++ b/packages/opencode/test/cli/run/runtime.queue.test.ts
@@ -431,11 +431,13 @@ describe("run runtime queue", () => {
     const ui = footer()
     const seen: string[] = []
     let abortActive: (() => void) | undefined
+    let pendingQueue: (() => number) | undefined
 
     const task = runPromptQueue({
       footer: ui.api,
-      bindInterrupt: (abort) => {
-        abortActive = abort
+      bindInterrupt: (handle) => {
+        abortActive = handle.abortActive
+        pendingQueue = handle.pendingQueue
       },
       run: async (input, signal) => {
         seen.push(input.text)
@@ -459,6 +461,7 @@ describe("run runtime queue", () => {
     await Promise.resolve()
     ui.submit("two")
     await Promise.resolve()
+    expect(pendingQueue?.()).toBe(1)
     abortActive?.()
     await task
 

--- a/packages/opencode/test/cli/run/runtime.queue.test.ts
+++ b/packages/opencode/test/cli/run/runtime.queue.test.ts
@@ -427,6 +427,44 @@ describe("run runtime queue", () => {
     expect(seen).toEqual(["one", "two"])
   })
 
+  test("runs queued prompts after interrupt aborts the active turn", async () => {
+    const ui = footer()
+    const seen: string[] = []
+    let abortActive: (() => void) | undefined
+
+    const task = runPromptQueue({
+      footer: ui.api,
+      bindInterrupt: (abort) => {
+        abortActive = abort
+      },
+      run: async (input, signal) => {
+        seen.push(input.text)
+        if (input.text !== "one") {
+          ui.api.close()
+          return
+        }
+
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    ui.submit("one")
+    await Promise.resolve()
+    ui.submit("two")
+    await Promise.resolve()
+    abortActive?.()
+    await task
+
+    expect(seen).toEqual(["one", "two"])
+  })
+
   test("close aborts the active run and drops pending queued work", async () => {
     const ui = footer()
     const seen: string[] = []


### PR DESCRIPTION
### Issue for this PR

Closes #33812 (CLI / `opencode run` scope)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**CLI-only** — the web app follow-up queue fix lives in #33808; this PR no longer touches `packages/app`.

In direct CLI mode (`opencode run`), interrupt only called `session.abort` on the server and did not abort the active turn's local `AbortSignal`, so the prompt queue could stay blocked behind an in-flight turn. This wires Esc interrupt to:

1. Abort the active turn's local signal so `runPromptQueue` can finish the current turn and drain the next queued prompt
2. Expose pending queue depth via `bindInterrupt` for the runtime interrupt handler
3. Show a footer status hint when interrupting with queued prompts (e.g. `interrupting · 1 queued`)

Stacks cleanly on top of #33808 for the shared issue.

### How did you verify your code works?

- `bun test test/cli/run/runtime.queue.test.ts` — 17 pass, including abort-active-turn + pending-queue count + queued prompt still runs
- `bun typecheck` in `packages/opencode`

Manual checks still needed:

- CLI direct mode: queue while running, double-press Esc, confirm the next queued prompt runs and the footer shows the interrupt hint

### Screenshots / recordings

Terminal captures via rudycanshoot (attached in PR comments):

- `opencode-fix-queued-interrupt-runtime-queue-test.png`
- `opencode-fix-queued-interrupt-typecheck.png`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR