### PR TITLE
feat(server): add lazy simulation layer replacements

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -16,7 +16,7 @@ import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
 import { HttpRouter, HttpServer } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
-import { Layer, Option } from "effect"
+import { Effect, Layer, Option } from "effect"
 import { Api } from "./api"
 import { ServerAuth } from "./auth"
 import { handlers } from "./handlers"
@@ -58,15 +58,24 @@ function makeRoutes<AuthError, AuthServices>(
   sdkPlugins?: SdkPlugins.Store,
 ) {
   const pluginRuntimeCell = PluginRuntime.makeCell()
-  const serviceLayer = AppNodeBuilder.build(
-    applicationServices,
-    [
-      [SessionExecution.node, SessionExecutionLocal.node],
-      [PluginRuntime.node, PluginRuntime.layerWithCell(pluginRuntimeCell)],
-      [PluginRuntime.providerNode, PluginRuntime.providerNodeWithCell(pluginRuntimeCell)],
-      ...(sdkPlugins ? [[SdkPlugins.node, SdkPlugins.layerWithStore(sdkPlugins)] as const] : []),
-    ],
-  )
+  const replacements: LayerNode.Replacements = [
+    [SessionExecution.node, SessionExecutionLocal.node],
+    [PluginRuntime.node, PluginRuntime.layerWithCell(pluginRuntimeCell)],
+    [PluginRuntime.providerNode, PluginRuntime.providerNodeWithCell(pluginRuntimeCell)],
+    ...(sdkPlugins ? [[SdkPlugins.node, SdkPlugins.layerWithStore(sdkPlugins)] as const] : []),
+  ]
+  // Simulation replacements are loaded via dynamic import so the simulation
+  // module is never eagerly loaded. Layer.unwrap defers both the import and
+  // the app-node build to layer-build time; when simulation is off the branch
+  // is byte-for-byte identical to a plain AppNodeBuilder.build call.
+  const serviceLayer = simulationEnabled()
+    ? Layer.unwrap(
+        Effect.gen(function* () {
+          const { simulationReplacements } = yield* Effect.promise(() => import("./simulation"))
+          return AppNodeBuilder.build(applicationServices, [...replacements, ...simulationReplacements])
+        }),
+      )
+    : AppNodeBuilder.build(applicationServices, replacements)
 
   return HttpApiBuilder.layer(Api, { openapiPath: "/openapi.json" }).pipe(
     Layer.provide(handlers),
@@ -77,6 +86,10 @@ function makeRoutes<AuthError, AuthServices>(
     Layer.provide(auth),
     Layer.provide(serviceLayer),
   )
+}
+
+function simulationEnabled() {
+  return !!process.env.OPENCODE_SIMULATION
 }
 
 export const routes = createRoutes()

--- a/packages/server/src/simulation/index.ts
+++ b/packages/server/src/simulation/index.ts
@@ -1,0 +1,14 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+
+/**
+ * Layer replacements applied when the server is built in simulation mode.
+ *
+ * Empty for now; simulation-mode implementations will populate this with
+ * replacement nodes/layers that swap real services for simulated ones (e.g.
+ * a fake filesystem). The server merges these into the app node build when
+ * `OPENCODE_SIMULATION` is enabled, via a dynamic import so this module is
+ * never loaded eagerly.
+ */
+export const simulationReplacements: LayerNode.Replacements = []
+
+export * as Simulation from "./index"


### PR DESCRIPTION
## Summary

Adds the simulation replacement scaffolding to the server package, isolated from unrelated working-tree work.

## Changes

- **New `packages/server/src/simulation/`** directory with `index.ts` exporting `simulationReplacements: LayerNode.Replacements` (empty scaffold). Simulation-mode implementations will later populate this with replacement nodes/layers that swap real services for simulated ones (e.g. a fake filesystem).
- **`makeRoutes` wiring** in `packages/server/src/routes.ts`: the app-node replacements are extracted into a `replacements` const. When `OPENCODE_SIMULATION` is set, replacements are merged with `simulationReplacements` loaded via a dynamic `import("./simulation")` wrapped in `Layer.unwrap`. When the flag is off, `makeRoutes` calls `AppNodeBuilder.build(applicationServices, replacements)` directly.

## Design notes

- `makeRoutes` stays **synchronous**: `Layer.unwrap` defers both the dynamic `import()` and the app-node build to layer-build time, so the function itself never becomes async.
- The simulation module is **never eagerly loaded** — it is only imported when `OPENCODE_SIMULATION` is enabled.
- **Behavior is identical when simulation is off**: the off-branch is byte-for-byte equivalent to the prior plain `AppNodeBuilder.build` call.
- Gated on `OPENCODE_SIMULATION` (`1` or `true`).

## Verification

`bun typecheck` passes in `packages/server` (no errors).

## Base branch

Based on `simulation-spec-v2` because `makeRoutes` depends on the `PluginRuntime` / `SdkPlugins` / `sdkPlugins` parameter wiring introduced on that branch, which is not yet in `dev`.