### PR TITLE
fix(opencode): send xai prompt cache routing key

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1705,9 +1705,7 @@ const layer = Layer.effect(
         const existing = s.sdk.get(key)
         if (existing) return existing
 
-        // Composes with any auth fetch already in options (e.g. the xAI OAuth
-        // plugin loader): the body is rewritten first, then the wrapped fetch
-        // still applies its own header handling.
+        // Rewrites the body before any auth fetch from options (e.g. the xAI OAuth loader) runs.
         const customFetch =
           model.api.npm === "@ai-sdk/xai" ? XaiCache.withPromptCacheKey(options["fetch"]) : options["fetch"]
         const chunkTimeout = options["chunkTimeout"]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1705,7 +1705,8 @@ const layer = Layer.effect(
         const existing = s.sdk.get(key)
         if (existing) return existing
 
-        // Rewrites the body before any auth fetch from options (e.g. the xAI OAuth loader) runs.
+        // Rewrites the request body before any auth fetch from options, such
+        // as the xAI OAuth loader, runs.
         const customFetch =
           model.api.npm === "@ai-sdk/xai" ? XaiCache.withPromptCacheKey(options["fetch"]) : options["fetch"]
         const chunkTimeout = options["chunkTimeout"]

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -26,6 +26,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { isRecord } from "@/util/record"
 import { optional } from "@opencode-ai/core/schema"
 import { ProviderTransform } from "./transform"
+import { XaiCache } from "./xai-cache"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
@@ -1704,7 +1705,11 @@ const layer = Layer.effect(
         const existing = s.sdk.get(key)
         if (existing) return existing
 
-        const customFetch = options["fetch"]
+        // Composes with any auth fetch already in options (e.g. the xAI OAuth
+        // plugin loader): the body is rewritten first, then the wrapped fetch
+        // still applies its own header handling.
+        const customFetch =
+          model.api.npm === "@ai-sdk/xai" ? XaiCache.withPromptCacheKey(options["fetch"]) : options["fetch"]
         const chunkTimeout = options["chunkTimeout"]
         const headerTimeout = options["headerTimeout"]
         delete options["chunkTimeout"]

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1217,8 +1217,8 @@ export function options(input: {
     result["promptCacheKey"] = input.sessionID
   }
 
-  // No-op until @ai-sdk/xai supports promptCacheKey; Provider.resolveSDK
-  // injects prompt_cache_key at the fetch boundary meanwhile.
+  // @ai-sdk/xai ignores this option today; Provider.resolveSDK adds
+  // prompt_cache_key to the request body instead.
   if (input.model.api.npm === "@ai-sdk/xai") {
     result["promptCacheKey"] = input.sessionID
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1217,6 +1217,13 @@ export function options(input: {
     result["promptCacheKey"] = input.sessionID
   }
 
+  // Forward-compatible with @ai-sdk/xai gaining promptCacheKey support; until
+  // then the SDK strips it and Provider.resolveSDK injects prompt_cache_key at
+  // the fetch boundary instead.
+  if (input.model.api.npm === "@ai-sdk/xai") {
+    result["promptCacheKey"] = input.sessionID
+  }
+
   if (input.model.providerID === "openrouter") {
     result["prompt_cache_key"] = input.sessionID
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1217,9 +1217,8 @@ export function options(input: {
     result["promptCacheKey"] = input.sessionID
   }
 
-  // Forward-compatible with @ai-sdk/xai gaining promptCacheKey support; until
-  // then the SDK strips it and Provider.resolveSDK injects prompt_cache_key at
-  // the fetch boundary instead.
+  // No-op until @ai-sdk/xai supports promptCacheKey; Provider.resolveSDK
+  // injects prompt_cache_key at the fetch boundary meanwhile.
   if (input.model.api.npm === "@ai-sdk/xai") {
     result["promptCacheKey"] = input.sessionID
   }

--- a/packages/opencode/src/provider/xai-cache.ts
+++ b/packages/opencode/src/provider/xai-cache.ts
@@ -1,0 +1,30 @@
+export * as XaiCache from "./xai-cache"
+
+// xAI's Responses API takes the cache routing key as a `prompt_cache_key`
+// body field, but @ai-sdk/xai exposes no provider option for it, so the
+// session identity only reaches the wire as the per-request x-grok-conv-id
+// header set by LLMRequestPrep. Mirror that header into the body at the
+// fetch boundary so /responses requests carry the documented field.
+// https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
+export function withPromptCacheKey(baseFetch?: typeof fetch): typeof fetch {
+  const inner = baseFetch ?? fetch
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const body = promptCacheKeyBody(input, init)
+    return body === undefined ? inner(input, init) : inner(input, { ...init, body })
+  }) as typeof fetch
+}
+
+function promptCacheKeyBody(input: RequestInfo | URL, init?: RequestInit) {
+  if (typeof init?.body !== "string") return
+  const url = input instanceof Request ? input.url : input.toString()
+  if (!new URL(url, "http://localhost").pathname.endsWith("/responses")) return
+  const convID = new Headers(init.headers).get("x-grok-conv-id")
+  if (!convID) return
+  try {
+    const parsed = JSON.parse(init.body)
+    if (typeof parsed !== "object" || parsed === null || "prompt_cache_key" in parsed) return
+    return JSON.stringify({ ...parsed, prompt_cache_key: convID })
+  } catch {
+    return
+  }
+}

--- a/packages/opencode/src/provider/xai-cache.ts
+++ b/packages/opencode/src/provider/xai-cache.ts
@@ -1,7 +1,7 @@
 export * as XaiCache from "./xai-cache"
 
-// @ai-sdk/xai has no provider option for the Responses API's prompt_cache_key,
-// so mirror the x-grok-conv-id header set by LLMRequestPrep into the body here.
+// Copies the x-grok-conv-id header set by LLMRequestPrep into the request
+// body as prompt_cache_key, because @ai-sdk/xai has no option for that field.
 // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
 export function withPromptCacheKey(baseFetch?: typeof fetch): typeof fetch {
   const inner = baseFetch ?? fetch

--- a/packages/opencode/src/provider/xai-cache.ts
+++ b/packages/opencode/src/provider/xai-cache.ts
@@ -1,10 +1,7 @@
 export * as XaiCache from "./xai-cache"
 
-// xAI's Responses API takes the cache routing key as a `prompt_cache_key`
-// body field, but @ai-sdk/xai exposes no provider option for it, so the
-// session identity only reaches the wire as the per-request x-grok-conv-id
-// header set by LLMRequestPrep. Mirror that header into the body at the
-// fetch boundary so /responses requests carry the documented field.
+// @ai-sdk/xai has no provider option for the Responses API's prompt_cache_key,
+// so mirror the x-grok-conv-id header set by LLMRequestPrep into the body here.
 // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
 export function withPromptCacheKey(baseFetch?: typeof fetch): typeof fetch {
   const inner = baseFetch ?? fetch

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -196,9 +196,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
         : {
             "x-session-affinity": input.sessionID,
             "X-Session-Id": input.sessionID,
-            // xAI routes requests with the same conversation ID to the same
-            // server so prompt cache hits survive load balancing.
-            // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
+            // xAI prompt cache routing: https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
             ...(input.model.api.npm === "@ai-sdk/xai" ? { "x-grok-conv-id": input.sessionID } : {}),
             ...(input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
             "User-Agent": USER_AGENT,

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -196,6 +196,10 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
         : {
             "x-session-affinity": input.sessionID,
             "X-Session-Id": input.sessionID,
+            // xAI routes requests with the same conversation ID to the same
+            // server so prompt cache hits survive load balancing.
+            // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
+            ...(input.model.api.npm === "@ai-sdk/xai" ? { "x-grok-conv-id": input.sessionID } : {}),
             ...(input.parentSessionID ? { "x-parent-session-id": input.parentSessionID } : {}),
             "User-Agent": USER_AGENT,
           }),

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -87,19 +87,6 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBe(sessionID)
   })
 
-  test("should set promptCacheKey for xai models regardless of setCacheKey", () => {
-    const xaiModel = {
-      ...mockModel,
-      providerID: "xai",
-      api: {
-        id: "grok-4.3",
-        url: "https://api.x.ai/v1",
-        npm: "@ai-sdk/xai",
-      },
-    }
-    const result = ProviderTransform.options({ model: xaiModel, sessionID, providerOptions: {} })
-    expect(result.promptCacheKey).toBe(sessionID)
-  })
 
   test("should set store=false for openai provider", () => {
     const openaiModel = {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -87,6 +87,20 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBe(sessionID)
   })
 
+  test("should set promptCacheKey for xai models regardless of setCacheKey", () => {
+    const xaiModel = {
+      ...mockModel,
+      providerID: "xai",
+      api: {
+        id: "grok-4.3",
+        url: "https://api.x.ai/v1",
+        npm: "@ai-sdk/xai",
+      },
+    }
+    const result = ProviderTransform.options({ model: xaiModel, sessionID, providerOptions: {} })
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
   test("should set store=false for openai provider", () => {
     const openaiModel = {
       ...mockModel,
@@ -406,6 +420,53 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.params.options.reasoningSummary).toBeUndefined()
     expect(result.params.options.include).toBeUndefined()
     expect(result.tools.lookup.strict).toBe(false)
+  })
+
+  test("xai requests carry x-grok-conv-id for prompt cache routing", async () => {
+    const model = {
+      ...createGpt5Model("grok-4.3"),
+      id: "xai/grok-4.3",
+      providerID: "xai",
+      api: {
+        id: "grok-4.3",
+        url: "https://api.x.ai/v1",
+        npm: "@ai-sdk/xai",
+      },
+    }
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        user: {
+          id: "msg_user-test",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID: "xai", modelID: "grok-4.3" },
+        } as any,
+        sessionID,
+        model,
+        agent: {
+          name: "test",
+          mode: "primary",
+          options: {},
+          permission: [],
+        } as any,
+        system: [],
+        messages: [{ role: "user", content: "Hello" }],
+        tools: {},
+        provider: { id: "xai", options: {} } as any,
+        auth: undefined,
+        plugin: {
+          trigger: (_name: string, _input: unknown, output: unknown) => Effect.succeed(output),
+          list: () => Effect.succeed([]),
+          init: () => Effect.void,
+        } as any,
+        flags: { outputTokenMax: 32_000, client: "test" } as any,
+        isWorkflow: false,
+      }),
+    )
+    expect((result.headers as Record<string, string>)["x-grok-conv-id"]).toBe(sessionID)
+    expect(result.params.options.promptCacheKey).toBe(sessionID)
   })
 
   test("gpt-5.1 should have textVerbosity set to low", () => {

--- a/packages/opencode/test/provider/xai-cache.test.ts
+++ b/packages/opencode/test/provider/xai-cache.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test"
+import { XaiCache } from "@/provider/xai-cache"
+
+function capture() {
+  const calls: { input: RequestInfo | URL; init?: RequestInit }[] = []
+  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ input, init })
+    return new Response("{}")
+  }) as typeof fetch
+  return { calls, fetchFn }
+}
+
+describe("XaiCache.withPromptCacheKey", () => {
+  const url = "https://api.x.ai/v1/responses"
+  const headers = { "x-grok-conv-id": "ses_abc123", "content-type": "application/json" }
+
+  test("mirrors x-grok-conv-id into prompt_cache_key on /responses bodies", async () => {
+    const { calls, fetchFn } = capture()
+    await XaiCache.withPromptCacheKey(fetchFn)(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ model: "grok-4.3", input: [] }),
+    })
+    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+      model: "grok-4.3",
+      input: [],
+      prompt_cache_key: "ses_abc123",
+    })
+  })
+
+  test("preserves an explicit prompt_cache_key", async () => {
+    const { calls, fetchFn } = capture()
+    const body = JSON.stringify({ model: "grok-4.3", prompt_cache_key: "custom" })
+    await XaiCache.withPromptCacheKey(fetchFn)(url, { method: "POST", headers, body })
+    expect(calls[0].init?.body).toBe(body)
+  })
+
+  test("leaves non-responses endpoints untouched", async () => {
+    const { calls, fetchFn } = capture()
+    const body = JSON.stringify({ model: "grok-4.3", messages: [] })
+    await XaiCache.withPromptCacheKey(fetchFn)("https://api.x.ai/v1/chat/completions", {
+      method: "POST",
+      headers,
+      body,
+    })
+    expect(calls[0].init?.body).toBe(body)
+  })
+
+  test("skips requests without the conv id header", async () => {
+    const { calls, fetchFn } = capture()
+    const body = JSON.stringify({ model: "grok-4.3", input: [] })
+    await XaiCache.withPromptCacheKey(fetchFn)(url, { method: "POST", body })
+    expect(calls[0].init?.body).toBe(body)
+  })
+
+  test("passes through non-JSON bodies", async () => {
+    const { calls, fetchFn } = capture()
+    await XaiCache.withPromptCacheKey(fetchFn)(url, { method: "POST", headers, body: "not json" })
+    expect(calls[0].init?.body).toBe("not json")
+  })
+})

--- a/packages/opencode/test/provider/xai-cache.test.ts
+++ b/packages/opencode/test/provider/xai-cache.test.ts
@@ -1,61 +1,24 @@
 import { describe, expect, test } from "bun:test"
 import { XaiCache } from "@/provider/xai-cache"
 
-function capture() {
-  const calls: { input: RequestInfo | URL; init?: RequestInit }[] = []
-  const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    calls.push({ input, init })
-    return new Response("{}")
-  }) as typeof fetch
-  return { calls, fetchFn }
-}
-
 describe("XaiCache.withPromptCacheKey", () => {
-  const url = "https://api.x.ai/v1/responses"
-  const headers = { "x-grok-conv-id": "ses_abc123", "content-type": "application/json" }
+  test("mirrors x-grok-conv-id into prompt_cache_key on /responses requests only", async () => {
+    const calls: RequestInit[] = []
+    const wrapped = XaiCache.withPromptCacheKey((async (_input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push(init!)
+      return new Response("{}")
+    }) as typeof fetch)
+    const headers = { "x-grok-conv-id": "ses_abc123" }
+    const body = JSON.stringify({ model: "grok-4.3", input: [] })
 
-  test("mirrors x-grok-conv-id into prompt_cache_key on /responses bodies", async () => {
-    const { calls, fetchFn } = capture()
-    await XaiCache.withPromptCacheKey(fetchFn)(url, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ model: "grok-4.3", input: [] }),
-    })
-    expect(JSON.parse(calls[0].init?.body as string)).toEqual({
+    await wrapped("https://api.x.ai/v1/responses", { method: "POST", headers, body })
+    await wrapped("https://api.x.ai/v1/chat/completions", { method: "POST", headers, body })
+
+    expect(JSON.parse(calls[0].body as string)).toEqual({
       model: "grok-4.3",
       input: [],
       prompt_cache_key: "ses_abc123",
     })
-  })
-
-  test("preserves an explicit prompt_cache_key", async () => {
-    const { calls, fetchFn } = capture()
-    const body = JSON.stringify({ model: "grok-4.3", prompt_cache_key: "custom" })
-    await XaiCache.withPromptCacheKey(fetchFn)(url, { method: "POST", headers, body })
-    expect(calls[0].init?.body).toBe(body)
-  })
-
-  test("leaves non-responses endpoints untouched", async () => {
-    const { calls, fetchFn } = capture()
-    const body = JSON.stringify({ model: "grok-4.3", messages: [] })
-    await XaiCache.withPromptCacheKey(fetchFn)("https://api.x.ai/v1/chat/completions", {
-      method: "POST",
-      headers,
-      body,
-    })
-    expect(calls[0].init?.body).toBe(body)
-  })
-
-  test("skips requests without the conv id header", async () => {
-    const { calls, fetchFn } = capture()
-    const body = JSON.stringify({ model: "grok-4.3", input: [] })
-    await XaiCache.withPromptCacheKey(fetchFn)(url, { method: "POST", body })
-    expect(calls[0].init?.body).toBe(body)
-  })
-
-  test("passes through non-JSON bodies", async () => {
-    const { calls, fetchFn } = capture()
-    await XaiCache.withPromptCacheKey(fetchFn)(url, { method: "POST", headers, body: "not json" })
-    expect(calls[0].init?.body).toBe("not json")
+    expect(calls[1].body).toBe(body)
   })
 })

--- a/packages/opencode/test/provider/xai-cache.test.ts
+++ b/packages/opencode/test/provider/xai-cache.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { XaiCache } from "@/provider/xai-cache"
 
 describe("XaiCache.withPromptCacheKey", () => {
-  test("mirrors x-grok-conv-id into prompt_cache_key on /responses requests only", async () => {
+  test("injects prompt_cache_key on /responses without touching other requests", async () => {
     const calls: RequestInit[] = []
     const wrapped = XaiCache.withPromptCacheKey((async (_input: RequestInfo | URL, init?: RequestInit) => {
       calls.push(init!)
@@ -10,15 +10,22 @@ describe("XaiCache.withPromptCacheKey", () => {
     }) as typeof fetch)
     const headers = { "x-grok-conv-id": "ses_abc123" }
     const body = JSON.stringify({ model: "grok-4.3", input: [] })
+    const explicit = JSON.stringify({ model: "grok-4.3", prompt_cache_key: "custom" })
 
     await wrapped("https://api.x.ai/v1/responses", { method: "POST", headers, body })
     await wrapped("https://api.x.ai/v1/chat/completions", { method: "POST", headers, body })
+    await wrapped("https://api.x.ai/v1/responses", { method: "POST", headers, body: explicit })
+    await wrapped("https://api.x.ai/v1/responses", { method: "POST", headers, body: "not json" })
 
+    // The conv id header becomes prompt_cache_key on /responses bodies.
     expect(JSON.parse(calls[0].body as string)).toEqual({
       model: "grok-4.3",
       input: [],
       prompt_cache_key: "ses_abc123",
     })
+    // Other endpoints, explicit keys, and unparseable bodies pass through unchanged.
     expect(calls[1].body).toBe(body)
+    expect(calls[2].body).toBe(explicit)
+    expect(calls[3].body).toBe("not json")
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #35033

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

xAI stores cached prompts per server, so each request needs a stable conversation identifier to reach the server that holds its cache: the `x-grok-conv-id` header, or the `prompt_cache_key` body field on the Responses API. opencode sent neither for xai models, so sessions missed their cached prefixes under load balancing.

- `LLMRequestPrep` sends `x-grok-conv-id` with the session ID on `@ai-sdk/xai` requests
- A new fetch wrapper, `XaiCache.withPromptCacheKey`, copies that header into `prompt_cache_key` on `/responses` bodies. The wrapper exists because `@ai-sdk/xai` drops the field from provider options. `Provider.resolveSDK` applies it ahead of the xAI OAuth plugin's fetch override
- `ProviderTransform.options` sets `promptCacheKey` for `@ai-sdk/xai`. The SDK ignores it today; once vercel/ai#16659 lands, the value flows without the wrapper

The session ID is stable for the life of a conversation, which is what makes it a valid routing key.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts test/provider/xai-cache.test.ts` and `bun typecheck` from packages/opencode
- Live call to `api.x.ai` using the production composition with a capture fetch: request bodies carried `prompt_cache_key` and responses streamed normally

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
