### PR TITLE
feat(core): route xai models through native responses runner

### DIFF
--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -128,8 +128,7 @@ const withVariant = (
 const apiName = (model: ModelV2.Info) =>
   model.api.type === "aisdk" ? `${model.api.type}:${model.api.package}` : model.api.type
 
-// Catalog xAI models may omit an explicit URL; the OpenAIResponses route
-// default points at OpenAI, so fall back to xAI's endpoint explicitly.
+// The OpenAIResponses route's default baseURL points at OpenAI.
 const XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
 
 export const fromCatalogModel = (
@@ -151,8 +150,7 @@ export const fromCatalogModel = (
     )
   }
   if (resolved.api.type === "aisdk" && resolved.api.package === "@ai-sdk/xai") {
-    // xAI's Responses API is OpenAI-shaped, including prompt_cache_key, which
-    // the runner already populates for prompt cache routing.
+    // xAI's Responses API is OpenAI-shaped, including prompt_cache_key.
     return Effect.succeed(
       withDefaults(resolved, OpenAIResponses.route)
         .with({

--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -128,6 +128,10 @@ const withVariant = (
 const apiName = (model: ModelV2.Info) =>
   model.api.type === "aisdk" ? `${model.api.type}:${model.api.package}` : model.api.type
 
+// Catalog xAI models may omit an explicit URL; the OpenAIResponses route
+// default points at OpenAI, so fall back to xAI's endpoint explicitly.
+const XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
+
 export const fromCatalogModel = (
   model: ModelV2.Info,
   credential?: Credential.Value,
@@ -143,6 +147,18 @@ export const fromCatalogModel = (
     return Effect.succeed(
       withDefaults(resolved, OpenAIResponses.route)
         .with({ auth: key === undefined ? Auth.none : Auth.bearer(key) })
+        .model({ id: resolved.api.id }),
+    )
+  }
+  if (resolved.api.type === "aisdk" && resolved.api.package === "@ai-sdk/xai") {
+    // xAI's Responses API is OpenAI-shaped, including prompt_cache_key, which
+    // the runner already populates for prompt cache routing.
+    return Effect.succeed(
+      withDefaults(resolved, OpenAIResponses.route)
+        .with({
+          auth: key === undefined ? Auth.none : Auth.bearer(key),
+          ...(resolved.api.url === undefined ? { endpoint: { baseURL: XAI_DEFAULT_BASE_URL } } : {}),
+        })
         .model({ id: resolved.api.id }),
     )
   }
@@ -176,6 +192,7 @@ export const supported = (model: ModelV2.Info) =>
   model.api.type === "aisdk" &&
   (model.api.package === "@ai-sdk/openai" ||
     model.api.package === "@ai-sdk/anthropic" ||
+    model.api.package === "@ai-sdk/xai" ||
     (model.api.package === "@ai-sdk/openai-compatible" && model.api.url !== undefined))
 
 /** Resolves models from the catalog belonging to the current Location runtime. */

--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -128,7 +128,8 @@ const withVariant = (
 const apiName = (model: ModelV2.Info) =>
   model.api.type === "aisdk" ? `${model.api.type}:${model.api.package}` : model.api.type
 
-// The OpenAIResponses route's default baseURL points at OpenAI.
+// The OpenAIResponses route's default baseURL points at OpenAI, so xAI models
+// without a catalog URL need their own default.
 const XAI_DEFAULT_BASE_URL = "https://api.x.ai/v1"
 
 export const fromCatalogModel = (
@@ -150,7 +151,7 @@ export const fromCatalogModel = (
     )
   }
   if (resolved.api.type === "aisdk" && resolved.api.package === "@ai-sdk/xai") {
-    // xAI's Responses API is OpenAI-shaped, including prompt_cache_key.
+    // xAI's Responses API matches the OpenAI Responses API, including prompt_cache_key.
     return Effect.succeed(
       withDefaults(resolved, OpenAIResponses.route)
         .with({

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -234,6 +234,47 @@ describe("SessionRunnerModel", () => {
     }),
   )
 
+  it.effect("maps catalog xAI AI SDK models into native Responses routes", () =>
+    Effect.gen(function* () {
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(
+        model({ type: "aisdk", package: "@ai-sdk/xai", url: "https://xai.example/v1" }),
+      )
+
+      expect(resolved.route).toMatchObject({
+        id: "openai-responses",
+        endpoint: { baseURL: "https://xai.example/v1" },
+      })
+    }),
+  )
+
+  it.effect("defaults catalog xAI models without a URL to the xAI endpoint", () =>
+    Effect.gen(function* () {
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(model({ type: "aisdk", package: "@ai-sdk/xai" }))
+
+      expect(resolved.route).toMatchObject({
+        id: "openai-responses",
+        endpoint: { baseURL: "https://api.x.ai/v1" },
+      })
+    }),
+  )
+
+  it.effect("lowers the runner prompt cache key into xAI request bodies", () =>
+    Effect.gen(function* () {
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(
+        model({ type: "aisdk", package: "@ai-sdk/xai", url: "https://xai.example/v1" }),
+      )
+      const prepared = yield* LLMClient.prepare(
+        LLM.request({
+          model: resolved,
+          prompt: "Hello",
+          providerOptions: { openai: { promptCacheKey: "ses_cache_key" } },
+        }),
+      )
+
+      expect(prepared.body).toMatchObject({ prompt_cache_key: "ses_cache_key" })
+    }),
+  )
+
   it.effect("maps catalog Anthropic AI SDK models into native routes", () =>
     Effect.gen(function* () {
       const resolved = yield* SessionRunnerModel.fromCatalogModel(
@@ -336,6 +377,7 @@ describe("SessionRunnerModel", () => {
           model({ type: "aisdk", package: "@ai-sdk/openai", url: "https://openai.example/v1" }),
         ),
       ).toBe(true)
+      expect(SessionRunnerModel.supported(model({ type: "aisdk", package: "@ai-sdk/xai" }))).toBe(true)
       expect(
         SessionRunnerModel.supported(
           model({ type: "aisdk", package: "@ai-sdk/google", url: "https://google.example/v1" }),

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -234,19 +234,6 @@ describe("SessionRunnerModel", () => {
     }),
   )
 
-  it.effect("maps catalog xAI AI SDK models into native Responses routes", () =>
-    Effect.gen(function* () {
-      const resolved = yield* SessionRunnerModel.fromCatalogModel(
-        model({ type: "aisdk", package: "@ai-sdk/xai", url: "https://xai.example/v1" }),
-      )
-
-      expect(resolved.route).toMatchObject({
-        id: "openai-responses",
-        endpoint: { baseURL: "https://xai.example/v1" },
-      })
-    }),
-  )
-
   it.effect("defaults catalog xAI models without a URL to the xAI endpoint", () =>
     Effect.gen(function* () {
       const resolved = yield* SessionRunnerModel.fromCatalogModel(model({ type: "aisdk", package: "@ai-sdk/xai" }))


### PR DESCRIPTION
### Issue for this PR

Closes #35100

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The V2 runner sets a prompt cache key on every request, and the OpenAIResponses protocol writes it to the `prompt_cache_key` body field. `fromCatalogModel` had no branch for `@ai-sdk/xai`, so xai models failed with `UnsupportedApiError` and fell back to paths that drop the key.

- `fromCatalogModel` maps `@ai-sdk/xai` onto the OpenAIResponses route with bearer auth. xAI's Responses API matches the OpenAI Responses API, including `prompt_cache_key`
- Models without a catalog URL default to `https://api.x.ai/v1`, since the route's own default points at OpenAI
- `supported()` now includes `@ai-sdk/xai`

### How did you verify your code works?

- `bun test test/session-runner-model.test.ts` and `bun typecheck` from packages/core
- Live call to `api.x.ai` through the native LLMClient stack: the endpoint defaulted correctly, the request body carried `prompt_cache_key`, and the model responded

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

