### PR TITLE
fix(core): remove mcp tool call timeout

### DIFF
--- a/packages/core/src/config/mcp.ts
+++ b/packages/core/src/config/mcp.ts
@@ -8,7 +8,7 @@ export class Timeout extends Schema.Class<Timeout>("ConfigV2.MCP.Timeout")({
     description: "Maximum time in milliseconds to establish and initialize the MCP server.",
   }),
   request: PositiveInt.pipe(Schema.optional).annotate({
-    description: "Maximum time in milliseconds to wait for each MCP request after initialization.",
+    description: "Maximum time in milliseconds to wait for MCP catalog/list requests after initialization.",
   }),
 }) {}
 

--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -250,7 +250,7 @@ export const connect = Effect.fnUntraced(function* (
               { name: input.name, arguments: input.args ?? {} },
               CallToolResultSchema,
               // Keep progress tokens available without imposing a client timeout on tool execution.
-              { signal, onprogress: () => {} },
+              { signal, resetTimeoutOnProgress: true, onprogress: () => {} },
             ),
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         }).pipe(

--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -235,7 +235,7 @@ export const connect = Effect.fnUntraced(function* (
             client.request(
               { method: "prompts/get", params: { name: input.name, arguments: input.args ?? {} } },
               GetPromptResultSchema,
-              { signal, timeout: requestTimeout, resetTimeoutOnProgress: true, onprogress: () => {} },
+              { signal },
             ),
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         }).pipe(
@@ -249,8 +249,8 @@ export const connect = Effect.fnUntraced(function* (
             client.callTool(
               { name: input.name, arguments: input.args ?? {} },
               CallToolResultSchema,
-              // The SDK only sends a progress token when onprogress is present, which enables timeout resets.
-              { signal, timeout: requestTimeout, resetTimeoutOnProgress: true, onprogress: () => {} },
+              // Keep progress tokens available without imposing a client timeout on tool execution.
+              { signal, onprogress: () => {} },
             ),
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         }).pipe(


### PR DESCRIPTION
## Summary

- stop applying MCP request timeout to prompt retrieval and tool execution
- keep MCP request timeout scoped to catalog/list requests
- clarify the MCP timeout config description

## Testing

- cd packages/core && bun typecheck
- git diff --check