### PR TITLE
fix(core): skip ahead by counting newlines when reading at a high offset

### DIFF
--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -283,6 +283,38 @@ export const read = Effect.fn("ReadTool.read")(function* (
       }
       const consumeChunk = Effect.fnUntraced(function* (chunk: Uint8Array) {
         let start = 0
+        // Fast-forward through the lines preceding `offset` by counting newline
+        // bytes directly, instead of decoding and running the binary heuristic
+        // on every skipped line. For a multi-million-line file read at a high
+        // offset this replaces millions of per-line UTF-8 decodes with a single
+        // byte scan. Counting 0x0A at the byte level is safe because UTF-8
+        // continuation bytes are always 0x80–0xBF, so 0x0A never appears inside
+        // a multi-byte sequence and the byte right after a `\n` is always a
+        // character boundary — the decoder can start fresh there. Null bytes in
+        // the skipped region (the definitive binary marker) are still rejected;
+        // the per-line non-printable heuristic is skipped for discarded lines.
+        if (line < offset) {
+          const need = offset - line
+          let counted = 0
+          let pos = 0
+          while (counted < need) {
+            const newline = chunk.indexOf(10, pos)
+            if (newline === -1) {
+              pos = chunk.length
+              break
+            }
+            counted++
+            pos = newline + 1
+          }
+          if (chunk.subarray(0, pos).includes(0))
+            return yield* Effect.fail(new BinaryFileError({ resource }))
+          if (counted < need) {
+            line += counted
+            return true
+          }
+          line = offset
+          start = pos
+        }
         while (start < chunk.length) {
           if (lines.length >= limit || bytes >= MAX_READ_BYTES) {
             next = line

--- a/packages/core/test/tool-read-filesystem.test.ts
+++ b/packages/core/test/tool-read-filesystem.test.ts
@@ -100,6 +100,106 @@ describe("ReadToolFileSystem", () => {
     }),
   )
 
+  it.effect("returns the correct page when reading at a high line offset", () =>
+    Effect.gen(function* () {
+      const { fs, files, directory } = yield* fixture
+      const file = path.join(directory, "numbered.txt")
+      const lines = Array.from({ length: 5_000 }, (_, i) => `line-${i + 1}`)
+      yield* files.writeFileString(file, lines.join("\n"))
+
+      const result = yield* ReadToolFileSystem.read(fs, file, "numbered.txt", { offset: 4_000, limit: 3 })
+
+      expect(result).toBeInstanceOf(ReadToolFileSystem.TextPage)
+      if (result instanceof ReadToolFileSystem.TextPage) {
+        expect(result.offset).toBe(4_000)
+        expect(result.content).toBe("line-4000\nline-4001\nline-4002")
+        expect(result.truncated).toBe(true)
+        expect(result.next).toBe(4_003)
+      }
+    }),
+  )
+
+  it.effect("decodes multibyte UTF-8 correctly when starting after a skip", () =>
+    // Guards against the byte-level skip landing mid-codepoint: the position
+    // right after a `\n` must be a valid character boundary so the decoder can
+    // start fresh on multibyte sequences (ä, γ, 🎉).
+    Effect.gen(function* () {
+      const { fs, files, directory } = yield* fixture
+      const file = path.join(directory, "utf8.txt")
+      const lines = ["alpha", "betä", "γgamma", "🎉delta", "epsilon"]
+      yield* files.writeFileString(file, lines.join("\n"))
+
+      const result = yield* ReadToolFileSystem.read(fs, file, "utf8.txt", { offset: 3, limit: 2 })
+
+      expect(result).toBeInstanceOf(ReadToolFileSystem.TextPage)
+      if (result instanceof ReadToolFileSystem.TextPage) {
+        expect(result.content).toBe("γgamma\n🎉delta")
+        expect(result.offset).toBe(3)
+        expect(result.truncated).toBe(true)
+        expect(result.next).toBe(5)
+      }
+    }),
+  )
+
+  it.effect("strips carriage returns from lines read after a skip", () =>
+    Effect.gen(function* () {
+      const { fs, files, directory } = yield* fixture
+      const file = path.join(directory, "crlf.txt")
+      yield* files.writeFileString(file, "a\r\nb\r\nc\r\nd\r\ne")
+
+      const result = yield* ReadToolFileSystem.read(fs, file, "crlf.txt", { offset: 3, limit: 2 })
+
+      expect(result).toBeInstanceOf(ReadToolFileSystem.TextPage)
+      if (result instanceof ReadToolFileSystem.TextPage) {
+        expect(result.content).toBe("c\nd")
+        expect(result.offset).toBe(3)
+      }
+    }),
+  )
+
+  it.effect("rejects a null byte in the skipped region before the offset", () =>
+    // The byte-level skip must still catch binary content (null bytes) in the
+    // lines it discards, not just in the lines it returns.
+    Effect.gen(function* () {
+      const { fs, files, directory } = yield* fixture
+      const file = path.join(directory, "binary-skipped.txt")
+      yield* files.writeFile(file, new TextEncoder().encode("bad\x00line\ngood\ngood\n"))
+
+      const error = yield* ReadToolFileSystem.read(fs, file, "binary-skipped.txt", { offset: 2 }).pipe(Effect.flip)
+
+      expect(error).toBeInstanceOf(ReadToolFileSystem.BinaryFileError)
+    }),
+  )
+
+  it.effect("reads a high offset out of a large file without scanning every line", () =>
+    // Regression guard for #35044: reading near the end of a large file must
+    // stay fast. The byte-level skip advances past filler lines without
+    // decoding them, so reaching the trailing marker stays cheap even with
+    // hundreds of thousands of preceding lines spread across many chunks.
+    Effect.gen(function* () {
+      const { fs, files, directory } = yield* fixture
+      const file = path.join(directory, "massive.txt")
+      const total = 200_000
+      const filler = "filler\n".repeat(total - 1)
+      const marker = "MARKER-LINE"
+      yield* files.writeFileString(file, filler + marker)
+
+      const startedAt = Date.now()
+      const result = yield* ReadToolFileSystem.read(fs, file, "massive.txt", { offset: total })
+      const elapsed = Date.now() - startedAt
+
+      expect(result).toBeInstanceOf(ReadToolFileSystem.TextPage)
+      if (result instanceof ReadToolFileSystem.TextPage) {
+        expect(result.content).toBe(marker)
+        expect(result.offset).toBe(total)
+        expect(result.truncated).toBe(false)
+      }
+      // Generous ceiling so this is not flaky on slow CI, while still catching
+      // the multi-second regression where every skipped line is decoded.
+      expect(elapsed).toBeLessThan(5_000)
+    }),
+  )
+
   it.effect("preserves the media ingestion limit message", () =>
     Effect.gen(function* () {
       const { fs, files, directory } = yield* fixture


### PR DESCRIPTION
### Issue for this PR

Closes #35044

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reading a text page at a high line offset was slow because `ReadTool.read` (`packages/core/src/tool/read-filesystem.ts`, `consumeChunk`) decoded every line and ran the binary heuristic on each one — including the lines it was about to discard. For a 6.7M-line file (e.g. a large Ghidra decompilation listing), reading at offset 5,000,000 meant ~5M per-line UTF-8 decodes plus per-line `binary()` byte scans before the first requested line was even reached, so each offset read walked the entire prefix of the file.

`consumeChunk` now fast-forwards through the lines preceding `offset` by counting `0x0A` bytes with `Uint8Array.indexOf` until it reaches the requested line, and only then starts decoding. This is safe at the byte level because UTF-8 continuation bytes are always `0x80–0xBF`, so `0x0A` never appears inside a multi-byte sequence and the byte right after a `\n` is always a character boundary — the `TextDecoder` can start fresh at that position. Null bytes in the skipped region are still rejected (via a single `Uint8Array.includes(0)` scan per chunk, the definitive binary marker); only the per-line non-printable ratio heuristic is skipped for discarded lines. The collected lines are still checked with the full `binary()` heuristic as before.

This complements the early-termination work already in `consumeChunk` (which stops once the page is full): after this change the reader does work proportional to `offset + limit` rather than to the whole file, for both the skip and the collect phases.

### How did you verify your code works?

Added tests in `packages/core/test/tool-read-filesystem.test.ts`:

- Reading at a high offset (offset 4000 of a 5000-line file) returns exactly the right lines with the right `offset`/`truncated`/`next`.
- Multibyte UTF-8 (`ä`, `γ`, `🎉`) decodes correctly when the skip lands right after a newline, i.e. the decoder starts on a character boundary.
- `\r\n` line endings are stripped for lines read after a skip.
- A null byte in the skipped region (before the offset) is still rejected as `BinaryFileError`.
- Regression guard for #35044: reading the last line of a 200,000-line file returns the correct content and completes in well under the pre-regression ceiling.

Ran locally with `bun test ./test/tool-read-filesystem.test.ts` — 12/12 pass. `bun run typecheck` (packages/core) passes. The pre-existing tests in `tool-read.test.ts` still pass (19/19).

### Screenshots / recordings

N/A — pure code change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
