### PR TITLE
fix(tui): listen for v2 question events instead of v1

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -8,7 +8,7 @@ import type {
   Todo,
   Command,
   PermissionRequest,
-  QuestionRequest,
+  QuestionV2Request,
   LspStatus,
   McpStatus,
   McpResource,
@@ -77,7 +77,7 @@ export const {
         [sessionID: string]: PermissionRequest[]
       }
       question: {
-        [sessionID: string]: QuestionRequest[]
+        [sessionID: string]: QuestionV2Request[]
       }
       config: Config
       session: Session[]
@@ -218,8 +218,8 @@ export const {
           break
         }
 
-        case "question.replied":
-        case "question.rejected": {
+        case "question.v2.replied":
+        case "question.v2.rejected": {
           const requests = store.question[event.properties.sessionID]
           if (!requests) break
           const match = search(requests, event.properties.requestID, (r) => r.id)
@@ -234,7 +234,7 @@ export const {
           break
         }
 
-        case "question.asked": {
+        case "question.v2.asked": {
           const request = event.properties
           const requests = store.question[request.sessionID]
           if (!requests) {

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -3,7 +3,7 @@ import { createMemo, createSignal, For, onCleanup, onMount, Show } from "solid-j
 import { useRenderer } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
-import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
+import type { QuestionAnswer, QuestionV2Request } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../ui/border"
 import { useTuiConfig } from "../../config"
@@ -11,7 +11,7 @@ import { useBindings, useOpencodeModeStack } from "../../keymap"
 
 const QUESTION_MODE = "question"
 
-export function QuestionPrompt(props: { request: QuestionRequest; directory?: string }) {
+export function QuestionPrompt(props: { request: QuestionV2Request; directory?: string }) {
   const sdk = useSDK()
   const { theme } = useTheme()
   const renderer = useRenderer()


### PR DESCRIPTION
### Issue for this PR

Closes #31383

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI sync layer listens for v1 event types (`question.asked`, `question.replied`, `question.rejected`) but the server only emits v2 event types (`question.v2.asked`, `question.v2.replied`, `question.v2.rejected`). The v1 events are defined in the schema but never emitted by any service — the entire server-side stack uses v2.

This causes the TUI's event handler to silently ignore all question events. `sync.data.question` is never populated, the `QuestionPrompt` component never renders, and the question tool call hangs indefinitely (appearing as infinite loading to the user).

The fix changes the event type strings in the TUI sync layer to match what the server actually emits:
- `"question.asked"` → `"question.v2.asked"`
- `"question.replied"` → `"question.v2.replied"`
- `"question.rejected"` → `"question.v2.rejected"`

The store type and component prop type are updated from `QuestionRequest` to `QuestionV2Request` — these are structurally identical (same fields, same optionality), so this is purely a TypeScript type name change to match the v2 event properties.

### How did you verify your code works?

The v1 and v2 types are structurally identical — this is a string literal fix plus TypeScript type rename. The server handler for replies (`POST /api/session/:sessionID/question/:requestID/reply`) already delegates to `QuestionV2.Service`, so the reply path works unchanged.

### Screenshots / recordings

N/A — bug fix with no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR