### PR TITLE
fix(app): keep v2 review pane mounted across session tab switches

### DIFF
--- a/packages/app/e2e/regression/review-tab-switch.spec.ts
+++ b/packages/app/e2e/regression/review-tab-switch.spec.ts
@@ -1,0 +1,129 @@
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { expect, test, type Page } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible, expectSessionTitle } from "../utils/waits"
+
+const directory = "C:/OpenCode/ReviewTabSwitch"
+const projectID = "proj_review_tab_switch"
+const sessionA = "ses_review_tab_a"
+const sessionB = "ses_review_tab_b"
+const titleA = "Alpha session"
+const titleB = "Beta session"
+const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+// Marks the review pane DOM node so a remount (fresh node) is detectable.
+const PROBE = "original"
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+// The v2 review pane's diff data is workspace-scoped: switching between session
+// tabs in the same workspace must update its parameters reactively instead of
+// tearing the pane down and remounting it (which flickers).
+test("keeps the v2 review pane mounted when switching session tabs in a workspace", async ({ page }) => {
+  await setup(page)
+
+  await page.goto(sessionHref(sessionA))
+  await expectSessionTitle(page, titleA)
+
+  await page.getByRole("button", { name: "Toggle review" }).click()
+  const review = page.locator('#review-panel [data-component="session-review-v2"]')
+  await expectAppVisible(review)
+  await expectAppVisible(page.getByRole("button", { name: /example\.ts/ }))
+  await writeProbe(page)
+
+  await switchTab(page, titleB)
+  await expectSessionTitle(page, titleB)
+  await expectAppVisible(review)
+  expect(await readProbe(page)).toBe(PROBE)
+
+  await switchTab(page, titleA)
+  await expectSessionTitle(page, titleA)
+  await expectAppVisible(review)
+  expect(await readProbe(page)).toBe(PROBE)
+})
+
+type Probed = HTMLElement & { __e2eProbe?: string }
+
+async function switchTab(page: Page, title: string) {
+  await page.locator("[data-titlebar-tab-slot]", { hasText: title }).click()
+}
+
+async function writeProbe(page: Page) {
+  await page.locator('#review-panel [data-component="session-review-v2"]').evaluate((el, probe) => {
+    ;(el as Probed).__e2eProbe = probe
+  }, PROBE)
+}
+
+async function readProbe(page: Page) {
+  return page.locator('#review-panel [data-component="session-review-v2"]').evaluate((el) => (el as Probed).__e2eProbe)
+}
+
+async function setup(page: Page) {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: projectID,
+      worktree: directory,
+      vcs: "git",
+      name: "review-tab-switch",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: {
+      all: [
+        {
+          id: "opencode",
+          name: "OpenCode",
+          models: { test: { id: "test", name: "Test", limit: { context: 200_000 } } },
+        },
+      ],
+      connected: ["opencode"],
+      default: { providerID: "opencode", modelID: "test" },
+    },
+    sessions: [session(sessionA, titleA, 1700000000000), session(sessionB, titleB, 1700000001000)],
+    vcsDiff: [
+      {
+        file: "src/example.ts",
+        additions: 1,
+        deletions: 1,
+        status: "modified",
+        patch:
+          "diff --git a/src/example.ts b/src/example.ts\n--- a/src/example.ts\n+++ b/src/example.ts\n@@ -1 +1 @@\n-export const value = 'before'\n+export const value = 'after'\n",
+      },
+    ],
+    pageMessages: () => ({ items: [] }),
+  })
+
+  await page.addInitScript(
+    ({ directory, server, sessions }) => {
+      localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+      localStorage.setItem(
+        "opencode.global.dat:server",
+        JSON.stringify({
+          projects: { local: [{ worktree: directory, expanded: true }] },
+          lastProject: { local: directory },
+        }),
+      )
+      localStorage.setItem(
+        "opencode.window.browser.dat:tabs",
+        JSON.stringify(sessions.map((sessionId: string) => ({ type: "session", server, sessionId }))),
+      )
+    },
+    { directory, server, sessions: [sessionA, sessionB] },
+  )
+}
+
+function session(id: string, title: string, created: number) {
+  return {
+    id,
+    slug: id,
+    projectID,
+    directory,
+    title,
+    version: "dev",
+    time: { created, updated: created },
+  }
+}
+
+function sessionHref(sessionID: string) {
+  return `/server/${base64Encode(server)}/session/${sessionID}`
+}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1210,11 +1210,14 @@ export default function Page() {
     },
   })
 
+  // Latch: defer only the first diff render off the mount critical path. This Page
+  // stays mounted across same-workspace session tab switches, so gating on every
+  // deferRender flip tore down and remounted the whole review pane on tab switch.
+  const reviewPanelV2Rendered = createMemo<boolean>((prev) => prev || !store.deferRender, false)
+
   const reviewPanelV2 = () => (
     <div class="flex flex-col h-full overflow-hidden bg-background-stronger contain-strict">
-      {/* The route remounts per session; defer the diff render off the switch critical path
-          like the legacy review tab does. */}
-      <Show when={!store.deferRender}>
+      <Show when={reviewPanelV2Rendered()}>
         <ReviewPanelV2 {...reviewPanelV2Props()} />
       </Show>
     </div>


### PR DESCRIPTION
## Problem

In the desktop app with the new layout (v2), switching between session tabs in the same workspace fully remounts the v2 review pane, causing a visible flicker.

Since the session-tab-remount work, `Page` stays mounted across same-workspace tab switches and only `params.id` changes. But the v2 review panel was still gated on `<Show when={!store.deferRender}>`, and `deferRender` flips true/false on **every** `sessionKey` change - so each tab switch disposed and recreated the entire `ReviewPanelV2` one frame later. The comment on that gate (\"The route remounts per session\") was stale.

The pane's inputs are already tab-switch stable: the vcs diff query is keyed per workspace directory, panel state is a global persist, and all props are lazy getters - so once the gate is fixed, tab switches are purely reactive parameter updates.

## Fix

Replace the per-session gate with a mount-once latch:

```ts
const reviewPanelV2Rendered = createMemo<boolean>((prev) => prev || !store.deferRender, false)
```

- The initial diff render still stays off the mount critical path (`deferRender` starts true, clears after the first frame).
- Once rendered, the latch short-circuits and never tears the panel down again for the lifetime of the `Page` (which is keyed per workspace, so cross-workspace switches still remount as before).
- Scoped to the v2 review pane only: the composer `ready` gate and the legacy review tab keep their existing per-session defer behavior.

## Test

TDD: added `e2e/regression/review-tab-switch.spec.ts` (modeled on `terminal-tab-switch.spec.ts`) which marks the mounted review pane DOM node with a probe, switches tabs both ways, and asserts the node survives. Verified failing before the fix and passing after, with no test changes.

## Verification

From `packages/app`:
- `bun run test:e2e e2e/regression/review-tab-switch.spec.ts` - fails on dev, passes with fix
- `bun run test:e2e` for `review-image-flash`, `review-line-comment`, `terminal-tab-switch`, `tab-navigate-mousedown`, `cross-server-tab-close`, `remote-tab-busy` - all pass
- `bun typecheck` and `bun run typecheck:e2e` - clean