### PR TITLE
docs: add oh-my-loop to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [oh-my-loop](https://github.com/vc999999999/oh-my-loop)                                    | OpenCode loop controller with budgets, gates, and worktrees      |
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -67,6 +67,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [OpenWork](https://github.com/different-ai/openwork)                                       | Claude Cowork 的开源替代方案，由 OpenCode 驱动                |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode 扩展管理器，支持可移植的隔离配置                     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | OpenCode 的桌面、Web、移动和远程客户端应用                    |
+| [oh-my-loop](https://github.com/vc999999999/oh-my-loop)                                    | 带预算、验证门和 worktree 的 OpenCode 外层循环控制器          |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #35251

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds oh-my-loop to the Projects section of the English and Simplified Chinese ecosystem docs.

It links the project repo and describes it as an external OpenCode loop controller with budgets, verification gates, and worktrees.

### How did you verify your code works?

Ran:

- `bunx prettier --check packages/web/src/content/docs/ecosystem.mdx packages/web/src/content/docs/zh-cn/ecosystem.mdx`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR