### PR TITLE
fix(ci): setup Node 24 before bun install for node-gyp

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -8,6 +8,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # node-gyp@latest (invoked via bunx for native install scripts) requires Node >=22;
+    # some runner images ship an older system Node on PATH
+    - name: Setup Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: "24"
+
     - name: Get baseline download URL
       id: bun-url
       shell: bash


### PR DESCRIPTION
## Problem

CI jobs using the `setup-bun` composite action started failing intermittently during `bun install`:

```
gyp ERR! stack TypeError: webidl.util.markAsUncloneable is not a function
gyp ERR! stack at new CacheStorage (/tmp/bunx-1001-node-gyp@latest/node_modules/undici/lib/web/cache/cachestorage.js:20:17)
error: install script from "tree-sitter-powershell" exited with 1
```

Example: https://github.com/anomalyco/opencode/actions/runs/28637513272/job/84927250731

## Root cause

- `node-gyp` is not a repo dependency, so bun runs native install scripts (`tree-sitter-powershell`, `tree-sitter`, `node-pty`, ...) via `bunx node-gyp@latest`, resolved fresh from npm at job time
- `node-gyp@13.0.1` (published 2026-07-02, ~5h before the first failure) bumped undici `^6.25.0` -> `^8.4.1`
- undici 8 requires Node >= 22.19 and crashes at module load on Node 20 (nodejs/undici#5024); node-gyp 13 itself declares `node ^22.22.2 || ^24.15.0 || >=26`
- The Blacksmith runner image ships Node 20.20.0 on PATH, so node-gyp's `#!/usr/bin/env node` picks an unsupported runtime

Failures are intermittent because bunx caches `node-gyp@latest` per-VM in `/tmp`; warm VMs with a pre-13.0.1 cache still pass. Expect failure rates to climb as those caches expire.

`test.yml` was unaffected because it already runs `actions/setup-node` with Node 24 before installing.

## Fix

Add `actions/setup-node` (Node 24, same pinned SHA already used in test/publish/deploy workflows) to the `setup-bun` composite action, before `bun install`. This covers all 13 workflows that previously installed deps without a modern Node on PATH.

Cost is negligible: Node 24 is pre-seeded in the runner tool cache (0-4s in existing jobs, usually no download).

## Follow-up (not in this PR)

Pinning `node-gyp` as a root devDependency would remove the `bunx node-gyp@latest` resolution entirely and make builds deterministic against future node-gyp releases.
