### PR TITLE
fix(opencode): use toLowerCase instead of toLocaleLowerCase for ACP tool name comparison

### DIFF
--- a/packages/opencode/src/acp/permission.ts
+++ b/packages/opencode/src/acp/permission.ts
@@ -137,7 +137,7 @@ async function permissionToolCall(input: {
 }
 
 function permissionTitle(toolName: string, input: ToolInput) {
-  const tool = toolName.toLocaleLowerCase()
+  const tool = toolName.toLowerCase()
   switch (tool) {
     case "external_directory":
       return stringValue(input.description) ?? stringValue(input.command) ?? stringValue(input.parentDir)
@@ -181,7 +181,7 @@ function permissionLocations(toolName: string, input: ToolInput): ToolCallLocati
 }
 
 async function permissionContent(toolName: string, input: ToolInput): Promise<ToolCallContent[]> {
-  if (toolName.toLocaleLowerCase() !== "edit") return []
+  if (toolName.toLowerCase() !== "edit") return []
 
   const files = fileMetadata(input)
   if (files.length) return diffContentForFiles(files)

--- a/packages/opencode/src/acp/tool.ts
+++ b/packages/opencode/src/acp/tool.ts
@@ -36,7 +36,7 @@ export type ImageAttachment = {
 }
 
 export function toToolKind(toolName: string): ToolKind {
-  const tool = toolName.toLocaleLowerCase()
+  const tool = toolName.toLowerCase()
 
   switch (tool) {
     case "bash":
@@ -71,7 +71,7 @@ export function toToolKind(toolName: string): ToolKind {
 }
 
 export function toLocations(toolName: string, input: ToolInput, cwd?: string): ToolCallLocation[] {
-  const tool = toolName.toLocaleLowerCase()
+  const tool = toolName.toLowerCase()
 
   switch (tool) {
     case "bash":
@@ -102,7 +102,7 @@ export function toLocations(toolName: string, input: ToolInput, cwd?: string): T
 
 export function completedToolContent(toolName: string, state: CompletedToolState): ToolCallContent[] {
   const text =
-    toolName.toLocaleLowerCase() === "read" ? (readDisplayText(state.metadata) ?? state.output) : state.output
+    toolName.toLowerCase() === "read" ? (readDisplayText(state.metadata) ?? state.output) : state.output
   const content: ToolCallContent[] = [
     {
       type: "content",
@@ -292,7 +292,7 @@ function shellCommand(input: ToolInput) {
 }
 
 function isShell(toolName: string) {
-  const tool = toolName.toLocaleLowerCase()
+  const tool = toolName.toLowerCase()
   return tool === "bash" || tool === "shell"
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #35096

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replaces `toLocaleLowerCase()` with `toLowerCase()` for tool name comparison in the ACP module. Tool names like `"bash"`, `"shell"`, `"edit"`, `"read"` are fixed identifiers and should use locale-invariant comparison. Using `toLocaleLowerCase()` breaks in Turkish/Azerbaijani locale where, for example, `"EDIT".toLocaleLowerCase("tr-TR")` produces `"edıt"` (dotless ı) instead of `"edit"`, causing silent tool kind mismatch.

Same root cause as #33109 which was already merged for `provider/transform.ts`.

### How did you verify your code works?

- `bun typecheck` passes with no errors
- Verified that `"EDIT".toLocaleLowerCase("tr-TR")` → `"edıt"` vs `"EDIT".toLowerCase()` → `"edit"`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR