### PR TITLE
refactor(opencode): expose MCP tools in native shape from the service

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -1,7 +1,6 @@
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { type Tool } from "ai"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { Client, type ClientOptions } from "@modelcontextprotocol/sdk/client/index.js"
@@ -154,11 +153,18 @@ export interface ServerInstructions {
   tools: string[]
 }
 
+/** An MCP tool in its native shape; consumers adapt it to their own tool format. */
+export interface McpTool {
+  def: MCPToolDef
+  client: MCPClient
+  timeout?: number
+}
+
 export interface Interface {
   readonly status: () => Effect.Effect<Record<string, Status>>
   readonly clients: () => Effect.Effect<Record<string, MCPClient>>
   readonly instructions: () => Effect.Effect<ServerInstructions[]>
-  readonly tools: () => Effect.Effect<Record<string, Tool>>
+  readonly tools: () => Effect.Effect<Record<string, McpTool>>
   readonly prompts: () => Effect.Effect<Record<string, PromptInfo & { client: string }>>
   readonly resources: (clientName?: string) => Effect.Effect<Record<string, ResourceInfo & { client: string }>>
   readonly resourceTemplates: (
@@ -656,7 +662,7 @@ const layer = Layer.effect(
     }
 
     const tools = Effect.fn("MCP.tools")(function* () {
-      const result: Record<string, Tool> = {}
+      const result: Record<string, McpTool> = {}
       const s = yield* InstanceState.get(state)
 
       const cfg = yield* cfgSvc.get()
@@ -672,9 +678,8 @@ const layer = Layer.effect(
           continue
         }
         const timeout = requestTimeout(s, clientName, mcpConfig, defaultTimeout)
-        for (const mcpTool of listed) {
-          const key = McpCatalog.toolName(clientName, mcpTool.name)
-          result[key] = McpCatalog.convertTool(mcpTool, client, timeout)
+        for (const def of listed) {
+          result[McpCatalog.toolName(clientName, def.name)] = { def, client, timeout }
         }
       }
       return result

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -155,9 +155,10 @@ export interface ServerInstructions {
 
 /** An MCP tool in its native shape; consumers adapt it to their own tool format. */
 export interface McpTool {
-  def: MCPToolDef
-  client: MCPClient
-  timeout?: number
+  /** Shared cached definition; consumers must copy rather than mutate it. */
+  readonly def: MCPToolDef
+  readonly client: MCPClient
+  readonly timeout?: number
 }
 
 export interface Interface {

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -3,6 +3,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import { MCP } from "@/mcp"
+import { McpCatalog } from "@/mcp/catalog"
 import { Permission } from "@/permission"
 import { Tool } from "@/tool/tool"
 import { ToolJsonSchema } from "@/tool/json-schema"
@@ -381,7 +382,8 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     })
   }
 
-  for (const [key, item] of Object.entries(yield* mcp.tools())) {
+  for (const [key, entry] of Object.entries(yield* mcp.tools())) {
+    const item = McpCatalog.convertTool(entry.def, entry.client, entry.timeout)
     const execute = item.execute
     if (!execute) continue
 


### PR DESCRIPTION
## What

Changes `MCP.tools()` to return MCP tools in their native shape instead of AI-SDK `Tool` objects:

```ts
export interface McpTool {
  def: MCPToolDef
  client: MCPClient
  timeout?: number
}
```

The single consumer (`session/tools.ts`) now adapts entries at its own boundary via `McpCatalog.convertTool(entry.def, entry.client, entry.timeout)` — the exact same call the service was making internally, so runtime behavior is unchanged.

## Why

The MCP service should hand out MCP things; the AI-SDK tool shape is a concern of the session tool loop that consumes it. Upcoming consumers (the CodeMode adapter, #35085) need the native def/client rather than the type-erased AI-SDK wrapper, and unwrapping `convertTool`'s output loses the schema-validated `CallToolResult` type.

This also drops the `ai` import from `src/mcp/index.ts`.

## Verification

- `bun typecheck` (packages/opencode)
- `bun test test/mcp test/session/prompt.test.ts test/session/snapshot-tool-race.test.ts` — 127 pass (lifecycle tests assert on `tools()` keys only, which are unchanged)