### PR TITLE
feat(tui): render code-mode execute tool with child calls

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2350,22 +2350,14 @@ function Execute(props: ToolProps) {
   const showOutput = createMemo(() => output() && hasRuntimeError())
   const detailPadding = 3 + INLINE_TOOL_ICON_WIDTH
 
-  const complete = createMemo(() => (props.part.state.status === "pending" ? false : "execute"))
-
   return (
     <>
       <InlineTool
-        icon={
-          props.part.state.status === "completed" && !hasRuntimeError()
-            ? "✓"
-            : props.part.state.status === "error" || hasRuntimeError()
-              ? "✗"
-              : "│"
-        }
+        icon={hasRuntimeError() ? "✗" : props.part.state.status === "completed" ? "✓" : "│"}
         color={hasRuntimeError() ? theme.error : undefined}
         spinner={isLoading()}
         pending="execute"
-        complete={complete()}
+        complete={true}
         part={props.part}
       >
         execute

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2348,7 +2348,6 @@ function Execute(props: ToolProps) {
   const hasRuntimeError = createMemo(() => props.metadata.error === true)
   const outputPreview = createMemo(() => collapseToolOutput(output(), 4, 4 * Math.max(20, ctx.width - 6)).output)
   const showOutput = createMemo(() => output() && hasRuntimeError())
-  const detailPadding = 3 + INLINE_TOOL_ICON_WIDTH
 
   return (
     <>
@@ -2366,8 +2365,8 @@ function Execute(props: ToolProps) {
         {(call) => {
           const args = input(call.input ?? {})
           return (
-            <box paddingLeft={detailPadding}>
-              <text fg={call.status === "error" ? theme.error : theme.textMuted}>
+            <box paddingLeft={3}>
+              <text paddingLeft={3} fg={call.status === "error" ? theme.error : theme.textMuted}>
                 ↳ {call.tool}
                 {args ? ` ${args}` : ""}
                 {call.status === "error" ? " (failed)" : ""}
@@ -2377,10 +2376,10 @@ function Execute(props: ToolProps) {
         }}
       </For>
       <Show when={showOutput()}>
-        <box paddingLeft={detailPadding}>
+        <box paddingLeft={3}>
           <For each={outputPreview().split("\n")}>
             {(line, index) => (
-              <text fg={theme.error}>
+              <text paddingLeft={3} fg={theme.error}>
                 {index() === 0 ? "↳ " : "  "}
                 {line}
               </text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1758,6 +1758,9 @@ function ToolPart(props: { last: boolean; part: ToolPart; message: AssistantMess
         <Match when={display() === "task"}>
           <Task {...toolprops} />
         </Match>
+        <Match when={display() === "execute"}>
+          <Execute {...toolprops} />
+        </Match>
         <Match when={display() === "apply_patch"}>
           <ApplyPatch {...toolprops} />
         </Match>
@@ -2322,6 +2325,81 @@ export function formatCompletedSubagentDetail(toolcalls: number, duration: strin
   return `${formatSubagentToolcalls(toolcalls)} · ${duration}`
 }
 
+type ExecuteCall = { tool: string; status: "running" | "completed" | "error"; input?: Record<string, unknown> }
+
+function executeCalls(value: unknown): ExecuteCall[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((call) => {
+    const item = recordValue(call)
+    const tool = stringValue(item?.tool)
+    const status = stringValue(item?.status)
+    if (!tool || !status || !["running", "completed", "error"].includes(status)) return []
+    return [{ tool, status: status as ExecuteCall["status"], input: recordValue(item?.input) }]
+  })
+}
+
+// The `execute` tool streams child tool calls through metadata, not a child session like Task.
+function Execute(props: ToolProps) {
+  const ctx = use()
+  const { theme } = useTheme()
+  const isLoading = createMemo(() => props.part.state.status === "pending" || props.part.state.status === "running")
+  const calls = createMemo(() => executeCalls(props.metadata.toolCalls))
+  const output = createMemo(() => stripAnsi(props.output?.trim() ?? ""))
+  const hasRuntimeError = createMemo(() => props.metadata.error === true)
+  const outputPreview = createMemo(() => collapseToolOutput(output(), 4, 4 * Math.max(20, ctx.width - 6)).output)
+  const showOutput = createMemo(() => output() && hasRuntimeError())
+  const detailPadding = 3 + INLINE_TOOL_ICON_WIDTH
+
+  const complete = createMemo(() => (props.part.state.status === "pending" ? false : "execute"))
+
+  return (
+    <>
+      <InlineTool
+        icon={
+          props.part.state.status === "completed" && !hasRuntimeError()
+            ? "✓"
+            : props.part.state.status === "error" || hasRuntimeError()
+              ? "✗"
+              : "│"
+        }
+        color={hasRuntimeError() ? theme.error : undefined}
+        spinner={isLoading()}
+        pending="execute"
+        complete={complete()}
+        part={props.part}
+      >
+        execute
+      </InlineTool>
+      <For each={calls()}>
+        {(call) => {
+          const args = input(call.input ?? {})
+          return (
+            <box paddingLeft={detailPadding}>
+              <text fg={call.status === "error" ? theme.error : theme.textMuted}>
+                ↳ {call.tool}
+                {args ? ` ${args}` : ""}
+                {call.status === "error" ? " (failed)" : ""}
+              </text>
+            </box>
+          )
+        }}
+      </For>
+      <Show when={showOutput()}>
+        <box paddingLeft={detailPadding}>
+          <For each={outputPreview().split("\n")}>
+            {(line, index) => (
+              <text fg={theme.error}>
+                {index() === 0 ? "↳ " : "  "}
+                {line}
+              </text>
+            )}
+          </For>
+        </box>
+      </Show>
+    </>
+  )
+}
+
 function Edit(props: ToolProps) {
   const ctx = use()
   const { theme, syntax } = useTheme()
@@ -2578,6 +2656,7 @@ const toolDisplays = new Set([
   "todowrite",
   "question",
   "skill",
+  "execute",
 ])
 
 export function toolDisplay(tool: string) {


### PR DESCRIPTION
Stacked on #35085. Restores the TUI rendering for the code-mode `execute` tool from the original experimental PR (#34677, reverted in #35077), with one behavior change.

## What

- `execute` renders as an `InlineTool` row (spinner while running, `✓` on success, `✗` on error/runtime failure)
- Each child tool call streams in below it as `↳ server.tool {args}`, with error coloring and a `(failed)` suffix on failed calls
- On runtime error, a short collapsed output preview renders below the calls in error color

## Changed from the original

The original showed an output preview whenever the program made no tool calls. That's removed: a successful `execute` now shows only the header and its child calls, never an output preview.

## Verification

- `cd packages/tui && bun typecheck`
- `cd packages/tui && bun test` — 191 pass