### PR TITLE
feat(opencode): add codex estimated cost flag

### DIFF
--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -53,6 +53,9 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   bashDefaultTimeoutMs: positiveInteger("OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS"),
   experimentalNativeLlm: bool("OPENCODE_EXPERIMENTAL_NATIVE_LLM"),
   experimentalWebSockets: bool("OPENCODE_EXPERIMENTAL_WEBSOCKETS"),
+  // ChatGPT/Codex subscription auth has no per-token API charge. Keep the default
+  // at actual marginal cost ($0) unless the user explicitly wants an estimate.
+  codexShowEstimatedCost: bool("OPENCODE_CODEX_SHOW_ESTIMATED_COST"),
   client: Config.string("OPENCODE_CLIENT").pipe(Config.withDefault("cli")),
 }) {}
 

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -68,6 +68,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     (input) =>
       CodexAuthPlugin(input, {
         experimentalWebSockets: experimentalWebSocketsEnabled({ enabled: flags.experimentalWebSockets }),
+        showEstimatedCost: flags.codexShowEstimatedCost,
       }),
     CopilotAuthPlugin,
     GitlabAuthPlugin,

--- a/packages/opencode/src/plugin/openai/README.md
+++ b/packages/opencode/src/plugin/openai/README.md
@@ -2,6 +2,10 @@
 
 Enabled by default on `local`, `dev`, and `beta`. On `latest` and `prod`, set `OPENCODE_EXPERIMENTAL_WEBSOCKETS=true`.
 
+## Codex Subscription Cost
+
+ChatGPT Plus/Pro Codex auth shows `$0.00` by default because subscription usage is not billed per token like the OpenAI API. Set `OPENCODE_CODEX_SHOW_ESTIMATED_COST=true` to show an API-equivalent estimate from model pricing.
+
 ## Flow
 
 1. A streamed `POST /responses` request arrives.

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -102,6 +102,7 @@ interface CodexAuthPluginOptions {
   issuer?: string
   codexApiEndpoint?: string
   experimentalWebSockets?: boolean
+  showEstimatedCost?: boolean
 }
 
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
@@ -292,11 +293,16 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               modelID,
               {
                 ...model,
-                cost: {
-                  input: 0,
-                  output: 0,
-                  cache: { read: 0, write: 0 },
-                },
+                // Subscription usage is not billed like API usage, so default to
+                // actual marginal cost. Opt-in keeps models.dev pricing as an
+                // API-equivalent estimate for users who want spend visibility.
+                cost: options.showEstimatedCost
+                  ? model.cost
+                  : {
+                      input: 0,
+                      output: 0,
+                      cache: { read: 0, write: 0 },
+                    },
                 limit: model.id.includes("gpt-5.5")
                   ? {
                       context: 400_000,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -149,6 +149,44 @@ describe("plugin.codex", () => {
     await enabled.dispose?.()
   })
 
+  test("zeros model pricing for OAuth by default", async () => {
+    const hooks = await CodexAuthPlugin({} as never)
+    const models = await hooks.provider!.models!(
+      {
+        models: {
+          "gpt-5.4": {
+            id: "gpt-5.4",
+            api: { id: "gpt-5.4" },
+            cost: { input: 2, output: 8, cache: { read: 0.5, write: 1 } },
+            limit: { context: 128_000, output: 16_000 },
+          },
+        },
+      } as never,
+      { auth: { type: "oauth" } } as never,
+    )
+
+    expect(models["gpt-5.4"].cost).toEqual({ input: 0, output: 0, cache: { read: 0, write: 0 } })
+  })
+
+  test("keeps model pricing for opted-in OAuth usage estimates", async () => {
+    const hooks = await CodexAuthPlugin({} as never, { showEstimatedCost: true })
+    const models = await hooks.provider!.models!(
+      {
+        models: {
+          "gpt-5.4": {
+            id: "gpt-5.4",
+            api: { id: "gpt-5.4" },
+            cost: { input: 2, output: 8, cache: { read: 0.5, write: 1 } },
+            limit: { context: 128_000, output: 16_000 },
+          },
+        },
+      } as never,
+      { auth: { type: "oauth" } } as never,
+    )
+
+    expect(models["gpt-5.4"].cost).toEqual({ input: 2, output: 8, cache: { read: 0.5, write: 1 } })
+  })
+
   test("deduplicates concurrent Codex token refreshes", async () => {
     let auth = {
       type: "oauth" as const,


### PR DESCRIPTION
### Issue for this PR

Closes #35133

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Keeps ChatGPT/Codex subscription auth showing actual marginal cost as `$0.00` by default.

Adds `OPENCODE_CODEX_SHOW_ESTIMATED_COST=true` so users can opt in to API-equivalent estimated costs for Codex models.

Documents the flag and covers default/opt-in model pricing behavior.

### How did you verify your code works?

- `bunx prettier --check packages/opencode/src/effect/runtime-flags.ts packages/opencode/src/plugin/index.ts packages/opencode/src/plugin/openai/README.md packages/opencode/src/plugin/openai/codex.ts packages/opencode/test/plugin/codex.test.ts`
- `cd packages/opencode && bun test test/plugin/codex.test.ts`
- `cd packages/opencode && bun typecheck`
- pre-push hook: `bun turbo typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
