### PR TITLE
fix(tui): keep session running until execution settles

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -344,7 +344,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           })
           break
         case "session.next.step.ended":
-          setStore("session", "status", event.data.sessionID, event.data.finish === "tool-calls" ? "running" : "idle")
+          setStore("session", "status", event.data.sessionID, "running")
           message.update(event.data.sessionID, (draft, index) => {
             const currentAssistant = message.assistant(draft, index, event.data.assistantMessageID)
             if (!currentAssistant) return
@@ -357,7 +357,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           })
           break
         case "session.next.step.failed":
-          setStore("session", "status", event.data.sessionID, "idle")
           message.update(event.data.sessionID, (draft, index) => {
             const currentAssistant = message.assistant(draft, index, event.data.assistantMessageID)
             if (!currentAssistant) return
@@ -526,6 +525,9 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         case "session.next.retried":
         case "session.next.compaction.started":
           setStore("session", "status", event.data.sessionID, "running")
+          break
+        case "session.next.execution.settled":
+          setStore("session", "status", event.data.sessionID, "idle")
           break
         case "session.next.revert.staged":
           if (store.session.info[event.data.sessionID])

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -283,6 +283,21 @@ test("tracks session status from active sessions and execution events", async ()
         tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
       },
     })
+    await wait(() => {
+      const assistant = data.session.message.get("session-live", "message-live")
+      return assistant?.type === "assistant" && assistant.finish === "stop"
+    })
+    expect(data.session.status("session-live")).toBe("running")
+
+    emitEvent(events, {
+      id: "evt_execution_settled",
+      type: "session.next.execution.settled",
+      data: {
+        sessionID: "session-live",
+        timestamp: 3,
+        outcome: "success",
+      },
+    })
     await wait(() => data.session.status("session-live") === "idle")
 
     emitEvent(events, {
@@ -305,6 +320,22 @@ test("tracks session status from active sessions and execution events", async ()
         sessionID: "session-failed",
         assistantMessageID: "message-failed",
         timestamp: 4,
+        error: { type: "unknown", message: "Provider unavailable" },
+      },
+    })
+    await wait(() => {
+      const assistant = data.session.message.get("session-failed", "message-failed")
+      return assistant?.type === "assistant" && assistant.finish === "error"
+    })
+    expect(data.session.status("session-failed")).toBe("running")
+
+    emitEvent(events, {
+      id: "evt_failed_execution_settled",
+      type: "session.next.execution.settled",
+      data: {
+        sessionID: "session-failed",
+        timestamp: 5,
+        outcome: "failure",
         error: { type: "unknown", message: "Provider unavailable" },
       },
     })


### PR DESCRIPTION
## Problem

When a queued message is promoted to a normal user message, the TUI flickers: the busy spinner + "esc interrupt" footer row briefly unmounts and remounts right as the QUEUED badge clears.

## Root cause

The TUI infers session status from step events (`packages/tui/src/context/data.tsx`): `session.next.step.ended` with a non-`tool-calls` finish flipped status to `idle`. But a queued prompt is promoted *after* the previous turn's `step.ended` and *before* the next `session.next.prompted`/`step.started`, so every promotion produced an idle blip between turns. The same blip existed on provider retries and terminal step failures mid-drain.

V1 didn't have this because status was server-owned: busy was set at run start and idle only when the whole run settled, covering queue drains (`packages/opencode/src/session/run-state.ts`).

## Fix

V2 already publishes the equivalent server-owned boundary: `session.next.execution.settled`, emitted once per execution (busy period) by `SessionExecution`, covering every coalesced drain (`packages/core/src/session/execution/local.ts`). The TUI just never handled it.

- `session.next.execution.settled` now owns the idle transition
- `step.ended` keeps the session running (turn boundary, not busy-period end)
- `step.failed` no longer writes status; settlement follows with `failure`/`interrupted`

## Testing

- Updated `data.test.tsx` status test: asserts running after `step.ended`/`step.failed`, idle only after `execution.settled`
- `bun test` and `bun typecheck` pass from `packages/tui`