### PR TITLE
fix(transform): set minimax-m3 thinking type to enabled

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -683,7 +683,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   ) {
     return {
       none: { thinking: { type: "disabled" } },
-      thinking: { thinking: { type: "adaptive" } },
+      thinking: { thinking: { type: "enabled" } },
     }
   }
   const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
@@ -1144,9 +1144,8 @@ export function options(input: {
 
   const modelId = input.model.api.id.toLowerCase()
 
-  // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
   if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
-    result["thinking"] = { type: "adaptive" }
+    result["thinking"] = { type: "enabled" }
   }
 
   // Enable thinking by default for kimi models using anthropic SDK


### PR DESCRIPTION
## Problem

MiniMax M3's Anthropic-compatible API only accepts `thinking.type` as `"enabled"` or `"disabled"`, not `"adaptive"`. This caused a "Bad Request: Validation: `thinking.type` must be `enabled` or `disabled`" error when toggling thinking on.

## Fix

Changed `thinking.type` from `"adaptive"` to `"enabled"` for MiniMax M3 in `packages/opencode/src/provider/transform.ts`.

## Verification

- [ ] `bun test test/provider/transform.test.ts`
- [ ] `bun typecheck`

Fixes #35138