### PR TITLE
fix(core): log background models.dev refresh failures at debug

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import { Context, Duration, Effect, Layer, Option, Schedule, Schema } from "effect"
-import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { ModelsDev } from "@opencode-ai/schema/models-dev"
 import { Global } from "./global"
 import { Flag } from "./flag/flag"
@@ -212,7 +212,7 @@ const layer = Layer.effect(
 
     const get = (): Effect.Effect<Record<string, Provider>> => cachedGet
 
-    const refresh = Effect.fn("ModelsDev.refresh")(function* (force = false) {
+    const attempt = Effect.fn("ModelsDev.refresh.attempt")(function* (force = false) {
       if (!force && (yield* fresh())) return
       yield* Effect.scoped(
         Effect.gen(function* () {
@@ -224,7 +224,11 @@ const layer = Layer.effect(
           yield* invalidate
           yield* events.publish(Event.Refreshed, {})
         }),
-      ).pipe(
+      )
+    })
+
+    const refresh = Effect.fn("ModelsDev.refresh")(function* (force = false) {
+      yield* attempt(force).pipe(
         Effect.tapCause((cause) => Effect.logError("Failed to fetch models.dev", { cause: cause })),
         Effect.ignore,
       )
@@ -232,7 +236,16 @@ const layer = Layer.effect(
 
     if (!Flag.OPENCODE_DISABLE_MODELS_FETCH && !process.argv.includes("--get-yargs-completions")) {
       // Schedule.spaced runs the effect once, then waits between completions.
-      yield* Effect.forkScoped(refresh().pipe(Effect.repeat(Schedule.spaced("60 minutes")), Effect.ignore))
+      // Keep best-effort background failures at Debug: before the file logger is
+      // installed, Effect's default logger writes to stdout, which corrupts the TUI.
+      yield* Effect.forkScoped(
+        attempt().pipe(
+          Effect.tapCause((cause) => Effect.logDebug("Failed to fetch models.dev", { cause: cause })),
+          Effect.ignore,
+          Effect.repeat(Schedule.spaced("60 minutes")),
+          Effect.ignore,
+        ),
+      )
     }
 
     return Service.of({ get, refresh })

--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, beforeAll, beforeEach, afterAll } from "bun:test"
-import { Effect, Layer, Ref } from "effect"
+import { Effect, Layer, Logger, Ref, References } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNodePlatform } from "@opencode-ai/core/effect/app-node-platform"
-import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Global } from "@opencode-ai/core/global"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
@@ -96,6 +95,22 @@ const buildLayer = (state: Ref.Ref<MockState>) =>
       [LayerNodePlatform.httpClient, Layer.succeed(HttpClient.HttpClient, makeMockClient(state))],
     ]),
   )
+
+const makeCaptureLoggerLayer = (entries: Array<{ message: string; logLevel: string }>) =>
+  Layer.mergeAll(
+    Logger.layer(
+      [
+        Logger.make<unknown, void>((options) => {
+          entries.push({ message: logMessage(options.message), logLevel: options.logLevel })
+        }),
+      ],
+      { mergeWithExisting: false },
+    ),
+    Layer.succeed(References.MinimumLogLevel, "Debug"),
+  )
+
+const logMessage = (message: unknown) =>
+  Array.isArray(message) ? message.map((item) => String(item)).join(" ") : String(message)
 
 const writeCacheText = (text: string, mtimeMs?: number) =>
   Effect.promise(async () => {
@@ -285,6 +300,45 @@ describe("ModelsDev Service", () => {
       // retryTransient retries 5xx, so calls may be > 1.
       const final = yield* Ref.get(state)
       expect(final.calls.length).toBeGreaterThanOrEqual(1)
+    }),
+  )
+
+  it.live("background refresh logs fetch failures at Debug", () =>
+    Effect.gen(function* () {
+      const entries: Array<{ message: string; logLevel: string }> = []
+      const state = yield* Ref.make({ ...initialState, status: 404, body: "boom" })
+      yield* Effect.acquireUseRelease(
+        Effect.sync(() => {
+          Flag.OPENCODE_DISABLE_MODELS_FETCH = false
+        }),
+        () =>
+          Effect.gen(function* () {
+            yield* Layer.build(buildLayer(state))
+            yield* Effect.sleep("1 second")
+          }).pipe(Effect.scoped, Effect.provide(makeCaptureLoggerLayer(entries))),
+        () =>
+          Effect.sync(() => {
+            Flag.OPENCODE_DISABLE_MODELS_FETCH = true
+          }),
+      )
+      const failures = entries.filter((entry) => entry.message.includes("Failed to fetch models.dev"))
+      expect(failures.some((entry) => entry.logLevel === "Debug")).toBe(true)
+      expect(failures.some((entry) => entry.logLevel === "Error")).toBe(false)
+    }),
+  )
+
+  it.live("manual refresh logs fetch failures at Error", () =>
+    Effect.gen(function* () {
+      yield* writeCache(fixture)
+      const entries: Array<{ message: string; logLevel: string }> = []
+      const state = yield* Ref.make({ ...initialState, status: 404, body: "boom" })
+      yield* ModelsDev.Service.use((s) => s.refresh(true)).pipe(
+        Effect.provide(buildLayer(state)),
+        Effect.provide(makeCaptureLoggerLayer(entries)),
+      )
+      const failures = entries.filter((entry) => entry.message.includes("Failed to fetch models.dev"))
+      expect(failures.some((entry) => entry.logLevel === "Error")).toBe(true)
+      expect(failures.some((entry) => entry.logLevel === "Debug")).toBe(false)
     }),
   )
 })


### PR DESCRIPTION
Fixes #34730

## Problem

`ModelsDev`'s layer construction eagerly forks a background `refresh()` on a 60-minute schedule. When `https://models.dev/api.json` is unreachable (corporate proxy, VPN, air-gapped), each attempt logged `Failed to fetch models.dev` at ERROR. Two consequences:

1. **TUI corruption** — if the log fires before OpenCode's file logger is installed, Effect's default logger writes to stdout, which OpenTUI owns as its frame buffer, so the error text is rendered into the terminal frame (see the bootstrap-ordering investigation in https://github.com/anomalyco/opencode/issues/34730#issuecomment-4872173290).
2. **Log spam** — even with the file logger installed, a blocked network produces an ERROR on every cycle (189 entries in the reporter's log) for a best-effort refresh that has disk/bundled fallbacks.

## Fix

Split failure logging by invocation kind in `packages/core/src/models-dev.ts` (shared with V1, so this reaches the shipped app without V1 changes):

- The eager background scheduled refresh now logs failures at **Debug**. The default logger's minimum level is Info, so this can never leak to stdout regardless of logger bootstrap ordering, and the ERROR spam stops. Still diagnosable via `OPENCODE_LOG_LEVEL=DEBUG`.
- The public `refresh()` (e.g. `opencode models --refresh`) keeps the ERROR log so explicit user actions still surface failures. Interface unchanged.

Disabling the auto-fetch entirely remains available via the existing documented `OPENCODE_DISABLE_MODELS_FETCH` flag.

## Verification

- 2 new tests in `packages/core/test/models.test.ts` asserting the log level for both paths via a capturing logger (11/11 pass)
- `bun typecheck` clean in `packages/core` and `packages/opencode`
- Re-ran the minimal repro from the issue comment (eager fork + failing HTTP client, no observability layer): stdout bytes went from 135 to **0**