### PR TITLE
chore: typecheck only affected packages in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -17,4 +17,6 @@ if (process.versions.bun !== expectedBunVersion) {
   console.warn(`Warning: Bun version ${process.versions.bun} differs from expected ${expectedBunVersion}`);
 }
 '
-bun typecheck
+# Only typecheck packages affected since the merge base with origin/dev,
+# plus their dependents. Override the base with TURBO_SCM_BASE if needed.
+TURBO_SCM_BASE="${TURBO_SCM_BASE:-origin/dev}" bun turbo typecheck --affected


### PR DESCRIPTION
## Summary

The pre-push hook currently runs `bun typecheck`, which typechecks every workspace package (~25 packages) regardless of what changed, since the turbo `typecheck` task has no filtering.

This changes the hook to use turbo's `--affected` flag so only packages changed since the merge base with `origin/dev` — plus all their transitive dependents — are typechecked.

```sh
TURBO_SCM_BASE="${TURBO_SCM_BASE:-origin/dev}" bun turbo typecheck --affected
```

`TURBO_SCM_BASE` must be set explicitly because turbo's default base is `main`, which doesn't exist locally in this repo; without it turbo falls back to typechecking everything. The env var remains overridable for anyone who wants a different base.

## Behavior

- Changed packages **and their transitive dependents** are checked, so type contract breakage downstream is still caught (e.g. touching `packages/tui` checks `tui`, `cli`, `web`, `opencode`; touching `packages/schema` still fans out to the whole repo).
- Both committed and uncommitted working-tree changes are included in the diff detection.
- No changes on top of `origin/dev` → 0 tasks in ~300ms instead of typechecking all packages.

## Tradeoff

A package that is already broken but untouched by the current branch will no longer be caught locally; CI remains the backstop for that case.

## Testing

- Clean tree at `origin/dev`: hook runs 0 tasks.
- Touched `packages/tui/src/index.tsx`: scope was `tui`, `cli`, `web`, `opencode` only.
- Bun version check portion of the hook is unchanged.