### PR TITLE
fix(opencode): provide Observability beneath all route service graphs

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -292,8 +292,6 @@ export function createRoutes(
       HttpServer.layerServices,
     ]),
     Layer.provide(Layer.succeed(CorsConfig)(corsOptions)),
-    Layer.provideMerge(Observability.layer),
-
     Layer.provide(sessionLocationLayer),
     Layer.provide(locationLayer),
     Layer.provide(PtyEnvironment.layer),
@@ -306,6 +304,11 @@ export function createRoutes(
     Layer.provide(locationServiceMapV2),
 
     Layer.provide(AppNodeBuilderV1.build(app)),
+    // Must stay last: layers provided later in this pipe build beneath earlier ones,
+    // so Observability must come after every service graph. Otherwise eagerly forked
+    // fibers (e.g. the ModelsDev background refresh) capture Effect's default stdout
+    // logger and corrupt the TUI (#34730).
+    Layer.provideMerge(Observability.layer),
   )
 }
 


### PR DESCRIPTION
Fixes the root composition bug behind #34730. Complements #35164 (core-side log-level backstop).

## Problem

In `createRoutes()` (`packages/opencode/src/server/routes/instance/httpapi/server.ts`), `Layer.provideMerge(Observability.layer)` sat in the middle of the pipe while `Layer.provide(AppNodeBuilderV1.build(app))` came last. Layers provided later in a pipe build beneath (before/without) layers provided earlier, so the `app` node graph — including `ModelsDev.node` — was constructed **without** the observability logger in its fiber context. `ModelsDev` forks its eager background refresh during layer construction, so that fiber permanently captured Effect's default stdout logger.

The V1 TUI runs this server in a worker thread of the same process. Worker-thread `console.log` bypasses OpenTUI's main-thread console patch and writes to the shared process stdout — i.e. directly onto the rendered frame. With `models.dev` unreachable, `Failed to fetch models.dev` corrupted the TUI at startup and every 60 minutes. `Server.listen` builds with a fresh memo map and empty context, so this happened on every listener, deterministically.

v1.15.6 had the correct ordering (Observability last); the AppNodeBuilderV1 restructuring flipped it.

## Fix

Move `Layer.provideMerge(Observability.layer)` to the final position of the pipe so every service graph in `createRoutes` builds beneath it, and add a comment stating the invariant so it stays last.

Audited the rest of the file: no other site composes `Observability.layer` with node graphs; `webHandler` consumes `routes` and inherits the fix.

## Verification

- Empirical repro (build routes with `OPENCODE_MODELS_URL=https://offline.invalid` and an empty cache dir, capture streams): before — 189 bytes on stdout including `ERROR ... Failed to fetch models.dev`; after — **0 bytes** on stdout and stderr.
- `bun typecheck` in `packages/opencode`: pass
- `bun run test -- test/server`: 293 pass, 2 skip, 0 fail
- prettier + oxlint clean