### PR TITLE
fix(core): rewrite replacements while hoisting layers

### DIFF
--- a/packages/core/src/effect/layer-node.ts
+++ b/packages/core/src/effect/layer-node.ts
@@ -230,7 +230,7 @@ export function hoist<A, E, T extends Tag, const Items extends Replacements = re
         if (existing && existing !== node) {
           throw new Error(`Tag ${tag} has conflicting implementations for ${node.name}`)
         }
-        hoisted.set(node.name, node)
+        hoisted.set(node.name, rewriteReplacementDependencies(node, replacementMap))
         return group([])
       }
       if (node.kind === "unbound") {

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -109,6 +109,10 @@ export function buildLocationServiceMap(
     LayerMap.make(
       (ref: Location.Ref) => {
         const allReplacements = replacements.concat([[Location.node, Location.boundNode(ref)]])
+        // Apply replacements during hoist, not afterward: replacements can
+        // introduce new tagged dependencies (Location.boundNode depends on
+        // Project), and the hoist walk is the only pass that can still slice
+        // those back out.
         const location = LayerNode.hoist(locationServices, Node.tags.values.global, allReplacements)
 
         return LayerNode.compile(location.node).pipe(


### PR DESCRIPTION
## Summary

- Keep `LayerNode.hoist(...)` responsible for applying replacements.
- When a tagged node is moved into the hoisted group, rewrite that hoisted node's dependency tree with `rewriteReplacementDependencies(node, replacementMap)` before storing it.
- `buildLocationServiceMap` passes replacements into `hoist(...)` and compiles both returned graphs plainly.

## Why

`hoist(...)` stops descending when it reaches a tagged node. Without rewriting that hoisted node's dependencies at the point it is stored, dependencies under hoisted globals keep their original implementations (for example, a global service depending on `httpClient` would bypass an `httpClient` replacement). Rewriting on store keeps the invariant that after `hoist(...)`, replacements are already done.

## Verification

- `bun test test/effect/layer-node/layer-node.test.ts` from `packages/core` passes on this branch.
- The equivalent `dev` branch also passes `bun test test/effect/layer-node/node-build.test.ts test/effect/layer-node/layer-node.test.ts`, including the prior CI failure: `node build > shares top-level project with location services`.