### PR TITLE
fix(core): match explicitly requested hidden globs

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -160,7 +160,7 @@ const layer = Layer.effect(
           args: [
             "--no-config",
             "--files",
-            ...(input.hidden ? ["--hidden"] : []),
+            ...(input.hidden ?? targetsHiddenPath(input.pattern) ? ["--hidden"] : []),
             ...(input.follow ? ["--follow"] : []),
             `--glob=${input.pattern}`,
             "--glob=!**/.git/**",
@@ -277,5 +277,8 @@ const layer = Layer.effect(
     })
   }),
 )
+
+const targetsHiddenPath = (pattern: string) =>
+  pattern.split(/[\\/]/u).some((part) => part.startsWith(".") || part.includes("{."))
 
 export const node = makeGlobalNode({ service: Service, layer: layer, deps: [RipgrepBinary.node, AppProcess.node] })

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -279,6 +279,6 @@ const layer = Layer.effect(
 )
 
 const targetsHiddenPath = (pattern: string) =>
-  pattern.split(/[\\/]/u).some((part) => part.startsWith(".") || part.includes("{."))
+  pattern.split(/[\\/]/u).some((part) => part.startsWith(".") || part.startsWith("{."))
 
 export const node = makeGlobalNode({ service: Service, layer: layer, deps: [RipgrepBinary.node, AppProcess.node] })

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -35,12 +35,30 @@ describe("Ripgrep", () => {
       Effect.gen(function* () {
         yield* Effect.promise(() => fs.mkdir(path.join(cwd, ".hidden"), { recursive: true }))
         yield* Effect.promise(() => fs.writeFile(path.join(cwd, ".hidden", "resource.md"), "needle\n"))
+        yield* Effect.promise(() => fs.mkdir(path.join(cwd, "visible"), { recursive: true }))
+        yield* Effect.promise(() => fs.writeFile(path.join(cwd, "visible", "resource.md"), "needle\n"))
         yield* Effect.promise(() => fs.mkdir(path.join(cwd, "src", ".hidden"), { recursive: true }))
         yield* Effect.promise(() => fs.writeFile(path.join(cwd, "src", ".hidden", "resource.md"), "needle\n"))
+        yield* Effect.promise(() => fs.mkdir(path.join(cwd, "src", "visible"), { recursive: true }))
+        yield* Effect.promise(() => fs.writeFile(path.join(cwd, "src", "visible", "resource.md"), "needle\n"))
         const rootResult = yield* (yield* Ripgrep.Service).glob({ cwd, pattern: ".hidden/*", limit: 10 })
         const nestedResult = yield* (yield* Ripgrep.Service).glob({ cwd, pattern: "src/.hidden/*", limit: 10 })
+        const rootBraceResult = yield* (yield* Ripgrep.Service).glob({ cwd, pattern: "{.hidden,visible}/*", limit: 10 })
+        const nestedBraceResult = yield* (yield* Ripgrep.Service).glob({
+          cwd,
+          pattern: "src/{.hidden,visible}/*",
+          limit: 10,
+        })
         expect(rootResult.map((item) => item.path)).toEqual([RelativePath.make(".hidden/resource.md")])
         expect(nestedResult.map((item) => item.path)).toEqual([RelativePath.make("src/.hidden/resource.md")])
+        expect(rootBraceResult.map((item) => item.path).sort()).toEqual([
+          RelativePath.make(".hidden/resource.md"),
+          RelativePath.make("visible/resource.md"),
+        ])
+        expect(nestedBraceResult.map((item) => item.path).sort()).toEqual([
+          RelativePath.make("src/.hidden/resource.md"),
+          RelativePath.make("src/visible/resource.md"),
+        ])
       }),
     ),
   )

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -21,9 +21,26 @@ describe("Ripgrep", () => {
     withTmp((cwd) =>
       Effect.gen(function* () {
         yield* Effect.promise(() => fs.mkdir(path.join(cwd, "src")))
+        yield* Effect.promise(() => fs.mkdir(path.join(cwd, ".hidden")))
         yield* Effect.promise(() => fs.writeFile(path.join(cwd, "src", "match.ts"), "needle\n"))
+        yield* Effect.promise(() => fs.writeFile(path.join(cwd, ".hidden", "match.ts"), "needle\n"))
         const result = yield* (yield* Ripgrep.Service).glob({ cwd, pattern: "**/*.ts", limit: 10 })
         expect(result.map((item) => item.path)).toEqual([RelativePath.make("src/match.ts")])
+      }),
+    ),
+  )
+
+  it.live("globs explicitly named hidden directories", () =>
+    withTmp((cwd) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => fs.mkdir(path.join(cwd, ".hidden"), { recursive: true }))
+        yield* Effect.promise(() => fs.writeFile(path.join(cwd, ".hidden", "resource.md"), "needle\n"))
+        yield* Effect.promise(() => fs.mkdir(path.join(cwd, "src", ".hidden"), { recursive: true }))
+        yield* Effect.promise(() => fs.writeFile(path.join(cwd, "src", ".hidden", "resource.md"), "needle\n"))
+        const rootResult = yield* (yield* Ripgrep.Service).glob({ cwd, pattern: ".hidden/*", limit: 10 })
+        const nestedResult = yield* (yield* Ripgrep.Service).glob({ cwd, pattern: "src/.hidden/*", limit: 10 })
+        expect(rootResult.map((item) => item.path)).toEqual([RelativePath.make(".hidden/resource.md")])
+        expect(nestedResult.map((item) => item.path)).toEqual([RelativePath.make("src/.hidden/resource.md")])
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #32669

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

AI agents often try to glob explicitly requested hidden directories like `.ai/*`, `.github/*`, or `src/.hidden/*`, but those searches currently return no results because ripgrep is not run with `--hidden`.

This adds hidden-file scanning only when the glob pattern itself names a hidden path segment. Broad patterns like `**/*.ts` keep the existing behavior and still exclude hidden directories by default.

### How did you verify your code works?

Tests added

### Screenshots / recordings

Tests added

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
