### PR TITLE
fix(transform): set minimax-m3 thinking type to enabled

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -683,7 +683,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   ) {
     return {
       none: { thinking: { type: "disabled" } },
-      thinking: { thinking: { type: "adaptive" } },
+      thinking: { thinking: { type: "enabled" } },
     }
   }
   const adaptiveThinkingOmitted = anthropicOmitsThinking(model.api.id)
@@ -1144,9 +1144,8 @@ export function options(input: {
 
   const modelId = input.model.api.id.toLowerCase()
 
-  // MiniMax's Anthropic interface defaults thinking off, unlike Chat Completions.
   if (modelId.includes("minimax-m3") && input.model.api.npm === "@ai-sdk/anthropic") {
-    result["thinking"] = { type: "adaptive" }
+    result["thinking"] = { type: "enabled" }
   }
 
   // Enable thinking by default for kimi models using anthropic SDK


### PR DESCRIPTION
### Issue for this PR

Closes #35138

### Type of change

- [x] Bug fix

### What does this PR do?

MiniMax M3's Anthropic-compatible API only accepts `thinking.type` as `"enabled"` or `"disabled"`, not `"adaptive"`. This caused the following error when toggling thinking on:

Bad Request: Validation: thinking.type must be enabled or disabled

Changed `"adaptive"` to `"enabled"` in two places in `packages/opencode/src/provider/transform.ts`:

- **`variants()` (L686):** The thinking variant value sent when the user selects "thinking" mode.
- **`options()` (L1148):** The default thinking value when MiniMax M3 is used with the Anthropic SDK. The adjacent comment was removed since the code is now self-explanatory.

### How did you verify your code works?

- `bun test test/provider/transform.test.ts`
- `bun typecheck`

### Screenshots / recordings

<img width="1343" height="410" alt="image" src="https://github.com/user-attachments/assets/b7f597c3-11e5-40e5-ab0f-d1bcb3a7ce03" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR