### PR TITLE
fix(tui): align execute child calls with task indentation

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2348,6 +2348,14 @@ function Execute(props: ToolProps) {
   const hasRuntimeError = createMemo(() => props.metadata.error === true)
   const outputPreview = createMemo(() => collapseToolOutput(output(), 4, 4 * Math.max(20, ctx.width - 6)).output)
   const showOutput = createMemo(() => output() && hasRuntimeError())
+  const content = createMemo(() => {
+    const lines = ["execute"]
+    for (const call of calls()) {
+      const args = input(call.input ?? {})
+      lines.push(`↳ ${call.tool}${args ? ` ${args}` : ""}${call.status === "error" ? " (failed)" : ""}`)
+    }
+    return lines.join("\n")
+  })
 
   return (
     <>
@@ -2359,22 +2367,8 @@ function Execute(props: ToolProps) {
         complete={true}
         part={props.part}
       >
-        execute
+        {content()}
       </InlineTool>
-      <For each={calls()}>
-        {(call) => {
-          const args = input(call.input ?? {})
-          return (
-            <box paddingLeft={3}>
-              <text paddingLeft={3} fg={call.status === "error" ? theme.error : theme.textMuted}>
-                ↳ {call.tool}
-                {args ? ` ${args}` : ""}
-                {call.status === "error" ? " (failed)" : ""}
-              </text>
-            </box>
-          )
-        }}
-      </For>
       <Show when={showOutput()}>
         <box paddingLeft={3}>
           <For each={outputPreview().split("\n")}>


### PR DESCRIPTION
## Summary
- render execute child call rows as newline-delimited InlineTool content
- match the task tool indentation behavior for nested ↳ lines
- remove the extra sibling-row padding that made execute children over-indent

## Testing
- Not run locally per request; CI will verify.