### PR TITLE
feat(plugin): expose skills API to plugins via PluginInput.skills

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -194,7 +194,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -221,7 +221,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -243,7 +243,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -267,7 +267,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -381,7 +381,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "effect": "catalog:",
@@ -435,7 +435,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -449,7 +449,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -461,7 +461,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -493,7 +493,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -509,7 +509,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -540,7 +540,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -559,7 +559,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -690,7 +690,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -766,7 +766,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -781,7 +781,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -796,7 +796,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -841,7 +841,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -854,7 +854,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -888,7 +888,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -907,7 +907,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -949,7 +949,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -976,7 +976,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1027,7 +1027,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -31,6 +31,7 @@ import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
+import { Skill } from "../skill"
 
 type State = {
   hooks: Hooks[]
@@ -126,6 +127,7 @@ const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const config = yield* Config.Service
     const flags = yield* RuntimeFlags.Service
+    const skill = yield* Skill.Service
 
     const state = yield* InstanceState.make<State>(
       Effect.fn("Plugin.state")(function* (ctx) {
@@ -161,6 +163,23 @@ const layer = Layer.effect(
           },
           // @ts-expect-error
           $: typeof Bun === "undefined" ? undefined : Bun.$,
+          skills: {
+            all: () =>
+              bridge.promise(
+                skill.all().pipe(
+                  Effect.orDie,
+                  Effect.map((items) => items.map((item) => ({ ...item, description: item.description ?? "" }))),
+                ),
+              ),
+            get: (name: string) =>
+              bridge.promise(
+                skill.get(name).pipe(
+                  Effect.orDie,
+                  Effect.map((item) => (item ? { ...item, description: item.description ?? "" } : item)),
+                ),
+              ),
+            dirs: () => bridge.promise(skill.dirs().pipe(Effect.orDie)),
+          },
         }
 
         for (const plugin of flags.disableDefaultPlugins ? [] : internalPlugins(flags)) {
@@ -184,9 +203,9 @@ const layer = Layer.effect(
             items: plugins,
             kind: "server",
             report: {
-              start(candidate) {},
-              missing(candidate, _retry, message) {},
-              error(candidate, _retry, stage, error, resolved) {
+              start(_candidate) {},
+              missing(_candidate, _retry, _message) {},
+              error(candidate, _retry, stage, error, _resolved) {
                 const spec = candidate.plan.spec
                 const cause = error instanceof Error ? (error.cause ?? error) : error
                 const message = stage === "load" ? errorMessage(error) : errorMessage(cause)
@@ -308,7 +327,7 @@ const layer = Layer.effect(
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [EventV2Bridge.node, Config.node, RuntimeFlags.node],
+  deps: [EventV2Bridge.node, Config.node, Skill.node, RuntimeFlags.node],
 })
 
 export * as Plugin from "."

--- a/packages/opencode/test/plugin/auth-override.test.ts
+++ b/packages/opencode/test/plugin/auth-override.test.ts
@@ -8,7 +8,9 @@ import { provideInstance, TestInstance, tmpdirScoped } from "../fixture/fixture"
 import { ProviderAuth } from "@/provider/auth"
 
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Skill } from "@/skill"
 import { TestConfig } from "../fixture/config"
+import { SkillTest } from "../fake/skill"
 import { testEffect } from "../lib/effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -33,6 +35,7 @@ function providerAuthLayer(directory: string, plugins: string[]) {
         directories: () => Effect.succeed([directory]),
       }),
     ],
+    [Skill.node, SkillTest.empty],
     [RuntimeFlags.node, RuntimeFlags.layer()],
   ])
 }

--- a/packages/opencode/test/plugin/cloudflare.test.ts
+++ b/packages/opencode/test/plugin/cloudflare.test.ts
@@ -11,6 +11,11 @@ const pluginInput = {
   },
   serverUrl: new URL("https://example.com"),
   $: {} as never,
+  skills: {
+    all: async () => [],
+    get: async () => undefined,
+    dirs: async () => [],
+  },
 }
 
 function makeHookInput(overrides: { providerID?: string; apiId?: string; reasoning?: boolean }) {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -261,6 +261,11 @@ describe("plugin.codex", () => {
         },
         serverUrl: new URL("https://example.com"),
         $: {} as never,
+        skills: {
+          all: async () => [],
+          get: async () => undefined,
+          dirs: async () => [],
+        },
       },
       {
         issuer: server.url.origin,

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -391,6 +391,11 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
     },
     serverUrl: new URL("https://example.com"),
     $: {} as never,
+    skills: {
+      all: async () => [],
+      get: async () => undefined,
+      dirs: async () => [],
+    },
   })
 
   const models = await hooks.provider!.models!(

--- a/packages/opencode/test/plugin/loader-shared.test.ts
+++ b/packages/opencode/test/plugin/loader-shared.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, spyOn } from "bun:test"
+import { afterAll, afterEach, describe, expect, spyOn } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Effect, Layer } from "effect"
 import fs from "fs/promises"
@@ -10,12 +10,32 @@ import { Config } from "@/config/config"
 import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 
+const disableDefault = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+const configContent = process.env.OPENCODE_CONFIG_CONTENT
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+delete process.env.OPENCODE_CONFIG_CONTENT
+
 const { Plugin } = await import("../../src/plugin/index")
 const { PluginLoader } = await import("../../src/plugin/loader")
 const { readPackageThemes } = await import("../../src/plugin/shared")
+const { Skill } = await import("../../src/skill")
+const { SkillTest } = await import("../fake/skill")
 const { Npm } = await import("@opencode-ai/core/npm")
 const { TestConfig } = await import("../fixture/config")
 const { RuntimeFlags } = await import("../../src/effect/runtime-flags")
+
+afterAll(() => {
+  if (disableDefault === undefined) {
+    delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+  } else {
+    process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disableDefault
+  }
+  if (configContent === undefined) {
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    return
+  }
+  process.env.OPENCODE_CONFIG_CONTENT = configContent
+})
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -60,6 +80,7 @@ function load(dir: string, flags?: Parameters<typeof RuntimeFlags.layer>[0]) {
               directories: () => Effect.succeed([dir]),
             }),
           ],
+          [Skill.node, SkillTest.empty],
           [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true, ...flags })],
         ]),
       ),

--- a/packages/opencode/test/plugin/native-skills.test.ts
+++ b/packages/opencode/test/plugin/native-skills.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { disposeAllInstances, provideInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
+
+const disable = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+const cfg = process.env.OPENCODE_CONFIG_DIR
+const content = process.env.OPENCODE_CONFIG_CONTENT
+const home = process.env.OPENCODE_TEST_HOME
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Effect } = await import("effect")
+const { MessageID, SessionID } = await import("../../src/session/schema")
+const { ToolRegistry } = await import("../../src/tool/registry")
+
+afterEach(async () => {
+  if (disable === undefined) delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+  else process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disable
+  if (cfg === undefined) delete process.env.OPENCODE_CONFIG_DIR
+  else process.env.OPENCODE_CONFIG_DIR = cfg
+  if (content === undefined) delete process.env.OPENCODE_CONFIG_CONTENT
+  else process.env.OPENCODE_CONFIG_CONTENT = content
+  if (home === undefined) delete process.env.OPENCODE_TEST_HOME
+  else process.env.OPENCODE_TEST_HOME = home
+  await disposeAllInstances()
+})
+
+// Validates the OMO+superpowers coexistence pattern:
+// A plugin captures ctx.skills during server(), then calls ctx.skills.all()
+// LAZILY (via a tool execute) after plugin loading completes.
+// Native skills must be visible in the lazy call.
+test("plugin tool can lazily call ctx.skills.all() and see native skills", async () => {
+  await using tmp = await tmpdir({
+    init: async (dir) => {
+      // Create a native skill in the standard location
+      const skill = path.join(dir, ".opencode", "skill", "test-native")
+      await fs.mkdir(skill, { recursive: true })
+      await Bun.write(
+        path.join(skill, "SKILL.md"),
+        ["---", "name: test-native", "description: A test native skill", "---", "", "# Test Native Skill", ""].join("\n"),
+      )
+
+      // Create a plugin that captures ctx.skills and exposes a tool
+      // whose execute calls ctx.skills.all() lazily
+      const plugin = path.join(dir, ".opencode", "plugin")
+      await fs.mkdir(plugin, { recursive: true })
+      const out = JSON.stringify(path.join(dir, "skills-result.json"))
+      await Bun.write(
+        path.join(plugin, "skill-reader.ts"),
+        [
+          'import { writeFileSync } from "fs"',
+          "",
+          "export default {",
+          '  id: \"test.skill-reader\",',
+          "  server: async (ctx) => {",
+          "    // Capture ctx.skills — do NOT call all() during server()",
+          "    const skills = ctx.skills",
+          "    return {",
+          "      tool: {",
+          "        check_native_skills: {",
+          '          description: \"Returns native skills found via ctx.skills.all()\",',
+          "          args: {},",
+          "          execute: async () => {",
+          "            // LAZY call — runs after server() has returned",
+          "            const all = await skills.all()",
+          `            writeFileSync(${out}, JSON.stringify(all.map(s => s.name)))`,
+          '            return all.map(s => s.name).join(\", \")',
+          "          }",
+          "        }",
+          "      }",
+          "    }",
+          "  },",
+          "}",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  process.env.OPENCODE_TEST_HOME = tmp.path
+  process.env.OPENCODE_CONFIG_DIR = path.join(tmp.path, ".config")
+  delete process.env.OPENCODE_CONFIG_CONTENT
+  await fs.mkdir(process.env.OPENCODE_CONFIG_DIR, { recursive: true })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const svc = yield* ToolRegistry.Service
+      const tools = yield* svc.all()
+      const tool = tools.find((t) => t.id === "check_native_skills")
+      if (!tool) throw new Error("Plugin tool not found")
+      yield* tool.execute(
+        {},
+        {
+          sessionID: SessionID.make("ses_test"),
+          messageID: MessageID.make("msg_test"),
+          agent: "test",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+    }).pipe(
+      provideInstance(tmp.path),
+      Effect.provide(testInstanceStoreLayer),
+      Effect.provide(LayerNode.compile(LayerNode.group([ToolRegistry.node, CrossSpawnSpawner.node, Ripgrep.node]))),
+    ),
+  )
+
+  const names = (await Bun.file(path.join(tmp.path, "skills-result.json")).json()) as string[]
+  expect(names).toContain("test-native")
+}, 30000)

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "bun:test"
+import { afterAll, describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { Npm } from "@opencode-ai/core/npm"
@@ -18,16 +18,30 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Skill } from "../../src/skill"
+import { SkillTest } from "../fake/skill"
+
+const configContent = process.env.OPENCODE_CONFIG_CONTENT
+delete process.env.OPENCODE_CONFIG_CONTENT
 
 const it = testEffect(
   AppNodeBuilder.build(LayerNode.group([Plugin.node, CrossSpawnSpawner.node]), [
     [Auth.node, AuthTest.empty],
     [Account.node, AccountTest.empty],
     [Npm.node, NpmTest.noop],
+    [Skill.node, SkillTest.empty],
     [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
   ]),
 )
 const systemHook = "experimental.chat.system.transform"
+
+afterAll(() => {
+  if (configContent === undefined) {
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    return
+  }
+  process.env.OPENCODE_CONFIG_CONTENT = configContent
+})
 
 function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
   return Effect.gen(function* () {

--- a/packages/opencode/test/plugin/workspace-adapter.test.ts
+++ b/packages/opencode/test/plugin/workspace-adapter.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect } from "bun:test"
+import { afterAll, afterEach, describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { Npm } from "@opencode-ai/core/npm"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
@@ -19,6 +19,11 @@ import { AuthTest } from "../fake/auth"
 import { NpmTest } from "../fake/npm"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Skill } from "../../src/skill"
+import { SkillTest } from "../fake/skill"
+
+const configContent = process.env.OPENCODE_CONFIG_CONTENT
+delete process.env.OPENCODE_CONFIG_CONTENT
 
 const noopBootstrapLayer = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
 const it = testEffect(
@@ -26,6 +31,7 @@ const it = testEffect(
     [Auth.node, AuthTest.empty],
     [Account.node, AccountTest.empty],
     [Npm.node, NpmTest.noop],
+    [Skill.node, SkillTest.empty],
     [InstanceStore.bootstrapNode, noopBootstrapLayer],
     [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true, experimentalWorkspaces: true })],
   ]),
@@ -33,6 +39,14 @@ const it = testEffect(
 
 afterEach(async () => {
   await disposeAllInstances()
+})
+
+afterAll(() => {
+  if (configContent === undefined) {
+    delete process.env.OPENCODE_CONFIG_CONTENT
+    return
+  }
+  process.env.OPENCODE_CONFIG_CONTENT = configContent
 })
 
 describe("plugin.workspace", () => {

--- a/packages/opencode/test/preload.ts
+++ b/packages/opencode/test/preload.ts
@@ -48,6 +48,7 @@ process.env["OPENCODE_TEST_HOME"] = testHome
 // Set test managed config directory to isolate tests from system managed settings
 const testManagedConfigDir = path.join(dir, "managed")
 process.env["OPENCODE_TEST_MANAGED_CONFIG_DIR"] = testManagedConfigDir
+delete process.env["OPENCODE_CONFIG_CONTENT"]
 
 // Write the cache version file to prevent global/index.ts from clearing the cache
 const cacheDir = path.join(dir, "cache", "opencode")

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -9,6 +9,12 @@ import { Config } from "../../src/config/config"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { Tool } from "../../src/tool/tool"
+import { ToolRegistry } from "../../src/tool/registry"
 import { provideInstance, provideTmpdirInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import path from "path"
@@ -31,6 +37,20 @@ const itWithoutExternalSkills = testEffect(
     testInstanceStoreLayer,
   ),
 )
+const kit = testEffect(
+  Layer.mergeAll(LayerNode.compile(LayerNode.group([ToolRegistry.node, CrossSpawnSpawner.node, Ripgrep.node])), testInstanceStoreLayer),
+)
+
+const toolCtx: Tool.Context = {
+  sessionID: SessionID.make("ses_test-plugin-skill"),
+  messageID: MessageID.make("msg_test-plugin-skill"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
 
 async function createGlobalSkill(homeDir: string) {
   const skillDir = path.join(homeDir, ".claude", "skills", "global-test-skill")
@@ -581,5 +601,247 @@ description: A skill in the .opencode/skills directory.
         }),
       { git: true },
     ),
+  )
+  it.live("discovers skills from config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(root, "config-skill", "SKILL.md"),
+              `---
+name: config-skill
+description: A skill registered via config.skills.paths.
+---
+
+# Config Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          const item = (yield* skill.all()).find((x) => x.name === "config-skill")
+          expect(item).toBeDefined()
+          expect(item!.description).toBe("A skill registered via config.skills.paths.")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("returns skill from config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(root, "get-test-skill", "SKILL.md"),
+              `---
+name: get-test-skill
+description: Skill for get() test.
+---
+
+# Get Test Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          const item = yield* skill.get("get-test-skill")
+          expect(item).toBeDefined()
+          expect(item!.name).toBe("get-test-skill")
+          expect(item!.description).toBe("Skill for get() test.")
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("includes config.skills.paths directories in dirs", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          const item = path.join(root, "dirs-test-skill")
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(item, "SKILL.md"),
+              `---
+name: dirs-test-skill
+description: Skill for dirs() test.
+---
+
+# Dirs Test Skill
+`,
+            ),
+          )
+          yield* Effect.promise(() =>
+            Bun.write(
+              path.join(dir, "opencode.json"),
+              JSON.stringify({
+                $schema: "https://opencode.ai/config.json",
+                skills: { paths: [root] },
+              }),
+            ),
+          )
+          const skill = yield* Skill.Service
+          expect(yield* skill.dirs()).toContain(item)
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("returns undefined for missing skills", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const skill = yield* Skill.Service
+          expect(yield* skill.get("nonexistent-skill")).toBeUndefined()
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("keeps opencode and claude skill loading with config.skills.paths", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const root = path.join(dir, "config-skills")
+          yield* Effect.promise(() =>
+            Promise.all([
+              Bun.write(
+                path.join(dir, ".opencode", "skill", "opencode-skill", "SKILL.md"),
+                `---
+name: opencode-skill
+description: Skill in .opencode/skill directory.
+---
+
+# OpenCode Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, ".claude", "skills", "claude-skill", "SKILL.md"),
+                `---
+name: claude-skill
+description: Skill in .claude/skills directory.
+---
+
+# Claude Skill
+`,
+              ),
+              Bun.write(
+                path.join(root, "config-skill", "SKILL.md"),
+                `---
+name: config-skill
+description: Skill in config.skills.paths.
+---
+
+# Config Skill
+`,
+              ),
+              Bun.write(
+                path.join(dir, "opencode.json"),
+                JSON.stringify({
+                  $schema: "https://opencode.ai/config.json",
+                  skills: { paths: [root] },
+                }),
+              ),
+            ]),
+          )
+          const skill = yield* Skill.Service
+          const list = (yield* skill.all()).filter((x) => x.location !== "<built-in>")
+          expect(list.length).toBe(3)
+          expect(list.find((x) => x.name === "opencode-skill")).toBeDefined()
+          expect(list.find((x) => x.name === "claude-skill")).toBeDefined()
+          expect(list.find((x) => x.name === "config-skill")).toBeDefined()
+        }),
+      { git: true },
+    ),
+  )
+
+  kit.live(
+    "PluginInput.skills works in plugin tool execute after config hooks populate skills.paths",
+    () =>
+      provideTmpdirInstance(
+        (dir) =>
+          Effect.gen(function* () {
+            const plugin = path.join(dir, ".opencode", "plugin")
+            yield* Effect.promise(() => fs.mkdir(plugin, { recursive: true }))
+            yield* Effect.promise(() =>
+              Bun.write(
+                path.join(dir, "plugin-config-skills", "plugin-config-skill", "SKILL.md"),
+                `---
+name: plugin-config-skill
+description: A skill registered by a plugin config hook.
+---
+
+# Plugin Config Skill
+`,
+              ),
+            )
+            yield* Effect.promise(() =>
+              Bun.write(
+                path.join(plugin, "plugin-skill-check.ts"),
+                [
+                  'import { tool } from "@opencode-ai/plugin"',
+                  "",
+                  "export default async (input) => ({",
+                  "  config: async (config) => {",
+                  "    config.skills ??= {}",
+                  "    config.skills.paths ??= []",
+                  '    config.skills.paths.push("./plugin-config-skills")',
+                  "  },",
+                  "  tool: {",
+                  '    "plugin-skill-check": tool({',
+                  '      description: "Checks PluginInput.skills access",',
+                  "      args: {},",
+                  "      execute: async () => {",
+                  '        const skill = await input.skills.get("plugin-config-skill")',
+                  "        const dirs = await input.skills.dirs()",
+                  "        const all = await input.skills.all()",
+                  '        return [skill?.name ?? "", skill?.description ?? "", String(all.length), ...dirs].join("\\n")',
+                  "      },",
+                  "    }),",
+                  "  },",
+                  "})",
+                  "",
+                ].join("\n"),
+              ),
+            )
+            const list = yield* ToolRegistry.Service.use((svc) =>
+              svc.tools({
+                providerID: ProviderV2.ID.make("opencode"),
+                modelID: ModelV2.ID.make("gpt-5"),
+                agent: { name: "build", mode: "primary", permission: [], options: {} },
+              }),
+            )
+            const tool = list.find((item) => item.id === "plugin-skill-check")
+            expect(tool).toBeDefined()
+            const out = yield* tool!.execute({}, toolCtx)
+            const lines = out.output.split("\n")
+            expect(lines[0]).toBe("plugin-config-skill")
+            expect(lines[1]).toBe("A skill registered by a plugin config hook.")
+            expect(Number(lines[2])).toBeGreaterThanOrEqual(1)
+            expect(lines).toContain(path.join(dir, "plugin-config-skills", "plugin-config-skill"))
+          }),
+        { git: true },
+      ),
+    30000,
   )
 })

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -53,6 +53,13 @@ export type WorkspaceAdapter = {
   target(config: WorkspaceInfo): WorkspaceTarget | Promise<WorkspaceTarget>
 }
 
+export type SkillInfo = {
+  name: string
+  description: string
+  location: string
+  content: string
+}
+
 export type PluginInput = {
   client: ReturnType<typeof createOpencodeClient>
   project: Project
@@ -63,6 +70,11 @@ export type PluginInput = {
   }
   serverUrl: URL
   $: BunShell
+  skills: {
+    all(): Promise<SkillInfo[]>
+    get(name: string): Promise<SkillInfo | undefined>
+    dirs(): Promise<string[]>
+  }
 }
 
 export type PluginOptions = Record<string, unknown>

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #18688

Re-submission of #18686 (closed by automated cleanup), rebased onto current dev. The previous PR could not be reopened because the branch has been force-pushed since closure.

### Type of change

- [ ] Bug fix
- [x] New feature

### What does this PR do?

Exposes the native skills API (`skill.all()`, `skill.get(name)`, `skill.dirs()`) to plugins via `PluginInput.skills`, matching the feature request in #18688. This lets plugins discover and reason about user-defined skills the same way the agent runtime does.

### How did you verify your code works?

New `test/plugin/native-skills.test.ts` covers the plugin-input surface end-to-end. Adjacent tests updated to provide the new `Skill` layer dependency. `bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Closes #18688

Supersedes #29356 (closed by the inactivity bot). Rebased onto latest `dev` with all merge conflicts resolved; typecheck and targeted tests pass on the fork branch.