### PR TITLE
feat(provider): support per-model limit overrides in user config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -194,7 +194,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -221,7 +221,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -243,7 +243,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -267,7 +267,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -381,7 +381,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "effect": "catalog:",
@@ -435,7 +435,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -449,7 +449,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -461,7 +461,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -493,7 +493,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -509,7 +509,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -540,7 +540,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -559,7 +559,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -690,7 +690,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -766,7 +766,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -781,7 +781,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -796,7 +796,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -841,7 +841,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -854,7 +854,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -888,7 +888,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -907,7 +907,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -949,7 +949,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -976,7 +976,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1027,7 +1027,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.6",
+      "version": "1.18.7",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -211,9 +211,9 @@ const layer = Layer.effect(
     const populate = Effect.gen(function* () {
       const fromDisk = yield* loadFromDisk
       if (fromDisk) return fromDisk
+      if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
       const snapshot = yield* loadSnapshot
       if (snapshot) return snapshot
-      if (Flag.OPENCODE_DISABLE_MODELS_FETCH) return {}
       // Flock is cross-process: concurrent opencode CLIs can race on this cache file.
       const text = yield* Effect.scoped(
         Effect.gen(function* () {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1644,6 +1644,13 @@ const layer = Layer.effect(
                 (v) => omit(v, ["disabled"]),
               )
             }
+
+            const configLimit = configProvider?.models?.[modelID]?.limit
+            if (configLimit) {
+              if (configLimit.context) model.limit.context = configLimit.context
+              if (configLimit.input) model.limit.input = configLimit.input
+              if (configLimit.output) model.limit.output = configLimit.output
+            }
           }
 
           if (Object.keys(provider.models).length === 0) {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1254,6 +1254,31 @@ it.instance(
 )
 
 it.instance(
+  "config provider model limit overrides individual fields",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.make("limit-override")].models[ModelV2.ID.make("model")]
+    expect(model.limit.context).toBe(100000)
+    expect(model.limit.input).toBe(80000)
+    expect(model.limit.output).toBe(16000)
+  }),
+  {
+    config: {
+      provider: {
+        "limit-override": {
+          name: "Limit Override Provider",
+          npm: "@ai-sdk/openai-compatible",
+          env: [],
+          models: { model: { name: "Model", tool_call: true, limit: { context: 100000, input: 80000, output: 16000 } } },
+          options: { apiKey: "test" },
+        },
+      },
+    },
+  },
+)
+
+
+it.instance(
   "provider options are deeply merged",
   Effect.gen(function* () {
     yield* set("ANTHROPIC_API_KEY", "test-api-key")

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #21564
Refs #8140

### Type of change

- [ ] Bug fix
- [x] New feature

### What does this PR do?

Users can already configure custom limits on a model in `opencode.json` (`limit.context`, `limit.input`, `limit.output`), but those values were being dropped when the model was sourced from models.dev — the materialised model always used the upstream metadata. This blocks workarounds for cases where models.dev lags actual provider behaviour (Copilot models, beta context-window extensions, etc.).

In `provider/provider.ts`, after the models.dev model is materialised, this merges the configured limit fields over the default values. Each field falls back individually so users can override just one and leave the others at defaults.

Also a small ordering fix in `core/models-dev.ts`: `OPENCODE_DISABLE_MODELS_FETCH` was being checked after a fetch attempt could still occur — moved it earlier so it actually short-circuits.

This was previously part of #20671 (closed as mixed scope); this PR contains only the model-limit override piece.

### How did you verify your code works?

`test/provider/provider.test.ts` adds a config provider with `limit: { context: 100000, input: 80000, output: 16000 }` and asserts the materialised model carries those values. `bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Closes #21564

_Note: #21564 was closed by the inactivity bot; a maintainer may need to reopen it for the `Closes` link to take effect on merge. Related: #8140._

Supersedes #29354 (closed by the inactivity bot). Rebased onto latest `dev` with all merge conflicts resolved; typecheck and targeted tests pass on the fork branch.