### PR TITLE
feat(tui): wire move session command

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -111,158 +111,167 @@ export type Endpoint4_8Input = {
 export type Endpoint4_8Output = EffectValue<ReturnType<RawClient["server.session"]["session.rename"]>>
 export type SessionRenameOperation<E = never> = (input: Endpoint4_8Input) => Effect.Effect<Endpoint4_8Output, E>
 
-type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.move"]>[0]
 export type Endpoint4_9Input = {
   readonly sessionID: Endpoint4_9Request["params"]["sessionID"]
-  readonly id?: Endpoint4_9Request["payload"]["id"]
-  readonly prompt: Endpoint4_9Request["payload"]["prompt"]
-  readonly delivery?: Endpoint4_9Request["payload"]["delivery"]
-  readonly resume?: Endpoint4_9Request["payload"]["resume"]
+  readonly destination: Endpoint4_9Request["payload"]["destination"]
+  readonly moveChanges?: Endpoint4_9Request["payload"]["moveChanges"]
 }
-export type Endpoint4_9Output = EffectValue<ReturnType<RawClient["server.session"]["session.prompt"]>>["data"]
-export type SessionPromptOperation<E = never> = (input: Endpoint4_9Input) => Effect.Effect<Endpoint4_9Output, E>
+export type Endpoint4_9Output = EffectValue<ReturnType<RawClient["server.session"]["session.move"]>>
+export type SessionMoveOperation<E = never> = (input: Endpoint4_9Input) => Effect.Effect<Endpoint4_9Output, E>
 
-type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.command"]>[0]
+type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
 export type Endpoint4_10Input = {
   readonly sessionID: Endpoint4_10Request["params"]["sessionID"]
   readonly id?: Endpoint4_10Request["payload"]["id"]
-  readonly command: Endpoint4_10Request["payload"]["command"]
-  readonly arguments?: Endpoint4_10Request["payload"]["arguments"]
-  readonly agent?: Endpoint4_10Request["payload"]["agent"]
-  readonly model?: Endpoint4_10Request["payload"]["model"]
-  readonly files?: Endpoint4_10Request["payload"]["files"]
-  readonly agents?: Endpoint4_10Request["payload"]["agents"]
+  readonly prompt: Endpoint4_10Request["payload"]["prompt"]
   readonly delivery?: Endpoint4_10Request["payload"]["delivery"]
   readonly resume?: Endpoint4_10Request["payload"]["resume"]
 }
-export type Endpoint4_10Output = EffectValue<ReturnType<RawClient["server.session"]["session.command"]>>["data"]
-export type SessionCommandOperation<E = never> = (input: Endpoint4_10Input) => Effect.Effect<Endpoint4_10Output, E>
+export type Endpoint4_10Output = EffectValue<ReturnType<RawClient["server.session"]["session.prompt"]>>["data"]
+export type SessionPromptOperation<E = never> = (input: Endpoint4_10Input) => Effect.Effect<Endpoint4_10Output, E>
 
-type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
+type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.command"]>[0]
 export type Endpoint4_11Input = {
   readonly sessionID: Endpoint4_11Request["params"]["sessionID"]
   readonly id?: Endpoint4_11Request["payload"]["id"]
-  readonly skill: Endpoint4_11Request["payload"]["skill"]
+  readonly command: Endpoint4_11Request["payload"]["command"]
+  readonly arguments?: Endpoint4_11Request["payload"]["arguments"]
+  readonly agent?: Endpoint4_11Request["payload"]["agent"]
+  readonly model?: Endpoint4_11Request["payload"]["model"]
+  readonly files?: Endpoint4_11Request["payload"]["files"]
+  readonly agents?: Endpoint4_11Request["payload"]["agents"]
+  readonly delivery?: Endpoint4_11Request["payload"]["delivery"]
   readonly resume?: Endpoint4_11Request["payload"]["resume"]
 }
-export type Endpoint4_11Output = EffectValue<ReturnType<RawClient["server.session"]["session.skill"]>>
-export type SessionSkillOperation<E = never> = (input: Endpoint4_11Input) => Effect.Effect<Endpoint4_11Output, E>
+export type Endpoint4_11Output = EffectValue<ReturnType<RawClient["server.session"]["session.command"]>>["data"]
+export type SessionCommandOperation<E = never> = (input: Endpoint4_11Input) => Effect.Effect<Endpoint4_11Output, E>
 
-type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
+type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
 export type Endpoint4_12Input = {
   readonly sessionID: Endpoint4_12Request["params"]["sessionID"]
-  readonly text: Endpoint4_12Request["payload"]["text"]
-  readonly description?: Endpoint4_12Request["payload"]["description"]
-  readonly metadata?: Endpoint4_12Request["payload"]["metadata"]
+  readonly id?: Endpoint4_12Request["payload"]["id"]
+  readonly skill: Endpoint4_12Request["payload"]["skill"]
   readonly resume?: Endpoint4_12Request["payload"]["resume"]
 }
-export type Endpoint4_12Output = EffectValue<ReturnType<RawClient["server.session"]["session.synthetic"]>>
-export type SessionSyntheticOperation<E = never> = (input: Endpoint4_12Input) => Effect.Effect<Endpoint4_12Output, E>
+export type Endpoint4_12Output = EffectValue<ReturnType<RawClient["server.session"]["session.skill"]>>
+export type SessionSkillOperation<E = never> = (input: Endpoint4_12Input) => Effect.Effect<Endpoint4_12Output, E>
 
-type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
+type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
 export type Endpoint4_13Input = {
   readonly sessionID: Endpoint4_13Request["params"]["sessionID"]
-  readonly id?: Endpoint4_13Request["payload"]["id"]
-  readonly command: Endpoint4_13Request["payload"]["command"]
+  readonly text: Endpoint4_13Request["payload"]["text"]
+  readonly description?: Endpoint4_13Request["payload"]["description"]
+  readonly metadata?: Endpoint4_13Request["payload"]["metadata"]
+  readonly resume?: Endpoint4_13Request["payload"]["resume"]
 }
-export type Endpoint4_13Output = EffectValue<ReturnType<RawClient["server.session"]["session.shell"]>>
-export type SessionShellOperation<E = never> = (input: Endpoint4_13Input) => Effect.Effect<Endpoint4_13Output, E>
+export type Endpoint4_13Output = EffectValue<ReturnType<RawClient["server.session"]["session.synthetic"]>>
+export type SessionSyntheticOperation<E = never> = (input: Endpoint4_13Input) => Effect.Effect<Endpoint4_13Output, E>
 
-type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
 export type Endpoint4_14Input = {
   readonly sessionID: Endpoint4_14Request["params"]["sessionID"]
   readonly id?: Endpoint4_14Request["payload"]["id"]
+  readonly command: Endpoint4_14Request["payload"]["command"]
 }
-export type Endpoint4_14Output = EffectValue<ReturnType<RawClient["server.session"]["session.compact"]>>["data"]
-export type SessionCompactOperation<E = never> = (input: Endpoint4_14Input) => Effect.Effect<Endpoint4_14Output, E>
+export type Endpoint4_14Output = EffectValue<ReturnType<RawClient["server.session"]["session.shell"]>>
+export type SessionShellOperation<E = never> = (input: Endpoint4_14Input) => Effect.Effect<Endpoint4_14Output, E>
 
-type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
-export type Endpoint4_15Input = { readonly sessionID: Endpoint4_15Request["params"]["sessionID"] }
-export type Endpoint4_15Output = EffectValue<ReturnType<RawClient["server.session"]["session.wait"]>>
-export type SessionWaitOperation<E = never> = (input: Endpoint4_15Input) => Effect.Effect<Endpoint4_15Output, E>
-
-type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-export type Endpoint4_16Input = {
-  readonly sessionID: Endpoint4_16Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_16Request["payload"]["messageID"]
-  readonly files?: Endpoint4_16Request["payload"]["files"]
+type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+export type Endpoint4_15Input = {
+  readonly sessionID: Endpoint4_15Request["params"]["sessionID"]
+  readonly id?: Endpoint4_15Request["payload"]["id"]
 }
-export type Endpoint4_16Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.stage"]>>["data"]
-export type SessionRevertStageOperation<E = never> = (input: Endpoint4_16Input) => Effect.Effect<Endpoint4_16Output, E>
+export type Endpoint4_15Output = EffectValue<ReturnType<RawClient["server.session"]["session.compact"]>>["data"]
+export type SessionCompactOperation<E = never> = (input: Endpoint4_15Input) => Effect.Effect<Endpoint4_15Output, E>
 
-type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-export type Endpoint4_17Input = { readonly sessionID: Endpoint4_17Request["params"]["sessionID"] }
-export type Endpoint4_17Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.clear"]>>
-export type SessionRevertClearOperation<E = never> = (input: Endpoint4_17Input) => Effect.Effect<Endpoint4_17Output, E>
+type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+export type Endpoint4_16Input = { readonly sessionID: Endpoint4_16Request["params"]["sessionID"] }
+export type Endpoint4_16Output = EffectValue<ReturnType<RawClient["server.session"]["session.wait"]>>
+export type SessionWaitOperation<E = never> = (input: Endpoint4_16Input) => Effect.Effect<Endpoint4_16Output, E>
 
-type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+export type Endpoint4_17Input = {
+  readonly sessionID: Endpoint4_17Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_17Request["payload"]["messageID"]
+  readonly files?: Endpoint4_17Request["payload"]["files"]
+}
+export type Endpoint4_17Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.stage"]>>["data"]
+export type SessionRevertStageOperation<E = never> = (input: Endpoint4_17Input) => Effect.Effect<Endpoint4_17Output, E>
+
+type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
 export type Endpoint4_18Input = { readonly sessionID: Endpoint4_18Request["params"]["sessionID"] }
-export type Endpoint4_18Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.commit"]>>
-export type SessionRevertCommitOperation<E = never> = (input: Endpoint4_18Input) => Effect.Effect<Endpoint4_18Output, E>
+export type Endpoint4_18Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.clear"]>>
+export type SessionRevertClearOperation<E = never> = (input: Endpoint4_18Input) => Effect.Effect<Endpoint4_18Output, E>
 
-type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
 export type Endpoint4_19Input = { readonly sessionID: Endpoint4_19Request["params"]["sessionID"] }
-export type Endpoint4_19Output = EffectValue<ReturnType<RawClient["server.session"]["session.context"]>>["data"]
-export type SessionContextOperation<E = never> = (input: Endpoint4_19Input) => Effect.Effect<Endpoint4_19Output, E>
+export type Endpoint4_19Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.commit"]>>
+export type SessionRevertCommitOperation<E = never> = (input: Endpoint4_19Input) => Effect.Effect<Endpoint4_19Output, E>
 
-type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
+type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.context"]>[0]
 export type Endpoint4_20Input = { readonly sessionID: Endpoint4_20Request["params"]["sessionID"] }
-export type Endpoint4_20Output = EffectValue<
+export type Endpoint4_20Output = EffectValue<ReturnType<RawClient["server.session"]["session.context"]>>["data"]
+export type SessionContextOperation<E = never> = (input: Endpoint4_20Input) => Effect.Effect<Endpoint4_20Output, E>
+
+type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
+export type Endpoint4_21Input = { readonly sessionID: Endpoint4_21Request["params"]["sessionID"] }
+export type Endpoint4_21Output = EffectValue<
   ReturnType<RawClient["server.session"]["session.instructions.entry.list"]>
 >["data"]
 export type SessionInstructionsEntryListOperation<E = never> = (
-  input: Endpoint4_20Input,
-) => Effect.Effect<Endpoint4_20Output, E>
-
-type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
-export type Endpoint4_21Input = {
-  readonly sessionID: Endpoint4_21Request["params"]["sessionID"]
-  readonly key: Endpoint4_21Request["params"]["key"]
-  readonly value: Endpoint4_21Request["payload"]["value"]
-}
-export type Endpoint4_21Output = EffectValue<ReturnType<RawClient["server.session"]["session.instructions.entry.put"]>>
-export type SessionInstructionsEntryPutOperation<E = never> = (
   input: Endpoint4_21Input,
 ) => Effect.Effect<Endpoint4_21Output, E>
 
-type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
+type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
 export type Endpoint4_22Input = {
   readonly sessionID: Endpoint4_22Request["params"]["sessionID"]
   readonly key: Endpoint4_22Request["params"]["key"]
+  readonly value: Endpoint4_22Request["payload"]["value"]
 }
-export type Endpoint4_22Output = EffectValue<
-  ReturnType<RawClient["server.session"]["session.instructions.entry.remove"]>
->
-export type SessionInstructionsEntryRemoveOperation<E = never> = (
+export type Endpoint4_22Output = EffectValue<ReturnType<RawClient["server.session"]["session.instructions.entry.put"]>>
+export type SessionInstructionsEntryPutOperation<E = never> = (
   input: Endpoint4_22Input,
 ) => Effect.Effect<Endpoint4_22Output, E>
 
-type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.log"]>[0]
+type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
 export type Endpoint4_23Input = {
   readonly sessionID: Endpoint4_23Request["params"]["sessionID"]
-  readonly after?: Endpoint4_23Request["query"]["after"]
-  readonly follow?: Endpoint4_23Request["query"]["follow"]
+  readonly key: Endpoint4_23Request["params"]["key"]
 }
-export type Endpoint4_23Output = StreamValue<EffectValue<ReturnType<RawClient["server.session"]["session.log"]>>>
-export type SessionLogOperation<E = never> = (input: Endpoint4_23Input) => Stream.Stream<Endpoint4_23Output, E>
+export type Endpoint4_23Output = EffectValue<
+  ReturnType<RawClient["server.session"]["session.instructions.entry.remove"]>
+>
+export type SessionInstructionsEntryRemoveOperation<E = never> = (
+  input: Endpoint4_23Input,
+) => Effect.Effect<Endpoint4_23Output, E>
 
-type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-export type Endpoint4_24Input = { readonly sessionID: Endpoint4_24Request["params"]["sessionID"] }
-export type Endpoint4_24Output = EffectValue<ReturnType<RawClient["server.session"]["session.interrupt"]>>
-export type SessionInterruptOperation<E = never> = (input: Endpoint4_24Input) => Effect.Effect<Endpoint4_24Output, E>
+type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.log"]>[0]
+export type Endpoint4_24Input = {
+  readonly sessionID: Endpoint4_24Request["params"]["sessionID"]
+  readonly after?: Endpoint4_24Request["query"]["after"]
+  readonly follow?: Endpoint4_24Request["query"]["follow"]
+}
+export type Endpoint4_24Output = StreamValue<EffectValue<ReturnType<RawClient["server.session"]["session.log"]>>>
+export type SessionLogOperation<E = never> = (input: Endpoint4_24Input) => Stream.Stream<Endpoint4_24Output, E>
 
-type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
 export type Endpoint4_25Input = { readonly sessionID: Endpoint4_25Request["params"]["sessionID"] }
-export type Endpoint4_25Output = EffectValue<ReturnType<RawClient["server.session"]["session.background"]>>
-export type SessionBackgroundOperation<E = never> = (input: Endpoint4_25Input) => Effect.Effect<Endpoint4_25Output, E>
+export type Endpoint4_25Output = EffectValue<ReturnType<RawClient["server.session"]["session.interrupt"]>>
+export type SessionInterruptOperation<E = never> = (input: Endpoint4_25Input) => Effect.Effect<Endpoint4_25Output, E>
 
-type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-export type Endpoint4_26Input = {
-  readonly sessionID: Endpoint4_26Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_26Request["params"]["messageID"]
+type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+export type Endpoint4_26Input = { readonly sessionID: Endpoint4_26Request["params"]["sessionID"] }
+export type Endpoint4_26Output = EffectValue<ReturnType<RawClient["server.session"]["session.background"]>>
+export type SessionBackgroundOperation<E = never> = (input: Endpoint4_26Input) => Effect.Effect<Endpoint4_26Output, E>
+
+type Endpoint4_27Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+export type Endpoint4_27Input = {
+  readonly sessionID: Endpoint4_27Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_27Request["params"]["messageID"]
 }
-export type Endpoint4_26Output = EffectValue<ReturnType<RawClient["server.session"]["session.message"]>>["data"]
-export type SessionMessageOperation<E = never> = (input: Endpoint4_26Input) => Effect.Effect<Endpoint4_26Output, E>
+export type Endpoint4_27Output = EffectValue<ReturnType<RawClient["server.session"]["session.message"]>>["data"]
+export type SessionMessageOperation<E = never> = (input: Endpoint4_27Input) => Effect.Effect<Endpoint4_27Output, E>
 
 export interface SessionApi<E = never> {
   readonly list: SessionListOperation<E>
@@ -274,6 +283,7 @@ export interface SessionApi<E = never> {
   readonly switchAgent: SessionSwitchAgentOperation<E>
   readonly switchModel: SessionSwitchModelOperation<E>
   readonly rename: SessionRenameOperation<E>
+  readonly move: SessionMoveOperation<E>
   readonly prompt: SessionPromptOperation<E>
   readonly command: SessionCommandOperation<E>
   readonly skill: SessionSkillOperation<E>

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -141,15 +141,27 @@ const Endpoint4_8 = (raw: RawClient["server.session"]) => (input: Endpoint4_8Inp
     Effect.mapError(mapClientError),
   )
 
-type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.move"]>[0]
 type Endpoint4_9Input = {
   readonly sessionID: Endpoint4_9Request["params"]["sessionID"]
-  readonly id?: Endpoint4_9Request["payload"]["id"]
-  readonly prompt: Endpoint4_9Request["payload"]["prompt"]
-  readonly delivery?: Endpoint4_9Request["payload"]["delivery"]
-  readonly resume?: Endpoint4_9Request["payload"]["resume"]
+  readonly destination: Endpoint4_9Request["payload"]["destination"]
+  readonly moveChanges?: Endpoint4_9Request["payload"]["moveChanges"]
 }
 const Endpoint4_9 = (raw: RawClient["server.session"]) => (input: Endpoint4_9Input) =>
+  raw["session.move"]({
+    params: { sessionID: input["sessionID"] },
+    payload: { destination: input["destination"], moveChanges: input["moveChanges"] },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint4_10Input = {
+  readonly sessionID: Endpoint4_10Request["params"]["sessionID"]
+  readonly id?: Endpoint4_10Request["payload"]["id"]
+  readonly prompt: Endpoint4_10Request["payload"]["prompt"]
+  readonly delivery?: Endpoint4_10Request["payload"]["delivery"]
+  readonly resume?: Endpoint4_10Request["payload"]["resume"]
+}
+const Endpoint4_10 = (raw: RawClient["server.session"]) => (input: Endpoint4_10Input) =>
   raw["session.prompt"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], prompt: input["prompt"], delivery: input["delivery"], resume: input["resume"] },
@@ -158,20 +170,20 @@ const Endpoint4_9 = (raw: RawClient["server.session"]) => (input: Endpoint4_9Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.command"]>[0]
-type Endpoint4_10Input = {
-  readonly sessionID: Endpoint4_10Request["params"]["sessionID"]
-  readonly id?: Endpoint4_10Request["payload"]["id"]
-  readonly command: Endpoint4_10Request["payload"]["command"]
-  readonly arguments?: Endpoint4_10Request["payload"]["arguments"]
-  readonly agent?: Endpoint4_10Request["payload"]["agent"]
-  readonly model?: Endpoint4_10Request["payload"]["model"]
-  readonly files?: Endpoint4_10Request["payload"]["files"]
-  readonly agents?: Endpoint4_10Request["payload"]["agents"]
-  readonly delivery?: Endpoint4_10Request["payload"]["delivery"]
-  readonly resume?: Endpoint4_10Request["payload"]["resume"]
+type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.command"]>[0]
+type Endpoint4_11Input = {
+  readonly sessionID: Endpoint4_11Request["params"]["sessionID"]
+  readonly id?: Endpoint4_11Request["payload"]["id"]
+  readonly command: Endpoint4_11Request["payload"]["command"]
+  readonly arguments?: Endpoint4_11Request["payload"]["arguments"]
+  readonly agent?: Endpoint4_11Request["payload"]["agent"]
+  readonly model?: Endpoint4_11Request["payload"]["model"]
+  readonly files?: Endpoint4_11Request["payload"]["files"]
+  readonly agents?: Endpoint4_11Request["payload"]["agents"]
+  readonly delivery?: Endpoint4_11Request["payload"]["delivery"]
+  readonly resume?: Endpoint4_11Request["payload"]["resume"]
 }
-const Endpoint4_10 = (raw: RawClient["server.session"]) => (input: Endpoint4_10Input) =>
+const Endpoint4_11 = (raw: RawClient["server.session"]) => (input: Endpoint4_11Input) =>
   raw["session.command"]({
     params: { sessionID: input["sessionID"] },
     payload: {
@@ -190,28 +202,28 @@ const Endpoint4_10 = (raw: RawClient["server.session"]) => (input: Endpoint4_10I
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
-type Endpoint4_11Input = {
-  readonly sessionID: Endpoint4_11Request["params"]["sessionID"]
-  readonly id?: Endpoint4_11Request["payload"]["id"]
-  readonly skill: Endpoint4_11Request["payload"]["skill"]
-  readonly resume?: Endpoint4_11Request["payload"]["resume"]
+type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
+type Endpoint4_12Input = {
+  readonly sessionID: Endpoint4_12Request["params"]["sessionID"]
+  readonly id?: Endpoint4_12Request["payload"]["id"]
+  readonly skill: Endpoint4_12Request["payload"]["skill"]
+  readonly resume?: Endpoint4_12Request["payload"]["resume"]
 }
-const Endpoint4_11 = (raw: RawClient["server.session"]) => (input: Endpoint4_11Input) =>
+const Endpoint4_12 = (raw: RawClient["server.session"]) => (input: Endpoint4_12Input) =>
   raw["session.skill"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], skill: input["skill"], resume: input["resume"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
-type Endpoint4_12Input = {
-  readonly sessionID: Endpoint4_12Request["params"]["sessionID"]
-  readonly text: Endpoint4_12Request["payload"]["text"]
-  readonly description?: Endpoint4_12Request["payload"]["description"]
-  readonly metadata?: Endpoint4_12Request["payload"]["metadata"]
-  readonly resume?: Endpoint4_12Request["payload"]["resume"]
+type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
+type Endpoint4_13Input = {
+  readonly sessionID: Endpoint4_13Request["params"]["sessionID"]
+  readonly text: Endpoint4_13Request["payload"]["text"]
+  readonly description?: Endpoint4_13Request["payload"]["description"]
+  readonly metadata?: Endpoint4_13Request["payload"]["metadata"]
+  readonly resume?: Endpoint4_13Request["payload"]["resume"]
 }
-const Endpoint4_12 = (raw: RawClient["server.session"]) => (input: Endpoint4_12Input) =>
+const Endpoint4_13 = (raw: RawClient["server.session"]) => (input: Endpoint4_13Input) =>
   raw["session.synthetic"]({
     params: { sessionID: input["sessionID"] },
     payload: {
@@ -222,41 +234,41 @@ const Endpoint4_12 = (raw: RawClient["server.session"]) => (input: Endpoint4_12I
     },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
-type Endpoint4_13Input = {
-  readonly sessionID: Endpoint4_13Request["params"]["sessionID"]
-  readonly id?: Endpoint4_13Request["payload"]["id"]
-  readonly command: Endpoint4_13Request["payload"]["command"]
+type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
+type Endpoint4_14Input = {
+  readonly sessionID: Endpoint4_14Request["params"]["sessionID"]
+  readonly id?: Endpoint4_14Request["payload"]["id"]
+  readonly command: Endpoint4_14Request["payload"]["command"]
 }
-const Endpoint4_13 = (raw: RawClient["server.session"]) => (input: Endpoint4_13Input) =>
+const Endpoint4_14 = (raw: RawClient["server.session"]) => (input: Endpoint4_14Input) =>
   raw["session.shell"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], command: input["command"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
-type Endpoint4_14Input = {
-  readonly sessionID: Endpoint4_14Request["params"]["sessionID"]
-  readonly id?: Endpoint4_14Request["payload"]["id"]
+type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+type Endpoint4_15Input = {
+  readonly sessionID: Endpoint4_15Request["params"]["sessionID"]
+  readonly id?: Endpoint4_15Request["payload"]["id"]
 }
-const Endpoint4_14 = (raw: RawClient["server.session"]) => (input: Endpoint4_14Input) =>
+const Endpoint4_15 = (raw: RawClient["server.session"]) => (input: Endpoint4_15Input) =>
   raw["session.compact"]({ params: { sessionID: input["sessionID"] }, payload: { id: input["id"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
-type Endpoint4_15Input = { readonly sessionID: Endpoint4_15Request["params"]["sessionID"] }
-const Endpoint4_15 = (raw: RawClient["server.session"]) => (input: Endpoint4_15Input) =>
+type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+type Endpoint4_16Input = { readonly sessionID: Endpoint4_16Request["params"]["sessionID"] }
+const Endpoint4_16 = (raw: RawClient["server.session"]) => (input: Endpoint4_16Input) =>
   raw["session.wait"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-type Endpoint4_16Input = {
-  readonly sessionID: Endpoint4_16Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_16Request["payload"]["messageID"]
-  readonly files?: Endpoint4_16Request["payload"]["files"]
+type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+type Endpoint4_17Input = {
+  readonly sessionID: Endpoint4_17Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_17Request["payload"]["messageID"]
+  readonly files?: Endpoint4_17Request["payload"]["files"]
 }
-const Endpoint4_16 = (raw: RawClient["server.session"]) => (input: Endpoint4_16Input) =>
+const Endpoint4_17 = (raw: RawClient["server.session"]) => (input: Endpoint4_17Input) =>
   raw["session.revert.stage"]({
     params: { sessionID: input["sessionID"] },
     payload: { messageID: input["messageID"], files: input["files"] },
@@ -265,61 +277,61 @@ const Endpoint4_16 = (raw: RawClient["server.session"]) => (input: Endpoint4_16I
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-type Endpoint4_17Input = { readonly sessionID: Endpoint4_17Request["params"]["sessionID"] }
-const Endpoint4_17 = (raw: RawClient["server.session"]) => (input: Endpoint4_17Input) =>
-  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
 type Endpoint4_18Input = { readonly sessionID: Endpoint4_18Request["params"]["sessionID"] }
 const Endpoint4_18 = (raw: RawClient["server.session"]) => (input: Endpoint4_18Input) =>
-  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
 type Endpoint4_19Input = { readonly sessionID: Endpoint4_19Request["params"]["sessionID"] }
 const Endpoint4_19 = (raw: RawClient["server.session"]) => (input: Endpoint4_19Input) =>
+  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint4_20Input = { readonly sessionID: Endpoint4_20Request["params"]["sessionID"] }
+const Endpoint4_20 = (raw: RawClient["server.session"]) => (input: Endpoint4_20Input) =>
   raw["session.context"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
-type Endpoint4_20Input = { readonly sessionID: Endpoint4_20Request["params"]["sessionID"] }
-const Endpoint4_20 = (raw: RawClient["server.session"]) => (input: Endpoint4_20Input) =>
+type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
+type Endpoint4_21Input = { readonly sessionID: Endpoint4_21Request["params"]["sessionID"] }
+const Endpoint4_21 = (raw: RawClient["server.session"]) => (input: Endpoint4_21Input) =>
   raw["session.instructions.entry.list"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
-type Endpoint4_21Input = {
-  readonly sessionID: Endpoint4_21Request["params"]["sessionID"]
-  readonly key: Endpoint4_21Request["params"]["key"]
-  readonly value: Endpoint4_21Request["payload"]["value"]
+type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
+type Endpoint4_22Input = {
+  readonly sessionID: Endpoint4_22Request["params"]["sessionID"]
+  readonly key: Endpoint4_22Request["params"]["key"]
+  readonly value: Endpoint4_22Request["payload"]["value"]
 }
-const Endpoint4_21 = (raw: RawClient["server.session"]) => (input: Endpoint4_21Input) =>
+const Endpoint4_22 = (raw: RawClient["server.session"]) => (input: Endpoint4_22Input) =>
   raw["session.instructions.entry.put"]({
     params: { sessionID: input["sessionID"], key: input["key"] },
     payload: { value: input["value"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
-type Endpoint4_22Input = {
-  readonly sessionID: Endpoint4_22Request["params"]["sessionID"]
-  readonly key: Endpoint4_22Request["params"]["key"]
+type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
+type Endpoint4_23Input = {
+  readonly sessionID: Endpoint4_23Request["params"]["sessionID"]
+  readonly key: Endpoint4_23Request["params"]["key"]
 }
-const Endpoint4_22 = (raw: RawClient["server.session"]) => (input: Endpoint4_22Input) =>
+const Endpoint4_23 = (raw: RawClient["server.session"]) => (input: Endpoint4_23Input) =>
   raw["session.instructions.entry.remove"]({ params: { sessionID: input["sessionID"], key: input["key"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.log"]>[0]
-type Endpoint4_23Input = {
-  readonly sessionID: Endpoint4_23Request["params"]["sessionID"]
-  readonly after?: Endpoint4_23Request["query"]["after"]
-  readonly follow?: Endpoint4_23Request["query"]["follow"]
+type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.log"]>[0]
+type Endpoint4_24Input = {
+  readonly sessionID: Endpoint4_24Request["params"]["sessionID"]
+  readonly after?: Endpoint4_24Request["query"]["after"]
+  readonly follow?: Endpoint4_24Request["query"]["follow"]
 }
-const Endpoint4_23 = (raw: RawClient["server.session"]) => (input: Endpoint4_23Input) =>
+const Endpoint4_24 = (raw: RawClient["server.session"]) => (input: Endpoint4_24Input) =>
   Stream.unwrap(
     raw["session.log"]({
       params: { sessionID: input["sessionID"] },
@@ -330,22 +342,22 @@ const Endpoint4_23 = (raw: RawClient["server.session"]) => (input: Endpoint4_23I
     ),
   )
 
-type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-type Endpoint4_24Input = { readonly sessionID: Endpoint4_24Request["params"]["sessionID"] }
-const Endpoint4_24 = (raw: RawClient["server.session"]) => (input: Endpoint4_24Input) =>
-  raw["session.interrupt"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
 type Endpoint4_25Input = { readonly sessionID: Endpoint4_25Request["params"]["sessionID"] }
 const Endpoint4_25 = (raw: RawClient["server.session"]) => (input: Endpoint4_25Input) =>
+  raw["session.interrupt"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+type Endpoint4_26Input = { readonly sessionID: Endpoint4_26Request["params"]["sessionID"] }
+const Endpoint4_26 = (raw: RawClient["server.session"]) => (input: Endpoint4_26Input) =>
   raw["session.background"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-type Endpoint4_26Input = {
-  readonly sessionID: Endpoint4_26Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_26Request["params"]["messageID"]
+type Endpoint4_27Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+type Endpoint4_27Input = {
+  readonly sessionID: Endpoint4_27Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_27Request["params"]["messageID"]
 }
-const Endpoint4_26 = (raw: RawClient["server.session"]) => (input: Endpoint4_26Input) =>
+const Endpoint4_27 = (raw: RawClient["server.session"]) => (input: Endpoint4_27Input) =>
   raw["session.message"]({ params: { sessionID: input["sessionID"], messageID: input["messageID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
@@ -361,22 +373,23 @@ const adaptGroup4 = (raw: RawClient["server.session"]) => ({
   switchAgent: Endpoint4_6(raw),
   switchModel: Endpoint4_7(raw),
   rename: Endpoint4_8(raw),
-  prompt: Endpoint4_9(raw),
-  command: Endpoint4_10(raw),
-  skill: Endpoint4_11(raw),
-  synthetic: Endpoint4_12(raw),
-  shell: Endpoint4_13(raw),
-  compact: Endpoint4_14(raw),
-  wait: Endpoint4_15(raw),
-  revertStage: Endpoint4_16(raw),
-  revertClear: Endpoint4_17(raw),
-  revertCommit: Endpoint4_18(raw),
-  context: Endpoint4_19(raw),
-  instructions: { entry: { list: Endpoint4_20(raw), put: Endpoint4_21(raw), remove: Endpoint4_22(raw) } },
-  log: Endpoint4_23(raw),
-  interrupt: Endpoint4_24(raw),
-  background: Endpoint4_25(raw),
-  message: Endpoint4_26(raw),
+  move: Endpoint4_9(raw),
+  prompt: Endpoint4_10(raw),
+  command: Endpoint4_11(raw),
+  skill: Endpoint4_12(raw),
+  synthetic: Endpoint4_13(raw),
+  shell: Endpoint4_14(raw),
+  compact: Endpoint4_15(raw),
+  wait: Endpoint4_16(raw),
+  revertStage: Endpoint4_17(raw),
+  revertClear: Endpoint4_18(raw),
+  revertCommit: Endpoint4_19(raw),
+  context: Endpoint4_20(raw),
+  instructions: { entry: { list: Endpoint4_21(raw), put: Endpoint4_22(raw), remove: Endpoint4_23(raw) } },
+  log: Endpoint4_24(raw),
+  interrupt: Endpoint4_25(raw),
+  background: Endpoint4_26(raw),
+  message: Endpoint4_27(raw),
 })
 
 type Endpoint5_0Request = Parameters<RawClient["server.message"]["session.messages"]>[0]

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -23,6 +23,8 @@ import type {
   SessionSwitchModelOutput,
   SessionRenameInput,
   SessionRenameOutput,
+  SessionMoveInput,
+  SessionMoveOutput,
   SessionPromptInput,
   SessionPromptOutput,
   SessionCommandInput,
@@ -481,6 +483,18 @@ export function make(options: ClientOptions) {
             method: "POST",
             path: `/api/session/${encodeURIComponent(input.sessionID)}/rename`,
             body: { title: input["title"] },
+            successStatus: 204,
+            declaredStatuses: [404, 400, 401],
+            empty: true,
+          },
+          requestOptions,
+        ),
+      move: (input: SessionMoveInput, requestOptions?: RequestOptions) =>
+        request<SessionMoveOutput>(
+          {
+            method: "POST",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/move`,
+            body: { destination: input["destination"], moveChanges: input["moveChanges"] },
             successStatus: 204,
             declaredStatuses: [404, 400, 401],
             empty: true,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -526,6 +526,20 @@ export type SessionRenameInput = {
 
 export type SessionRenameOutput = void
 
+export type SessionMoveInput = {
+  readonly sessionID: { readonly sessionID: string }["sessionID"]
+  readonly destination: {
+    readonly destination: { readonly directory: string }
+    readonly moveChanges?: boolean | undefined
+  }["destination"]
+  readonly moveChanges?: {
+    readonly destination: { readonly directory: string }
+    readonly moveChanges?: boolean | undefined
+  }["moveChanges"]
+}
+
+export type SessionMoveOutput = void
+
 export type SessionPromptInput = {
   readonly sessionID: { readonly sessionID: string }["sessionID"]
   readonly id?: {

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -475,6 +475,7 @@ export type TuiHostSlotMap = {
   }
   sidebar_footer: {
     session_id: string
+    directory: string
   }
 }
 

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -270,6 +270,25 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
         ),
     )
     .add(
+      HttpApiEndpoint.post("session.move", "/api/session/:sessionID/move", {
+        params: { sessionID: Session.ID },
+        payload: Schema.Struct({
+          destination: Schema.Struct({ directory: AbsolutePath }),
+          moveChanges: Schema.Boolean.pipe(Schema.optional),
+        }),
+        success: HttpApiSchema.NoContent,
+        error: [SessionNotFoundError, InvalidRequestError],
+      })
+        .middleware(sessionLocationMiddleware)
+        .annotateMerge(
+          OpenApi.annotations({
+            identifier: "v2.session.move",
+            summary: "Move session",
+            description: "Move a session to another project directory, optionally transferring local changes.",
+          }),
+        ),
+    )
+    .add(
       HttpApiEndpoint.post("session.prompt", "/api/session/:sessionID/prompt", {
         params: { sessionID: Session.ID },
         payload: Schema.Struct({

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -1,5 +1,6 @@
 import { SessionV2 } from "@opencode-ai/core/session"
 import { InstructionEntry } from "@opencode-ai/core/session/instruction-entry"
+import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
 import { DateTime, Effect, Stream } from "effect"
 import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
 import { Api } from "../api"
@@ -8,8 +9,8 @@ import {
   ConflictError,
   CommandEvaluationError,
   CommandNotFoundError,
-  InvalidCursorError,
   InvalidRequestError,
+  InvalidCursorError,
   MessageNotFoundError,
   ServiceUnavailableError,
   SessionBusyError,
@@ -24,6 +25,7 @@ const DefaultSessionsLimit = 50
 export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handlers) =>
   Effect.gen(function* () {
     const session = yield* SessionV2.Service
+    const moveSession = yield* MoveSession.Service
 
     return handlers
       .handle(
@@ -196,6 +198,43 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
                   message: `Session not found: ${error.sessionID}`,
                 }),
               ),
+            ),
+          )
+          return HttpApiSchema.NoContent.make()
+        }),
+      )
+      .handle(
+        "session.move",
+        Effect.fn(function* (ctx) {
+          yield* moveSession.moveSession({
+            sessionID: ctx.params.sessionID,
+            destination: ctx.payload.destination,
+            moveChanges: ctx.payload.moveChanges,
+          }).pipe(
+            Effect.catchTag("Session.NotFoundError", (error) =>
+              Effect.fail(
+                new SessionNotFoundError({
+                  sessionID: error.sessionID,
+                  message: `Session not found: ${error.sessionID}`,
+                }),
+              ),
+            ),
+            Effect.catchTag("MoveSession.DestinationProjectMismatchError", () =>
+              Effect.fail(new InvalidRequestError({ message: "Destination directory belongs to another project" })),
+            ),
+            Effect.catchTag("MoveSession.ApplyChangesError", () =>
+              Effect.fail(
+                new InvalidRequestError({
+                  message:
+                    "Unable to apply your changes in the destination directory. The files may conflict with existing changes.",
+                }),
+              ),
+            ),
+            Effect.catchTag("MoveSession.CaptureChangesError", (error) =>
+              Effect.fail(new InvalidRequestError({ message: error.message })),
+            ),
+            Effect.catchTag("MoveSession.ResetSourceChangesError", (error) =>
+              Effect.fail(new InvalidRequestError({ message: error.message })),
             ),
           )
           return HttpApiSchema.NoContent.make()

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -8,6 +8,7 @@ import { Observability } from "@opencode-ai/core/observability"
 import { Credential } from "@opencode-ai/core/credential"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
+import { MoveSession } from "@opencode-ai/core/control-plane/move-session"
 import { Project } from "@opencode-ai/core/project"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
@@ -37,6 +38,7 @@ const applicationServices = LayerNode.group([
   httpClient,
   ToolOutputStore.cleanupNode,
   Job.node,
+  MoveSession.node,
   Project.node,
   SessionV2.node,
   PluginRuntime.providerNode,

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -19,8 +19,7 @@ import { Spinner } from "./spinner"
 import { DialogWorkspaceFileChanges } from "./dialog-workspace-file-changes"
 import type { ProjectDirectoriesOutput } from "@opencode-ai/client/promise"
 import { useRoute } from "../context/route"
-import { DialogPrompt } from "../ui/dialog-prompt"
-import { Slug } from "@opencode-ai/core/util/slug"
+import { DialogProjectCopyName } from "./dialog-project-copy-name"
 
 export type MoveSessionSelection = { type: "directory"; directory: string; subdirectory: boolean } | { type: "new"; name: string }
 type ProjectDirectory = ProjectDirectoriesOutput[number]
@@ -294,13 +293,9 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
   }
 
   async function create() {
-    const value = await DialogPrompt.show(dialog, "Name worktree", {
-      placeholder: "Worktree name",
-      generateHint: "generate one",
-      onGenerate: Slug.create,
-    })
-    if (value === null) return
-    props.onSelect({ type: "new", name: slugify(value) || Slug.create() })
+    const name = await DialogProjectCopyName.show(dialog)
+    if (name === null) return
+    props.onSelect({ type: "new", name })
   }
 
   const fullHeight = createMemo(() =>
@@ -374,13 +369,4 @@ function contains(root: string, directory: string) {
   if (root === directory) return true
   const relative = path.relative(root, directory)
   return relative && relative !== ".." && !relative.startsWith(".." + path.sep) && !path.isAbsolute(relative)
-}
-
-function slugify(input: string) {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "")
 }

--- a/packages/tui/src/component/dialog-move-session.tsx
+++ b/packages/tui/src/component/dialog-move-session.tsx
@@ -19,8 +19,10 @@ import { Spinner } from "./spinner"
 import { DialogWorkspaceFileChanges } from "./dialog-workspace-file-changes"
 import type { ProjectDirectoriesOutput } from "@opencode-ai/client/promise"
 import { useRoute } from "../context/route"
+import { DialogPrompt } from "../ui/dialog-prompt"
+import { Slug } from "@opencode-ai/core/util/slug"
 
-export type MoveSessionSelection = { type: "directory"; directory: string; subdirectory: boolean } | { type: "new" }
+export type MoveSessionSelection = { type: "directory"; directory: string; subdirectory: boolean } | { type: "new"; name: string }
 type ProjectDirectory = ProjectDirectoriesOutput[number]
 
 type DialogMoveSessionProps = {
@@ -291,6 +293,16 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
     if (await removedCurrent(deletingCurrent)) return
   }
 
+  async function create() {
+    const value = await DialogPrompt.show(dialog, "Name worktree", {
+      placeholder: "Worktree name",
+      generateHint: "generate one",
+      onGenerate: Slug.create,
+    })
+    if (value === null) return
+    props.onSelect({ type: "new", name: slugify(value) || Slug.create() })
+  }
+
   const fullHeight = createMemo(() =>
     Math.max(8, Math.min(16, dimensions().height - Math.floor(dimensions().height / 4) - 2)),
   )
@@ -334,7 +346,7 @@ export function DialogMoveSession(props: DialogMoveSessionProps) {
                 {
                   command: "dialog.move_session.new",
                   title: "new",
-                  onTrigger: () => props.onSelect({ type: "new" }),
+                  onTrigger: () => void create(),
                 },
                 {
                   command: "dialog.move_session.delete",
@@ -362,4 +374,13 @@ function contains(root: string, directory: string) {
   if (root === directory) return true
   const relative = path.relative(root, directory)
   return relative && relative !== ".." && !relative.startsWith(".." + path.sep) && !path.isAbsolute(relative)
+}
+
+function slugify(input: string) {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "")
 }

--- a/packages/tui/src/component/dialog-project-copy-name.tsx
+++ b/packages/tui/src/component/dialog-project-copy-name.tsx
@@ -1,0 +1,95 @@
+import { InputRenderable, TextAttributes } from "@opentui/core"
+import { Slug } from "@opencode-ai/core/util/slug"
+import { createSignal, onMount } from "solid-js"
+import { useTuiConfig } from "../config"
+import { useTheme } from "../context/theme"
+import { useBindings, useCommandShortcut } from "../keymap"
+import { useDialog, type DialogContext } from "../ui/dialog"
+
+export function DialogProjectCopyName(props: { onConfirm: (name: string) => void }) {
+  const dialog = useDialog()
+  const { theme } = useTheme()
+  const tuiConfig = useTuiConfig()
+  const generateShortcut = useCommandShortcut("dialog.project_copy.generate")
+  const [inputTarget, setInputTarget] = createSignal<InputRenderable>()
+  let input: InputRenderable
+
+  function generate() {
+    input.value = Slug.create()
+    input.gotoLineEnd()
+  }
+
+  function confirm(value: string) {
+    props.onConfirm(slugify(value) || Slug.create())
+  }
+
+  useBindings(() => ({
+    target: inputTarget,
+    enabled: inputTarget() !== undefined,
+    priority: 1,
+    commands: [
+      {
+        name: "dialog.project_copy.generate",
+        title: "Generate project copy name",
+        category: "Dialog",
+        run: generate,
+      },
+    ],
+    bindings: tuiConfig.keybinds.get("dialog.project_copy.generate"),
+  }))
+
+  onMount(() => {
+    dialog.setSize("medium")
+    setTimeout(() => {
+      if (!input || input.isDestroyed) return
+      input.focus()
+    }, 1)
+  })
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          Name project copy
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+      <input
+        ref={(value: InputRenderable) => {
+          input = value
+          setInputTarget(value)
+        }}
+        onSubmit={confirm}
+        placeholder="Project copy name"
+        placeholderColor={theme.textMuted}
+        textColor={theme.text}
+        focusedTextColor={theme.text}
+        cursorColor={theme.text}
+      />
+      <box paddingBottom={1} flexDirection="row" gap={2}>
+        <text fg={theme.text}>
+          enter <span style={{ fg: theme.textMuted }}>submit</span>
+        </text>
+        <text fg={theme.text}>
+          {generateShortcut()} <span style={{ fg: theme.textMuted }}>generate one</span>
+        </text>
+      </box>
+    </box>
+  )
+}
+
+DialogProjectCopyName.show = (dialog: DialogContext) =>
+  new Promise<string | null>((resolve) => {
+    dialog.replace(() => <DialogProjectCopyName onConfirm={resolve} />, () => resolve(null))
+  })
+
+function slugify(input: string) {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "")
+}

--- a/packages/tui/src/component/dialog-project-copy-name.tsx
+++ b/packages/tui/src/component/dialog-project-copy-name.tsx
@@ -19,8 +19,8 @@ export function DialogProjectCopyName(props: { onConfirm: (name: string) => void
     input.gotoLineEnd()
   }
 
-  function confirm(value: string) {
-    props.onConfirm(slugify(value) || Slug.create())
+  function confirm() {
+    props.onConfirm(slugify(input.value) || Slug.create())
   }
 
   useBindings(() => ({

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -218,7 +218,10 @@ export function Prompt(props: PromptProps) {
   const editorContextLabelState = createMemo(() => editor.labelState())
   const [auto, setAuto] = createSignal<AutocompleteRef>()
   const workspace = usePromptWorkspace(props.sessionID)
-  const move = usePromptMove({ projectID: project.project, sessionID: () => props.sessionID })
+  const move = usePromptMove({
+    projectID: () => (props.sessionID ? data.session.get(props.sessionID)?.projectID : undefined) ?? project.project(),
+    sessionID: () => props.sessionID,
+  })
   const [cursorVersion, setCursorVersion] = createSignal(0)
   const currentProviderLabel = createMemo(() => local.model.parsed().provider)
   const connected = useConnected()
@@ -955,13 +958,13 @@ export function Prompt(props: PromptProps) {
     if (workspace.creating() || move.creating()) return false
     if (auto()?.visible) return false
     if (!store.prompt.text) return false
-    const agent = local.agent.current()
-    if (!agent) return false
     const trimmed = store.prompt.text.trim()
     if (trimmed === "exit" || trimmed === "quit" || trimmed === ":q") {
       void exit()
       return true
     }
+    const agent = local.agent.current()
+    if (!agent) return false
     const selectedModel = local.model.current()
     if (!selectedModel) {
       void promptModelWarning()
@@ -991,7 +994,7 @@ export function Prompt(props: PromptProps) {
       const selectedWorkspace = workspace.selection()
       const workspaceID = selectedWorkspace?.type === "existing" ? selectedWorkspace.workspaceID : undefined
 
-      const directory = await move.getDirectory(store.prompt.text)
+      const directory = await move.getDirectory()
       if (move.pending() && !directory) return false
       finishMoveProgress = Boolean(move.progress())
       const location = data.location.default()

--- a/packages/tui/src/component/prompt/move.tsx
+++ b/packages/tui/src/component/prompt/move.tsx
@@ -111,7 +111,9 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     setProgress("Moving session")
     try {
       await sdk.api.session.move({ sessionID, destination: { directory }, moveChanges: choice === "yes" })
-      await sdk.api.session.synthetic({ sessionID, text: moveReminderText(directory) }).catch(() => undefined)
+      await sdk.api.session
+        .synthetic({ sessionID, text: moveReminderText(directory), resume: false })
+        .catch(() => undefined)
       dialog.clear()
     } catch (error) {
       toast.error(error)

--- a/packages/tui/src/component/prompt/move.tsx
+++ b/packages/tui/src/component/prompt/move.tsx
@@ -4,12 +4,12 @@ import { useTuiPaths } from "../../context/runtime"
 import { errorMessage } from "../../util/error"
 import { useDialog } from "../../ui/dialog"
 import { useSDK } from "../../context/sdk"
-import { useSync } from "../../context/sync"
 import { useToast } from "../../ui/toast"
 import { DialogMoveSession, type MoveSessionSelection } from "../dialog-move-session"
 import { DialogWorkspaceFileChanges } from "../dialog-workspace-file-changes"
 import { useHomeSessionDestination } from "../../routes/home/session-destination"
 import { useProject } from "../../context/project"
+import { useData } from "../../context/data"
 
 function moveReminderText(directory: string) {
   return `<system-reminder>The user has changed the current working directory to "${directory}". This is still the same project but at a possibly new location; take this into account when working with any files from now on.</system-reminder>`
@@ -18,38 +18,33 @@ function moveReminderText(directory: string) {
 export function usePromptMove(input: { projectID: () => string | undefined; sessionID: () => string | undefined }) {
   const dialog = useDialog()
   const sdk = useSDK()
-  const sync = useSync()
   const toast = useToast()
   const homeDestination = useHomeSessionDestination()
   const project = useProject()
+  const data = useData()
   const paths = useTuiPaths()
   const [creating, setCreating] = createSignal(false)
   const [creatingDots, setCreatingDots] = createSignal(3)
   const [progress, setProgress] = createSignal<string>()
 
-  async function create(context?: string) {
-    const projectID = input.projectID()
+  async function create(name: string) {
+    const projectID = await resolveProjectID()
     if (!projectID) return
     setCreating(true)
     setProgress("Creating copy")
     try {
-      const generated = await sdk.client.experimental.projectCopy.generateName(
-        { projectID, context },
-        { throwOnError: true },
-      )
       const result = await sdk.api.projectCopy.create({
         projectID,
         location: { directory: project.instance.directory() || paths.cwd },
         strategy: "git_worktree",
         directory: path.join(paths.worktree, projectID.slice(0, 6)),
-        name: generated.data.name,
+        name,
       })
       const directory = result.directory
       if (!directory) throw new Error("No project copy directory returned")
 
-      // Call a location-based route to make sure it's bootstrapped
-      // before moving on
-      await sdk.client.path.get({ directory }, { throwOnError: true })
+      // Call a location-based route to make sure it's bootstrapped before moving on.
+      await sdk.api.location.get({ location: { directory } })
 
       setProgress("Creating session")
       return directory
@@ -62,11 +57,14 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     }
   }
 
-  function open() {
-    const projectID = input.projectID()
-    if (!projectID) return
+  async function open() {
+    const projectID = await resolveProjectID()
+    if (!projectID) {
+      toast.show({ message: "Unable to determine current project", variant: "error" })
+      return
+    }
     const sessionID = input.sessionID()
-    const session = sessionID ? sync.session.get(sessionID) : undefined
+    const session = sessionID ? await resolveSession(sessionID) : undefined
     dialog.replace(() => (
       <DialogMoveSession
         projectID={projectID}
@@ -75,8 +73,8 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
           (session
             ? {
                 type: "directory",
-                directory: session.directory,
-                subdirectory: !!session.path,
+                directory: session.location.directory,
+                subdirectory: !!session.subpath,
               }
             : {
                 type: "directory",
@@ -98,26 +96,13 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     ))
   }
 
-  function sessionContext(sessionID: string) {
-    const session = sync.session.get(sessionID)
-    const messages = (sync.data.message[sessionID] ?? [])
-      .slice(-6)
-      .map((message) =>
-        [
-          message.role + ":",
-          ...(sync.data.part[message.id] ?? []).flatMap((part) => (part.type === "text" ? [part.text] : [])),
-        ].join(" "),
-      )
-    return [session?.title, ...messages].filter(Boolean).join("\n") || undefined
-  }
-
   async function moveExistingSession(sessionID: string, selection: MoveSessionSelection) {
-    const session = sync.session.get(sessionID)
-    const status = await sdk.client.vcs.status({ directory: session?.directory }).catch(() => undefined)
+    const session = await resolveSession(sessionID)
+    const status = await sdk.client.vcs.status({ directory: session?.location.directory }).catch(() => undefined)
     const choice = status?.data?.length ? await DialogWorkspaceFileChanges.show(dialog, status.data) : "no"
     if (!choice) return
     dialog.clear()
-    const directory = selection.type === "new" ? await create(sessionContext(sessionID)) : selection.directory
+    const directory = selection.type === "new" ? await create(selection.name) : selection.directory
     if (!directory) {
       setProgress(undefined)
       dialog.clear()
@@ -125,28 +110,8 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     }
     setProgress("Moving session")
     try {
-      await sdk.client.experimental.controlPlane.moveSession(
-        {
-          sessionID,
-          destination: { directory },
-          moveChanges: choice === "yes",
-        },
-        { throwOnError: true },
-      )
-      await sdk.client.session
-        .promptAsync({
-          sessionID,
-          directory,
-          noReply: true,
-          parts: [
-            {
-              type: "text",
-              text: moveReminderText(directory),
-              synthetic: true,
-            },
-          ],
-        })
-        .catch(() => undefined)
+      await sdk.api.session.move({ sessionID, destination: { directory }, moveChanges: choice === "yes" })
+      await sdk.api.session.synthetic({ sessionID, text: moveReminderText(directory) }).catch(() => undefined)
       dialog.clear()
     } catch (error) {
       toast.error(error)
@@ -157,16 +122,34 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
     }
   }
 
+  async function resolveProjectID() {
+    const projectID = input.projectID()
+    if (projectID) return projectID
+    const sessionID = input.sessionID()
+    if (sessionID) return (await resolveSession(sessionID))?.projectID
+    return sdk.api.project
+      .current({ location: { directory: project.instance.directory() || paths.cwd } })
+      .then((project) => project.id)
+      .catch(() => undefined)
+  }
+
+  async function resolveSession(sessionID: string) {
+    const session = data.session.get(sessionID)
+    if (session) return session
+    await data.session.refresh(sessionID).catch(() => undefined)
+    return data.session.get(sessionID)
+  }
+
   const pending = createMemo(() => Boolean(homeDestination?.destination()))
   const pendingNew = createMemo(() => homeDestination?.destination()?.type === "new")
 
-  async function getDirectory(context?: string) {
+  async function getDirectory() {
     const value = homeDestination?.destination()
     if (!value) return
     if (value.type === "directory") {
       return value.directory
     }
-    return await create(context)
+    return await create(value.name)
   }
 
   function startSubmit() {

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -207,7 +207,7 @@ export const Definitions = {
   "dialog.select.end": keybind("end", "Move to last dialog item"),
   "dialog.select.submit": keybind("return", "Submit selected dialog item"),
   "dialog.prompt.submit": keybind("return", "Submit dialog prompt"),
-  "dialog.prompt.generate": keybind("tab", "Generate dialog prompt value"),
+  "dialog.project_copy.generate": keybind("tab", "Generate project copy name"),
   "dialog.mcp.toggle": keybind("space", "Toggle MCP in MCP dialog"),
   "dialog.move_session.new": keybind("ctrl+m", "New project copy"),
   "dialog.move_session.delete": keybind("ctrl+d", "Delete project copy"),

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -207,6 +207,7 @@ export const Definitions = {
   "dialog.select.end": keybind("end", "Move to last dialog item"),
   "dialog.select.submit": keybind("return", "Submit selected dialog item"),
   "dialog.prompt.submit": keybind("return", "Submit dialog prompt"),
+  "dialog.prompt.generate": keybind("tab", "Generate dialog prompt value"),
   "dialog.mcp.toggle": keybind("space", "Toggle MCP in MCP dialog"),
   "dialog.move_session.new": keybind("ctrl+m", "New project copy"),
   "dialog.move_session.delete": keybind("ctrl+d", "Delete project copy"),

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -304,6 +304,12 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           if (store.session.info[event.data.sessionID])
             setStore("session", "info", event.data.sessionID, "title", event.data.title)
           break
+        case "session.moved":
+          if (store.session.info[event.data.sessionID]) {
+            setStore("session", "info", event.data.sessionID, "location", mutable(event.data.location))
+            setStore("session", "info", event.data.sessionID, "subpath", event.data.subpath)
+          }
+          break
         case "session.prompt.promoted": {
           message.update(event.data.sessionID, (draft, index) => {
             const position = index.get(event.data.inputID)

--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -6,7 +6,7 @@ import { useTuiPaths } from "../../context/runtime"
 
 const id = "internal:sidebar-footer"
 
-function View(props: { api: TuiPluginApi; sessionID: string }) {
+function View(props: { api: TuiPluginApi; directory: string }) {
   const paths = useTuiPaths()
   const theme = () => props.api.theme.current
   const has = createMemo(() =>
@@ -17,10 +17,8 @@ function View(props: { api: TuiPluginApi; sessionID: string }) {
   const done = createMemo(() => props.api.kv.get("dismissed_getting_started", false))
   const show = createMemo(() => !has() && !done())
   const path = createMemo(() => {
-    const session = props.api.state.session.get(props.sessionID)
-    const dir = session?.directory || props.api.state.path.directory || paths.cwd
-    const out = abbreviateHome(dir, paths.home)
-    const branch = session?.directory === props.api.state.path.directory ? props.api.state.vcs?.branch : undefined
+    const out = abbreviateHome(props.directory, paths.home)
+    const branch = props.directory === props.api.state.path.directory ? props.api.state.vcs?.branch : undefined
     const text = branch ? out + ":" + branch : out
     const list = text.split("/")
     return {
@@ -84,7 +82,7 @@ const tui: TuiPlugin = async (api) => {
     order: 100,
     slots: {
       sidebar_footer(_ctx, props) {
-        return <View api={api} sessionID={props.session_id} />
+        return <View api={api} directory={props.directory} />
       },
     },
   })

--- a/packages/tui/src/routes/home/session-destination.tsx
+++ b/packages/tui/src/routes/home/session-destination.tsx
@@ -10,7 +10,7 @@ import {
 import { useSync } from "../../context/sync"
 import { useTuiPaths } from "../../context/runtime"
 
-export type HomeSessionDestination = { type: "directory"; directory: string; subdirectory: boolean } | { type: "new" }
+export type HomeSessionDestination = { type: "directory"; directory: string; subdirectory: boolean } | { type: "new"; name: string }
 
 type Context = {
   destination: Accessor<HomeSessionDestination | undefined>

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -85,7 +85,12 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
         </scrollbox>
 
         <box flexShrink={0} gap={1} paddingTop={1}>
-          <pluginRuntime.Slot name="sidebar_footer" mode="single_winner" session_id={props.sessionID}>
+          <pluginRuntime.Slot
+            name="sidebar_footer"
+            mode="single_winner"
+            session_id={props.sessionID}
+            directory={session()?.location.directory ?? ""}
+          >
             <text fg={theme.textMuted}>
               <span style={{ fg: theme.success }}>•</span> <b>Open</b>
               <span style={{ fg: theme.text }}>

--- a/packages/tui/src/ui/dialog-prompt.tsx
+++ b/packages/tui/src/ui/dialog-prompt.tsx
@@ -13,8 +13,6 @@ export type DialogPromptProps = {
   value?: string
   busy?: boolean
   busyText?: string
-  onGenerate?: () => string
-  generateHint?: string
   onConfirm?: (value: string) => void
   onCancel?: () => void
 }
@@ -32,13 +30,6 @@ export function DialogPrompt(props: DialogPromptProps) {
     props.onConfirm?.(textarea.plainText)
   }
 
-  function generate() {
-    if (props.busy) return
-    if (!props.onGenerate) return
-    textarea.setText(props.onGenerate())
-    textarea.gotoLineEnd()
-  }
-
   useBindings(() => ({
     target: textareaTarget,
     enabled: textareaTarget() !== undefined && !props.busy,
@@ -51,17 +42,8 @@ export function DialogPrompt(props: DialogPromptProps) {
         category: "Dialog",
         run: confirm,
       },
-      {
-        name: "dialog.prompt.generate",
-        title: "Generate dialog prompt value",
-        category: "Dialog",
-        run: generate,
-      },
     ],
-    bindings: tuiConfig.keybinds.gather("dialog.prompt", [
-      "dialog.prompt.submit",
-      ...(props.onGenerate ? ["dialog.prompt.generate"] : []),
-    ]),
+    bindings: tuiConfig.keybinds.gather("dialog.prompt", ["dialog.prompt.submit"]),
   }))
 
   onMount(() => {
@@ -124,11 +106,6 @@ export function DialogPrompt(props: DialogPromptProps) {
           <Show when={submitShortcut()}>
             <text fg={theme.text}>
               {submitShortcut()} <span style={{ fg: theme.textMuted }}>submit</span>
-            </text>
-          </Show>
-          <Show when={props.onGenerate}>
-            <text fg={theme.text}>
-              tab <span style={{ fg: theme.textMuted }}>{props.generateHint ?? "generate one"}</span>
             </text>
           </Show>
         </Show>

--- a/packages/tui/src/ui/dialog-prompt.tsx
+++ b/packages/tui/src/ui/dialog-prompt.tsx
@@ -13,6 +13,8 @@ export type DialogPromptProps = {
   value?: string
   busy?: boolean
   busyText?: string
+  onGenerate?: () => string
+  generateHint?: string
   onConfirm?: (value: string) => void
   onCancel?: () => void
 }
@@ -30,6 +32,13 @@ export function DialogPrompt(props: DialogPromptProps) {
     props.onConfirm?.(textarea.plainText)
   }
 
+  function generate() {
+    if (props.busy) return
+    if (!props.onGenerate) return
+    textarea.setText(props.onGenerate())
+    textarea.gotoLineEnd()
+  }
+
   useBindings(() => ({
     target: textareaTarget,
     enabled: textareaTarget() !== undefined && !props.busy,
@@ -42,8 +51,17 @@ export function DialogPrompt(props: DialogPromptProps) {
         category: "Dialog",
         run: confirm,
       },
+      {
+        name: "dialog.prompt.generate",
+        title: "Generate dialog prompt value",
+        category: "Dialog",
+        run: generate,
+      },
     ],
-    bindings: tuiConfig.keybinds.gather("dialog.prompt", ["dialog.prompt.submit"]),
+    bindings: tuiConfig.keybinds.gather("dialog.prompt", [
+      "dialog.prompt.submit",
+      ...(props.onGenerate ? ["dialog.prompt.generate"] : []),
+    ]),
   }))
 
   onMount(() => {
@@ -106,6 +124,11 @@ export function DialogPrompt(props: DialogPromptProps) {
           <Show when={submitShortcut()}>
             <text fg={theme.text}>
               {submitShortcut()} <span style={{ fg: theme.textMuted }}>submit</span>
+            </text>
+          </Show>
+          <Show when={props.onGenerate}>
+            <text fg={theme.text}>
+              tab <span style={{ fg: theme.textMuted }}>{props.generateHint ?? "generate one"}</span>
             </text>
           </Show>
         </Show>

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -108,6 +108,68 @@ test("refreshes resources into reactive getters", async () => {
   }
 })
 
+test("updates session location when moved", async () => {
+  const events = createEventStream()
+  const destination = "/tmp/opencode-moved"
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/session/ses_test")
+      return json({
+        data: {
+          id: "ses_test",
+          projectID: "proj_test",
+          cost: 0,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          time: { created: 0, updated: 0 },
+          title: "Test session",
+          location: { directory },
+        },
+      })
+  }, events)
+  let data!: ReturnType<typeof useData>
+  let ready!: () => void
+  const mounted = new Promise<void>((resolve) => {
+    ready = resolve
+  })
+
+  function Probe() {
+    data = useData()
+    onMount(ready)
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <SDKProvider client={createClient(calls.fetch)} api={createApi(calls.fetch)}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </SDKProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await mounted
+    await data.session.refresh("ses_test")
+    emitEvent(events, {
+      id: "evt_moved_1",
+      created: 1,
+      type: "session.moved",
+      durable: durable("ses_test"),
+      data: {
+        sessionID: "ses_test",
+        location: { directory: destination },
+        subpath: "packages/cli",
+      },
+    })
+    await wait(() => data.session.get("ses_test")?.location.directory === destination)
+    expect(data.session.get("ses_test")?.subpath).toBe("packages/cli")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
 test("restores running manual compaction before applying live deltas", async () => {
   const events = createEventStream()
   const calls = createFetch((url) => {


### PR DESCRIPTION
## Summary
- add a V2 session move endpoint backed by the existing MoveSession service
- wire the TUI /move flow to the V2 session API
- regenerate generated client and plugin API surfaces

## Verification
- packages/protocol: bun typecheck
- packages/client: bun typecheck
- packages/server: bun typecheck
- packages/tui: bun typecheck
- packages/plugin: bun typecheck
- packages/core: bun test test/move-session.test.ts

Note: initial git push pre-push hook ran full repo turbo typecheck and the parallel tui typecheck process was SIGKILLed; rerunning packages/tui serially passed.