### PR TITLE
fix(core): disable mcp tool call timeout

### DIFF
--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -32,7 +32,7 @@ import { InstallationVersion } from "../installation/version"
 
 const DEFAULT_STARTUP_TIMEOUT = 30_000
 const DEFAULT_REQUEST_TIMEOUT = 30_000
-const ELICITATION_PROGRESS_INTERVAL = 10_000
+const TOOL_CALL_TIMEOUT = 2_147_483_647
 
 type Transport = StdioClientTransport | StreamableHTTPClientTransport
 
@@ -183,31 +183,9 @@ export const connect = Effect.fnUntraced(function* (
     Promise.resolve({ roots: [{ uri: pathToFileURL(directory).href }] }),
   )
   if (elicitation) {
-    client.setRequestHandler(ElicitRequestSchema, async (request, extra) => {
-      const progressToken = extra._meta?.progressToken
-      const started = Date.now()
-      // Human input can exceed the server's request timeout; progress keeps cooperative callers alive.
-      const sendProgress = () => {
-        if (progressToken === undefined) return
-        void extra
-          .sendNotification({
-            method: "notifications/progress",
-            params: {
-              progressToken,
-              progress: Date.now() - started,
-              message: "Waiting for user response",
-            },
-          })
-          .catch(() => undefined)
-      }
-      const interval = progressToken === undefined ? undefined : setInterval(sendProgress, ELICITATION_PROGRESS_INTERVAL)
-      sendProgress()
-      try {
-        return await Effect.runPromise(elicitation.create({ server, params: request.params, signal: extra.signal }))
-      } finally {
-        if (interval !== undefined) clearInterval(interval)
-      }
-    })
+    client.setRequestHandler(ElicitRequestSchema, (request, extra) =>
+      Effect.runPromise(elicitation.create({ server, params: request.params, signal: extra.signal })),
+    )
     client.setNotificationHandler(ElicitationCompleteNotificationSchema, (notification) =>
       Effect.runPromise(elicitation.complete({ server, elicitationID: notification.params.elicitationId })),
     )
@@ -304,8 +282,8 @@ export const connect = Effect.fnUntraced(function* (
             client.callTool(
               { name: input.name, arguments: input.args ?? {} },
               CallToolResultSchema,
-              // Keep progress tokens available without imposing a client timeout on tool execution.
-              { signal, resetTimeoutOnProgress: true, onprogress: () => {} },
+              // The SDK does not support disabling request timeouts; use the setTimeout max.
+              { signal, timeout: TOOL_CALL_TIMEOUT, resetTimeoutOnProgress: true, onprogress: () => {} },
             ),
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         }).pipe(

--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -32,7 +32,7 @@ import { InstallationVersion } from "../installation/version"
 
 const DEFAULT_STARTUP_TIMEOUT = 30_000
 const DEFAULT_REQUEST_TIMEOUT = 30_000
-const TOOL_CALL_TIMEOUT = 2_147_483_647
+const DEFAULT_TOOL_CALL_TIMEOUT = 100_000_000
 
 type Transport = StdioClientTransport | StreamableHTTPClientTransport
 
@@ -282,8 +282,8 @@ export const connect = Effect.fnUntraced(function* (
             client.callTool(
               { name: input.name, arguments: input.args ?? {} },
               CallToolResultSchema,
-              // The SDK does not support disabling request timeouts; use the setTimeout max.
-              { signal, timeout: TOOL_CALL_TIMEOUT, resetTimeoutOnProgress: true, onprogress: () => {} },
+              // Human-driven tools can exceed the SDK default; use an effectively infinite timeout.
+              { signal, timeout: DEFAULT_TOOL_CALL_TIMEOUT, resetTimeoutOnProgress: true, onprogress: () => {} },
             ),
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         }).pipe(

--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -32,6 +32,7 @@ import { InstallationVersion } from "../installation/version"
 
 const DEFAULT_STARTUP_TIMEOUT = 30_000
 const DEFAULT_REQUEST_TIMEOUT = 30_000
+const ELICITATION_PROGRESS_INTERVAL = 10_000
 
 type Transport = StdioClientTransport | StreamableHTTPClientTransport
 
@@ -182,9 +183,31 @@ export const connect = Effect.fnUntraced(function* (
     Promise.resolve({ roots: [{ uri: pathToFileURL(directory).href }] }),
   )
   if (elicitation) {
-    client.setRequestHandler(ElicitRequestSchema, (request, extra) =>
-      Effect.runPromise(elicitation.create({ server, params: request.params, signal: extra.signal })),
-    )
+    client.setRequestHandler(ElicitRequestSchema, async (request, extra) => {
+      const progressToken = extra._meta?.progressToken
+      const started = Date.now()
+      // Human input can exceed the server's request timeout; progress keeps cooperative callers alive.
+      const sendProgress = () => {
+        if (progressToken === undefined) return
+        void extra
+          .sendNotification({
+            method: "notifications/progress",
+            params: {
+              progressToken,
+              progress: Date.now() - started,
+              message: "Waiting for user response",
+            },
+          })
+          .catch(() => undefined)
+      }
+      const interval = progressToken === undefined ? undefined : setInterval(sendProgress, ELICITATION_PROGRESS_INTERVAL)
+      sendProgress()
+      try {
+        return await Effect.runPromise(elicitation.create({ server, params: request.params, signal: extra.signal }))
+      } finally {
+        if (interval !== undefined) clearInterval(interval)
+      }
+    })
     client.setNotificationHandler(ElicitationCompleteNotificationSchema, (notification) =>
       Effect.runPromise(elicitation.complete({ server, elicitationID: notification.params.elicitationId })),
     )


### PR DESCRIPTION
## Summary

- pass an explicit long timeout to MCP `tools/call` requests
- preserve progress-token support for servers that send tool-call progress
- avoid the SDK default request timeout cancelling long-running MCP tools while waiting for user elicitation

The MCP SDK currently defaults requests when `timeout` is omitted. This follows Claude Code's approach of using an effectively infinite finite timeout (`100_000_000` ms) for MCP tool calls while still allowing opencode interruption through the existing abort signal.

## Testing

- `bun typecheck` from `packages/core`
