### PR TITLE
fix(core): clean up mcp event surface

### DIFF
--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -46,7 +46,11 @@ const TolerantListPromptsResult = ListPromptsResultSchema.extend({
 
 export class NeedsAuthError extends Schema.TaggedErrorClass<NeedsAuthError>()("MCP.NeedsAuthError", {
   server: Schema.String,
-}) {}
+}) {
+  override get message() {
+    return `MCP server requires authentication: ${this.server}`
+  }
+}
 
 export class ConnectError extends Schema.TaggedErrorClass<ConnectError>()("MCP.ConnectError", {
   server: Schema.String,

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -127,7 +127,11 @@ export class ResourceContent extends Schema.Class<ResourceContent>("MCP.Resource
 
 export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("MCP.NotFoundError", {
   server: ServerName,
-}) {}
+}) {
+  override get message() {
+    return `MCP server not found: ${this.server}`
+  }
+}
 
 export class ToolCallError extends Schema.TaggedErrorClass<ToolCallError>()("MCP.ToolCallError", {
   server: ServerName,

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { MCP } from "@opencode-ai/core/mcp/index"
+import { MCPClient } from "@opencode-ai/core/mcp/client"
+
+describe("MCP errors", () => {
+  test("expose useful messages", () => {
+    expect(new MCP.NotFoundError({ server: MCP.ServerName.make("demo") }).message).toBe("MCP server not found: demo")
+    expect(new MCP.ToolCallError({ server: MCP.ServerName.make("demo"), tool: "search", message: "failed" }).message).toBe(
+      "failed",
+    )
+    expect(new MCPClient.NeedsAuthError({ server: "demo" }).message).toBe("MCP server requires authentication: demo")
+    expect(new MCPClient.ConnectError({ server: "demo", message: "offline" }).message).toBe("offline")
+  })
+})

--- a/packages/schema/src/mcp-event.ts
+++ b/packages/schema/src/mcp-event.ts
@@ -27,4 +27,4 @@ export const StatusChanged = Event.ephemeral({
   },
 })
 
-export const Definitions = Event.inventory(ToolsChanged, BrowserOpenFailed, StatusChanged)
+export const Definitions = Event.inventory(ToolsChanged, StatusChanged)

--- a/packages/schema/test/event-manifest.test.ts
+++ b/packages/schema/test/event-manifest.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../src/index.js"
 import { EventManifest } from "../src/event-manifest.js"
 import { IdeEvent } from "../src/ide-event.js"
+import { McpEvent } from "../src/mcp-event.js"
 import { SessionEvent } from "../src/session-event.js"
 import { SessionTodo } from "../src/session-todo.js"
 import { SessionV1 } from "../src/session-v1.js"
@@ -63,6 +64,8 @@ describe("public event manifest", () => {
     expect(Permission.Event.Definitions).toEqual([Permission.Event.Asked, Permission.Event.Replied])
     expect(Form.Event.Definitions).toEqual([Form.Event.Created, Form.Event.Replied, Form.Event.Cancelled])
     expect(Reference.Event.Definitions).toEqual([Reference.Event.Updated])
+    expect(McpEvent.Definitions).toEqual([McpEvent.ToolsChanged, McpEvent.StatusChanged])
+    expect(EventManifest.Latest.has("mcp.browser.open.failed")).toBe(false)
     expect(EventManifest.Latest.has("ide.installed")).toBe(false)
     expect(IdeEvent.Definitions).toEqual([IdeEvent.Installed])
     const sessionV1TailStart = EventManifest.Definitions.indexOf(SessionV1.Event.PartDelta)

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -89,7 +89,6 @@ export type Event =
   | EventTuiToastShow2
   | EventTuiSessionSelect2
   | EventMcpToolsChanged
-  | EventMcpBrowserOpenFailed
   | EventMcpStatusChanged
   | EventCommandExecuted
   | EventProjectUpdated
@@ -1554,14 +1553,6 @@ export type GlobalEvent = {
         type: "mcp.tools.changed"
         properties: {
           server: string
-        }
-      }
-    | {
-        id: string
-        type: "mcp.browser.open.failed"
-        properties: {
-          mcpName: string
-          url: string
         }
       }
     | {
@@ -3177,7 +3168,6 @@ export type V2Event =
   | TuiToastShow
   | TuiSessionSelect
   | McpToolsChanged
-  | McpBrowserOpenFailed
   | McpStatusChanged
   | CommandExecuted
   | ProjectUpdated
@@ -6373,20 +6363,6 @@ export type McpToolsChanged = {
   }
 }
 
-export type McpBrowserOpenFailed = {
-  id: string
-  created: number
-  metadata?: {
-    [key: string]: unknown
-  }
-  type: "mcp.browser.open.failed"
-  location?: LocationRef
-  data: {
-    mcpName: string
-    url: string
-  }
-}
-
 export type McpStatusChanged = {
   id: string
   created: number
@@ -7490,15 +7466,6 @@ export type EventMcpToolsChanged = {
   type: "mcp.tools.changed"
   properties: {
     server: string
-  }
-}
-
-export type EventMcpBrowserOpenFailed = {
-  id: string
-  type: "mcp.browser.open.failed"
-  properties: {
-    mcpName: string
-    url: string
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the legacy browser-open-failed MCP event from the current MCP event inventory/generated V2 SDK event union
- keep the named schema export available for legacy V1 callers
- add explicit messages for MCP typed errors that did not already carry one

## Tests
- bun typecheck (packages/schema)
- bun typecheck (packages/core)
- bun typecheck (packages/sdk/js)
- bun test test/event-manifest.test.ts (packages/schema)
- bun test test/mcp.test.ts (packages/core)