### PR TITLE
fix: surface task_id in interrupted tool error text for LLM resume

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -340,7 +340,10 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
                 state: "output-error",
                 toolCallId: part.callID,
                 input: part.state.input,
-                errorText: part.state.error,
+                errorText: part.state.error
+                  + ("sessionId" in (part.state.metadata ?? {})
+                    ? `\n\n\`task_id: ${part.state.metadata.sessionId}\``
+                    : ""),
                 ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
                 ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
               })
@@ -354,7 +357,10 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               state: "output-error",
               toolCallId: part.callID,
               input: part.state.input,
-              errorText: "[Tool execution was interrupted]",
+              errorText: "[Tool execution was interrupted]"
+                + ("sessionId" in (part.state.metadata ?? {})
+                  ? `\n\`task_id: ${part.state.metadata.sessionId}\``
+                  : ""),
               ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
               ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
             })


### PR DESCRIPTION
The sub-agent session ID was persisted in DB metadata on abort but
never rendered to the LLM. Include task_id in the error text so the
agent can resume aborted sub-agents via the Task tool's task_id
parameter.

### Issue for this PR
Related to #35177
Closes #
Closes #35177
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The sub-agent session ID was persisted in DB metadata on abort but
never rendered to the LLM. Include task_id in the error text so the
agent can resume aborted sub-agents via the Task tool's task_id
parameter.

### How did you verify your code works?

I tested my changes locally

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

