### PR TITLE
fix(core): constrain location services

### DIFF
--- a/packages/cli/src/commands/handlers/serve.ts
+++ b/packages/cli/src/commands/handlers/serve.ts
@@ -3,6 +3,7 @@ import { Credential } from "@opencode-ai/core/credential"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
+import { Project } from "@opencode-ai/core/project"
 import { Global } from "@opencode-ai/core/global"
 import { Context, Effect, FileSystem, Layer, Option, Redacted, Schedule, Schema } from "effect"
 import { HttpRouter, HttpServer } from "effect/unstable/http"
@@ -144,7 +145,7 @@ function bind(hostname: string, port: number, password: string) {
   return Layer.build(
     HttpRouter.serve(createRoutes(password), { disableListenLog: true, disableLogger: true }).pipe(
       Layer.provideMerge(NodeHttpServer.layer(() => server, { port, host: hostname })),
-      Layer.provide(AppNodeBuilder.build(LayerNode.group([Credential.node, PermissionSaved.node]))),
+      Layer.provide(AppNodeBuilder.build(LayerNode.group([Credential.node, PermissionSaved.node, Project.node]))),
     ),
   ).pipe(
     Effect.tap(() => Effect.addFinalizer(() => Effect.sync(() => server.closeAllConnections()))),

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -22,7 +22,6 @@ import { PermissionV2 } from "./permission"
 import { PluginV2 } from "./plugin"
 import { PluginInternal } from "./plugin/internal"
 import { Policy } from "./policy"
-import { Project } from "./project"
 import { ProjectCopy } from "./project/copy"
 import { Pty } from "./pty"
 import { QuestionV2 } from "./question"
@@ -49,8 +48,7 @@ import { Vcs } from "./vcs"
 
 export { LocationServiceMap } from "./location-service-map"
 
-export const locationServices = LayerNode.group([
-  Project.node,
+const locationServiceNodes = [
   Location.node,
   Policy.node,
   Config.node,
@@ -96,7 +94,9 @@ export const locationServices = LayerNode.group([
   Snapshot.node,
   SessionRunnerLLM.node,
   Vcs.node,
-])
+] as const satisfies readonly Node.LocationNode<unknown, unknown>[]
+
+export const locationServices = LayerNode.group<typeof locationServiceNodes>(locationServiceNodes)
 
 export type LocationServices = LayerNode.Output<typeof locationServices>
 export type LocationError = LayerNode.Error<typeof locationServices>

--- a/packages/sdk-next/src/opencode.ts
+++ b/packages/sdk-next/src/opencode.ts
@@ -3,6 +3,7 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { Project } from "@opencode-ai/core/project"
 import { createEmbeddedRoutes } from "@opencode-ai/server/routes"
 import { Context, Effect, Layer, Scope } from "effect"
 import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http"
@@ -12,7 +13,7 @@ export const create = Effect.fn("OpenCode.create")(function* () {
   const memoMap = yield* Layer.makeMemoMap
   const sdkPlugins = SdkPlugins.makeStore()
   const context = yield* Layer.buildWithMemoMap(
-    AppNodeBuilder.build(LayerNode.group([PermissionSaved.node, SdkPlugins.node]), [
+    AppNodeBuilder.build(LayerNode.group([PermissionSaved.node, Project.node, SdkPlugins.node]), [
       [SdkPlugins.node, SdkPlugins.layerWithStore(sdkPlugins)],
     ]),
     memoMap,
@@ -20,11 +21,13 @@ export const create = Effect.fn("OpenCode.create")(function* () {
   )
   const plugins = Context.get(context, SdkPlugins.Service)
   const permissions = Context.get(context, PermissionSaved.Service)
+  const project = Context.get(context, Project.Service)
   const web = yield* Effect.acquireRelease(
     Effect.sync(() =>
       HttpRouter.toWebHandler(
         createEmbeddedRoutes(sdkPlugins).pipe(
           HttpRouter.provideRequest(Layer.succeed(PermissionSaved.Service, permissions)),
+          HttpRouter.provideRequest(Layer.succeed(Project.Service, project)),
           Layer.provide(HttpServer.layerServices),
         ),
         { disableLogger: true, memoMap },

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -6,6 +6,7 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { Credential } from "@opencode-ai/core/credential"
 import { PermissionSaved } from "@opencode-ai/core/permission/saved"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
+import { Project } from "@opencode-ai/core/project"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { Job } from "@opencode-ai/core/job"
@@ -33,6 +34,7 @@ const applicationServices = LayerNode.group([
   httpClient,
   ToolOutputStore.cleanupNode,
   Job.node,
+  Project.node,
   SessionV2.node,
   PluginRuntime.providerNode,
   PermissionSaved.node,


### PR DESCRIPTION
## Summary
- remove global Project.node from the location service node list
- constrain locationServices to only accept location-tagged nodes
- preserve exact tuple typing for LayerNode.group inference

## Verification
- packages/core: bun typecheck

Note: normal push pre-push hook ran full repo turbo typecheck and an unrelated packages/opencode typecheck was SIGKILLed under parallel load; targeted core typecheck passed.