### PR TITLE
refactor(core): step ledger and classified settlement

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -1,15 +1,6 @@
 export * as SessionRunnerLLM from "./llm"
 
-import {
-  LLM,
-  LLMClient,
-  LLMError,
-  LLMEvent,
-  Message,
-  SystemPart,
-  isContextOverflowFailure,
-  type ProviderErrorEvent,
-} from "@opencode-ai/llm"
+import { LLM, LLMClient, LLMError, LLMEvent, Message, SystemPart, isContextOverflowFailure } from "@opencode-ai/llm"
 import { Cause, DateTime, Effect, Exit, FiberSet, Layer, Option, Semaphore, Stream } from "effect"
 import { AgentV2 } from "../../agent"
 import { Config } from "../../config"
@@ -185,7 +176,6 @@ const layer = Layer.effect(
         session.id,
       )
       const toolFibers = yield* FiberSet.make<void, ToolOutputStore.Error>()
-      let needsContinuation = false
       let currentStep = step
       if (promotion) {
         let promoted = 0
@@ -236,14 +226,13 @@ const layer = Layer.effect(
       const serialized = <A, E, R>(effect: Effect.Effect<A, E, R>) => publication.withPermit(effect)
       const publish = (event: LLMEvent, outputPaths: ReadonlyArray<string> = []) =>
         serialized(ledger.publish(event, outputPaths))
-      let overflowFailure: ProviderErrorEvent | undefined
       const providerStream = llm.stream(request).pipe(
         Stream.runForEach((event) =>
           Effect.gen(function* () {
-            if (overflowFailure || ledger.hasProviderError()) return
+            if (ledger.heldOverflow() || ledger.hasProviderError()) return
             if (LLMEvent.is.providerError(event)) {
               if (isContextOverflowFailure(event) && !ledger.hasAssistantStarted()) {
-                overflowFailure = event
+                ledger.holdOverflow(event)
                 return
               }
             }
@@ -253,7 +242,7 @@ const layer = Layer.effect(
               yield* serialized(ledger.failUnsettledTools("Tools are disabled after the maximum agent steps"))
               return
             }
-            needsContinuation = true
+            ledger.admitLocalToolCall(event.id)
             const assistantMessageID = yield* ledger.assistantMessageID(event.id)
             yield* Effect.uninterruptibleMask((restore) =>
               restore(
@@ -320,7 +309,7 @@ const layer = Layer.effect(
           if (
             recoverOverflow &&
             !ledger.hasAssistantStarted() &&
-            isContextOverflowFailure(overflowFailure ?? streamFailure) &&
+            isContextOverflowFailure(ledger.heldOverflow() ?? streamFailure) &&
             (yield* restore(recoverOverflow({ sessionID: session.id, messages: context, request })))
           )
             return { _tag: "RestartAfterOverflowCompaction", step: currentStep } as const
@@ -328,7 +317,8 @@ const layer = Layer.effect(
           // An unrecovered held-back overflow becomes the step's durable provider error. A
           // thrown LLM failure fails hosted tool calls and the assistant unless a provider
           // error was already recorded from the stream.
-          if (overflowFailure) yield* publish(overflowFailure)
+          const heldOverflow = ledger.heldOverflow()
+          if (heldOverflow) yield* publish(heldOverflow)
           const llmFailure = streamFailure instanceof LLMError ? streamFailure : undefined
           if (llmFailure && !ledger.hasProviderError()) {
             yield* serialized(ledger.failUnsettledTools("Provider did not return a tool result", true))
@@ -379,7 +369,7 @@ const layer = Layer.effect(
             return yield* Effect.failCause(settled.cause)
           return {
             _tag: "Completed",
-            needsContinuation: !providerFailed && needsContinuation,
+            needsContinuation: !providerFailed && ledger.hasLocalToolCalls(),
             step: currentStep,
           } as const
         }),

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -36,7 +36,7 @@ import { SessionStore } from "../store"
 import { SessionTitle } from "../title"
 import { Service } from "./index"
 import { SessionRunnerModel } from "./model"
-import { createLLMEventPublisher } from "./publish-llm-event"
+import { createStepLedger } from "./step-ledger"
 import { toLLMMessages } from "./to-llm-message"
 import { MAX_STEPS_PROMPT } from "./max-steps"
 import { SessionRunnerSystemPrompt } from "./system-prompt"
@@ -222,7 +222,7 @@ const layer = Layer.effect(
       if (yield* compaction.compactIfNeeded({ sessionID: session.id, messages: context, request }))
         return { _tag: "RestartAfterCompaction", step: currentStep } as const
       const startSnapshot = yield* snapshots.capture()
-      const publisher = createLLMEventPublisher(events, {
+      const ledger = createStepLedger(events, {
         sessionID: session.id,
         agent: agent.id,
         // The selected catalog identity, not model.id: route-level ids are provider API
@@ -235,14 +235,14 @@ const layer = Layer.effect(
       // mid-event.
       const serialized = <A, E, R>(effect: Effect.Effect<A, E, R>) => publication.withPermit(effect)
       const publish = (event: LLMEvent, outputPaths: ReadonlyArray<string> = []) =>
-        serialized(publisher.publish(event, outputPaths))
+        serialized(ledger.publish(event, outputPaths))
       let overflowFailure: ProviderErrorEvent | undefined
       const providerStream = llm.stream(request).pipe(
         Stream.runForEach((event) =>
           Effect.gen(function* () {
-            if (overflowFailure || publisher.hasProviderError()) return
+            if (overflowFailure || ledger.hasProviderError()) return
             if (LLMEvent.is.providerError(event)) {
-              if (isContextOverflowFailure(event) && !publisher.hasAssistantStarted()) {
+              if (isContextOverflowFailure(event) && !ledger.hasAssistantStarted()) {
                 overflowFailure = event
                 return
               }
@@ -250,11 +250,11 @@ const layer = Layer.effect(
             yield* publish(event)
             if (event.type !== "tool-call" || event.providerExecuted) return
             if (!toolMaterialization) {
-              yield* serialized(publisher.failUnsettledTools("Tools are disabled after the maximum agent steps"))
+              yield* serialized(ledger.failUnsettledTools("Tools are disabled after the maximum agent steps"))
               return
             }
             needsContinuation = true
-            const assistantMessageID = yield* publisher.assistantMessageID(event.id)
+            const assistantMessageID = yield* ledger.assistantMessageID(event.id)
             yield* Effect.uninterruptibleMask((restore) =>
               restore(
                 toolMaterialization.settle({
@@ -279,12 +279,12 @@ const layer = Layer.effect(
             ).pipe(FiberSet.run(toolFibers))
           }),
         ),
-        Effect.ensuring(serialized(publisher.flush())),
+        Effect.ensuring(serialized(ledger.flush())),
       )
 
       // Captures the end snapshot, diffs it against the step's start, and durably ends the
       // assistant step.
-      const publishStepEnd = (settlement: NonNullable<ReturnType<typeof publisher.stepSettlement>>) =>
+      const publishStepEnd = (settlement: NonNullable<ReturnType<typeof ledger.stepSettlement>>) =>
         Effect.gen(function* () {
           const endSnapshot = yield* snapshots.capture()
           const files =
@@ -296,7 +296,7 @@ const layer = Layer.effect(
           yield* serialized(
             events.publish(SessionEvent.Step.Ended, {
               sessionID: session.id,
-              assistantMessageID: yield* publisher.startAssistant(),
+              assistantMessageID: yield* ledger.startAssistant(),
               finish: settlement.finish,
               cost: 0,
               tokens: settlement.tokens,
@@ -319,7 +319,7 @@ const layer = Layer.effect(
           // restart the step instead of surfacing the provider error.
           if (
             recoverOverflow &&
-            !publisher.hasAssistantStarted() &&
+            !ledger.hasAssistantStarted() &&
             isContextOverflowFailure(overflowFailure ?? streamFailure) &&
             (yield* restore(recoverOverflow({ sessionID: session.id, messages: context, request })))
           )
@@ -330,12 +330,12 @@ const layer = Layer.effect(
           // error was already recorded from the stream.
           if (overflowFailure) yield* publish(overflowFailure)
           const llmFailure = streamFailure instanceof LLMError ? streamFailure : undefined
-          if (llmFailure && !publisher.hasProviderError()) {
-            yield* serialized(publisher.failUnsettledTools("Provider did not return a tool result", true))
-            yield* serialized(publisher.failAssistant(llmFailure.reason.message))
+          if (llmFailure && !ledger.hasProviderError()) {
+            yield* serialized(ledger.failUnsettledTools("Provider did not return a tool result", true))
+            yield* serialized(ledger.failAssistant(llmFailure.reason.message))
           }
           // Provider error events only arrive from the stream, so the flag is final here.
-          const providerFailed = publisher.hasProviderError()
+          const providerFailed = ledger.hasProviderError()
 
           // Settle tool fibers: an interrupted stream abandons unstarted tool work first.
           if (streamInterrupted) yield* FiberSet.clear(toolFibers)
@@ -345,8 +345,8 @@ const layer = Layer.effect(
 
           if (questionDismissed || streamInterrupted || toolsInterrupted) {
             yield* FiberSet.clear(toolFibers)
-            yield* serialized(publisher.failUnsettledTools("Tool execution interrupted"))
-            yield* serialized(publisher.failAssistant("Step interrupted"))
+            yield* serialized(ledger.failUnsettledTools("Tool execution interrupted"))
+            yield* serialized(ledger.failAssistant("Step interrupted"))
             // Match V1: dismissing a question halts the loop like an interruption.
             if (questionDismissed) return yield* Effect.interrupt
           }
@@ -360,20 +360,19 @@ const layer = Layer.effect(
           if (settledFailure !== undefined) {
             const failure = infraError ?? Cause.squash(settledFailure)
             const message = failure instanceof Error ? failure.message : String(failure)
-            yield* serialized(publisher.failUnsettledTools(`Tool execution failed: ${message}`))
-            if (infraError !== undefined)
-              yield* serialized(publisher.failAssistant(`Tool execution failed: ${message}`))
+            yield* serialized(ledger.failUnsettledTools(`Tool execution failed: ${message}`))
+            if (infraError !== undefined) yield* serialized(ledger.failAssistant(`Tool execution failed: ${message}`))
           }
 
-          const stepSettlement = publisher.stepSettlement()
+          const stepSettlement = ledger.stepSettlement()
           const stepEndedCleanly =
             !streamInterrupted && !toolsInterrupted && infraError === undefined && !providerFailed
           if (stepSettlement && stepEndedCleanly) yield* publishStepEnd(stepSettlement)
           // A provider error orphans recorded local calls; a clean stream can still leave
           // hosted calls without results.
-          if (providerFailed) yield* serialized(publisher.failUnsettledTools("Tool execution interrupted"))
+          if (providerFailed) yield* serialized(ledger.failUnsettledTools("Tool execution interrupted"))
           if (stream._tag === "Success" && !providerFailed)
-            yield* serialized(publisher.failUnsettledTools("Provider did not return a tool result", true))
+            yield* serialized(ledger.failUnsettledTools("Provider did not return a tool result", true))
 
           if (stream._tag === "Failure") return yield* Effect.failCause(stream.cause)
           if (settled._tag === "Failure" && (toolsInterrupted || infraError !== undefined))

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -332,14 +332,6 @@ const layer = Layer.effect(
           const settled = yield* restore(awaitToolFibers(toolFibers)).pipe(Effect.exit)
           const toolsInterrupted = settled._tag === "Failure" && Cause.hasInterrupts(settled.cause)
           const questionDismissed = settled._tag === "Failure" && isQuestionRejected(settled.cause)
-
-          if (questionDismissed || streamInterrupted || toolsInterrupted) {
-            yield* FiberSet.clear(toolFibers)
-            yield* serialized(ledger.failUnsettledTools("Tool execution interrupted"))
-            yield* serialized(ledger.failAssistant("Step interrupted"))
-            // Match V1: dismissing a question halts the loop like an interruption.
-            if (questionDismissed) return yield* Effect.interrupt
-          }
           // A settled tool fiber failure is one of two things. A defect from a tool
           // implementation becomes a failed tool call the model can read, and the step still
           // settles so the model may recover. A typed infrastructure failure (tool output
@@ -347,21 +339,53 @@ const layer = Layer.effect(
           const settledFailure = settled._tag === "Failure" && !toolsInterrupted ? settled.cause : undefined
           const infraError =
             settledFailure === undefined ? undefined : Option.getOrUndefined(Cause.findErrorOption(settledFailure))
-          if (settledFailure !== undefined) {
-            const failure = infraError ?? Cause.squash(settledFailure)
-            const message = failure instanceof Error ? failure.message : String(failure)
-            yield* serialized(ledger.failUnsettledTools(`Tool execution failed: ${message}`))
-            if (infraError !== undefined) yield* serialized(ledger.failAssistant(`Tool execution failed: ${message}`))
+
+          const settlement =
+            questionDismissed || streamInterrupted || toolsInterrupted
+              ? { _tag: "Interrupted" as const, questionDismissed }
+              : providerFailed
+                ? { _tag: "ProviderFailed" as const }
+                : infraError !== undefined
+                  ? { _tag: "ToolInfraFailed" as const, cause: infraError }
+                  : { _tag: "Clean" as const }
+
+          if (settlement._tag === "Interrupted") {
+            yield* FiberSet.clear(toolFibers)
+            yield* serialized(ledger.failUnsettledTools("Tool execution interrupted"))
+            yield* serialized(ledger.failAssistant("Step interrupted"))
+            // Match V1: dismissing a question halts the loop like an interruption.
+            if (settlement.questionDismissed) return yield* Effect.interrupt
           }
 
-          const stepSettlement = ledger.stepSettlement()
-          const stepEndedCleanly =
-            !streamInterrupted && !toolsInterrupted && infraError === undefined && !providerFailed
-          if (stepSettlement && stepEndedCleanly) yield* publishStepEnd(stepSettlement)
-          // A provider error orphans recorded local calls; a clean stream can still leave
-          // hosted calls without results.
-          if (providerFailed) yield* serialized(ledger.failUnsettledTools("Tool execution interrupted"))
-          if (stream._tag === "Success" && !providerFailed)
+          if (settlement._tag === "ToolInfraFailed") {
+            const message = settlement.cause instanceof Error ? settlement.cause.message : String(settlement.cause)
+            yield* serialized(ledger.failUnsettledTools(`Tool execution failed: ${message}`))
+            yield* serialized(ledger.failAssistant(`Tool execution failed: ${message}`))
+          }
+
+          if (settlement._tag === "Clean") {
+            if (settledFailure !== undefined) {
+              const failure = Cause.squash(settledFailure)
+              const message = failure instanceof Error ? failure.message : String(failure)
+              yield* serialized(ledger.failUnsettledTools(`Tool execution failed: ${message}`))
+            }
+            const stepSettlement = ledger.stepSettlement()
+            if (stepSettlement) yield* publishStepEnd(stepSettlement)
+          }
+
+          // A provider error orphans recorded local calls. A tool fiber that failed
+          // alongside the provider error still settles with its own failure message first.
+          if (settlement._tag === "ProviderFailed") {
+            if (settledFailure !== undefined) {
+              const failure = infraError ?? Cause.squash(settledFailure)
+              const message = failure instanceof Error ? failure.message : String(failure)
+              yield* serialized(ledger.failUnsettledTools(`Tool execution failed: ${message}`))
+            }
+            yield* serialized(ledger.failUnsettledTools("Tool execution interrupted"))
+          }
+
+          // A clean stream can still leave hosted calls without results.
+          if (stream._tag === "Success" && settlement._tag !== "ProviderFailed")
             yield* serialized(ledger.failUnsettledTools("Provider did not return a tool result", true))
 
           if (stream._tag === "Failure") return yield* Effect.failCause(stream.cause)

--- a/packages/core/src/session/runner/step-ledger.ts
+++ b/packages/core/src/session/runner/step-ledger.ts
@@ -1,4 +1,11 @@
-import { ToolOutput, type LLMEvent, type ProviderMetadata, type ToolResultValue, type Usage } from "@opencode-ai/llm"
+import {
+  ToolOutput,
+  type LLMEvent,
+  type ProviderErrorEvent,
+  type ProviderMetadata,
+  type ToolResultValue,
+  type Usage,
+} from "@opencode-ai/llm"
 import { DateTime, Effect } from "effect"
 import { EventV2 } from "../../event"
 import { ModelV2 } from "../../model"
@@ -69,7 +76,9 @@ export const createStepLedger = (events: EventV2.Interface, input: Input) => {
   let assistantActive = false
   let assistantFailed = false
   let providerFailed = false
+  let heldOverflowEvent: ProviderErrorEvent | undefined
   let stepSettlement: { readonly finish: string; readonly tokens: ReturnType<typeof tokens> } | undefined
+  const localToolCalls = new Set<string>()
 
   const startAssistant = Effect.fnUntraced(function* () {
     if (assistantMessageID !== undefined) return assistantMessageID
@@ -227,6 +236,11 @@ export const createStepLedger = (events: EventV2.Interface, input: Input) => {
   const assistantMessageIDForTool = (callID: string) => {
     const tool = tools.get(callID)
     return tool ? Effect.succeed(tool.assistantMessageID) : Effect.die(new Error(`Unknown tool call: ${callID}`))
+  }
+
+  const admitLocalToolCall = (callID: string) => {
+    const tool = tools.get(callID)
+    if (tool?.called && !tool.providerExecuted) localToolCalls.add(callID)
   }
 
   const publish = Effect.fn("SessionRunner.publishLLMEvent")(function* (
@@ -397,8 +411,14 @@ export const createStepLedger = (events: EventV2.Interface, input: Input) => {
     flush,
     failAssistant,
     failUnsettledTools,
+    admitLocalToolCall,
+    holdOverflow: (event: ProviderErrorEvent) => {
+      heldOverflowEvent = event
+    },
+    heldOverflow: () => heldOverflowEvent,
     hasActiveAssistant: () => assistantActive,
     hasAssistantStarted: () => assistantMessageID !== undefined,
+    hasLocalToolCalls: () => localToolCalls.size > 0,
     hasProviderError: () => providerFailed,
     stepSettlement: () => stepSettlement,
     startAssistant,

--- a/packages/core/src/session/runner/step-ledger.ts
+++ b/packages/core/src/session/runner/step-ledger.ts
@@ -51,7 +51,7 @@ const settledOutput = (value: ToolOutput | undefined, result: ToolResultValue): 
 }
 
 /** Persist one step without executing tools or starting a continuation step. */
-export const createLLMEventPublisher = (events: EventV2.Interface, input: Input) => {
+export const createStepLedger = (events: EventV2.Interface, input: Input) => {
   const tools = new Map<
     string,
     {

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -7,7 +7,7 @@ import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
-import { createLLMEventPublisher } from "@opencode-ai/core/session/runner/publish-llm-event"
+import { createStepLedger } from "@opencode-ai/core/session/runner/step-ledger"
 
 const sessionID = SessionV2.ID.make("ses_tool_event_test")
 const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
@@ -40,7 +40,7 @@ const capture = () => {
   })
   return {
     published,
-    publisher: createLLMEventPublisher(events, {
+    publisher: createStepLedger(events, {
       sessionID,
       agent: "build",
       model: {


### PR DESCRIPTION
Implements the parked settlement refactor for the V2 runner (plan: branch `settlement-ledger`, PLAN.md). Follow-up to #35218 (step vocabulary) and #35227 (runner renames). Behavior-preserving: all 144 runner-adjacent tests pass with zero test-logic changes (one import path updated for the file rename).

## 1. `refactor(core): rename LLM event publisher to step ledger`

Pure rename: `publish-llm-event.ts` → `step-ledger.ts`, `createLLMEventPublisher` → `createStepLedger`, binding `publisher` → `ledger`. The object already owned the step's durable facts (assistant started, provider error, tool records, step settlement data); the name now says so.

## 2. `refactor(core): derive continuation and held overflow from step ledger`

Kills the attempt-scoped mutable evidence in `attemptStep`:

- `let needsContinuation` (flipped inside the stream closure, read ~130 lines later) → derived `ledger.hasLocalToolCalls()`. Semantics preserved exactly: the ledger admits a local call at the same point the old flag was set — after the provider-executed and tools-disabled early returns.
- `let overflowFailure` → `ledger.holdOverflow(event)` / `ledger.heldOverflow()`. The hold-back policy check (context overflow before any assistant output) stays at the call site; only the stash moved to the transcript owner.

The stream handler is now near-stateless: admit to ledger, spawn tool fibers.

## 3. `refactor(core): classify step settlement once`

The settlement block previously re-derived combinations of ~8 evidence booleans as it went. Now it classifies once —

```
Interrupted { questionDismissed } | ProviderFailed | ToolInfraFailed { cause } | Clean
```

— then runs flat, verdict-keyed effects. Effect ordering is load-bearing and unchanged: clear fibers before awaiting on interrupt, publish held overflow before classifying, failUnsettledTools before failAssistant, `Step.Ended` only on Clean, identical failure/interrupt propagation. LLM stream-failure handling stays before classification (it is evidence recording, not a settlement arm).

## Reviewable decisions

- **Ledger owns evidence, not effects**: `failUnsettledTools` / `failAssistant` / `publishStepEnd` stay in `attemptStep` where their ordering is visible. Deliberate boundary; could move later if the ledger grows.
- **Corner preserved during review**: a tool-fiber failure alongside a provider error still settles those tools with `Tool execution failed: <reason>` before the orphan sweep, matching the old unconditional defect-settle order (the naive classify-once shape would have lost the defect message).
- The hosted-calls-without-results fallback still runs for interrupted settlements with successful streams; the interrupt sweep has already settled everything, so it remains the same no-op as before.

## Verification

- 144 pass / 0 fail across session-runner, -recorded, -message, -tool-registry, -model, and run-coordinator suites (`packages/core`)
- `bun typecheck`, prettier, oxlint clean