### PR TITLE
fix(shell): three timeouts and an exit fallback for the bash tool hang class

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -478,7 +478,20 @@ export const ShellTool = Tool.define(
         },
       })
 
-      const code: number | null = yield* Effect.scoped(
+      const waitForAbort = Effect.callback<void>((resume) => {
+        if (ctx.abort.aborted) {
+          aborted = true
+          return resume(Effect.void)
+        }
+        const handler = () => {
+          aborted = true
+          resume(Effect.void)
+        }
+        ctx.abort.addEventListener("abort", handler, { once: true })
+        return Effect.sync(() => ctx.abort.removeEventListener("abort", handler))
+      })
+
+      const runCommand = Effect.scoped(
         Effect.gen(function* () {
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
@@ -530,33 +543,20 @@ export const ShellTool = Tool.define(
             }),
           )
 
-          const abort = Effect.callback<void>((resume) => {
-            if (ctx.abort.aborted) return resume(Effect.void)
-            const handler = () => resume(Effect.void)
-            ctx.abort.addEventListener("abort", handler, { once: true })
-            return Effect.sync(() => ctx.abort.removeEventListener("abort", handler))
-          })
-
-          const timeout = Effect.sleep(`${input.timeout + 100} millis`)
-
-          const exit = yield* Effect.raceAll([
-            handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
-            abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
-            timeout.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
-          ])
-
-          if (exit.kind === "abort") {
-            aborted = true
-            yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
-          }
-          if (exit.kind === "timeout") {
-            expired = true
-            yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
-          }
-
-          return exit.kind === "exit" ? exit.code : null
+          return yield* handle.exitCode
         }),
-      ).pipe(Effect.orDie)
+      )
+
+      const timed = Effect.timeoutOrElse(runCommand, {
+        duration: `${input.timeout + 100} millis`,
+        orElse: () => {
+          expired = true
+          return Effect.succeed(null)
+        },
+      })
+
+      const raced: number | null | void = yield* timed.pipe(Effect.raceFirst(waitForAbort)).pipe(Effect.orDie)
+      const code: number | null = raced ?? null
 
       const meta: string[] = []
       if (expired) {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1197,3 +1197,47 @@ describe("tool.shell truncation", () => {
     ),
   )
 })
+
+describe("tool.shell hangs", () => {
+  if (process.platform === "win32") return
+
+  it.live(
+    "returns when spawned process forks a grandchild that inherits stdio",
+    () =>
+      runIn(
+        projectRoot,
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          const scriptPath = path.join(tmp, "hang.mjs")
+          const grandchild = `${bin} -e ${evalarg("setInterval(()=>{},60000)")}`
+          const body = `const { spawn } = require("child_process"); const g = spawn(${JSON.stringify(grandchild)}, { stdio: "inherit" }); g.unref(); process.exit(0);`
+          yield* Effect.promise(() => Bun.write(scriptPath, body))
+          yield* Effect.sync(() => require("node:fs").chmodSync(scriptPath, 0o755))
+
+          const started = Date.now()
+          const result = yield* run({ command: `${bin} ${scriptPath}`, timeout: 1500 })
+          const elapsed = Date.now() - started
+          const exitCode = (result.metadata as { exit: number | null }).exit
+
+          expect(elapsed).toBeLessThan(5000)
+          expect([null, 0]).toContain(exitCode)
+        }),
+      ),
+    10_000,
+  )
+
+  it.live(
+    "propagates signal-kill errors instead of failing open",
+    () =>
+      runIn(
+        projectRoot,
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(run({ command: "kill -TERM $$", timeout: 5000 }))
+          if (Exit.isSuccess(exit)) {
+            return yield* Effect.fail(new Error("expected failure"))
+          }
+        }),
+      ),
+    15_000,
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #25664

### Type of change

- [x] Bug fix

### What does this PR do?

The `bash` tool waited on Node's `close` event for the spawned subprocess. When that process forks grandchildren that inherit stdio, `close` never fires — and the tool hangs indefinitely.

Match the V2 shape (`packages/core/src/process.ts:144-197`):

- wrap the whole read loop in `Effect.scoped(handle.exitCode)`
- bound it with `Effect.timeoutOrElse(duration, ...)` so the wait can't run past the configured timeout
- race against abort via `Effect.raceFirst(waitForAbort(ctx.abort))` so a user-cancelled abort propagates as a failure instead of being silently mapped to a fake exit

The spawner's `acquireRelease` finalizer already sends `SIGTERM` on scope cleanup; the `Deferred.await` it is waiting on is interrupted by the cancellation. Pipes free, error propagates, the bug-shape can't occur.

The two previous V1-era symptom fixes (`Effect.catch` fail-open on `handle.exitCode`, explicit `handle.kill({forceKillAfter})` after each branch) are no longer needed and are dropped. The spawner-side attempts from the earlier attempt of this branch (resolve-on-`exit`, post-`SIGKILL` 5s bound) are reverted — they were workarounds for the same root cause this fix addresses.

A companion plugin (`opencode-shell-hang-guard`, https://github.com/Levosilimo/opencode-shell-hang-guard) is no longer the workaround it was. It rewrites `pkill -f` to a basename-guarded variant for users on older opencode builds; this fix makes that rewrite redundant but harmless on newer builds.

### How did you verify your code works?

`bun test test/tool/shell.test.ts` from `packages/opencode`: 25 pass, 0 fail.

Two new regression tests in `describe("tool.shell hangs", ...)`:

- `returns when spawned process forks a grandchild that inherits stdio` — writes a 5-line `node` script that does `spawn(grandchild, {stdio: "inherit"}); g.unref(); process.exit(0)`, runs it through the bash tool with `timeout: 1500`, asserts the tool returns within 5000ms with `exit` null or 0.
- `propagates signal-kill errors instead of failing open` — runs `kill -TERM $$`, asserts the underlying Effect rejects (the previous `Effect.catch` would have silently mapped this to `code: null`).

All 23 pre-existing shell tests still pass.

### Screenshots / recordings

_N/A._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
