### PR TITLE
fix(core): tolerate minimal FSWatcher typings

### DIFF
--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -89,9 +89,11 @@ const layer = Layer.effect(
                     type: "update",
                   } satisfies Update)
                 })
-                subscription.on("error", (error) =>
-                  Effect.runFork(Effect.logError("watcher callback failed", { path: target, error })),
-                )
+                if ("on" in subscription && typeof subscription.on === "function") {
+                  subscription.on("error", (error: unknown) =>
+                    Effect.runFork(Effect.logError("watcher callback failed", { path: target, error })),
+                  )
+                }
                 return { unsubscribe: () => Promise.resolve(subscription.close()) }
               })
             : subscribeDirectory(native, backend, directory, ignore, pubsub)


### PR DESCRIPTION
## Summary
- guard FSWatcher error-listener registration for consumers whose Bun typings expose only the minimal watcher surface
- preserve runtime error logging when the EventEmitter-style on method exists

## Verification
- bun typecheck (packages/core)
- bun run typecheck:opencode-agent from the linked Experiments workspace