### PR TITLE
fix(desktop): stabilize esm shim injection

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -39,6 +39,17 @@ export default defineConfig({
     build: {
       rollupOptions: {
         input: { index: "src/main/index.ts", sidecar: "src/main/sidecar.ts" },
+        // Keep this identical to electron-vite's Node 20.11+ shim. Its regex insertion can
+        // corrupt bundled TypeScript, while a Rollup banner places the shim safely.
+        output: {
+          banner: `
+// -- CommonJS Shims --
+import __cjs_mod__ from 'node:module';
+const __filename = import.meta.filename;
+const __dirname = import.meta.dirname;
+const require = __cjs_mod__.createRequire(import.meta.url);
+`,
+        },
       },
       externalizeDeps: { include: [nodePtyPkg] },
     },


### PR DESCRIPTION
## Summary
- provide Electron Vite 5's Node 20.11+ CommonJS shim through Rollup's safe banner path
- prevent Electron Vite's regex-based insertion from corrupting bundled TypeScript source
- preserve require, __filename, and __dirname compatibility without changing dependencies

## Root cause
The code-mode integration brings TypeScript into the generated server bundle. Electron Vite 5 scans rendered chunks with a static-import regex, falsely matches import-shaped text inside the bundled compiler, and inserts its shim inside a string literal. The same failure reproduces when Electron Vite runs explicitly under Node 24, so this is not a Bun installation or runtime issue.

Related upstream report: https://github.com/alex8088/electron-vite/issues/906

## Bundle impact
- renderer and preload outputs are unchanged
- the exact 204-byte shim is emitted in each of the three main-process chunks
- compared with Electron Vite's normal selective injection, app.asar grows by 360 bytes
- the two additional entry-chunk shims add only built-in node:module resolution and createRequire calls
- no new runtime dependency, supplier, or eager server-chunk edge

## Maintenance
The banner intentionally matches Electron Vite 5.0.0's private shim string so its render hook skips regex insertion. Revalidate or remove it when upgrading Electron Vite or changing the main output away from ESM.

## Testing
- bun typecheck from packages/desktop
- bun run build from packages/desktop
- explicit Node Electron Vite build
- full pre-push workspace typecheck