### PR TITLE
test(core): release shell test locations

### DIFF
--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -171,9 +171,11 @@ const withSession = <A, E, R>(directory: string, body: (registry: ToolRegistry.I
     })
     const locations = yield* LocationServiceMap.Service
     const locationLayer = locations.get(location)
-    const registry = yield* ToolRegistry.Service.pipe(Effect.provide(locationLayer))
-    yield* waitForTool(registry, ShellTool.name)
-    return yield* body(registry).pipe(Effect.provide(locationLayer))
+    return yield* Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      yield* waitForTool(registry, ShellTool.name)
+      return yield* body(registry)
+    }).pipe(Effect.provide(locationLayer), Effect.ensuring(locations.invalidate(location)))
   })
 
 describe("ShellTool", () => {


### PR DESCRIPTION
## Summary

Fixes the aggregate `tool-shell.test.ts` hang by keeping each test's registry use inside one borrowed Location layer and invalidating that Location when the test body exits.

The production Location cache intentionally retains services for 60 minutes. The test previously let every temporary Location retain its full watcher/process service graph, eventually stalling acquisition of another Location layer. `Effect.ensuring` now releases the test Location on success, failure, or interruption.

## Verification

- Reproduced on clean `v2`: the full file stalled after several individually passing cases
- `bun test --timeout 5000 test/tool-shell.test.ts` passed three consecutive aggregate runs (39/39 cases)
- `bun typecheck` in `packages/core`
- Full-repo pre-push typecheck passed
- Prettier and file-scoped oxlint: 0 errors (existing warnings only)
