### PR TITLE
fix(llm): accept `reasoning` field in OpenAI-compatible streams

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -145,6 +145,10 @@ type OpenAIChatToolCallDelta = Schema.Schema.Type<typeof OpenAIChatToolCallDelta
 const OpenAIChatDelta = Schema.Struct({
   content: optionalNull(Schema.String),
   reasoning_content: optionalNull(Schema.String),
+  // Some OpenAI-compatible providers (Scaleway, vLLM/SGLang, OpenRouter, ...)
+  // stream reasoning under `reasoning` rather than `reasoning_content`. Accept
+  // both so their thinking is not silently dropped.
+  reasoning: optionalNull(Schema.String),
   tool_calls: optionalNull(Schema.Array(OpenAIChatToolCallDelta)),
 })
 
@@ -416,8 +420,8 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
 
     let lifecycle = state.lifecycle
 
-    if (delta?.reasoning_content)
-      lifecycle = Lifecycle.reasoningDelta(lifecycle, events, "reasoning-0", delta.reasoning_content)
+    const reasoningText = delta?.reasoning_content ?? delta?.reasoning
+    if (reasoningText) lifecycle = Lifecycle.reasoningDelta(lifecycle, events, "reasoning-0", reasoningText)
 
     if (delta?.content) {
       lifecycle = Lifecycle.reasoningEnd(lifecycle, events, "reasoning-0")

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -552,6 +552,47 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("parses OpenAI-compatible reasoning deltas from the `reasoning` field", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        { choices: [{ delta: { reasoning: "thinking" } }] },
+        { choices: [{ delta: { content: "Hello" } }] },
+        { choices: [{ delta: {}, finish_reason: "stop" }] },
+      )
+
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.reasoning).toBe("thinking")
+      expect(response.text).toBe("Hello")
+      expect(response.events).toMatchObject([
+        { type: "step-start", index: 0 },
+        { type: "reasoning-start", id: "reasoning-0" },
+        { type: "reasoning-delta", id: "reasoning-0", text: "thinking" },
+        { type: "reasoning-end", id: "reasoning-0" },
+        { type: "text-start", id: "text-0" },
+        { type: "text-delta", id: "text-0", text: "Hello" },
+        { type: "text-end", id: "text-0" },
+        { type: "step-finish", index: 0, reason: "stop" },
+        { type: "finish", reason: "stop" },
+      ])
+    }),
+  )
+
+  it.effect("prefers reasoning_content when both reasoning fields are present", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        { choices: [{ delta: { reasoning_content: "canonical", reasoning: "duplicate" } }] },
+        { choices: [{ delta: { content: "Hello" } }] },
+        { choices: [{ delta: {}, finish_reason: "stop" }] },
+      )
+
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.reasoning).toBe("canonical")
+      expect(response.text).toBe("Hello")
+    }),
+  )
+
   it.effect("assembles streamed tool call input", () =>
     Effect.gen(function* () {
       const body = sseEvents(


### PR DESCRIPTION
### Issue for this PR

Closes #35283

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The OpenAI Chat streaming delta schema (`OpenAIChatDelta` in `packages/llm/src/protocols/openai-chat.ts`) only declares `reasoning_content`. Each SSE chunk is decoded via `Protocol.jsonEvent` → `Schema.fromJsonString`, which strips any key that isn't on the struct. So when a provider streams its thinking under `reasoning` instead of `reasoning_content`, that key is dropped during decoding and `step()` never sees it — the reasoning is silently lost.

I hit this with Scaleway; it also affects self-hosted vLLM / SGLang deployments and OpenRouter's `reasoning` field. The model was clearly reasoning but nothing surfaced in the stream. I had been working around it by rewriting `reasoning` → `reasoning_content` in a proxy in front of `opencode serve`; this makes that workaround unnecessary.

Two changes:
- add `reasoning` to `OpenAIChatDelta` so the decoder keeps the field
- in `step()`, read `delta.reasoning_content ?? delta.reasoning`, so `reasoning_content` still takes precedence when a provider sends both

It's additive to the wire schema — providers that only send `reasoning_content` (DeepSeek etc.) take the exact same path as before.

### How did you verify your code works?

Added two streaming tests in `packages/llm/test/provider/openai-chat.test.ts`, next to the existing `reasoning_content` one:
- reasoning arriving via `reasoning` emits the expected reasoning-start / reasoning-delta / reasoning-end events
- when both fields are present, `reasoning_content` wins

`bun test` in `packages/llm`: 29 pass / 0 fail. `bun typecheck` clean (the pre-push hook also runs the full monorepo typecheck, 30/30).

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
