### PR TITLE
fix(tui): use current model for sidebar context limit after model switch

### DIFF
--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
 import { createMemo } from "solid-js"
+import { useLocal } from "../../context/local"
 
 const id = "internal:sidebar-context"
 
@@ -11,6 +12,7 @@ const money = new Intl.NumberFormat("en-US", {
 })
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
+  const local = useLocal()
   const theme = () => props.api.theme.current
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
@@ -27,7 +29,12 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
 
     const tokens =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    // Prefer the currently selected model so the limit reflects a mid-session
+    // model switch; fall back to the model of the last assistant message.
+    const selected = local.model.current()
+    const providerID = selected?.providerID ?? last.providerID
+    const modelID = selected?.modelID ?? last.modelID
+    const model = props.api.state.provider.find((item) => item.id === providerID)?.models[modelID]
     return {
       tokens,
       percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,


### PR DESCRIPTION
### Issue for this PR

Closes #35072

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The sidebar "Context" percentage is computed from the model of the *last assistant message* (`last.providerID` / `last.modelID`). After switching models mid-session, it keeps dividing the token count by the previous model's context window, so the percentage is wrong (e.g. it stays at 50% even after switching to a smaller-context model where it should read much higher).

The fix reads the currently selected model from `useLocal().model.current()` and uses that model's `limit.context` for the percentage, falling back to the last assistant message's model when nothing is selected yet. The token count is unchanged — only which model's context limit we divide by changes.

### How did you verify your code works?

- Confirmed `local.model.current()` returns the live selected `{ providerID, modelID }` (the same source the prompt and model dialogs use), and that the sidebar slot renders inside `LocalProvider`, so `useLocal()` is valid in this plugin (other sidebar/session feature-plugins already call it).
- Ran the monorepo typecheck (the repo's pre-push hook runs `turbo typecheck`); all packages pass.

### Screenshots / recordings

This is a TUI numeric readout, not a visual component. Behavior change: start a session on a model, switch to a model with a different context window, and the "% used" in the sidebar now recalculates against the newly selected model's limit instead of staying pinned to the old model's.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
