### PR TITLE
fix(tui): flush OSC 52 clipboard write, propagate errors on fallback

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -1,4 +1,5 @@
 import { execFile, spawn } from "node:child_process"
+import fs from "node:fs"
 import { readFile, rm } from "node:fs/promises"
 import { platform, release, tmpdir } from "node:os"
 import path from "node:path"
@@ -23,7 +24,12 @@ function command(command: string, args: string[] = [], input?: string) {
 function writeOsc52(text: string) {
   if (!process.stdout.isTTY) return
   const sequence = `\x1b]52;c;${Buffer.from(text).toString("base64")}\x07`
-  process.stdout.write(process.env.TMUX || process.env.STY ? `\x1bPtmux;\x1b${sequence}\x1b\\` : sequence)
+  const payload = process.env.TMUX || process.env.STY ? `\x1bPtmux;\x1b${sequence}\x1b\\` : sequence
+  try {
+    fs.writeSync(process.stdout.fd, payload)
+  } catch {
+    // Terminal not available
+  }
 }
 
 export async function read() {
@@ -80,7 +86,7 @@ export function copyCommand(
 ): string[] | undefined {
   if (os === "darwin" && has("osascript")) return ["osascript"]
   if (os === "linux" && wayland && has("wl-copy")) return ["wl-copy"]
-  if (os === "linux" && has("xclip")) return ["xclip", "-selection", "clipboard"]
+  if (os === "linux" && has("xclip")) return ["xclip", "-selection", "clipboard", "-i"]
   if (os === "linux" && has("xsel")) return ["xsel", "--clipboard", "--input"]
   if (os === "win32" && has("powershell.exe")) {
     return [
@@ -102,17 +108,17 @@ function getCopyMethod() {
     if (native?.[0] === "osascript") {
       return async (text: string) => {
         const escaped = text.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
-        await command("osascript", ["-e", `set the clipboard to "${escaped}"`]).catch(() => undefined)
+        await command("osascript", ["-e", `set the clipboard to "${escaped}"`])
       }
     }
     if (native) {
       return async (text: string) => {
-        await command(native[0], native.slice(1), text).catch(() => undefined)
+        await command(native[0], native.slice(1), text)
       }
     }
     return async (text: string) => {
       const { default: clipboardy } = await import("clipboardy")
-      await clipboardy.write(text).catch(() => undefined)
+      await clipboardy.write(text)
     }
   })())
 }

--- a/packages/tui/test/clipboard.test.ts
+++ b/packages/tui/test/clipboard.test.ts
@@ -10,7 +10,7 @@ test("uses osascript on macOS", () => {
 })
 
 test("falls back through X11 clipboard commands", () => {
-  expect(copyCommand("linux", true, (name) => name === "xclip")).toEqual(["xclip", "-selection", "clipboard"])
+  expect(copyCommand("linux", true, (name) => name === "xclip")).toEqual(["xclip", "-selection", "clipboard", "-i"])
   expect(copyCommand("linux", false, (name) => name === "xsel")).toEqual(["xsel", "--clipboard", "--input"])
 })
 


### PR DESCRIPTION
### Issue for this PR

Fixes #4283

### Type of change

- [x] Bug fix

### What does this PR do?

Copy-to-clipboard on Linux Wayland (e.g., Ubuntu 24.04) showed "Copied to clipboard" toast but paste returned old content. Two bugs:

1. OSC 52 escape sequence used `process.stdout.write()` which buffers/interleaves with TUI rendering — terminal never processes sequence. Changed to `fs.writeSync(process.stdout.fd, ...)` for immediate flush to TTY fd.

2. All clipboard write paths silently caught errors with `.catch(() => undefined)`, swallowing failures when no clipboard tool (`wl-copy`, `xclip`) available. Removed catch — errors now propagate to caller which shows error toast.

Also added `-i` flag to xclip command for explicit stdin read.

### How did you verify your code works?

Tested on Ubuntu 24.04 Wayland without `wl-clipboard` installed. Copy now works via OSC 52. All 192 existing tests pass. Typecheck clean across all 36 packages.

### Screenshots / recordings

N/A (terminal fix, no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR