### PR TITLE
fix: handle ENXIO errors during startup (#635)

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -63,6 +63,7 @@ export namespace FSUtil {
         return yield* fs
           .readFileString(path)
           .pipe(Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(undefined)))
+          .pipe(Effect.catchReason("PlatformError", "Unknown", () => Effect.succeed(undefined)))
       })
 
       const isDir = Effect.fn("FileSystem.isDir")(function* (path: string) {

--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -69,7 +69,7 @@ export async function substitute(input: SubstituteInput) {
         if (missing === "empty") return ""
 
         const errMsg = `bad file reference: "${token}"`
-        if (error.code === "ENOENT") {
+        if (error.code === "ENOENT" || error.code === "ENXIO") {
           throw new InvalidError(
             {
               path: configSource,

--- a/packages/opencode/src/plugin/install.ts
+++ b/packages/opencode/src/plugin/install.ts
@@ -355,7 +355,7 @@ async function patchOne(dir: string, target: Target, spec: string, force: boolea
   }
 
   const src = await dep.readText(cfg).catch((err: NodeJS.ErrnoException) => {
-    if (err.code === "ENOENT") return "{}"
+    if (err.code === "ENOENT" || err.code === "ENXIO") return "{}"
     return err
   })
   if (src instanceof Error) {

--- a/packages/opencode/src/storage/storage.ts
+++ b/packages/opencode/src/storage/storage.ts
@@ -66,7 +66,7 @@ function file(dir: string, key: string[]) {
 
 function missing(err: unknown) {
   if (!err || typeof err !== "object") return false
-  if ("code" in err && err.code === "ENOENT") return true
+  if ("code" in err && (err.code === "ENOENT" || err.code === "ENXIO")) return true
   if ("reason" in err && err.reason && typeof err.reason === "object" && "_tag" in err.reason) {
     return err.reason._tag === "NotFound"
   }

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -54,8 +54,8 @@ export async function readArrayBuffer(p: string): Promise<ArrayBuffer> {
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
 }
 
-function isEnoent(e: unknown): e is { code: "ENOENT" } {
-  return typeof e === "object" && e !== null && "code" in e && (e as { code: string }).code === "ENOENT"
+function isEnoent(e: unknown): e is { code: "ENOENT" | "ENXIO" } {
+  return typeof e === "object" && e !== null && "code" in e && ((e as { code: string }).code === "ENOENT" || (e as { code: string }).code === "ENXIO")
 }
 
 export async function write(p: string, content: string | Buffer | Uint8Array, mode?: number): Promise<void> {


### PR DESCRIPTION
Fixes #635

Adds ENXIO error handling alongside existing ENOENT checks across multiple files to prevent crash when stale Unix domain sockets (e.g. Citrix ICA client) are encountered during startup.