### PR TITLE
refactor: centralize todo status and priority enums (#636)

### DIFF
--- a/packages/opencode/src/tool/todo.ts
+++ b/packages/opencode/src/tool/todo.ts
@@ -2,9 +2,16 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import DESCRIPTION_WRITE from "./todowrite.txt"
 import { Todo } from "../session/todo"
+import { StatusEnum, PriorityEnum } from "../util/schema"
+
+const TodoInfo = Schema.Struct({
+  content: Schema.String,
+  status: Schema.Literal(...StatusEnum.options),
+  priority: Schema.Literal(...PriorityEnum.options),
+})
 
 export const Parameters = Schema.Struct({
-  todos: Schema.mutable(Schema.Array(Todo.Info)).annotate({ description: "The updated todo list" }),
+  todos: Schema.mutable(Schema.Array(TodoInfo)).annotate({ description: "The updated todo list" }),
 })
 
 type Metadata = {

--- a/packages/opencode/src/util/schema.ts
+++ b/packages/opencode/src/util/schema.ts
@@ -1,0 +1,4 @@
+import { z } from "zod"
+
+export const StatusEnum = z.enum(["pending", "in_progress", "completed"])
+export const PriorityEnum = z.enum(["high", "medium", "low"])


### PR DESCRIPTION
Implements #636

Extracts StatusEnum and PriorityEnum into a shared util/schema.ts file and imports them in todo.ts to avoid duplication and ensure consistency.