### PR TITLE
fix: handle AI_InvalidToolArgumentsError for Azure models (#663)

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -302,12 +302,12 @@ const live: Layer.Layer<
               }
             }
             return {
-              ...failed.toolCall,
-              input: JSON.stringify({
+              toolCallId: failed.toolCall.toolCallId,
+              toolName: "invalid",
+              args: JSON.stringify({
                 tool: failed.toolCall.toolName,
                 error: failed.error.message,
               }),
-              toolName: "invalid",
             }
           },
           temperature: prepared.params.temperature,


### PR DESCRIPTION
Fixes #663

Sets strict:false on tools for Azure/OpenAI providers to prevent the AI SDK's strict JSON Schema validation from rejecting MCP-sourced tool schemas that use  or other OpenAI-incompatible features.

Also improves the experimental_repairToolCall handler in session/llm.ts to properly return diagnostic information when tool call validation fails.