### PR TITLE
feat: replace unzip with @zip.js/zip.js for Windows compat (#662)

### DIFF
--- a/packages/core/src/ripgrep/binary.ts
+++ b/packages/core/src/ripgrep/binary.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { Context, Effect, Layer, Stream } from "effect"
+import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
@@ -53,39 +54,37 @@ export namespace RipgrepBinary {
         config: (typeof PLATFORM)[keyof typeof PLATFORM],
         target: string,
       ) {
+        if (config.extension === "zip") {
+          yield* Effect.tryPromise(async () => {
+            const zipFileReader = new ZipReader(new BlobReader(new Blob([await Bun.file(archive).arrayBuffer()])))
+            const entries = await zipFileReader.getEntries()
+            const entry = entries.find((e) => e.filename.endsWith("rg.exe"))
+            if (!entry) throw new Error("rg.exe not found in zip archive")
+            const blob = await entry.getData(new BlobWriter())
+            await Bun.write(target, blob)
+            await zipFileReader.close()
+          })
+          if (process.platform !== "win32") yield* fs.chmod(target, 0o755)
+          return
+        }
+
         const dir = yield* fs.makeTempDirectoryScoped({ directory: Global.Path.bin, prefix: "ripgrep-" })
 
-        if (config.extension === "zip") {
-          const shell = (yield* Effect.sync(() => which("powershell.exe") ?? which("pwsh.exe"))) ?? "powershell.exe"
-          const result = yield* run(shell, [
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath '${archive.replaceAll("'", "''")}' -DestinationPath '${dir.replaceAll("'", "''")}' -Force`,
-          ])
-          if (result.code !== 0)
-            throw new Error(
-              result.stderr.trim() || result.stdout.trim() || `ripgrep extraction failed with code ${result.code}`,
-            )
-        }
-
-        if (config.extension === "tar.gz") {
-          const result = yield* run("tar", ["-xzf", archive, "-C", dir])
-          if (result.code !== 0)
-            throw new Error(
-              result.stderr.trim() || result.stdout.trim() || `ripgrep extraction failed with code ${result.code}`,
-            )
-        }
+        const result = yield* run("tar", ["-xzf", archive, "-C", dir])
+        if (result.code !== 0)
+          throw new Error(
+            result.stderr.trim() || result.stdout.trim() || `ripgrep extraction failed with code ${result.code}`,
+          )
 
         const extracted = path.join(
           dir,
           `ripgrep-${VERSION}-${config.platform}`,
-          process.platform === "win32" ? "rg.exe" : "rg",
+          "rg",
         )
         if (!(yield* fs.isFile(extracted))) throw new Error(`ripgrep archive did not contain executable: ${extracted}`)
 
         yield* fs.copyFile(extracted, target)
-        if (process.platform !== "win32") yield* fs.chmod(target, 0o755)
+        yield* fs.chmod(target, 0o755)
       }, Effect.scoped)
 
       return Service.of({

--- a/packages/opencode/src/util/archive.ts
+++ b/packages/opencode/src/util/archive.ts
@@ -1,17 +1,20 @@
 import path from "path"
-import * as Process from "./process"
+import { ZipReader, BlobReader, BlobWriter } from "@zip.js/zip.js"
 
 export async function extractZip(zipPath: string, destDir: string) {
-  if (process.platform === "win32") {
-    const winZipPath = path.resolve(zipPath)
-    const winDestDir = path.resolve(destDir)
-    // $global:ProgressPreference suppresses PowerShell's blue progress bar popup
-    const cmd = `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path '${winZipPath}' -DestinationPath '${winDestDir}' -Force`
-    await Process.run(["powershell", "-NoProfile", "-NonInteractive", "-Command", cmd])
-    return
+  const zipFileReader = new ZipReader(new BlobReader(new Blob([await Bun.file(zipPath).arrayBuffer()])))
+  const entries = await zipFileReader.getEntries()
+  for (const entry of entries) {
+    const filePath = path.join(destDir, entry.filename)
+    if (entry.directory) {
+      await Bun.write(filePath, "")
+      continue
+    }
+    await Bun.mkdir(path.dirname(filePath), { recursive: true })
+    const blob = await entry.getData(new BlobWriter())
+    await Bun.write(filePath, blob)
   }
-
-  await Process.run(["unzip", "-o", "-q", zipPath, "-d", destDir])
+  await zipFileReader.close()
 }
 
 export * as Archive from "./archive"


### PR DESCRIPTION
Reimplements #662

Replaces Bun.spawn(['unzip', ...]) with @zip.js/zip.js for zip extraction in ripgrep binary installation and the archive utility, eliminating the dependency on the system unzip command which is not available on Windows.