### PR TITLE
docs: add opencode model scorecard to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -32,6 +32,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations     |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                 |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                          |
+| [opencode-model-scorecard](https://github.com/bnc4vk/opencode-model-scorecard)                     | Shows model benchmark scores, token costs, and token efficiency in the OpenCode TUI                 |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                            |
 | [opencode-morph-plugin](https://github.com/morphllm/opencode-morph-plugin)                         | Fast Apply editing, WarpGrep codebase search, and context compaction via Morph                     |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |


### PR DESCRIPTION
Adds OpenCode Model Scorecard to the ecosystem plugin list.\n\nThe plugin shows model benchmark scores, token costs, and token efficiency in the OpenCode TUI.\n\nValidation:\n- git diff --check\n- confirmed entry appears in packages/web/src/content/docs/ecosystem.mdx