### PR TITLE
fix(tui): distinguish variant switch notices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,7 @@ const table = sqliteTable("session", {
 
 ## V2 Session Core
 
+- Keep durable events minimal: record irreducible new facts and do not repeat state derivable by folding the ordered aggregate history. Enrich projections and read models with previous or derived state when consumers need self-contained views.
 - Keep durable prompt admission separate from model execution. `SessionV2.prompt(...)` admits one durable `session_input` row before scheduling advisory `SessionExecution.wake(sessionID)` unless `resume: false` requests admit-only behavior. The serialized runner promotes admitted inputs into visible user messages at safe boundaries.
 - Reusing a Session ID adopts the existing Session. Reusing a prompt message ID reconciles an exact retry only when Session, prompt, and delivery mode match; conflicting reuse fails. Historical projected prompts lazily synthesize promoted inbox records during exact retry.
 - Keep `SessionExecution` process-global and Session-ID based. Its local implementation owns the process-local Session coordinator and discovers placement through `SessionStore` plus `LocationServiceMap.get(session.location)` only when a drain starts; no layer should take a Session ID. V2 interruption targets the active process-local ownership chain for that Session; idle or missing interruption is a no-op.

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -928,7 +928,7 @@ export type SessionContextOutput = {
         readonly time: { readonly created: number }
         readonly type: "model-switched"
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
-        readonly change?: "model" | "variant"
+        readonly previous?: { readonly id: string; readonly providerID: string; readonly variant?: string }
       }
     | {
         readonly id: string
@@ -1143,7 +1143,6 @@ export type SessionLogOutput =
           readonly data: {
             readonly sessionID: string
             readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
-            readonly change?: "model" | "variant"
           }
         }
       | {
@@ -1623,7 +1622,7 @@ export type SessionMessageOutput = {
         readonly time: { readonly created: number }
         readonly type: "model-switched"
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
-        readonly change?: "model" | "variant"
+        readonly previous?: { readonly id: string; readonly providerID: string; readonly variant?: string }
       }
     | {
         readonly id: string
@@ -1823,7 +1822,7 @@ export type MessageListOutput = {
         readonly time: { readonly created: number }
         readonly type: "model-switched"
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
-        readonly change?: "model" | "variant"
+        readonly previous?: { readonly id: string; readonly providerID: string; readonly variant?: string }
       }
     | {
         readonly id: string
@@ -4416,7 +4415,6 @@ export type EventSubscribeOutput =
       readonly data: {
         readonly sessionID: string
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
-        readonly change?: "model" | "variant"
       }
     }
   | {

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -928,6 +928,7 @@ export type SessionContextOutput = {
         readonly time: { readonly created: number }
         readonly type: "model-switched"
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+        readonly change?: "model" | "variant"
       }
     | {
         readonly id: string
@@ -1142,6 +1143,7 @@ export type SessionLogOutput =
           readonly data: {
             readonly sessionID: string
             readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+            readonly change?: "model" | "variant"
           }
         }
       | {
@@ -1621,6 +1623,7 @@ export type SessionMessageOutput = {
         readonly time: { readonly created: number }
         readonly type: "model-switched"
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+        readonly change?: "model" | "variant"
       }
     | {
         readonly id: string
@@ -1820,6 +1823,7 @@ export type MessageListOutput = {
         readonly time: { readonly created: number }
         readonly type: "model-switched"
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+        readonly change?: "model" | "variant"
       }
     | {
         readonly id: string
@@ -4412,6 +4416,7 @@ export type EventSubscribeOutput =
       readonly data: {
         readonly sessionID: string
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+        readonly change?: "model" | "variant"
       }
     }
   | {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -540,7 +540,8 @@ const layer = Layer.effect(
             const started = yield* Effect.gen(function* () {
               const shell = yield* Shell.Service
               return yield* shell.create({ command: input.command, cwd: session.location.directory })
-            }).pipe(Effect.provide(locations.get(session.location)))
+            })
+              .pipe(Effect.provide(locations.get(session.location)))
             yield* events.publish(
               SessionEvent.Shell.Started,
               {
@@ -563,8 +564,7 @@ const layer = Layer.effect(
                     .pipe(Effect.catchTag("Shell.NotFoundError", () => Effect.succeed(missingShellOutput())))
                 : missingShellOutput()
               return { shell: terminal.info, output }
-            })
-              .pipe(Effect.provide(locations.get(session.location)))
+            }).pipe(Effect.provide(locations.get(session.location)))
             yield* events.publish(SessionEvent.Shell.Ended, {
               sessionID: input.sessionID,
               shell: completed.shell,
@@ -613,6 +613,10 @@ const layer = Layer.effect(
         yield* events.publish(SessionEvent.ModelSelected, {
           sessionID: input.sessionID,
           model: input.model,
+          change:
+            session.model?.providerID === input.model.providerID && session.model.id === input.model.id
+              ? "variant"
+              : "model",
         })
       }),
       rename: Effect.fn("V2Session.rename")(function* (input) {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -613,10 +613,6 @@ const layer = Layer.effect(
         yield* events.publish(SessionEvent.ModelSelected, {
           sessionID: input.sessionID,
           model: input.model,
-          change:
-            session.model?.providerID === input.model.providerID && session.model.id === input.model.id
-              ? "variant"
-              : "model",
         })
       }),
       rename: Effect.fn("V2Session.rename")(function* (input) {

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -121,6 +121,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
             type: "model-switched",
             metadata: event.metadata,
             model: event.data.model,
+            change: event.data.change,
             time: { created: event.created },
           }),
         )

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -8,6 +8,7 @@ export type MemoryState = {
 }
 
 export interface Adapter {
+  readonly getModel: () => Effect.Effect<SessionMessage.ModelSelected["model"] | undefined, never, never>
   readonly getCurrentAssistant: () => Effect.Effect<SessionMessage.Assistant | undefined, never, never>
   readonly getAssistant: (
     messageID: SessionMessage.ID,
@@ -29,6 +30,15 @@ export function memory(state: MemoryState): Adapter {
   const latestAssistantIndex = () => state.messages.findLastIndex((message) => message.type === "assistant")
 
   return {
+    getModel() {
+      return Effect.sync(
+        () =>
+          state.messages.findLast(
+            (message): message is SessionMessage.ModelSelected | SessionMessage.Assistant =>
+              message.type === "model-switched" || message.type === "assistant",
+          )?.model,
+      )
+    },
     getCurrentAssistant() {
       return Effect.sync(() => {
         const index = latestAssistantIndex()
@@ -115,16 +125,19 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
         )
       },
       "session.model.selected": (event) => {
-        return adapter.appendMessage(
-          SessionMessage.ModelSelected.make({
-            id: SessionMessage.ID.fromEvent(event.id),
-            type: "model-switched",
-            metadata: event.metadata,
-            model: event.data.model,
-            change: event.data.change,
-            time: { created: event.created },
-          }),
-        )
+        return Effect.gen(function* () {
+          const previous = yield* adapter.getModel()
+          yield* adapter.appendMessage(
+            SessionMessage.ModelSelected.make({
+              id: SessionMessage.ID.fromEvent(event.id),
+              type: "model-switched",
+              metadata: event.metadata,
+              model: event.data.model,
+              previous,
+              time: { created: event.created },
+            }),
+          )
+        })
       },
       "session.moved": () => Effect.void,
       "session.renamed": () => Effect.void,

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -5,6 +5,7 @@ import { DateTime, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
 import { EventV2 } from "../event"
 import { makeGlobalNode } from "../effect/app-node"
+import { ModelV2 } from "../model"
 import { SessionEvent } from "./event"
 import { SessionV1 } from "../v1/session"
 import { WorkspaceTable } from "../control-plane/workspace.sql"
@@ -356,6 +357,17 @@ function run(db: DatabaseService, event: MessageEvent) {
     }
     const appendMessage = (message: SessionMessage.Message) => insertMessage(db, event, message)
     const adapter: SessionMessageUpdater.Adapter = {
+      getModel() {
+        return db
+          .select({ model: SessionTable.model })
+          .from(SessionTable)
+          .where(eq(SessionTable.id, event.data.sessionID))
+          .get()
+          .pipe(
+            Effect.orDie,
+            Effect.map((row) => (row?.model ? Schema.decodeUnknownSync(ModelV2.Ref)(row.model) : undefined)),
+          )
+      },
       getCurrentAssistant() {
         return Effect.gen(function* () {
           // A newer step supersedes stale incomplete rows; never resume an older assistant projection.
@@ -570,13 +582,13 @@ const layer = Layer.effectDiscard(
     )
     yield* events.project(SessionEvent.ModelSelected, (event) =>
       Effect.gen(function* () {
+        yield* run(db, event)
         yield* db
           .update(SessionTable)
           .set({ model: event.data.model, time_updated: DateTime.toEpochMillis(event.created) })
           .where(eq(SessionTable.id, event.data.sessionID))
           .run()
           .pipe(Effect.orDie)
-        yield* run(db, event)
       }),
     )
     yield* events.project(SessionEvent.Renamed, (event) =>

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -564,7 +564,28 @@ describe("SessionV2.create", () => {
       expect(yield* session.get(created.id)).toMatchObject({ model })
       expect(
         Array.from(yield* logEvents(session, created.id, true).pipe(Stream.take(1), Stream.runCollect)),
-      ).toMatchObject([{ type: "session.model.selected", data: { model } }])
+      ).toMatchObject([{ type: "session.model.selected", data: { model, change: "model" } }])
+    }),
+  )
+
+  it.effect("labels a selection on the current model as a variant change", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionV2.Service
+      const model = ModelV2.Ref.make({
+        id: ModelV2.ID.make("sonnet"),
+        providerID: ProviderV2.ID.anthropic,
+        variant: ModelV2.VariantID.make("medium"),
+      })
+      const created = yield* session.create({ location, model })
+
+      yield* session.switchModel({
+        sessionID: created.id,
+        model: ModelV2.Ref.make({ ...model, variant: ModelV2.VariantID.make("high") }),
+      })
+
+      expect(
+        Array.from(yield* logEvents(session, created.id, true).pipe(Stream.take(1), Stream.runCollect)),
+      ).toMatchObject([{ type: "session.model.selected", data: { change: "variant" } }])
     }),
   )
 

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -562,30 +562,9 @@ describe("SessionV2.create", () => {
       yield* session.switchModel({ sessionID: created.id, model })
 
       expect(yield* session.get(created.id)).toMatchObject({ model })
-      expect(
-        Array.from(yield* logEvents(session, created.id, true).pipe(Stream.take(1), Stream.runCollect)),
-      ).toMatchObject([{ type: "session.model.selected", data: { model, change: "model" } }])
-    }),
-  )
-
-  it.effect("labels a selection on the current model as a variant change", () =>
-    Effect.gen(function* () {
-      const session = yield* SessionV2.Service
-      const model = ModelV2.Ref.make({
-        id: ModelV2.ID.make("sonnet"),
-        providerID: ProviderV2.ID.anthropic,
-        variant: ModelV2.VariantID.make("medium"),
-      })
-      const created = yield* session.create({ location, model })
-
-      yield* session.switchModel({
-        sessionID: created.id,
-        model: ModelV2.Ref.make({ ...model, variant: ModelV2.VariantID.make("high") }),
-      })
-
-      expect(
-        Array.from(yield* logEvents(session, created.id, true).pipe(Stream.take(1), Stream.runCollect)),
-      ).toMatchObject([{ type: "session.model.selected", data: { change: "variant" } }])
+      const events = Array.from(yield* logEvents(session, created.id, true).pipe(Stream.take(1), Stream.runCollect))
+      expect(events).toMatchObject([{ type: "session.model.selected" }])
+      expect(events[0]?.data).toEqual({ sessionID: created.id, model })
     }),
   )
 

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -34,6 +34,7 @@ const sessionsLayer = AppNodeBuilder.build(SessionV2.node, [[SessionExecution.no
 const sessionID = SessionV2.ID.make("ses_projector_test")
 const created = DateTime.makeUnsafe(0)
 const model = { id: ModelV2.ID.make("model"), providerID: ProviderV2.ID.make("provider") }
+const previousModel = { ...model, variant: ModelV2.VariantID.make("medium") }
 const encodeMessage = Schema.encodeSync(SessionMessage.Message)
 
 const assistantRow = (
@@ -238,6 +239,7 @@ describe("SessionProjector", () => {
           directory: "/project",
           title: "test",
           version: "test",
+          model: previousModel,
         })
         .run()
         .pipe(Effect.orDie)
@@ -250,7 +252,6 @@ describe("SessionProjector", () => {
       yield* events.publish(SessionEvent.ModelSelected, {
         sessionID,
         model,
-        change: "variant",
       })
       yield* events.publish(SessionEvent.Synthetic, {
         sessionID,
@@ -338,7 +339,7 @@ describe("SessionProjector", () => {
         text: "synthetic context",
         metadata: { source: "projector-test" },
       })
-      expect(messages.find((message) => message.type === "model-switched")).toMatchObject({ change: "variant" })
+      expect(messages.find((message) => message.type === "model-switched")).toMatchObject({ previous: previousModel })
       expect(messages.find((message) => message.type === "shell")).toMatchObject({
         shell: { command: "pwd", status: "exited", exit: 0 },
         output: { output: "/project", truncated: false },

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -250,6 +250,7 @@ describe("SessionProjector", () => {
       yield* events.publish(SessionEvent.ModelSelected, {
         sessionID,
         model,
+        change: "variant",
       })
       yield* events.publish(SessionEvent.Synthetic, {
         sessionID,
@@ -337,6 +338,7 @@ describe("SessionProjector", () => {
         text: "synthetic context",
         metadata: { source: "projector-test" },
       })
+      expect(messages.find((message) => message.type === "model-switched")).toMatchObject({ change: "variant" })
       expect(messages.find((message) => message.type === "shell")).toMatchObject({
         shell: { command: "pwd", status: "exited", exit: 0 },
         output: { output: "/project", truncated: false },

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -67,6 +67,7 @@ export const ModelSelected = Event.durable({
   schema: {
     ...Base,
     model: Model.Ref,
+    change: Schema.Literals(["model", "variant"]).pipe(optional),
   },
 })
 export type ModelSelected = typeof ModelSelected.Type

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -67,7 +67,6 @@ export const ModelSelected = Event.durable({
   schema: {
     ...Base,
     model: Model.Ref,
-    change: Schema.Literals(["model", "variant"]).pipe(optional),
   },
 })
 export type ModelSelected = typeof ModelSelected.Type

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -44,7 +44,7 @@ export const ModelSelected = Schema.Struct({
   ...Base,
   type: Schema.Literal("model-switched"),
   model: Model.Ref,
-  change: Schema.Literals(["model", "variant"]).pipe(optional),
+  previous: Model.Ref.pipe(optional),
 }).annotate({ identifier: "Session.Message.ModelSelected" })
 
 export interface User extends Schema.Schema.Type<typeof User> {}

--- a/packages/schema/src/session-message.ts
+++ b/packages/schema/src/session-message.ts
@@ -44,6 +44,7 @@ export const ModelSelected = Schema.Struct({
   ...Base,
   type: Schema.Literal("model-switched"),
   model: Model.Ref,
+  change: Schema.Literals(["model", "variant"]).pipe(optional),
 }).annotate({ identifier: "Session.Message.ModelSelected" })
 
 export interface User extends Schema.Schema.Type<typeof User> {}

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -871,6 +871,7 @@ export type GlobalEvent = {
         properties: {
           sessionID: string
           model: ModelRef
+          change?: "model" | "variant"
         }
       }
     | {
@@ -3645,6 +3646,7 @@ export type SyncEventSessionModelSelected = {
     data: {
       sessionID: string
       model: ModelRef
+      change?: "model" | "variant"
     }
   }
 }
@@ -4310,6 +4312,7 @@ export type SessionMessageModelSelected = {
   }
   type: "model-switched"
   model: ModelRef
+  change?: "model" | "variant"
 }
 
 export type SessionMessageUser = {
@@ -4565,6 +4568,7 @@ export type SessionModelSelected = {
   data: {
     sessionID: string
     model: ModelRef
+    change?: "model" | "variant"
   }
 }
 
@@ -6774,6 +6778,7 @@ export type EventSessionModelSelected = {
   properties: {
     sessionID: string
     model: ModelRef
+    change?: "model" | "variant"
   }
 }
 
@@ -7985,6 +7990,7 @@ export type SessionMessageModelSelected2 = {
   }
   type: "model-switched"
   model: ModelRef2
+  change?: "model" | "variant"
 }
 
 export type SessionMessageUser2 = {
@@ -8286,6 +8292,7 @@ export type SessionModelSelected2 = {
   data: {
     sessionID: string
     model: ModelRef2
+    change?: "model" | "variant"
   }
 }
 

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -871,7 +871,6 @@ export type GlobalEvent = {
         properties: {
           sessionID: string
           model: ModelRef
-          change?: "model" | "variant"
         }
       }
     | {
@@ -3646,7 +3645,6 @@ export type SyncEventSessionModelSelected = {
     data: {
       sessionID: string
       model: ModelRef
-      change?: "model" | "variant"
     }
   }
 }
@@ -4312,7 +4310,7 @@ export type SessionMessageModelSelected = {
   }
   type: "model-switched"
   model: ModelRef
-  change?: "model" | "variant"
+  previous?: ModelRef
 }
 
 export type SessionMessageUser = {
@@ -4568,7 +4566,6 @@ export type SessionModelSelected = {
   data: {
     sessionID: string
     model: ModelRef
-    change?: "model" | "variant"
   }
 }
 
@@ -6778,7 +6775,6 @@ export type EventSessionModelSelected = {
   properties: {
     sessionID: string
     model: ModelRef
-    change?: "model" | "variant"
   }
 }
 
@@ -7990,7 +7986,7 @@ export type SessionMessageModelSelected2 = {
   }
   type: "model-switched"
   model: ModelRef2
-  change?: "model" | "variant"
+  previous?: ModelRef2
 }
 
 export type SessionMessageUser2 = {
@@ -8292,7 +8288,6 @@ export type SessionModelSelected2 = {
   data: {
     sessionID: string
     model: ModelRef2
-    change?: "model" | "variant"
   }
 }
 

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -240,6 +240,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               id: messageIDFromEvent(event.id),
               type: "model-switched",
               model: event.data.model,
+              change: event.data.change,
               time: { created: event.created },
             })
           })

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -117,11 +117,6 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         index.set(item.id, messages.length)
         messages.push(item)
       },
-      replace(messages: SessionMessage[], index: Map<string, number>, item: SessionMessage) {
-        const position = index.get(item.id)
-        if (position === undefined) return message.append(messages, index, item)
-        messages[position] = item
-      },
       activeAssistant(messages: SessionMessage[]) {
         const item = messages.findLast((item) => item.type === "assistant" && !item.time.completed)
         return item?.type === "assistant" ? item : undefined
@@ -240,21 +235,24 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         case "session.model.selected":
           if (store.session.info[event.data.sessionID])
             setStore("session", "info", event.data.sessionID, "model", event.data.model)
+          if (!store.session.message[event.data.sessionID]) break
           message.update(event.data.sessionID, (draft, index) => {
             message.append(draft, index, {
               id: messageIDFromEvent(event.id),
               type: "model-switched",
               model: event.data.model,
-              metadata: { "projection-pending": true },
               time: { created: event.created },
             })
           })
           void sdk.api.session
             .message({ sessionID: event.data.sessionID, messageID: messageIDFromEvent(event.id) })
-            .then((item) =>
-              message.update(event.data.sessionID, (draft, index) => message.replace(draft, index, mutable(item))),
-            )
-            .catch(() => result.session.message.refresh(event.data.sessionID))
+            .then((item) => {
+              message.update(event.data.sessionID, (draft, index) => {
+                const position = index.get(item.id)
+                if (position === undefined) return message.append(draft, index, mutable(item))
+                draft[position] = mutable(item)
+              })
+            })
             .catch((error) => console.error("Failed to load projected model switch message", error))
           break
         case "session.renamed":
@@ -696,9 +694,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             const messages = [
               ...loaded.map((message) => {
                 if (message.type === "user") return message
-                const live = liveByID.get(message.id)
-                if (live?.metadata?.["projection-pending"] === true) return message
-                return live ?? message
+                return liveByID.get(message.id) ?? message
               }),
               ...live.filter((message) => !loadedIDs.has(message.id)),
             ].toSorted((a, b) => a.time.created - b.time.created)

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -117,6 +117,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         index.set(item.id, messages.length)
         messages.push(item)
       },
+      replace(messages: SessionMessage[], index: Map<string, number>, item: SessionMessage) {
+        const position = index.get(item.id)
+        if (position === undefined) return message.append(messages, index, item)
+        messages[position] = item
+      },
       activeAssistant(messages: SessionMessage[]) {
         const item = messages.findLast((item) => item.type === "assistant" && !item.time.completed)
         return item?.type === "assistant" ? item : undefined
@@ -240,10 +245,17 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
               id: messageIDFromEvent(event.id),
               type: "model-switched",
               model: event.data.model,
-              change: event.data.change,
+              metadata: { "projection-pending": true },
               time: { created: event.created },
             })
           })
+          void sdk.api.session
+            .message({ sessionID: event.data.sessionID, messageID: messageIDFromEvent(event.id) })
+            .then((item) =>
+              message.update(event.data.sessionID, (draft, index) => message.replace(draft, index, mutable(item))),
+            )
+            .catch(() => result.session.message.refresh(event.data.sessionID))
+            .catch((error) => console.error("Failed to load projected model switch message", error))
           break
         case "session.renamed":
           if (store.session.info[event.data.sessionID])
@@ -684,7 +696,9 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             const messages = [
               ...loaded.map((message) => {
                 if (message.type === "user") return message
-                return liveByID.get(message.id) ?? message
+                const live = liveByID.get(message.id)
+                if (live?.metadata?.["projection-pending"] === true) return message
+                return live ?? message
               }),
               ...live.filter((message) => !loadedIDs.has(message.id)),
             ].toSorted((a, b) => a.time.created - b.time.created)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1070,7 +1070,12 @@ function SessionMessageView(props: { message: SessionMessage }) {
       <Match when={props.message.type === "shell"}>
         <ShellMessage message={props.message as Extract<SessionMessage, { type: "shell" }>} />
       </Match>
-      <Match when={props.message.type === "agent-switched" || props.message.type === "model-switched"}>
+      <Match
+        when={
+          props.message.type === "agent-switched" ||
+          (props.message.type === "model-switched" && props.message.metadata?.["projection-pending"] !== true)
+        }
+      >
         <SessionSwitchMessageV2 message={props.message} />
       </Match>
       <Match
@@ -1232,7 +1237,7 @@ function SessionSwitchMessageV2(props: { message: SessionMessage }) {
   const text = () => {
     if (props.message.type === "agent-switched") return `Switched agent to ${props.message.agent}`
     if (props.message.type === "model-switched")
-      return switchLabel(props.message.model, ctx.models(), props.message.change)
+      return switchLabel(props.message.model, ctx.models(), props.message.previous)
     return ""
   }
   return <text fg={theme.textMuted}>{text()}</text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -130,7 +130,6 @@ const context = createContext<{
   groupExploration: () => boolean
   diffWrapMode: () => "word" | "none"
   models: () => ModelV2Info[]
-  messages: () => SessionMessage[]
   tui: ReturnType<typeof useTuiConfig>
 }>()
 
@@ -884,7 +883,6 @@ export function Session() {
           groupExploration,
           diffWrapMode,
           models,
-          messages,
           tui: tuiConfig,
         }}
       >
@@ -1231,17 +1229,10 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
 function SessionSwitchMessageV2(props: { message: SessionMessage }) {
   const ctx = use()
   const { theme } = useTheme()
-  const previousModel = () => {
-    const index = ctx.messages().findIndex((message) => message.id === props.message.id)
-    const previous = ctx
-      .messages()
-      .slice(0, index)
-      .findLast((message) => message.type === "model-switched" || message.type === "assistant")
-    return previous?.type === "model-switched" || previous?.type === "assistant" ? previous.model : undefined
-  }
   const text = () => {
     if (props.message.type === "agent-switched") return `Switched agent to ${props.message.agent}`
-    if (props.message.type === "model-switched") return switchLabel(props.message.model, ctx.models(), previousModel())
+    if (props.message.type === "model-switched")
+      return switchLabel(props.message.model, ctx.models(), props.message.change)
     return ""
   }
   return <text fg={theme.textMuted}>{text()}</text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1070,12 +1070,7 @@ function SessionMessageView(props: { message: SessionMessage }) {
       <Match when={props.message.type === "shell"}>
         <ShellMessage message={props.message as Extract<SessionMessage, { type: "shell" }>} />
       </Match>
-      <Match
-        when={
-          props.message.type === "agent-switched" ||
-          (props.message.type === "model-switched" && props.message.metadata?.["projection-pending"] !== true)
-        }
-      >
+      <Match when={props.message.type === "agent-switched" || props.message.type === "model-switched"}>
         <SessionSwitchMessageV2 message={props.message} />
       </Match>
       <Match

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -130,6 +130,7 @@ const context = createContext<{
   groupExploration: () => boolean
   diffWrapMode: () => "word" | "none"
   models: () => ModelV2Info[]
+  messages: () => SessionMessage[]
   tui: ReturnType<typeof useTuiConfig>
 }>()
 
@@ -883,6 +884,7 @@ export function Session() {
           groupExploration,
           diffWrapMode,
           models,
+          messages,
           tui: tuiConfig,
         }}
       >
@@ -1229,9 +1231,17 @@ function AssistantFooter(props: { message: SessionMessageAssistant }) {
 function SessionSwitchMessageV2(props: { message: SessionMessage }) {
   const ctx = use()
   const { theme } = useTheme()
+  const previousModel = () => {
+    const index = ctx.messages().findIndex((message) => message.id === props.message.id)
+    const previous = ctx
+      .messages()
+      .slice(0, index)
+      .findLast((message) => message.type === "model-switched" || message.type === "assistant")
+    return previous?.type === "model-switched" || previous?.type === "assistant" ? previous.model : undefined
+  }
   const text = () => {
     if (props.message.type === "agent-switched") return `Switched agent to ${props.message.agent}`
-    if (props.message.type === "model-switched") return switchLabel(props.message.model, ctx.models())
+    if (props.message.type === "model-switched") return switchLabel(props.message.model, ctx.models(), previousModel())
     return ""
   }
   return <text fg={theme.textMuted}>{text()}</text>

--- a/packages/tui/src/util/model.ts
+++ b/packages/tui/src/util/model.ts
@@ -34,11 +34,12 @@ export function formatRef(model: { providerID: string; id: string; variant?: str
 export function switchLabel(
   model: { providerID: string; id: string; variant?: string },
   models?: readonly { providerID: string; id: string; name: string }[],
+  previous?: { providerID: string; id: string; variant?: string },
 ) {
+  if (previous?.providerID === model.providerID && previous.id === model.id && previous.variant !== model.variant)
+    return `Switched variant to ${model.variant ?? "default"}`
   const display = models?.find((item) => item.providerID === model.providerID && item.id === model.id)?.name
   if (display === undefined) return `Switched model to ${formatRef(model)}`
-  // Variant-only switches publish the same model id; without the variant the
-  // notice would look like a redundant model switch.
   const variant = model.variant && model.variant !== "default" ? ` (${model.variant})` : ""
   return `Switched model to ${display}${variant}`
 }

--- a/packages/tui/src/util/model.ts
+++ b/packages/tui/src/util/model.ts
@@ -34,9 +34,10 @@ export function formatRef(model: { providerID: string; id: string; variant?: str
 export function switchLabel(
   model: { providerID: string; id: string; variant?: string },
   models?: readonly { providerID: string; id: string; name: string }[],
-  change?: "model" | "variant",
+  previous?: { providerID: string; id: string; variant?: string },
 ) {
-  if (change === "variant") return `Switched variant to ${model.variant ?? "default"}`
+  if (previous?.providerID === model.providerID && previous.id === model.id)
+    return `Switched variant to ${model.variant ?? "default"}`
   const display = models?.find((item) => item.providerID === model.providerID && item.id === model.id)?.name
   if (display === undefined) return `Switched model to ${formatRef(model)}`
   const variant = model.variant && model.variant !== "default" ? ` (${model.variant})` : ""

--- a/packages/tui/src/util/model.ts
+++ b/packages/tui/src/util/model.ts
@@ -34,10 +34,9 @@ export function formatRef(model: { providerID: string; id: string; variant?: str
 export function switchLabel(
   model: { providerID: string; id: string; variant?: string },
   models?: readonly { providerID: string; id: string; name: string }[],
-  previous?: { providerID: string; id: string; variant?: string },
+  change?: "model" | "variant",
 ) {
-  if (previous?.providerID === model.providerID && previous.id === model.id && previous.variant !== model.variant)
-    return `Switched variant to ${model.variant ?? "default"}`
+  if (change === "variant") return `Switched variant to ${model.variant ?? "default"}`
   const display = models?.find((item) => item.providerID === model.providerID && item.id === model.id)?.name
   if (display === undefined) return `Switched model to ${formatRef(model)}`
   const variant = model.variant && model.variant !== "default" ? ` (${model.variant})` : ""

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -767,7 +767,18 @@ test("adds and dismisses question requests from live events", async () => {
 
 test("settles pending tools when a live failure arrives", async () => {
   const events = createEventStream()
-  const calls = createFetch(undefined, events)
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/session/session-1/message/msg_model_1")
+      return json({
+        data: {
+          id: "msg_model_1",
+          type: "model-switched",
+          previous: { id: "model-1", providerID: "provider-1", variant: "medium" },
+          model: { id: "model-1", providerID: "provider-1", variant: "high" },
+          time: { created: 0 },
+        },
+      })
+  }, events)
   let sync!: ReturnType<typeof useData>
   let ready!: () => void
   const mounted = new Promise<void>((resolve) => {
@@ -808,7 +819,7 @@ test("settles pending tools when a live failure arrives", async () => {
       durable: durable("session-1", 1),
       data: {
         sessionID: "session-1",
-        model: { id: "model-1", providerID: "provider-1" },
+        model: { id: "model-1", providerID: "provider-1", variant: "high" },
       },
     })
     emitEvent(events, {
@@ -895,6 +906,11 @@ test("settles pending tools when a live failure arrives", async () => {
       "model-switched",
       "assistant",
     ])
+    expect(sync.session.message.get("session-1", "msg_model_1")).toMatchObject({
+      type: "model-switched",
+      previous: { id: "model-1", providerID: "provider-1", variant: "medium" },
+      model: { id: "model-1", providerID: "provider-1", variant: "high" },
+    })
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/util/model.test.ts
+++ b/packages/tui/test/util/model.test.ts
@@ -34,4 +34,16 @@ describe("util.model", () => {
       "Switched model to removed/gone/high",
     )
   })
+
+  test("distinguishes variant-only switches from model switches", () => {
+    const previous = { providerID: "openai", id: "gpt-5.5", variant: "medium" }
+
+    expect(switchLabel({ ...previous, variant: "high" }, undefined, previous)).toBe("Switched variant to high")
+    expect(switchLabel({ providerID: "openai", id: "gpt-5.5" }, undefined, previous)).toBe(
+      "Switched variant to default",
+    )
+    expect(switchLabel({ providerID: "anthropic", id: "sonnet", variant: "high" }, undefined, previous)).toBe(
+      "Switched model to anthropic/sonnet/high",
+    )
+  })
 })

--- a/packages/tui/test/util/model.test.ts
+++ b/packages/tui/test/util/model.test.ts
@@ -36,13 +36,13 @@ describe("util.model", () => {
   })
 
   test("distinguishes variant-only switches from model switches", () => {
-    expect(switchLabel({ providerID: "openai", id: "gpt-5.5", variant: "high" }, undefined, "variant")).toBe(
-      "Switched variant to high",
-    )
-    expect(switchLabel({ providerID: "openai", id: "gpt-5.5" }, undefined, "variant")).toBe(
+    const previous = { providerID: "openai", id: "gpt-5.5", variant: "medium" }
+
+    expect(switchLabel({ ...previous, variant: "high" }, undefined, previous)).toBe("Switched variant to high")
+    expect(switchLabel({ providerID: "openai", id: "gpt-5.5" }, undefined, previous)).toBe(
       "Switched variant to default",
     )
-    expect(switchLabel({ providerID: "anthropic", id: "sonnet", variant: "high" }, undefined, "model")).toBe(
+    expect(switchLabel({ providerID: "anthropic", id: "sonnet", variant: "high" }, undefined, previous)).toBe(
       "Switched model to anthropic/sonnet/high",
     )
   })

--- a/packages/tui/test/util/model.test.ts
+++ b/packages/tui/test/util/model.test.ts
@@ -36,13 +36,13 @@ describe("util.model", () => {
   })
 
   test("distinguishes variant-only switches from model switches", () => {
-    const previous = { providerID: "openai", id: "gpt-5.5", variant: "medium" }
-
-    expect(switchLabel({ ...previous, variant: "high" }, undefined, previous)).toBe("Switched variant to high")
-    expect(switchLabel({ providerID: "openai", id: "gpt-5.5" }, undefined, previous)).toBe(
+    expect(switchLabel({ providerID: "openai", id: "gpt-5.5", variant: "high" }, undefined, "variant")).toBe(
+      "Switched variant to high",
+    )
+    expect(switchLabel({ providerID: "openai", id: "gpt-5.5" }, undefined, "variant")).toBe(
       "Switched variant to default",
     )
-    expect(switchLabel({ providerID: "anthropic", id: "sonnet", variant: "high" }, undefined, previous)).toBe(
+    expect(switchLabel({ providerID: "anthropic", id: "sonnet", variant: "high" }, undefined, "model")).toBe(
       "Switched model to anthropic/sonnet/high",
     )
   })


### PR DESCRIPTION
## Summary

- keep `session.model.selected` minimal, containing only the newly selected model
- derive and persist the previous model in the projected `model-switched` message
- fetch that authoritative projection for live switch events instead of duplicating projection logic in the TUI
- render same-model transitions as variant switches and preserve the model-switch fallback for older projected messages
- document the minimal durable-event principle in `AGENTS.md`
- regenerate both client surfaces

## Testing

- 40 focused core tests
- 29 focused TUI tests
- package typechecks for schema, core, protocol, server, client, SDK, and TUI
- repository pre-push typecheck (31 packages)
- Terminal Control V2 TUI recording