### PR TITLE
fix(tui): clear completed background shell status

### DIFF
--- a/packages/core/src/tool/shell.ts
+++ b/packages/core/src/tool/shell.ts
@@ -18,8 +18,9 @@ export const DEFAULT_TIMEOUT_MS = 2 * 60 * 1_000
 export const MAX_TIMEOUT_MS = 10 * 60 * 1_000
 export const MAX_CAPTURE_BYTES = 1024 * 1024
 
-const BACKGROUND_STARTED =
-  "The command has not completed; it is now running in the background."
+const BACKGROUND_STARTED = "The command was moved to the background."
+const BACKGROUND_INSTRUCTION =
+  "You will be notified automatically when the command finishes. DO NOT sleep, poll, or proactively check on its progress."
 
 export const Input = Schema.Struct({
   command: Schema.String.annotate({ description: "Shell command string to execute" }),
@@ -54,10 +55,11 @@ const Output = Schema.Struct({
 type Output = typeof Output.Type
 
 const modelOutput = (output: Output): string | undefined => {
-  if (output.status === "running") return undefined
   const warnings = output.warnings?.length
     ? `\n\nWarnings:\n${output.warnings.map((warning) => `- ${warning}`).join("\n")}`
     : ""
+  if (output.status === "running")
+    return `${warnings.trimStart()}${warnings ? "\n\n" : ""}${BACKGROUND_INSTRUCTION}`
   if (output.timeout) return `${warnings.trimStart()}${warnings ? "\n\n" : ""}Command timed out before completion.`
   return `${warnings.trimStart()}${warnings ? "\n\n" : ""}Command exited with code ${output.exit}.`
 }

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -478,9 +478,13 @@ describe("ShellTool", () => {
             const structured = settled.output?.structured as Record<string, unknown> | undefined
             const shellID = typeof structured?.shellID === "string" ? structured.shellID : undefined
             expect(settled.output?.structured).toMatchObject({ truncated: false })
-            expect(settled.output?.content[0]).toMatchObject({
+            expect(settled.output?.content[0]).toEqual({
               type: "text",
-              text: expect.stringContaining("running in the background"),
+              text: "The command was moved to the background.",
+            })
+            expect(settled.output?.content[1]).toMatchObject({
+              type: "text",
+              text: expect.stringContaining("DO NOT sleep, poll"),
             })
             expect(shellID).toStartWith("sh_")
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2079,14 +2079,16 @@ function Shell(props: ToolProps) {
     return request?.source?.type === "tool" && request.source.callID === props.part.id
   })
   const color = createMemo(() => (permission() ? theme.warning : theme.text))
-  const isRunning = createMemo(() => {
-    if (props.part.state.status === "running") return true
-    const shellID = stringValue(props.metadata.shellID)
-    return Boolean(shellID && data.shell.get(shellID))
+  const shellID = createMemo(() => stringValue(props.metadata.shellID))
+  const backgrounded = createMemo(() => {
+    const id = shellID()
+    return Boolean(id && data.shell.get(id))
   })
+  const isRunning = createMemo(() => props.part.state.status === "running")
   const command = createMemo(() => stringValue(props.input.command))
   const output = createMemo(() => {
     if (props.part.state.status === "pending") return ""
+    if (shellID()) return ""
     const content = props.part.state.content[0]
     return stripAnsi(content?.type === "text" ? content.text.trim() : "")
   })
@@ -2128,6 +2130,11 @@ function Shell(props: ToolProps) {
               <span style={{ fg: theme.textMuted }}>{limited().slice(input().length)}</span>
             </Spinner>
           </Show>
+        </Show>
+        <Show when={backgrounded()}>
+          <text>
+            <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> Backgrounded </span>
+          </text>
         </Show>
         <Show when={collapsed().overflow}>
           <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2080,11 +2080,11 @@ function Shell(props: ToolProps) {
   })
   const color = createMemo(() => (permission() ? theme.warning : theme.text))
   const shellID = createMemo(() => stringValue(props.metadata.shellID))
-  const backgrounded = createMemo(() => {
+  const backgroundRunning = createMemo(() => {
     const id = shellID()
     return Boolean(id && data.shell.get(id))
   })
-  const isRunning = createMemo(() => props.part.state.status === "running")
+  const isRunning = createMemo(() => props.part.state.status === "running" || backgroundRunning())
   const command = createMemo(() => stringValue(props.input.command))
   const output = createMemo(() => {
     if (props.part.state.status === "pending") return ""
@@ -2131,7 +2131,7 @@ function Shell(props: ToolProps) {
             </Spinner>
           </Show>
         </Show>
-        <Show when={backgrounded()}>
+        <Show when={shellID()}>
           <text>
             <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> Backgrounded </span>
           </text>


### PR DESCRIPTION
## Summary

- render a compact gray `Backgrounded` badge once a shell is moved to the background
- keep the shell spinner active while the background command is still running
- switch the command to the normal `$` completed state when the shell exits while retaining the `Backgrounded` badge
- keep persisted shell output timeless for reloads and non-TUI clients while retaining model-only completion guidance

Supersedes #34851.

## Visual follow-up

The persistent `Backgrounded` status is correct, but giving it a dedicated row feels more prominent than it should. Explore a subtler treatment separately, likely inline placement and/or a quieter color.

## Verification

- `bun typecheck` in `packages/core`
- focused shell background regression test
- `bun typecheck` in `packages/tui`
- all 203 TUI tests
- repository pre-push typecheck (31 packages)
- Terminal Control verification of foreground shell -> `Ctrl-B` -> persistent badge with spinner -> completed `$` state with persistent badge