### PR TITLE
fix: show agent descriptions in @ autocomplete menu

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -405,6 +405,7 @@ export function Autocomplete(props: {
       .map(
         (agent): AutocompleteOption => ({
           display: "@" + agent.name,
+          description: agent.description,
           onSelect: () => {
             insertPart(agent.name, {
               type: "agent",


### PR DESCRIPTION
## Problem

When typing `@` in the TUI prompt, the autocomplete menu shows agent names but not their descriptions. This makes it hard to know what each agent does without memorizing them or checking the config.

## Root Cause

The `agents` createMemo in `packages/tui/src/component/prompt/autocomplete.tsx` creates `AutocompleteOption` objects without the `description` field, even though:

1. `AutocompleteOption` type supports `description?: string`
2. The rendering code already renders descriptions via `<Show when={option().description}>`
3. All other option sources (`commands`, `referenceAliases`, `mcpResources`) already pass `description`

## Fix

One-line change: add `description: agent.description` to the agent AutocompleteOption mapping.

## Before

```typescript
(agent): AutocompleteOption => ({
    display: "@" + agent.name,
    onSelect: () => { ... },
})
```

## After

```typescript
(agent): AutocompleteOption => ({
    display: "@" + agent.name,
    description: agent.description,
    onSelect: () => { ... },
})
```

## Verification

The rendering logic (lines at bottom of the file) already handles descriptions:
```tsx
<Show when={option().description}>
    <text ...>
        {" " + option().description?.trimStart()}
    </text>
</Show>
```