### PR TITLE
fix(build): gracefully handle models.dev fetch failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,13 @@ Then run it with:
 
 Replace `<platform>` with your platform (e.g., `darwin-arm64`, `linux-x64`).
 
+> [!NOTE]
+> The build embeds a snapshot of the model catalog from [models.dev](https://models.dev). If that service is unreachable in your environment (VPN, firewall, etc.), the build falls back to an empty snapshot. To use a local cached copy instead:
+>
+> ```bash
+> MODELS_DEV_API_JSON=packages/opencode/test/tool/fixtures/models-api.json ./packages/opencode/script/build.ts --single
+> ```
+
 - Core pieces:
   - `packages/opencode`: OpenCode core business logic & server.
   - `packages/opencode/src/cli/cmd/tui/`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)

--- a/packages/cli/script/generate.ts
+++ b/packages/cli/script/generate.ts
@@ -1,7 +1,12 @@
 const modelsUrl = process.env.OPENCODE_MODELS_URL || "https://models.dev"
 
-export const modelsData = process.env.MODELS_DEV_API_JSON
+export const modelsData: string = process.env.MODELS_DEV_API_JSON
   ? await Bun.file(process.env.MODELS_DEV_API_JSON).text()
-  : await fetch(`${modelsUrl}/api.json`).then((response) => response.text())
+  : await fetch(`${modelsUrl}/api.json`)
+    .then((response) => response.text())
+    .catch(() => {
+      console.warn(`Warning: unable to fetch models from ${modelsUrl}/api.json — embedding empty snapshot`)
+      return "{}"
+    })
 
 console.log("Loaded models.dev snapshot")

--- a/packages/opencode/script/generate.ts
+++ b/packages/opencode/script/generate.ts
@@ -8,7 +8,12 @@ const dir = path.resolve(__dirname, "..")
 process.chdir(dir)
 
 const modelsUrl = process.env.OPENCODE_MODELS_URL || "https://models.dev"
-export const modelsData = process.env.MODELS_DEV_API_JSON
+export const modelsData: string = process.env.MODELS_DEV_API_JSON
   ? await Bun.file(process.env.MODELS_DEV_API_JSON).text()
-  : await fetch(`${modelsUrl}/api.json`).then((x) => x.text())
+  : await fetch(`${modelsUrl}/api.json`)
+    .then((x) => x.text())
+    .catch(() => {
+      console.warn(`Warning: unable to fetch models from ${modelsUrl}/api.json — embedding empty snapshot`)
+      return "{}"
+    })
 console.log("Loaded models.dev snapshot")


### PR DESCRIPTION
### Issue for this PR

Closes #35358

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The build script's `generate.ts` hard-failed when `models.dev` was unreachable (VPN, Wi-Fi, transient outage)

- Add `.catch()` fallback in build-time model fetch returning `"{}"` with `console.warn`, matching runtime graceful degradation in `packages/core/src/models-dev.ts:228`
- Apply the same fix to both `packages/opencode/script/generate.ts` and `packages/cli/script/generate.ts`
- Document the `MODELS_DEV_API_JSON` env var workaround in CONTRIBUTING.md under "Building a localcode"

### How did you verify your code works?

- `bun typecheck` — clean across all 36 packages
- `bun run script/build.ts --single` — builds successfully with and without `models.dev` reachable
- Smoke test: binary produces correct version output

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR