### PR TITLE
feat(core): expose deferred tools through execute

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -321,6 +321,7 @@
         "@modelcontextprotocol/sdk": "1.29.0",
         "@npmcli/arborist": "9.4.0",
         "@npmcli/config": "10.8.1",
+        "@opencode-ai/codemode": "workspace:*",
         "@opencode-ai/effect-drizzle-sqlite": "workspace:*",
         "@opencode-ai/effect-sqlite-node": "workspace:*",
         "@opencode-ai/llm": "workspace:*",

--- a/packages/codemode/codemode.md
+++ b/packages/codemode/codemode.md
@@ -1132,6 +1132,12 @@ Post-MVP (logged, not blocking an experimental flag):
 - [ ] Reviewer observation worth keeping: MCP server instructions (`sys.mcp`,
       `session/system.ts:110-126`) still inject prose referencing server-native tool
       names that are no longer directly callable under code mode.
+- [ ] Tool-tree path segments named `__proto__`, `constructor`, or `prototype` are included
+      in discovery but rejected by `ToolRuntime` resolution even when supplied as safe own
+      properties on null-prototype host records. Hosts should preserve registered names rather
+      than invent incompatible aliases. CodeMode should own a consistent policy: safely admit
+      these names as own tool-tree members, reject them before catalog generation with a clear
+      diagnostic, or define one canonical escaping contract.
 
 ### Backlog / loose ends (non-blocking, any order)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,6 +90,7 @@
     "@ff-labs/fff-bun": "0.9.4",
     "@npmcli/arborist": "9.4.0",
     "@npmcli/config": "10.8.1",
+    "@opencode-ai/codemode": "workspace:*",
     "@opencode-ai/effect-drizzle-sqlite": "workspace:*",
     "@opencode-ai/effect-sqlite-node": "workspace:*",
     "@opencode-ai/llm": "workspace:*",

--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -52,6 +52,9 @@ export const Flag = {
   get OPENCODE_EXPERIMENTAL_REFERENCES() {
     return enabledByExperimental("OPENCODE_EXPERIMENTAL_REFERENCES")
   },
+  get CODEMODE_ENABLED() {
+    return process.env["CODEMODE_ENABLED"] === undefined || truthy("CODEMODE_ENABLED")
+  },
   get OPENCODE_TUI_CONFIG() {
     return process.env["OPENCODE_TUI_CONFIG"]
   },

--- a/packages/core/src/mcp/guidance.ts
+++ b/packages/core/src/mcp/guidance.ts
@@ -6,7 +6,6 @@ import { Context, Effect, Layer, Schema } from "effect"
 import { AgentV2 } from "../agent"
 import { PermissionV2 } from "../permission"
 import { McpTool } from "../tool/mcp"
-import { ToolRegistry } from "../tool/registry"
 import { MCP } from "./index"
 import { SystemContext } from "../system-context/index"
 
@@ -21,7 +20,7 @@ const entries = (servers: ReadonlyArray<Summary>) =>
     `  <server name="${server.server}">`,
     ...(Flag.CODEMODE_ENABLED
       ? [
-          `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.codeModeGroup(server.server))}]\`.`,
+          `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.group(server.server))}]\`.`,
         ]
       : []),
     ...server.instructions.split("\n").map((line) => `    ${line}`),
@@ -66,16 +65,16 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const mcp = yield* MCP.Service
-    const registry = yield* ToolRegistry.Service
 
     return Service.of({
       load: Effect.fn("McpGuidance.load")(function* (selection) {
         const agent = selection.info
         if (!agent) return SystemContext.empty
+        if (Flag.CODEMODE_ENABLED && PermissionV2.evaluate("execute", "*", agent.permissions).effect === "deny")
+          return SystemContext.empty
         const [instructions, tools] = yield* Effect.all([mcp.instructions(), mcp.tools()], {
           concurrency: "unbounded",
         })
-        if (Flag.CODEMODE_ENABLED && !(yield* registry.executeAvailable(agent.permissions))) return SystemContext.empty
         // Instructions are useful only when this agent can reach at least one server tool.
         const visible = instructions
           .filter((item) => {
@@ -103,4 +102,4 @@ export const layer = Layer.effect(
   }),
 )
 
-export const node = makeLocationNode({ service: Service, layer, deps: [MCP.node, ToolRegistry.node] })
+export const node = makeLocationNode({ service: Service, layer, deps: [MCP.node] })

--- a/packages/core/src/mcp/guidance.ts
+++ b/packages/core/src/mcp/guidance.ts
@@ -1,10 +1,12 @@
 export * as McpGuidance from "./guidance"
 
 import { makeLocationNode } from "../effect/app-node"
+import { Flag } from "../flag/flag"
 import { Context, Effect, Layer, Schema } from "effect"
 import { AgentV2 } from "../agent"
 import { PermissionV2 } from "../permission"
 import { McpTool } from "../tool/mcp"
+import { ToolRegistry } from "../tool/registry"
 import { MCP } from "./index"
 import { SystemContext } from "../system-context/index"
 
@@ -17,6 +19,11 @@ type Summary = typeof Summary.Type
 const entries = (servers: ReadonlyArray<Summary>) =>
   servers.flatMap((server) => [
     `  <server name="${server.server}">`,
+    ...(Flag.CODEMODE_ENABLED
+      ? [
+          `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.codeModeGroup(server.server))}]\`.`,
+        ]
+      : []),
     ...server.instructions.split("\n").map((line) => `    ${line}`),
     "  </server>",
   ])
@@ -59,6 +66,7 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const mcp = yield* MCP.Service
+    const registry = yield* ToolRegistry.Service
 
     return Service.of({
       load: Effect.fn("McpGuidance.load")(function* (selection) {
@@ -67,12 +75,13 @@ export const layer = Layer.effect(
         const [instructions, tools] = yield* Effect.all([mcp.instructions(), mcp.tools()], {
           concurrency: "unbounded",
         })
-        // Hide a server only when every tool it contributes is wholly denied for this agent.
+        if (Flag.CODEMODE_ENABLED && !(yield* registry.executeAvailable(agent.permissions))) return SystemContext.empty
+        // Instructions are useful only when this agent can reach at least one server tool.
         const visible = instructions
           .filter((item) => {
             const owned = tools.filter((tool) => tool.server === item.server)
             return (
-              owned.length === 0 ||
+              (!Flag.CODEMODE_ENABLED && owned.length === 0) ||
               owned.some(
                 (tool) =>
                   PermissionV2.evaluate(McpTool.name(tool.server, tool.name), "*", agent.permissions).effect !== "deny",
@@ -94,4 +103,4 @@ export const layer = Layer.effect(
   }),
 )
 
-export const node = makeLocationNode({ service: Service, layer, deps: [MCP.node] })
+export const node = makeLocationNode({ service: Service, layer, deps: [MCP.node, ToolRegistry.node] })

--- a/packages/core/src/tool/execute.ts
+++ b/packages/core/src/tool/execute.ts
@@ -1,0 +1,140 @@
+export * as ExecuteTool from "./execute"
+
+import {
+  CodeMode,
+  ExecuteInputSchema,
+  ExecuteResultSchema,
+  Tool,
+  toolError,
+  type ToolDefinition,
+} from "@opencode-ai/codemode"
+import { ToolOutput } from "@opencode-ai/llm"
+import { Effect, Ref, Schema } from "effect"
+import { definition, make, settle, type AnyTool } from "./tool"
+
+const ExecuteFile = Schema.Struct({
+  data: Schema.String,
+  mime: Schema.String,
+  name: Schema.optionalKey(Schema.String),
+})
+
+const ExecuteOutput = Schema.Struct({
+  result: ExecuteResultSchema,
+  files: Schema.Array(ExecuteFile),
+})
+
+type CollectedFiles = {
+  readonly index: number
+  readonly files: Array<typeof ExecuteFile.Type>
+}
+
+export interface Registration {
+  readonly identity: object
+  readonly tool: AnyTool
+  readonly name: string
+  readonly group?: string
+}
+
+export const create = (options: {
+  readonly registrations: ReadonlyMap<string, Registration>
+  readonly current: (name: string) => Registration | undefined
+}) => {
+  const runtime = (
+    invoke: (name: string, registration: Registration, input: unknown) => Effect.Effect<unknown, unknown>,
+  ) => {
+    const tools: Record<string, ToolDefinition<never> | Record<string, ToolDefinition<never>>> = {}
+    for (const [name, registration] of options.registrations) {
+      const child = definition(name, registration.tool)
+      const value = Tool.make({
+        description: child.description,
+        input: child.inputSchema,
+        output: child.outputSchema,
+        run: (input) => invoke(name, registration, input),
+      })
+      if (registration.group === undefined) {
+        const path = registration.name
+        if (Object.hasOwn(tools, path)) throw new TypeError(`Deferred tool namespace conflict: ${path}`)
+        tools[path] = value
+        continue
+      }
+      const path = registration.name
+      const namespace = registration.group
+      const group = tools[namespace]
+      if (group && Tool.isDefinition(group)) throw new TypeError(`Deferred tool namespace conflict: ${namespace}`)
+      if (group) {
+        if (Object.hasOwn(group, path)) throw new TypeError(`Deferred tool namespace conflict: ${namespace}.${path}`)
+        group[path] = value
+        continue
+      }
+      const entries: Record<string, ToolDefinition<never>> = {}
+      entries[path] = value
+      tools[namespace] = entries
+    }
+    return CodeMode.make<typeof tools>({ tools })
+  }
+  const discovery = runtime(() => Effect.fail(toolError("Execute context is unavailable")))
+  return make({
+    description: discovery.instructions(),
+    input: ExecuteInputSchema,
+    output: ExecuteOutput,
+    structured: ExecuteResultSchema,
+    toStructuredOutput: ({ output }) => output.result,
+    toModelOutput: ({ output }) => [
+      { type: "text" as const, text: JSON.stringify(output.result) },
+      ...output.files.map((file) => ({
+        type: "file" as const,
+        data: file.data,
+        mime: file.mime,
+        ...(file.name === undefined ? {} : { name: file.name }),
+      })),
+    ],
+    execute: ({ code }, context) =>
+      Effect.gen(function* () {
+        const callIndex = yield* Ref.make(0)
+        const files = yield* Ref.make<Array<CollectedFiles>>([])
+        const result = yield* runtime((name, registration, input) =>
+          Effect.gen(function* () {
+            const index = yield* Ref.getAndUpdate(callIndex, (index) => index + 1)
+            const current = options.current(name)
+            if (!current || current.identity !== registration.identity)
+              return yield* Effect.fail(toolError(`Stale tool call: ${name}`))
+            const output = yield* settle(
+              current.tool,
+              { type: "tool-call", id: context.toolCallID, name, input },
+              {
+                sessionID: context.sessionID,
+                agent: context.agent,
+                assistantMessageID: context.assistantMessageID,
+                toolCallID: context.toolCallID,
+              },
+            ).pipe(Effect.mapError((failure) => toolError(failure.message, failure)))
+            const outputFileParts = outputFiles(output)
+            if (outputFileParts.length > 0)
+              yield* Ref.update(files, (items) => [...items, { index, files: outputFileParts }])
+            return output.structured
+          }),
+        ).execute(code)
+        return {
+          result,
+          files: (yield* Ref.get(files))
+            .toSorted((left, right) => left.index - right.index)
+            .flatMap((item) => item.files),
+        }
+      }),
+  })
+}
+
+function outputFiles(output: ToolOutput): Array<typeof ExecuteFile.Type> {
+  return output.content.flatMap((part) => {
+    if (part.type !== "file") return []
+    const prefix = `data:${part.mime};base64,`
+    if (!part.uri.startsWith(prefix)) return []
+    return [
+      {
+        data: part.uri.slice(prefix.length),
+        mime: part.mime,
+        ...(part.name === undefined ? {} : { name: part.name }),
+      },
+    ]
+  })
+}

--- a/packages/core/src/tool/execute.ts
+++ b/packages/core/src/tool/execute.ts
@@ -3,9 +3,11 @@ export * as ExecuteTool from "./execute"
 import {
   CodeMode,
   ExecuteInputSchema,
-  ExecuteResultSchema,
   Tool,
   toolError,
+  type DataValue,
+  type ExecuteResult,
+  type ToolCallHooks,
   type ToolDefinition,
 } from "@opencode-ai/codemode"
 import { ToolOutput } from "@opencode-ai/llm"
@@ -18,8 +20,23 @@ const ExecuteFile = Schema.Struct({
   name: Schema.optionalKey(Schema.String),
 })
 
+const ExecuteCall = Schema.Struct({
+  tool: Schema.String,
+  status: Schema.Literals(["running", "completed", "error"]),
+  input: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
+})
+
+type ExecuteCall = typeof ExecuteCall.Type
+
+const ExecuteMetadata = Schema.Struct({
+  toolCalls: Schema.Array(ExecuteCall),
+  error: Schema.optionalKey(Schema.Literal(true)),
+})
+
 const ExecuteOutput = Schema.Struct({
-  result: ExecuteResultSchema,
+  output: Schema.String,
+  toolCalls: Schema.Array(ExecuteCall),
+  error: Schema.optionalKey(Schema.Literal(true)),
   files: Schema.Array(ExecuteFile),
 })
 
@@ -41,6 +58,7 @@ export const create = (options: {
 }) => {
   const runtime = (
     invoke: (name: string, registration: Registration, input: unknown) => Effect.Effect<unknown, unknown>,
+    hooks?: ToolCallHooks,
   ) => {
     const tools: Record<string, ToolDefinition<never> | Record<string, ToolDefinition<never>>> = {}
     for (const [name, registration] of options.registrations) {
@@ -70,17 +88,20 @@ export const create = (options: {
       entries[path] = value
       tools[namespace] = entries
     }
-    return CodeMode.make<typeof tools>({ tools })
+    return CodeMode.make<typeof tools>({ tools, ...hooks })
   }
   const discovery = runtime(() => Effect.fail(toolError("Execute context is unavailable")))
   return make({
     description: discovery.instructions(),
     input: ExecuteInputSchema,
     output: ExecuteOutput,
-    structured: ExecuteResultSchema,
-    toStructuredOutput: ({ output }) => output.result,
+    structured: ExecuteMetadata,
+    toStructuredOutput: ({ output }) => ({
+      toolCalls: output.toolCalls,
+      ...(output.error ? { error: true as const } : {}),
+    }),
     toModelOutput: ({ output }) => [
-      { type: "text" as const, text: JSON.stringify(output.result) },
+      { type: "text" as const, text: output.output },
       ...output.files.map((file) => ({
         type: "file" as const,
         data: file.data,
@@ -92,36 +113,86 @@ export const create = (options: {
       Effect.gen(function* () {
         const callIndex = yield* Ref.make(0)
         const files = yield* Ref.make<Array<CollectedFiles>>([])
-        const result = yield* runtime((name, registration, input) =>
-          Effect.gen(function* () {
-            const index = yield* Ref.getAndUpdate(callIndex, (index) => index + 1)
-            const current = options.current(name)
-            if (!current || current.identity !== registration.identity)
-              return yield* Effect.fail(toolError(`Stale tool call: ${name}`))
-            const output = yield* settle(
-              current.tool,
-              { type: "tool-call", id: context.toolCallID, name, input },
-              {
-                sessionID: context.sessionID,
-                agent: context.agent,
-                assistantMessageID: context.assistantMessageID,
-                toolCallID: context.toolCallID,
-              },
-            ).pipe(Effect.mapError((failure) => toolError(failure.message, failure)))
-            const outputFileParts = outputFiles(output)
-            if (outputFileParts.length > 0)
-              yield* Ref.update(files, (items) => [...items, { index, files: outputFileParts }])
-            return output.structured
-          }),
+        const calls = yield* Ref.make<Array<ExecuteCall>>([])
+        // TODO: Publish live call-list updates once V2 has a generic tool progress API.
+        const finalCalls = Ref.get(calls).pipe(
+          Effect.map((items) =>
+            items.map((call) => (call.status === "running" ? { ...call, status: "error" as const } : call)),
+          ),
+        )
+        const result = yield* runtime(
+          (name, registration, input) =>
+            Effect.gen(function* () {
+              const index = yield* Ref.getAndUpdate(callIndex, (index) => index + 1)
+              const current = options.current(name)
+              if (!current || current.identity !== registration.identity)
+                return yield* Effect.fail(toolError(`Stale tool call: ${name}`))
+              const output = yield* settle(
+                current.tool,
+                { type: "tool-call", id: context.toolCallID, name, input },
+                {
+                  sessionID: context.sessionID,
+                  agent: context.agent,
+                  assistantMessageID: context.assistantMessageID,
+                  toolCallID: context.toolCallID,
+                },
+              ).pipe(Effect.mapError((failure) => toolError(failure.message, failure)))
+              const outputFileParts = outputFiles(output)
+              if (outputFileParts.length > 0)
+                yield* Ref.update(files, (items) => [...items, { index, files: outputFileParts }])
+              return output.structured
+            }),
+          {
+            onToolCallStart: ({ index, name, input }) =>
+              Effect.gen(function* () {
+                const shown = displayInput(input)
+                yield* Ref.update(calls, (items) => {
+                  const next = [...items]
+                  next[index] = { tool: name, status: "running", ...(shown ? { input: shown } : {}) }
+                  return next
+                })
+              }),
+            onToolCallEnd: ({ index, outcome }) =>
+              Ref.update(calls, (items) => {
+                const current = items[index]
+                if (!current) return items
+                const next = [...items]
+                next[index] = { ...current, status: outcome === "success" ? "completed" : "error" }
+                return next
+              }),
+          },
         ).execute(code)
-        return {
-          result,
-          files: (yield* Ref.get(files))
-            .toSorted((left, right) => left.index - right.index)
-            .flatMap((item) => item.files),
-        }
+        const toolCalls = yield* finalCalls
+        const collected = (yield* Ref.get(files))
+          .toSorted((left, right) => left.index - right.index)
+          .flatMap((item) => item.files)
+        const output = formatResult(result)
+        return { output, toolCalls, files: collected, ...(result.ok ? {} : { error: true as const }) }
       }),
   })
+}
+
+function displayInput(input: unknown): Record<string, unknown> | undefined {
+  if (input === null || input === undefined) return
+  if (typeof input !== "object" || Array.isArray(input)) return { input }
+  if (Object.keys(input).length === 0) return
+  return input as Record<string, unknown>
+}
+
+function formatResult(result: ExecuteResult) {
+  const output = result.ok
+    ? formatValue(result.value)
+    : [result.error.message, ...(result.error.suggestions ?? []).filter((hint) => !result.error.message.includes(hint))]
+        .join("\n")
+        .trim()
+  if (!result.logs || result.logs.length === 0) return output
+  const logs = `Logs:\n${result.logs.join("\n")}`
+  return output === "" ? logs : `${output}\n\n${logs}`
+}
+
+function formatValue(value: DataValue) {
+  if (typeof value === "string") return value
+  return JSON.stringify(value, null, 2) ?? String(value)
 }
 
 function outputFiles(output: ToolOutput): Array<typeof ExecuteFile.Type> {

--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -5,6 +5,7 @@ import { McpEvent } from "@opencode-ai/schema/mcp-event"
 import { Effect, Exit, type JsonSchema, Layer, Scope, Semaphore, Stream } from "effect"
 import { makeLocationNode } from "../effect/app-node"
 import { EventV2 } from "../event"
+import { Flag } from "../flag/flag"
 import { MCP } from "../mcp"
 import { PermissionV2 } from "../permission"
 import { Tool } from "./tool"
@@ -12,10 +13,10 @@ import { Tools } from "./tools"
 import { ToolRegistry } from "./registry"
 
 /**
- * Registry and permission action name for an MCP tool.
+ * Registry group and permission action names for MCP tools.
  */
-export const name = (server: string, tool: string) =>
-  `${server.replace(/[^a-zA-Z0-9_-]/g, "_")}_${tool.replace(/[^a-zA-Z0-9_-]/g, "_")}`
+export const group = (server: string) => server.replace(/[^a-zA-Z0-9_-]/g, "_")
+export const name = (server: string, tool: string) => `${group(server)}_${tool.replace(/[^a-zA-Z0-9_-]/g, "_")}`
 
 export const layer = Layer.effectDiscard(
   Effect.gen(function* () {
@@ -35,72 +36,81 @@ export const layer = Layer.effectDiscard(
         for (const tool of yield* mcp.tools()) {
           const group = groups.get(tool.server) ?? {}
           const schema = (tool.inputSchema ?? {}) as JsonSchema.JsonSchema
-          group[tool.name] = Tool.make({
-            description: tool.description ?? "",
-            jsonSchema: {
-              ...schema,
-              type: "object",
-              properties: schema.properties ?? {},
-              additionalProperties: false,
-            },
-            execute: (input, context) =>
-              Effect.gen(function* () {
-                yield* permission.assert({
-                  action: name(tool.server, tool.name),
-                  resources: ["*"],
-                  save: ["*"],
-                  metadata: {},
-                  sessionID: context.sessionID,
-                  agent: context.agent,
-                  source: {
-                    type: "tool",
-                    messageID: context.assistantMessageID,
-                    callID: context.toolCallID,
-                  },
-                })
-                const result = yield* mcp
-                  .callTool({
-                    server: tool.server,
-                    name: tool.name,
-                    args: (input ?? {}) as Record<string, unknown>,
+          group[tool.name] = Tool.withPermission(
+            Tool.make({
+              description: tool.description ?? "",
+              jsonSchema: {
+                ...schema,
+                type: "object",
+                properties: schema.properties ?? {},
+                additionalProperties: false,
+              },
+              execute: (input, context) =>
+                Effect.gen(function* () {
+                  yield* permission.assert({
+                    action: name(tool.server, tool.name),
+                    resources: ["*"],
+                    save: ["*"],
+                    metadata: {},
+                    sessionID: context.sessionID,
+                    agent: context.agent,
+                    source: {
+                      type: "tool",
+                      messageID: context.assistantMessageID,
+                      callID: context.toolCallID,
+                    },
                   })
-                  .pipe(
-                    Effect.catchTags({
-                      "MCP.NotFoundError": (error) =>
-                        new ToolFailure({ message: `MCP server "${error.server}" is not available` }),
-                      "MCP.ToolCallError": (error) => new ToolFailure({ message: error.message }),
-                    }),
-                  )
-                if (result.isError)
-                  return yield* new ToolFailure({
-                    message:
-                      result.content
-                        .flatMap((part) => (part.type === "text" ? [part.text] : []))
-                        .join("\n")
-                        .trim() || "MCP tool returned an error",
-                  })
-                return {
-                  structured: result.structured ?? {},
-                  content: result.content.map((part) =>
+                  const result = yield* mcp
+                    .callTool({
+                      server: tool.server,
+                      name: tool.name,
+                      args: (input ?? {}) as Record<string, unknown>,
+                    })
+                    .pipe(
+                      Effect.catchTags({
+                        "MCP.NotFoundError": (error) =>
+                          new ToolFailure({ message: `MCP server "${error.server}" is not available` }),
+                        "MCP.ToolCallError": (error) => new ToolFailure({ message: error.message }),
+                      }),
+                    )
+                  if (result.isError)
+                    return yield* new ToolFailure({
+                      message:
+                        result.content
+                          .flatMap((part) => (part.type === "text" ? [part.text] : []))
+                          .join("\n")
+                          .trim() || "MCP tool returned an error",
+                    })
+                  const content = result.content.map((part) =>
                     part.type === "text"
                       ? { type: "text" as const, text: part.text }
                       : { type: "file" as const, data: part.data, mime: part.mimeType },
+                  )
+                  const text = content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n")
+                  return {
+                    structured: result.structured ?? (text === "" ? null : text),
+                    content,
+                  }
+                }).pipe(
+                  Effect.mapError((error) =>
+                    error instanceof ToolFailure
+                      ? error
+                      : new ToolFailure({ message: `Unable to execute ${name(tool.server, tool.name)}` }),
                   ),
-                }
-              }).pipe(
-                Effect.mapError((error) =>
-                  error instanceof ToolFailure
-                    ? error
-                    : new ToolFailure({ message: `Unable to execute ${name(tool.server, tool.name)}` }),
                 ),
-              ),
-          })
+            }),
+            name(tool.server, tool.name),
+          )
           groups.set(tool.server, group)
         }
         const next = yield* Scope.fork(scope)
-        yield* Effect.forEach(groups, ([group, record]) => tools.register(record, { group }), {
-          discard: true,
-        }).pipe(Scope.provide(next), Effect.orDie)
+        yield* Effect.forEach(
+          groups,
+          ([group, record]) => tools.register(record, { group, deferred: Flag.CODEMODE_ENABLED }),
+          {
+            discard: true,
+          },
+        ).pipe(Scope.provide(next), Effect.orDie)
         if (current) yield* Scope.close(current, Exit.void)
         current = next
       }),

--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -45,35 +45,19 @@ export const layer = Layer.effectDiscard(
             },
             execute: (input, context) =>
               Effect.gen(function* () {
-                yield* permission
-                  .assert({
-                    action: name(tool.server, tool.name),
-                    resources: ["*"],
-                    save: ["*"],
-                    metadata: {},
-                    sessionID: context.sessionID,
-                    agent: context.agent,
-                    source: {
-                      type: "tool",
-                      messageID: context.assistantMessageID,
-                      callID: context.toolCallID,
-                    },
-                  })
-                  .pipe(
-                    Effect.mapError(
-                      (error) =>
-                        new ToolFailure({
-                          message:
-                            error instanceof PermissionV2.CorrectedError
-                              ? error.feedback
-                              : error instanceof PermissionV2.DeniedError
-                                ? "Permission denied"
-                                : error instanceof PermissionV2.RejectedError
-                                  ? "Permission rejected"
-                                  : error.message,
-                        }),
-                    ),
-                  )
+                yield* permission.assert({
+                  action: name(tool.server, tool.name),
+                  resources: ["*"],
+                  save: ["*"],
+                  metadata: {},
+                  sessionID: context.sessionID,
+                  agent: context.agent,
+                  source: {
+                    type: "tool",
+                    messageID: context.assistantMessageID,
+                    callID: context.toolCallID,
+                  },
+                })
                 const result = yield* mcp
                   .callTool({
                     server: tool.server,
@@ -103,7 +87,13 @@ export const layer = Layer.effectDiscard(
                       : { type: "file" as const, data: part.data, mime: part.mimeType },
                   ),
                 }
-              }),
+              }).pipe(
+                Effect.mapError((error) =>
+                  error instanceof ToolFailure
+                    ? error
+                    : new ToolFailure({ message: `Unable to execute ${name(tool.server, tool.name)}` }),
+                ),
+              ),
           })
           groups.set(tool.server, group)
         }

--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -45,19 +45,35 @@ export const layer = Layer.effectDiscard(
             },
             execute: (input, context) =>
               Effect.gen(function* () {
-                yield* permission.assert({
-                  action: name(tool.server, tool.name),
-                  resources: ["*"],
-                  save: ["*"],
-                  metadata: {},
-                  sessionID: context.sessionID,
-                  agent: context.agent,
-                  source: {
-                    type: "tool",
-                    messageID: context.assistantMessageID,
-                    callID: context.toolCallID,
-                  },
-                })
+                yield* permission
+                  .assert({
+                    action: name(tool.server, tool.name),
+                    resources: ["*"],
+                    save: ["*"],
+                    metadata: {},
+                    sessionID: context.sessionID,
+                    agent: context.agent,
+                    source: {
+                      type: "tool",
+                      messageID: context.assistantMessageID,
+                      callID: context.toolCallID,
+                    },
+                  })
+                  .pipe(
+                    Effect.mapError(
+                      (error) =>
+                        new ToolFailure({
+                          message:
+                            error instanceof PermissionV2.CorrectedError
+                              ? error.feedback
+                              : error instanceof PermissionV2.DeniedError
+                                ? "Permission denied"
+                                : error instanceof PermissionV2.RejectedError
+                                  ? "Permission rejected"
+                                  : error.message,
+                        }),
+                    ),
+                  )
                 const result = yield* mcp
                   .callTool({
                     server: tool.server,

--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -6,6 +6,7 @@ import { Effect, Exit, type JsonSchema, Layer, Scope, Semaphore, Stream } from "
 import { makeLocationNode } from "../effect/app-node"
 import { EventV2 } from "../event"
 import { MCP } from "../mcp"
+import { PermissionV2 } from "../permission"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
 import { ToolRegistry } from "./registry"
@@ -21,6 +22,7 @@ export const layer = Layer.effectDiscard(
     const mcp = yield* MCP.Service
     const tools = yield* Tools.Service
     const events = yield* EventV2.Service
+    const permission = yield* PermissionV2.Service
     const scope = yield* Scope.Scope
     const lock = Semaphore.makeUnsafe(1)
     let current: Scope.Closeable | undefined
@@ -41,8 +43,21 @@ export const layer = Layer.effectDiscard(
               properties: schema.properties ?? {},
               additionalProperties: false,
             },
-            execute: (input) =>
+            execute: (input, context) =>
               Effect.gen(function* () {
+                yield* permission.assert({
+                  action: name(tool.server, tool.name),
+                  resources: ["*"],
+                  save: ["*"],
+                  metadata: {},
+                  sessionID: context.sessionID,
+                  agent: context.agent,
+                  source: {
+                    type: "tool",
+                    messageID: context.assistantMessageID,
+                    callID: context.toolCallID,
+                  },
+                })
                 const result = yield* mcp
                   .callTool({
                     server: tool.server,
@@ -96,5 +111,5 @@ export const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "mcp-tools",
   layer,
-  deps: [ToolRegistry.toolsNode, MCP.node, EventV2.node],
+  deps: [ToolRegistry.toolsNode, MCP.node, EventV2.node, PermissionV2.node],
 })

--- a/packages/core/src/tool/registry.ts
+++ b/packages/core/src/tool/registry.ts
@@ -35,7 +35,7 @@ export interface MaterializeInput {
 }
 
 export interface Materialization {
-  readonly definitions: ReadonlyArray<ToolDefinition>
+  readonly definitions: ReadonlyArray<ReturnType<typeof definition>>
   readonly settle: (input: ExecuteInput) => Effect.Effect<Settlement, ToolOutputStore.Error>
 }
 

--- a/packages/core/src/tool/registry.ts
+++ b/packages/core/src/tool/registry.ts
@@ -3,12 +3,14 @@ export * as ToolRegistry from "./registry"
 import { ToolOutput, type ToolCall, type ToolDefinition, type ToolResultValue } from "@opencode-ai/llm"
 import { Context, Effect, Layer, Scope } from "effect"
 import type { AgentV2 } from "../agent"
+import { Flag } from "../flag/flag"
 import { PermissionV2 } from "../permission"
 import { SessionMessage } from "../session/message"
 import { SessionSchema } from "../session/schema"
 import { ToolOutputStore } from "../tool-output-store"
 import { Wildcard } from "../util/wildcard"
-import { definition, permission, registrationEntries, settle, type AnyTool, type RegistrationError } from "./tool"
+import { ExecuteTool } from "./execute"
+import { definition, permission, registrationEntries, RegistrationError, settle, type AnyTool } from "./tool"
 import { Tools } from "./tools"
 import { ToolHooks } from "./hooks"
 import { makeLocationNode } from "../effect/app-node"
@@ -35,7 +37,7 @@ export interface MaterializeInput {
 }
 
 export interface Materialization {
-  readonly definitions: ReadonlyArray<ReturnType<typeof definition>>
+  readonly definitions: ReadonlyArray<ToolDefinition>
   readonly settle: (input: ExecuteInput) => Effect.Effect<Settlement, ToolOutputStore.Error>
 }
 
@@ -61,18 +63,8 @@ const registryLayer = Layer.effect(
     }
     const local = new Map<string, Array<{ readonly token: object; readonly registration: Registration }>>()
 
-    const settleWith = Effect.fn("ToolRegistry.settle")(function* (input: ExecuteInput, advertised?: object) {
-      const registration = local.get(input.call.name)?.at(-1)?.registration
-      if (!registration)
-        return {
-          result: {
-            type: "error" as const,
-            value: advertised ? `Stale tool call: ${input.call.name}` : `Unknown tool: ${input.call.name}`,
-          },
-        }
-      if (advertised && registration.identity !== advertised)
-        return { result: { type: "error" as const, value: `Stale tool call: ${input.call.name}` } }
-      // Hooks fire only for hosted/local tools; provider-executed calls never reach settleWith.
+    const settleTool = Effect.fn("ToolRegistry.settleTool")(function* (input: ExecuteInput, tool: AnyTool) {
+      // Hooks fire only for hosted/local tools; provider-executed calls never reach settleTool.
       const beforeEvent: ToolHooks.BeforeEvent = {
         tool: input.call.name,
         sessionID: input.sessionID,
@@ -83,7 +75,7 @@ const registryLayer = Layer.effect(
       }
       yield* toolHooks.runBefore(beforeEvent)
       const pending = yield* settle(
-        registration.tool,
+        tool,
         { ...input.call, input: beforeEvent.input },
         {
           sessionID: input.sessionID,
@@ -135,10 +127,29 @@ const registryLayer = Layer.effect(
       }
     })
 
+    const settleWith = Effect.fn("ToolRegistry.settle")(function* (input: ExecuteInput, advertised: object) {
+      const registration = local.get(input.call.name)?.at(-1)?.registration
+      if (!registration)
+        return {
+          result: {
+            type: "error" as const,
+            value: `Stale tool call: ${input.call.name}`,
+          },
+        }
+      if (registration.identity !== advertised)
+        return { result: { type: "error" as const, value: `Stale tool call: ${input.call.name}` } }
+      return yield* settleTool(input, registration.tool)
+    })
+
     return Service.of({
       register: Effect.fn("ToolRegistry.register")(function* (tools, options) {
         const entries = registrationEntries(tools, options?.group)
         if (entries.length === 0) return
+        const reserved = options?.deferred ? undefined : entries.find((entry) => entry.key === "execute")
+        if (reserved)
+          return yield* Effect.fail(
+            new RegistrationError({ name: reserved.key, message: 'Tool name "execute" is reserved for CodeMode' }),
+          )
         yield* Effect.uninterruptible(
           Effect.gen(function* () {
             const token = {}
@@ -180,16 +191,29 @@ const registryLayer = Layer.effect(
         for (const [name, registration] of registrations) {
           const wrongEditTool = name === "apply_patch" ? !usePatch : (name === "edit" || name === "write") && usePatch
           if (
-            registration.deferred ||
             wrongEditTool ||
+            (registration.deferred && !Flag.CODEMODE_ENABLED) ||
             whollyDisabled(permission(registration.tool, name), input.permissions ?? [])
           )
             registrations.delete(name)
         }
+        const direct = new Map(Array.from(registrations).filter(([, registration]) => !registration.deferred))
+        const deferred = new Map(Array.from(registrations).filter(([, registration]) => registration.deferred))
+        const execute =
+          deferred.size > 0 && !whollyDisabled("execute", input.permissions ?? [])
+            ? ExecuteTool.create({
+                registrations: deferred,
+                current: (name) => local.get(name)?.at(-1)?.registration,
+              })
+            : undefined
         return {
-          definitions: Array.from(registrations, ([name, registration]) => definition(name, registration.tool)),
+          definitions: [
+            ...Array.from(direct, ([name, registration]) => definition(name, registration.tool)),
+            ...(execute ? [definition("execute", execute)] : []),
+          ],
           settle: (input) => {
-            const registration = registrations.get(input.call.name)
+            if (input.call.name === "execute" && execute) return settleTool(input, execute)
+            const registration = direct.get(input.call.name)
             if (registration) return settleWith(input, registration.identity)
             return Effect.succeed({ result: { type: "error", value: `Unknown tool: ${input.call.name}` } })
           },

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -79,12 +79,17 @@ it.effect("waits for permission before calling an MCP tool", () =>
     const permission = yield* Deferred.make<void>()
     decision = Deferred.await(permission)
     const registry = yield* ToolRegistry.Service
-    yield* waitForTool(registry, "demo_search")
+    yield* waitForTool(registry, "execute")
 
     const fiber = yield* settleTool(registry, {
       sessionID: SessionV2.ID.make("ses_mcp_permission"),
       ...toolIdentity,
-      call: { type: "tool-call", id: "call_mcp_permission", name: "demo_search", input: {} },
+      call: {
+        type: "tool-call",
+        id: "call_mcp_permission",
+        name: "execute",
+        input: { code: "return await tools.demo.search({})" },
+      },
     }).pipe(Effect.forkScoped)
     expect(yield* Deferred.await(assertion)).toEqual({
       action: "demo_search",
@@ -113,15 +118,23 @@ it.effect("does not call MCP when permission is rejected", () =>
     assertion = yield* Deferred.make<PermissionV2.AssertInput>()
     decision = Effect.fail(new PermissionV2.RejectedError())
     const registry = yield* ToolRegistry.Service
-    yield* waitForTool(registry, "demo_search")
+    yield* waitForTool(registry, "execute")
 
-    expect(
-      yield* settleTool(registry, {
-        sessionID: SessionV2.ID.make("ses_mcp_rejected"),
-        ...toolIdentity,
-        call: { type: "tool-call", id: "call_mcp_rejected", name: "demo_search", input: {} },
-      }),
-    ).toEqual({ result: { type: "error", value: "Unable to execute demo_search" } })
+    const settlement = yield* settleTool(registry, {
+      sessionID: SessionV2.ID.make("ses_mcp_rejected"),
+      ...toolIdentity,
+      call: {
+        type: "tool-call",
+        id: "call_mcp_rejected",
+        name: "execute",
+        input: { code: "return await tools.demo.search({})" },
+      },
+    })
+    expect(settlement.result).toEqual({ type: "text", value: "Unable to execute demo_search" })
+    expect(settlement.output?.structured).toEqual({
+      toolCalls: [{ tool: "demo.search", status: "error" }],
+      error: true,
+    })
     expect(calls).toBe(0)
   }),
 )

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -14,7 +14,7 @@ import { testEffect } from "./lib/effect"
 import { settleTool, toolIdentity, waitForTool } from "./lib/tool"
 
 let assertion: Deferred.Deferred<PermissionV2.AssertInput> | undefined
-let permission: Deferred.Deferred<void> | undefined
+let decision: Effect.Effect<void, PermissionV2.Error> = Effect.void
 let calls = 0
 
 const mcp = Layer.mock(MCP.Service, {
@@ -42,9 +42,9 @@ const mcp = Layer.mock(MCP.Service, {
 const permissions = Layer.mock(PermissionV2.Service, {
   assert: (input) =>
     Effect.gen(function* () {
-      if (!assertion || !permission) return yield* Effect.die("Permission test is not initialized")
+      if (!assertion) return yield* Effect.die("Permission test is not initialized")
       yield* Deferred.succeed(assertion, input)
-      yield* Deferred.await(permission)
+      yield* decision
     }),
 })
 const events = Layer.mock(EventV2.Service, { subscribe: () => Stream.never })
@@ -76,7 +76,8 @@ it.effect("waits for permission before calling an MCP tool", () =>
   Effect.gen(function* () {
     calls = 0
     assertion = yield* Deferred.make<PermissionV2.AssertInput>()
-    permission = yield* Deferred.make<void>()
+    const permission = yield* Deferred.make<void>()
+    decision = Deferred.await(permission)
     const registry = yield* ToolRegistry.Service
     yield* waitForTool(registry, "demo_search")
 
@@ -103,5 +104,24 @@ it.effect("waits for permission before calling an MCP tool", () =>
     yield* Deferred.succeed(permission, undefined)
     yield* Fiber.join(fiber)
     expect(calls).toBe(1)
+  }),
+)
+
+it.effect("does not call MCP when permission is rejected", () =>
+  Effect.gen(function* () {
+    calls = 0
+    assertion = yield* Deferred.make<PermissionV2.AssertInput>()
+    decision = Effect.fail(new PermissionV2.RejectedError())
+    const registry = yield* ToolRegistry.Service
+    yield* waitForTool(registry, "demo_search")
+
+    expect(
+      yield* settleTool(registry, {
+        sessionID: SessionV2.ID.make("ses_mcp_rejected"),
+        ...toolIdentity,
+        call: { type: "tool-call", id: "call_mcp_rejected", name: "demo_search", input: {} },
+      }),
+    ).toEqual({ result: { type: "error", value: "Unable to execute demo_search" } })
+    expect(calls).toBe(0)
   }),
 )

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -1,7 +1,61 @@
 import { describe, expect, test } from "bun:test"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { EventV2 } from "@opencode-ai/core/event"
 import { MCP } from "@opencode-ai/core/mcp/index"
 import { MCPClient } from "@opencode-ai/core/mcp/client"
+import { PermissionV2 } from "@opencode-ai/core/permission"
+import { SessionV2 } from "@opencode-ai/core/session"
 import { McpTool } from "@opencode-ai/core/tool/mcp"
+import { ToolRegistry } from "@opencode-ai/core/tool/registry"
+import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
+import { Deferred, Effect, Fiber, Layer, Stream } from "effect"
+import { testEffect } from "./lib/effect"
+import { settleTool, toolIdentity, waitForTool } from "./lib/tool"
+
+let assertion: Deferred.Deferred<PermissionV2.AssertInput> | undefined
+let permission: Deferred.Deferred<void> | undefined
+let calls = 0
+
+const mcp = Layer.mock(MCP.Service, {
+  tools: () =>
+    Effect.succeed([
+      new MCP.Tool({
+        server: MCP.ServerName.make("demo"),
+        name: "search",
+        description: "Search",
+        inputSchema: { type: "object", properties: {} },
+      }),
+    ]),
+  callTool: (input) =>
+    Effect.sync(() => {
+      calls += 1
+      return new MCP.ToolResult({
+        server: MCP.ServerName.make(input.server),
+        tool: input.name,
+        isError: false,
+        structured: { ok: true },
+        content: [],
+      })
+    }),
+})
+const permissions = Layer.mock(PermissionV2.Service, {
+  assert: (input) =>
+    Effect.gen(function* () {
+      if (!assertion || !permission) return yield* Effect.die("Permission test is not initialized")
+      yield* Deferred.succeed(assertion, input)
+      yield* Deferred.await(permission)
+    }),
+})
+const events = Layer.mock(EventV2.Service, { subscribe: () => Stream.never })
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([ToolRegistry.node, ToolRegistry.toolsNode, McpTool.node]), [
+    [MCP.node, mcp],
+    [PermissionV2.node, permissions],
+    [EventV2.node, events],
+    [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
+  ]),
+)
 
 describe("MCP errors", () => {
   test("expose useful messages", () => {
@@ -17,3 +71,37 @@ describe("MCP errors", () => {
 test("MCP tool names match V1 sanitization", () => {
   expect(McpTool.name("context 7", "resolve.library/id")).toBe("context_7_resolve_library_id")
 })
+
+it.effect("waits for permission before calling an MCP tool", () =>
+  Effect.gen(function* () {
+    calls = 0
+    assertion = yield* Deferred.make<PermissionV2.AssertInput>()
+    permission = yield* Deferred.make<void>()
+    const registry = yield* ToolRegistry.Service
+    yield* waitForTool(registry, "demo_search")
+
+    const fiber = yield* settleTool(registry, {
+      sessionID: SessionV2.ID.make("ses_mcp_permission"),
+      ...toolIdentity,
+      call: { type: "tool-call", id: "call_mcp_permission", name: "demo_search", input: {} },
+    }).pipe(Effect.forkScoped)
+    expect(yield* Deferred.await(assertion)).toEqual({
+      action: "demo_search",
+      resources: ["*"],
+      save: ["*"],
+      metadata: {},
+      sessionID: SessionV2.ID.make("ses_mcp_permission"),
+      agent: toolIdentity.agent,
+      source: {
+        type: "tool",
+        messageID: toolIdentity.assistantMessageID,
+        callID: "call_mcp_permission",
+      },
+    })
+    expect(calls).toBe(0)
+
+    yield* Deferred.succeed(permission, undefined)
+    yield* Fiber.join(fiber)
+    expect(calls).toBe(1)
+  }),
+)

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -154,6 +154,7 @@ describe("PluginV2", () => {
       expect((yield* registry.materialize({ model: testModel })).definitions.map((tool) => tool.name)).toEqual([
         "plain",
         "context_7_look_up",
+        "execute",
       ])
     }),
   )


### PR DESCRIPTION
## Summary
- expose deferred Core tools through a synthetic CodeMode `execute` tool
- defer MCP tools behind Execute when CodeMode is enabled while preserving direct fallback
- project nested call metadata and forward file content through Execute

## Verification
- `bun typecheck` in `packages/codemode`
- targeted Core typecheck for changed feature files
- `git diff --check`

Tests were not run per instruction.