### PR TITLE
fix(protocol): expose MCP tool change events

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -5406,6 +5406,14 @@ export type EventSubscribeOutput =
       readonly id: string
       readonly created: number
       readonly metadata?: { readonly [x: string]: unknown }
+      readonly type: "mcp.tools.changed"
+      readonly location?: { readonly directory: string; readonly workspaceID?: string }
+      readonly data: { readonly server: string }
+    }
+  | {
+      readonly id: string
+      readonly created: number
+      readonly metadata?: { readonly [x: string]: unknown }
       readonly type: "mcp.status.changed"
       readonly location?: { readonly directory: string; readonly workspaceID?: string }
       readonly data: { readonly server: string }

--- a/packages/protocol/test/event.test.ts
+++ b/packages/protocol/test/event.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { Event } from "@opencode-ai/schema/event"
+import { AbsolutePath } from "@opencode-ai/schema/schema"
+import { DateTime, Schema } from "effect"
+import { OpenCodeEvent } from "../src/groups/event.js"
+
+test("encodes MCP tool changes emitted by the server", () => {
+  expect(
+    Schema.encodeSync(OpenCodeEvent)({
+      id: Event.ID.make("evt_test"),
+      created: DateTime.makeUnsafe(0),
+      type: "mcp.tools.changed",
+      location: { directory: AbsolutePath.make("/tmp") },
+      data: { server: "example" },
+    }),
+  ).toEqual({
+    id: "evt_test",
+    created: 0,
+    type: "mcp.tools.changed",
+    location: { directory: "/tmp" },
+    data: { server: "example" },
+  })
+})

--- a/packages/schema/src/event-manifest.ts
+++ b/packages/schema/src/event-manifest.ts
@@ -78,7 +78,7 @@ export const ServerDefinitions = Event.inventory(
   ...TuiEvent.Definitions,
   ...InstallationEvent.Definitions,
   ...VcsEvent.Definitions,
-  McpEvent.StatusChanged,
+  ...McpEvent.Definitions,
   // Shared transitional: V1 contracts the current TUI still consumes during
   // the migration (permission.asked/replied, question.asked, session.error).
   // Remove when the TUI moves to the current permission/question surfaces.

--- a/packages/schema/test/event-manifest.test.ts
+++ b/packages/schema/test/event-manifest.test.ts
@@ -27,6 +27,7 @@ describe("public event manifest", () => {
       Agent.Event.Updated,
     ])
     expect(EventManifest.Definitions).toContain(Agent.Event.Updated)
+    expect(EventManifest.ServerDefinitions).toContain(McpEvent.ToolsChanged)
     expect(EventManifest.Definitions.filter((definition) => definition.type === "agent.updated")).toEqual([
       Agent.Event.Updated,
     ])


### PR DESCRIPTION
## Summary

- expose `mcp.tools.changed` in the V2 server event manifest
- prevent the SSE encoder from rejecting MCP tool refresh events and terminating connected daemons
- regenerate the promise client event union and add regression coverage

## Root cause

Core publishes `McpEvent.ToolsChanged` after an MCP server connects, but `EventManifest.ServerDefinitions` only included `McpEvent.StatusChanged`. `/api/event` therefore failed to encode the tool-change event as `V2Event`, closing the event stream and causing the shared V2 daemon to restart repeatedly.

## Verification

- `packages/schema`: `bun test --timeout 5000 test/event-manifest.test.ts`
- `packages/schema`: `bun typecheck`
- `packages/protocol`: `bun test --timeout 5000 test/event.test.ts test/session-cursor.test.ts`
- `packages/protocol`: `bun typecheck`
- `packages/client`: `bun typecheck`
- repository pre-push typecheck
- file-scoped Prettier and oxlint
- direct A/B schema check confirms the old event union rejects the logged payload and the patched `OpenCodeEvent` encodes it