### PR TITLE
fix(opencode): guard plugin SDK bootstrap version against dev placeholder

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -12,6 +12,7 @@ import { Auth } from "../auth"
 import { Env } from "../env"
 import { applyEdits, modify } from "jsonc-parser"
 import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
+import { pluginSdkVersion } from "./plugin-sdk-version"
 import { existsSync } from "fs"
 import { Account } from "@/account/account"
 import { isRecord } from "@/util/record"
@@ -439,7 +440,7 @@ const layer = Layer.effect(
               add: [
                 {
                   name: "@opencode-ai/plugin",
-                  version: InstallationLocal ? undefined : InstallationVersion,
+                  version: pluginSdkVersion(InstallationVersion, InstallationLocal),
                 },
               ],
             })

--- a/packages/opencode/src/config/plugin-sdk-version.ts
+++ b/packages/opencode/src/config/plugin-sdk-version.ts
@@ -1,0 +1,28 @@
+import { InstallationLocal, InstallationVersion } from "@opencode-ai/core/installation/version"
+
+/**
+ * Resolves the version spec used to bootstrap the `@opencode-ai/plugin` SDK
+ * into a config directory.
+ *
+ * Returns `undefined` when the resolved version is missing or holds the dev
+ * placeholder `"local"`, so the package manager falls back to the latest
+ * published release instead of failing on `@opencode-ai/plugin@local`.
+ *
+ * `InstallationVersion` defaults to the string `"local"` when the build-time
+ * `OPENCODE_VERSION` define is absent (e.g. some local/dev builds). That value
+ * is fine for display (User-Agent, telemetry) but is not a valid npm version,
+ * and leaking it into the bootstrap install produces a recurring
+ * `NpmInstallFailedError` on every config-directory scan.
+ */
+export function pluginSdkVersion(version: string | undefined, isLocal: boolean): string | undefined {
+  if (isLocal) return undefined
+  if (!version) return undefined
+  if (version === "local") return undefined
+  return version
+}
+
+/**
+ * Convenience binding to the live installation constants. Kept as a thunk so
+ * the resolution is testable against arbitrary inputs via {@link pluginSdkVersion}.
+ */
+export const livePluginSdkVersion = (): string | undefined => pluginSdkVersion(InstallationVersion, InstallationLocal)

--- a/packages/opencode/test/config/plugin-sdk-version.test.ts
+++ b/packages/opencode/test/config/plugin-sdk-version.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import { pluginSdkVersion } from "@/config/plugin-sdk-version"
+
+// `pluginSdkVersion` decides what version spec — if any — gets handed to the
+// package manager when bootstrapping `@opencode-ai/plugin` into a config
+// directory. It must never forward the dev placeholder `"local"`: that string
+// is a valid display value for User-Agent/telemetry but is not a valid npm
+// version, and leaking it surfaces as a recurring `NpmInstallFailedError`
+// (`@opencode-ai/plugin@local`) on every config-directory scan.
+
+describe("pluginSdkVersion", () => {
+  test("returns undefined for a local channel, even with a real version", () => {
+    expect(pluginSdkVersion("1.2.3", true)).toBeUndefined()
+  })
+
+  test("returns undefined when the version is the dev placeholder `local`", () => {
+    expect(pluginSdkVersion("local", false)).toBeUndefined()
+  })
+
+  test("returns undefined when the version is empty", () => {
+    expect(pluginSdkVersion("", false)).toBeUndefined()
+  })
+
+  test("returns undefined when the version is absent", () => {
+    expect(pluginSdkVersion(undefined, false)).toBeUndefined()
+  })
+
+  test("passes a published version through unchanged", () => {
+    expect(pluginSdkVersion("1.2.3", false)).toBe("1.2.3")
+  })
+
+  // Regression: the previous inline ternary at the config-dir bootstrap site —
+  //   `version: InstallationLocal ? undefined : InstallationVersion`
+  // — only guarded on the *channel* (`InstallationLocal`). When the channel
+  // resolved to a real value but the build-time `OPENCODE_VERSION` define was
+  // absent (so `InstallationVersion === "local"`), the dev placeholder leaked
+  // straight through into the npm spec and every scan failed with
+  // `@opencode-ai/plugin@local`.
+  test("regression: channel is non-local but version defaulted to `local` no longer leaks", () => {
+    // Models the desktop case: OPENCODE_VERSION define missing → "local",
+    // while OPENCODE_CHANNEL resolved to a real channel (so InstallationLocal is false).
+    expect(pluginSdkVersion("local", false)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

opencode emits a recurring background install failure on every config-directory scan:

```
NpmInstallFailedError: Failed to install dependencies.
@opencode-ai/plugin@local.
```

The bootstrap in `packages/opencode/src/config/config.ts` hands `InstallationVersion` to the package manager as the version spec for `@opencode-ai/plugin`. `InstallationVersion` defaults to the string `"local"` when the build-time `OPENCODE_VERSION` define is absent (`packages/core/src/installation/version.ts`):

```ts
export const InstallationVersion = typeof OPENCODE_VERSION === "string" ? OPENCODE_VERSION : "local"
```

That `"local"` placeholder is a valid display value for User-Agent / telemetry, but it is **not** a valid npm version. The inline guard at the call site keyed on the *channel*, not the version:

```ts
version: InstallationLocal ? undefined : InstallationVersion
```

So any build whose channel resolved to a real value (non-local) while `OPENCODE_VERSION` was unset — e.g. local/desktop builds where the define is not injected into the bundle — leaked `"local"` straight into the npm spec, and every scan failed.

## Fix

Extracts a pure, unit-tested helper that rejects `"local"` / empty / absent versions and returns `undefined` (so the package manager resolves the latest published release) regardless of channel:

```ts
// packages/opencode/src/config/plugin-sdk-version.ts
export function pluginSdkVersion(version: string | undefined, isLocal: boolean): string | undefined {
  if (isLocal) return undefined
  if (!version) return undefined
  if (version === "local") return undefined
  return version
}
```

Call site:

```ts
version: pluginSdkVersion(InstallationVersion, InstallationLocal),
```

Keeping the helper pure (constants passed in, no globals) makes the failure mode directly unit-testable — the regression case is exactly the desktop scenario: channel non-local, version defaulted to `"local"`.

## Why a defensive guard (and not just the build)

The deeper root cause is that some build targets do not inject `OPENCODE_VERSION` into the core bundle. Fixing every build target is valuable, but a defensive guard at the npm-spec boundary prevents any future regression from producing a hard, recurring install failure — `"local"` is never a valid npm version, so rejecting it here is correct on its own merits. The guard is belt-and-suspenders; it does not preclude also fixing the build injection.

## Tests

New `packages/opencode/test/config/plugin-sdk-version.test.ts` (6 cases) mirrors the style of the existing `entry-name.test.ts`:

- returns `undefined` for a local channel, even with a real version
- returns `undefined` when version is the dev placeholder `"local"`
- returns `undefined` when version is empty
- returns `undefined` when version is absent
- passes a published version through unchanged
- **regression**: channel non-local + version defaulted to `"local"` no longer leaks

## Verification

| Check | Result |
|---|---|
| New tests | 6/6 pass |
| `test/config/` suite (regression) | 187 pass / 0 fail |
| `bun run typecheck` (all 30 packages) | clean |
| `bun run lint` (changed files) | 0 errors |

## Scope

3 files, +74/-1. No behavior change for published builds (`InstallationVersion` is a real semver → passed through unchanged). Only builds where the version resolves to `"local"`/empty are affected, and they now fall back to latest instead of crashing.