### PR TITLE
fix(protocol): keep internal events off SSE

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -5406,14 +5406,6 @@ export type EventSubscribeOutput =
       readonly id: string
       readonly created: number
       readonly metadata?: { readonly [x: string]: unknown }
-      readonly type: "mcp.tools.changed"
-      readonly location?: { readonly directory: string; readonly workspaceID?: string }
-      readonly data: { readonly server: string }
-    }
-  | {
-      readonly id: string
-      readonly created: number
-      readonly metadata?: { readonly [x: string]: unknown }
       readonly type: "mcp.status.changed"
       readonly location?: { readonly directory: string; readonly workspaceID?: string }
       readonly data: { readonly server: string }

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -11,6 +11,7 @@ import { Location } from "./location"
 import { makeGlobalNode } from "./effect/app-node"
 import { isDeepStrictEqual } from "node:util"
 import { Durable } from "@opencode-ai/schema/durable-event-manifest"
+import { EventManifest } from "@opencode-ai/schema/event-manifest"
 
 export const ID = Event.ID
 export type ID = import("@opencode-ai/schema/event").ID
@@ -160,19 +161,29 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Event") {}
 
-export const liveBounded = (events: Interface, capacity: number) =>
+const isServerEvent = Schema.is(Schema.Union(EventManifest.ServerDefinitions))
+
+export const serverLive = (events: Interface) => events.live().pipe(Stream.filter(isServerEvent))
+
+const bounded = (events: Interface, capacity: number, accept: (event: Payload) => boolean) =>
   Effect.gen(function* () {
     const queue = yield* Queue.dropping<Payload, SubscriberOverflowError>(capacity)
     const unsubscribe = yield* events.listen((event) =>
-      Queue.offer(queue, event).pipe(
-        Effect.flatMap((accepted) =>
-          accepted ? Effect.void : Queue.fail(queue, new SubscriberOverflowError({ capacity })).pipe(Effect.asVoid),
-        ),
-      ),
+      !accept(event)
+        ? Effect.void
+        : Queue.offer(queue, event).pipe(
+            Effect.flatMap((accepted) =>
+              accepted ? Effect.void : Queue.fail(queue, new SubscriberOverflowError({ capacity })).pipe(Effect.asVoid),
+            ),
+          ),
     )
     yield* Effect.addFinalizer(() => unsubscribe.pipe(Effect.andThen(Queue.shutdown(queue)), Effect.asVoid))
     return Stream.fromQueue(queue)
   })
+
+export const liveBounded = (events: Interface, capacity: number) => bounded(events, capacity, () => true)
+
+export const serverLiveBounded = (events: Interface, capacity: number) => bounded(events, capacity, isServerEvent)
 
 export interface LayerOptions {
   readonly beforeAggregateRead?: (aggregateID: string) => Effect.Effect<void>

--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -11,7 +11,6 @@ import { Location } from "./location"
 import { makeGlobalNode } from "./effect/app-node"
 import { isDeepStrictEqual } from "node:util"
 import { Durable } from "@opencode-ai/schema/durable-event-manifest"
-import { EventManifest } from "@opencode-ai/schema/event-manifest"
 
 export const ID = Event.ID
 export type ID = import("@opencode-ai/schema/event").ID
@@ -161,29 +160,26 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Event") {}
 
-const isServerEvent = Schema.is(Schema.Union(EventManifest.ServerDefinitions))
-
-export const serverLive = (events: Interface) => events.live().pipe(Stream.filter(isServerEvent))
-
-const bounded = (events: Interface, capacity: number, accept: (event: Payload) => boolean) =>
+export const liveBounded = (
+  events: Interface,
+  options: { readonly capacity: number; readonly accept?: (event: Payload) => boolean },
+) =>
   Effect.gen(function* () {
-    const queue = yield* Queue.dropping<Payload, SubscriberOverflowError>(capacity)
+    const queue = yield* Queue.dropping<Payload, SubscriberOverflowError>(options.capacity)
     const unsubscribe = yield* events.listen((event) =>
-      !accept(event)
+      options.accept && !options.accept(event)
         ? Effect.void
         : Queue.offer(queue, event).pipe(
             Effect.flatMap((accepted) =>
-              accepted ? Effect.void : Queue.fail(queue, new SubscriberOverflowError({ capacity })).pipe(Effect.asVoid),
+              accepted
+                ? Effect.void
+                : Queue.fail(queue, new SubscriberOverflowError({ capacity: options.capacity })).pipe(Effect.asVoid),
             ),
           ),
     )
     yield* Effect.addFinalizer(() => unsubscribe.pipe(Effect.andThen(Queue.shutdown(queue)), Effect.asVoid))
     return Stream.fromQueue(queue)
   })
-
-export const liveBounded = (events: Interface, capacity: number) => bounded(events, capacity, () => true)
-
-export const serverLiveBounded = (events: Interface, capacity: number) => bounded(events, capacity, isServerEvent)
 
 export interface LayerOptions {
   readonly beforeAggregateRead?: (aggregateID: string) => Effect.Effect<void>

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -1,7 +1,8 @@
 export * as PluginHost from "./host"
 
 import type { PluginContext } from "@opencode-ai/plugin/v2/effect"
-import { Effect, Schema } from "effect"
+import { EventManifest } from "@opencode-ai/schema/event-manifest"
+import { Effect, Schema, Stream } from "effect"
 import { AgentV2 } from "../agent"
 import { AISDK } from "../aisdk"
 import { Catalog } from "../catalog"
@@ -157,7 +158,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: PluginV2.Int
         }),
     },
     event: {
-      subscribe: () => EventV2.serverLive(events),
+      subscribe: () => events.live().pipe(Stream.filter(EventManifest.isServer)),
     },
     integration: {
       list: () => response(integration.list()),

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -1,8 +1,7 @@
 export * as PluginHost from "./host"
 
 import type { PluginContext } from "@opencode-ai/plugin/v2/effect"
-import { EventManifest } from "@opencode-ai/schema/event-manifest"
-import { Effect, Schema, Stream } from "effect"
+import { Effect, Schema } from "effect"
 import { AgentV2 } from "../agent"
 import { AISDK } from "../aisdk"
 import { Catalog } from "../catalog"
@@ -23,8 +22,6 @@ import { ToolHooks } from "../tool/hooks"
 import { WorkspaceV2 } from "../workspace"
 
 const mutable = <T>(value: T) => value as DeepMutable<T>
-const isEvent = Schema.is(Schema.Union(EventManifest.ServerDefinitions))
-
 export const make = Effect.fn("PluginHost.make")(function* (plugin: PluginV2.Interface) {
   const agents = yield* AgentV2.Service
   const aisdk = yield* AISDK.Service
@@ -160,7 +157,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: PluginV2.Int
         }),
     },
     event: {
-      subscribe: () => events.live().pipe(Stream.filter(isEvent)),
+      subscribe: () => EventV2.serverLive(events),
     },
     integration: {
       list: () => response(integration.list()),

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { Cause, DateTime, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Schema, Stream } from "effect"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Event } from "@opencode-ai/schema/event"
+import { McpEvent } from "@opencode-ai/schema/mcp-event"
 import { Session } from "@opencode-ai/schema/session"
 import { SessionEvent } from "@opencode-ai/schema/session-event"
 import { SessionV1 } from "@opencode-ai/schema/session-v1"
@@ -352,6 +353,20 @@ describe("EventV2", () => {
         expect.objectContaining({ data: { text: "overflow" } }),
         last,
       ])
+    }),
+  )
+
+  it.effect("filters internal events before they enter a bounded server stream", () =>
+    Effect.gen(function* () {
+      const events = yield* EventV2.Service
+      const stream = yield* EventV2.serverLiveBounded(events, 1)
+      const received = yield* stream.pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
+
+      yield* events.publish(McpEvent.BrowserOpenFailed, { mcpName: "one", url: "https://example.com/one" })
+      yield* events.publish(McpEvent.BrowserOpenFailed, { mcpName: "two", url: "https://example.com/two" })
+      const published = yield* events.publish(McpEvent.StatusChanged, { server: "example" })
+
+      expect(Array.from(yield* Fiber.join(received))).toEqual([published])
     }),
   )
 

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { Cause, DateTime, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Schema, Stream } from "effect"
 import { EventV2 } from "@opencode-ai/core/event"
 import { Event } from "@opencode-ai/schema/event"
+import { EventManifest } from "@opencode-ai/schema/event-manifest"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"
 import { Session } from "@opencode-ai/schema/session"
 import { SessionEvent } from "@opencode-ai/schema/session-event"
@@ -330,8 +331,8 @@ describe("EventV2", () => {
       const events = yield* EventV2.Service
       const consuming = yield* Deferred.make<void>()
       const release = yield* Deferred.make<void>()
-      const slowStream = yield* EventV2.liveBounded(events, 1)
-      const fastStream = yield* EventV2.liveBounded(events, 8)
+      const slowStream = yield* EventV2.liveBounded(events, { capacity: 1 })
+      const fastStream = yield* EventV2.liveBounded(events, { capacity: 8 })
       const slow = yield* slowStream.pipe(
         Stream.runForEach(() => Deferred.succeed(consuming, undefined).pipe(Effect.andThen(Deferred.await(release)))),
         Effect.forkScoped,
@@ -359,11 +360,11 @@ describe("EventV2", () => {
   it.effect("filters internal events before they enter a bounded server stream", () =>
     Effect.gen(function* () {
       const events = yield* EventV2.Service
-      const stream = yield* EventV2.serverLiveBounded(events, 1)
+      const stream = yield* EventV2.liveBounded(events, { capacity: 1, accept: EventManifest.isServer })
       const received = yield* stream.pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
 
-      yield* events.publish(McpEvent.BrowserOpenFailed, { mcpName: "one", url: "https://example.com/one" })
-      yield* events.publish(McpEvent.BrowserOpenFailed, { mcpName: "two", url: "https://example.com/two" })
+      yield* events.publish(McpEvent.ToolsChanged, { server: "one" })
+      yield* events.publish(McpEvent.ToolsChanged, { server: "two" })
       const published = yield* events.publish(McpEvent.StatusChanged, { server: "example" })
 
       expect(Array.from(yield* Fiber.join(received))).toEqual([published])

--- a/packages/protocol/src/groups/event.ts
+++ b/packages/protocol/src/groups/event.ts
@@ -67,3 +67,5 @@ export const EventGroup = event.group
 export const OpenCodeEvent = event.schema
 export type OpenCodeEvent = typeof OpenCodeEvent.Type
 export type OpenCodeEventEncoded = typeof OpenCodeEvent.Encoded
+export const isOpenCodeEvent = (event: { readonly type: string }): event is OpenCodeEvent =>
+  event.type === "server.connected" || EventManifest.isServer(event)

--- a/packages/protocol/test/event.test.ts
+++ b/packages/protocol/test/event.test.ts
@@ -1,23 +1,8 @@
 import { expect, test } from "bun:test"
-import { Event } from "@opencode-ai/schema/event"
-import { AbsolutePath } from "@opencode-ai/schema/schema"
-import { DateTime, Schema } from "effect"
-import { OpenCodeEvent } from "../src/groups/event.js"
+import { isOpenCodeEvent } from "../src/groups/event.js"
 
-test("encodes MCP tool changes emitted by the server", () => {
-  expect(
-    Schema.encodeSync(OpenCodeEvent)({
-      id: Event.ID.make("evt_test"),
-      created: DateTime.makeUnsafe(0),
-      type: "mcp.tools.changed",
-      location: { directory: AbsolutePath.make("/tmp") },
-      data: { server: "example" },
-    }),
-  ).toEqual({
-    id: "evt_test",
-    created: 0,
-    type: "mcp.tools.changed",
-    location: { directory: "/tmp" },
-    data: { server: "example" },
-  })
+test("classifies public events by type", () => {
+  expect(isOpenCodeEvent({ type: "server.connected" })).toBe(true)
+  expect(isOpenCodeEvent({ type: "mcp.status.changed" })).toBe(true)
+  expect(isOpenCodeEvent({ type: "mcp.tools.changed" })).toBe(false)
 })

--- a/packages/schema/src/event-manifest.ts
+++ b/packages/schema/src/event-manifest.ts
@@ -1,5 +1,6 @@
 export * as EventManifest from "./event-manifest.js"
 
+import { Schema } from "effect"
 import { Agent } from "./agent.js"
 import { Catalog } from "./catalog.js"
 import { Command } from "./command.js"
@@ -78,7 +79,7 @@ export const ServerDefinitions = Event.inventory(
   ...TuiEvent.Definitions,
   ...InstallationEvent.Definitions,
   ...VcsEvent.Definitions,
-  ...McpEvent.Definitions,
+  McpEvent.StatusChanged,
   // Shared transitional: V1 contracts the current TUI still consumes during
   // the migration (permission.asked/replied, question.asked, session.error).
   // Remove when the TUI moves to the current permission/question surfaces.
@@ -86,6 +87,9 @@ export const ServerDefinitions = Event.inventory(
   ...QuestionV1.Event.Definitions,
   SessionV1.Error,
 )
+export const Server = Event.latest(ServerDefinitions)
+export type ServerEvent = Schema.Schema.Type<(typeof ServerDefinitions)[number]>
+export const isServer = (event: { readonly type: string }): event is ServerEvent => Server.has(event.type)
 
 export const Definitions = Event.inventory(
   ...foundationDefinitions,

--- a/packages/schema/test/event-manifest.test.ts
+++ b/packages/schema/test/event-manifest.test.ts
@@ -27,7 +27,6 @@ describe("public event manifest", () => {
       Agent.Event.Updated,
     ])
     expect(EventManifest.Definitions).toContain(Agent.Event.Updated)
-    expect(EventManifest.ServerDefinitions).toContain(McpEvent.ToolsChanged)
     expect(EventManifest.Definitions.filter((definition) => definition.type === "agent.updated")).toEqual([
       Agent.Event.Updated,
     ])
@@ -47,6 +46,8 @@ describe("public event manifest", () => {
       EventManifest.Definitions.map((definition) => definition.type),
     )
     expect(EventManifest.Latest.get("agent.updated")).toBe(Agent.Event.Updated)
+    expect(EventManifest.Server.get("mcp.status.changed")).toBe(McpEvent.StatusChanged)
+    expect(EventManifest.Server.has("mcp.tools.changed")).toBe(false)
     expect(Agent.Event.Updated.durable).toBeUndefined()
     expect(EventManifest.Durable.has("agent.updated")).toBe(false)
   })

--- a/packages/server/src/handlers/event.ts
+++ b/packages/server/src/handlers/event.ts
@@ -35,7 +35,7 @@ export const EventHandler = HttpApiBuilder.group(Api, "server.event", (handlers)
           const output = Stream.unwrap(
             Effect.gen(function* () {
               // Acquiring the bounded stream installs its listener before readiness is observable.
-              const live = yield* EventV2.liveBounded(events, subscriberCapacity)
+              const live = yield* EventV2.serverLiveBounded(events, subscriberCapacity)
               return Stream.make(connected).pipe(Stream.concat(live))
             }),
           ).pipe(Stream.map(eventData), Stream.pipeThroughChannel(Sse.encode()))

--- a/packages/server/src/handlers/event.ts
+++ b/packages/server/src/handlers/event.ts
@@ -1,5 +1,5 @@
 import { EventV2 } from "@opencode-ai/core/event"
-import { OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
+import { isOpenCodeEvent, OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
 import { Effect, Schema, Stream } from "effect"
 import { Sse } from "effect/unstable/encoding"
 import { HttpServerResponse } from "effect/unstable/http"
@@ -35,7 +35,10 @@ export const EventHandler = HttpApiBuilder.group(Api, "server.event", (handlers)
           const output = Stream.unwrap(
             Effect.gen(function* () {
               // Acquiring the bounded stream installs its listener before readiness is observable.
-              const live = yield* EventV2.serverLiveBounded(events, subscriberCapacity)
+              const live = yield* EventV2.liveBounded(events, {
+                capacity: subscriberCapacity,
+                accept: isOpenCodeEvent,
+              })
               return Stream.make(connected).pipe(Stream.concat(live))
             }),
           ).pipe(Stream.map(eventData), Stream.pipeThroughChannel(Sse.encode()))


### PR DESCRIPTION
## Summary

- keep `mcp.tools.changed` on the internal event bus and remove it from the generated public client
- classify public events with a precomputed type registry instead of validating every payload per subscriber
- let bounded streams reject internal events before enqueueing
- reuse the same public-event classifier for SSE and plugin subscriptions

## Why

Follow-up to #35373. `mcp.tools.changed` is an internal invalidation consumed by Core to rebuild the model tool registry. The public `/api/mcp` resource exposes connection status only, and the TUI refreshes it from the separate public `mcp.status.changed` event.

The daemon failure happened because `/api/event` sent the broad internal bus directly into the narrower public encoder. This change enforces the public manifest before enqueueing while preserving strict schema encoding for events that are public.

The longer-term question of explicit event visibility remains tracked in #35379.

## Verification

- `packages/core`: `bun run test -- test/event.test.ts` (53 passing)
- `packages/schema`: `bun test --timeout 5000 test/event-manifest.test.ts`
- `packages/protocol`: `bun test --timeout 5000 test/event.test.ts test/session-cursor.test.ts`
- Schema, Protocol, Client, Core, and Server typechecks
- repository pre-push typecheck (31 packages)
- Prettier and file-scoped oxlint (no new warnings)