### PR TITLE
fix(core): await OpenCode provider readiness

### DIFF
--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -104,6 +104,11 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
       })
       draft.method.update(oauth(http))
       draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key (service account)" } })
+      const env = draft.method.list("opencode").find((method) => method.type === "env")
+      draft.method.update({
+        integrationID: "opencode",
+        method: { type: "env", names: Array.from(new Set([...(env?.names ?? []), "OPENCODE_CONSOLE_TOKEN"])) },
+      })
     })
 
     connected = (yield* ctx.integration.connection.active("opencode")) !== undefined
@@ -188,7 +193,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
       Stream.runForEach(refresh),
       Effect.forkScoped({ startImmediately: true }),
     )
-    yield* refresh().pipe(Effect.forkScoped)
+    yield* refresh()
   }),
 })
 

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Fiber } from "effect"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { EventV2 } from "@opencode-ai/core/event"
@@ -28,20 +28,6 @@ const addPlugin = Effect.fn(function* () {
 function required<T>(value: T | undefined): T {
   if (value === undefined) throw new Error("Expected value")
   return value
-}
-
-function eventually<A>(
-  effect: Effect.Effect<A>,
-  predicate: (value: A) => boolean,
-  remaining = 1000,
-): Effect.Effect<A, Error> {
-  return Effect.gen(function* () {
-    const value = yield* effect
-    if (predicate(value)) return value
-    if (remaining === 0) return yield* Effect.fail(new Error("Timed out waiting for value"))
-    yield* Effect.promise(() => Bun.sleep(1))
-    return yield* eventually(effect, predicate, remaining - 1)
-  })
 }
 
 function withEnv<A, E, R>(vars: Record<string, string | undefined>, effect: () => Effect.Effect<A, E, R>) {
@@ -78,6 +64,7 @@ describe("OpencodePlugin", () => {
           label: "OpenCode Console account",
         },
         { type: "key", label: "API key (service account)" },
+        { type: "env", names: ["OPENCODE_CONSOLE_TOKEN"] },
       ])
     }),
   )
@@ -159,16 +146,12 @@ describe("OpencodePlugin", () => {
             }),
           })
 
-          yield* addPlugin()
+          const loading = yield* Effect.forkScoped(addPlugin())
           expect(authorization).toEqual([])
           release()
+          yield* Fiber.join(loading)
 
-          const provider = required(
-            yield* eventually(
-              catalog.provider.get(ProviderV2.ID.make("remote")),
-              (item) => item?.integrationID === Integration.ID.make("opencode"),
-            ),
-          )
+          const provider = required(yield* catalog.provider.get(ProviderV2.ID.make("remote")))
           expect(provider).toMatchObject({
             name: "Remote",
             integrationID: "opencode",
@@ -215,7 +198,7 @@ describe("OpencodePlugin", () => {
   )
 
   it.effect("uses a public key and disables paid models without credentials", () =>
-    withEnv({ OPENCODE_API_KEY: undefined }, () =>
+    withEnv({ OPENCODE_API_KEY: undefined, OPENCODE_CONSOLE_TOKEN: undefined }, () =>
       Effect.gen(function* () {
         const catalog = yield* Catalog.Service
         yield* catalog.transform((catalog) => {
@@ -241,7 +224,7 @@ describe("OpencodePlugin", () => {
   )
 
   it.effect("keeps free models without credentials", () =>
-    withEnv({ OPENCODE_API_KEY: undefined }, () =>
+    withEnv({ OPENCODE_API_KEY: undefined, OPENCODE_CONSOLE_TOKEN: undefined }, () =>
       Effect.gen(function* () {
         const catalog = yield* Catalog.Service
         yield* catalog.transform((catalog) => {
@@ -267,7 +250,7 @@ describe("OpencodePlugin", () => {
   )
 
   it.effect("treats output-only cost as free without credentials", () =>
-    withEnv({ OPENCODE_API_KEY: undefined }, () =>
+    withEnv({ OPENCODE_API_KEY: undefined, OPENCODE_CONSOLE_TOKEN: undefined }, () =>
       Effect.gen(function* () {
         const catalog = yield* Catalog.Service
         yield* catalog.transform((catalog) => {
@@ -295,7 +278,7 @@ describe("OpencodePlugin", () => {
   )
 
   it.effect("uses OPENCODE_API_KEY as credentials", () =>
-    withEnv({ OPENCODE_API_KEY: "secret" }, () =>
+    withEnv({ OPENCODE_API_KEY: "secret", OPENCODE_CONSOLE_TOKEN: undefined }, () =>
       Effect.gen(function* () {
         const catalog = yield* Catalog.Service
         yield* catalog.transform((catalog) => {
@@ -321,7 +304,7 @@ describe("OpencodePlugin", () => {
   )
 
   it.effect("uses configured provider env vars as credentials", () =>
-    withEnv({ OPENCODE_API_KEY: undefined, CUSTOM_OPENCODE_API_KEY: "secret" }, () =>
+    withEnv({ OPENCODE_API_KEY: undefined, OPENCODE_CONSOLE_TOKEN: undefined, CUSTOM_OPENCODE_API_KEY: "secret" }, () =>
       Effect.gen(function* () {
         const catalog = yield* Catalog.Service
         const integrations = yield* Integration.Service
@@ -354,7 +337,7 @@ describe("OpencodePlugin", () => {
   )
 
   it.effect("uses configured apiKey as credentials", () =>
-    withEnv({ OPENCODE_API_KEY: undefined }, () =>
+    withEnv({ OPENCODE_API_KEY: undefined, OPENCODE_CONSOLE_TOKEN: undefined }, () =>
       Effect.gen(function* () {
         const catalog = yield* Catalog.Service
         yield* catalog.transform((catalog) => {
@@ -387,7 +370,7 @@ describe("OpencodePlugin", () => {
   )
 
   it.effect("ignores non-opencode providers and models", () =>
-    withEnv({ OPENCODE_API_KEY: undefined }, () =>
+    withEnv({ OPENCODE_API_KEY: undefined, OPENCODE_CONSOLE_TOKEN: undefined }, () =>
       Effect.gen(function* () {
         const catalog = yield* Catalog.Service
         yield* catalog.transform((catalog) => {


### PR DESCRIPTION
## Summary
- register `OPENCODE_CONSOLE_TOKEN` as an OpenCode integration env credential without replacing configured env names
- wait for the initial remote provider configuration refresh before the plugin becomes ready
- update provider tests to assert readiness synchronously and isolate Console-token environment state

This prevents the first prompt in a cold or reactivated Location from resolving paid models before the Console catalog and credential route are ready.

## Testing
- `bun test test/plugin/provider-opencode.test.ts`
- `bun typecheck` in `packages/core`
- repository pre-push `bun turbo typecheck` (31 packages passed)

## Additional test note
Running all provider test files in one Bun invocation currently hits an unrelated existing provider-plugin circular initialization error (`AzureCognitiveServicesPlugin` before initialization). The focused suite, Core typecheck, and repository pre-push typecheck pass.