### PR TITLE
fix(github): tolerate a rate-limited release lookup

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -44,8 +44,15 @@ runs:
     - name: Get opencode version
       id: version
       shell: bash
+      env:
+        # Authenticate the API request to use the 1000/hr rate limit instead of
+        # the 60/hr unauthenticated per-IP limit that shared runners often hit.
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
-        VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+        # `shell: bash` runs with `-e -o pipefail`, so a failed lookup (e.g. an
+        # API rate-limit 403) would abort the step before the ${VERSION:-latest}
+        # fallback runs. `|| true` keeps the failure non-fatal so we fall back.
+        VERSION=$(curl -sf -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4 || true)
         echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
 
     - name: Cache opencode


### PR DESCRIPTION
### Problem

The `Get opencode version` step in `github/action.yml` resolves the release tag with:

```sh
VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
```

Composite `shell: bash` steps run under `bash -e -o pipefail`. When the **unauthenticated** GitHub API call hits the 60-requests/hour per-IP rate limit — common on shared runners — `curl -sf` fails, `pipefail` propagates the non-zero status to the `$(...)` assignment, and `-e` aborts the step **before** the `${VERSION:-latest}` fallback on the next line can run. The whole action then fails, even though the author clearly intended the lookup to be best-effort.

In consumers this surfaces as short (~20–30s) spurious failures of the review job; the same endpoint returns `200` when retried moments later.

### Fix

Two minimal changes, confined to that one step:

- Append `|| true` inside the command substitution so a failed lookup yields an empty `VERSION` and falls back to `latest`, as originally intended.
- Send `Authorization: Bearer ${{ github.token }}` so the request uses the 1000/hr authenticated limit instead of the 60/hr per-IP one — making the failure rare in the first place.

The `version` output is only used as the `actions/cache` key for `~/.opencode/bin`; the install step always fetches from `https://opencode.ai/install`, so falling back to `latest` is functionally harmless — it just changes the cache key.

### Verification

Reproduced locally under `bash -e -o pipefail`, pointing `curl` at a non-2xx endpoint to simulate a rate-limited response:

| Case | Result |
| --- | --- |
| **Before**, failed lookup | step exits `1`; the `version=` fallback line never executes |
| **After** (`\|\| true`), failed lookup | step exits `0` and emits `version=latest` |
| **After**, happy path (auth + real endpoint) | resolves the real tag (`v1.17.13`) |
