### PR TITLE
fix(core): resolve MCP union ambiguity with discriminator

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -108,7 +108,12 @@ export const Info = Schema.Struct({
     description: "Custom provider configurations and model overrides",
   }),
   mcp: Schema.optional(
-    Schema.Record(Schema.String, Schema.Union([ConfigMCPV1.Info, Schema.Struct({ enabled: Schema.Boolean })])),
+    Schema.Record(
+      Schema.String,
+      Schema.Union([ConfigMCPV1.Info, Schema.Struct({ enabled: Schema.Boolean })]).annotate({
+        discriminator: "type",
+      }),
+    ),
   ).annotate({ description: "MCP (Model Context Protocol) server configurations" }),
   formatter: Schema.optional(ConfigFormatterV1.Info).annotate({
     description:


### PR DESCRIPTION
### Issue for this PR

Closes #35359

### Type of change

- [x] Bug fix

### What does this PR do?

When MCP config entries include `enabled` or `environment` keys, all CLI commands exit 1 with zero stdout/stderr. The root cause is a non-discriminated `Schema.Union([ConfigMCPV1.Info, Schema.Struct({ enabled: Schema.Boolean })])` in the `mcp` field of `ConfigV1.Info`. With `errors: "all"` mode in `ConfigParse.schema`, all union members are evaluated. When an entry has `enabled: true` (also an optional field on `Local`), both members match the input, creating an ambiguity that Effect Schema 4.0.0-beta.83 reports as a parse error. This throws an `InvalidError` inside `Effect.fnUntraced`, becoming an uncaught defect that kills the process.

Added `{ discriminator: "type" }` to the outer `Schema.Union`. The discriminator routes entries with `type: "local"/"remote"` unambiguously to `ConfigMCPV1.Info`, while entries without `type` fall through to `{ enabled: boolean }` (used for config-layering disable overrides).

### How did you verify your code works?

The change is a one-line addition of `{ discriminator: "type" }` annotation to an existing `Schema.Union`, following the exact same pattern already used by `ConfigMCPV1.Info` (line 62 of mcp.ts). The discriminator makes the union unambiguous: entries with `type` route exclusively to `ConfigMCPV1.Info`, entries without `type` fall through to `{ enabled: boolean }`. The existing `isMcpConfigured` check (`"type" in entry`) in the MCP service remains correct since the decoded output shape is unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
