### PR TITLE
fix(core): sync __drizzle_migrations when behind migration table

### DIFF
--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -66,6 +66,31 @@ export function applyOnly(db: Database, input: Migration[]) {
       }
     }
 
+    // Reverse sync: if __drizzle_migrations is behind the migration table,
+    // backfill it so Drizzle's schema tracker stays coherent. This happens
+    // when the CLI binary ships more migrations than the plugin has tracked.
+    if (
+      completed.size > 0 &&
+      (yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${"__drizzle_migrations"}`))
+    ) {
+      const maxId = (yield* db.get<{ maxId: number }>(
+        sql`SELECT COALESCE(MAX(id), 0) as maxId FROM __drizzle_migrations`,
+      ))?.maxId ?? 0
+      yield* db.run(sql`
+        INSERT OR IGNORE INTO __drizzle_migrations (id, hash, created_at, name, applied_at)
+        SELECT
+          ${maxId} + ROW_NUMBER() OVER (ORDER BY m.id) - 1,
+          'synced',
+          CAST(strftime('%s', 'now') AS INTEGER),
+          m.id,
+          CAST(strftime('%s', 'now') AS INTEGER)
+        FROM migration m
+        WHERE m.id NOT IN (
+          SELECT d.name FROM __drizzle_migrations d WHERE d.name IS NOT NULL
+        )
+      `)
+    }
+
     for (const migration of input) {
       if (completed.has(migration.id)) continue
       yield* db.transaction((tx) =>


### PR DESCRIPTION
### Issue for this PR

Fixes #35403

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The existing migration reconciliation only seeds the `migration` table from `__drizzle_migrations` -- not the reverse. When the CLI binary auto-updates past the plugin's migration count, `__drizzle_migrations` falls behind. The task tool then fails because Drizzle's tracker doesn't know about columns added by later migrations.

After the existing forward-seed (where an empty `migration` table is populated from the old Drizzle journal), this adds a reverse-sync that backfills any migration IDs present in the `migration` table but missing from `__drizzle_migrations`. Uses sequential IDs after the current max, with `'synced'` as hash.

### How did you verify your code works?

Applied the equivalent SQL manually on a real database where `migration` had 38 entries and `__drizzle_migrations` had 21. After the backfill, both tables were in sync and the task tool ran without errors.

### Screenshots / recordings

N/A -- non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR