### PR TITLE
fix(tui): align integration empty state

### DIFF
--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -81,7 +81,11 @@ export function DialogIntegration(props: { onConnected?: OnIntegrationConnected 
     <DialogSelect
       title="Connect a service"
       options={options()}
-      emptyView={<text fg={theme.textMuted}>No integrations available</text>}
+      emptyView={
+        <box paddingLeft={4} paddingRight={4} paddingTop={1}>
+          <text fg={theme.textMuted}>No integrations available</text>
+        </box>
+      }
     />
   )
 }


### PR DESCRIPTION
## Summary
- wrap the integration dialog empty state with the standard select content padding
- align the empty message with the dialog title and search field

## Testing
- `bun typecheck` in `packages/tui`
- `bun test` in `packages/tui` (204 pass, 1 skip)
- verified the zero-result integration dialog with `termctrl`

Fixes #35216