### PR TITLE
fix(opencode): stop sending tools when `tool_call` is false

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1223,24 +1223,26 @@ const layer = Layer.effect(
             const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
             const promptOps = yield* ops()
 
-            const tools = yield* SessionTools.resolve({
-              agent,
-              session,
-              model,
-              processor: handle,
-              bypassAgentCheck,
-              messages: msgs,
-              promptOps,
-            }).pipe(
-              Effect.provideService(Plugin.Service, plugin),
-              Effect.provideService(Permission.Service, permission),
-              Effect.provideService(ToolRegistry.Service, registry),
-              Effect.provideService(MCP.Service, mcp),
-              Effect.provideService(Truncate.Service, truncate),
-              Effect.provideService(RuntimeFlags.Service, flags),
-            )
+            const tools: Record<string, AITool> = model.capabilities.toolcall
+              ? yield* SessionTools.resolve({
+                  agent,
+                  session,
+                  model,
+                  processor: handle,
+                  bypassAgentCheck,
+                  messages: msgs,
+                  promptOps,
+                }).pipe(
+                  Effect.provideService(Plugin.Service, plugin),
+                  Effect.provideService(Permission.Service, permission),
+                  Effect.provideService(ToolRegistry.Service, registry),
+                  Effect.provideService(MCP.Service, mcp),
+                  Effect.provideService(Truncate.Service, truncate),
+                  Effect.provideService(RuntimeFlags.Service, flags),
+                )
+              : {}
 
-            if (lastUser.format?.type === "json_schema") {
+            if (lastUser.format?.type === "json_schema" && model.capabilities.toolcall) {
               tools["StructuredOutput"] = createStructuredOutputTool({
                 schema: lastUser.format.schema,
                 onSuccess(output) {
@@ -1268,6 +1270,15 @@ const layer = Layer.effect(
               ...(skills ? [skills] : []),
             ]
             const format = lastUser.format ?? { type: "text" as const }
+            if (format.type === "json_schema" && !model.capabilities.toolcall) {
+              handle.message.error = new SessionV1.StructuredOutputError({
+                message: "Structured output format requires tool calls, but tool_call is disabled for this model",
+                retries: 0,
+              }).toObject()
+              handle.message.time.completed = Date.now()
+              yield* sessions.updateMessage(handle.message)
+              return "break" as const
+            }
             if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({
               user: lastUser,
@@ -1282,7 +1293,7 @@ const layer = Layer.effect(
               ],
               tools,
               model,
-              toolChoice: format.type === "json_schema" ? "required" : undefined,
+              toolChoice: !model.capabilities.toolcall ? "none" : format.type === "json_schema" ? "required" : undefined,
             })
 
             if (structured !== undefined) {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -714,6 +714,25 @@ noLLMServer.instance.skip(
   { config: cfg },
 )
 
+noLLMServer.instance(
+  "prompt loop does not crash when toolcall is false",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "No toolcall" })
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      const result = yield* prompt.loop({ sessionID: session.id })
+      expect(result.info.role).toBe("assistant")
+    }),
+  { config: { ...cfg, provider: { test: { ...cfg.provider.test, models: { "test-model": { ...cfg.provider.test.models["test-model"], tool_call: false } } } } } },
+)
+
 it.instance("static loop returns assistant text through local provider", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #19966
Closes #35432

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`tool_call: false` in model config was stored in `capabilities.toolcall` but never checked in the prompt loop. `SessionTools.resolve()` ran unconditionally, tools were sent in every LLM request with `tool_choice: "auto"`. Providers that do not support tool calling (e.g. local Ollama models, morphllm without special flags) returned 400.

Three changes in `packages/opencode/src/session/prompt.ts`:

1. Guard `SessionTools.resolve()` behind `model.capabilities.toolcall` - skip tools entirely when `false`.
2. Set `toolChoice: "none"` when `toolcall` is `false` (the default `undefined` becomes `"auto"` at the provider).
3. When `format.type === "json_schema"` and `toolcall` is `false`, fail fast with a clear `StructuredOutputError` instead of pushing a misleading system prompt and making a doomed LLM call.

### How did you verify your code works?

- Read the AI SDK source: `prepareToolsAndToolChoice` drops both empty tools and `toolChoice` before the HTTP body is serialized, so no `tools` or `tool_choice` key reaches the provider when toolcalling is disabled.
- `bun typecheck` passes.
- Existing prompt tests pass. Added a regression test under `noLLMServer.instance` that verifies the loop does not crash with `tool_call: false`.
- Built a single binary and ran the smoke test.

### Screenshots / recordings

Not a UI change.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
