### PR TITLE
docs: add model scorecard to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-model-scorecard](https://github.com/bnc4vk/opencode-model-scorecard)                     | Show model task scores, token prices, and token efficiency on the TUI home screen                  |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #35436

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

this PR adds a single line to link the model scorecard TUI plugin within the ecosystem documentation.

### How did you verify your code works?

- `git diff --check`
- Confirmed the entry appears in `packages/web/src/content/docs/ecosystem.mdx` under `## Plugins`
- Confirmed the diff only adds one ecosystem documentation row

### Screenshots / recordings

N/A, docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR