### PR TITLE
fix(opencode): stop silent session title generation failures

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -215,10 +215,23 @@ const layer = Layer.effect(
 
       const ag = yield* agents.get("title")
       if (!ag) return
-      const mdl = ag.model
-        ? yield* provider.getModel(ag.model.providerID, ag.model.modelID)
-        : ((yield* provider.getSmallModel(input.providerID)) ??
-          (yield* provider.getModel(input.providerID, input.modelID)))
+
+      // Typed Fail from getModel/getSmallModel used to kill the forked fiber; with
+      // Effect.ignore at the call site that left titles stuck on the default name (#13710).
+      // Effect.option only maps Fail→None (defects still surface via catchCause below).
+      const mdlOpt = yield* Effect.gen(function* () {
+        if (ag.model) return yield* provider.getModel(ag.model.providerID, ag.model.modelID)
+        return (
+          (yield* provider.getSmallModel(input.providerID)) ??
+          (yield* provider.getModel(input.providerID, input.modelID))
+        )
+      }).pipe(
+        Effect.tapError((err) => Effect.logWarning("title model resolution failed", { error: err })),
+        Effect.option,
+      )
+      if (Option.isNone(mdlOpt)) return
+      const mdl = mdlOpt.value
+
       const msgs = onlySubtasks
         ? [{ role: "user" as const, content: subtasks.map((p) => p.prompt).join("\n") }]
         : yield* MessageV2.toModelMessagesEffect(context, mdl)
@@ -238,7 +251,10 @@ const layer = Layer.effect(
           Stream.filter(LLMEvent.is.textDelta),
           Stream.map((e) => e.text),
           Stream.mkString,
-          Effect.orDie,
+          // Fail channel errors: log and yield empty title instead of dying the fiber.
+          Effect.catchAll((err) =>
+            Effect.logWarning("title generation LLM call failed", { error: err }).pipe(Effect.as("")),
+          ),
         )
       const cleaned = text
         .replace(/<think>[\s\S]*?<\/think>\s*/g, "")
@@ -1136,7 +1152,16 @@ const layer = Layer.effect(
               modelID: lastUser.model.modelID,
               providerID: lastUser.model.providerID,
               history: msgs,
-            }).pipe(Effect.ignore, Effect.forkIn(scope))
+            }).pipe(
+              Effect.catchCause((cause) =>
+                Cause.hasInterruptsOnly(cause)
+                  ? Effect.void
+                  : Effect.logWarning("title generation background task failed", {
+                      error: Cause.squash(cause),
+                    }),
+              ),
+              Effect.forkIn(scope),
+            )
 
           const model = yield* getModel(lastUser.model.providerID, lastUser.model.modelID, sessionID)
           const task = tasks.pop()


### PR DESCRIPTION
### Issue for this PR

Closes #13710

### Type of change

- [x] Bug fix

### What does this PR do?

Session auto-naming (`ensureTitle`) can fail **silently**, leaving sessions as `New session - <timestamp>`.

**Confirmed root causes on `dev`:**

| Layer | Before | After |
|-------|--------|--------|
| Model resolution | unguarded `getModel` Fail → fiber dies | `Effect.option` + warning log |
| LLM stream | `Effect.orDie` → unlogged defect | `Effect.catchAll` → log + empty text |
| Fork call site | `Effect.ignore` swallows everything | `Effect.catchCause` logs (skips interrupt-only) |
| `small: true` | present | **kept** (preserves `smallOptions`, avoids #20269 / #20323) |

**Out of scope:** multi-provider fallback, smallOptions gaps, speculative multi-second retry loops.

### How did you verify your code works?

- Diff-reviewed against upstream `ensureTitle` failure chain
- Single-file, ~30 lines, no behavior policy change beyond observability + survival

### Author

- @1837620622 (传康Kk)
- `35034498+1837620622@users.noreply.github.com` (GitHub-verified)

### Checklist

- [x] Linked issue
- [x] Minimal, focused change