### PR TITLE
docs: add @jorgelorenz/opencode-latex-pdf-review to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [@jorgelorenz/opencode-latex-pdf-review](https://github.com/jorgelorenz/latex-pdf-review)          | Synchronized LaTeX ↔ PDF review viewer with SyncTeX forward/inverse search |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds my plugin to the ecosystem list. It opens a split PDF + LaTeX editor in the browser with SyncTeX support — click in the PDF to jump to the source line, and vice versa. Useful for reviewing LaTeX documents inside an OpenCode session.

### How did you verify your code works?

I use it in my own LaTeX projects. Published on npm as `@jorgelorenz/opencode-latex-pdf-review`.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR