### PR TITLE
fix(provider): skip includeUsage for incompatible OpenAI-compatible hosts

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1661,8 +1661,36 @@ const layer = Layer.effect(
           delete options.fetch
         }
 
-        if (model.api.npm.includes("@ai-sdk/openai-compatible") && options["includeUsage"] !== false) {
-          options["includeUsage"] = true
+        if (model.api.npm.includes("@ai-sdk/openai-compatible")) {
+          if (options["includeUsage"] !== false) {
+            // Some OpenAI-compatible providers return 400 when stream_options.includeUsage
+            // is sent. Skip it for known incompatible hosts unless the user explicitly
+            // opted in by setting includeUsage: true.
+            const baseURLValue = typeof options["baseURL"] === "string" ? options["baseURL"] : model.api.url
+            let isIncompatible = false
+            if (baseURLValue) {
+              try {
+                const host = new URL(baseURLValue).host.toLowerCase()
+                const incompatibleHosts = [
+                  "api.xiaomimimo.com",
+                  "open.bigmodel.cn",
+                  "dashscope.aliyuncs.com",
+                  "qianfan.baidubce.com",
+                  "api.minimax.io",
+                  "ark.cn-beijing.volces.com",
+                  "api.lkeap.cloud.tencent.com",
+                  "api-ai.gitcode.com",
+                  "api-inference.modelscope.cn",
+                ]
+                isIncompatible = incompatibleHosts.some((h) => host === h || host.endsWith(`.${h}`))
+              } catch {
+                // ignore invalid URLs
+              }
+            }
+            if (!isIncompatible) {
+              options["includeUsage"] = true
+            }
+          }
         }
 
         const baseURL = iife(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #31156

### Type of change

- [x] Bug fix

### What does this PR do?

Several OpenAI-compatible providers (Chinese AI gateways like Volcengine, Qianfan, DashScope, ModelScope, etc.) return HTTP 400 Bad Request when `stream_options.include_usage` is sent in the request body. The current code unconditionally sets `includeUsage: true` for all `@ai-sdk/openai-compatible` providers, causing failures for these hosts.

This PR adds a host-based check: before setting `includeUsage`, it parses the `baseURL` and compares the host against a list of known incompatible providers. If the host matches, `includeUsage` is skipped. Users can still explicitly opt in by setting `includeUsage: true` in their provider config (the `!== false` check is preserved).

The incompatible hosts were identified from issue #31156 and community reports — all are major Chinese AI platforms that use non-standard OpenAI-compatible API implementations.

### How did you verify your code works?

- Verified that the `baseURL` parsing correctly matches hosts like `https://ark.cn-beijing.volces.com/api/v3` → host `ark.cn-beijing.volces.com`
- Confirmed that explicitly setting `includeUsage: true` in config still works (the outer `!== false` guard is preserved)
- Tested with a Volcengine endpoint that previously returned 400 — with this fix, the request succeeds because `includeUsage` is no longer sent
- Verified that standard OpenAI-compatible providers (OpenRouter, Together, etc.) still get `includeUsage: true` as before

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR