### PR TITLE
fix(app): respect safe area in web titlebar

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -87,7 +87,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
     const height = useV2Titlebar() ? v2TitlebarHeight : legacyTitlebarHeight
     if (mac()) return `${height / zoom()}px`
     if (windows()) return `${height / Math.min(titlebarZoom(), 1)}px`
-    return undefined
+    return `calc(${height}px + env(safe-area-inset-top, 0px))`
   }
   const windowsControlsWidth = () => `${windowsControlsBaseWidth / Math.max(titlebarZoom(), 1)}px`
 
@@ -230,7 +230,9 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
       style={{
         "min-height": minHeight(),
         // Keep native macOS traffic lights clear even when the desktop window is narrow.
-        "padding-left": mac() ? `${84 / zoom()}px` : 0,
+        "padding-top": "env(safe-area-inset-top, 0px)",
+        "padding-left": mac() ? `${84 / zoom()}px` : "env(safe-area-inset-left, 0px)",
+        "padding-right": "env(safe-area-inset-right, 0px)",
         width: electronWindows() ? `env(titlebar-area-width, calc(100vw - ${windowsControlsWidth()}))` : undefined,
         "max-width": electronWindows()
           ? `env(titlebar-area-width, calc(100vw - ${windowsControlsWidth()}))`


### PR DESCRIPTION
### Issue for this PR

Closes #35480

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the web/PWA titlebar overlapping the iOS safe area when opencode is saved to the home screen.

The page already opts into `viewport-fit=cover`, so standalone PWAs can draw under the status bar. This updates the titlebar to reserve the CSS safe-area insets for top/left/right spacing while keeping the existing desktop macOS and Windows handling.

### How did you verify your code works?

- `bun run typecheck` from `packages/app`
- `bun run build` from `packages/app`
- Built a local Linux binary and switched a local opencode server to it
- Confirmed the installed PWA titlebar is reachable on the affected VM setup

Note: a repo-wide pre-push typecheck failed in `packages/codemode` with missing dependency/type errors unrelated to this app-only change.

### Screenshots / recordings

Before:

![Before: titlebar overlaps iOS status bar](https://raw.githubusercontent.com/Vercantez/opencode/pwa-safe-area-assets/screenshots/pwa-safe-area-before.png)

After:

![After: titlebar respects iOS safe area](https://raw.githubusercontent.com/Vercantez/opencode/pwa-safe-area-assets/screenshots/pwa-safe-area-after.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
