### PR TITLE
refactor(app): remove behavior-neutral effects

### DIFF
--- a/packages/app/src/components/dialog-select-server.tsx
+++ b/packages/app/src/components/dialog-select-server.tsx
@@ -19,6 +19,7 @@ import { normalizeServerUrl, ServerConnection, useServer } from "@/context/serve
 import { type ServerHealth, useCheckServerHealth } from "@/utils/server-health"
 import { useSettings } from "@/context/settings"
 import { useTabs } from "@/context/tabs"
+import { completeServerForm } from "./server-form-lifecycle"
 
 const DEFAULT_USERNAME = "opencode"
 
@@ -189,7 +190,9 @@ export function DialogSelectServer() {
   )
 }
 
-export function useServerManagementController(options: { onSelect?: () => void; navigateOnAdd?: boolean } = {}) {
+export function useServerManagementController(
+  options: { onSelect?: () => void; onFormExit?: () => void; navigateOnAdd?: boolean } = {},
+) {
   const navigate = useNavigate()
   const server = useServer()
   const tabs = useTabs()
@@ -247,7 +250,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
     mutationFn: async (value: string) => {
       const normalized = normalizeServerUrl(value)
       if (!normalized) {
-        resetAdd()
+        completeServerForm(resetAdd, options.onFormExit)
         return
       }
 
@@ -264,13 +267,16 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         return
       }
 
-      resetAdd()
       if (options.navigateOnAdd === false) {
-        server.add(conn)
-        options.onSelect?.()
+        completeServerForm(resetAdd, options.onFormExit, () => {
+          server.add(conn)
+          options.onSelect?.()
+        })
         return
       }
+      resetAdd()
       await select(conn, true)
+      options.onFormExit?.()
     },
   }))
 
@@ -279,7 +285,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
       if (input.original.type !== "http") return
       const normalized = normalizeServerUrl(input.value)
       if (!normalized) {
-        resetEdit()
+        completeServerForm(resetEdit, options.onFormExit)
         return
       }
 
@@ -293,7 +299,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         username === input.original.http.username &&
         password === input.original.http.password
       ) {
-        resetEdit()
+        completeServerForm(resetEdit, options.onFormExit)
         return
       }
 
@@ -313,7 +319,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
         replaceServer(input.original, conn)
       }
 
-      resetEdit()
+      completeServerForm(resetEdit, options.onFormExit)
     },
   }))
 
@@ -506,7 +512,7 @@ export function useServerManagementController(options: { onSelect?: () => void; 
   createEffect(() => {
     if (!store.editServer.id) return
     if (editing()) return
-    resetEdit()
+    completeServerForm(resetEdit, options.onFormExit)
   })
 
   async function handleRemove(key: ServerConnection.Key) {

--- a/packages/app/src/components/server-form-lifecycle.test.ts
+++ b/packages/app/src/components/server-form-lifecycle.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { completeServerForm } from "./server-form-lifecycle"
+
+describe("completeServerForm", () => {
+  test("preserves reset-before-exit ordering", () => {
+    const calls: string[] = []
+
+    completeServerForm(
+      () => calls.push("reset"),
+      () => calls.push("exit"),
+      () => calls.push("action"),
+    )
+
+    expect(calls).toEqual(["reset", "exit", "action"])
+  })
+
+  test("preserves legacy reset behavior without an exit callback", () => {
+    let resets = 0
+
+    completeServerForm(() => resets++)
+
+    expect(resets).toBe(1)
+  })
+})

--- a/packages/app/src/components/server-form-lifecycle.ts
+++ b/packages/app/src/components/server-form-lifecycle.ts
@@ -1,0 +1,5 @@
+export function completeServerForm(reset: () => void, onExit?: () => void, action?: () => void) {
+  reset()
+  onExit?.()
+  action?.()
+}

--- a/packages/app/src/components/settings-v2/dialog-server-v2.tsx
+++ b/packages/app/src/components/settings-v2/dialog-server-v2.tsx
@@ -3,7 +3,7 @@ import { Dialog, DialogBody, DialogFooter, DialogHeader, DialogTitle } from "@op
 import { DividerV2 } from "@opencode-ai/ui/v2/divider-v2"
 import { TextInputV2 } from "@opencode-ai/ui/v2/text-input-v2"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { type Component, Show, createEffect, createSignal, onCleanup, onMount } from "solid-js"
+import { type Component, Show, onCleanup, onMount } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { type ServerConnection } from "@/context/server"
 import { useServerManagementController } from "../dialog-select-server"
@@ -16,25 +16,21 @@ export const DialogServerV2: Component<{
   const dialog = useDialog()
   const language = useLanguage()
   const controller = useServerManagementController({
-    onSelect: () => dialog.close(),
+    onFormExit: () => dialog.close(),
     navigateOnAdd: false,
   })
-  const [opened, setOpened] = createSignal(false)
 
   onMount(() => {
     if (props.mode === "add") controller.startAdd()
-    if (props.mode === "edit" && props.server) controller.startEdit(props.server)
-    setOpened(true)
+    if (props.mode === "edit" && props.server) {
+      controller.startEdit(props.server)
+      return
+    }
+    if (props.mode === "edit") dialog.close()
   })
 
   onCleanup(() => {
     controller.resetForm()
-  })
-
-  createEffect(() => {
-    if (!opened()) return
-    if (controller.isFormMode()) return
-    dialog.close()
   })
 
   const keyDown = (event: KeyboardEvent) => {

--- a/packages/app/src/components/status-popover-body.tsx
+++ b/packages/app/src/components/status-popover-body.tsx
@@ -248,7 +248,7 @@ function ServerStatusList(props: { state: ServerStatusState }) {
   )
 }
 
-export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
+export function StatusPopoverBody(_props: { shown: Accessor<boolean> }) {
   const sync = useSync()
   const global = useGlobal()
   const server = useServer()
@@ -265,10 +265,6 @@ export function StatusPopoverBody(props: { shown: Accessor<boolean> }) {
       description: err instanceof Error ? err.message : String(err),
     })
   }
-
-  createEffect(() => {
-    if (!props.shown()) return
-  })
 
   let dialogRun = 0
   let dialogDead = false

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -102,8 +102,6 @@ const HOME_SEARCH_RESULT_TITLE =
 const HOME_SEARCH_RESULT_META =
   "min-w-0 flex-[1_1_auto] overflow-hidden text-ellipsis whitespace-nowrap text-[13px] leading-4 tracking-[-0.04px] text-v2-text-text-muted [font-weight:440]"
 
-let pendingHomeNavigation: { server: ServerConnection.Key; href: string } | undefined
-
 function buildHomeSessionRecords(input: {
   sync: Pick<ServerSync, "child">
   projectDirectories: () => string[]
@@ -414,13 +412,6 @@ export function NewHome() {
     if (list.some((conn) => ServerConnection.key(conn) === selection().server)) return
     const conn = list.find((conn) => ServerConnection.key(conn) === server.key) ?? list[0]
     if (conn) setSelection({ server: ServerConnection.key(conn) })
-  })
-
-  createEffect(() => {
-    const pending = pendingHomeNavigation
-    if (!pending || pending.server !== server.key) return
-    pendingHomeNavigation = undefined
-    navigate(pending.href)
   })
 
   function focusServer(conn: ServerConnection.Any) {


### PR DESCRIPTION
## Summary
- move V2 server-dialog closing from a derived form-mode effect to explicit form-exit callbacks
- preserve reset, close, mutation, invalid-input, and missing-edit-server behavior and ordering
- remove a no-op status-popover effect and an unreachable home-navigation effect
- leave v1 behavior unchanged

## Testing
- packages/app: 539 unit and 26 browser tests
- focused server-form lifecycle test
- app typecheck
- push-hook workspace typecheck: 30 tasks passed
- Prettier and git diff checks

Reference: https://react.dev/learn/you-might-not-need-an-effect