### PR TITLE
fix(plugin): skip non-function exports instead of throwing

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -100,7 +100,9 @@ function getLegacyPlugins(mod: Record<string, unknown>) {
     if (seen.has(entry)) continue
     seen.add(entry)
     const plugin = getServerPlugin(entry)
-    if (!plugin) throw new TypeError("Plugin export is not a function")
+    // Skip non-plugin exports (constants, helpers, etc.) instead of throwing —
+    // a single non-function export must not discard the module's real plugins.
+    if (!plugin) continue
     result.push(plugin)
   }
 

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -105,4 +105,21 @@ describe("plugin.trigger", () => {
       }),
     ),
   )
+
+  it.instance("loads a plugin module that also exports non-function values", () =>
+    withProject(
+      [
+        'export const VERSION = "1.0.0"',
+        "export const plugin = async () => ({",
+        `  ${JSON.stringify(systemHook)}: (_input, output) => {`,
+        '    output.system.unshift("sync")',
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        expect(yield* triggerSystemTransform()).toEqual(["sync"])
+      }),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #31575

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`getLegacyPlugins` loops over every export of a plugin module and throws a `TypeError` on the first one that isn't a plugin function. That throw gets swallowed by the `Effect.catch` in the plugin apply loop, so if a module exports anything alongside its plugin (a version constant, a helper), the whole plugin is dropped and no hooks register, with no error anywhere.

This changes the throw to `continue`, so non-plugin exports are skipped instead of discarding the module's real plugins. It matches the `seen`-entry skip on the line right above. The `export default { server }` path is unaffected because it resolves through `readV1Plugin` before this loop, so only the legacy named-export path was hitting the throw.

### How did you verify your code works?

Added a test in `test/plugin/trigger.test.ts` that loads a plugin module with an extra `export const VERSION` beside the plugin function. It fails on `dev` (the hook never fires and `trigger` returns `[]`) and passes with this change. The full plugin suite stays green (164 pass), and `bun typecheck`, Prettier, and oxlint are clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
