### PR TITLE
fix(app): support slash command picker on any line of multiline input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -954,7 +954,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
 
     if (!shellMode) {
       const atMatch = rawText.substring(0, cursorPosition).match(/@(\S*)$/)
-      const slashMatch = rawText.match(/^\/(\S*)$/)
+      const slashQuery = rawText.substring(0, cursorPosition)
+      const slashMatch = slashQuery.match(/(?:^|\n)\/(\S*)$/)
 
       if (atMatch) {
         atOnInput(atMatch[1])


### PR DESCRIPTION
### Issue for this PR

Closes #35520

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The slash command picker (`/`) only worked on the first line of multiline input. The regex `/^\/(\S*)$/` matched against the entire `rawText`, requiring the text to start with `/`. In multiline input where `/` was on a later line, the regex failed to match.

This fix:
1. Only considers text up to the cursor position (`rawText.substring(0, cursorPosition)`) — same as how the `@` mention picker already works
2. Uses `/(?:^|\n)\/(\S*)$/` to match a `/` at the start of any line

### How did you verify your code works?

Tested locally with `bun dev`:
- Typed multiline input and used `/` on different lines — the slash command picker appears on any line
- Same scenario with `@` mentions — continues to work as before
- Both pickers respect cursor position on each line

### Screenshots / recordings

_Not applicable — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR