### PR TITLE
fix(opencode): include skill files when invoking via slash command

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -4,6 +4,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { EffectBridge } from "@/effect/bridge"
 import type { InstanceContext } from "@/project/instance-context"
 import { Effect, Layer, Context, Schema } from "effect"
+import { Glob } from "@opencode-ai/core/util/glob"
 import { Config } from "@/config/config"
 import { MCP } from "../mcp"
 import { Skill } from "../skill"
@@ -138,14 +139,33 @@ const layer = Layer.effect(
           name: item.name,
           description: item.description,
           source: "skill",
-          get template() {
+          get template(): string | Promise<string> {
             if (!dir) return item.content
-            return [
+            const base = [
               item.content,
               "",
               `Base directory for this skill: ${dir}`,
               "Relative paths in this skill (e.g., scripts/, references/) are relative to this base directory.",
-            ].join("\n")
+            ]
+            return Glob.scan("**", {
+              cwd: dir,
+              absolute: false,
+              include: "file",
+              symlink: true,
+              dot: true,
+            }).then((files) => {
+              const sampled = files
+                .filter((f) => f !== "SKILL.md" && !f.endsWith("/SKILL.md"))
+                .slice(0, 10)
+                .map((f) => `<file>${path.resolve(dir, f)}</file>`)
+              return [
+                ...base,
+                "",
+                "<skill_files>",
+                sampled.length > 0 ? sampled.join("\n") : "(no files found)",
+                "</skill_files>",
+              ].join("\n")
+            })
           },
           hints: [],
         }


### PR DESCRIPTION
### Issue for this PR

Closes #24831

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/skill-name` only injected the skill markdown body as prompt text, without the `<skill_files>` section that the `skill` tool provides. This meant referenced files (e.g. scripts, reference docs) were not discoverable by the model when using the slash command shortcut.

The fix makes the skill command template include sampled files (up to 10) from the skill directory, matching the behavior of the `skill` tool (`tool/skill.ts`).

The change is in `command/index.ts`: for skills with a real location, the template now uses `Glob.scan` to list files and appends a `<skill_files>` section, same format as the skill tool output.

### How did you verify your code works?

- Verified TypeScript compiles cleanly in `packages/opencode`
- The output format matches the existing `<skill_files>` format from `tool/skill.ts`
- Built-in skills (with `<built-in>` location) are unchanged — they still return just the content

### Screenshots / recordings

_No UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR