### PR TITLE
feat(plugin): add hook for PII and sensitive data redaction

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -178,7 +178,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
     ? (yield* InstanceState.context).project.id
     : undefined
 
-  return {
+  const request = {
     system,
     messages,
     tools: Object.fromEntries(Object.entries(tools).toSorted(([a], [b]) => a.localeCompare(b))),
@@ -202,6 +202,34 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
       ...input.model.headers,
       ...headers,
     },
+  }
+
+  const transformed = yield* input.plugin.trigger(
+    "model.request.before",
+    {
+      sessionID: input.sessionID,
+      agent: input.agent.name,
+      model: input.model,
+      provider: input.provider,
+      message: input.user,
+    },
+    {
+      system: request.system,
+      messages: request.messages,
+      tools: request.tools,
+      params: request.params,
+      headers: request.headers,
+    },
+  )
+
+  return {
+    ...request,
+    system: transformed.system,
+    messages: transformed.messages as Prepared["messages"],
+    tools: transformed.tools as Prepared["tools"],
+    params: transformed.params,
+    messageTransformOptions: transformed.params.options,
+    headers: transformed.headers,
   }
 })
 

--- a/packages/opencode/test/session/llm-request.test.ts
+++ b/packages/opencode/test/session/llm-request.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { jsonSchema } from "ai"
+import { LLMRequestPrep } from "@/session/llm/request"
+
+const sessionID = "test-session-123"
+
+const model = {
+  id: "openai/gpt-4",
+  providerID: "openai",
+  api: {
+    id: "gpt-4",
+    npm: "@ai-sdk/openai",
+  },
+  capabilities: {
+    temperature: true,
+    reasoning: false,
+  },
+  limit: { output: 4096 },
+  options: {},
+  headers: {},
+} as any
+
+type RequestHookOutput = {
+  system: string[]
+  messages: Array<{ role: string; content: string }>
+  headers: Record<string, string>
+  params: {
+    options: Record<string, unknown>
+  }
+}
+
+describe("LLMRequestPrep.prepare", () => {
+  test("runs model request hook before provider execution", async () => {
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        user: {
+          id: "msg_user-test",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID: "openai", modelID: "gpt-4" },
+        } as any,
+        sessionID,
+        model,
+        agent: {
+          name: "test",
+          prompt: "system",
+          mode: "primary",
+          options: {},
+          permission: [],
+        } as any,
+        system: [],
+        messages: [{ role: "user", content: "secret@example.com" }],
+        tools: {
+          lookup: {
+            description: "Look up a value",
+            inputSchema: jsonSchema({ type: "object", properties: {} }),
+          },
+        },
+        provider: { id: "openai", options: {} } as any,
+        auth: undefined,
+        plugin: {
+          trigger: (name: string, _input: unknown, output: unknown) => {
+            if (name !== "model.request.before") return Effect.succeed(output)
+            const request = output as RequestHookOutput
+            request.system = ["redacted system"]
+            request.messages = [{ role: "user", content: "[redacted]" }]
+            request.headers["x-redacted"] = "1"
+            request.params.options.redacted = true
+            return Effect.succeed(output)
+          },
+          list: () => Effect.succeed([]),
+          init: () => Effect.void,
+        } as any,
+        flags: { outputTokenMax: 32_000, client: "test" } as any,
+        isWorkflow: false,
+      }),
+    )
+
+    expect(result.system).toEqual(["redacted system"])
+    expect(result.messages).toEqual([{ role: "user", content: "[redacted]" }])
+    expect((result.headers as Record<string, string>)["x-redacted"]).toBe("1")
+    expect(result.params.options.redacted).toBe(true)
+    expect(result.messageTransformOptions.redacted).toBe(true)
+    expect(result.tools.lookup.strict).toBe(false)
+  })
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -258,6 +258,25 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { headers: Record<string, string> },
   ) => Promise<void>
+  /**
+   * Modify the model request before it is sent to the provider
+   */
+  "model.request.before"?: (
+    input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
+    output: {
+      system: string[]
+      messages: unknown[]
+      tools: Record<string, unknown>
+      params: {
+        temperature: number | undefined
+        topP: number | undefined
+        topK: number | undefined
+        maxOutputTokens: number | undefined
+        options: Record<string, any>
+      }
+      headers: Record<string, string>
+    },
+  ) => Promise<void>
   "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -335,6 +335,25 @@ Levels: `debug`, `info`, `warn`, `error`. See [SDK documentation](https://openco
 
 ---
 
+### Model request
+
+Use `model.request.before` to modify the provider-bound request after OpenCode resolves messages, tools, parameters, and headers.
+Use `tool.execute.before` and `tool.execute.after` for tool arguments and tool results.
+
+```ts title=".opencode/plugins/redact.ts"
+export const RedactPlugin = async () => ({
+  "model.request.before": async (_input, output) => {
+    output.messages = output.messages.map((message) => {
+      if (typeof message !== "object" || !message || !("content" in message)) return message
+      if (typeof message.content !== "string") return message
+      return { ...message, content: message.content.replaceAll("secret@example.com", "[redacted]") }
+    })
+  },
+})
+```
+
+---
+
 ### Compaction hooks
 
 Customize the context included when a session is compacted:


### PR DESCRIPTION
### Issue for this PR

No issue. Small plugin API addition.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a `model.request.before` server plugin hook after OpenCode prepares the provider request and before it is sent. It exposes system messages, model messages, tools, params, and headers for final request mutation.

This is intended for plugins that need a last-mile request policy, such as redacting sensitive data or PII before provider calls. It does not add any redaction policy to OpenCode itself.

Tool arguments and results remain covered by the existing `tool.execute.before` and `tool.execute.after` hooks.

### How did you verify your code works?

- `bun typecheck` in `packages/plugin`
- `bun typecheck` in `packages/opencode`
- `bun test test/session/llm-request.test.ts test/provider/transform.test.ts test/plugin/trigger.test.ts --timeout 30000` in `packages/opencode`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR