### PR TITLE
fix(app): use selected home project for new sessions

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -334,6 +334,21 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                 return
               }
 
+              if (route.type === "home") {
+                const selection = layout.home.selection()
+                const conn = global.servers.list().find((item) => ServerConnection.key(item) === selection.server)
+                const project = conn
+                  ? global
+                      .ensureServerCtx(conn)
+                      .projects.list()
+                      .find((item) => item.worktree === selection.directory)
+                  : undefined
+                if (conn && project) {
+                  tabs.newDraft({ server: ServerConnection.key(conn), directory: project.worktree }, "")
+                  return
+                }
+              }
+
               const current = layout.projects.list()[0]
               if (current) {
                 tabs.newDraft({ server: server.key, directory: current.worktree }, "")


### PR DESCRIPTION
## Summary
- resolve the selected Home server and project when opening a new tab
- make the titlebar + button and keyboard shortcut create drafts in that project
- preserve existing fallbacks when Home has no selected project

## Testing
- `bun typecheck` (packages/app)
- `bunx prettier --check src/components/titlebar.tsx`
- `git diff --check`