### PR TITLE
fix(provider): ensure required array is present in object schemas

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1432,6 +1432,15 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
   }
   */
 
+  // Ensure `required` is always an array when `properties` is present.
+  // Strict JSON Schema validators (e.g. ajv used by some API gateways/proxies)
+  // reject schemas where `additionalProperties: false` is set but `required`
+  // is missing or null. This normalizes all object schemas to include an
+  // explicit (possibly empty) `required` array.
+  if (schema.type === "object" && schema.properties && !Array.isArray(schema.required)) {
+    schema.required = []
+  }
+
   if (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") {
     schema = sanitizeOpenAISchema(schema) as JSONSchema7
     // Codex also applies lossy compaction above 4 KB; defer that until OpenCode needs the same schema budget.

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -150,6 +150,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             },
           },
           additionalProperties: false,
+          required: [],
         }),
       ),
       execute(args, opts) {
@@ -233,6 +234,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             },
           },
           additionalProperties: false,
+          required: [],
         }),
       ),
       execute(args, opts) {


### PR DESCRIPTION
Fixes #35528

## What changed

Normalize all object schemas in `ProviderTransform.schema()` to include an explicit `required` array when `properties` is present. Also add `required: []` directly to `list_mcp_resources` and `list_mcp_resource_templates` in `session/tools.ts` as a defensive measure.

## Why

Several built-in tools define `inputSchema` with `additionalProperties: false` but without a `required` field. Strict JSON Schema validators (ajv in strict mode, used by some OpenAI-compatible API gateways) reject this because `required` becomes `null` when serialized, and `null` is not a valid array. The result is `AI_APICallError: Invalid schema for function 'X': null is not of type "array"` on every request, which blocks usage of any model behind a strict-validating gateway.

`required: []` means "no fields are required", which is semantically identical to omitting `required`. Lenient validators (OpenAI, Anthropic, official DeepSeek API) ignore it. Strict validators now see a valid array. No behavior change for existing providers.

## How I verified

- Before: `opencode run -m <provider>/deepseek-v4-flash "say hi"` with default config (plugins + MCP servers) produces `AI_APICallError: Invalid schema for function 'list_mcp_resource_templates'`.
- After: same command returns a normal model response.
- Tested on 1.17.13 with default config (oh-my-opencode-slim plugin + minimax-coding-plan-mcp connected). All four scenarios from the issue confirmed: only the strict-validator + MCP-with-resources combination was broken before, and it works after the fix.
