### PR TITLE
fix(opencode): JSON-escape {env:} values in config substitution

### DIFF
--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -34,7 +34,9 @@ function dir(input: ParseSource) {
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
   let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-    return (input.env?.[varName] ?? process.env[varName]) || ""
+    const val = input.env?.[varName] ?? process.env[varName]
+    if (!val) return ""
+    return JSON.stringify(val).slice(1, -1)
   })
 
   const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))


### PR DESCRIPTION
### Issue for this PR

Closes #35536

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`{env:VAR}` values are substituted verbatim into config text before JSON parsing. On Windows, env vars like `USERPROFILE` contain backslashes, producing invalid JSON escape sequences (`\U`, `\L`) and crashing the parser.

Fix: wrap env values with `JSON.stringify().slice(1, -1)` — same as `{file:}` already does in the same function.

### How did you verify your code works?

- Existing `OPENCODE_CONFIG_CONTENT token substitution > substitutes {env:} tokens` test passes unchanged
- Verified manually: plain strings, Windows-style backslash paths, embedded quotes, and empty vars all produce valid parseable JSON

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
