### PR TITLE
fix(tui): use current model for context-limit display after switch

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -269,7 +269,13 @@ export function Prompt(props: PromptProps) {
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
     if (tokens <= 0) return
 
-    const model = sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    // Use the currently selected model for the context-limit denominator so it
+    // updates immediately after a model switch, falling back to the last
+    // assistant message's model when nothing is selected yet.
+    const selected = local.model.current()
+    const model =
+      (selected && sync.data.provider.find((item) => item.id === selected.providerID)?.models[selected.modelID]) ??
+      sync.data.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     const pct = model?.limit.context ? `${Math.round((tokens / model.limit.context) * 100)}%` : undefined
     const cost = session?.cost ?? 0
     return {

--- a/packages/tui/src/feature-plugins/sidebar/context.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/context.tsx
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "@opencode-ai/sdk/v2"
 import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
 import type { BuiltinTuiPlugin } from "../builtins"
 import { createMemo } from "solid-js"
+import { useLocal } from "../../context/local"
 
 const id = "internal:sidebar-context"
 
@@ -12,6 +13,7 @@ const money = new Intl.NumberFormat("en-US", {
 
 function View(props: { api: TuiPluginApi; session_id: string }) {
   const theme = () => props.api.theme.current
+  const local = useLocal()
   const msg = createMemo(() => props.api.state.session.messages(props.session_id))
   const session = createMemo(() => props.api.state.session.get(props.session_id))
   const cost = createMemo(() => session()?.cost ?? 0)
@@ -27,7 +29,16 @@ function View(props: { api: TuiPluginApi; session_id: string }) {
 
     const tokens =
       last.tokens.input + last.tokens.output + last.tokens.reasoning + last.tokens.cache.read + last.tokens.cache.write
-    const model = props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
+    // Use the currently selected model for the context-limit denominator so it
+    // updates immediately after a model switch, falling back to the last
+    // assistant message's model when nothing is selected yet. The global model
+    // picker only applies to the top-level session, so for subagent sessions
+    // (which run their own agent's model and can be viewed via the sidebar) use
+    // the session's own last-message model instead.
+    const selected = session()?.parentID ? undefined : local.model.current()
+    const model =
+      (selected && props.api.state.provider.find((item) => item.id === selected.providerID)?.models[selected.modelID]) ??
+      props.api.state.provider.find((item) => item.id === last.providerID)?.models[last.modelID]
     return {
       tokens,
       percent: model?.limit.context ? Math.round((tokens / model.limit.context) * 100) : null,


### PR DESCRIPTION
### Issue for this PR

Addresses upstream anomalyco/opencode#35072. Opened against my own fork first as a staging/review step — not raised upstream yet.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The context-limit percentage derived its denominator from the last assistant message's model. After a mid-session model switch it kept showing the previous model's limit until a new assistant message arrived — e.g. switching from a 128k model to a 32k model still displayed the 128k-based percentage.

The fix uses the currently-selected model (`local.model.current()`) as the denominator, falling back to the last assistant message's model when nothing is selected yet:

- `packages/tui/src/component/prompt/index.tsx` — composer footer usage memo.
- `packages/tui/src/feature-plugins/sidebar/context.tsx` — the sidebar meter named in the issue. The sidebar can display a subagent session, where the global model picker is unrelated to the subagent's own model, so it uses `current()` only for top-level sessions (via a `session()?.parentID` guard) and otherwise keeps the session's own last-message model.

Token count still comes from the last message (real occupancy); only the limit denominator changed. `subagent-footer.tsx` is intentionally left unchanged — a completed subagent's model is fixed, so its last-message model is already the correct denominator there.

### How did you verify your code works?

- `bun run typecheck` (tsgo) in `packages/tui` passes clean.
- Traced the switch flow: `local.model.current()` resolves to the just-selected model, so the denominator updates on the next render instead of waiting for an assistant reply. The `?? last`-message fallback preserves the pre-existing behavior when no model is selected yet, and both call sites read `current()` inside a `createMemo`, so reactive tracking is preserved.

### Screenshots / recordings

_TUI-only change; no screenshot._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

