### PR TITLE
fix(shell): drain stdout before reading output to avoid "(no output)" on exit 0

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -483,7 +483,7 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const reader = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -545,6 +545,21 @@ export const ShellTool = Tool.define(
             timeout.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
           ])
 
+          if (exit.kind === "exit") {
+            // On a clean exit, join the reader fiber so the merged stdout/stderr
+            // stream drains to EOF before the scope closes and interrupts it.
+            // Without this, buffered output can be lost, yielding "(no output)"
+            // on exit 0 (#35511).
+            //
+            // A backgrounded child can keep the stdout/stderr write end open past
+            // the parent's exit, so the stream may never reach EOF. Bound the
+            // best-effort drain with abort/timeout so it can't hang forever (the
+            // reader fiber is interrupted on scope close). The process already
+            // exited cleanly here, so we do NOT set aborted/expired if the drain
+            // is cut short — that would mislabel a successful command as
+            // terminated/aborted despite its clean exit code.
+            yield* Fiber.join(reader).pipe(Effect.race(abort), Effect.race(timeout))
+          }
           if (exit.kind === "abort") {
             aborted = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -194,6 +194,29 @@ describe("tool.shell", () => {
     ),
   )
 
+  // Regression for #35511: the merged stdout/stderr reader must drain to EOF
+  // before output is assembled, otherwise buffered output is lost and the tool
+  // returns "(no output)" on exit 0. Loop to catch the race.
+  each("drains stdout before reading output (#35511)", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        for (let i = 0; i < 10; i++) {
+          const result = yield* run({
+            command: "echo hi",
+          })
+          expect(result.metadata.exit).toBe(0)
+          expect(result.output).not.toBe("(no output)")
+          expect(result.output).toContain("hi")
+          // metadata.output (the streaming `last` preview) is populated from the
+          // same drained list, so it must also carry the output, not "(no output)".
+          expect(result.metadata.output).not.toBe("(no output)")
+          expect(result.metadata.output).toContain("hi")
+        }
+      }),
+    ),
+  )
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })


### PR DESCRIPTION
### Issue for this PR

Closes anomalyco/opencode#35511 (staged on fork against `dev`).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The shell tool can return `(no output)` with exit `0` on the first call, even when the command clearly printed to stdout.

**Root cause.** The merged stdout+stderr reader runs in a `forkScoped` fiber, but the main flow only awaits `handle.exitCode`. When the process exits, the enclosing `Effect.scoped` block closes and interrupts the reader fiber *before* it has drained the buffered chunks to EOF, so the assembled `list` is empty and the tool reports `(no output)` despite a clean exit.

**Fix.** Capture the reader fiber and, on the clean-exit branch, `Fiber.join` it so the merged stream drains to EOF before the scope closes. A backgrounded child can keep the stdout/stderr write end open past the parent's exit, so the join is bounded by the same `abort`/`timeout` races to avoid hanging forever. Because the process already exited cleanly on this branch, a cut-short drain is *not* relabelled as aborted/terminated — that would contradict the clean exit code and print a misleading "terminated after exceeding timeout" message.

Ordering that the fix guarantees:

```mermaid
sequenceDiagram
    participant Tool as ShellTool
    participant Proc as Process
    participant Reader as reader fiber (forkScoped)
    participant Scope as Effect.scoped

    Tool->>Proc: spawn(command)
    Tool->>Reader: forkScoped(Stream.runForEach handle.all)
    Tool->>Tool: raceAll [exitCode, abort, timeout]
    Proc-->>Tool: exitCode resolves (exit.kind = exit)
    Note over Tool,Reader: Fiber.join(reader), bounded by abort/timeout
    Reader-->>Tool: buffered stdout/stderr drained to EOF
    Tool->>Scope: scope closes (reader already finished)
    Note over Tool: output assembled from full list
    Note over Tool,Scope: Before: scope closed on exit, reader interrupted mid-buffer -> "(no output)"
```

### How did you verify your code works?

- `bun run typecheck` (tsgo, `packages/opencode`) — passes.
- `bun test test/tool/shell.test.ts` — 24 pass / 0 fail. Includes a new regression that runs `echo hi` 10x and asserts exit `0` with output (and `metadata.output`) never equal to `(no output)`; this reliably reproduced the race before the fix.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

