### PR TITLE
fix(tui): add ctrl+h as backspace alias for herdr/ConPTY compatibility

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -185,7 +185,7 @@ export const Definitions = {
   input_delete_line: keybind("ctrl+shift+d", "Delete line in input"),
   input_delete_to_line_end: keybind("ctrl+k", "Delete to end of line in input"),
   input_delete_to_line_start: keybind("ctrl+u", "Delete to start of line in input"),
-  input_backspace: keybind("backspace,shift+backspace", "Backspace in input"),
+  input_backspace: keybind("backspace,shift+backspace,ctrl+h", "Backspace in input"),
   input_delete: keybind("ctrl+d,delete,shift+delete", "Delete character in input"),
   input_undo: keybind("ctrl+-,super+z", "Undo in input"),
   input_redo: keybind("ctrl+.,super+shift+z", "Redo in input"),


### PR DESCRIPTION
### Issue for this PR

Closes #34878

### Type of change

- [x] Bug fix

### What does this PR do?

Inside herdr (Windows ConPTY terminal multiplexer), physical Backspace
sends byte 0x08 (VT100 BS / ctrl+h) rather than 0x7f. OpenCode's
input_backspace only handled 0x7f and shift+backspace, so the 0x08 byte
matched nothing and Backspace silently did nothing.

Fix: add ctrl+h to input_backspace. No conflict with
input_delete_word_backward, which already owns ctrl+backspace.

### How did you verify your code works?

Reproduced on Windows 11 + herdr + Windows Terminal: Backspace did
nothing. After the fix, Backspace deletes characters as expected.
Verified ctrl+backspace still triggers word deletion (no regression).

### Screenshots / recordings

N/A — no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR