### PR TITLE
fix(tui): add cmd paste binding

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -159,7 +159,7 @@ export const Definitions = {
   workspace_set: keybind("none", "Set workspace"),
 
   input_clear: keybind("ctrl+c", "Clear input field"),
-  input_paste: keybind({ key: "ctrl+v", preventDefault: false }, "Paste from clipboard"),
+  input_paste: keybind({ key: "super+v,ctrl+v", preventDefault: false }, "Paste from clipboard"),
   input_submit: keybind("return", "Submit input"),
   input_newline: keybind("shift+return,ctrl+return,alt+return,ctrl+j", "Insert newline in input"),
   input_move_left: keybind("left,ctrl+b", "Move cursor left in input"),

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -86,6 +86,12 @@ test("resolves a session move keybind", () => {
   expect(config.keybinds.get("session.move")).toMatchObject([{ key: "ctrl+o" }])
 })
 
+test("includes Cmd-compatible paste binding by default", () => {
+  const config = resolve({}, { terminalSuspend: true })
+
+  expect(config.keybinds.get("prompt.paste")).toMatchObject([{ key: "super+v,ctrl+v" }])
+})
+
 test("disables suspend and assigns ctrl+z to undo when unsupported", () => {
   const config = resolve({}, { terminalSuspend: false })
 


### PR DESCRIPTION
## Summary
- add `super+v` to the default `input_paste` binding while preserving `ctrl+v`
- add regression coverage that resolved `prompt.paste` bindings include the Cmd-compatible paste key

## Root cause
The TUI native clipboard image path is handled by the `prompt.paste` command in `packages/tui/src/component/prompt/index.tsx`. That command reads the native clipboard via `clipboard.read()` and attaches image content when the MIME type starts with `image/`.

The configured `input_paste` keybind maps to that same command through `packages/tui/src/config/keybind.ts`, but its default was only `ctrl+v` at `packages/tui/src/config/keybind.ts:162`. On macOS terminals that pass Cmd+V through as `super+v`, text paste can still be handled by the terminal, but image-only paste never dispatches `prompt.paste`, so the native image clipboard reader is skipped.

This changes the default to `super+v,ctrl+v` so Cmd+V and Ctrl+V dispatch the same paste command.

Fixes #26695

## Verification
- `bun test test/config.test.tsx --timeout 30000` from `packages/tui`
- `bun typecheck` from `packages/tui`
- `bun run lint packages/tui/src/config/keybind.ts packages/tui/test/config.test.tsx` from repo root (0 errors; existing warnings in `keybind.ts`)
- push hook ran root `bun turbo typecheck` successfully
