### PR TITLE
feat(codemode): math parity

### DIFF
--- a/packages/codemode/codemode.md
+++ b/packages/codemode/codemode.md
@@ -155,6 +155,7 @@ current omissions to implement, not intentional product boundaries.
       collection values, then extend it to bounded host streams when a stream boundary exists.
 - [ ] Support callback-bearing standard-library variants that models commonly generate: the mapper argument to
       `Array.from(...)` and replacers for `JSON.stringify(...)`, including Effect-aware callbacks where needed.
+- [ ] Add `Object.is` after runtime method and tool references have stable identity semantics.
 - [ ] Add deterministic modern collection conveniences where they improve orchestration: `Object.groupBy`, Set
       composition methods, and `Array.prototype.toSpliced`.
 - [ ] Decide whether nondeterministic `Math.random` and iterable `Math.sumPrecise` belong in the runtime.

--- a/packages/codemode/codemode.md
+++ b/packages/codemode/codemode.md
@@ -155,12 +155,9 @@ current omissions to implement, not intentional product boundaries.
       collection values, then extend it to bounded host streams when a stream boundary exists.
 - [ ] Support callback-bearing standard-library variants that models commonly generate: the mapper argument to
       `Array.from(...)` and replacers for `JSON.stringify(...)`, including Effect-aware callbacks where needed.
-- [ ] Close basic `Object` parity gaps: let `Object.values`/`Object.entries` accept arrays, make `Object.assign` validate
-      and mutate its target, add `Object.is`, and let `Object.fromEntries` consume every supported iterable.
 - [ ] Add deterministic modern collection conveniences where they improve orchestration: `Object.groupBy`, Set
       composition methods, and `Array.prototype.toSpliced`.
-- [ ] Complete the deterministic `Math` surface beyond the current arithmetic, rounding, root, power, and logarithm
-      helpers. Decide separately whether nondeterministic `Math.random` belongs in the runtime.
+- [ ] Decide whether nondeterministic `Math.random` and iterable `Math.sumPrecise` belong in the runtime.
 - [ ] Refine diagnostics so user throws, expected tool failures, unexpected host/tool defects, and genuine interpreter
       defects are distinguishable without leaking private causes.
 

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -112,42 +112,6 @@ import {
   SandboxURLSearchParams,
 } from "../values.js"
 
-const intrinsicReceiverKind = (value: unknown): string | undefined => {
-  if (typeof value === "string") return "String"
-  if (typeof value === "number") return "Number"
-  if (Array.isArray(value)) return "Array"
-  if (value instanceof SandboxDate) return "Date"
-  if (value instanceof SandboxRegExp) return "RegExp"
-  if (value instanceof SandboxMap) return "Map"
-  if (value instanceof SandboxSet) return "Set"
-  if (value instanceof SandboxURL) return "URL"
-  if (value instanceof SandboxURLSearchParams) return "URLSearchParams"
-}
-
-const intrinsicAliases = new Map([
-  ["String.trimLeft", "String.trimStart"],
-  ["String.trimRight", "String.trimEnd"],
-  ["Set.keys", "Set.values"],
-])
-
-const runtimeReferenceIdentity = (value: unknown): string | undefined => {
-  if (value instanceof ToolReference) return `Tool:${JSON.stringify(value.path)}`
-  if (value instanceof PromiseMethodReference) return `Promise:${value.name}`
-  if (value instanceof CoercionFunction) return `Coercion:${value.name}`
-  if (value instanceof GlobalMethodReference) {
-    if (value.namespace === "Number" && (value.name === "parseInt" || value.name === "parseFloat")) {
-      return `Coercion:${value.name}`
-    }
-    return `Global:${value.namespace}.${value.name}`
-  }
-  if (value instanceof IntrinsicReference) {
-    const kind = intrinsicReceiverKind(value.receiver)
-    if (kind === undefined) return
-    const method = `${kind}.${value.name}`
-    return `Intrinsic:${intrinsicAliases.get(method) ?? method}`
-  }
-}
-
 const parseProgram = (code: string): ProgramNode => {
   const transpiled = transpileModule(`async function __codemode__() {\n${code}\n}`, {
     reportDiagnostics: true,
@@ -2045,7 +2009,7 @@ class Interpreter<R> {
       }
       if (callable instanceof GlobalMethodReference) {
         if (callable.namespace === "console") return self.invokeConsole(callable.name, args, node)
-        if (callable.namespace === "Object" && callable.name === "is") return self.objectIs(args)
+        if (callable.namespace === "Object" && callable.name === "is") return invokeGlobalMethod(callable, args, node)
         if (callable.namespace === "Object" && args[0] instanceof ToolReference) {
           return self.invokeObjectMethodOnTools(callable.name, args[0], node)
         }
@@ -2081,13 +2045,6 @@ class Interpreter<R> {
       node,
       "InvalidDataValue",
     )
-  }
-
-  private objectIs(args: Array<unknown>): boolean {
-    const [left, right] = args
-    if (Object.is(left, right)) return true
-    const identity = runtimeReferenceIdentity(left)
-    return identity !== undefined && identity === runtimeReferenceIdentity(right)
   }
 
   private invokeConsole(name: string, args: Array<unknown>, node: AstNode): undefined {

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -112,6 +112,43 @@ import {
   SandboxURLSearchParams,
 } from "../values.js"
 
+const intrinsicReceiverKind = (value: unknown): string | undefined => {
+  if (typeof value === "string") return "String"
+  if (typeof value === "number") return "Number"
+  if (Array.isArray(value)) return "Array"
+  if (value instanceof SandboxDate) return "Date"
+  if (value instanceof SandboxRegExp) return "RegExp"
+  if (value instanceof SandboxMap) return "Map"
+  if (value instanceof SandboxSet) return "Set"
+  if (value instanceof SandboxURL) return "URL"
+  if (value instanceof SandboxURLSearchParams) return "URLSearchParams"
+}
+
+const runtimeReferenceIdentity = (value: unknown): string | undefined => {
+  if (value instanceof ToolReference) return `Tool:${JSON.stringify(value.path)}`
+  if (value instanceof PromiseMethodReference) return `Promise:${value.name}`
+  if (value instanceof CoercionFunction) return `Coercion:${value.name}`
+  if (value instanceof GlobalMethodReference) {
+    if (value.namespace === "Number" && (value.name === "parseInt" || value.name === "parseFloat")) {
+      return `Coercion:${value.name}`
+    }
+    return `Global:${value.namespace}.${value.name}`
+  }
+  if (value instanceof IntrinsicReference) {
+    const kind = intrinsicReceiverKind(value.receiver)
+    if (kind === undefined) return
+    const name =
+      kind === "String" && value.name === "trimLeft"
+        ? "trimStart"
+        : kind === "String" && value.name === "trimRight"
+          ? "trimEnd"
+          : kind === "Set" && value.name === "keys"
+            ? "values"
+            : value.name
+    return `Intrinsic:${kind}.${name}`
+  }
+}
+
 const parseProgram = (code: string): ProgramNode => {
   const transpiled = transpileModule(`async function __codemode__() {\n${code}\n}`, {
     reportDiagnostics: true,
@@ -2009,10 +2046,17 @@ class Interpreter<R> {
       }
       if (callable instanceof GlobalMethodReference) {
         if (callable.namespace === "console") return self.invokeConsole(callable.name, args, node)
+        if (callable.namespace === "Object" && callable.name === "is") return self.objectIs(args)
         if (callable.namespace === "Object" && args[0] instanceof ToolReference) {
           return self.invokeObjectMethodOnTools(callable.name, args, node)
         }
-        if (callable.namespace === "Object" && callable.name === "assign") {
+        if (
+          callable.namespace === "Object" &&
+          (callable.name === "assign" ||
+            callable.name === "values" ||
+            callable.name === "entries" ||
+            callable.name === "fromEntries")
+        ) {
           return invokeGlobalMethod(callable, args, node)
         }
         return boundedData(invokeGlobalMethod(callable, args, node), `${callable.namespace}.${callable.name} result`)
@@ -2033,10 +2077,9 @@ class Interpreter<R> {
 
   // Object.* over a tool reference: `Object.keys(tools)` / `Object.keys(tools.ns)` enumerate
   // namespace/tool names from the host tool tree - the discovery idiom a model reaches for
-  // first. Object.is may compare the opaque reference without reading it. Every other Object
-  // helper fails with a pointer at the working idioms instead of a generic plain-data message.
+  // first. Other Object helpers fail with a pointer at the working idioms instead of a generic
+  // plain-data message.
   private invokeObjectMethodOnTools(name: string, args: Array<unknown>, node: AstNode): unknown {
-    if (name === "is") return invokeObjectMethod(name, args, node)
     if (name === "keys") {
       return boundedData(this.enumerableKeys(args[0] as ToolReference)!, "Object.keys result")
     }
@@ -2045,6 +2088,13 @@ class Interpreter<R> {
       node,
       "InvalidDataValue",
     )
+  }
+
+  private objectIs(args: Array<unknown>): boolean {
+    const [left, right] = args
+    if (Object.is(left, right)) return true
+    const identity = runtimeReferenceIdentity(left)
+    return identity !== undefined && identity === runtimeReferenceIdentity(right)
   }
 
   private invokeConsole(name: string, args: Array<unknown>, node: AstNode): undefined {

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -66,7 +66,7 @@ import {
   numberMethods,
   numberStatics,
 } from "../stdlib/number.js"
-import { invokeObjectMethod } from "../stdlib/object.js"
+import { invokeObjectMethod, objectMethodsPreservingIdentity } from "../stdlib/object.js"
 import { promiseStatics, TOOL_CALL_CONCURRENCY } from "../stdlib/promise.js"
 import {
   escapeRegexHint,
@@ -124,6 +124,12 @@ const intrinsicReceiverKind = (value: unknown): string | undefined => {
   if (value instanceof SandboxURLSearchParams) return "URLSearchParams"
 }
 
+const intrinsicAliases = new Map([
+  ["String.trimLeft", "String.trimStart"],
+  ["String.trimRight", "String.trimEnd"],
+  ["Set.keys", "Set.values"],
+])
+
 const runtimeReferenceIdentity = (value: unknown): string | undefined => {
   if (value instanceof ToolReference) return `Tool:${JSON.stringify(value.path)}`
   if (value instanceof PromiseMethodReference) return `Promise:${value.name}`
@@ -137,15 +143,8 @@ const runtimeReferenceIdentity = (value: unknown): string | undefined => {
   if (value instanceof IntrinsicReference) {
     const kind = intrinsicReceiverKind(value.receiver)
     if (kind === undefined) return
-    const name =
-      kind === "String" && value.name === "trimLeft"
-        ? "trimStart"
-        : kind === "String" && value.name === "trimRight"
-          ? "trimEnd"
-          : kind === "Set" && value.name === "keys"
-            ? "values"
-            : value.name
-    return `Intrinsic:${kind}.${name}`
+    const method = `${kind}.${value.name}`
+    return `Intrinsic:${intrinsicAliases.get(method) ?? method}`
   }
 }
 
@@ -2048,15 +2047,9 @@ class Interpreter<R> {
         if (callable.namespace === "console") return self.invokeConsole(callable.name, args, node)
         if (callable.namespace === "Object" && callable.name === "is") return self.objectIs(args)
         if (callable.namespace === "Object" && args[0] instanceof ToolReference) {
-          return self.invokeObjectMethodOnTools(callable.name, args, node)
+          return self.invokeObjectMethodOnTools(callable.name, args[0], node)
         }
-        if (
-          callable.namespace === "Object" &&
-          (callable.name === "assign" ||
-            callable.name === "values" ||
-            callable.name === "entries" ||
-            callable.name === "fromEntries")
-        ) {
+        if (callable.namespace === "Object" && objectMethodsPreservingIdentity.has(callable.name)) {
           return invokeGlobalMethod(callable, args, node)
         }
         return boundedData(invokeGlobalMethod(callable, args, node), `${callable.namespace}.${callable.name} result`)
@@ -2079,9 +2072,9 @@ class Interpreter<R> {
   // namespace/tool names from the host tool tree - the discovery idiom a model reaches for
   // first. Other Object helpers fail with a pointer at the working idioms instead of a generic
   // plain-data message.
-  private invokeObjectMethodOnTools(name: string, args: Array<unknown>, node: AstNode): unknown {
+  private invokeObjectMethodOnTools(name: string, ref: ToolReference, node: AstNode): unknown {
     if (name === "keys") {
-      return boundedData(this.enumerableKeys(args[0] as ToolReference)!, "Object.keys result")
+      return boundedData(this.enumerableKeys(ref)!, "Object.keys result")
     }
     throw new InterpreterRuntimeError(
       `Object.${name}(...) cannot read tool references: they are not plain data. Use Object.keys(tools) for names, or tools.$codemode.search({ query }) for signatures.`,

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -2981,7 +2981,7 @@ class Interpreter<R> {
     return Effect.gen(function* () {
       for (const elementValue of elements) {
         if (elementValue === null) {
-          values.length += 1
+          values.push(undefined)
           continue
         }
         const element = asNode(elementValue, "elements")

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -2009,7 +2009,6 @@ class Interpreter<R> {
       }
       if (callable instanceof GlobalMethodReference) {
         if (callable.namespace === "console") return self.invokeConsole(callable.name, args, node)
-        if (callable.namespace === "Object" && callable.name === "is") return invokeGlobalMethod(callable, args, node)
         if (callable.namespace === "Object" && args[0] instanceof ToolReference) {
           return self.invokeObjectMethodOnTools(callable.name, args[0], node)
         }

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -2009,7 +2009,7 @@ class Interpreter<R> {
       }
       if (callable instanceof GlobalMethodReference) {
         if (callable.namespace === "console") return self.invokeConsole(callable.name, args, node)
-        if (callable.namespace === "Object" && args[0] instanceof ToolReference) {
+        if (callable.namespace === "Object" && callable.name !== "is" && args[0] instanceof ToolReference) {
           return self.invokeObjectMethodOnTools(callable.name, args[0] as ToolReference, node)
         }
         if (callable.namespace === "Object" && callable.name === "assign") {
@@ -2980,7 +2980,7 @@ class Interpreter<R> {
     return Effect.gen(function* () {
       for (const elementValue of elements) {
         if (elementValue === null) {
-          values.push(undefined)
+          values.length += 1
           continue
         }
         const element = asNode(elementValue, "elements")

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -2009,8 +2009,8 @@ class Interpreter<R> {
       }
       if (callable instanceof GlobalMethodReference) {
         if (callable.namespace === "console") return self.invokeConsole(callable.name, args, node)
-        if (callable.namespace === "Object" && callable.name !== "is" && args[0] instanceof ToolReference) {
-          return self.invokeObjectMethodOnTools(callable.name, args[0] as ToolReference, node)
+        if (callable.namespace === "Object" && args[0] instanceof ToolReference) {
+          return self.invokeObjectMethodOnTools(callable.name, args, node)
         }
         if (callable.namespace === "Object" && callable.name === "assign") {
           return invokeGlobalMethod(callable, args, node)
@@ -2033,11 +2033,12 @@ class Interpreter<R> {
 
   // Object.* over a tool reference: `Object.keys(tools)` / `Object.keys(tools.ns)` enumerate
   // namespace/tool names from the host tool tree - the discovery idiom a model reaches for
-  // first. Every other Object helper cannot produce data from a tool reference, so it fails
-  // with a pointer at the working idioms instead of the generic plain-objects-only message.
-  private invokeObjectMethodOnTools(name: string, ref: ToolReference, node: AstNode): unknown {
+  // first. Object.is may compare the opaque reference without reading it. Every other Object
+  // helper fails with a pointer at the working idioms instead of a generic plain-data message.
+  private invokeObjectMethodOnTools(name: string, args: Array<unknown>, node: AstNode): unknown {
+    if (name === "is") return invokeObjectMethod(name, args, node)
     if (name === "keys") {
-      return boundedData(this.enumerableKeys(ref)!, "Object.keys result")
+      return boundedData(this.enumerableKeys(args[0] as ToolReference)!, "Object.keys result")
     }
     throw new InterpreterRuntimeError(
       `Object.${name}(...) cannot read tool references: they are not plain data. Use Object.keys(tools) for names, or tools.$codemode.search({ query }) for signatures.`,

--- a/packages/codemode/src/stdlib/math.ts
+++ b/packages/codemode/src/stdlib/math.ts
@@ -4,6 +4,13 @@ export const mathMethods = new Set([
   "max",
   "min",
   "abs",
+  "acos",
+  "acosh",
+  "asin",
+  "asinh",
+  "atan",
+  "atan2",
+  "atanh",
   "floor",
   "ceil",
   "round",
@@ -13,10 +20,22 @@ export const mathMethods = new Set([
   "cbrt",
   "pow",
   "hypot",
+  "cos",
+  "cosh",
+  "sin",
+  "sinh",
+  "tan",
+  "tanh",
   "log",
   "log2",
   "log10",
+  "log1p",
   "exp",
+  "expm1",
+  "f16round",
+  "fround",
+  "clz32",
+  "imul",
 ])
 
 export const invokeMathMethod = (name: string, args: Array<unknown>, node: AstNode): number => {
@@ -33,6 +52,20 @@ export const invokeMathMethod = (name: string, args: Array<unknown>, node: AstNo
       return Math.min(...nums)
     case "abs":
       return Math.abs(a)
+    case "acos":
+      return Math.acos(a)
+    case "acosh":
+      return Math.acosh(a)
+    case "asin":
+      return Math.asin(a)
+    case "asinh":
+      return Math.asinh(a)
+    case "atan":
+      return Math.atan(a)
+    case "atan2":
+      return Math.atan2(a, b)
+    case "atanh":
+      return Math.atanh(a)
     case "floor":
       return Math.floor(a)
     case "ceil":
@@ -51,14 +84,38 @@ export const invokeMathMethod = (name: string, args: Array<unknown>, node: AstNo
       return Math.pow(a, b)
     case "hypot":
       return Math.hypot(...nums)
+    case "cos":
+      return Math.cos(a)
+    case "cosh":
+      return Math.cosh(a)
+    case "sin":
+      return Math.sin(a)
+    case "sinh":
+      return Math.sinh(a)
+    case "tan":
+      return Math.tan(a)
+    case "tanh":
+      return Math.tanh(a)
     case "log":
       return Math.log(a)
     case "log2":
       return Math.log2(a)
     case "log10":
       return Math.log10(a)
+    case "log1p":
+      return Math.log1p(a)
     case "exp":
       return Math.exp(a)
+    case "expm1":
+      return Math.expm1(a)
+    case "f16round":
+      return Math.f16round(a)
+    case "fround":
+      return Math.fround(a)
+    case "clz32":
+      return Math.clz32(a)
+    case "imul":
+      return Math.imul(a, b)
   }
   throw new InterpreterRuntimeError(`Math.${name} is not available in CodeMode.`, node)
 }

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -8,7 +8,9 @@ export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "is
 export const invokeObjectMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   if (!objectStatics.has(name)) throw new InterpreterRuntimeError(`Object.${name} is not available in CodeMode.`, node)
   const requireObject = (): Record<string, unknown> => {
+    const input = args[0]
     const value = boundedData(args[0], `Object.${name} input`)
+    if (Array.isArray(input)) return input as unknown as Record<string, unknown>
     if (isSandboxValue(value)) return {}
     if (value === null || typeof value !== "object") {
       throw new InterpreterRuntimeError(`Object.${name} expects a data object or array.`, node)
@@ -57,7 +59,11 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
     case "fromEntries": {
       if (args[0] instanceof SandboxMap) {
         const out: Record<string, unknown> = Object.create(null)
-        for (const [key, item] of args[0].map.entries()) guardedSet(out, coerceToString(key), item)
+        for (const [key, item] of args[0].map.entries()) {
+          boundedData(key, "Object.fromEntries key")
+          boundedData(item, "Object.fromEntries value")
+          guardedSet(out, coerceToString(key), item)
+        }
         return out
       }
       if (args[0] instanceof SandboxURLSearchParams) {
@@ -65,16 +71,15 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
         for (const [key, value] of args[0].params.entries()) guardedSet(out, key, value)
         return out
       }
-      const pairs =
-        args[0] instanceof SandboxSet
-          ? Array.from(args[0].set.values())
-          : boundedData(args[0], "Object.fromEntries input")
+      const pairs = args[0] instanceof SandboxSet ? Array.from(args[0].set.values()) : args[0]
+      if (!(args[0] instanceof SandboxSet)) boundedData(args[0], "Object.fromEntries input")
       if (!Array.isArray(pairs)) {
         throw new InterpreterRuntimeError("Object.fromEntries expects an array of [key, value] pairs.", node)
       }
       const out: Record<string, unknown> = Object.create(null)
       for (const pair of pairs) {
-        if (pair === null || typeof pair !== "object" || isSandboxValue(pair))
+        const validated = boundedData(pair, "Object.fromEntries entry")
+        if (validated === null || typeof validated !== "object" || isSandboxValue(validated))
           throw new InterpreterRuntimeError("Object.fromEntries expects [key, value] entry objects.", node)
         const entry = pair as Record<string, unknown>
         guardedSet(out, coerceToString(entry[0]), entry[1])

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -1,17 +1,17 @@
 import { type AstNode, InterpreterRuntimeError } from "../interpreter/model.js"
 import { isBlockedMember } from "../tool-runtime.js"
-import { isSandboxValue, SandboxMap, SandboxURLSearchParams } from "../values.js"
+import { isSandboxValue, SandboxMap, SandboxSet, SandboxURLSearchParams } from "../values.js"
 import { boundedData, coerceToString } from "./value.js"
 
-export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "assign", "fromEntries"])
+export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "is", "assign", "fromEntries"])
 
 export const invokeObjectMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   if (!objectStatics.has(name)) throw new InterpreterRuntimeError(`Object.${name} is not available in CodeMode.`, node)
   const requireObject = (): Record<string, unknown> => {
     const value = boundedData(args[0], `Object.${name} input`)
     if (isSandboxValue(value)) return {}
-    if (value === null || typeof value !== "object" || Array.isArray(value)) {
-      throw new InterpreterRuntimeError(`Object.${name} expects a data object.`, node)
+    if (value === null || typeof value !== "object") {
+      throw new InterpreterRuntimeError(`Object.${name} expects a data object or array.`, node)
     }
     return value as Record<string, unknown>
   }
@@ -35,6 +35,8 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
       return Object.entries(requireObject()).map(([key, item]) => [key, item])
     case "hasOwn":
       return Object.hasOwn(requireObject(), String(args[1]))
+    case "is":
+      return Object.is(args[0], args[1])
     case "assign": {
       const target = args[0]
       if (target === null || typeof target !== "object" || Array.isArray(target) || isSandboxValue(target)) {
@@ -63,16 +65,19 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
         for (const [key, value] of args[0].params.entries()) guardedSet(out, key, value)
         return out
       }
-      const pairs = boundedData(args[0], "Object.fromEntries input")
+      const pairs =
+        args[0] instanceof SandboxSet
+          ? Array.from(args[0].set.values())
+          : boundedData(args[0], "Object.fromEntries input")
       if (!Array.isArray(pairs)) {
         throw new InterpreterRuntimeError("Object.fromEntries expects an array of [key, value] pairs.", node)
       }
       const out: Record<string, unknown> = Object.create(null)
       for (const pair of pairs) {
-        if (!Array.isArray(pair)) {
-          throw new InterpreterRuntimeError("Object.fromEntries expects [key, value] pairs.", node)
-        }
-        guardedSet(out, String(pair[0]), pair[1])
+        if (pair === null || typeof pair !== "object" || isSandboxValue(pair))
+          throw new InterpreterRuntimeError("Object.fromEntries expects [key, value] entry objects.", node)
+        const entry = pair as Record<string, unknown>
+        guardedSet(out, String(entry[0]), entry[1])
       }
       return out
     }

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -4,6 +4,7 @@ import { isSandboxValue, SandboxMap, SandboxSet, SandboxURLSearchParams } from "
 import { boundedData, coerceToString } from "./value.js"
 
 export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "is", "assign", "fromEntries"])
+export const objectMethodsPreservingIdentity = new Set(["assign", "values", "entries", "fromEntries"])
 
 export const invokeObjectMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   if (!objectStatics.has(name)) throw new InterpreterRuntimeError(`Object.${name} is not available in CodeMode.`, node)
@@ -20,6 +21,11 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
   const guardedSet = (out: Record<string, unknown>, key: string, item: unknown): void => {
     if (isBlockedMember(key)) throw new InterpreterRuntimeError(`Property '${key}' is not available in CodeMode.`, node)
     out[key] = item
+  }
+  const addEntry = (out: Record<string, unknown>, key: unknown, item: unknown): void => {
+    boundedData(key, "Object.fromEntries key")
+    boundedData(item, "Object.fromEntries value")
+    guardedSet(out, coerceToString(key), item)
   }
   switch (name) {
     case "keys": {
@@ -59,11 +65,7 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
     case "fromEntries": {
       if (args[0] instanceof SandboxMap) {
         const out: Record<string, unknown> = Object.create(null)
-        for (const [key, item] of args[0].map.entries()) {
-          boundedData(key, "Object.fromEntries key")
-          boundedData(item, "Object.fromEntries value")
-          guardedSet(out, coerceToString(key), item)
-        }
+        for (const [key, item] of args[0].map.entries()) addEntry(out, key, item)
         return out
       }
       if (args[0] instanceof SandboxURLSearchParams) {
@@ -72,8 +74,8 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
         return out
       }
       const pairs = args[0] instanceof SandboxSet ? Array.from(args[0].set.values()) : args[0]
-      if (!(args[0] instanceof SandboxSet)) boundedData(args[0], "Object.fromEntries input")
       if (!Array.isArray(pairs)) {
+        boundedData(args[0], "Object.fromEntries input")
         throw new InterpreterRuntimeError("Object.fromEntries expects an array of [key, value] pairs.", node)
       }
       const out: Record<string, unknown> = Object.create(null)
@@ -82,7 +84,7 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
         if (validated === null || typeof validated !== "object" || isSandboxValue(validated))
           throw new InterpreterRuntimeError("Object.fromEntries expects [key, value] entry objects.", node)
         const entry = pair as Record<string, unknown>
-        guardedSet(out, coerceToString(entry[0]), entry[1])
+        addEntry(out, entry[0], entry[1])
       }
       return out
     }

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -3,7 +3,7 @@ import { isBlockedMember } from "../tool-runtime.js"
 import { isSandboxValue, SandboxMap, SandboxSet, SandboxURLSearchParams } from "../values.js"
 import { boundedData, coerceToString } from "./value.js"
 
-export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "is", "assign", "fromEntries"])
+export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "assign", "fromEntries"])
 export const objectMethodsPreservingIdentity = new Set(["assign", "values", "entries", "fromEntries"])
 
 export const invokeObjectMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
@@ -43,8 +43,6 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
       return Object.entries(requireObject()).map(([key, item]) => [key, item])
     case "hasOwn":
       return Object.hasOwn(requireObject(), String(args[1]))
-    case "is":
-      return Object.is(args[0], args[1])
     case "assign": {
       const target = args[0]
       if (target === null || typeof target !== "object" || Array.isArray(target) || isSandboxValue(target)) {

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -77,7 +77,7 @@ export const invokeObjectMethod = (name: string, args: Array<unknown>, node: Ast
         if (pair === null || typeof pair !== "object" || isSandboxValue(pair))
           throw new InterpreterRuntimeError("Object.fromEntries expects [key, value] entry objects.", node)
         const entry = pair as Record<string, unknown>
-        guardedSet(out, String(entry[0]), entry[1])
+        guardedSet(out, coerceToString(entry[0]), entry[1])
       }
       return out
     }

--- a/packages/codemode/src/tool-runtime.ts
+++ b/packages/codemode/src/tool-runtime.ts
@@ -275,12 +275,13 @@ const copyBounded = (
   if (Array.isArray(value)) {
     const copied = value.map((item) => copyBounded(item, label, depth + 1, seen, preserveSandboxValues))
     if (preserveSandboxValues) {
+      // Array metadata is not serialized, but intra-sandbox copies must retain it.
       for (const [key, item] of Object.entries(value)) {
         if (Object.hasOwn(copied, key)) continue
         if (isBlockedMember(key)) {
           throw new ToolRuntimeError("InvalidDataValue", `${label} contains blocked property '${key}'.`)
         }
-        Object.assign(copied, { [key]: copyBounded(item, label, depth + 1, seen, true) })
+        Reflect.set(copied, key, copyBounded(item, label, depth + 1, seen, true))
       }
     }
     seen.delete(value)

--- a/packages/codemode/src/tool-runtime.ts
+++ b/packages/codemode/src/tool-runtime.ts
@@ -274,6 +274,15 @@ const copyBounded = (
 
   if (Array.isArray(value)) {
     const copied = value.map((item) => copyBounded(item, label, depth + 1, seen, preserveSandboxValues))
+    if (preserveSandboxValues) {
+      for (const [key, item] of Object.entries(value)) {
+        if (Object.hasOwn(copied, key)) continue
+        if (isBlockedMember(key)) {
+          throw new ToolRuntimeError("InvalidDataValue", `${label} contains blocked property '${key}'.`)
+        }
+        Object.assign(copied, { [key]: copyBounded(item, label, depth + 1, seen, true) })
+      }
+    }
     seen.delete(value)
     return copied
   }

--- a/packages/codemode/test/stdlib.test.ts
+++ b/packages/codemode/test/stdlib.test.ts
@@ -613,9 +613,16 @@ describe("stdlib integration", () => {
           Object.is(object, object),
           Object.is({}, {}),
           Object.is(tools, tools),
+          Object.is(tools.host, tools.host),
+          Object.is(Math.max, Math.max),
+          Object.is([].map, [].map),
+          Object.is("".trimLeft, "".trimStart),
+          Object.is(new Set().keys, new Set().values),
+          Object.is(Number.parseInt, parseInt),
         ]
       `),
-    ).toEqual([true, false, true, false, true])
+    ).toEqual([true, false, true, false, true, true, true, true, true, true, true])
+    expect(await value(`const object = {}; return Object.is(Object.values([object])[0], object)`)).toBe(true)
   })
 
   test("Object.fromEntries accepts every supported entry collection", async () => {
@@ -638,6 +645,17 @@ describe("stdlib integration", () => {
       { e: 5 },
       { "[object Object]": 6, "1970-01-01T00:00:00.000Z": 7, null: 8, undefined: 9 },
     ])
+    expect(await value(`try { Object.fromEntries(new Set([Math.max])); return false } catch { return true }`)).toBe(
+      true,
+    )
+    expect(
+      await value(
+        `try { Object.fromEntries(new Map([["fn", Math.max]])); return false } catch { return true }`,
+      ),
+    ).toBe(true)
+    expect(
+      await value(`const object = {}; return Object.is(Object.fromEntries([["value", object]]).value, object)`),
+    ).toBe(true)
   })
 
   test("deterministic Math methods match the host runtime", async () => {

--- a/packages/codemode/test/stdlib.test.ts
+++ b/packages/codemode/test/stdlib.test.ts
@@ -614,15 +614,9 @@ describe("stdlib integration", () => {
           Object.is(object, object),
           Object.is({}, {}),
           Object.is(tools, tools),
-          Object.is(tools.host, tools.host),
-          Object.is(Math.max, Math.max),
-          Object.is([].map, [].map),
-          Object.is("".trimLeft, "".trimStart),
-          Object.is(new Set().keys, new Set().values),
-          Object.is(Number.parseInt, parseInt),
         ]
       `),
-    ).toEqual([true, false, true, false, true, true, true, true, true, true, true])
+    ).toEqual([true, false, true, false, true])
     expect(await value(`const object = {}; return Object.is(Object.values([object])[0], object)`)).toBe(true)
   })
 

--- a/packages/codemode/test/stdlib.test.ts
+++ b/packages/codemode/test/stdlib.test.ts
@@ -594,10 +594,12 @@ describe("stdlib integration", () => {
         ["1", "b"],
       ],
     ])
-    expect(await value(`return [Object.keys([, "a"]), Object.values([, "a"]), Object.entries([, "a"])]`)).toEqual([
-      ["1"],
-      ["a"],
-      [["1", "a"]],
+    expect(await value(`const match = /a/.exec("ba"); return [Object.values(match), Object.entries(match)]`)).toEqual([
+      ["a", 1],
+      [
+        ["0", "a"],
+        ["index", 1],
+      ],
     ])
   })
 
@@ -625,9 +627,17 @@ describe("stdlib integration", () => {
           Object.fromEntries(new Set([["c", 3]])),
           Object.fromEntries(new URLSearchParams("d=4")),
           Object.fromEntries([{ 0: "e", 1: 5 }]),
+          Object.fromEntries(new Set([[{}, 6], [new Date(0), 7], [null, 8], [undefined, 9]])),
         ]
       `),
-    ).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }, { d: "4" }, { e: 5 }])
+    ).toEqual([
+      { a: 1 },
+      { b: 2 },
+      { c: 3 },
+      { d: "4" },
+      { e: 5 },
+      { "[object Object]": 6, "1970-01-01T00:00:00.000Z": 7, null: 8, undefined: 9 },
+    ])
   })
 
   test("deterministic Math methods match the host runtime", async () => {

--- a/packages/codemode/test/stdlib.test.ts
+++ b/packages/codemode/test/stdlib.test.ts
@@ -601,6 +601,7 @@ describe("stdlib integration", () => {
         ["index", 1],
       ],
     ])
+    expect(await value(`return Object.keys(Object.values({ match: /a/.exec("ba") })[0])`)).toEqual(["0", "index"])
   })
 
   test("Object.is preserves SameValue identity semantics", async () => {

--- a/packages/codemode/test/stdlib.test.ts
+++ b/packages/codemode/test/stdlib.test.ts
@@ -604,22 +604,6 @@ describe("stdlib integration", () => {
     expect(await value(`return Object.keys(Object.values({ match: /a/.exec("ba") })[0])`)).toEqual(["0", "index"])
   })
 
-  test("Object.is preserves SameValue identity semantics", async () => {
-    expect(
-      await value(`
-        const object = {}
-        return [
-          Object.is(NaN, NaN),
-          Object.is(0, -0),
-          Object.is(object, object),
-          Object.is({}, {}),
-          Object.is(tools, tools),
-        ]
-      `),
-    ).toEqual([true, false, true, false, true])
-    expect(await value(`const object = {}; return Object.is(Object.values([object])[0], object)`)).toBe(true)
-  })
-
   test("Object.fromEntries accepts every supported entry collection", async () => {
     expect(
       await value(`
@@ -647,9 +631,6 @@ describe("stdlib integration", () => {
       await value(
         `try { Object.fromEntries(new Map([["fn", Math.max]])); return false } catch { return true }`,
       ),
-    ).toBe(true)
-    expect(
-      await value(`const object = {}; return Object.is(Object.fromEntries([["value", object]]).value, object)`),
     ).toBe(true)
   })
 

--- a/packages/codemode/test/stdlib.test.ts
+++ b/packages/codemode/test/stdlib.test.ts
@@ -586,6 +586,81 @@ describe("Set", () => {
 })
 
 describe("stdlib integration", () => {
+  test("Object values and entries accept arrays", async () => {
+    expect(await value(`return [Object.values(["a", "b"]), Object.entries(["a", "b"])]`)).toEqual([
+      ["a", "b"],
+      [
+        ["0", "a"],
+        ["1", "b"],
+      ],
+    ])
+    expect(await value(`return [Object.keys([, "a"]), Object.values([, "a"]), Object.entries([, "a"])]`)).toEqual([
+      ["1"],
+      ["a"],
+      [["1", "a"]],
+    ])
+  })
+
+  test("Object.is preserves SameValue identity semantics", async () => {
+    expect(
+      await value(`
+        const object = {}
+        return [
+          Object.is(NaN, NaN),
+          Object.is(0, -0),
+          Object.is(object, object),
+          Object.is({}, {}),
+          Object.is(tools, tools),
+        ]
+      `),
+    ).toEqual([true, false, true, false, true])
+  })
+
+  test("Object.fromEntries accepts every supported entry collection", async () => {
+    expect(
+      await value(`
+        return [
+          Object.fromEntries([["a", 1]]),
+          Object.fromEntries(new Map([["b", 2]])),
+          Object.fromEntries(new Set([["c", 3]])),
+          Object.fromEntries(new URLSearchParams("d=4")),
+          Object.fromEntries([{ 0: "e", 1: 5 }]),
+        ]
+      `),
+    ).toEqual([{ a: 1 }, { b: 2 }, { c: 3 }, { d: "4" }, { e: 5 }])
+  })
+
+  test("deterministic Math methods match the host runtime", async () => {
+    const result = await value(`
+      return [
+        Math.acos(0.5), Math.acosh(2), Math.asin(0.5), Math.asinh(2), Math.atan(1), Math.atan2(1, 2), Math.atanh(0.5),
+        Math.cos(0.5), Math.cosh(0.5), Math.sin(0.5), Math.sinh(0.5), Math.tan(0.5), Math.tanh(0.5),
+        Math.log1p(0.5), Math.expm1(0.5), Math.f16round(1.337), Math.fround(1.337), Math.clz32(1), Math.imul(2, 3),
+      ]
+    `)
+    expect(result).toEqual([
+      Math.acos(0.5),
+      Math.acosh(2),
+      Math.asin(0.5),
+      Math.asinh(2),
+      Math.atan(1),
+      Math.atan2(1, 2),
+      Math.atanh(0.5),
+      Math.cos(0.5),
+      Math.cosh(0.5),
+      Math.sin(0.5),
+      Math.sinh(0.5),
+      Math.tan(0.5),
+      Math.tanh(0.5),
+      Math.log1p(0.5),
+      Math.expm1(0.5),
+      Math.f16round(1.337),
+      Math.fround(1.337),
+      Math.clz32(1),
+      Math.imul(2, 3),
+    ])
+  })
+
   test("Object.assign mutates and returns its target", async () => {
     expect(
       await value(`


### PR DESCRIPTION
## Summary

- add the remaining deterministic numeric Math helpers except the separately-deferred random and iterable APIs
- support array values/entries, including enumerable array metadata
- support Map, Set, URLSearchParams, and plain-entry Object.fromEntries inputs with consistent sandbox key coercion
- defer Object.is until runtime references have stable identity semantics
- update the living CodeMode backlog

## Tests

- `bun test` from `packages/codemode`
- `bun run typecheck` from `packages/codemode`
- `git diff --check`