### PR TITLE
fix(nvidia): send correct reasoning control for MiniMax M3

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -681,6 +681,15 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     model.api.id.toLowerCase().includes("minimax-m3") &&
     ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)
   ) {
+    if (model.api.npm === "@ai-sdk/openai-compatible") {
+      // NVIDIA NIM controls MiniMax-M3 reasoning via chat_template_kwargs.thinking_mode.
+      // The openai-compatible provider forwards this to the request body root.
+      return {
+        none: { chat_template_kwargs: { thinking_mode: "disabled" } },
+        thinking: { chat_template_kwargs: { thinking_mode: "adaptive" } },
+        enabled: { chat_template_kwargs: { thinking_mode: "enabled" } },
+      }
+    }
     return {
       none: { thinking: { type: "disabled" } },
       thinking: { thinking: { type: "adaptive" } },


### PR DESCRIPTION
## Summary

NVIDIA NIM's MiniMax-M3 controls reasoning via \chat_template_kwargs.thinking_mode\ (see https://docs.api.nvidia.com/nim/reference/minimaxai-minimax-m3-infer), not the Anthropic-style \	hinking: { type: ... }\ shape.

The \ariants()\ branch for \minimax-m3\ was sending the Anthropic format for **both** the Anthropic and the openai-compatible (NVIDIA) providers, so on NVIDIA the reasoning/effort control had no effect - the wrong value was sent.

## Change

Route the \@ai-sdk/openai-compatible\ (NVIDIA) case to \chat_template_kwargs.thinking_mode\ (\disabled\ / \daptive\ / \enabled\) while keeping the Anthropic path unchanged.

## Test plan

- [x] Configure NVIDIA provider with \minimaxai/minimax-m3\
- [ ] Select reasoning effort (none / thinking / enabled)
- [ ] Confirm \chat_template_kwargs.thinking_mode\ is sent in the request body