### PR TITLE
feat(plugin): tool.execute.before can shortcircuit with a canned output

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -103,11 +103,24 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
         return run.promise(
           Effect.gen(function* () {
             const ctx = context(args, options)
+            const beforeOutput: { args: any; shortcircuit?: { title: string; output: string; metadata: any } } = { args }
             yield* plugin.trigger(
               "tool.execute.before",
               { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
-              { args },
+              beforeOutput,
             )
+            if (beforeOutput.shortcircuit) {
+              const output = beforeOutput.shortcircuit
+              yield* plugin.trigger(
+                "tool.execute.after",
+                { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
+                output,
+              )
+              if (options.abortSignal?.aborted) {
+                yield* input.processor.completeToolCall(options.toolCallId, output)
+              }
+              return output
+            }
             const result = yield* item.execute(args, ctx)
             const output = {
               ...result,

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -185,11 +185,24 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             const permissionPatterns = parsed.server
               ? [`mcp:${parsed.server}:*`]
               : resourceServers.map((server) => `mcp:${server}:*`)
+            const beforeOutput: { args: any; shortcircuit?: { title: string; output: string; metadata: any } } = { args }
             yield* plugin.trigger(
               "tool.execute.before",
               { tool: MCP_RESOURCE_TOOLS.list, sessionID: ctx.sessionID, callID: opts.toolCallId },
-              { args },
+              beforeOutput,
             )
+            if (beforeOutput.shortcircuit) {
+              const output = beforeOutput.shortcircuit
+              yield* plugin.trigger(
+                "tool.execute.after",
+                { tool: MCP_RESOURCE_TOOLS.list, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
+                output,
+              )
+              if (opts.abortSignal?.aborted) {
+                yield* input.processor.completeToolCall(opts.toolCallId, output)
+              }
+              return output
+            }
             yield* ctx.ask({
               permission: "read",
               metadata: parsed.server ? { server: parsed.server } : {},
@@ -268,11 +281,24 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             const permissionPatterns = parsed.server
               ? [`mcp:${parsed.server}:*`]
               : resourceServers.map((server) => `mcp:${server}:*`)
+            const beforeOutput: { args: any; shortcircuit?: { title: string; output: string; metadata: any } } = { args }
             yield* plugin.trigger(
               "tool.execute.before",
               { tool: MCP_RESOURCE_TOOLS.listTemplates, sessionID: ctx.sessionID, callID: opts.toolCallId },
-              { args },
+              beforeOutput,
             )
+            if (beforeOutput.shortcircuit) {
+              const output = beforeOutput.shortcircuit
+              yield* plugin.trigger(
+                "tool.execute.after",
+                { tool: MCP_RESOURCE_TOOLS.listTemplates, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
+                output,
+              )
+              if (opts.abortSignal?.aborted) {
+                yield* input.processor.completeToolCall(opts.toolCallId, output)
+              }
+              return output
+            }
             yield* ctx.ask({
               permission: "read",
               metadata: parsed.server ? { server: parsed.server } : {},
@@ -348,11 +374,24 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             if (!client.getServerCapabilities()?.resources) {
               throw new Error(`MCP server "${parsed.server}" does not support resources`)
             }
+            const beforeOutput: { args: any; shortcircuit?: { title: string; output: string; metadata: any } } = { args }
             yield* plugin.trigger(
               "tool.execute.before",
               { tool: MCP_RESOURCE_TOOLS.read, sessionID: ctx.sessionID, callID: opts.toolCallId },
-              { args },
+              beforeOutput,
             )
+            if (beforeOutput.shortcircuit) {
+              const output = beforeOutput.shortcircuit
+              yield* plugin.trigger(
+                "tool.execute.after",
+                { tool: MCP_RESOURCE_TOOLS.read, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
+                output,
+              )
+              if (opts.abortSignal?.aborted) {
+                yield* input.processor.completeToolCall(opts.toolCallId, output)
+              }
+              return output
+            }
             yield* ctx.ask({
               permission: "read",
               metadata: { server: parsed.server, uri: parsed.uri },
@@ -412,11 +451,30 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
       run.promise(
         Effect.gen(function* () {
           const ctx = context(args, opts)
+          const beforeOutput: { args: any; shortcircuit?: { title: string; output: string; metadata: any } } = { args }
           yield* plugin.trigger(
             "tool.execute.before",
             { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
-            { args },
+            beforeOutput,
           )
+          if (beforeOutput.shortcircuit) {
+            const output = {
+              title: beforeOutput.shortcircuit.title,
+              metadata: beforeOutput.shortcircuit.metadata,
+              output: beforeOutput.shortcircuit.output,
+              attachments: [],
+              content: [{ type: "text" as const, text: beforeOutput.shortcircuit.output }],
+            }
+            yield* plugin.trigger(
+              "tool.execute.after",
+              { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
+              { title: output.title, output: output.output, metadata: output.metadata },
+            )
+            if (opts.abortSignal?.aborted) {
+              yield* input.processor.completeToolCall(opts.toolCallId, output)
+            }
+            return output
+          }
           const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
             yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
             return yield* Effect.promise(() => execute(args, opts))

--- a/packages/opencode/src/tool/code-mode.ts
+++ b/packages/opencode/src/tool/code-mode.ts
@@ -138,11 +138,23 @@ const invokeChildTool = Effect.fn("CodeMode.invokeChildTool")(function* (input: 
   callID: string
   ctx: Tool.Context
 }) {
+  const beforeOutput: { args: any; shortcircuit?: { title: string; output: string; metadata: any } } = { args: input.args }
   yield* input.plugin.trigger(
     "tool.execute.before",
     { tool: input.entry.key, sessionID: input.ctx.sessionID, callID: input.callID },
-    { args: input.args },
+    beforeOutput,
   )
+  if (beforeOutput.shortcircuit) {
+    const result: CallToolResult = {
+      content: [{ type: "text", text: beforeOutput.shortcircuit.output }],
+    }
+    yield* input.plugin.trigger(
+      "tool.execute.after",
+      { tool: input.entry.key, sessionID: input.ctx.sessionID, callID: input.callID, args: input.args },
+      { title: beforeOutput.shortcircuit.title, output: beforeOutput.shortcircuit.output, metadata: beforeOutput.shortcircuit.metadata },
+    )
+    return result
+  }
   const result: CallToolResult = yield* Effect.gen(function* () {
     yield* input.ctx.ask({ permission: input.entry.key, metadata: {}, patterns: ["*"], always: ["*"] })
     // Deliberately mirrors McpCatalog.convertTool's transport call so the MCP service stays free of tool-loop concerns.

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -265,7 +265,14 @@ export interface Hooks {
   ) => Promise<void>
   "tool.execute.before"?: (
     input: { tool: string; sessionID: string; callID: string },
-    output: { args: any },
+    output: {
+      args: any
+      shortcircuit?: {
+        title: string
+        output: string
+        metadata: any
+      }
+    },
   ) => Promise<void>
   "shell.env"?: (
     input: { cwd: string; sessionID?: string; callID?: string },


### PR DESCRIPTION
## What

Adds an optional `shortcircuit` field to the output object passed to the `tool.execute.before` plugin hook. When a plugin sets it to a `{ title, output, metadata }` object, opencode skips the real tool execution and returns that value as the tool_result, firing the normal `tool.execute.after` hook with the shortcircuited output.

## Why

Enables use cases where a plugin already knows the correct tool result and wants to serve it without executing the actual tool. Original motivation: **historical session replay for local-model training.** When replaying an old conversation to harvest training data, we want the LLM to see the exact same tool_result it saw the first time — no re-reading files, no re-running shells, no re-fetching URLs — while its reasoning path stays identical. Shortcircuit is the minimum runtime hook that makes this possible without either forking the tool registry or writing an MCP proxy layer.

Other plausible uses:
- Caching an expensive tool result across replays or CI runs.
- Deterministic tests / recordings.
- Sandboxing tool calls to a canned safe response during audit.

## How

Every `tool.execute.before` trigger in the codebase now inspects the mutated output object. If `shortcircuit` is set, opencode:

1. Uses `shortcircuit` as the tool result.
2. Fires `tool.execute.after` with that result (plugins that log/react to tool completion still work).
3. Returns without ever invoking the tool's real `execute`.

Instrumented sites:
- `packages/opencode/src/session/tools.ts` — primary built-in tool execute path
- `packages/opencode/src/session/tools.ts` — MCP resource list / listTemplates / read paths
- `packages/opencode/src/session/tools.ts` — generic MCP-served tool execute path
- `packages/opencode/src/tool/code-mode.ts` — MCP catalog tool execute path

`packages/opencode/src/session/prompt.ts` (task tool dispatching to a sub-agent) is intentionally **not** shortcircuited: it spawns a sub-agent session whose own tool calls go through the already-instrumented paths, so shortcircuit still applies at leaf tools while sub-agent reasoning is preserved.

## Compatibility

Fully backwards-compatible. The new field is optional; existing plugins that don't set `shortcircuit` see identical behavior to before.

## Testing

- `bun typecheck` from `packages/opencode` and `packages/plugin` — passes.
- Built a fork binary via `bun run build --single --skip-embed-web-ui`; smoke test (`opencode --version`) passes.

## Downstream

Consuming plugin implementation (for context): [jackieju/AIAgentLocalMemory](https://github.com/jackieju/AIAgentLocalMemory) uses this hook to replay historical opencode sessions into a training dataset for a local LLM, with zero side effects on the user's filesystem.
