### PR TITLE
fix(app): load capped review patches

### DIFF
--- a/packages/app/e2e/regression/review-terminal-stacked.spec.ts
+++ b/packages/app/e2e/regression/review-terminal-stacked.spec.ts
@@ -9,12 +9,15 @@ const title = "Review terminal stacked"
 const branchDiffs = [
   fileDiff(".github/actions/setup-bun/action.yml", 7),
   ...Array.from({ length: 2_739 }, (_, index) =>
-    fileDiff(`src/branch/generated-${String(index).padStart(4, "0")}.ts`, 100),
+    fileDiff(`src/branch/generated-${String(index).padStart(4, "0")}.ts`, 100, false),
   ),
 ]
 
 test("keeps the review tree and terminal sized when both panels are open", async ({ page }) => {
   test.setTimeout(120_000)
+  const events: Array<{ directory: string; payload: Record<string, unknown> }> = []
+  let detailVersion = 1
+  let detailFailures = 1
   await page.setViewportSize({ width: 1400, height: 900 })
   await mockOpenCodeServer(page, {
     directory,
@@ -48,7 +51,10 @@ test("keeps the review tree and terminal sized when both panels are open", async
         time: { created: 1700000000000, updated: 1700000000000 },
       },
     ],
+    sessionStatus: { [sessionID]: { type: "idle" } },
     pageMessages: () => ({ items: [] }),
+    events: () => events.splice(0, 1),
+    eventRetry: 16,
   })
   await page.route(/\/vcs(?:\?.*)?$/, (route) =>
     route.fulfill({
@@ -57,17 +63,22 @@ test("keeps the review tree and terminal sized when both panels are open", async
       body: JSON.stringify({ branch: "review-pane-performance", default_branch: "dev" }),
     }),
   )
-  await page.route("**/vcs/diff**", (route) =>
-    route.fulfill({
+  await page.route("**/vcs/diff**", (route) => {
+    const url = new URL(route.request().url())
+    const file = url.searchParams.get("file")
+    if (file && detailFailures-- > 0) return route.fulfill({ status: 500, body: "retry detail" })
+    return route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify(
-        new URL(route.request().url()).searchParams.get("mode") === "branch"
-          ? branchDiffs
+        url.searchParams.get("mode") === "branch"
+          ? file
+            ? [fileDiff(file, 100, true, detailVersion)]
+            : branchDiffs
           : Array.from({ length: 7 }, (_, index) => fileDiff(`src/git-${index}.ts`, 1)),
       ),
-    }),
-  )
+    })
+  })
   await page.route("**/pty", (route) =>
     route.fulfill({
       status: 200,
@@ -113,8 +124,27 @@ test("keeps the review tree and terminal sized when both panels are open", async
   })
   expect(bottomGap).toBeGreaterThanOrEqual(0)
   expect(bottomGap).toBeLessThanOrEqual(16)
+  const lazyDiff = page.waitForRequest((request) => {
+    const url = new URL(request.url())
+    return url.pathname === "/vcs/diff" && url.searchParams.get("file") === "src/branch/generated-2738.ts"
+  })
+  await lastFile.click()
+  await lazyDiff
+  const preview = page.locator('[data-slot="session-review-v2-diff-scroll"]')
+  await expect(preview).toContainText("after-1")
+  detailVersion = 2
+  events.push(statusEvent("busy"))
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible()
+  const refreshedDiff = page.waitForRequest((request) => {
+    const url = new URL(request.url())
+    return url.pathname === "/vcs/diff" && url.searchParams.get("file") === "src/branch/generated-2738.ts"
+  })
+  events.push(statusEvent("idle"))
+  await refreshedDiff
+  await expect(preview).toContainText("after-2")
   await selectMode(page, "Branch changes", "Git changes")
   await expectTree(page, 8, "git-0.ts")
+  await page.getByRole("button", { name: "git-0.ts" }).click()
   await selectMode(page, "Git changes", "Branch changes")
   await expectTree(page, 2_745, "action.yml")
 
@@ -201,12 +231,21 @@ function base64Encode(value: string) {
   return Buffer.from(value, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")
 }
 
-function fileDiff(file: string, additions: number) {
+function statusEvent(type: "busy" | "idle") {
+  return {
+    directory,
+    payload: { type: "session.status", properties: { sessionID, status: { type } } },
+  }
+}
+
+function fileDiff(file: string, additions: number, loaded = true, version = 1) {
   return {
     file,
     additions,
     deletions: 0,
     status: "modified",
-    patch: `diff --git a/${file} b/${file}\n--- a/${file}\n+++ b/${file}\n@@ -1 +1 @@\n-export const value = 'before'\n+export const value = 'after'\n`,
+    patch: loaded
+      ? `diff --git a/${file} b/${file}\n--- a/${file}\n+++ b/${file}\n@@ -1 +1 @@\n-export const value = 'before'\n+export const value = 'after-${version}'\n`
+      : `diff --git a/${file} b/${file}\n--- a/${file}\n+++ b/${file}`,
   }
 }

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1,4 +1,4 @@
-import type { Project, UserMessage } from "@opencode-ai/sdk/v2"
+import type { Project, UserMessage, VcsFileDiff } from "@opencode-ai/sdk/v2"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createQuery, skipToken, useMutation, useQueryClient } from "@tanstack/solid-query"
 import {
@@ -651,6 +651,23 @@ export default function Page() {
     if (store.changes === "git" || store.changes === "branch") return !vcsQuery.isPending
     return true
   }
+  const loadReviewDiff = async (file: string, version?: number): Promise<VcsFileDiff | undefined> => {
+    const mode = vcsMode()
+    if (!mode) return
+    return queryClient
+      .fetchQuery({
+        queryKey: [...vcsKey(), mode, "file", file, version] as const,
+        retry: 2,
+        queryFn: () =>
+          sdk()
+            .client.vcs.diff({ mode, file })
+            .then((result) => result.data?.find((diff) => diff.file === file)),
+      })
+      .catch((error) => {
+        console.debug("[session-review] failed to load vcs file diff", { mode, file, error })
+        return undefined
+      })
+  }
 
   const newSessionWorktree = createMemo(() => {
     if (store.newSessionWorktree === "create") return "create"
@@ -1182,6 +1199,10 @@ export default function Page() {
     },
     diffs: reviewDiffs,
     diffsReady: reviewReady,
+    get diffVersion() {
+      return vcsQuery.dataUpdatedAt
+    },
+    loadDiff: loadReviewDiff,
     get activeFile() {
       return tree.activeDiff
     },

--- a/packages/app/src/pages/session/v2/review-diff-kinds.test.ts
+++ b/packages/app/src/pages/session/v2/review-diff-kinds.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { filterReviewFiles, reviewDiffKinds } from "./review-diff-kinds"
+import { filterReviewFiles, reviewDiffKinds, reviewDiffNeedsLoad } from "./review-diff-kinds"
 
 describe("reviewDiffKinds", () => {
   test("maps file and directory kinds", () => {
@@ -26,5 +26,30 @@ describe("filterReviewFiles", () => {
     const files = ["src/a.ts", "src/b.ts", "lib/c.ts"]
     expect(filterReviewFiles(files, "b.ts")).toEqual(["src/b.ts"])
     expect(filterReviewFiles(files, "")).toEqual(files)
+  })
+})
+
+describe("reviewDiffNeedsLoad", () => {
+  test("loads changed files whose aggregate patch has no hunks", () => {
+    expect(
+      reviewDiffNeedsLoad({
+        file: "src/a.ts",
+        additions: 1,
+        deletions: 0,
+        patch: "diff --git a/src/a.ts b/src/a.ts\n--- a/src/a.ts\n+++ b/src/a.ts",
+      }),
+    ).toBe(true)
+  })
+
+  test("keeps complete patches and empty changes", () => {
+    expect(
+      reviewDiffNeedsLoad({
+        file: "src/a.ts",
+        additions: 1,
+        deletions: 0,
+        patch: "@@ -0,0 +1 @@\n+value",
+      }),
+    ).toBe(false)
+    expect(reviewDiffNeedsLoad({ file: "empty.txt", additions: 0, deletions: 0 })).toBe(false)
   })
 })

--- a/packages/app/src/pages/session/v2/review-diff-kinds.ts
+++ b/packages/app/src/pages/session/v2/review-diff-kinds.ts
@@ -12,6 +12,11 @@ export function filterRenderableDiff(value: SnapshotFileDiff | VcsFileDiff): val
   return typeof value.file === "string"
 }
 
+export function reviewDiffNeedsLoad(diff: RenderDiff) {
+  if (diff.additions === 0 && diff.deletions === 0) return false
+  return !diff.patch || !/^@@ /m.test(diff.patch)
+}
+
 export function reviewDiffKinds(diffs: RenderDiff[]) {
   const merge = (a: Kind | undefined, b: Kind) => {
     if (!a) return b

--- a/packages/app/src/pages/session/v2/review-panel-v2.tsx
+++ b/packages/app/src/pages/session/v2/review-panel-v2.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, Show, type JSX } from "solid-js"
+import { createEffect, createMemo, createSignal, onCleanup, Show, type JSX } from "solid-js"
 import type { SnapshotFileDiff, VcsFileDiff } from "@opencode-ai/sdk/v2"
 import {
   SESSION_REVIEW_V2_SIDEBAR_WIDTH_MAX,
@@ -25,6 +25,7 @@ import {
   filterRenderableDiff,
   filterReviewFiles,
   reviewDiffKinds,
+  reviewDiffNeedsLoad,
   type RenderDiff,
 } from "@/pages/session/v2/review-diff-kinds"
 import type { ReviewPanelV2State } from "@/pages/session/v2/review-panel-v2-state"
@@ -37,6 +38,8 @@ export type ReviewPanelV2Props = {
   empty?: JSX.Element
   diffs: () => ReviewDiff[]
   diffsReady: () => boolean
+  diffVersion?: number
+  loadDiff?: (path: string, version?: number) => Promise<RenderDiff | undefined>
   activeFile?: string
   onSelectFile: (path: string) => void
   diffStyle: SessionReviewDiffStyle
@@ -74,7 +77,30 @@ export function ReviewPanelV2(props: ReviewPanelV2Props) {
     if (active && files.includes(active)) return active
     return files[0]
   })
-  const activeItem = createMemo(() => diffs().find((diff) => diff.file === activeDiff()))
+  const sourceActiveItem = createMemo(() => diffs().find((diff) => diff.file === activeDiff()))
+  const [loadedDiff, setLoadedDiff] = createSignal<{ source: RenderDiff; version?: number; value: RenderDiff }>()
+  let loadToken = 0
+
+  createEffect(() => {
+    const diff = sourceActiveItem()
+    const load = props.loadDiff
+    const version = props.diffVersion
+    const token = ++loadToken
+    setLoadedDiff(undefined)
+    if (!diff || !load || !reviewDiffNeedsLoad(diff)) return
+    void load(diff.file, version).then((result) => {
+      if (token !== loadToken || result?.file !== diff.file) return
+      setLoadedDiff({ source: diff, version, value: result })
+    })
+  })
+  onCleanup(() => loadToken++)
+
+  const activeItem = createMemo(() => {
+    const source = sourceActiveItem()
+    const loaded = loadedDiff()
+    if (loaded && loaded.source === source && loaded.version === props.diffVersion) return loaded.value
+    return source
+  })
 
   const readFile = async (path: string) =>
     sdk()

--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -80,9 +80,9 @@ export interface Interface {
   readonly hasHead: (cwd: string) => Effect.Effect<boolean>
   readonly mergeBase: (cwd: string, base: string, head?: string) => Effect.Effect<string | undefined>
   readonly show: (cwd: string, ref: string, file: string, prefix?: string) => Effect.Effect<string>
-  readonly status: (cwd: string) => Effect.Effect<Item[]>
-  readonly diff: (cwd: string, ref: string) => Effect.Effect<Item[]>
-  readonly stats: (cwd: string, ref: string) => Effect.Effect<Stat[]>
+  readonly status: (cwd: string, file?: string) => Effect.Effect<Item[]>
+  readonly diff: (cwd: string, ref: string, file?: string) => Effect.Effect<Item[]>
+  readonly stats: (cwd: string, ref: string, file?: string) => Effect.Effect<Stat[]>
   readonly patch: (cwd: string, ref: string, file: string, options?: PatchOptions) => Effect.Effect<Patch>
   readonly patchAll: (cwd: string, ref: string, options?: PatchOptions) => Effect.Effect<Patch>
   readonly patchUntracked: (cwd: string, file: string, options?: PatchOptions) => Effect.Effect<Patch>
@@ -97,6 +97,8 @@ const kind = (code: string): Kind => {
   if (code.includes("D") && !code.includes("A")) return "deleted"
   return "modified"
 }
+
+const pathspec = (file: string | undefined) => (file ? `:(literal)${file}` : ".")
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Git") {}
 
@@ -212,11 +214,12 @@ const layer = Layer.effect(
       return result.text()
     })
 
-    const status = Effect.fn("Git.status")(function* (cwd: string) {
+    const status = Effect.fn("Git.status")(function* (cwd: string, file?: string) {
       return nuls(
-        yield* text(["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", "."], {
-          cwd,
-        }),
+        yield* text(
+          ["status", "--porcelain=v1", "--untracked-files=all", "--no-renames", "-z", "--", pathspec(file)],
+          { cwd },
+        ),
       ).flatMap((item) => {
         const file = item.slice(3)
         if (!file) return []
@@ -225,9 +228,11 @@ const layer = Layer.effect(
       })
     })
 
-    const diff = Effect.fn("Git.diff")(function* (cwd: string, ref: string) {
+    const diff = Effect.fn("Git.diff")(function* (cwd: string, ref: string, file?: string) {
       const list = nuls(
-        yield* text(["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", ref, "--", "."], { cwd }),
+        yield* text(["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", ref, "--", pathspec(file)], {
+          cwd,
+        }),
       )
       return list.flatMap((code, idx) => {
         if (idx % 2 !== 0) return []
@@ -237,9 +242,11 @@ const layer = Layer.effect(
       })
     })
 
-    const stats = Effect.fn("Git.stats")(function* (cwd: string, ref: string) {
+    const stats = Effect.fn("Git.stats")(function* (cwd: string, ref: string, file?: string) {
       return nuls(
-        yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
+        yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", pathspec(file)], {
+          cwd,
+        }),
       ).flatMap((item) => {
         const a = item.indexOf("\t")
         const b = item.indexOf("\t", a + 1)
@@ -262,7 +269,16 @@ const layer = Layer.effect(
 
     const patch = Effect.fn("Git.patch")(function* (cwd: string, ref: string, file: string, options?: PatchOptions) {
       const result = yield* run(
-        ["diff", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", file],
+        [
+          "diff",
+          "--patch",
+          "--no-ext-diff",
+          "--no-renames",
+          `--unified=${options?.context ?? 3}`,
+          ref,
+          "--",
+          pathspec(file),
+        ],
         { cwd, maxOutputBytes: options?.maxOutputBytes },
       )
       return { text: result.truncated ? "" : result.text(), truncated: result.truncated } satisfies Patch

--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -13,6 +13,7 @@ const MAX_PATCH_BYTES = 10_000_000
 const MAX_TOTAL_PATCH_BYTES = 10_000_000
 type DiffOptions = {
   readonly context?: number
+  readonly file?: string
 }
 
 const emptyPatch = (file: string) => formatPatch(structuredPatch(file, file, "", "", "", "", { context: 0 }))
@@ -205,9 +206,10 @@ const diffAgainstRef = Effect.fnUntraced(function* (
   ref: string,
   options?: DiffOptions,
 ) {
-  const [list, stats, extra] = yield* Effect.all([git.diff(cwd, ref), git.stats(cwd, ref), git.status(cwd)], {
-    concurrency: 3,
-  })
+  const [list, stats, extra] = yield* Effect.all(
+    [git.diff(cwd, ref, options?.file), git.stats(cwd, ref, options?.file), git.status(cwd, options?.file)],
+    { concurrency: 3 },
+  )
   return yield* files(
     git,
     cwd,
@@ -217,7 +219,7 @@ const diffAgainstRef = Effect.fnUntraced(function* (
       extra.filter((item) => item.code === "??"),
     ),
     nums(stats),
-    yield* batchPatches(git, cwd, ref, list, options),
+    options?.file ? emptyBatch() : yield* batchPatches(git, cwd, ref, list, options),
     options,
   )
 })
@@ -228,7 +230,7 @@ const track = Effect.fnUntraced(function* (
   ref: string | undefined,
   options?: DiffOptions,
 ) {
-  if (!ref) return yield* files(git, cwd, ref, yield* git.status(cwd), new Map(), emptyBatch(), options)
+  if (!ref) return yield* files(git, cwd, ref, yield* git.status(cwd, options?.file), new Map(), emptyBatch(), options)
   return yield* diffAgainstRef(git, cwd, ref, options)
 })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/instance.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/instance.ts
@@ -26,6 +26,7 @@ const PathInfo = Schema.Struct({
 export const VcsDiffQuery = Schema.Struct({
   ...WorkspaceRoutingQueryFields,
   mode: Vcs.Mode,
+  file: Schema.optional(Schema.String),
   context: Schema.optional(Schema.NumberFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0))),
 })
 

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/instance.ts
@@ -49,9 +49,9 @@ export const instanceHandlers = HttpApiBuilder.group(InstanceHttpApi, "instance"
     })
 
     const getVcsDiff = Effect.fn("InstanceHttpApi.vcsDiff")(function* (ctx: {
-      query: { mode: Vcs.Mode; context?: number }
+      query: { mode: Vcs.Mode; file?: string; context?: number }
     }) {
-      return yield* vcs.diff(ctx.query.mode, { context: ctx.query.context })
+      return yield* vcs.diff(ctx.query.mode, { file: ctx.query.file, context: ctx.query.context })
     })
 
     const getVcsDiffRaw = Effect.fn("InstanceHttpApi.vcsDiffRaw")(function* () {

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -237,6 +237,51 @@ describe("Vcs diff", () => {
   )
 
   it.instance(
+    "diff('git') loads one selected file",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* write(path.join(test.directory, "first.txt"), "original\n")
+        yield* write(path.join(test.directory, "second.txt"), "original\n")
+        yield* git(test.directory, ["add", "."])
+        yield* git(test.directory, ["commit", "--no-gpg-sign", "-m", "add files"])
+        yield* write(path.join(test.directory, "first.txt"), "first\n")
+        yield* write(path.join(test.directory, "second.txt"), "second\n")
+
+        const vcs = yield* init()
+        const diff = yield* vcs.diff("git", { file: "second.txt" })
+
+        expect(diff).toHaveLength(1)
+        expect(diff[0]?.file).toBe("second.txt")
+        expect(diff[0]?.patch).toContain("+second")
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "diff('git') treats a selected filename as a literal pathspec",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        yield* write(path.join(test.directory, "literal[1].txt"), "original\n")
+        yield* write(path.join(test.directory, "literal1.txt"), "original\n")
+        yield* git(test.directory, ["add", "."])
+        yield* git(test.directory, ["commit", "--no-gpg-sign", "-m", "add files"])
+        yield* write(path.join(test.directory, "literal[1].txt"), "selected\n")
+        yield* write(path.join(test.directory, "literal1.txt"), "other\n")
+
+        const vcs = yield* init()
+        const diff = yield* vcs.diff("git", { file: "literal[1].txt" })
+
+        expect(diff).toHaveLength(1)
+        expect(diff[0]?.file).toBe("literal[1].txt")
+        expect(diff[0]?.patch).toContain("+selected")
+        expect(diff[0]?.patch).not.toContain("+other")
+      }),
+    { git: true },
+  )
+
+  it.instance(
     "diff('git') handles special filenames",
     () =>
       Effect.gen(function* () {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2089,6 +2089,7 @@ export class Vcs extends HeyApiClient {
       directory?: string
       workspace?: string
       mode: "git" | "branch"
+      file?: string
       context?: number
     },
     options?: Options<never, ThrowOnError>,
@@ -2101,6 +2102,7 @@ export class Vcs extends HeyApiClient {
             { in: "query", key: "directory" },
             { in: "query", key: "workspace" },
             { in: "query", key: "mode" },
+            { in: "query", key: "file" },
             { in: "query", key: "context" },
           ],
         },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -8195,6 +8195,7 @@ export type VcsDiffData = {
     directory?: string
     workspace?: string
     mode: "git" | "branch"
+    file?: string
     context?: number
   }
   url: "/vcs/diff"

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -2475,6 +2475,14 @@
             "required": true
           },
           {
+            "name": "file",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
             "name": "context",
             "in": "query",
             "schema": {


### PR DESCRIPTION
## Summary
- lazily load selected review patches omitted by the aggregate 10 MB cap
- add literal, file-scoped VCS diff requests with generated SDK support
- retry and refresh detail patches without accepting stale responses

## Testing
- app, opencode, and SDK typechecks
- VCS and review diff unit tests
- review lifecycle regression in dev and production builds
- capped 10,000-file review benchmark