### PR TITLE
fix(provider): ensure required array is present in object schemas

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1432,6 +1432,15 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
   }
   */
 
+  // Ensure `required` is always an array when `properties` is present.
+  // Strict JSON Schema validators (e.g. ajv used by some API gateways/proxies)
+  // reject schemas where `additionalProperties: false` is set but `required`
+  // is missing or null. This normalizes all object schemas to include an
+  // explicit (possibly empty) `required` array.
+  if (schema.type === "object" && schema.properties && !Array.isArray(schema.required)) {
+    schema.required = []
+  }
+
   if (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") {
     schema = sanitizeOpenAISchema(schema) as JSONSchema7
     // Codex also applies lossy compaction above 4 KB; defer that until OpenCode needs the same schema budget.

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -150,6 +150,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             },
           },
           additionalProperties: false,
+          required: [],
         }),
       ),
       execute(args, opts) {
@@ -233,6 +234,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             },
           },
           additionalProperties: false,
+          required: [],
         }),
       ),
       execute(args, opts) {


### PR DESCRIPTION
### Issue for this PR

Closes #35528

### Type of change

- [x] Bug fix

### What does this PR do?

Tool schemas with `additionalProperties: false` but no `required` field fail strict JSON Schema validators. When serialized and sent to the model, the missing `required` becomes `null`, which validators like ajv (used by some OpenAI-compatible API gateways) reject with `null is not of type "array"`.

This hits `list_mcp_resources`, `list_mcp_resource_templates`, `skill_get_gold_advice`, and any other tool with the same pattern. The bug has been around since at least v0.1.109 (#250, Context7 MCP via OpenAI) and was reported again in #13618.

The fix normalizes all object schemas in `ProviderTransform.schema()` to include an explicit `required` array (empty if no fields are required) when `properties` is present. This function is the common path for all tool schemas, so one change covers every affected tool.

`required: []` means no fields are required, semantically identical to omitting `required`. Lenient validators ignore it. Strict validators now see a valid array instead of `null`. No behavior change for existing providers.

Also added `required: []` directly to `list_mcp_resources` and `list_mcp_resource_templates` in `session/tools.ts` as a defensive measure, though the `transform.ts` fix alone covers all cases.

### How did you verify your code works?

Built from dev branch with the patch applied. On 1.17.13 with default config (oh-my-opencode-slim plugin + minimax-coding-plan-mcp connected):

- Before fix: `opencode run -m <provider>/deepseek-v4-flash "say hi"` produces `AI_APICallError: Invalid schema for function 'list_mcp_resource_templates': null is not of type "array"`.
- After fix: same command returns a normal model response.

Tested four configurations: only the strict-validator + MCP-with-resources combination was broken before, and it works after the fix.

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR