### PR TITLE
fix(git): add --ignore-cr-at-eol to git diff commands

### DIFF
--- a/packages/opencode/src/git/index.ts
+++ b/packages/opencode/src/git/index.ts
@@ -227,7 +227,7 @@ const layer = Layer.effect(
 
     const diff = Effect.fn("Git.diff")(function* (cwd: string, ref: string) {
       const list = nuls(
-        yield* text(["diff", "--no-ext-diff", "--no-renames", "--name-status", "-z", ref, "--", "."], { cwd }),
+        yield* text(["diff", "--ignore-cr-at-eol", "--no-ext-diff", "--no-renames", "--name-status", "-z", ref, "--", "."], { cwd }),
       )
       return list.flatMap((code, idx) => {
         if (idx % 2 !== 0) return []
@@ -239,7 +239,7 @@ const layer = Layer.effect(
 
     const stats = Effect.fn("Git.stats")(function* (cwd: string, ref: string) {
       return nuls(
-        yield* text(["diff", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
+        yield* text(["diff", "--ignore-cr-at-eol", "--no-ext-diff", "--no-renames", "--numstat", "-z", ref, "--", "."], { cwd }),
       ).flatMap((item) => {
         const a = item.indexOf("\t")
         const b = item.indexOf("\t", a + 1)
@@ -262,7 +262,7 @@ const layer = Layer.effect(
 
     const patch = Effect.fn("Git.patch")(function* (cwd: string, ref: string, file: string, options?: PatchOptions) {
       const result = yield* run(
-        ["diff", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", file],
+        ["diff", "--ignore-cr-at-eol", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", file],
         { cwd, maxOutputBytes: options?.maxOutputBytes },
       )
       return { text: result.truncated ? "" : result.text(), truncated: result.truncated } satisfies Patch
@@ -270,7 +270,7 @@ const layer = Layer.effect(
 
     const patchAll = Effect.fn("Git.patchAll")(function* (cwd: string, ref: string, options?: PatchOptions) {
       const result = yield* run(
-        ["diff", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", "."],
+        ["diff", "--ignore-cr-at-eol", "--patch", "--no-ext-diff", "--no-renames", `--unified=${options?.context ?? 3}`, ref, "--", "."],
         { cwd, maxOutputBytes: options?.maxOutputBytes },
       )
       return { text: result.text(), truncated: result.truncated } satisfies Patch


### PR DESCRIPTION
### Issue for this PR

Closes #27276, Closes #30357

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, the Review window and Changes tab show modified files as if the entire file was rewritten. The root cause is the hardcoded `core.autocrlf=false` in `packages/opencode/src/git/index.ts`.

Windows defaults to `core.autocrlf=true`, which converts LF->CRLF on checkout. The VCS layer overrides this to `false`, so `git diff` compares CRLF working trees against LF repository blobs literally, marking every text file line as changed.

**Fix:** Add `--ignore-cr-at-eol` to all 4 `git diff` commands in `git/index.ts` so git ignores carriage-return at end-of-line during comparison. This makes a single-line edit in a 1000-line file show as +1/-1 instead of +1000/-1000.

### How did you verify your code works?

- `--ignore-cr-at-eol` makes git treat `\r\n` and `\n` as identical in diff computation. Affects all diff modes: `--name-status`, `--numstat`, `--patch` (single and bulk).
- Works on every git diff variant. Supported since Git 2.26 (2020).
- No-op on platforms without CRLF working trees (macOS/Linux).
- Actual file content is unchanged -- only the diff display ignores CR at line endings.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
