### PR TITLE
fix(core): skip oversized ripgrep match lines instead of aborting grep

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -232,7 +232,11 @@ const layer = Layer.effect(
           ],
           parse: (line) =>
             (Buffer.byteLength(line, "utf8") > MAX_RECORD_BYTES
-              ? Effect.fail(failure(`Ripgrep JSON record exceeded ${MAX_RECORD_BYTES} bytes`))
+              ? // Oversized JSON records (lines longer than ~64 KiB — minified
+                // bundles, base64, data rows) cannot usefully be surfaced and
+                // would abort the whole grep if failed. Skip them so the rest of
+                // the matches are still returned. (#35523)
+                Effect.succeed(undefined)
               : decodeJsonRecord(line).pipe(Effect.mapError((cause) => failure("Invalid ripgrep JSON output", cause)))
             ).pipe(
               Effect.flatMap((json) => {

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -62,4 +62,36 @@ describe("Ripgrep", () => {
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
   )
+
+  // Regression for #35523: a single match whose JSON record exceeds the
+  // 64 KiB parse guard (a line longer than ~65536 bytes) used to fail the
+  // entire grep with "Ripgrep JSON record exceeded N bytes". Such oversized
+  // lines (minified bundles, base64, data rows) should be skipped so the rest
+  // of the search results are still returned, instead of aborting the whole call.
+  it.live("skips oversized match lines instead of failing the whole grep", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const ripgrep = yield* Ripgrep.Service
+
+          // A line longer than MAX_RECORD_BYTES (64 * 1024). The match record
+          // rg emits carries the full line in lines.text, so its JSON record
+          // exceeds the guard.
+          const oversized = "needle" + "x".repeat(70_000) + "\n"
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "big.txt"), oversized))
+          // A normal short line in a different file, matching the same pattern.
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "small.txt"), "needle here\n"))
+
+          const matches = yield* ripgrep.grep({ cwd: tmp.path, pattern: "needle", limit: 10 })
+
+          // The short-line match must still be returned.
+          expect(matches.map((item) => item.entry.path)).toContain(RelativePath.make("small.txt"))
+          // The oversized line is skipped (not returned), but crucially the call
+          // did not throw — confirmed by reaching this assertion.
+          expect(matches.map((item) => item.entry.path)).not.toContain(RelativePath.make("big.txt"))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #35523

### Type of change

- [x] Bug fix

### What does this PR do?

`grep` aborts the entire search with `Ripgrep JSON record exceeded 65536 bytes` whenever a single match sits on a line longer than ~64 KiB (minified bundles, base64, large data rows) — every other match in the same call is thrown away.

The guard is opencode's own, in `packages/core/src/ripgrep.ts` (the `parse` callback inside `run`, `grep` branch):

```ts
Buffer.byteLength(line, "utf8") > MAX_RECORD_BYTES  // 64 * 1024
  ? Effect.fail(failure(`Ripgrep JSON record exceeded ${MAX_RECORD_BYTES} bytes`))
  : decodeJsonRecord(line)...
```

ripgrep itself exits 0 and emits the record fine — the failure is purely opencode rejecting its own output. I confirmed with real rg 15.1.0 that `--max-columns` does not help here: in `--json` mode it leaves `lines.text` at the full length, and `--max-columns-long` drops the match entirely. So the fix belongs in the parse guard, not the rg args.

Change: when a record exceeds `MAX_RECORD_BYTES`, return `undefined` (skipped by the existing `Stream.filter` just downstream) instead of failing. The remaining matches are still returned. Truly invalid JSON at normal length still fails with the same error as before.

Why this is the right trade: the display path already truncates `lines.text` to 2000 chars (in `Match.make` further down in `grep`), so the full content of an oversized line was never surfaced to the model/user anyway. Skipping one unusable line is strictly better than discarding the whole result set.

Credit: the reporter (@verkadabambam) identified the symptom and the failing message; this PR implements the fix on opencode's side after verifying rg's behavior ruled out an rg-args fix.

### How did you verify your code works?

Ran in an `oven/bun:1.3.14` container with git installed (the existing "keeps ignored files out of catch-all find results" test shells out to `git init`), against the v2 branch tip:

```
cd packages/core
bun test test/ripgrep.test.ts
bun run typecheck
```

- Added a regression test `skips oversized match lines instead of failing the whole grep`: writes `big.txt` (a 70000-byte line containing the pattern) and `small.txt` (a normal line), greps the pattern, asserts `small.txt` is returned, `big.txt` is skipped, and the call does not throw.
- Confirmed the regression test **fails** with the original `Effect.fail` and **passes** with the fix.
- All 3 tests in `ripgrep.test.ts` pass.
- `bun run typecheck` (`tsgo --noEmit`) in `packages/core` is clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR