### PR TITLE
fix(mcp): tolerate invalid output schema patterns

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -162,8 +162,13 @@ function listTools(client: Client, timeout: number) {
 }
 
 function isOutputSchemaValidationError(error: Error) {
-  return /can't resolve reference|resolves to more than one schema|outputSchema|schema.*reference|reference.*schema/i.test(
-    error.message,
+  return (
+    /can't resolve reference|resolves to more than one schema|outputSchema|schema.*reference|reference.*schema/i.test(
+      error.message,
+    ) ||
+    // The SDK compiles outputSchema validators during listTools.
+    // Malformed ECMA patterns surface without the outputSchema prefix.
+    /invalid regular expression/i.test(error.message)
   )
 }
 

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -105,3 +105,43 @@ test("preserves output schema validation across paginated tool discovery", async
     await Promise.all([client.close(), server.close()])
   }
 })
+
+test("falls back to raw tool discovery when an output schema pattern is not ECMAScript", async () => {
+  const server = new Server({ name: "invalid-pattern", version: "1.0.0" }, { capabilities: { tools: {} } })
+  server.setRequestHandler(ListToolsRequestSchema, () =>
+    Promise.resolve({
+      tools: [
+        {
+          name: "python_pattern",
+          inputSchema: { type: "object" },
+          outputSchema: {
+            type: "object",
+            properties: {
+              workflow: {
+                type: "string",
+                pattern: "(?P<workflow_id>wf-[0-9a-f]{32})",
+              },
+            },
+          },
+        },
+        {
+          name: "plain",
+          inputSchema: { type: "object" },
+        },
+      ],
+    }),
+  )
+
+  const client = new Client({ name: "invalid-pattern-test", version: "1.0.0" })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+  try {
+    await expect(client.listTools()).rejects.toThrow("Invalid regular expression")
+
+    const tools = await Effect.runPromise(McpCatalog.defs(client))
+    expect(tools?.map((tool) => tool.name)).toEqual(["python_pattern", "plain"])
+  } finally {
+    await Promise.all([client.close(), server.close()])
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35624

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`client.listTools()` can throw while the MCP SDK precompiles outputSchema validators when a tool declares a non-ECMAScript `pattern`, for example a Python-style named group. `McpCatalog.defs()` then treats discovery as failed and hides the server tools.

This change classifies that SDK `Invalid regular expression` failure as one of the output-schema validation cases that already fall back to a raw `tools/list` request with `outputSchema` omitted, so the catalog still exposes the tool list.

The regression test keeps normal output-schema validation coverage intact and proves this fallback for a malformed output schema pattern. I intentionally kept the code scoped to the observed SDK failure path instead of changing input schema handling.

### How did you verify your code works?

- `cd packages/opencode && bun test test/mcp/catalog.test.ts`
- `cd packages/opencode && bun test test/mcp/oauth-auto-connect.test.ts`
- `cd packages/opencode && bun typecheck`
- `git diff --check`
- pre-push hook: `bun turbo typecheck` (30 tasks)

### Screenshots / recordings

N/A, MCP catalog behavior change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR