### PR TITLE
fix(mcp): decode text resource blobs

### DIFF
--- a/packages/opencode/src/session/mcp-resource-content.ts
+++ b/packages/opencode/src/session/mcp-resource-content.ts
@@ -1,0 +1,37 @@
+export const MAX_MCP_RESOURCE_BLOB_BYTES = 10 * 1024 * 1024
+
+const SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES = new Set([
+  "application/pdf",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+])
+
+export function normalizeMcpResourceMime(value: string | undefined) {
+  return value?.split(";")[0]?.trim().toLowerCase() || "application/octet-stream"
+}
+
+export function isSupportedMcpResourceAttachmentMime(value: string) {
+  return SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(normalizeMcpResourceMime(value))
+}
+
+export function isTextMcpResourceMime(value: string) {
+  return normalizeMcpResourceMime(value).startsWith("text/")
+}
+
+export function decodeMcpResourceTextBlob(value: string) {
+  return Buffer.from(value.replace(/\s/g, ""), "base64").toString("utf8")
+}
+
+export function mcpResourceBase64Size(value: string) {
+  const trimmed = value.replace(/\s/g, "")
+  const padding = trimmed.endsWith("==") ? 2 : trimmed.endsWith("=") ? 1 : 0
+  return Math.max(0, Math.floor((trimmed.length * 3) / 4) - padding)
+}
+
+export function formatMcpResourceBytes(value: number) {
+  if (value < 1024) return `${value} B`
+  if (value < 1024 * 1024) return `${Math.ceil(value / 1024)} KB`
+  return `${Math.ceil(value / (1024 * 1024))} MB`
+}

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -56,21 +56,21 @@ import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import {
+  MAX_MCP_RESOURCE_BLOB_BYTES,
+  decodeMcpResourceTextBlob,
+  formatMcpResourceBytes,
+  isSupportedMcpResourceAttachmentMime,
+  isTextMcpResourceMime,
+  mcpResourceBase64Size,
+  normalizeMcpResourceMime,
+} from "./mcp-resource-content"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
 
 const decodeMessageInfo = Schema.decodeUnknownExit(SessionV1.Info)
 const decodeMessagePart = Schema.decodeUnknownExit(SessionV1.Part)
-const MAX_MCP_RESOURCE_BLOB_BYTES = 10 * 1024 * 1024
-const SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES = new Set([
-  "application/pdf",
-  "image/gif",
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-])
-
 const STRUCTURED_OUTPUT_DESCRIPTION = `Use this tool to return your final response in the requested structured format.
 
 IMPORTANT:
@@ -80,18 +80,6 @@ IMPORTANT:
 - This tool provides your final answer - no further actions are taken after calling it`
 
 const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema.`
-
-function mcpResourceBase64Size(value: string) {
-  const trimmed = value.replace(/\s/g, "")
-  const padding = trimmed.endsWith("==") ? 2 : trimmed.endsWith("=") ? 1 : 0
-  return Math.max(0, Math.floor((trimmed.length * 3) / 4) - padding)
-}
-
-function formatMcpResourceBytes(value: number) {
-  if (value < 1024) return `${value} B`
-  if (value < 1024 * 1024) return `${Math.ceil(value / 1024)} KB`
-  return `${Math.ceil(value / (1024 * 1024))} MB`
-}
 
 function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   // cleanup() marks abandoned tool_use blocks this way after retries/aborts.
@@ -728,10 +716,32 @@ const layer = Layer.effect(
                     text: c.text,
                   })
                 } else if ("blob" in c && typeof c.blob === "string" && c.blob) {
-                  const mime = "mimeType" in c && typeof c.mimeType === "string" ? c.mimeType : part.mime
+                  const mime = normalizeMcpResourceMime(
+                    "mimeType" in c && typeof c.mimeType === "string" ? c.mimeType : part.mime,
+                  )
                   const filename = "uri" in c && typeof c.uri === "string" ? c.uri : part.filename
                   const size = mcpResourceBase64Size(c.blob)
-                  if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
+                  if (isTextMcpResourceMime(mime)) {
+                    if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
+                      pieces.push({
+                        messageID: info.id,
+                        sessionID: input.sessionID,
+                        type: "text",
+                        synthetic: true,
+                        text: `[Binary MCP resource omitted: ${filename ?? uri} (${mime}, ${formatMcpResourceBytes(size)}) exceeds ${formatMcpResourceBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
+                      })
+                      continue
+                    }
+                    pieces.push({
+                      messageID: info.id,
+                      sessionID: input.sessionID,
+                      type: "text",
+                      synthetic: true,
+                      text: decodeMcpResourceTextBlob(c.blob),
+                    })
+                    continue
+                  }
+                  if (!isSupportedMcpResourceAttachmentMime(mime)) {
                     pieces.push({
                       messageID: info.id,
                       sessionID: input.sessionID,

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -23,21 +23,21 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { isRecord } from "@/util/record"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import {
+  MAX_MCP_RESOURCE_BLOB_BYTES,
+  decodeMcpResourceTextBlob,
+  formatMcpResourceBytes as formatBytes,
+  isSupportedMcpResourceAttachmentMime,
+  isTextMcpResourceMime,
+  mcpResourceBase64Size as base64Size,
+  normalizeMcpResourceMime,
+} from "./mcp-resource-content"
 
 const MCP_RESOURCE_TOOLS = {
   list: "list_mcp_resources",
   listTemplates: "list_mcp_resource_templates",
   read: "read_mcp_resource",
 } as const
-const MAX_MCP_RESOURCE_BLOB_BYTES = 10 * 1024 * 1024
-const SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES = new Set([
-  "application/pdf",
-  "image/gif",
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-])
-
 export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   agent: Agent.Info
   model: Provider.Model
@@ -437,9 +437,21 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               const { resource } = contentItem
               if (resource.text) textParts.push(resource.text)
               if (resource.blob) {
-                const mime = resource.mimeType ?? "application/octet-stream"
+                const mime = normalizeMcpResourceMime(resource.mimeType)
                 const size = base64Size(resource.blob)
-                if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
+                if (isTextMcpResourceMime(mime)) {
+                  if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
+                    textParts.push(
+                      `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) exceeds ${formatBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
+                    )
+                    continue
+                  }
+                  textParts.push(
+                    `Resource: ${resource.uri}\nMIME: ${mime}\n${decodeMcpResourceTextBlob(resource.blob)}`,
+                  )
+                  continue
+                }
+                if (!isSupportedMcpResourceAttachmentMime(mime)) {
                   textParts.push(
                     `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
                   )
@@ -530,21 +542,31 @@ function formatMcpResourceTemplate(template: Record<string, unknown> & { client:
   return { ...result, server: template.client }
 }
 
-function formatMcpResourceContent(server: string, uri: string, content: { contents: unknown }) {
+export function formatMcpResourceContent(server: string, uri: string, content: { contents: unknown }) {
   const items = (Array.isArray(content.contents) ? content.contents : [content.contents]).filter(isRecord)
   const text: string[] = []
   const attachments: Omit<SessionV1.FilePart, "id" | "sessionID" | "messageID">[] = []
 
   for (const item of items) {
     const itemUri = typeof item.uri === "string" ? item.uri : uri
-    const mime = typeof item.mimeType === "string" ? item.mimeType : "application/octet-stream"
+    const mime = normalizeMcpResourceMime(typeof item.mimeType === "string" ? item.mimeType : undefined)
     if (typeof item.text === "string") {
       text.push(`Resource: ${itemUri}\nMIME: ${mime}\n${item.text}`)
       continue
     }
     if (typeof item.blob === "string") {
       const size = base64Size(item.blob)
-      if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
+      if (isTextMcpResourceMime(mime)) {
+        if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
+          text.push(
+            `[Binary MCP resource omitted: ${itemUri} (${mime}, ${formatBytes(size)}) exceeds ${formatBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
+          )
+          continue
+        }
+        text.push(`Resource: ${itemUri}\nMIME: ${mime}\n${decodeMcpResourceTextBlob(item.blob)}`)
+        continue
+      }
+      if (!isSupportedMcpResourceAttachmentMime(mime)) {
         text.push(
           `[Binary MCP resource omitted: ${itemUri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
         )
@@ -573,18 +595,6 @@ function formatMcpResourceContent(server: string, uri: string, content: { conten
     attachments,
     text: text.join("\n\n") || `MCP resource ${uri} from ${server} returned no contents.`,
   }
-}
-
-function base64Size(value: string) {
-  const trimmed = value.replace(/\s/g, "")
-  const padding = trimmed.endsWith("==") ? 2 : trimmed.endsWith("=") ? 1 : 0
-  return Math.max(0, Math.floor((trimmed.length * 3) / 4) - padding)
-}
-
-function formatBytes(value: number) {
-  if (value < 1024) return `${value} B`
-  if (value < 1024 * 1024) return `${Math.ceil(value / 1024)} KB`
-  return `${Math.ceil(value / (1024 * 1024))} MB`
 }
 
 export * as SessionTools from "./tools"

--- a/packages/opencode/test/session/mcp-resource-content.test.ts
+++ b/packages/opencode/test/session/mcp-resource-content.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test"
+import { SessionTools } from "@/session/tools"
+
+test("decodes textual MCP resource blobs into model-visible text", () => {
+  const markdown = "# Example Implementation Plan\n\nShip the small fix first.\n"
+  const result = SessionTools.formatMcpResourceContent("jira", "attachment:///EXAMPLE-123/plan.md", {
+    contents: [
+      {
+        uri: "attachment:///EXAMPLE-123/plan.md",
+        mimeType: "text/markdown",
+        blob: Buffer.from(markdown, "utf8").toString("base64"),
+      },
+    ],
+  })
+
+  expect(result.attachments).toEqual([])
+  expect(result.text).toContain("Resource: attachment:///EXAMPLE-123/plan.md")
+  expect(result.text).toContain("MIME: text/markdown")
+  expect(result.text).toContain(markdown)
+  expect(result.text).not.toContain("Binary MCP resource omitted")
+})
+
+test("keeps supported binary MCP resource blobs as attachments", () => {
+  const result = SessionTools.formatMcpResourceContent("docs", "file:///tmp/report.pdf", {
+    contents: [
+      {
+        uri: "file:///tmp/report.pdf",
+        mimeType: "application/pdf",
+        blob: "JVBERg==",
+      },
+    ],
+  })
+
+  expect(result.text).toContain("[Binary MCP resource attached: file:///tmp/report.pdf (application/pdf)]")
+  expect(result.attachments).toEqual([
+    {
+      type: "file",
+      mime: "application/pdf",
+      url: "data:application/pdf;base64,JVBERg==",
+      filename: "file:///tmp/report.pdf",
+    },
+  ])
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35538

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP tool results and `read_mcp_resource` can return `EmbeddedResource` items with a textual MIME type and a base64 `blob`, for example Jira attachments with `mimeType: "text/markdown"`. OpenCode previously treated those blobs as unsupported binary attachments and emitted an omission notice, so the model never saw the Markdown content.

This change adds shared MCP resource blob handling for session tool output and prompt resource reads. `text/*` resource blobs are decoded as UTF-8 text and included in model-visible text, while the existing PDF/image attachment behavior and the 10 MB blob limit remain in place.

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/mcp-resource-content.test.ts test/session/prompt.test.ts`
- `cd packages/opencode && bun typecheck`
- `git diff --check`
- pre-push hook: `bun turbo typecheck` (30 tasks)

### Screenshots / recordings

N/A, MCP resource handling change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR