### PR TITLE
fix(app): hide markdown task markers

### DIFF
--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -123,15 +123,16 @@
 
   li:has(> input[type="checkbox"]),
   li:has(> p > input[type="checkbox"]) {
+    position: relative;
     list-style-type: none;
   }
 
-  li:has(> input[type="checkbox"]),
-  li > p:has(> input[type="checkbox"]) {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-left: -20px;
+  li > input[type="checkbox"],
+  li > p > input[type="checkbox"] {
+    position: absolute;
+    top: 4px;
+    left: -20px;
+    margin: 0;
   }
 
   li > p + p {

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -121,6 +121,19 @@
     margin: 0;
   }
 
+  li:has(> input[type="checkbox"]),
+  li:has(> p > input[type="checkbox"]) {
+    list-style-type: none;
+  }
+
+  li:has(> input[type="checkbox"]),
+  li > p:has(> input[type="checkbox"]) {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: -20px;
+  }
+
   li > p + p {
     display: block;
     margin-top: 0.5rem;


### PR DESCRIPTION
## Summary

- hide native list markers for Markdown task items
- preserve markers for regular ordered and unordered lists

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/b62850f7-448d-4fb9-813e-664de0e20705" />


## Validation

- `bun test src --only-failures` in `packages/session-ui`
- `bun typecheck` in `packages/session-ui`
- pre-push full workspace typecheck (30 packages)