### PR TITLE
fix(llm): classify zai token limit overflow

### DIFF
--- a/packages/llm/src/provider-error.ts
+++ b/packages/llm/src/provider-error.ts
@@ -6,6 +6,7 @@ const patterns = [
   /input is too long for requested model/i,
   /exceeds the context window/i,
   /input token count.*exceeds the maximum/i,
+  /tokens in request more than max tokens allowed/i,
   /maximum prompt length is \d+/i,
   /reduce the length of the messages/i,
   /maximum context length is \d+ tokens/i,

--- a/packages/llm/test/provider-error.test.ts
+++ b/packages/llm/test/provider-error.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test"
+import { isContextOverflow } from "../src"
+
+describe("provider error classification", () => {
+  test("classifies Z.AI GLM token limit messages as context overflow", () => {
+    expect(isContextOverflow("tokens in request more than max tokens allowed")).toBe(true)
+  })
+})

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1448,6 +1448,7 @@ describe("session.message-v2.fromError", () => {
       "prompt is too long: 213462 tokens > 200000 maximum",
       "Your input exceeds the context window of this model",
       "The input token count (1196265) exceeds the maximum number of tokens allowed (1048575)",
+      "tokens in request more than max tokens allowed",
       "Please reduce the length of the messages or completion",
       "400 status code (no body)",
       "413 status code (no body)",


### PR DESCRIPTION
### Issue for this PR

Fixes #27519
Also covers the Z.AI/GLM repro in #27629.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the Z.AI/GLM error text `tokens in request more than max tokens allowed` to the shared context-overflow matcher. That makes APICallError conversion produce `ContextOverflowError`, so the existing compaction path can run instead of treating the provider response as a generic API error.

I added coverage at the shared LLM matcher and at the opencode session error conversion layer.

### How did you verify your code works?

Before the implementation, `bun test --timeout 30000 test/session/message-v2.test.ts` from `packages/opencode` failed on the added provider message case.

Passing checks after the fix:

- `bun test --timeout 30000 test/provider-error.test.ts` from `packages/llm`
- `bun test --timeout 30000 test/session/message-v2.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/llm`
- `bun typecheck` from `packages/opencode`
- Pre-push hook: `bun turbo typecheck` from repo root, 30 successful / 30 total

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
