### PR TITLE
fix(config): resolve API credential templates

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -214,13 +214,14 @@ const layer = Layer.effect(
       text: string,
       options: { path: string } | { dir: string; source: string },
       env?: Record<string, string>,
+      credentials?: Record<string, string>,
     ) {
       const source = "path" in options ? options.path : options.source
       const expanded = yield* Effect.promise(() =>
         ConfigVariable.substitute(
           "path" in options
-            ? { text, type: "path", path: options.path, env }
-            : { text, type: "virtual", ...options, env },
+            ? { text, type: "path", path: options.path, env, credentials }
+            : { text, type: "virtual", ...options, env, credentials },
         ),
       )
       const parsed = ConfigParse.jsonc(expanded, source)
@@ -236,14 +237,21 @@ const layer = Layer.effect(
       return data
     })
 
-    const loadFile = Effect.fnUntraced(function* (filepath: string, env?: Record<string, string>) {
+    const loadFile = Effect.fnUntraced(function* (
+      filepath: string,
+      env?: Record<string, string>,
+      credentials?: Record<string, string>,
+    ) {
       yield* Effect.logInfo("loading", { path: filepath })
       const text = yield* readConfigFile(filepath)
       if (!text) return {} as Info
-      return yield* loadConfig(text, { path: filepath }, env)
+      return yield* loadConfig(text, { path: filepath }, env, credentials)
     })
 
-    const loadGlobal = Effect.fnUntraced(function* (env?: Record<string, string>) {
+    const loadGlobal = Effect.fnUntraced(function* (
+      env?: Record<string, string>,
+      credentials?: Record<string, string>,
+    ) {
       let result: Info = {}
       // Seed the default global config with the schema for editor completion, but avoid writing when the user
       // explicitly routes config through env-provided paths or content.
@@ -255,9 +263,9 @@ const layer = Layer.effect(
             .pipe(Effect.catch(() => Effect.void))
         }
       }
-      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "config.json"), env))
-      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.json"), env))
-      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.jsonc"), env))
+      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "config.json"), env, credentials))
+      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.json"), env, credentials))
+      result = mergeConfig(result, yield* loadFile(path.join(Global.Path.config, "opencode.jsonc"), env, credentials))
 
       const legacy = path.join(Global.Path.config, "config")
       if (existsSync(legacy)) {
@@ -317,6 +325,7 @@ const layer = Layer.effect(
 
         let result: Info = {}
         const authEnv: Record<string, string> = {}
+        const authCredentials: Record<string, string> = {}
         const consoleManagedProviders = new Set<string>()
         let activeOrgName: string | undefined
 
@@ -351,6 +360,10 @@ const layer = Layer.effect(
         const merge = (source: string, next: Info, kind?: ConfigPlugin.Scope) => {
           result = mergeConfigConcatArrays(result, next)
           return mergePluginOrigins(source, next.plugin, kind)
+        }
+
+        for (const [key, value] of Object.entries(auth)) {
+          if (value.type === "api") authCredentials[key.replace(/\/+$/, "")] = value.key
         }
 
         for (const [key, value] of Object.entries(auth)) {
@@ -395,17 +408,18 @@ const layer = Layer.effect(
           }
         }
 
-        const global = Object.keys(authEnv).length ? yield* loadGlobal(authEnv) : yield* getGlobal()
+        const hasAuthSubstitutions = Object.keys(authEnv).length > 0 || Object.keys(authCredentials).length > 0
+        const global = hasAuthSubstitutions ? yield* loadGlobal(authEnv, authCredentials) : yield* getGlobal()
         yield* merge(Global.Path.config, global, "global")
 
         if (Flag.OPENCODE_CONFIG) {
-          yield* merge(Flag.OPENCODE_CONFIG, yield* loadFile(Flag.OPENCODE_CONFIG, authEnv))
+          yield* merge(Flag.OPENCODE_CONFIG, yield* loadFile(Flag.OPENCODE_CONFIG, authEnv, authCredentials))
           yield* Effect.logDebug("loaded custom config", { path: Flag.OPENCODE_CONFIG })
         }
 
         if (!Flag.OPENCODE_DISABLE_PROJECT_CONFIG) {
           for (const file of yield* ConfigPaths.files("opencode", ctx.directory, ctx.worktree).pipe(Effect.orDie)) {
-            yield* merge(file, yield* loadFile(file, authEnv), "local")
+            yield* merge(file, yield* loadFile(file, authEnv, authCredentials), "local")
           }
         }
 
@@ -426,7 +440,7 @@ const layer = Layer.effect(
             for (const file of ["opencode.json", "opencode.jsonc"]) {
               const source = path.join(dir, file)
               yield* Effect.logDebug(`loading config from ${source}`)
-              yield* merge(source, yield* loadFile(source, authEnv))
+              yield* merge(source, yield* loadFile(source, authEnv, authCredentials))
               result.agent ??= {}
               result.mode ??= {}
               result.plugin ??= []
@@ -467,10 +481,15 @@ const layer = Layer.effect(
 
         if (process.env.OPENCODE_CONFIG_CONTENT) {
           const source = "OPENCODE_CONFIG_CONTENT"
-          const next = yield* loadConfig(process.env.OPENCODE_CONFIG_CONTENT, {
-            dir: ctx.directory,
-            source,
-          })
+          const next = yield* loadConfig(
+            process.env.OPENCODE_CONFIG_CONTENT,
+            {
+              dir: ctx.directory,
+              source,
+            },
+            authEnv,
+            authCredentials,
+          )
           yield* merge(source, next, "local")
           yield* Effect.logDebug("loaded custom config from OPENCODE_CONFIG_CONTENT")
         }

--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -20,6 +20,7 @@ type SubstituteInput = ParseSource & {
   text: string
   missing?: "error" | "empty"
   env?: Record<string, string>
+  credentials?: Record<string, string>
 }
 
 function source(input: ParseSource) {
@@ -30,12 +31,17 @@ function dir(input: ParseSource) {
   return input.type === "path" ? path.dirname(input.path) : input.dir
 }
 
-/** Apply {env:VAR} and {file:path} substitutions to config text. */
+/** Apply {env:VAR}, {cred:id}, and {file:path} substitutions to config text. */
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
   let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
     return (input.env?.[varName] ?? process.env[varName]) || ""
   })
+  if (input.credentials) {
+    text = text.replace(/\{cred:([^}]+)\}/g, (_, id) => {
+      return input.credentials?.[id] ?? ""
+    })
+  }
 
   const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))
   if (!fileMatches.length) return text

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -554,6 +554,40 @@ it.instance("handles file inclusion with replacement tokens", () =>
   }),
 )
 
+const apiCredentialIt = configIt({
+  auth: Layer.mock(Auth.Service)({
+    all: () =>
+      Effect.succeed({
+        abc: new Auth.Api({ type: "api", key: "sk-test-abc" }),
+      }),
+  }),
+})
+
+apiCredentialIt.instance("resolves cred templates in provider options from auth credentials", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    yield* writeConfigEffect(test.directory, {
+      $schema: "https://opencode.ai/config.json",
+      provider: {
+        abc: {
+          npm: "@ai-sdk/openai-compatible",
+          options: {
+            baseURL: "https://api.example.com/v1",
+            apiKey: "{cred:abc}",
+          },
+          models: {
+            "example-model": {
+              name: "Example Model",
+            },
+          },
+        },
+      },
+    })
+    const config = yield* Config.use.get()
+    expect(config.provider?.abc?.options?.apiKey).toBe("sk-test-abc")
+  }),
+)
+
 const accountTokenIt = configIt({
   account: Layer.mock(Account.Service)({
     active: () =>


### PR DESCRIPTION
### Issue for this PR

Closes #31085

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom provider config can reference a saved API auth entry with `{cred:provider}`. Previously config substitution only handled `{env}` and `{file}`, so `options.apiKey: "{cred:abc}"` stayed literal and was sent as the bearer token.

This adds credential-aware substitution for local config loads and builds the substitution map from `type: "api"` auth entries.

### How did you verify your code works?

- `bun test --timeout 30000 test/config/config.test.ts -t "resolves cred templates"`
- `bun test --timeout 30000 test/config/config.test.ts`
- `bun run typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`
- `git diff --check`

### Screenshots / recordings

N/A, config loading change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR