### PR TITLE
fix(session): bound html retry messages

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -119,7 +119,7 @@ export function retryable(error: Err, provider: string) {
         },
       }
     }
-    return { message: error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message }
+    return { message: retryMessage(error) }
   }
 
   // Check for rate limit patterns in plain text error messages
@@ -149,6 +149,21 @@ export function retryable(error: Err, provider: string) {
     return { message: "Rate Limited" }
   }
   return undefined
+}
+
+function retryMessage(error: SessionV1.APIError) {
+  if (error.data.message.includes("Overloaded")) return "Provider is overloaded"
+  if (isHtmlDocument(error.data.message) || isHtmlDocument(error.data.responseBody)) {
+    const status = error.data.statusCode
+    if (status !== undefined && status >= 500) return `Provider temporarily unavailable (HTTP ${status})`
+    if (status !== undefined) return `Provider request failed (HTTP ${status})`
+    return "Provider request failed"
+  }
+  return error.data.message
+}
+
+function isHtmlDocument(value: unknown) {
+  return typeof value === "string" && /<(?:!doctype\s+html|html|head|body)(?:\s|>)/i.test(value)
 }
 
 function str(value: unknown) {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -228,6 +228,28 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "Service unavailable" })
   })
 
+  test("bounds html retry messages for provider 503 errors", () => {
+    const html = `<html>
+<head><title>503 Service Temporarily Unavailable</title></head>
+<body>
+<center><h1>503 Service Temporarily Unavailable</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>`
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: `Provider request failed with HTTP 503: ${html}`,
+        isRetryable: false,
+        statusCode: 503,
+        responseBody: html,
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "Provider temporarily unavailable (HTTP 503)",
+    })
+  })
+
   test("does not retry 4xx errors when isRetryable is false", () => {
     const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
       new SessionV1.APIError({


### PR DESCRIPTION
### Issue for this PR

Closes #35640

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a retryable provider error includes an HTML response body, keep the retry status message short instead of surfacing the raw HTML. The existing retry decision is unchanged; only the displayed message is bounded for HTML provider failures.

### How did you verify your code works?

- `bun test --timeout 30000 test/session/retry.test.ts`
- `bun run typecheck` from `packages/opencode`
- `bun run lint` from the repo root
- `git diff --check`

### Screenshots / recordings

N/A, retry status text only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR