### PR TITLE
fix(mcp): tolerate invalid output schema patterns

### DIFF
--- a/packages/opencode/src/mcp/catalog.ts
+++ b/packages/opencode/src/mcp/catalog.ts
@@ -162,7 +162,7 @@ function listTools(client: Client, timeout: number) {
 }
 
 function isOutputSchemaValidationError(error: Error) {
-  return /can't resolve reference|resolves to more than one schema|outputSchema|schema.*reference|reference.*schema/i.test(
+  return /can't resolve reference|resolves to more than one schema|outputSchema|schema.*reference|reference.*schema|invalid regular expression|unrecognized character after/i.test(
     error.message,
   )
 }

--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -105,3 +105,46 @@ test("preserves output schema validation across paginated tool discovery", async
     await Promise.all([client.close(), server.close()])
   }
 })
+
+test("falls back when a tool output schema contains a non-ECMAScript pattern", async () => {
+  const server = new Server({ name: "invalid-pattern", version: "1.0.0" }, { capabilities: { tools: {} } })
+  server.setRequestHandler(ListToolsRequestSchema, () =>
+    Promise.resolve({
+      tools: [
+        {
+          name: "valid",
+          inputSchema: { type: "object" },
+          outputSchema: {
+            type: "object",
+            properties: { value: { type: "string" } },
+          },
+        },
+        {
+          name: "invalid_pattern",
+          inputSchema: { type: "object" },
+          outputSchema: {
+            type: "object",
+            properties: {
+              workflow: {
+                type: "string",
+                pattern: "(?P<workflow_id>wf-[0-9a-f]{32})",
+              },
+            },
+          },
+        },
+      ],
+    }),
+  )
+
+  const client = new Client({ name: "invalid-pattern-test", version: "1.0.0" })
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+
+  try {
+    const tools = await Effect.runPromise(McpCatalog.defs(client))
+    expect(tools?.map((tool) => tool.name)).toEqual(["valid", "invalid_pattern"])
+    expect(tools?.some((tool) => Object.hasOwn(tool, "outputSchema"))).toBe(false)
+  } finally {
+    await Promise.all([client.close(), server.close()])
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35624

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some MCP servers can return a tool `outputSchema` whose `pattern` is not valid in ECMAScript regex syntax. The MCP SDK validates `tools/list`, then precompiles output schema validators in `Client.listTools()`. When that precompile throws, OpenCode currently treats the whole tool discovery as failed.

OpenCode already has a tolerant `tools/list` retry path for output schema validation problems. This PR extends that same fallback to SDK errors caused by invalid output schema regex patterns, so the server can still connect and list tools while output-schema validation is skipped for that fallback response.

### How did you verify your code works?

- Added a regression test that reproduces the current failure with `(?P<workflow_id>...)` in a tool output schema pattern. Before the fix, `McpCatalog.defs()` returned `undefined` for the whole tool list.
- `bun test --timeout 30000 test/mcp/catalog.test.ts`
- `bun test --timeout 30000 test/mcp`
- `bunx prettier --check packages/opencode/src/mcp/catalog.ts packages/opencode/test/mcp/catalog.test.ts`
- `bun run typecheck` from `packages/opencode`
- `bun run lint` from the repo root
- pre-push `bun turbo typecheck`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
