### PR TITLE
fix(grep): enforce permissions on matched files

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -73,6 +73,16 @@ export const GrepTool = Tool.define(
             line: item.line,
             text: item.text,
           }))
+          yield* ctx.ask({
+            permission: "grep",
+            patterns: Array.from(new Set(rows.map((item) => path.relative(ins.worktree, item.path)))),
+            always: ["*"],
+            metadata: {
+              pattern: params.pattern,
+              path: params.path,
+              include: params.include,
+            },
+          })
 
           const limit = 100
           const truncated = rows.length === limit

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -170,6 +170,47 @@ describe("tool.grep", () => {
     }),
   )
 
+  it.instance("checks grep permission rules against matched files", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const file = path.join(test.directory, "src", "config.php")
+      yield* Effect.promise(() => fs.mkdir(path.dirname(file), { recursive: true }))
+      yield* Effect.promise(() => Bun.write(file, "any-string"))
+
+      const ruleset = Permission.fromConfig({
+        grep: {
+          "**": "allow",
+          "**/config.php": "deny",
+        },
+      })
+      const next: Tool.Context = {
+        ...ctx,
+        ask: (req) =>
+          Effect.sync(() => {
+            const denied = req.patterns.some(
+              (pattern) => Permission.evaluate(req.permission, pattern, ruleset).action === "deny",
+            )
+            if (denied) throw new PermissionV1.DeniedError({ ruleset })
+          }),
+      }
+
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      const exit = yield* grep
+        .execute(
+          {
+            pattern: "any-string",
+            path: test.directory,
+            include: "config.php",
+          },
+          next,
+        )
+        .pipe(Effect.exit)
+
+      expect(exit._tag).toBe("Failure")
+    }),
+  )
+
   it.instance("does not ask for external_directory when alias path is allowed", () =>
     Effect.gen(function* () {
       if (process.platform === "win32") return


### PR DESCRIPTION
### Issue for this PR

Closes #35503

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`grep` previously asked permission only for the search regex, so path-scoped `grep` rules never saw the files returned by ripgrep. This PR keeps that existing search-pattern check and adds a second permission check for the matched worktree-relative file paths before returning results.

This is a narrow result-path permission fix and does not change wildcard matching semantics. A denied matched path rejects the grep call through the existing `ctx.ask` flow, matching issue #35503's requested permission-denied behavior and the existing read/glob permission model.

Current `dev@34e58090595d44e3e7cc37498f16753a98627456` still returns matched file contents without a result-path permission check.

### Related implementation

Later PR #35696 addresses the same issue by adding a non-interactive `Tool.Context.evaluate` API across the tool framework and silently filtering denied matches. This PR intentionally retains the smaller two-file shape and existing interactive permission semantics; there is no maintainer selection signal between the alternatives yet.

### How did you verify your code works?

- `bun test --timeout 30000 test/tool/grep.test.ts test/tool/read.test.ts test/tool/glob.test.ts test/permission/next.test.ts` -> 127 passed
- `bun test --timeout 30000 test/tool` -> 337 passed
- `bun run typecheck` from `packages/opencode`
- `bun turbo typecheck` from repository root -> 30/30 tasks passed
- `bunx prettier --check src/tool/grep.ts test/tool/grep.test.ts`
- `bun run lint packages/opencode/src/tool/grep.ts packages/opencode/test/tool/grep.test.ts` -> 0 errors
- `git diff --check origin/dev...HEAD`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR