### PR TITLE
fix(glob): enforce permissions on matched files

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -49,6 +49,19 @@ export const GlobTool = Tool.define(
           const limit = 100
           const files = yield* ripgrep.glob({ cwd: search, pattern: params.pattern, limit })
           const truncated = files.length === limit
+          if (files.length > 0) {
+            yield* ctx.ask({
+              permission: "glob",
+              patterns: Array.from(
+                new Set(files.map((file) => path.relative(ins.worktree, path.resolve(search, file.path)))),
+              ),
+              always: ["*"],
+              metadata: {
+                pattern: params.pattern,
+                path: params.path,
+              },
+            })
+          }
 
           const output = []
           if (files.length === 0) output.push("No files found")

--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -1,5 +1,6 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { describe, expect } from "bun:test"
+import fs from "fs/promises"
 import path from "path"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Cause, Effect, Exit, Layer } from "effect"
@@ -127,6 +128,46 @@ describe("tool.glob", () => {
         const err = Cause.squash(exit.cause)
         expect(err instanceof Error ? err.message : String(err)).toContain("glob path must be a directory")
       }
+    }),
+  )
+
+  it.instance("checks glob permission rules against matched files", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const file = path.join(test.directory, "src", "secret.txt")
+      yield* Effect.promise(() => fs.mkdir(path.dirname(file), { recursive: true }))
+      yield* Effect.promise(() => Bun.write(file, "secret"))
+
+      const ruleset = Permission.fromConfig({
+        glob: {
+          "**": "allow",
+          "**/secret.txt": "deny",
+        },
+      })
+      const next: Tool.Context = {
+        ...ctx,
+        ask: (req) =>
+          Effect.sync(() => {
+            const denied = req.patterns.some(
+              (pattern) => Permission.evaluate(req.permission, pattern, ruleset).action === "deny",
+            )
+            if (denied) throw new PermissionV1.DeniedError({ ruleset })
+          }),
+      }
+
+      const info = yield* GlobTool
+      const glob = yield* info.init()
+      const exit = yield* glob
+        .execute(
+          {
+            pattern: "**/*.txt",
+            path: test.directory,
+          },
+          next,
+        )
+        .pipe(Effect.exit)
+
+      expect(exit._tag).toBe("Failure")
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #35684

Related to #29674, but scoped only to glob result-path permission enforcement.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`glob` previously asked permission only for the requested glob pattern. If that broad pattern was allowed, path-scoped deny rules never saw the files returned by ripgrep, so denied paths could still appear in the tool output.

This PR keeps the existing pattern permission check and adds a second permission check for the unique worktree-relative matched file paths before formatting results.

This is a narrow result-path permission fix and does not change wildcard matching semantics. A denied result path rejects the glob call through the existing `ctx.ask` flow, so the denied path is never returned.

Current `dev@34e58090595d44e3e7cc37498f16753a98627456` still formats matched files without a result-path permission check. #35683 is the only open PR linked to #35684.

### Relationship to grep

PR #35682 applies the same existing permission invariant to grep, under its separate issue #35503. The two patches remain separate two-file changes so each tool's result-path behavior and regression test can be reviewed independently.

### How did you verify your code works?

- `bun test --timeout 30000 test/tool/glob.test.ts test/tool/grep.test.ts test/tool/read.test.ts test/permission/next.test.ts` -> 127 passed
- `bun test --timeout 30000 test/tool` -> 337 passed
- `bun run typecheck` from `packages/opencode`
- `bun turbo typecheck` from repository root -> 30/30 tasks passed
- `bunx prettier --check src/tool/glob.ts test/tool/glob.test.ts`
- `bun run lint packages/opencode/src/tool/glob.ts packages/opencode/test/tool/glob.test.ts` -> 0 errors
- `git diff --check origin/dev...HEAD`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR