### PR TITLE
fix(app): guard missing notification server state

### DIFF
--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -54,6 +54,7 @@ type NotificationIndex = {
 
 const MAX_NOTIFICATIONS = 500
 const NOTIFICATION_TTL_MS = 1000 * 60 * 60 * 24 * 30
+const EMPTY_NOTIFICATIONS: Notification[] = []
 
 function pruneNotifications(list: Notification[]) {
   const cutoff = Date.now() - NOTIFICATION_TTL_MS
@@ -123,6 +124,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     const language = useLanguage()
     const owner = getOwner()
     const states = new Map<ServerScope, { dispose: () => void; state: NotificationState }>()
+    const missingServerState = createMissingServerNotificationState()
 
     const activeServer = createMemo(() => {
       if (params.serverKey) return requireServerKey(params.serverKey)
@@ -137,7 +139,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
 
     const ensure = (key: ServerConnection.Key) => {
       const conn = global.servers.list().find((item) => ServerConnection.key(item) === key)
-      if (!conn) throw new Error(`Notification server not found: ${key}`)
+      if (!conn) return missingServerState
       const ctx = global.ensureServerCtx(conn)
       const existing = states.get(ctx.sdk.scope)
       if (existing) return existing.state
@@ -200,6 +202,26 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
 })
 
 type NotificationState = ReturnType<typeof createServerNotificationState>
+
+function createMissingServerNotificationState(): NotificationState {
+  return {
+    ready: Object.assign(() => false, { promise: undefined }),
+    session: {
+      all: () => EMPTY_NOTIFICATIONS,
+      unseen: () => EMPTY_NOTIFICATIONS,
+      unseenCount: () => 0,
+      unseenHasError: () => false,
+      markViewed: () => {},
+    },
+    project: {
+      all: () => EMPTY_NOTIFICATIONS,
+      unseen: () => EMPTY_NOTIFICATIONS,
+      unseenCount: () => 0,
+      unseenHasError: () => false,
+      markViewed: () => {},
+    },
+  }
+}
 
 function createServerNotificationState(input: {
   sdk: ServerSDK


### PR DESCRIPTION
### Issue for this PR

Closes #35686

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevents the app notification context from crashing the renderer when notification state is requested for a server key that is not present in the current server list.

I hit this in OpenCode Desktop v1.17.14 on macOS. After startup, the app entered an infinite crash loop with:

```text
Error: Notification server not found: http://[server-ip]:4096
```

Restart and Reload Webview did not clear it; the same error returned on the next launch. The IP address is an OpenCode server on my local network, and I can connect to it normally.

The crash started after a hard reset on macOS 27.0 beta. The entire macOS UI froze, so I forced a restart. After that, OpenCode Desktop was stuck showing this startup error and could not be used.

This change makes missing notification server state degrade to an empty/no-op notification state instead of throwing during render. Notification badges may be absent for that stale server key, but the app remains usable.

### How did you verify your code works?

Ran:

```bash
npm exec --yes --package bun@1.3.14 -- bun run typecheck
npm exec --yes --package bun@1.3.14 -- bun run test:unit
```

Both passed from `packages/app`.

### Screenshots / recordings

Before:

![OpenCode Desktop Notification server not found startup crash](https://i.imgur.com/PrzmNdu.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
