### PR TITLE
feat(core): configure tool availability per session

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -103,165 +103,173 @@ export type Endpoint4_7Input = {
 export type Endpoint4_7Output = EffectValue<ReturnType<RawClient["server.session"]["session.switchModel"]>>
 export type SessionSwitchModelOperation<E = never> = (input: Endpoint4_7Input) => Effect.Effect<Endpoint4_7Output, E>
 
-type Endpoint4_8Request = Parameters<RawClient["server.session"]["session.rename"]>[0]
+type Endpoint4_8Request = Parameters<RawClient["server.session"]["session.configure"]>[0]
 export type Endpoint4_8Input = {
   readonly sessionID: Endpoint4_8Request["params"]["sessionID"]
-  readonly title: Endpoint4_8Request["payload"]["title"]
+  readonly tools?: Endpoint4_8Request["payload"]["tools"]
 }
-export type Endpoint4_8Output = EffectValue<ReturnType<RawClient["server.session"]["session.rename"]>>
-export type SessionRenameOperation<E = never> = (input: Endpoint4_8Input) => Effect.Effect<Endpoint4_8Output, E>
+export type Endpoint4_8Output = EffectValue<ReturnType<RawClient["server.session"]["session.configure"]>>
+export type SessionConfigureOperation<E = never> = (input: Endpoint4_8Input) => Effect.Effect<Endpoint4_8Output, E>
 
-type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.rename"]>[0]
 export type Endpoint4_9Input = {
   readonly sessionID: Endpoint4_9Request["params"]["sessionID"]
-  readonly id?: Endpoint4_9Request["payload"]["id"]
-  readonly prompt: Endpoint4_9Request["payload"]["prompt"]
-  readonly delivery?: Endpoint4_9Request["payload"]["delivery"]
-  readonly resume?: Endpoint4_9Request["payload"]["resume"]
+  readonly title: Endpoint4_9Request["payload"]["title"]
 }
-export type Endpoint4_9Output = EffectValue<ReturnType<RawClient["server.session"]["session.prompt"]>>["data"]
-export type SessionPromptOperation<E = never> = (input: Endpoint4_9Input) => Effect.Effect<Endpoint4_9Output, E>
+export type Endpoint4_9Output = EffectValue<ReturnType<RawClient["server.session"]["session.rename"]>>
+export type SessionRenameOperation<E = never> = (input: Endpoint4_9Input) => Effect.Effect<Endpoint4_9Output, E>
 
-type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.command"]>[0]
+type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
 export type Endpoint4_10Input = {
   readonly sessionID: Endpoint4_10Request["params"]["sessionID"]
   readonly id?: Endpoint4_10Request["payload"]["id"]
-  readonly command: Endpoint4_10Request["payload"]["command"]
-  readonly arguments?: Endpoint4_10Request["payload"]["arguments"]
-  readonly agent?: Endpoint4_10Request["payload"]["agent"]
-  readonly model?: Endpoint4_10Request["payload"]["model"]
-  readonly files?: Endpoint4_10Request["payload"]["files"]
-  readonly agents?: Endpoint4_10Request["payload"]["agents"]
+  readonly prompt: Endpoint4_10Request["payload"]["prompt"]
   readonly delivery?: Endpoint4_10Request["payload"]["delivery"]
   readonly resume?: Endpoint4_10Request["payload"]["resume"]
 }
-export type Endpoint4_10Output = EffectValue<ReturnType<RawClient["server.session"]["session.command"]>>["data"]
-export type SessionCommandOperation<E = never> = (input: Endpoint4_10Input) => Effect.Effect<Endpoint4_10Output, E>
+export type Endpoint4_10Output = EffectValue<ReturnType<RawClient["server.session"]["session.prompt"]>>["data"]
+export type SessionPromptOperation<E = never> = (input: Endpoint4_10Input) => Effect.Effect<Endpoint4_10Output, E>
 
-type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
+type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.command"]>[0]
 export type Endpoint4_11Input = {
   readonly sessionID: Endpoint4_11Request["params"]["sessionID"]
   readonly id?: Endpoint4_11Request["payload"]["id"]
-  readonly skill: Endpoint4_11Request["payload"]["skill"]
+  readonly command: Endpoint4_11Request["payload"]["command"]
+  readonly arguments?: Endpoint4_11Request["payload"]["arguments"]
+  readonly agent?: Endpoint4_11Request["payload"]["agent"]
+  readonly model?: Endpoint4_11Request["payload"]["model"]
+  readonly files?: Endpoint4_11Request["payload"]["files"]
+  readonly agents?: Endpoint4_11Request["payload"]["agents"]
+  readonly delivery?: Endpoint4_11Request["payload"]["delivery"]
   readonly resume?: Endpoint4_11Request["payload"]["resume"]
 }
-export type Endpoint4_11Output = EffectValue<ReturnType<RawClient["server.session"]["session.skill"]>>
-export type SessionSkillOperation<E = never> = (input: Endpoint4_11Input) => Effect.Effect<Endpoint4_11Output, E>
+export type Endpoint4_11Output = EffectValue<ReturnType<RawClient["server.session"]["session.command"]>>["data"]
+export type SessionCommandOperation<E = never> = (input: Endpoint4_11Input) => Effect.Effect<Endpoint4_11Output, E>
 
-type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
+type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
 export type Endpoint4_12Input = {
   readonly sessionID: Endpoint4_12Request["params"]["sessionID"]
-  readonly text: Endpoint4_12Request["payload"]["text"]
-  readonly description?: Endpoint4_12Request["payload"]["description"]
-  readonly metadata?: Endpoint4_12Request["payload"]["metadata"]
+  readonly id?: Endpoint4_12Request["payload"]["id"]
+  readonly skill: Endpoint4_12Request["payload"]["skill"]
+  readonly resume?: Endpoint4_12Request["payload"]["resume"]
 }
-export type Endpoint4_12Output = EffectValue<ReturnType<RawClient["server.session"]["session.synthetic"]>>
-export type SessionSyntheticOperation<E = never> = (input: Endpoint4_12Input) => Effect.Effect<Endpoint4_12Output, E>
+export type Endpoint4_12Output = EffectValue<ReturnType<RawClient["server.session"]["session.skill"]>>
+export type SessionSkillOperation<E = never> = (input: Endpoint4_12Input) => Effect.Effect<Endpoint4_12Output, E>
 
-type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
+type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
 export type Endpoint4_13Input = {
   readonly sessionID: Endpoint4_13Request["params"]["sessionID"]
-  readonly id?: Endpoint4_13Request["payload"]["id"]
-  readonly command: Endpoint4_13Request["payload"]["command"]
+  readonly text: Endpoint4_13Request["payload"]["text"]
+  readonly description?: Endpoint4_13Request["payload"]["description"]
+  readonly metadata?: Endpoint4_13Request["payload"]["metadata"]
 }
-export type Endpoint4_13Output = EffectValue<ReturnType<RawClient["server.session"]["session.shell"]>>
-export type SessionShellOperation<E = never> = (input: Endpoint4_13Input) => Effect.Effect<Endpoint4_13Output, E>
+export type Endpoint4_13Output = EffectValue<ReturnType<RawClient["server.session"]["session.synthetic"]>>
+export type SessionSyntheticOperation<E = never> = (input: Endpoint4_13Input) => Effect.Effect<Endpoint4_13Output, E>
 
-type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
 export type Endpoint4_14Input = {
   readonly sessionID: Endpoint4_14Request["params"]["sessionID"]
   readonly id?: Endpoint4_14Request["payload"]["id"]
+  readonly command: Endpoint4_14Request["payload"]["command"]
 }
-export type Endpoint4_14Output = EffectValue<ReturnType<RawClient["server.session"]["session.compact"]>>["data"]
-export type SessionCompactOperation<E = never> = (input: Endpoint4_14Input) => Effect.Effect<Endpoint4_14Output, E>
+export type Endpoint4_14Output = EffectValue<ReturnType<RawClient["server.session"]["session.shell"]>>
+export type SessionShellOperation<E = never> = (input: Endpoint4_14Input) => Effect.Effect<Endpoint4_14Output, E>
 
-type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
-export type Endpoint4_15Input = { readonly sessionID: Endpoint4_15Request["params"]["sessionID"] }
-export type Endpoint4_15Output = EffectValue<ReturnType<RawClient["server.session"]["session.wait"]>>
-export type SessionWaitOperation<E = never> = (input: Endpoint4_15Input) => Effect.Effect<Endpoint4_15Output, E>
-
-type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-export type Endpoint4_16Input = {
-  readonly sessionID: Endpoint4_16Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_16Request["payload"]["messageID"]
-  readonly files?: Endpoint4_16Request["payload"]["files"]
+type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+export type Endpoint4_15Input = {
+  readonly sessionID: Endpoint4_15Request["params"]["sessionID"]
+  readonly id?: Endpoint4_15Request["payload"]["id"]
 }
-export type Endpoint4_16Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.stage"]>>["data"]
-export type SessionRevertStageOperation<E = never> = (input: Endpoint4_16Input) => Effect.Effect<Endpoint4_16Output, E>
+export type Endpoint4_15Output = EffectValue<ReturnType<RawClient["server.session"]["session.compact"]>>["data"]
+export type SessionCompactOperation<E = never> = (input: Endpoint4_15Input) => Effect.Effect<Endpoint4_15Output, E>
 
-type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-export type Endpoint4_17Input = { readonly sessionID: Endpoint4_17Request["params"]["sessionID"] }
-export type Endpoint4_17Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.clear"]>>
-export type SessionRevertClearOperation<E = never> = (input: Endpoint4_17Input) => Effect.Effect<Endpoint4_17Output, E>
+type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+export type Endpoint4_16Input = { readonly sessionID: Endpoint4_16Request["params"]["sessionID"] }
+export type Endpoint4_16Output = EffectValue<ReturnType<RawClient["server.session"]["session.wait"]>>
+export type SessionWaitOperation<E = never> = (input: Endpoint4_16Input) => Effect.Effect<Endpoint4_16Output, E>
 
-type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+export type Endpoint4_17Input = {
+  readonly sessionID: Endpoint4_17Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_17Request["payload"]["messageID"]
+  readonly files?: Endpoint4_17Request["payload"]["files"]
+}
+export type Endpoint4_17Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.stage"]>>["data"]
+export type SessionRevertStageOperation<E = never> = (input: Endpoint4_17Input) => Effect.Effect<Endpoint4_17Output, E>
+
+type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
 export type Endpoint4_18Input = { readonly sessionID: Endpoint4_18Request["params"]["sessionID"] }
-export type Endpoint4_18Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.commit"]>>
-export type SessionRevertCommitOperation<E = never> = (input: Endpoint4_18Input) => Effect.Effect<Endpoint4_18Output, E>
+export type Endpoint4_18Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.clear"]>>
+export type SessionRevertClearOperation<E = never> = (input: Endpoint4_18Input) => Effect.Effect<Endpoint4_18Output, E>
 
-type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
 export type Endpoint4_19Input = { readonly sessionID: Endpoint4_19Request["params"]["sessionID"] }
-export type Endpoint4_19Output = EffectValue<ReturnType<RawClient["server.session"]["session.context"]>>["data"]
-export type SessionContextOperation<E = never> = (input: Endpoint4_19Input) => Effect.Effect<Endpoint4_19Output, E>
+export type Endpoint4_19Output = EffectValue<ReturnType<RawClient["server.session"]["session.revert.commit"]>>
+export type SessionRevertCommitOperation<E = never> = (input: Endpoint4_19Input) => Effect.Effect<Endpoint4_19Output, E>
 
-type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
+type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.context"]>[0]
 export type Endpoint4_20Input = { readonly sessionID: Endpoint4_20Request["params"]["sessionID"] }
-export type Endpoint4_20Output = EffectValue<
+export type Endpoint4_20Output = EffectValue<ReturnType<RawClient["server.session"]["session.context"]>>["data"]
+export type SessionContextOperation<E = never> = (input: Endpoint4_20Input) => Effect.Effect<Endpoint4_20Output, E>
+
+type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
+export type Endpoint4_21Input = { readonly sessionID: Endpoint4_21Request["params"]["sessionID"] }
+export type Endpoint4_21Output = EffectValue<
   ReturnType<RawClient["server.session"]["session.instructions.entry.list"]>
 >["data"]
 export type SessionInstructionsEntryListOperation<E = never> = (
-  input: Endpoint4_20Input,
-) => Effect.Effect<Endpoint4_20Output, E>
-
-type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
-export type Endpoint4_21Input = {
-  readonly sessionID: Endpoint4_21Request["params"]["sessionID"]
-  readonly key: Endpoint4_21Request["params"]["key"]
-  readonly value: Endpoint4_21Request["payload"]["value"]
-}
-export type Endpoint4_21Output = EffectValue<ReturnType<RawClient["server.session"]["session.instructions.entry.put"]>>
-export type SessionInstructionsEntryPutOperation<E = never> = (
   input: Endpoint4_21Input,
 ) => Effect.Effect<Endpoint4_21Output, E>
 
-type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
+type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
 export type Endpoint4_22Input = {
   readonly sessionID: Endpoint4_22Request["params"]["sessionID"]
   readonly key: Endpoint4_22Request["params"]["key"]
+  readonly value: Endpoint4_22Request["payload"]["value"]
 }
-export type Endpoint4_22Output = EffectValue<
-  ReturnType<RawClient["server.session"]["session.instructions.entry.remove"]>
->
-export type SessionInstructionsEntryRemoveOperation<E = never> = (
+export type Endpoint4_22Output = EffectValue<ReturnType<RawClient["server.session"]["session.instructions.entry.put"]>>
+export type SessionInstructionsEntryPutOperation<E = never> = (
   input: Endpoint4_22Input,
 ) => Effect.Effect<Endpoint4_22Output, E>
 
-type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.log"]>[0]
+type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
 export type Endpoint4_23Input = {
   readonly sessionID: Endpoint4_23Request["params"]["sessionID"]
-  readonly after?: Endpoint4_23Request["query"]["after"]
-  readonly follow?: Endpoint4_23Request["query"]["follow"]
+  readonly key: Endpoint4_23Request["params"]["key"]
 }
-export type Endpoint4_23Output = StreamValue<EffectValue<ReturnType<RawClient["server.session"]["session.log"]>>>
-export type SessionLogOperation<E = never> = (input: Endpoint4_23Input) => Stream.Stream<Endpoint4_23Output, E>
+export type Endpoint4_23Output = EffectValue<
+  ReturnType<RawClient["server.session"]["session.instructions.entry.remove"]>
+>
+export type SessionInstructionsEntryRemoveOperation<E = never> = (
+  input: Endpoint4_23Input,
+) => Effect.Effect<Endpoint4_23Output, E>
 
-type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-export type Endpoint4_24Input = { readonly sessionID: Endpoint4_24Request["params"]["sessionID"] }
-export type Endpoint4_24Output = EffectValue<ReturnType<RawClient["server.session"]["session.interrupt"]>>
-export type SessionInterruptOperation<E = never> = (input: Endpoint4_24Input) => Effect.Effect<Endpoint4_24Output, E>
+type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.log"]>[0]
+export type Endpoint4_24Input = {
+  readonly sessionID: Endpoint4_24Request["params"]["sessionID"]
+  readonly after?: Endpoint4_24Request["query"]["after"]
+  readonly follow?: Endpoint4_24Request["query"]["follow"]
+}
+export type Endpoint4_24Output = StreamValue<EffectValue<ReturnType<RawClient["server.session"]["session.log"]>>>
+export type SessionLogOperation<E = never> = (input: Endpoint4_24Input) => Stream.Stream<Endpoint4_24Output, E>
 
-type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
 export type Endpoint4_25Input = { readonly sessionID: Endpoint4_25Request["params"]["sessionID"] }
-export type Endpoint4_25Output = EffectValue<ReturnType<RawClient["server.session"]["session.background"]>>
-export type SessionBackgroundOperation<E = never> = (input: Endpoint4_25Input) => Effect.Effect<Endpoint4_25Output, E>
+export type Endpoint4_25Output = EffectValue<ReturnType<RawClient["server.session"]["session.interrupt"]>>
+export type SessionInterruptOperation<E = never> = (input: Endpoint4_25Input) => Effect.Effect<Endpoint4_25Output, E>
 
-type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-export type Endpoint4_26Input = {
-  readonly sessionID: Endpoint4_26Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_26Request["params"]["messageID"]
+type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+export type Endpoint4_26Input = { readonly sessionID: Endpoint4_26Request["params"]["sessionID"] }
+export type Endpoint4_26Output = EffectValue<ReturnType<RawClient["server.session"]["session.background"]>>
+export type SessionBackgroundOperation<E = never> = (input: Endpoint4_26Input) => Effect.Effect<Endpoint4_26Output, E>
+
+type Endpoint4_27Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+export type Endpoint4_27Input = {
+  readonly sessionID: Endpoint4_27Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_27Request["params"]["messageID"]
 }
-export type Endpoint4_26Output = EffectValue<ReturnType<RawClient["server.session"]["session.message"]>>["data"]
-export type SessionMessageOperation<E = never> = (input: Endpoint4_26Input) => Effect.Effect<Endpoint4_26Output, E>
+export type Endpoint4_27Output = EffectValue<ReturnType<RawClient["server.session"]["session.message"]>>["data"]
+export type SessionMessageOperation<E = never> = (input: Endpoint4_27Input) => Effect.Effect<Endpoint4_27Output, E>
 
 export interface SessionApi<E = never> {
   readonly list: SessionListOperation<E>
@@ -272,6 +280,7 @@ export interface SessionApi<E = never> {
   readonly fork: SessionForkOperation<E>
   readonly switchAgent: SessionSwitchAgentOperation<E>
   readonly switchModel: SessionSwitchModelOperation<E>
+  readonly configure: SessionConfigureOperation<E>
   readonly rename: SessionRenameOperation<E>
   readonly prompt: SessionPromptOperation<E>
   readonly command: SessionCommandOperation<E>

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -131,25 +131,35 @@ const Endpoint4_7 = (raw: RawClient["server.session"]) => (input: Endpoint4_7Inp
     Effect.mapError(mapClientError),
   )
 
-type Endpoint4_8Request = Parameters<RawClient["server.session"]["session.rename"]>[0]
+type Endpoint4_8Request = Parameters<RawClient["server.session"]["session.configure"]>[0]
 type Endpoint4_8Input = {
   readonly sessionID: Endpoint4_8Request["params"]["sessionID"]
-  readonly title: Endpoint4_8Request["payload"]["title"]
+  readonly tools?: Endpoint4_8Request["payload"]["tools"]
 }
 const Endpoint4_8 = (raw: RawClient["server.session"]) => (input: Endpoint4_8Input) =>
+  raw["session.configure"]({ params: { sessionID: input["sessionID"] }, payload: { tools: input["tools"] } }).pipe(
+    Effect.mapError(mapClientError),
+  )
+
+type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.rename"]>[0]
+type Endpoint4_9Input = {
+  readonly sessionID: Endpoint4_9Request["params"]["sessionID"]
+  readonly title: Endpoint4_9Request["payload"]["title"]
+}
+const Endpoint4_9 = (raw: RawClient["server.session"]) => (input: Endpoint4_9Input) =>
   raw["session.rename"]({ params: { sessionID: input["sessionID"] }, payload: { title: input["title"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint4_9Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
-type Endpoint4_9Input = {
-  readonly sessionID: Endpoint4_9Request["params"]["sessionID"]
-  readonly id?: Endpoint4_9Request["payload"]["id"]
-  readonly prompt: Endpoint4_9Request["payload"]["prompt"]
-  readonly delivery?: Endpoint4_9Request["payload"]["delivery"]
-  readonly resume?: Endpoint4_9Request["payload"]["resume"]
+type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.prompt"]>[0]
+type Endpoint4_10Input = {
+  readonly sessionID: Endpoint4_10Request["params"]["sessionID"]
+  readonly id?: Endpoint4_10Request["payload"]["id"]
+  readonly prompt: Endpoint4_10Request["payload"]["prompt"]
+  readonly delivery?: Endpoint4_10Request["payload"]["delivery"]
+  readonly resume?: Endpoint4_10Request["payload"]["resume"]
 }
-const Endpoint4_9 = (raw: RawClient["server.session"]) => (input: Endpoint4_9Input) =>
+const Endpoint4_10 = (raw: RawClient["server.session"]) => (input: Endpoint4_10Input) =>
   raw["session.prompt"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], prompt: input["prompt"], delivery: input["delivery"], resume: input["resume"] },
@@ -158,20 +168,20 @@ const Endpoint4_9 = (raw: RawClient["server.session"]) => (input: Endpoint4_9Inp
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_10Request = Parameters<RawClient["server.session"]["session.command"]>[0]
-type Endpoint4_10Input = {
-  readonly sessionID: Endpoint4_10Request["params"]["sessionID"]
-  readonly id?: Endpoint4_10Request["payload"]["id"]
-  readonly command: Endpoint4_10Request["payload"]["command"]
-  readonly arguments?: Endpoint4_10Request["payload"]["arguments"]
-  readonly agent?: Endpoint4_10Request["payload"]["agent"]
-  readonly model?: Endpoint4_10Request["payload"]["model"]
-  readonly files?: Endpoint4_10Request["payload"]["files"]
-  readonly agents?: Endpoint4_10Request["payload"]["agents"]
-  readonly delivery?: Endpoint4_10Request["payload"]["delivery"]
-  readonly resume?: Endpoint4_10Request["payload"]["resume"]
+type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.command"]>[0]
+type Endpoint4_11Input = {
+  readonly sessionID: Endpoint4_11Request["params"]["sessionID"]
+  readonly id?: Endpoint4_11Request["payload"]["id"]
+  readonly command: Endpoint4_11Request["payload"]["command"]
+  readonly arguments?: Endpoint4_11Request["payload"]["arguments"]
+  readonly agent?: Endpoint4_11Request["payload"]["agent"]
+  readonly model?: Endpoint4_11Request["payload"]["model"]
+  readonly files?: Endpoint4_11Request["payload"]["files"]
+  readonly agents?: Endpoint4_11Request["payload"]["agents"]
+  readonly delivery?: Endpoint4_11Request["payload"]["delivery"]
+  readonly resume?: Endpoint4_11Request["payload"]["resume"]
 }
-const Endpoint4_10 = (raw: RawClient["server.session"]) => (input: Endpoint4_10Input) =>
+const Endpoint4_11 = (raw: RawClient["server.session"]) => (input: Endpoint4_11Input) =>
   raw["session.command"]({
     params: { sessionID: input["sessionID"] },
     payload: {
@@ -190,67 +200,67 @@ const Endpoint4_10 = (raw: RawClient["server.session"]) => (input: Endpoint4_10I
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_11Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
-type Endpoint4_11Input = {
-  readonly sessionID: Endpoint4_11Request["params"]["sessionID"]
-  readonly id?: Endpoint4_11Request["payload"]["id"]
-  readonly skill: Endpoint4_11Request["payload"]["skill"]
-  readonly resume?: Endpoint4_11Request["payload"]["resume"]
+type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.skill"]>[0]
+type Endpoint4_12Input = {
+  readonly sessionID: Endpoint4_12Request["params"]["sessionID"]
+  readonly id?: Endpoint4_12Request["payload"]["id"]
+  readonly skill: Endpoint4_12Request["payload"]["skill"]
+  readonly resume?: Endpoint4_12Request["payload"]["resume"]
 }
-const Endpoint4_11 = (raw: RawClient["server.session"]) => (input: Endpoint4_11Input) =>
+const Endpoint4_12 = (raw: RawClient["server.session"]) => (input: Endpoint4_12Input) =>
   raw["session.skill"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], skill: input["skill"], resume: input["resume"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_12Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
-type Endpoint4_12Input = {
-  readonly sessionID: Endpoint4_12Request["params"]["sessionID"]
-  readonly text: Endpoint4_12Request["payload"]["text"]
-  readonly description?: Endpoint4_12Request["payload"]["description"]
-  readonly metadata?: Endpoint4_12Request["payload"]["metadata"]
+type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.synthetic"]>[0]
+type Endpoint4_13Input = {
+  readonly sessionID: Endpoint4_13Request["params"]["sessionID"]
+  readonly text: Endpoint4_13Request["payload"]["text"]
+  readonly description?: Endpoint4_13Request["payload"]["description"]
+  readonly metadata?: Endpoint4_13Request["payload"]["metadata"]
 }
-const Endpoint4_12 = (raw: RawClient["server.session"]) => (input: Endpoint4_12Input) =>
+const Endpoint4_13 = (raw: RawClient["server.session"]) => (input: Endpoint4_13Input) =>
   raw["session.synthetic"]({
     params: { sessionID: input["sessionID"] },
     payload: { text: input["text"], description: input["description"], metadata: input["metadata"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
-type Endpoint4_13Input = {
-  readonly sessionID: Endpoint4_13Request["params"]["sessionID"]
-  readonly id?: Endpoint4_13Request["payload"]["id"]
-  readonly command: Endpoint4_13Request["payload"]["command"]
+type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.shell"]>[0]
+type Endpoint4_14Input = {
+  readonly sessionID: Endpoint4_14Request["params"]["sessionID"]
+  readonly id?: Endpoint4_14Request["payload"]["id"]
+  readonly command: Endpoint4_14Request["payload"]["command"]
 }
-const Endpoint4_13 = (raw: RawClient["server.session"]) => (input: Endpoint4_13Input) =>
+const Endpoint4_14 = (raw: RawClient["server.session"]) => (input: Endpoint4_14Input) =>
   raw["session.shell"]({
     params: { sessionID: input["sessionID"] },
     payload: { id: input["id"], command: input["command"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_14Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
-type Endpoint4_14Input = {
-  readonly sessionID: Endpoint4_14Request["params"]["sessionID"]
-  readonly id?: Endpoint4_14Request["payload"]["id"]
+type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.compact"]>[0]
+type Endpoint4_15Input = {
+  readonly sessionID: Endpoint4_15Request["params"]["sessionID"]
+  readonly id?: Endpoint4_15Request["payload"]["id"]
 }
-const Endpoint4_14 = (raw: RawClient["server.session"]) => (input: Endpoint4_14Input) =>
+const Endpoint4_15 = (raw: RawClient["server.session"]) => (input: Endpoint4_15Input) =>
   raw["session.compact"]({ params: { sessionID: input["sessionID"] }, payload: { id: input["id"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_15Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
-type Endpoint4_15Input = { readonly sessionID: Endpoint4_15Request["params"]["sessionID"] }
-const Endpoint4_15 = (raw: RawClient["server.session"]) => (input: Endpoint4_15Input) =>
+type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.wait"]>[0]
+type Endpoint4_16Input = { readonly sessionID: Endpoint4_16Request["params"]["sessionID"] }
+const Endpoint4_16 = (raw: RawClient["server.session"]) => (input: Endpoint4_16Input) =>
   raw["session.wait"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_16Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
-type Endpoint4_16Input = {
-  readonly sessionID: Endpoint4_16Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_16Request["payload"]["messageID"]
-  readonly files?: Endpoint4_16Request["payload"]["files"]
+type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.stage"]>[0]
+type Endpoint4_17Input = {
+  readonly sessionID: Endpoint4_17Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_17Request["payload"]["messageID"]
+  readonly files?: Endpoint4_17Request["payload"]["files"]
 }
-const Endpoint4_16 = (raw: RawClient["server.session"]) => (input: Endpoint4_16Input) =>
+const Endpoint4_17 = (raw: RawClient["server.session"]) => (input: Endpoint4_17Input) =>
   raw["session.revert.stage"]({
     params: { sessionID: input["sessionID"] },
     payload: { messageID: input["messageID"], files: input["files"] },
@@ -259,61 +269,61 @@ const Endpoint4_16 = (raw: RawClient["server.session"]) => (input: Endpoint4_16I
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_17Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
-type Endpoint4_17Input = { readonly sessionID: Endpoint4_17Request["params"]["sessionID"] }
-const Endpoint4_17 = (raw: RawClient["server.session"]) => (input: Endpoint4_17Input) =>
-  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
+type Endpoint4_18Request = Parameters<RawClient["server.session"]["session.revert.clear"]>[0]
 type Endpoint4_18Input = { readonly sessionID: Endpoint4_18Request["params"]["sessionID"] }
 const Endpoint4_18 = (raw: RawClient["server.session"]) => (input: Endpoint4_18Input) =>
-  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+  raw["session.revert.clear"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint4_19Request = Parameters<RawClient["server.session"]["session.revert.commit"]>[0]
 type Endpoint4_19Input = { readonly sessionID: Endpoint4_19Request["params"]["sessionID"] }
 const Endpoint4_19 = (raw: RawClient["server.session"]) => (input: Endpoint4_19Input) =>
+  raw["session.revert.commit"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.context"]>[0]
+type Endpoint4_20Input = { readonly sessionID: Endpoint4_20Request["params"]["sessionID"] }
+const Endpoint4_20 = (raw: RawClient["server.session"]) => (input: Endpoint4_20Input) =>
   raw["session.context"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_20Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
-type Endpoint4_20Input = { readonly sessionID: Endpoint4_20Request["params"]["sessionID"] }
-const Endpoint4_20 = (raw: RawClient["server.session"]) => (input: Endpoint4_20Input) =>
+type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.list"]>[0]
+type Endpoint4_21Input = { readonly sessionID: Endpoint4_21Request["params"]["sessionID"] }
+const Endpoint4_21 = (raw: RawClient["server.session"]) => (input: Endpoint4_21Input) =>
   raw["session.instructions.entry.list"]({ params: { sessionID: input["sessionID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
   )
 
-type Endpoint4_21Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
-type Endpoint4_21Input = {
-  readonly sessionID: Endpoint4_21Request["params"]["sessionID"]
-  readonly key: Endpoint4_21Request["params"]["key"]
-  readonly value: Endpoint4_21Request["payload"]["value"]
+type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.put"]>[0]
+type Endpoint4_22Input = {
+  readonly sessionID: Endpoint4_22Request["params"]["sessionID"]
+  readonly key: Endpoint4_22Request["params"]["key"]
+  readonly value: Endpoint4_22Request["payload"]["value"]
 }
-const Endpoint4_21 = (raw: RawClient["server.session"]) => (input: Endpoint4_21Input) =>
+const Endpoint4_22 = (raw: RawClient["server.session"]) => (input: Endpoint4_22Input) =>
   raw["session.instructions.entry.put"]({
     params: { sessionID: input["sessionID"], key: input["key"] },
     payload: { value: input["value"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_22Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
-type Endpoint4_22Input = {
-  readonly sessionID: Endpoint4_22Request["params"]["sessionID"]
-  readonly key: Endpoint4_22Request["params"]["key"]
+type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.instructions.entry.remove"]>[0]
+type Endpoint4_23Input = {
+  readonly sessionID: Endpoint4_23Request["params"]["sessionID"]
+  readonly key: Endpoint4_23Request["params"]["key"]
 }
-const Endpoint4_22 = (raw: RawClient["server.session"]) => (input: Endpoint4_22Input) =>
+const Endpoint4_23 = (raw: RawClient["server.session"]) => (input: Endpoint4_23Input) =>
   raw["session.instructions.entry.remove"]({ params: { sessionID: input["sessionID"], key: input["key"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint4_23Request = Parameters<RawClient["server.session"]["session.log"]>[0]
-type Endpoint4_23Input = {
-  readonly sessionID: Endpoint4_23Request["params"]["sessionID"]
-  readonly after?: Endpoint4_23Request["query"]["after"]
-  readonly follow?: Endpoint4_23Request["query"]["follow"]
+type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.log"]>[0]
+type Endpoint4_24Input = {
+  readonly sessionID: Endpoint4_24Request["params"]["sessionID"]
+  readonly after?: Endpoint4_24Request["query"]["after"]
+  readonly follow?: Endpoint4_24Request["query"]["follow"]
 }
-const Endpoint4_23 = (raw: RawClient["server.session"]) => (input: Endpoint4_23Input) =>
+const Endpoint4_24 = (raw: RawClient["server.session"]) => (input: Endpoint4_24Input) =>
   Stream.unwrap(
     raw["session.log"]({
       params: { sessionID: input["sessionID"] },
@@ -324,22 +334,22 @@ const Endpoint4_23 = (raw: RawClient["server.session"]) => (input: Endpoint4_23I
     ),
   )
 
-type Endpoint4_24Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
-type Endpoint4_24Input = { readonly sessionID: Endpoint4_24Request["params"]["sessionID"] }
-const Endpoint4_24 = (raw: RawClient["server.session"]) => (input: Endpoint4_24Input) =>
-  raw["session.interrupt"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
-
-type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+type Endpoint4_25Request = Parameters<RawClient["server.session"]["session.interrupt"]>[0]
 type Endpoint4_25Input = { readonly sessionID: Endpoint4_25Request["params"]["sessionID"] }
 const Endpoint4_25 = (raw: RawClient["server.session"]) => (input: Endpoint4_25Input) =>
+  raw["session.interrupt"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.background"]>[0]
+type Endpoint4_26Input = { readonly sessionID: Endpoint4_26Request["params"]["sessionID"] }
+const Endpoint4_26 = (raw: RawClient["server.session"]) => (input: Endpoint4_26Input) =>
   raw["session.background"]({ params: { sessionID: input["sessionID"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint4_26Request = Parameters<RawClient["server.session"]["session.message"]>[0]
-type Endpoint4_26Input = {
-  readonly sessionID: Endpoint4_26Request["params"]["sessionID"]
-  readonly messageID: Endpoint4_26Request["params"]["messageID"]
+type Endpoint4_27Request = Parameters<RawClient["server.session"]["session.message"]>[0]
+type Endpoint4_27Input = {
+  readonly sessionID: Endpoint4_27Request["params"]["sessionID"]
+  readonly messageID: Endpoint4_27Request["params"]["messageID"]
 }
-const Endpoint4_26 = (raw: RawClient["server.session"]) => (input: Endpoint4_26Input) =>
+const Endpoint4_27 = (raw: RawClient["server.session"]) => (input: Endpoint4_27Input) =>
   raw["session.message"]({ params: { sessionID: input["sessionID"], messageID: input["messageID"] } }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
@@ -354,23 +364,24 @@ const adaptGroup4 = (raw: RawClient["server.session"]) => ({
   fork: Endpoint4_5(raw),
   switchAgent: Endpoint4_6(raw),
   switchModel: Endpoint4_7(raw),
-  rename: Endpoint4_8(raw),
-  prompt: Endpoint4_9(raw),
-  command: Endpoint4_10(raw),
-  skill: Endpoint4_11(raw),
-  synthetic: Endpoint4_12(raw),
-  shell: Endpoint4_13(raw),
-  compact: Endpoint4_14(raw),
-  wait: Endpoint4_15(raw),
-  revertStage: Endpoint4_16(raw),
-  revertClear: Endpoint4_17(raw),
-  revertCommit: Endpoint4_18(raw),
-  context: Endpoint4_19(raw),
-  instructions: { entry: { list: Endpoint4_20(raw), put: Endpoint4_21(raw), remove: Endpoint4_22(raw) } },
-  log: Endpoint4_23(raw),
-  interrupt: Endpoint4_24(raw),
-  background: Endpoint4_25(raw),
-  message: Endpoint4_26(raw),
+  configure: Endpoint4_8(raw),
+  rename: Endpoint4_9(raw),
+  prompt: Endpoint4_10(raw),
+  command: Endpoint4_11(raw),
+  skill: Endpoint4_12(raw),
+  synthetic: Endpoint4_13(raw),
+  shell: Endpoint4_14(raw),
+  compact: Endpoint4_15(raw),
+  wait: Endpoint4_16(raw),
+  revertStage: Endpoint4_17(raw),
+  revertClear: Endpoint4_18(raw),
+  revertCommit: Endpoint4_19(raw),
+  context: Endpoint4_20(raw),
+  instructions: { entry: { list: Endpoint4_21(raw), put: Endpoint4_22(raw), remove: Endpoint4_23(raw) } },
+  log: Endpoint4_24(raw),
+  interrupt: Endpoint4_25(raw),
+  background: Endpoint4_26(raw),
+  message: Endpoint4_27(raw),
 })
 
 type Endpoint5_0Request = Parameters<RawClient["server.message"]["session.messages"]>[0]

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -21,6 +21,8 @@ import type {
   SessionSwitchAgentOutput,
   SessionSwitchModelInput,
   SessionSwitchModelOutput,
+  SessionConfigureInput,
+  SessionConfigureOutput,
   SessionRenameInput,
   SessionRenameOutput,
   SessionPromptInput,
@@ -467,6 +469,18 @@ export function make(options: ClientOptions) {
             method: "POST",
             path: `/api/session/${encodeURIComponent(input.sessionID)}/model`,
             body: { model: input["model"] },
+            successStatus: 204,
+            declaredStatuses: [404, 400, 401],
+            empty: true,
+          },
+          requestOptions,
+        ),
+      configure: (input: SessionConfigureInput, requestOptions?: RequestOptions) =>
+        request<SessionConfigureOutput>(
+          {
+            method: "POST",
+            path: `/api/session/${encodeURIComponent(input.sessionID)}/configure`,
+            body: { tools: input["tools"] },
             successStatus: 204,
             declaredStatuses: [404, 400, 401],
             empty: true,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -354,6 +354,11 @@ export type SessionListOutput = {
         readonly patch: string
       }>
     }
+    readonly tools?: ReadonlyArray<{
+      readonly action: string
+      readonly resource: string
+      readonly effect: "allow" | "deny" | "ask"
+    }>
   }>
   readonly cursor: { readonly previous?: string | null; readonly next?: string | null }
 }
@@ -417,6 +422,11 @@ export type SessionCreateOutput = {
         readonly patch: string
       }>
     }
+    readonly tools?: ReadonlyArray<{
+      readonly action: string
+      readonly resource: string
+      readonly effect: "allow" | "deny" | "ask"
+    }>
   }
 }["data"]
 
@@ -456,6 +466,11 @@ export type SessionGetOutput = {
         readonly patch: string
       }>
     }
+    readonly tools?: ReadonlyArray<{
+      readonly action: string
+      readonly resource: string
+      readonly effect: "allow" | "deny" | "ask"
+    }>
   }
 }["data"]
 
@@ -500,6 +515,11 @@ export type SessionForkOutput = {
         readonly patch: string
       }>
     }
+    readonly tools?: ReadonlyArray<{
+      readonly action: string
+      readonly resource: string
+      readonly effect: "allow" | "deny" | "ask"
+    }>
   }
 }["data"]
 
@@ -518,6 +538,13 @@ export type SessionSwitchModelInput = {
 }
 
 export type SessionSwitchModelOutput = void
+
+export type SessionConfigureInput = {
+  readonly sessionID: { readonly sessionID: string }["sessionID"]
+  readonly tools?: { readonly tools?: { readonly [x: string]: boolean } | undefined }["tools"]
+}
+
+export type SessionConfigureOutput = void
 
 export type SessionRenameInput = {
   readonly sessionID: { readonly sessionID: string }["sessionID"]
@@ -1166,6 +1193,22 @@ export type SessionLogOutput =
           readonly data: {
             readonly sessionID: string
             readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+          }
+        }
+      | {
+          readonly id: string
+          readonly created: number
+          readonly metadata?: { readonly [x: string]: unknown }
+          readonly type: "session.tools.configured"
+          readonly durable: { readonly aggregateID: string; readonly seq: number; readonly version: number }
+          readonly location?: { readonly directory: string; readonly workspaceID?: string }
+          readonly data: {
+            readonly sessionID: string
+            readonly tools?: ReadonlyArray<{
+              readonly action: string
+              readonly resource: string
+              readonly effect: "allow" | "deny" | "ask"
+            }>
           }
         }
       | {
@@ -4465,6 +4508,22 @@ export type EventSubscribeOutput =
       readonly data: {
         readonly sessionID: string
         readonly model: { readonly id: string; readonly providerID: string; readonly variant?: string }
+      }
+    }
+  | {
+      readonly id: string
+      readonly created: number
+      readonly metadata?: { readonly [x: string]: unknown }
+      readonly type: "session.tools.configured"
+      readonly durable: { readonly aggregateID: string; readonly seq: number; readonly version: number }
+      readonly location?: { readonly directory: string; readonly workspaceID?: string }
+      readonly data: {
+        readonly sessionID: string
+        readonly tools?: ReadonlyArray<{
+          readonly action: string
+          readonly resource: string
+          readonly effect: "allow" | "deny" | "ask"
+        }>
       }
     }
   | {

--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,8 +1,8 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "b0355fd9-bf41-42e3-9dca-76107de27ecd",
-  "prevIds": ["95328a41-789d-44de-9643-6ac6ecd6b4ec"],
+  "id": "b83ca28c-b8a4-4245-ab57-5bbb08fdb0bc",
+  "prevIds": ["b0355fd9-bf41-42e3-9dca-76107de27ecd"],
   "ddl": [
     {
       "name": "workspace",
@@ -1381,6 +1381,16 @@
       "default": null,
       "generated": null,
       "name": "permission",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tool_permissions",
       "entityType": "columns",
       "table": "session"
     },

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -48,5 +48,6 @@ export const migrations = (
     import("./migration/20260705180000_rename_instructions"),
     import("./migration/20260706223930_add-session-fork"),
     import("./migration/20260707010146_durable_session_inbox"),
+    import("./migration/20260707075505_add-session-tool-permissions"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260707075505_add-session-tool-permissions.ts
+++ b/packages/core/src/database/migration/20260707075505_add-session-tool-permissions.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260707075505_add-session-tool-permissions",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`ALTER TABLE \`session\` ADD \`tool_permissions\` text;`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -218,6 +218,7 @@ export default {
           \`tokens_cache_write\` integer DEFAULT 0 NOT NULL,
           \`revert\` text,
           \`permission\` text,
+          \`tool_permissions\` text,
           \`agent\` text,
           \`model\` text,
           \`time_created\` integer NOT NULL,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -196,6 +196,10 @@ export interface Interface {
     sessionID: SessionSchema.ID
     model: ModelV2.Ref
   }) => Effect.Effect<void, NotFoundError>
+  readonly configure: (input: {
+    sessionID: SessionSchema.ID
+    tools?: Record<string, boolean>
+  }) => Effect.Effect<void, NotFoundError>
   readonly rename: (input: { sessionID: SessionSchema.ID; title: string }) => Effect.Effect<void, NotFoundError>
   readonly prompt: (input: {
     id?: SessionMessage.ID
@@ -624,6 +628,20 @@ const layer = Layer.effect(
         yield* events.publish(SessionEvent.ModelSelected, {
           sessionID: input.sessionID,
           model: input.model,
+        })
+      }),
+      configure: Effect.fn("V2Session.configure")(function* (input) {
+        yield* result.get(input.sessionID)
+        const tools = input.tools
+          ? Object.entries(input.tools).map(([action, allowed]) => ({
+              action,
+              resource: "*" as const,
+              effect: allowed ? ("allow" as const) : ("deny" as const),
+            }))
+          : undefined
+        yield* events.publish(SessionEvent.ToolsConfigured, {
+          sessionID: input.sessionID,
+          tools,
         })
       }),
       rename: Effect.fn("V2Session.rename")(function* (input) {

--- a/packages/core/src/session/info.ts
+++ b/packages/core/src/session/info.ts
@@ -47,6 +47,7 @@ export function fromRow(row: typeof SessionTable.$inferSelect): SessionSchema.In
     }),
     subpath: row.path ? RelativePath.make(row.path) : undefined,
     revert: row.revert ? { ...row.revert, messageID: SessionMessage.ID.make(row.revert.messageID) } : undefined,
+    tools: row.tool_permissions ?? undefined,
     time: {
       created: DateTime.makeUnsafe(row.time_created),
       updated: DateTime.makeUnsafe(row.time_updated),

--- a/packages/core/src/session/message-updater.ts
+++ b/packages/core/src/session/message-updater.ts
@@ -173,6 +173,7 @@ export function update(adapter: Adapter, event: SessionEvent.Event) {
       "session.renamed": () => Effect.void,
       "session.deleted": () => Effect.void,
       "session.forked": () => Effect.void,
+      "session.tools.configured": () => Effect.void,
       "session.prompt.promoted": () => Effect.void,
       "session.prompt.admitted": () => Effect.void,
       "session.execution.started": () => Effect.void,

--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -28,7 +28,7 @@ import { Slug } from "../util/slug"
 type DatabaseService = Database.Interface["db"]
 type MessageEvent = Exclude<
   SessionEvent.DurableEvent,
-  typeof SessionEvent.Forked.Type | typeof SessionEvent.Deleted.Type
+  typeof SessionEvent.Forked.Type | typeof SessionEvent.Deleted.Type | typeof SessionEvent.ToolsConfigured.Type
 >
 
 const decodeMessage = Schema.decodeUnknownSync(SessionMessage.Message)
@@ -622,6 +622,14 @@ const layer = Layer.effectDiscard(
           .run()
           .pipe(Effect.orDie)
       }),
+    )
+    yield* events.project(SessionEvent.ToolsConfigured, (event) =>
+      db
+        .update(SessionTable)
+        .set({ tool_permissions: event.data.tools ?? null, time_updated: DateTime.toEpochMillis(event.created) })
+        .where(eq(SessionTable.id, event.data.sessionID))
+        .run()
+        .pipe(Effect.orDie),
     )
     yield* events.project(SessionEvent.Renamed, (event) =>
       db

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -207,9 +207,8 @@ const layer = Layer.effect(
       const entries = yield* SessionHistory.entriesForRunner(db, session.id, checkpoint.baselineSeq)
       const context = entries.map((entry) => entry.message)
       const isLastStep = agent.info?.steps !== undefined && currentStep >= agent.info.steps
-      const toolMaterialization = isLastStep
-        ? undefined
-        : yield* tools.materialize({ permissions: agent.info?.permissions, model })
+      const permissions = [...(agent.info?.permissions ?? []), ...(session.tools ?? [])]
+      const toolMaterialization = isLastStep ? undefined : yield* tools.materialize({ permissions, model })
       const promptCacheKey = /^ses_[0-9a-f]{64}$/.test(session.id) ? session.id.slice(4) : session.id
       const request = LLM.request({
         model,

--- a/packages/core/src/session/sql.ts
+++ b/packages/core/src/session/sql.ts
@@ -6,6 +6,7 @@ import type { SessionMessage } from "./message"
 import type { Prompt } from "@opencode-ai/schema/prompt"
 import type { SessionInput } from "./input"
 import type { Snapshot } from "../snapshot"
+import type { Permission } from "@opencode-ai/schema/permission"
 import { PermissionV1 } from "../v1/permission"
 import { ProjectV2 } from "../project"
 import type { SessionSchema } from "./schema"
@@ -51,6 +52,7 @@ export const SessionTable = sqliteTable(
     tokens_cache_write: integer().notNull().default(0),
     revert: text({ mode: "json" }).$type<Revert.State>(),
     permission: text({ mode: "json" }).$type<PermissionV1.Ruleset>(),
+    tool_permissions: text({ mode: "json" }).$type<Permission.Ruleset>(),
     agent: text(),
     model: text({ mode: "json" }).$type<{
       id: string

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -254,6 +254,25 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
         ),
     )
     .add(
+      HttpApiEndpoint.post("session.configure", "/api/session/:sessionID/configure", {
+        params: { sessionID: Session.ID },
+        payload: Schema.Struct({
+          tools: Schema.Record(Schema.String, Schema.Boolean).pipe(Schema.optional),
+        }),
+        success: HttpApiSchema.NoContent,
+        error: SessionNotFoundError,
+      })
+        .middleware(sessionLocationMiddleware)
+        .annotateMerge(
+          OpenApi.annotations({
+            identifier: "v2.session.configure",
+            summary: "Configure session",
+            description:
+              "Configure session-scoped tool availability. Tools set to false are denied; tools set to true are explicitly allowed. Omit tools or pass null to clear session overrides.",
+          }),
+        ),
+    )
+    .add(
       HttpApiEndpoint.post("session.rename", "/api/session/:sessionID/rename", {
         params: { sessionID: Session.ID },
         payload: Schema.Struct({ title: Schema.String }),

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -9,6 +9,7 @@ import { Delivery } from "./session-delivery.js"
 import { Model } from "./model.js"
 import { NonNegativeInt, PositiveInt, RelativePath } from "./schema.js"
 import { FileAttachment, Prompt } from "./prompt.js"
+import { Permission } from "./permission.js"
 import { SessionID } from "./session-id.js"
 import { Location } from "./location.js"
 import { SessionMessage } from "./session-message.js"
@@ -62,6 +63,16 @@ export const ModelSelected = Event.durable({
   },
 })
 export type ModelSelected = typeof ModelSelected.Type
+
+export const ToolsConfigured = Event.durable({
+  type: "session.tools.configured",
+  ...options,
+  schema: {
+    ...Base,
+    tools: Permission.Ruleset.pipe(optional),
+  },
+})
+export type ToolsConfigured = typeof ToolsConfigured.Type
 
 export const Moved = Event.durable({
   type: "session.moved",
@@ -502,6 +513,7 @@ export namespace RevertEvent {
 export const Definitions = Event.inventory(
   AgentSelected,
   ModelSelected,
+  ToolsConfigured,
   Moved,
   Renamed,
   Deleted,

--- a/packages/schema/src/session.ts
+++ b/packages/schema/src/session.ts
@@ -4,6 +4,7 @@ import { Schema } from "effect"
 import { Agent } from "./agent.js"
 import { Location } from "./location.js"
 import { Model } from "./model.js"
+import { Permission } from "./permission.js"
 import { Project } from "./project.js"
 import { DateTimeUtcFromMillis, optional, RelativePath } from "./schema.js"
 import { SessionEvent } from "./session-event.js"
@@ -46,6 +47,7 @@ export const Info = Schema.Struct({
   location: Location.Ref,
   subpath: RelativePath.pipe(optional),
   revert: Revert.State.pipe(optional),
+  tools: Permission.Ruleset.pipe(optional),
 }).annotate({ identifier: "SessionV2.Info" })
 
 export const ListAnchor = Schema.Struct({

--- a/packages/schema/test/event-manifest.test.ts
+++ b/packages/schema/test/event-manifest.test.ts
@@ -103,6 +103,7 @@ describe("public event manifest", () => {
         "message.part.removed.1",
         "session.agent.selected.1",
         "session.model.selected.1",
+        "session.tools.configured.1",
         "session.moved.1",
         "session.renamed.1",
         "session.forked.1",

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -186,6 +186,22 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
         }),
       )
       .handle(
+        "session.configure",
+        Effect.fn(function* (ctx) {
+          yield* session.configure({ sessionID: ctx.params.sessionID, tools: ctx.payload.tools }).pipe(
+            Effect.catchTag("Session.NotFoundError", (error) =>
+              Effect.fail(
+                new SessionNotFoundError({
+                  sessionID: error.sessionID,
+                  message: `Session not found: ${error.sessionID}`,
+                }),
+              ),
+            ),
+          )
+          return HttpApiSchema.NoContent.make()
+        }),
+      )
+      .handle(
         "session.rename",
         Effect.fn(function* (ctx) {
           yield* session.rename({ sessionID: ctx.params.sessionID, title: ctx.payload.title }).pipe(


### PR DESCRIPTION
### Issue for this PR

Closes #35647

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Implements session-scoped tool configuration through a new `POST /api/session/:sessionID/configure` endpoint.

The endpoint accepts `{tools: {bash: false, edit: true}}` and translates that into Permission.Ruleset entries stored via a durable `session.tools.configured` event. At materialization time, session rules are appended after agent permissions so they win via findLast semantics in `whollyDisabled()`.

Passing tools as undefined clears session overrides.

### How did you verify your code works?

- Typecheck passes across all packages (schema, core, protocol, server, client, sdk-next)
- event-manifest test updated and green
- Migration generated with `bun run migration`, SDK regenerated with `bun run generate`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR