### PR TITLE
fix(tui): settle stale replay work

### DIFF
--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -54,6 +54,7 @@ type SessionCommit = StreamCommit
 //
 // - ids:    parts and error keys we've already committed (dedup guard)
 // - tools:  tool parts we've emitted a "start" for but not yet completed
+// - toolPart: latest full tool payload for active tool parts
 // - call:   tool call inputs, keyed by msg:call, for enriching permission views
 // - role:   message ID → "assistant" | "user", learned from message.updated
 // - msg:    part ID → message ID
@@ -74,6 +75,7 @@ export type SessionData = {
   announced: boolean
   ids: Set<string>
   tools: Set<string>
+  toolPart: Map<string, ToolPart>
   call: Map<string, Dict>
   shell: Map<string, ShellCall>
   permissions: PermissionRequest[]
@@ -112,6 +114,7 @@ export function createSessionData(
     announced: false,
     ids: new Set(),
     tools: new Set(),
+    toolPart: new Map(),
     call: new Map(),
     shell: new Map(),
     permissions: [],
@@ -758,6 +761,21 @@ export function flushInterrupted(data: SessionData, commits: SessionCommit[]) {
     data.ids.add(partID)
     drop(data, partID)
   }
+
+  for (const partID of data.tools) {
+    const part = data.toolPart.get(partID)
+    data.tools.delete(partID)
+    data.toolPart.delete(partID)
+    if (!part || data.ids.has(partID)) {
+      continue
+    }
+
+    data.ids.add(partID)
+    commits.push({
+      ...failTool(part, "Tool execution interrupted"),
+      interrupted: true,
+    })
+  }
 }
 
 // The main reducer. Takes one SDK event and returns scrollback commits and
@@ -930,6 +948,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
       }
 
       if (part.state.status === "running") {
+        data.toolPart.set(part.id, part)
         if (data.ids.has(part.id)) {
           return out(data, commits, view)
         }
@@ -946,6 +965,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
         const seen = data.tools.has(part.id)
         const mode = toolView(part.tool)
         data.tools.delete(part.id)
+        data.toolPart.delete(part.id)
         if (data.ids.has(part.id)) {
           return out(data, commits, view)
         }
@@ -982,6 +1002,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
       if (part.state.status === "error") {
         const seen = data.tools.has(part.id)
         data.tools.delete(part.id)
+        data.toolPart.delete(part.id)
         if (data.ids.has(part.id)) {
           return out(data, commits, view)
         }

--- a/packages/opencode/src/cli/cmd/run/session-replay.test.ts
+++ b/packages/opencode/src/cli/cmd/run/session-replay.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import { replaySession } from "./session-replay"
+import type { SessionMessages } from "./session.shared"
+
+const sessionID = "ses_replay_interrupted"
+const userID = "msg_user"
+const assistantID = "msg_assistant"
+
+const messages: SessionMessages = [
+  {
+    info: {
+      id: userID,
+      sessionID,
+      role: "user",
+      time: { created: 1 },
+      agent: "build",
+      model: { providerID: "provider", modelID: "model" },
+    },
+    parts: [{ id: "prt_user", sessionID, messageID: userID, type: "text", text: "check health" }],
+  },
+  {
+    info: {
+      id: assistantID,
+      sessionID,
+      role: "assistant",
+      time: { created: 2 },
+      agent: "build",
+      parentID: userID,
+      modelID: "model",
+      providerID: "provider",
+      mode: "build",
+      path: { cwd: "/project", root: "/project" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [
+      {
+        id: "prt_tool",
+        sessionID,
+        messageID: assistantID,
+        type: "tool",
+        callID: "call_health",
+        tool: "bash",
+        state: {
+          status: "running",
+          input: { command: "bun ops prod health" },
+          title: "bun ops prod health",
+          time: { start: 3 },
+        },
+      },
+    ],
+  },
+]
+
+describe("replaySession", () => {
+  test("keeps replayed active work running by default", () => {
+    const replay = replaySession({
+      messages,
+      permissions: [],
+      questions: [],
+      thinking: true,
+      limits: {},
+    })
+
+    expect(replay.patch?.phase).toBe("running")
+    expect(replay.commits).not.toContainEqual(
+      expect.objectContaining({
+        partID: "prt_tool",
+        interrupted: true,
+      }),
+    )
+  })
+
+  test("settles replayed active work when the session is no longer running", () => {
+    const replay = replaySession({
+      messages,
+      permissions: [],
+      questions: [],
+      thinking: true,
+      limits: {},
+      settleActive: true,
+    })
+
+    expect(replay.patch?.phase).toBe("idle")
+    expect(replay.commits).toContainEqual(
+      expect.objectContaining({
+        kind: "tool",
+        phase: "final",
+        partID: "prt_tool",
+        interrupted: true,
+      }),
+    )
+  })
+})

--- a/packages/opencode/src/cli/cmd/run/session-replay.ts
+++ b/packages/opencode/src/cli/cmd/run/session-replay.ts
@@ -1,5 +1,11 @@
 import type { Event, PermissionRequest, QuestionRequest } from "@opencode-ai/sdk/v2"
-import { bootstrapSessionData, createSessionData, reduceSessionData, type SessionData } from "./session-data"
+import {
+  bootstrapSessionData,
+  createSessionData,
+  flushInterrupted,
+  reduceSessionData,
+  type SessionData,
+} from "./session-data"
 import { messagePrompt, type SessionMessages } from "./session.shared"
 import { messageTurnSummaryCommit } from "./turn-summary"
 import type { FooterPatch, LocalReplayRow, RunProvider, StreamCommit } from "./types"
@@ -11,6 +17,7 @@ type ReplayInput = {
   thinking: boolean
   limits: Record<string, number>
   providers?: RunProvider[]
+  settleActive?: boolean
 }
 
 type ReplayConfig = {
@@ -251,6 +258,10 @@ export function replaySession(input: ReplayInput): SessionReplay {
     })
     commits.push(...next.commits)
     patch = mergePatch(patch, next.patch)
+  }
+
+  if (input.settleActive) {
+    flushInterrupted(data, commits)
   }
 
   return {

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -674,7 +674,7 @@ function createLayer(input: StreamInput) {
         })
 
         const bootstrap = Effect.fn("RunStreamTransport.bootstrap")(function* () {
-          const [messagesList, children, permissions, questions] = yield* Effect.all(
+          const [messagesList, children, permissions, questions, statuses] = yield* Effect.all(
             [
               messages(
                 input.sessionID,
@@ -700,6 +700,10 @@ function createLayer(input: StreamInput) {
                 Effect.map((item) => item.data ?? []),
                 Effect.orElseSucceed(() => []),
               ),
+              Effect.promise(() => input.sdk.session.status()).pipe(
+                Effect.map((item): Record<string, { type: string }> => item.data ?? {}),
+                Effect.orElseSucceed((): Record<string, { type: string }> => ({})),
+              ),
             ],
             {
               concurrency: "unbounded",
@@ -708,6 +712,8 @@ function createLayer(input: StreamInput) {
 
           const sessionPermissions = permissions.filter((item) => item.sessionID === input.sessionID)
           const sessionQuestions = questions.filter((item) => item.sessionID === input.sessionID)
+          const status = statuses[input.sessionID]?.type
+          const settleActive = status !== "busy" && status !== "retry"
           const history = input.replay
             ? replaySession({
                 messages: messagesList,
@@ -716,6 +722,7 @@ function createLayer(input: StreamInput) {
                 thinking: input.thinking,
                 limits: input.limits(),
                 providers: input.providers?.(),
+                settleActive,
               })
             : undefined
           const replay =
@@ -727,6 +734,7 @@ function createLayer(input: StreamInput) {
                   thinking: input.thinking,
                   limits: input.limits(),
                   providers: input.providers?.(),
+                  settleActive,
                 })
               : history
 


### PR DESCRIPTION
### Issue for this PR

Fixes #35642

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the TUI replays a session after reconnect/restart, it now checks `session.status()` before treating replayed active parts as still running. If the session is not busy/retrying, replay flushes stale active text/tool entries as interrupted instead of leaving spinners and the running footer active.

If the session is still busy/retrying, replay keeps those parts active so attaching to real background work still behaves normally.

This is scoped to the concrete TUI replay symptom. The broader durable core recovery contract remains tracked in #35467.

### How did you verify your code works?

- `bun test src/cli/cmd/run/session-replay.test.ts`
- `bun test src/cli/cmd/run`
- `bun typecheck` from `packages/opencode`
- `bunx prettier --check src/cli/cmd/run/session-data.ts src/cli/cmd/run/session-replay.ts src/cli/cmd/run/session-replay.test.ts src/cli/cmd/run/stream.transport.ts`
- `bunx oxlint packages/opencode/src/cli/cmd/run/session-data.ts packages/opencode/src/cli/cmd/run/session-replay.ts packages/opencode/src/cli/cmd/run/session-replay.test.ts packages/opencode/src/cli/cmd/run/stream.transport.ts` (0 errors; existing warnings in `stream.transport.ts`)
- pre-push hook: `bun turbo typecheck` (30/30 tasks successful)

### Screenshots / recordings

Not included; this is replay-state logic covered by the regression test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
