### PR TITLE
fix: gate non-media files to prevent converter crash

### DIFF
--- a/packages/core/src/github-copilot/chat/convert-to-openai-compatible-chat-messages.ts
+++ b/packages/core/src/github-copilot/chat/convert-to-openai-compatible-chat-messages.ts
@@ -1,7 +1,6 @@
 import {
   type LanguageModelV3Prompt,
   type SharedV3ProviderOptions,
-  UnsupportedFunctionalityError,
 } from "@ai-sdk/provider"
 import type { OpenAICompatibleChatPrompt } from "./openai-compatible-api-types"
 import { convertToBase64 } from "@ai-sdk/provider-utils"
@@ -36,14 +35,17 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
 
         messages.push({
           role: "user",
-          content: content.map((part) => {
-            const partMetadata = getOpenAIMetadata(part)
-            switch (part.type) {
-              case "text": {
-                return { type: "text", text: part.text, ...partMetadata }
-              }
-              case "file": {
-                if (part.mediaType.startsWith("image/")) {
+          content: content
+            .filter(
+              (part) => part.type !== "file" || part.mediaType.startsWith("image/")
+            )
+            .map((part) => {
+              const partMetadata = getOpenAIMetadata(part)
+              switch (part.type) {
+                case "text": {
+                  return { type: "text", text: part.text, ...partMetadata }
+                }
+                case "file": {
                   const mediaType = part.mediaType === "image/*" ? "image/jpeg" : part.mediaType
 
                   return {
@@ -56,14 +58,9 @@ export function convertToOpenAICompatibleChatMessages(prompt: LanguageModelV3Pro
                     },
                     ...partMetadata,
                   }
-                } else {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: `file part media type ${part.mediaType}`,
-                  })
                 }
               }
-            }
-          }),
+            }),
           ...metadata,
         })
 

--- a/packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
+++ b/packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
@@ -2,11 +2,10 @@ import {
   type LanguageModelV3Prompt,
   type LanguageModelV3ToolCallPart,
   type SharedV3Warning,
-  UnsupportedFunctionalityError,
 } from "@ai-sdk/provider"
 import { convertToBase64, parseProviderOptions } from "@ai-sdk/provider-utils"
 import { z } from "zod/v4"
-import type { OpenAIResponsesInput, OpenAIResponsesReasoning } from "./openai-responses-api-types"
+import type { OpenAIResponsesInput, OpenAIResponsesReasoning, OpenAIResponsesUserMessage } from "./openai-responses-api-types"
 import { localShellInputSchema, localShellOutputSchema } from "./tool/local-shell"
 
 /**
@@ -68,16 +67,16 @@ export async function convertToOpenAIResponsesInput({
       case "user": {
         input.push({
           role: "user",
-          content: content.map((part, index) => {
+          content: content.flatMap<OpenAIResponsesUserMessage["content"][number]>((part, index) => {
             switch (part.type) {
               case "text": {
-                return { type: "input_text", text: part.text }
+                return [{ type: "input_text", text: part.text }]
               }
               case "file": {
                 if (part.mediaType.startsWith("image/")) {
                   const mediaType = part.mediaType === "image/*" ? "image/jpeg" : part.mediaType
 
-                  return {
+                  return [{
                     type: "input_image",
                     ...(part.data instanceof URL
                       ? { image_url: part.data.toString() }
@@ -87,15 +86,15 @@ export async function convertToOpenAIResponsesInput({
                             image_url: `data:${mediaType};base64,${convertToBase64(part.data)}`,
                           }),
                     detail: part.providerOptions?.copilot?.imageDetail,
-                  }
+                  }]
                 } else if (part.mediaType === "application/pdf") {
                   if (part.data instanceof URL) {
-                    return {
+                    return [{
                       type: "input_file",
                       file_url: part.data.toString(),
-                    }
+                    }]
                   }
-                  return {
+                  return [{
                     type: "input_file",
                     ...(typeof part.data === "string" && isFileId(part.data, fileIdPrefixes)
                       ? { file_id: part.data }
@@ -103,11 +102,9 @@ export async function convertToOpenAIResponsesInput({
                           filename: part.filename ?? `part-${index}.pdf`,
                           file_data: `data:application/pdf;base64,${convertToBase64(part.data)}`,
                         }),
-                  }
+                  }]
                 } else {
-                  throw new UnsupportedFunctionalityError({
-                    functionality: `file part media type ${part.mediaType}`,
-                  })
+                  return []
                 }
               }
             }

--- a/packages/core/test/github-copilot/convert-to-copilot-messages.test.ts
+++ b/packages/core/test/github-copilot/convert-to-copilot-messages.test.ts
@@ -116,6 +116,29 @@ describe("user messages", () => {
     ])
   })
 
+  test("should skip non-image file parts without throwing", () => {
+    const result = convertToCopilotMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Hello" },
+          {
+            type: "file",
+            data: Buffer.from([0, 1, 2, 3]).toString("base64"),
+            mediaType: "application/octet-stream",
+          },
+        ],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    ])
+  })
+
   test("should handle multiple text parts without flattening", () => {
     const result = convertToCopilotMessages([
       {

--- a/packages/core/test/github-copilot/openai-responses-language-model.test.ts
+++ b/packages/core/test/github-copilot/openai-responses-language-model.test.ts
@@ -203,4 +203,28 @@ describe("convertToOpenAIResponsesInput", () => {
 
     expect((input[0] as any).content[0].detail).toBe("high")
   })
+
+  test("skips unsupported file parts file parts without throwing", async () => {
+    const { input } = await convertToOpenAIResponsesInput({
+      prompt: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Hello" },
+            {
+              type: "file",
+              mediaType: "application/octet-stream",
+              data: Buffer.from([0, 1, 2, 3]).toString("base64"),
+            },
+          ],
+        },
+      ],
+      systemMessageMode: "system",
+      store: false,
+    })
+
+    expect(input).toHaveLength(1)
+    expect((input[0] as any).content).toHaveLength(1)
+    expect((input[0] as any).content[0]).toEqual({ type: "input_text", text: "Hello" })
+  })
 })

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -210,17 +210,17 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
           })
         // text/plain and directory files are converted into text parts, ignore them
         if (part.type === "file" && part.mime !== "text/plain" && part.mime !== "application/x-directory") {
-          if (options?.stripMedia && isMedia(part.mime)) {
-            userMessage.parts.push({
-              type: "text",
-              text: `[Attached ${part.mime}: ${part.filename ?? "file"}]`,
-            })
-          } else {
+          if (isMedia(part.mime) && !options?.stripMedia) {
             userMessage.parts.push({
               type: "file",
               url: part.url,
               mediaType: part.mime,
               filename: part.filename,
+            })
+          } else {
+            userMessage.parts.push({
+              type: "text",
+              text: `[Attached ${part.mime}: ${part.filename ?? "file"}]`,
             })
           }
         }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -286,6 +286,13 @@ describe("session.message-v2.toModelMessage", () => {
             url: "https://example.com/dir",
           },
           {
+            ...basePart(messageID, "p-octet"),
+            type: "file",
+            mime: "application/octet-stream",
+            filename: "blob.bin",
+            url: "https://example.com/blob.bin",
+          },
+          {
             ...basePart(messageID, "p6"),
             type: "compaction",
             auto: true,
@@ -311,6 +318,10 @@ describe("session.message-v2.toModelMessage", () => {
             mediaType: "image/png",
             filename: "img.png",
             data: "https://example.com/img.png",
+          },
+          {
+            type: "text",
+            text: "[Attached application/octet-stream: blob.bin]",
           },
           { type: "text", text: "What did we do so far?" },
           { type: "text", text: "The following tool was executed by the user" },


### PR DESCRIPTION
Fixes #35697

Two changes:

1. **`message-v2.ts` gate** — invert condition so only `isMedia(mime) && !stripMedia` pushes as `file` part; everything else (e.g. `application/octet-stream`) becomes `[Attached ${mime}: ${name}]` text placeholder
2. **Both copilot converters (chat + responses)** — silently skip file parts with unsupported media types instead of throwing `UnsupportedFunctionalityError`

Tested: 37/37 core copilot tests + 36/36 message-v2 tests pass, turbo typecheck clean (30/30 packages).