### PR TITLE
fix(tool): enforce grep deny rules by filtering matched files

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.handler.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.handler.ts
@@ -189,5 +189,8 @@ const createToolContext = Effect.fn("Cli.debug.agent.createToolContext")(functio
         }
       })
     },
+    evaluate({ permission, pattern }: { permission: string; pattern: string }) {
+      return Permission.evaluate(permission, pattern, ruleset)
+    },
   }
 })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -346,6 +346,8 @@ const layer = Layer.effect(
                 ruleset: Permission.merge(taskAgent.permission, session.permission ?? []),
               })
               .pipe(Effect.orDie),
+          evaluate: ({ permission: p, pattern }) =>
+            Permission.evaluate(p, pattern, Permission.merge(taskAgent.permission, session.permission ?? [])),
         })
         .pipe(
           Effect.catchCause((cause) => {
@@ -823,6 +825,7 @@ const layer = Layer.effect(
                     messages: [],
                     metadata: () => Effect.void,
                     ask: () => Effect.void,
+                    evaluate: ({ permission, pattern }) => ({ permission, pattern, action: "ask" as const }),
                   })
                   .pipe(Effect.onInterrupt(() => Effect.sync(() => controller.abort())))
               }

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -87,6 +87,12 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
         })
         .pipe(Effect.orDie),
+    evaluate: (req) =>
+      Permission.evaluate(
+        req.permission,
+        req.pattern,
+        Permission.merge(input.agent.permission, input.session.permission ?? []),
+      ),
   })
 
   for (const item of yield* registry.tools({

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -68,11 +68,20 @@ export const GrepTool = Tool.define(
           })
           if (result.length === 0) return empty
 
-          const rows = result.map((item) => ({
+          const allRows = result.map((item) => ({
             path: path.resolve(cwd, item.entry.path),
             line: item.line,
             text: item.text,
           }))
+
+          // Filter out matches in files denied by grep permission rules. Unlike
+          // read/glob, grep can't check up front — it only learns which files
+          // matched from ripgrep output — so denied paths are filtered here,
+          // after the search. (#35503)
+          const rows = allRows.filter((row) => {
+            const relPath = path.relative(ins.worktree, row.path)
+            return ctx.evaluate({ permission: "grep", pattern: relPath }).action !== "deny"
+          })
 
           const limit = 100
           const truncated = rows.length === limit

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -82,11 +82,12 @@ export const GrepTool = Tool.define(
             const relPath = path.relative(ins.worktree, row.path)
             return ctx.evaluate({ permission: "grep", pattern: relPath }).action !== "deny"
           })
+          const denied = allRows.length - rows.length
 
           const limit = 100
           const truncated = rows.length === limit
           const final = rows
-          if (final.length === 0) return empty
+          if (final.length === 0 && denied === 0) return empty
 
           const total = rows.length
           const hasMore = truncated || result.length === limit
@@ -105,6 +106,16 @@ export const GrepTool = Tool.define(
           if (truncated) {
             output.push("")
             output.push("(Results truncated. Consider using a more specific path or pattern.)")
+          }
+
+          // Surface that some matches were hidden by deny rules, without
+          // revealing the denied paths themselves. Keeps the user/agent aware
+          // that the result is partial rather than silently dropping matches.
+          if (denied > 0) {
+            output.push("")
+            output.push(
+              `(${denied} match${denied === 1 ? "" : "es"} hidden by grep deny rules.)`,
+            )
           }
 
           return {

--- a/packages/opencode/src/tool/tool.ts
+++ b/packages/opencode/src/tool/tool.ts
@@ -43,6 +43,17 @@ export type Context<M extends Metadata = Metadata> = {
   messages: SessionV1.WithParts[]
   metadata(input: { title?: string; metadata?: M }): Effect.Effect<void>
   ask(input: Omit<PermissionV1.Request, "id" | "sessionID" | "tool">): Effect.Effect<void>
+  /**
+   * Silently evaluate a permission rule against the static config ruleset,
+   * without triggering the ask UI. Checks config rules only — does NOT include
+   * dynamic session-approved rules (rules approved at runtime via "always allow").
+   * Use `ask()` when you need the full permission flow including dynamic approvals.
+   *
+   * Tools that discover affected files only after running (e.g. grep, which
+   * learns matched paths from ripgrep output) use this to filter out denied
+   * results they couldn't have checked up front.
+   */
+  evaluate(input: { permission: string; pattern: string }): PermissionV1.Rule
 }
 
 export interface ExecuteResult<M extends Metadata = Metadata> {

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -28,6 +28,7 @@ const baseCtx = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 type AskInput = {

--- a/packages/opencode/test/tool/code-mode-integration.test.ts
+++ b/packages/opencode/test/tool/code-mode-integration.test.ts
@@ -32,6 +32,7 @@ const ctx: Tool.Context = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 // Avoid the SDK Client here; other MCP tests mock it process-globally.

--- a/packages/opencode/test/tool/code-mode.test.ts
+++ b/packages/opencode/test/tool/code-mode.test.ts
@@ -21,6 +21,7 @@ const ctx: Tool.Context = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 function mcpTool(

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -25,6 +25,7 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 afterEach(async () => {

--- a/packages/opencode/test/tool/external-directory.test.ts
+++ b/packages/opencode/test/tool/external-directory.test.ts
@@ -22,6 +22,7 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 const glob = (p: string) =>

--- a/packages/opencode/test/tool/glob.test.ts
+++ b/packages/opencode/test/tool/glob.test.ts
@@ -37,6 +37,7 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 const asks = () => {

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -255,6 +255,36 @@ describe("tool.grep", () => {
       // ...and the denied file is filtered out.
       expect(result.output).not.toContain("secret.txt")
       expect(result.output).not.toContain("needle here")
+      // A notice surfaces that matches were hidden, without leaking the path.
+      expect(result.output).toContain("1 match hidden by grep deny rules.")
+    }),
+  )
+
+  // When every match is denied, the result must not read "No files found"
+  // (misleading — matches were found, just hidden). Instead it reports zero
+  // visible matches plus the hidden-by-deny notice. (#35503)
+  it.instance("reports hidden matches instead of 'No files found' when all matches are denied", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "secret.txt"), "needle here\n"))
+
+      const deniedCtx: Tool.Context = {
+        ...ctx,
+        evaluate: ({ permission, pattern }) => ({
+          permission,
+          pattern,
+          action: pattern.endsWith("secret.txt") ? "deny" : "allow",
+        }),
+      }
+
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      const result = yield* grep.execute({ pattern: "needle", path: test.directory, include: "*.txt" }, deniedCtx)
+
+      expect(result.output).not.toContain("No files found")
+      expect(result.output).toContain("Found 0 matches")
+      expect(result.output).toContain("1 match hidden by grep deny rules.")
+      expect(result.output).not.toContain("secret.txt")
     }),
   )
 })

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -39,6 +39,11 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }): PermissionV1.Rule => ({
+    permission,
+    pattern,
+    action: "ask",
+  }),
 }
 
 const root = path.join(__dirname, "../..")
@@ -216,6 +221,40 @@ describe("tool.grep", () => {
 
       expect(result.metadata.matches).toBe(1)
       expect(requests.find((req) => req.permission === "external_directory")).toBeUndefined()
+    }),
+  )
+
+  // Regression for #35503: per-pattern deny rules under "grep" were ignored
+  // because grep passed the search regex (not file paths) to the permission
+  // check. Denied files should now be filtered out of the results, while
+  // matches in allowed files are still returned.
+  it.instance("filters out matches in files denied by grep permission rules", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      // Two files, both containing the pattern. "secret.txt" is denied.
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "secret.txt"), "needle here\n"))
+      yield* Effect.promise(() => Bun.write(path.join(test.directory, "open.txt"), "needle there\n"))
+
+      const deniedCtx: Tool.Context = {
+        ...ctx,
+        evaluate: ({ permission, pattern }) => ({
+          permission,
+          pattern,
+          // deny anything matching the secret file; allow everything else
+          action: pattern.endsWith("secret.txt") ? "deny" : "allow",
+        }),
+      }
+
+      const info = yield* GrepTool
+      const grep = yield* info.init()
+      const result = yield* grep.execute({ pattern: "needle", path: test.directory, include: "*.txt" }, deniedCtx)
+
+      // The allowed file's match is returned...
+      expect(result.output).toContain("open.txt")
+      expect(result.output).toContain("needle there")
+      // ...and the denied file is filtered out.
+      expect(result.output).not.toContain("secret.txt")
+      expect(result.output).not.toContain("needle here")
     }),
   )
 })

--- a/packages/opencode/test/tool/lsp.test.ts
+++ b/packages/opencode/test/tool/lsp.test.ts
@@ -28,6 +28,7 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 const workspaceSymbolQueries: string[] = []

--- a/packages/opencode/test/tool/question.test.ts
+++ b/packages/opencode/test/tool/question.test.ts
@@ -18,6 +18,7 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 const it = testEffect(

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -42,6 +42,7 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 const readLayer = (flags: Partial<RuntimeFlags.Info> = {}) =>

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -453,6 +453,7 @@ describe("tool.registry", () => {
         messages: [],
         metadata: () => Effect.void,
         ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
       } satisfies Tool.Context)
 
       expect(result.output).toBe("here is an image")

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -80,6 +80,11 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({
+    permission,
+    pattern,
+    action: "ask" as const,
+  }),
 }
 
 Shell.acceptable.reset()

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -21,6 +21,11 @@ const baseCtx: Omit<Tool.Context, "ask"> = {
   abort: AbortSignal.any([]),
   messages: [],
   metadata: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({
+    permission,
+    pattern,
+    action: "ask" as const,
+  }),
 }
 
 afterEach(async () => {

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -242,6 +242,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 
@@ -282,6 +283,7 @@ describe("tool.task", () => {
               Effect.sync(() => {
                 calls.push(input)
               }),
+            evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
           },
         )
 
@@ -338,6 +340,7 @@ describe("tool.task", () => {
             messages: [],
             metadata: () => Effect.void,
             ask: () => Effect.void,
+            evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
           },
         )
         .pipe(Effect.forkChild)
@@ -376,6 +379,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 
@@ -414,6 +418,7 @@ describe("tool.task", () => {
             messages: [],
             metadata: () => Effect.void,
             ask: () => Effect.void,
+            evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
           },
         )
 
@@ -479,6 +484,7 @@ describe("tool.task", () => {
             messages: [],
             metadata: () => Effect.void,
             ask: () => Effect.void,
+            evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
           },
         )
         .pipe(Effect.exit)
@@ -529,6 +535,7 @@ describe("tool.task", () => {
             messages: [],
             metadata: () => Effect.void,
             ask: () => Effect.void,
+            evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
           },
         )
         .pipe(Effect.forkChild)
@@ -581,6 +588,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 
@@ -624,6 +632,7 @@ describe("tool.task", () => {
         messages: [],
         metadata: () => Effect.void,
         ask: () => Effect.void,
+        evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
       }
 
       const started = yield* def.execute(
@@ -688,6 +697,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 
@@ -727,6 +737,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 
@@ -765,6 +776,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 
@@ -804,6 +816,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 
@@ -843,6 +856,7 @@ describe("tool.task", () => {
           messages: [],
           metadata: () => Effect.void,
           ask: () => Effect.void,
+          evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
         },
       )
 

--- a/packages/opencode/test/tool/tool-define.test.ts
+++ b/packages/opencode/test/tool/tool-define.test.ts
@@ -24,6 +24,9 @@ function makeCtx(): Tool.Context {
     ask() {
       return Effect.void
     },
+    evaluate({ permission, pattern }) {
+      return { permission, pattern, action: "ask" as const }
+    },
   }
 }
 

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -25,6 +25,7 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 const withFetch = <A, E, R>(

--- a/packages/opencode/test/tool/write.test.ts
+++ b/packages/opencode/test/tool/write.test.ts
@@ -25,6 +25,7 @@ const ctx = {
   messages: [],
   metadata: () => Effect.void,
   ask: () => Effect.void,
+  evaluate: ({ permission, pattern }: { permission: string; pattern: string }) => ({ permission, pattern, action: "ask" as const }),
 }
 
 afterEach(async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #35503

### Type of change

- [x] Bug fix

### What does this PR do?

`grep` passes the **search regex** (e.g. `"any-string"`) to the permission check, not file paths, so per-pattern deny rules under `grep` never match — a denied file (e.g. `**/config.php: "deny"`) still has its matched content surfaced. `read` and `glob` don't hit this because they send file paths / globs up front; `grep` only learns which files matched from ripgrep output, **after** the search runs, so it can't check deny rules up front the way `read` does.

Fix: filter denied matches **post-search**. Add a non-interactive `evaluate()` to `Tool.Context` that checks the static config ruleset only (no ask UI, no dynamic session-approved rules — those only apply to the `ask()` flow). After ripgrep returns, filter out any match whose worktree-relative path evaluates to `deny` under the `grep` permission; remaining matches are returned as usual.

```ts
const allRows = result.map(...)
const rows = allRows.filter((row) => {
  const relPath = path.relative(ins.worktree, row.path)
  return ctx.evaluate({ permission: "grep", pattern: relPath }).action !== "deny"
})
```

`evaluate` is wired through the three places that construct a `Tool.Context` (`session/tools.ts`, `session/prompt.ts` taskTool + read paths, `cli/cmd/debug/agent.handler.ts`). It uses the same merged ruleset (`agent.permission` + `session.permission`) as `ask()`.

Why `evaluate` and not just calling `ask()` per match: `ask()` triggers the ask UI / can reject the whole call, and would fire per-file on up to 100 matches. `evaluate` is a silent static-rule check — deny → filter that one match, everything else flows normally. This mirrors the approach in the closed-due-to-staleness #29755 (credit to that author for the `ctx.evaluate` design).

### How did you verify your code works?

Ran in an `oven/bun:1.3.14` container with git installed:

```
cd packages/opencode
bun run typecheck
bun test test/tool/grep.test.ts
```

- Added regression test `filters out matches in files denied by grep permission rules`: writes `secret.txt` + `open.txt` (both containing the pattern), uses a ctx whose `evaluate` denies `secret.txt`, asserts `open.txt` is returned and `secret.txt` is filtered out.
- `bun run typecheck` (`tsgo --noEmit`) clean across `packages/opencode` (the new `evaluate` field is implemented on every `Tool.Context` mock in the test suite).
- All 7 `grep.test.ts` tests pass.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR