### PR TITLE
fix(cli): hide dead --interactive flag from run --help

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -236,7 +236,12 @@ export const RunCommand = effectCmd({
       .option("interactive", {
         alias: ["i"],
         type: "boolean",
-        describe: "run in direct interactive split-footer mode",
+        // The `--mini` flag (and the bare `opencode --mini` entry point) is the
+        // only path that actually enables interactive split-footer mode — see
+        // `const interactive = args.mini` below. `--interactive`/`-i` is parsed
+        // but its value is never read, so advertising it in `--help` is
+        // misleading. Hide it until it is either wired up or removed. (#35623)
+        hidden: true,
         default: false,
       })
       .option("auto", {

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -76,34 +76,31 @@ Positionals:
   message  message to send                                                     [array] [default: []]
 
 Options:
-  -h, --help         show help                                                             [boolean]
-  -v, --version      show version number                                                   [boolean]
-      --print-logs   print logs to stderr                                                  [boolean]
-      --log-level    log level                  [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
-      --pure         run without external plugins                                          [boolean]
-      --command      the command to run, use message for args                               [string]
-  -c, --continue     continue the last session                                             [boolean]
-  -s, --session      session id to continue                                                 [string]
-      --fork         fork the session before continuing (requires --continue or --session) [boolean]
-      --share        share the session                                                     [boolean]
-  -m, --model        model to use in the format of provider/model                           [string]
-      --agent        agent to use                                                           [string]
-      --format       format: default (formatted) or json (raw JSON events)
+  -h, --help        show help                                                              [boolean]
+  -v, --version     show version number                                                    [boolean]
+      --print-logs  print logs to stderr                                                   [boolean]
+      --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
+      --pure        run without external plugins                                           [boolean]
+      --command     the command to run, use message for args                                [string]
+  -c, --continue    continue the last session                                              [boolean]
+  -s, --session     session id to continue                                                  [string]
+      --fork        fork the session before continuing (requires --continue or --session)  [boolean]
+      --share       share the session                                                      [boolean]
+  -m, --model       model to use in the format of provider/model                            [string]
+      --agent       agent to use                                                            [string]
+      --format      format: default (formatted) or json (raw JSON events)
                                           [string] [choices: "default", "json"] [default: "default"]
-  -f, --file         file(s) to attach to message                                            [array]
-      --title        title for the session (uses truncated prompt if no value provided)     [string]
-      --attach       attach to a running opencode server (e.g., http://localhost:4096)      [string]
-  -p, --password     basic auth password (defaults to OPENCODE_SERVER_PASSWORD)             [string]
-  -u, --username     basic auth username (defaults to OPENCODE_SERVER_USERNAME or 'opencode')
+  -f, --file        file(s) to attach to message                                             [array]
+      --title       title for the session (uses truncated prompt if no value provided)      [string]
+      --attach      attach to a running opencode server (e.g., http://localhost:4096)       [string]
+  -p, --password    basic auth password (defaults to OPENCODE_SERVER_PASSWORD)              [string]
+  -u, --username    basic auth username (defaults to OPENCODE_SERVER_USERNAME or 'opencode')[string]
+      --dir         directory to run in, path on remote server if attaching                 [string]
+      --port        port for the local server (defaults to random port if no value provided)[number]
+      --variant     model variant (provider-specific reasoning effort, e.g., high, max, minimal)
                                                                                             [string]
-      --dir          directory to run in, path on remote server if attaching                [string]
-      --port         port for the local server (defaults to random port if no value provided)
-                                                                                            [number]
-      --variant      model variant (provider-specific reasoning effort, e.g., high, max, minimal)
-                                                                                            [string]
-      --thinking     show thinking blocks                                                  [boolean]
-  -i, --interactive  run in direct interactive split-footer mode          [boolean] [default: false]
-      --auto         auto-approve permissions that are not explicitly denied (dangerous!)
+      --thinking    show thinking blocks                                                   [boolean]
+      --auto        auto-approve permissions that are not explicitly denied (dangerous!)
                                                                           [boolean] [default: false]"
 `;
 


### PR DESCRIPTION
### Issue for this PR

Closes #35623

### Type of change

- [x] Bug fix

### What does this PR do?

`opencode run -i / --interactive` is declared and shown in `--help`, but its value is never read. Interactive mode is gated solely by `--mini` (and the bare `opencode --mini` entry point) via `const interactive = args.mini` in `run.ts`. So `opencode run -i "..."` silently takes the non-interactive path — identical to `opencode run "..."`. The flag is a no-op advertised to users.

This hides the option (`hidden: true`) so `run --help` stops surfacing a dead flag. The option is still parsed, so any script passing `-i` keeps working — no breaking change, it's just no longer advertised. Help snapshot updated accordingly.

### How did you verify your code works?

- `COLUMNS=120 bun src/index.ts run --help` — confirmed `-i, --interactive` no longer appears, and every other flag is unchanged.
- Diffed the full `run --help` output before/after: the only content change is the removal of the `--interactive` line (the rest is yargs re-aligning columns after the longest flag got shorter).
- Updated the `help-snapshots` snapshot for `opencode run --help` and confirmed it matches the real output byte-for-byte.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
