### PR TITLE
feat(session): 添加会话历史问题索引按钮

### DIFF
--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -664,6 +664,7 @@ export const dict = {
   "session.todo.expand": "Expand",
   "session.todo.progress": "{{done}} of {{total}} todos completed",
   "session.question.progress": "{{current}} of {{total}} questions",
+  "session.history.index": "Question index",
   "session.question.minimize": "Minimize question",
   "session.question.restore": "Restore question",
   "session.question.pending.one": "{{count}} pending question",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -873,6 +873,7 @@ export const dict = {
   "session.review.noVcs.createGit.action": "创建 Git 仓库",
   "session.todo.progress": "已完成 {{done}} 个任务（共 {{total}} 个）",
   "session.question.progress": "{{current}}/{{total}} 个问题",
+  "session.history.index": "问题索引",
   "session.header.open.finder": "访达",
   "session.header.open.fileExplorer": "文件资源管理器",
   "session.header.open.fileManager": "文件管理器",

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -544,6 +544,7 @@ export function MessageTimeline(props: {
     pendingRename: false,
     pendingShare: false,
   })
+  const [historyMenuOpen, setHistoryMenuOpen] = createSignal(false)
   let titleRef: HTMLInputElement | undefined
 
   const [share, setShare] = createStore({
@@ -551,6 +552,47 @@ export function MessageTimeline(props: {
     dismiss: null as "escape" | "outside" | null,
   })
   let more: HTMLButtonElement | undefined
+
+  const scrollToMessage = (userMessageID: string) => {
+    const tryScroll = () => {
+      const root = listRoot()
+      if (!root) {
+        requestAnimationFrame(tryScroll)
+        return
+      }
+      const element = root.querySelector(`[data-message-id="${CSS.escape(userMessageID)}"]`)
+      if (!element) {
+        requestAnimationFrame(tryScroll)
+        return
+      }
+      const rootRect = root.getBoundingClientRect()
+      const elementRect = element.getBoundingClientRect()
+      const targetScrollTop = Math.max(0, root.scrollTop + elementRect.top - rootRect.top - root.clientHeight / 3)
+      const startScrollTop = root.scrollTop
+      const distance = targetScrollTop - startScrollTop
+      if (Math.abs(distance) < 1) return
+
+      const duration = 600
+      const startTime = performance.now()
+
+      const easeInOutCubic = (t: number) => {
+        return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
+      }
+
+      const animate = (now: number) => {
+        const elapsed = now - startTime
+        const progress = Math.min(elapsed / duration, 1)
+        root.scrollTop = startScrollTop + distance * easeInOutCubic(progress)
+        if (progress < 1) {
+          requestAnimationFrame(animate)
+        }
+      }
+
+      requestAnimationFrame(animate)
+    }
+
+    requestAnimationFrame(tryScroll)
+  }
 
   const bindListRoot = (root: HTMLDivElement) => {
     if (root === listRoot()) return
@@ -1479,7 +1521,46 @@ export function MessageTimeline(props: {
                       placement="bottom"
                       buttonAppearance={settings.general.newLayoutDesigns() ? "v2" : "default"}
                     />
-                    <Show when={!parentID()}>
+                    <DropdownMenu
+                      gutter={4}
+                      placement="bottom-end"
+                      open={historyMenuOpen()}
+                      onOpenChange={(open) => {
+                        setHistoryMenuOpen(open)
+                      }}
+                    >
+                      <DropdownMenu.Trigger
+                        as={IconButton}
+                        icon="bullet-list"
+                        variant="ghost"
+                        class="size-6 rounded-md data-[expanded]:bg-surface-base-active"
+                        aria-label={language.t("session.history.index")}
+                        disabled={props.userMessages.length === 0}
+                      />
+                      <DropdownMenu.Portal>
+                        <DropdownMenu.Content style={{ "min-width": "240px", "max-height": "360px", overflow: "auto" }}>
+                          <Show when={props.userMessages.length > 0}>
+                            <For each={props.userMessages}>
+                              {(userMessage) => {
+                                const parts = getMsgParts(userMessage.id)
+                                const textPart = parts.find((p) => p.type === "text" && !(p as any).synthetic)
+                                const text = (textPart as any)?.text || ""
+                                const summary = text.trim().slice(0, 60) + (text.trim().length > 60 ? "..." : "")
+                                return (
+                                  <DropdownMenu.Item onSelect={() => {
+                                    scrollToMessage(userMessage.id)
+                                    setHistoryMenuOpen(false)
+                                  }}>
+                                    <DropdownMenu.ItemLabel>{summary}</DropdownMenu.ItemLabel>
+                                  </DropdownMenu.Item>
+                                )
+                              }}
+                            </For>
+                          </Show>
+                        </DropdownMenu.Content>
+                      </DropdownMenu.Portal>
+                    </DropdownMenu>
+                <Show when={!parentID()}>
                       <Show
                         when={settings.general.newLayoutDesigns()}
                         fallback={


### PR DESCRIPTION
### Issue for this PR

Closes #（如果有对应 Issue 填编号，没有就删掉这行）

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

在消息时间线标题栏新增「问题索引」按钮：
- 点击按钮展示历史用户问题列表，超过10条时支持滚动
- 点击列表中的问题项，页面以 easeInOutCubic 缓动动画平滑滚动到对应消息位置
- 滚动目标定位在视图的 1/3 处

### How did you verify your code works?

本地已验证功能正常。

### Screenshots / recordings
<img width="1675" height="983" alt="Screenshots" src="https://github.com/user-attachments/assets/a360f6d1-ccb2-4f8c-9015-2fa6c7ddb4c0" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR