### PR TITLE
Update ecosystem.mdx

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-copilot-usage](https://github.com/fitri/opencode-copilot-usage-plugin)                   | View Github Copilot usage and quota in Opencode TUI sidebar                                        |
 
 ---
 


### PR DESCRIPTION
add copilot usage and quota viewer plugins to the list

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

Adds my plugin, Copilot Quota for OpenCode, to the Plugins table in the ecosystem docs.

It's a TUI plugin that shows live GitHub Copilot usage in the right sidebar, next to Context and LSP: your plan, a used/remaining bar, premium interactions used vs. entitlement, and the days until reset. It reuses the Copilot OAuth token OpenCode already stores after `/connect`, so there's no extra setup — no PAT, no org config. It calls the same internal endpoint the official Copilot editors use (`copilot_internal/user`), which is unversioned, so the widget falls back to a plain status message if that endpoint ever changes shape instead of crashing.

Repo: https://github.com/fitri/opencode-copilot-usage-plugin

### How did you verify your code works?

Ran it against my own OpenCode setup with a live Copilot Business account. Confirmed the sidebar renders inside an open session (plan, bar, premium usage, reset countdown), updates after each assistant response, and that `tsc` passes with no errors.

### Screenshots / recordings

<img width="391" height="297" alt="image" src="https://github.com/user-attachments/assets/083c9938-31ea-4085-96e5-632ac8418993" />

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
