### PR TITLE
fix(mcp): scope remembered resource reads

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -340,11 +340,12 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               { tool: MCP_RESOURCE_TOOLS.read, sessionID: ctx.sessionID, callID: opts.toolCallId },
               { args },
             )
+            const permissionPattern = `mcp:${parsed.server}:${parsed.uri}`
             yield* ctx.ask({
               permission: "read",
               metadata: { server: parsed.server, uri: parsed.uri },
-              patterns: [`mcp:${parsed.server}:${parsed.uri}`],
-              always: [`mcp:${parsed.server}:*`],
+              patterns: [permissionPattern],
+              always: [permissionPattern],
             })
 
             const content = yield* mcp.readResource(parsed.server, parsed.uri)

--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -1,0 +1,132 @@
+import { expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { SessionTools } from "@/session/tools"
+import { MessageID, SessionID } from "@/session/schema"
+import { Plugin } from "@/plugin"
+import { Permission } from "@/permission"
+import { ToolRegistry } from "@/tool/registry"
+import { Truncate } from "@/tool/truncate"
+import { MCP } from "@/mcp"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { testEffect } from "../lib/effect"
+
+const resourceClient = {
+  getServerCapabilities() {
+    return { resources: {} }
+  },
+}
+
+const baseLayer = Layer.mergeAll(
+  Layer.succeed(
+    Plugin.Service,
+    Plugin.Service.of({
+      init: () => Effect.void,
+      list: () => Effect.succeed([]),
+      trigger: ((_name: unknown, _input: unknown, output: unknown) =>
+        Effect.succeed(output)) as Plugin.Interface["trigger"],
+    }),
+  ),
+  Layer.succeed(
+    ToolRegistry.Service,
+    ToolRegistry.Service.of({
+      ids: () => Effect.succeed([]),
+      all: () => Effect.succeed([]),
+      tools: () => Effect.succeed([]),
+      named: () => Effect.die("unused"),
+    }),
+  ),
+  Layer.succeed(
+    MCP.Service,
+    MCP.Service.of({
+      status: () => Effect.succeed({}),
+      clients: () => Effect.succeed({ docs: resourceClient as never }),
+      instructions: () => Effect.succeed([]),
+      tools: () => Effect.succeed({}),
+      prompts: () => Effect.succeed({}),
+      resources: () => Effect.succeed({}),
+      resourceTemplates: () => Effect.succeed({}),
+      add: () => Effect.succeed({ status: {} }),
+      connect: () => Effect.void,
+      disconnect: () => Effect.void,
+      getPrompt: () => Effect.succeed(undefined),
+      readResource: () => Effect.succeed({ contents: [{ uri: "file://docs/one.md", text: "hello" }] }),
+      startAuth: () => Effect.die("unused"),
+      authenticate: () => Effect.die("unused"),
+      finishAuth: () => Effect.die("unused"),
+      removeAuth: () => Effect.void,
+      supportsOAuth: () => Effect.succeed(false),
+      hasStoredTokens: () => Effect.succeed(false),
+      getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+    }),
+  ),
+  Layer.succeed(
+    Truncate.Service,
+    Truncate.Service.of({
+      cleanup: () => Effect.void,
+      write: (text) => Effect.succeed(text),
+      output: (text) => Effect.succeed({ content: text, truncated: false }),
+      limits: () => Effect.succeed({ maxLines: 1000, maxBytes: 1_000_000 }),
+    }),
+  ),
+  RuntimeFlags.layer(),
+)
+
+const it = testEffect(baseLayer)
+
+it.effect("read_mcp_resource remember scope stays bound to the requested URI", () => {
+  const asks: PermissionV1.AskInput[] = []
+  return Effect.gen(function* () {
+    const tools = yield* SessionTools.resolve({
+      agent: {
+        name: "build",
+        permission: [],
+        mode: "primary",
+        options: {},
+      } as never,
+      model: {
+        id: ModelV2.ID.make("test-model"),
+        providerID: ProviderV2.ID.make("test"),
+        api: { id: "test-model" },
+      } as never,
+      session: { id: SessionID.make("ses_test"), permission: [] } as never,
+      processor: {
+        message: { id: MessageID.make("msg_test") },
+        updateToolCall: () => Effect.succeed(undefined),
+        completeToolCall: () => Effect.void,
+      } as never,
+      bypassAgentCheck: false,
+      messages: [],
+      promptOps: {} as never,
+    })
+
+    yield* Effect.promise(() =>
+      tools.read_mcp_resource.execute?.(
+        { server: "docs", uri: "file://docs/one.md" },
+        {
+          toolCallId: "call_test",
+          abortSignal: new AbortController().signal,
+          messages: [],
+        },
+      ),
+    )
+
+    expect(asks).toHaveLength(1)
+    expect(asks[0].patterns).toEqual(["mcp:docs:file://docs/one.md"])
+    expect(asks[0].always).toEqual(["mcp:docs:file://docs/one.md"])
+  }).pipe(
+    Effect.provideService(
+      Permission.Service,
+      Permission.Service.of({
+        ask: (input) =>
+          Effect.sync(() => {
+            asks.push(input)
+          }),
+        reply: () => Effect.void,
+        list: () => Effect.succeed([]),
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35720

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`read_mcp_resource` already asks for the exact resource pattern (`mcp:<server>:<uri>`), but the remember/always option persisted `mcp:<server>:*`. This scopes the remembered permission to the same exact resource URI, so choosing always for one MCP resource does not grant every resource from that server.

It also adds a focused regression test for the permission ask payload.

Current `dev@34e58090595d44e3e7cc37498f16753a98627456` still contains the server-wide always scope, issue #35720 remains open, and no competing PR is linked to the issue.

### How did you verify your code works?

- `bun test test/session/tools.test.ts --timeout 30000` -> 1 passed
- `bun run typecheck` from `packages/opencode`
- `bun turbo typecheck` from the repository root -> 30/30 tasks passed
- `bunx prettier --check src/session/tools.ts test/session/tools.test.ts`
- `bun run lint packages/opencode/src/session/tools.ts packages/opencode/test/session/tools.test.ts` -> 0 errors
- `git diff --check origin/dev...HEAD`

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR