### PR TITLE
fix(mcp): forward piped stderr from local MCP servers to error diagnostics

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -337,6 +337,10 @@ const layer = Layer.effect(
       }
     })
 
+    // Tracks the last stderr output from each MCP server for diagnostics.
+    // Keyed by server name; cleared on successful connection.
+    const stderrBuffers = new Map<string, string>()
+
     const connectLocal = Effect.fn("MCP.connectLocal")(function* (
       key: string,
       mcp: ConfigMCPV1.Info & { type: "local" },
@@ -356,15 +360,31 @@ const layer = Layer.effect(
         },
       })
 
+      // Capture stderr from the MCP server process for diagnostics.
+      // Without this, startup errors (e.g. missing files, bad config) are
+      // silently lost and the user only sees "Connection closed".
+      const MAX_STDERR_BYTES = 4096
+      let stderrTail = ""
+      const stderrStream = transport.stderr
+      if (stderrStream) {
+        stderrStream.on("data", (chunk: Buffer) => {
+          const text = chunk.toString()
+          stderrTail = (stderrTail + text).slice(-MAX_STDERR_BYTES)
+        })
+      }
+
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       return yield* connectTransport(transport, connectTimeout).pipe(
-        Effect.map((client): { client: MCPClient | undefined; status: Status } => ({
-          client,
-          status: { status: "connected" },
-        })),
+        Effect.map((client): { client: MCPClient | undefined; status: Status } => {
+          stderrBuffers.delete(key)
+          return { client, status: { status: "connected" } }
+        }),
         Effect.catch((error): Effect.Effect<{ client: MCPClient | undefined; status: Status }> => {
           const msg = error instanceof Error ? error.message : String(error)
-          return Effect.succeed({ client: undefined, status: { status: "failed", error: msg } })
+          const stderr = stderrTail.trim()
+          if (stderr) stderrBuffers.set(key, stderr)
+          const detail = stderr ? `${msg}\nServer stderr: ${stderr}` : msg
+          return Effect.succeed({ client: undefined, status: { status: "failed", error: detail } })
         }),
       )
     })
@@ -445,9 +465,11 @@ const layer = Layer.effect(
         delete s.clients[name]
         delete s.defs[name]
         delete s.instructions[name]
-        s.status[name] = { status: "failed", error: "Connection closed" }
+        const stderr = stderrBuffers.get(name)?.trim()
+        const error = stderr ? `Connection closed\nServer stderr: ${stderr}` : "Connection closed"
+        s.status[name] = { status: "failed", error }
         bridge.fork(
-          Effect.logWarning("MCP connection closed", { server: name }).pipe(
+          Effect.logWarning("MCP connection closed", { server: name, ...(stderr ? { stderr } : {}) }).pipe(
             Effect.andThen(events.publish(ToolsChanged, { server: name })),
             Effect.ignore,
           ),


### PR DESCRIPTION
## Summary

Fixes #35719 -- When a local MCP server writes to stderr (startup errors, crash output, warnings), the output was silently discarded because `stderr: "pipe"` was set on the `StdioClientTransport` but no listener was ever attached. Users only saw "Connection closed" with no diagnostic context.

### Before

```
MCP server "complypack": failed
Error: Connection closed
```

### After

```
MCP server "complypack": failed
Error: Connection closed
Server stderr: Error: failed to create MCP server: failed to load artifacts from
file://./governance/guidance/container-security-guidance.yaml: failed to read
file: open ./governance/guidance/container-security-guidance.yaml: no such file
or directory
```

## Changes

**`packages/opencode/src/mcp/index.ts`**

- **Stderr capture:** After creating the `StdioClientTransport`, attaches a `data` listener on `transport.stderr` that buffers the last 4KB of output per server
- **Connection failure:** When `connectLocal` fails, appends the buffered stderr to the error message in the failure status
- **Connection closed:** The `onclose` handler includes buffered stderr context in the error string and as a structured log field
- **Cleanup:** The stderr buffer for a server is cleared on successful connection

## Design Notes

- **Bounded buffer:** Only the last 4KB of stderr is retained per server to avoid unbounded memory growth
- **No UI changes:** The stderr context appears in the existing error status string, which is already displayed by the TUI when an MCP server shows as "failed". No new UI components needed.
- **Backward compatible:** If stderr is empty (server died cleanly or wrote nothing), behavior is identical to before
- **Also addresses #34271:** By properly consuming the piped stderr stream, this prevents backpressure issues that could cause stderr data to leak into unexpected places

## Related

- Upstream server-side fix: complytime/complypack#114 (writes JSON-RPC error to stdout)
- Related issue: #34271 (stderr leaks into TUI input placeholder)