### PR TITLE
refactor(simulation): type RPC request payloads

### DIFF
--- a/packages/simulation/src/backend/control.ts
+++ b/packages/simulation/src/backend/control.ts
@@ -25,11 +25,11 @@ import { SimulationNetwork } from "./network"
 type ControlSocket = Bun.ServerWebSocket<{ unsubscribe?: () => void }>
 
 function parseRequest(input: string | Buffer) {
-  return SimulationProtocol.JsonRpc.decodeRequest(JSON.parse(typeof input === "string" ? input : input.toString()))
+  return SimulationProtocol.Backend.decodeRequest(JSON.parse(typeof input === "string" ? input : input.toString()))
 }
 
-async function handle(socket: ControlSocket, request: SimulationProtocol.JsonRpc.Request): Promise<unknown> {
-  switch (SimulationProtocol.Backend.decodeMethod(request.method)) {
+async function handle(socket: ControlSocket, request: SimulationProtocol.Backend.Request): Promise<unknown> {
+  switch (request.method) {
     case "llm.attach": {
       socket.data.unsubscribe?.()
       socket.data.unsubscribe = SimulationLLMExchange.subscribe((exchange) => {
@@ -38,23 +38,22 @@ async function handle(socket: ControlSocket, request: SimulationProtocol.JsonRpc
       return { attached: true }
     }
     case "llm.chunk": {
-      const params = await SimulationProtocol.Backend.decodeChunkParams(request.params)
       await Effect.runPromise(
         SimulationLLMExchange.push(
-          params.id,
-          params.items.map((item) => ({ type: "item", item }) as const),
+          request.params.id,
+          request.params.items.map((item) => ({ type: "item", item }) as const),
         ),
       )
       return { ok: true }
     }
     case "llm.finish": {
-      const params = await SimulationProtocol.Backend.decodeFinishParams(request.params)
-      await Effect.runPromise(SimulationLLMExchange.push(params.id, [{ type: "finish", reason: params.reason }]))
+      await Effect.runPromise(
+        SimulationLLMExchange.push(request.params.id, [{ type: "finish", reason: request.params.reason }]),
+      )
       return { ok: true }
     }
     case "llm.disconnect": {
-      const params = await SimulationProtocol.Backend.decodeDisconnectParams(request.params)
-      await Effect.runPromise(SimulationLLMExchange.disconnect(params.id))
+      await Effect.runPromise(SimulationLLMExchange.disconnect(request.params.id))
       return { ok: true }
     }
     case "llm.pending":
@@ -78,7 +77,7 @@ export function start(endpoint: string) {
         socket.data.unsubscribe?.()
       },
       async message(socket, message) {
-        let request: SimulationProtocol.JsonRpc.Request | undefined
+        let request: SimulationProtocol.Backend.Request | undefined
         try {
           request = parseRequest(message)
           const result = await handle(socket, request)

--- a/packages/simulation/src/backend/control.ts
+++ b/packages/simulation/src/backend/control.ts
@@ -29,7 +29,7 @@ function parseRequest(input: string | Buffer) {
 }
 
 async function handle(socket: ControlSocket, request: SimulationProtocol.JsonRpc.Request): Promise<unknown> {
-  switch (request.method) {
+  switch (SimulationProtocol.Backend.decodeMethod(request.method)) {
     case "llm.attach": {
       socket.data.unsubscribe?.()
       socket.data.unsubscribe = SimulationLLMExchange.subscribe((exchange) => {
@@ -62,7 +62,6 @@ async function handle(socket: ControlSocket, request: SimulationProtocol.JsonRpc
     case "network.log":
       return { entries: SimulationNetwork.log() }
   }
-  throw new Error(`Unknown simulation control method: ${request.method}`)
 }
 
 export function start(endpoint: string) {

--- a/packages/simulation/src/frontend/actions.ts
+++ b/packages/simulation/src/frontend/actions.ts
@@ -47,7 +47,7 @@ function hit(renderer: CliRenderer, renderable: Renderable) {
 /**
  * Builds the harness the simulation server drives.
  *
- * When the renderer is the fake simulation renderer, its TestRendererSetup
+ * When the renderer is the headless simulation renderer, its TestRendererSetup
  * provides the supported testing APIs. For the visible terminal renderer the
  * harness falls back to `requestRender` + `idle` and reading the private
  * `currentRenderBuffer`.

--- a/packages/simulation/src/frontend/renderer.ts
+++ b/packages/simulation/src/frontend/renderer.ts
@@ -4,7 +4,7 @@ import { createTestRenderer, type TestRendererSetup } from "@opentui/core/testin
 const setups = new WeakMap<CliRenderer, TestRendererSetup>()
 
 /**
- * Creates the fake simulation renderer: a real CliRenderer backed by an
+ * Creates the headless simulation renderer: a real CliRenderer backed by an
  * in-memory screen buffer instead of a terminal. The TestRendererSetup is
  * kept module-side (keyed by renderer) so the harness can use the supported
  * testing APIs without app code carrying it around.

--- a/packages/simulation/src/frontend/server.ts
+++ b/packages/simulation/src/frontend/server.ts
@@ -7,16 +7,12 @@ export interface Server {
   readonly stop: () => void
 }
 
-function actionParam(params: unknown) {
-  return SimulationProtocol.Frontend.decodeActionParams(params).action
-}
-
 function parseRequest(input: string | Buffer) {
-  return SimulationProtocol.JsonRpc.decodeRequest(JSON.parse(typeof input === "string" ? input : input.toString()))
+  return SimulationProtocol.Frontend.decodeRequest(JSON.parse(typeof input === "string" ? input : input.toString()))
 }
 
-async function handle(harness: Harness, request: SimulationProtocol.JsonRpc.Request, headless: boolean) {
-  switch (SimulationProtocol.Frontend.decodeMethod(request.method)) {
+async function handle(harness: Harness, request: SimulationProtocol.Frontend.Request, headless: boolean) {
+  switch (request.method) {
     case "ui.state": {
       if (headless) await harness.renderOnce()
       const result = SimulationActions.state(harness)
@@ -24,7 +20,7 @@ async function handle(harness: Harness, request: SimulationProtocol.JsonRpc.Requ
       return result
     }
     case "ui.action":
-      return SimulationActions.execute(harness, actionParam(request.params))
+      return SimulationActions.execute(harness, request.params.action)
     case "trace.list":
       return { records: SimulationTrace.list() }
     case "trace.clear":
@@ -52,7 +48,7 @@ export function start(harness: Harness, endpoint: string, headless: boolean): Se
         SimulationTrace.add("control.disconnect")
       },
       async message(socket, message) {
-        let request: SimulationProtocol.JsonRpc.Request | undefined
+        let request: SimulationProtocol.Frontend.Request | undefined
         try {
           request = parseRequest(message)
           const result = await handle(harness, request, headless)

--- a/packages/simulation/src/frontend/server.ts
+++ b/packages/simulation/src/frontend/server.ts
@@ -16,7 +16,7 @@ function parseRequest(input: string | Buffer) {
 }
 
 async function handle(harness: Harness, request: SimulationProtocol.JsonRpc.Request, headless: boolean) {
-  switch (request.method) {
+  switch (SimulationProtocol.Frontend.decodeMethod(request.method)) {
     case "ui.state": {
       if (headless) await harness.renderOnce()
       const result = SimulationActions.state(harness)
@@ -33,7 +33,6 @@ async function handle(harness: Harness, request: SimulationProtocol.JsonRpc.Requ
     case "trace.export":
       return SimulationTrace.exportTrace()
   }
-  throw new Error(`Unknown simulation method: ${request.method}`)
 }
 
 export function start(harness: Harness, endpoint: string, headless: boolean): Server {

--- a/packages/simulation/src/frontend/server.ts
+++ b/packages/simulation/src/frontend/server.ts
@@ -15,21 +15,16 @@ function parseRequest(input: string | Buffer) {
   return SimulationProtocol.JsonRpc.decodeRequest(JSON.parse(typeof input === "string" ? input : input.toString()))
 }
 
-async function handle(harness: Harness, request: SimulationProtocol.JsonRpc.Request) {
+async function handle(harness: Harness, request: SimulationProtocol.JsonRpc.Request, headless: boolean) {
   switch (request.method) {
     case "ui.state": {
+      if (headless) await harness.renderOnce()
       const result = SimulationActions.state(harness)
       SimulationTrace.add("ui.state", { elements: result.elements.length, actions: result.actions.length })
       return result
     }
     case "ui.action":
       return SimulationActions.execute(harness, actionParam(request.params))
-    case "ui.render": {
-      await harness.renderOnce()
-      const result = SimulationActions.state(harness)
-      SimulationTrace.add("ui.render", { elements: result.elements.length, actions: result.actions.length })
-      return result
-    }
     case "trace.list":
       return { records: SimulationTrace.list() }
     case "trace.clear":
@@ -41,7 +36,7 @@ async function handle(harness: Harness, request: SimulationProtocol.JsonRpc.Requ
   throw new Error(`Unknown simulation method: ${request.method}`)
 }
 
-export function start(harness: Harness, endpoint: string): Server {
+export function start(harness: Harness, endpoint: string, headless: boolean): Server {
   const url = new URL(endpoint)
   const server = Bun.serve<{ readonly drive: true }>({
     hostname: url.hostname,
@@ -61,7 +56,7 @@ export function start(harness: Harness, endpoint: string): Server {
         let request: SimulationProtocol.JsonRpc.Request | undefined
         try {
           request = parseRequest(message)
-          const result = await handle(harness, request)
+          const result = await handle(harness, request, headless)
           const next = SimulationProtocol.JsonRpc.success(request.id, result)
           if (next) socket.send(JSON.stringify(next))
         } catch (error) {

--- a/packages/simulation/src/frontend/simulation.ts
+++ b/packages/simulation/src/frontend/simulation.ts
@@ -7,19 +7,18 @@ import { SimulationServer } from "./server"
 /**
  * Drive-mode renderer entry point.
  *
- * Creates the renderer (fake when OPENCODE_DRIVE_RENDERER=fake, the normal
+ * Creates the renderer (headless when OPENCODE_DRIVE_RENDERER=headless, the normal
  * visible renderer otherwise) and starts the UI control
  * server against it. The server stops when the renderer is destroyed, so the
  * caller only manages the renderer lifecycle.
  */
 export async function create(options: CliRendererConfig): Promise<CliRenderer> {
-  const renderer =
-    process.env.OPENCODE_DRIVE_RENDERER === "fake"
-      ? await SimulationRenderer.create(options)
-      : await createCliRenderer(options)
+  const headless = process.env.OPENCODE_DRIVE_RENDERER === "headless"
+  const renderer = headless ? await SimulationRenderer.create(options) : await createCliRenderer(options)
   const server = SimulationServer.start(
     SimulationActions.createHarness(renderer),
     DriveManifest.resolve().endpoints.ui,
+    headless,
   )
   process.stderr.write(`opencode drive ui websocket: ${server.url}\n`)
   renderer.once("destroy", () => server.stop())

--- a/packages/simulation/src/protocol/index.ts
+++ b/packages/simulation/src/protocol/index.ts
@@ -4,9 +4,12 @@ const JsonRpcID = Schema.Union([Schema.String, Schema.Number, Schema.Null])
 type Json = Schema.Schema.Type<typeof Schema.Json>
 
 export namespace JsonRpc {
-  export const Request = Schema.Struct({
+  export const RequestFields = {
     jsonrpc: Schema.Literal("2.0"),
     id: Schema.optional(JsonRpcID),
+  }
+  export const Request = Schema.Struct({
+    ...RequestFields,
     method: Schema.String,
     params: Schema.optional(Schema.Json),
   })
@@ -46,10 +49,6 @@ export namespace JsonRpc {
 }
 
 export namespace Frontend {
-  export const Method = Schema.Literals(["ui.state", "ui.action", "trace.list", "trace.clear", "trace.export"])
-  export type Method = Schema.Schema.Type<typeof Method>
-  export const decodeMethod = Schema.decodeUnknownSync(Method)
-
   export const KeyModifiers = Schema.Struct({
     ctrl: Schema.optional(Schema.Boolean),
     shift: Schema.optional(Schema.Boolean),
@@ -96,7 +95,16 @@ export namespace Frontend {
 
   export const ActionParams = Schema.Struct({ action: Action })
   export interface ActionParams extends Schema.Schema.Type<typeof ActionParams> {}
-  export const decodeActionParams = Schema.decodeUnknownSync(ActionParams)
+
+  export const Request = Schema.Union([
+    Schema.Struct({ ...JsonRpc.RequestFields, method: Schema.Literal("ui.action"), params: ActionParams }),
+    Schema.Struct({
+      ...JsonRpc.RequestFields,
+      method: Schema.Literals(["ui.state", "trace.list", "trace.clear", "trace.export"]),
+    }),
+  ])
+  export type Request = Schema.Schema.Type<typeof Request>
+  export const decodeRequest = Schema.decodeUnknownSync(Request)
 
   export const TraceRecord = Schema.Struct({
     id: Schema.Number,
@@ -111,17 +119,6 @@ export namespace Frontend {
 }
 
 export namespace Backend {
-  export const Method = Schema.Literals([
-    "llm.attach",
-    "llm.chunk",
-    "llm.finish",
-    "llm.disconnect",
-    "llm.pending",
-    "network.log",
-  ])
-  export type Method = Schema.Schema.Type<typeof Method>
-  export const decodeMethod = Schema.decodeUnknownSync(Method)
-
   export const Item = Schema.Union([
     Schema.Struct({ type: Schema.Literal("textDelta"), text: Schema.String }),
     Schema.Struct({ type: Schema.Literal("reasoningDelta"), text: Schema.String }),
@@ -145,6 +142,18 @@ export namespace Backend {
   export const DisconnectParams = Schema.Struct({ id: Schema.String })
   export interface DisconnectParams extends Schema.Schema.Type<typeof DisconnectParams> {}
 
+  export const Request = Schema.Union([
+    Schema.Struct({ ...JsonRpc.RequestFields, method: Schema.Literal("llm.chunk"), params: ChunkParams }),
+    Schema.Struct({ ...JsonRpc.RequestFields, method: Schema.Literal("llm.finish"), params: FinishParams }),
+    Schema.Struct({ ...JsonRpc.RequestFields, method: Schema.Literal("llm.disconnect"), params: DisconnectParams }),
+    Schema.Struct({
+      ...JsonRpc.RequestFields,
+      method: Schema.Literals(["llm.attach", "llm.pending", "network.log"]),
+    }),
+  ])
+  export type Request = Schema.Schema.Type<typeof Request>
+  export const decodeRequest = Schema.decodeUnknownSync(Request)
+
   export const OpenedExchange = Schema.Struct({ id: Schema.String, url: Schema.String, body: Schema.Json })
   export interface OpenedExchange extends Schema.Schema.Type<typeof OpenedExchange> {}
 
@@ -156,9 +165,6 @@ export namespace Backend {
   })
   export interface NetworkLogEntry extends Schema.Schema.Type<typeof NetworkLogEntry> {}
 
-  export const decodeChunkParams = Schema.decodeUnknownPromise(ChunkParams)
-  export const decodeFinishParams = Schema.decodeUnknownPromise(FinishParams)
-  export const decodeDisconnectParams = Schema.decodeUnknownPromise(DisconnectParams)
 }
 
 export * as SimulationProtocol from "./index"

--- a/packages/simulation/src/protocol/index.ts
+++ b/packages/simulation/src/protocol/index.ts
@@ -46,6 +46,10 @@ export namespace JsonRpc {
 }
 
 export namespace Frontend {
+  export const Method = Schema.Literals(["ui.state", "ui.action", "trace.list", "trace.clear", "trace.export"])
+  export type Method = Schema.Schema.Type<typeof Method>
+  export const decodeMethod = Schema.decodeUnknownSync(Method)
+
   export const KeyModifiers = Schema.Struct({
     ctrl: Schema.optional(Schema.Boolean),
     shift: Schema.optional(Schema.Boolean),

--- a/packages/simulation/src/protocol/index.ts
+++ b/packages/simulation/src/protocol/index.ts
@@ -111,6 +111,17 @@ export namespace Frontend {
 }
 
 export namespace Backend {
+  export const Method = Schema.Literals([
+    "llm.attach",
+    "llm.chunk",
+    "llm.finish",
+    "llm.disconnect",
+    "llm.pending",
+    "network.log",
+  ])
+  export type Method = Schema.Schema.Type<typeof Method>
+  export const decodeMethod = Schema.decodeUnknownSync(Method)
+
   export const Item = Schema.Union([
     Schema.Struct({ type: Schema.Literal("textDelta"), text: Schema.String }),
     Schema.Struct({ type: Schema.Literal("reasoningDelta"), text: Schema.String }),


### PR DESCRIPTION
## Summary
- rename the fake drive renderer mode to headless and track it explicitly in the frontend WebSocket server
- consolidate `ui.render` into `ui.state`, rendering once before state capture in headless mode
- model frontend and backend JSON-RPC requests as Effect Schema discriminated unions
- validate method-specific payloads at request decode time and narrow params in handlers

## Testing
- `bun typecheck` in `packages/simulation`