### PR TITLE
fix(core): lower failed reasoning to text

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -120,12 +120,12 @@ const assistant = (message: SessionMessage.Assistant, model: ModelV2.Ref) => {
   const content = message.content.flatMap((item): ContentPart[] => {
     if (item.type === "text") return [{ type: "text", text: item.text }]
     if (item.type === "reasoning")
-      return sameModel
+      return reuseProviderMetadata
         ? [
             {
               type: "reasoning",
               text: item.text,
-              providerMetadata: reuseProviderMetadata ? providerMetadata(model.providerID, item.state) : undefined,
+              providerMetadata: providerMetadata(model.providerID, item.state),
             },
           ]
         : item.text.length > 0

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -461,7 +461,7 @@ Recent work
     ])
   })
 
-  test("drops provider-native continuation metadata from failed assistant turns", () => {
+  test("lowers failed assistant reasoning to text", () => {
     const messages = toLLMMessages(
       [
         SessionMessage.Assistant.make({
@@ -501,7 +501,7 @@ Recent work
     )
 
     expect(messages[0]?.content).toEqual([
-      { type: "reasoning", text: "Partial thought", providerMetadata: undefined },
+      { type: "text", text: "Partial thought" },
       {
         type: "tool-call",
         id: "hosted-failed",


### PR DESCRIPTION
## Summary

- lower reasoning from failed or interrupted assistant steps to ordinary text
- preserve provider-native reasoning only when its continuation metadata is reusable
- update the existing history-lowering regression test

## Why

If a reasoning step is interrupted after emitting partial reasoning, the durable assistant message has an error. V2 correctly drops its provider continuation metadata, but previously still replayed the content as native reasoning. Providers that require signed or encrypted reasoning state can reject the next independent prompt as an invalid request.

This is not specific to Big Pickle. It affects any provider whose native reasoning history requires provider metadata.

## Verification

- `bun run test test/session-runner-message.test.ts` from `packages/core`
- `bun typecheck` from `packages/core`
- repository pre-push typecheck gate