### PR TITLE
fix(core): normalize Location.Ref keys in LocationServiceMap

### DIFF
--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -150,31 +150,44 @@ export type LocationError = LayerNode.Error<typeof locationServices>
 export function buildLocationServiceMap(
   replacements: LayerNode.Replacements = [],
 ): Layer.Layer<LocationServiceMap.Service> {
+  // Structural Equal is own-key-set sensitive, so `{ directory }` (schema-decoded
+  // payloads omit optional keys) and `{ directory, workspaceID: undefined }` are
+  // different RcMap keys. The RcMap caches by the raw key before the build
+  // callback runs, so canonicalize at the map boundary to the key-present shape.
+  const canonical = (ref: Location.Ref) => Location.Ref.make({ directory: ref.directory, workspaceID: ref.workspaceID })
   return Layer.effect(
     LocationServiceMap.Service,
-    LayerMap.make(
-      (ref: Location.Ref) => {
-        const startedAt = performance.now()
-        const allReplacements = replacements.concat([[Location.node, Location.boundNode(ref)]])
-        // Apply replacements during hoist, not afterward: replacements can
-        // introduce new tagged dependencies (Location.boundNode depends on
-        // Project), and the hoist walk is the only pass that can still slice
-        // those back out.
-        const location = LayerNode.hoist(locationServices, Node.tags.values.global, allReplacements)
+    Effect.map(
+      LayerMap.make(
+        (ref: Location.Ref) => {
+          const startedAt = performance.now()
+          const allReplacements = replacements.concat([[Location.node, Location.boundNode(ref)]])
+          // Apply replacements during hoist, not afterward: replacements can
+          // introduce new tagged dependencies (Location.boundNode depends on
+          // Project), and the hoist walk is the only pass that can still slice
+          // those back out.
+          const location = LayerNode.hoist(locationServices, Node.tags.values.global, allReplacements)
 
-        return LayerNode.compile(location.node).pipe(
-          Layer.fresh,
-          Layer.tap(() =>
-            Effect.logInfo("location services booted", {
-              directory: ref.directory,
-              workspaceID: ref.workspaceID,
-              durationMs: Math.round(performance.now() - startedAt),
-            }),
-          ),
-          Layer.provide(LayerNode.compile(location.hoisted)),
-        )
-      },
-      { idleTimeToLive: "60 minutes" },
+          return LayerNode.compile(location.node).pipe(
+            Layer.fresh,
+            Layer.tap(() =>
+              Effect.logInfo("location services booted", {
+                directory: ref.directory,
+                workspaceID: ref.workspaceID,
+                durationMs: Math.round(performance.now() - startedAt),
+              }),
+            ),
+            Layer.provide(LayerNode.compile(location.hoisted)),
+          )
+        },
+        { idleTimeToLive: "60 minutes" },
+      ),
+      (inner) => ({
+        ...inner,
+        get: (ref: Location.Ref) => inner.get(canonical(ref)),
+        contextEffect: (ref: Location.Ref) => inner.contextEffect(canonical(ref)),
+        invalidate: (ref: Location.Ref) => inner.invalidate(canonical(ref)),
+      }),
     ),
   )
 }

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -3,7 +3,7 @@ import path from "path"
 import { describe, expect } from "bun:test"
 import { Config } from "@opencode-ai/schema/config"
 import { Plugin } from "@opencode-ai/schema/plugin"
-import { Context, DateTime, Effect, Equal, Hash, Schema, Stream } from "effect"
+import { Context, DateTime, Effect, Equal, Hash, RcMap, Schema, Stream } from "effect"
 import { define } from "@opencode-ai/plugin/v2/effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
 import { Catalog } from "@opencode-ai/core/catalog"
@@ -202,6 +202,36 @@ describe("LocationServiceMap", () => {
             expect(Equal.equals(constructed, decoded)).toBe(true)
             expect(Hash.hash(constructed)).toBe(Hash.hash(decoded))
             expect(yield* locations.contextEffect(constructed)).toBe(yield* locations.contextEffect(decoded))
+          }),
+        ),
+      ),
+    ),
+  )
+
+  it.live("normalizes ref key shapes to one cached location graph", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const locations = yield* LocationServiceMap.Service
+            const directory = AbsolutePath.make(dir.path)
+            const absent = Location.Ref.make({ directory })
+            const present = Location.Ref.make({ directory, workspaceID: undefined })
+            // The two shapes are not structurally Equal: own-key sets differ.
+            expect(Object.keys(absent)).toEqual(["directory"])
+            expect(Object.keys(present)).toEqual(["directory", "workspaceID"])
+            expect(Equal.equals(absent, present)).toBe(false)
+
+            const first = yield* locations.contextEffect(absent)
+            expect(yield* locations.contextEffect(present)).toBe(first)
+            expect(Array.from(yield* RcMap.keys(locations.rcMap))).toHaveLength(1)
+
+            // Invalidating with the shape opposite to the one that booted must evict.
+            yield* locations.invalidate(present)
+            expect(Array.from(yield* RcMap.keys(locations.rcMap))).toHaveLength(0)
           }),
         ),
       ),


### PR DESCRIPTION
### Issue for this PR

Closes #35754

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`LocationServiceMap` caches Location service graphs in a `LayerMap` keyed by `Location.Ref`. Effect v4's structural `Equal` compares own-key sets, so `{ directory, workspaceID: undefined }` (key present, what `requestRef` / `fromRow` / middleware produce) and `{ directory }` (key absent, what schema-decoded payloads produce) are different `RcMap` keys. Two shapes for the same directory would boot two independent Location graphs (duplicate watchers, duplicate `PluginSupervisor`, duplicate MCP connections), and `invalidate` with the opposite shape was a silent no-op.

The fix normalizes the key at the `LayerMap` boundary in `buildLocationServiceMap`. Normalizing inside the `LayerMap.make` build callback does not work because the internal `RcMap` caches by the raw key before that callback runs. Instead the inner map is wrapped so `get`, `contextEffect`, and `invalidate` canonicalize the ref first to the key-present shape (`Location.Ref.make({ directory: ref.directory, workspaceID: ref.workspaceID })`), which matches every existing producer, so cache behavior is unchanged for current callers. The rest of the `LayerMap` interface (including `rcMap`, which the debug handlers read) is preserved by spreading the inner map.

### How did you verify your code works?

- Added a regression test in `packages/core/test/location-layer.test.ts` that gets the same directory through both ref shapes and asserts they share one cached graph (`contextEffect` returns the identical context and `RcMap.keys(locations.rcMap)` has length 1), then invalidates with the shape opposite to the one that booted and asserts the entry is evicted (`RcMap.keys` length 0).
- Verified the test fails without the fix: with the `location-services.ts` change stashed, the test fails at `expect(yield* locations.contextEffect(present)).toBe(first)` — the second shape boots a distinct context. With the fix restored it passes.
- `cd packages/core && bun test test/location-layer.test.ts` (10 pass, 0 fail). Note: `bun run test` (`bun test --only-failures`) SIGTRAPs on this file even on clean `origin/v2`, a pre-existing bun crash unrelated to this change.
- `cd packages/core && bun typecheck` and `cd packages/server && bun typecheck` both pass.
- `bunx prettier --write` and `bunx oxlint` on the changed files (two pre-existing warnings only, untouched by this change).
