### PR TITLE
fix(core): retain reasoning delta state

### DIFF
--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -101,27 +101,36 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     ended: (id: string, value: string, ordinal: number, state?: Record<string, unknown>) => Effect.Effect<void>,
     single = false,
   ) => {
-    const chunks = new Map<string, { readonly ordinal: number; readonly values: string[] }>()
+    const chunks = new Map<
+      string,
+      { readonly ordinal: number; readonly values: string[]; state?: Record<string, unknown> }
+    >()
     let nextOrdinal = 0
-    const start = (id: string) =>
+    const start = (id: string, state?: Record<string, unknown>) =>
       Effect.suspend(() => {
         if (chunks.has(id)) return Effect.die(new Error(`Duplicate ${name} start: ${id}`))
         if (single && chunks.size > 0) return Effect.die(new Error(`${name} start before end: ${id}`))
         const ordinal = nextOrdinal++
-        chunks.set(id, { ordinal, values: [] })
+        chunks.set(id, { ordinal, values: [], state })
         return Effect.succeed(ordinal)
       })
-    const append = (id: string, value: string) =>
+    const append = (id: string, value: string, state?: Record<string, unknown>) =>
       Effect.suspend(() => {
         const current = chunks.get(id)
         if (!current) return Effect.die(new Error(`${name} delta before start: ${id}`))
         current.values.push(value)
+        if (state !== undefined) current.state = { ...current.state, ...state }
         return Effect.succeed(current.ordinal)
       })
     const end = Effect.fnUntraced(function* (id: string, state?: Record<string, unknown>) {
       const current = chunks.get(id)
       if (!current) return yield* Effect.die(new Error(`${name} end before start: ${id}`))
-      yield* ended(id, current.values.join(""), current.ordinal, state)
+      yield* ended(
+        id,
+        current.values.join(""),
+        current.ordinal,
+        state === undefined ? current.state : { ...current.state, ...state },
+      )
       chunks.delete(id)
     })
     const flush = Effect.fnUntraced(function* () {
@@ -284,7 +293,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         return
       case "reasoning-start":
         retryEvidence = true
-        const startedReasoningOrdinal = yield* reasoning.start(event.id)
+        const startedReasoningOrdinal = yield* reasoning.start(event.id, providerState(event.providerMetadata))
         yield* events.publish(SessionEvent.Reasoning.Started, {
           sessionID: input.sessionID,
           assistantMessageID: yield* startAssistant(),
@@ -293,7 +302,11 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         })
         return
       case "reasoning-delta":
-        const deltaReasoningOrdinal = yield* reasoning.append(event.id, event.text)
+        const deltaReasoningOrdinal = yield* reasoning.append(
+          event.id,
+          event.text,
+          providerState(event.providerMetadata),
+        )
         yield* events.publish(SessionEvent.Reasoning.Delta, {
           sessionID: input.sessionID,
           assistantMessageID: yield* currentAssistantMessageID(),

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -110,6 +110,25 @@ test("provider state uses the route provider instead of the catalog provider", a
   })
 })
 
+test("reasoning state from an empty delta is retained at reasoning end", async () => {
+  const { published, publisher } = capture()
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningStart({ id: "reasoning" })))
+  await Effect.runPromise(
+    publisher.publish(
+      LLMEvent.reasoningDelta({
+        id: "reasoning",
+        text: "",
+        providerMetadata: { openai: { signature: "signed" } },
+      }),
+    ),
+  )
+  await Effect.runPromise(publisher.publish(LLMEvent.reasoningEnd({ id: "reasoning" })))
+
+  expect(published.find((event) => event.type === "session.reasoning.ended.1")?.data).toMatchObject({
+    state: { signature: "signed" },
+  })
+})
+
 test("binary failure emits no success event", async () => {
   const { published, publisher } = capture()
   await Effect.runPromise(publisher.publish(call))


### PR DESCRIPTION
## Summary

- retain route provider state received on reasoning delta events
- merge reasoning state across start, delta, and end before durable publication
- cover the empty Anthropic signature delta sequence with a regression test

## Why

Anthropic streams the thinking signature as provider metadata on an empty reasoning delta. The V2 publisher previously retained state only from reasoning start and end, so the signature was dropped. The next tool continuation replayed an unsigned thinking block and the provider rejected the request with HTTP 400.

## Reproduction

The regression emits `reasoning-start`, an empty `reasoning-delta` carrying a signature, then `reasoning-end`. Before the fix, the durable reasoning end had `state: undefined`; after the fix it retains the signature.

## Verification

- `cd packages/core && bun run test test/session-runner-tool-events.test.ts test/session-runner-message.test.ts`
- `cd packages/core && bun typecheck`