### PR TITLE
feat(opencode): add planner/worker/reviewer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,18 +99,47 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 
 ### Agents
 
-OpenCode includes two built-in agents you can switch between with the `Tab` key.
+OpenCode includes three built-in agents you can switch between with the `Tab` key.
 
 - **build** - Default, full-access agent for development work
 - **plan** - Read-only agent for analysis and code exploration
   - Denies file edits by default
   - Asks permission before running bash commands
   - Ideal for exploring unfamiliar codebases or planning changes
+- **review** - Read-only agent that reviews an implementation for correctness, completeness, and quality
+  - Denies file edits, inspects diffs and runs read-only verification
+  - Reports findings by severity instead of making changes
 
 Also included is a **general** subagent for complex searches and multistep tasks.
 This is used internally and can be invoked using `@general` in messages.
 
 Learn more about [agents](https://opencode.ai/docs/agents).
+
+### Multi-model workflows
+
+You can chain agents into a planner → worker → reviewer workflow, with each role running on its own model. Add a `workflow` key to your `opencode.json` and give each agent its own model:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "workflow": {}, // enables defaults: planner=plan, worker=build, reviewer=review
+  "agent": {
+    "plan": { "model": "anthropic/claude-opus-4-8" }, // strong model for planning
+    "build": { "model": "opencode/glm-4.7" }, // fast model for implementation
+    "review": { "model": "openai/gpt-5.2-codex" } // independent model for review
+  }
+}
+```
+
+How to use it:
+
+1. Press `Tab` to select **plan** and describe the task. The planner explores and designs without touching your code.
+2. Switch to **build** when the plan is ready (with `OPENCODE_EXPERIMENTAL_PLAN_MODE=true` the planner offers the switch itself). The worker implements the plan on its own model.
+3. When the implementation is done, the worker calls the `review_exit` tool to hand the session to the **reviewer**, which checks the changes against the plan and reports findings by severity.
+
+Every handoff asks for your confirmation first, and the model switches automatically at each stage. Roles can also point at your own custom agents via `"workflow": { "planner": "...", "worker": "...", "reviewer": "..." }`. Without a `workflow` key, sessions behave exactly as before.
+
+Learn more in the [workflows docs](https://opencode.ai/docs/agents#workflows).
 
 ### Documentation
 

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -16,6 +16,7 @@ import { ConfigPluginV1 } from "./plugin"
 import { ConfigProviderV1 } from "./provider"
 import { ConfigServerV1 } from "./server"
 import { ConfigSkillsV1 } from "./skills"
+import { ConfigWorkflowV1 } from "./workflow"
 
 export type Layout = ConfigLayoutV1.Layout
 
@@ -81,6 +82,10 @@ export const Info = Schema.Struct({
     description:
       "Default agent to use when none is specified. Must be a primary agent. Falls back to 'build' if not set or if the specified agent is invalid.",
   }),
+  workflow: Schema.optional(ConfigWorkflowV1.Info).annotate({
+    description:
+      "Map workflow roles (planner, worker, reviewer) to agents so each stage can run on a different model via per-agent 'model' overrides, see https://opencode.ai/docs/agents",
+  }),
   username: Schema.optional(Schema.String).annotate({
     description: "Custom username to display in conversations instead of system username",
   }),
@@ -97,6 +102,7 @@ export const Info = Schema.Struct({
         build: Schema.optional(ConfigAgentV1.Info),
         general: Schema.optional(ConfigAgentV1.Info),
         explore: Schema.optional(ConfigAgentV1.Info),
+        review: Schema.optional(ConfigAgentV1.Info),
         title: Schema.optional(ConfigAgentV1.Info),
         summary: Schema.optional(ConfigAgentV1.Info),
         compaction: Schema.optional(ConfigAgentV1.Info),

--- a/packages/core/src/v1/config/workflow.ts
+++ b/packages/core/src/v1/config/workflow.ts
@@ -1,0 +1,26 @@
+export * as ConfigWorkflowV1 from "./workflow"
+
+import { Schema } from "effect"
+
+export const Info = Schema.Struct({
+  planner: Schema.optional(Schema.String).annotate({
+    description: "Agent that plans work before implementation. Defaults to 'plan'.",
+  }),
+  worker: Schema.optional(Schema.String).annotate({
+    description: "Agent that implements approved plans. Defaults to 'build'.",
+  }),
+  reviewer: Schema.optional(Schema.String).annotate({
+    description:
+      "Agent that reviews the worker's implementation. Defaults to 'review'. The worker hands the session off for review via the review_exit tool.",
+  }),
+}).annotate({ identifier: "WorkflowConfig" })
+export type Info = Schema.Schema.Type<typeof Info>
+
+// The reviewer stage is opt-in: it only activates when a `workflow` config is present.
+export function roles(workflow: Info | undefined) {
+  return {
+    planner: workflow?.planner ?? "plan",
+    worker: workflow?.worker ?? "build",
+    reviewer: workflow ? (workflow.reviewer ?? "review") : undefined,
+  }
+}

--- a/packages/core/test/config/workflow.test.ts
+++ b/packages/core/test/config/workflow.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test"
+import { ConfigWorkflowV1 } from "../../src/v1/config/workflow"
+
+describe("ConfigWorkflowV1.roles", () => {
+  test("no workflow config disables the reviewer stage", () => {
+    expect(ConfigWorkflowV1.roles(undefined)).toEqual({
+      planner: "plan",
+      worker: "build",
+      reviewer: undefined,
+    })
+  })
+
+  test("empty workflow config enables defaults for every role", () => {
+    expect(ConfigWorkflowV1.roles({})).toEqual({
+      planner: "plan",
+      worker: "build",
+      reviewer: "review",
+    })
+  })
+
+  test("configured roles override defaults", () => {
+    expect(ConfigWorkflowV1.roles({ planner: "architect", worker: "impl", reviewer: "checker" })).toEqual({
+      planner: "architect",
+      worker: "impl",
+      reviewer: "checker",
+    })
+  })
+
+  test("partial config keeps defaults for unset roles", () => {
+    expect(ConfigWorkflowV1.roles({ reviewer: "checker" })).toEqual({
+      planner: "plan",
+      worker: "build",
+      reviewer: "checker",
+    })
+  })
+})

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -12,6 +12,7 @@ import { ProviderTransform } from "@/provider/transform"
 import PROMPT_GENERATE from "./generate.txt"
 import PROMPT_COMPACTION from "./prompt/compaction.txt"
 import PROMPT_EXPLORE from "./prompt/explore.txt"
+import PROMPT_REVIEW from "./prompt/review.txt"
 import PROMPT_SUMMARY from "./prompt/summary.txt"
 import PROMPT_TITLE from "./prompt/title.txt"
 import { Permission } from "@/permission"
@@ -31,6 +32,7 @@ import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/l
 import { Reference } from "@opencode-ai/core/reference"
 import { Location } from "@opencode-ai/core/location"
 import { PluginV2 } from "@opencode-ai/core/plugin"
+import { ConfigWorkflowV1 } from "@opencode-ai/core/v1/config/workflow"
 
 export const Info = Schema.Struct({
   name: Schema.String,
@@ -126,6 +128,7 @@ const layer = Layer.effect(
           question: "deny",
           plan_enter: "deny",
           plan_exit: "deny",
+          review_exit: "deny",
           // mirrors github.com/github/gitignore Node.gitignore pattern for .env files
           read: {
             "*": "allow",
@@ -216,6 +219,28 @@ const layer = Layer.effect(
             mode: "subagent",
             native: true,
           },
+          review: {
+            name: "review",
+            description:
+              "Reviews an implementation for correctness, completeness, and quality without modifying code. Give it the requirements or plan to verify against.",
+            options: {},
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                question: "allow",
+                task: {
+                  general: "deny",
+                },
+                edit: {
+                  "*": "deny",
+                },
+              }),
+              user,
+            ),
+            prompt: PROMPT_REVIEW,
+            mode: "all",
+            native: true,
+          },
           compaction: {
             name: "compaction",
             mode: "primary",
@@ -291,6 +316,16 @@ const layer = Layer.effect(
           item.steps = value.steps ?? item.steps
           item.options = mergeDeep(item.options, value.options ?? {})
           item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
+        }
+
+        // The review handoff is opt-in: only the configured worker agent may call
+        // review_exit, and only when a workflow with a valid reviewer is configured.
+        const workflow = ConfigWorkflowV1.roles(cfg.workflow)
+        if (workflow.reviewer && agents[workflow.reviewer] && agents[workflow.worker]) {
+          agents[workflow.worker].permission = Permission.merge(
+            agents[workflow.worker].permission,
+            Permission.fromConfig({ review_exit: "allow" }),
+          )
         }
 
         // Ensure Truncate.GLOB is allowed unless explicitly configured

--- a/packages/opencode/src/agent/prompt/review.txt
+++ b/packages/opencode/src/agent/prompt/review.txt
@@ -1,0 +1,17 @@
+You are a code review specialist. You review implementations for correctness, completeness, and quality without modifying any code.
+
+Your strengths:
+- Inspecting diffs and recent changes with git commands
+- Reading and analyzing file contents in depth
+- Verifying an implementation against its stated requirements or plan
+
+Guidelines:
+- Start by inspecting what changed: use `git diff`, `git status`, and `git log` to find the modified files
+- If a plan or specification is referenced, read it and verify every requirement is addressed
+- Read the changed files fully enough to judge correctness in context, not just the diff hunks
+- Look for bugs, missing edge cases, broken or missing tests, security issues, and deviations from the surrounding code style
+- Run read-only verification commands (tests, typecheckers, linters) when available
+- Do not edit files, create files, or run bash commands that modify the user's system state in any way
+- For clear communication, avoid using emojis
+
+Report your findings ordered by severity. For each finding include the file path, what is wrong, and a concrete suggestion. If the implementation is sound, say so plainly and list what you verified.

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -445,6 +445,11 @@ export const RunCommand = effectCmd({
               action: "deny",
               pattern: "*",
             },
+            {
+              permission: "review_exit",
+              action: "deny",
+              pattern: "*",
+            },
           ]
 
       function title() {

--- a/packages/opencode/src/cli/cmd/run/tool.ts
+++ b/packages/opencode/src/cli/cmd/run/tool.ts
@@ -25,6 +25,7 @@ import type { GrepTool } from "@/tool/grep"
 import type { InvalidTool } from "@/tool/invalid"
 import type { LspTool } from "@/tool/lsp"
 import type { PlanExitTool } from "@/tool/plan"
+import type { ReviewExitTool } from "@/tool/review"
 import type { QuestionTool } from "@/tool/question"
 import type { ReadTool } from "@/tool/read"
 import type { SkillTool } from "@/tool/skill"
@@ -110,6 +111,7 @@ type ToolDefs = {
   websearch: typeof WebSearchTool
   skill: typeof SkillTool
   plan_exit: typeof PlanExitTool
+  review_exit: typeof ReviewExitTool
 }
 
 type ToolName = keyof ToolDefs
@@ -474,6 +476,15 @@ function runPlanExit(p: ToolProps<typeof PlanExitTool>): ToolInline {
   return {
     icon: "→",
     title: text(p.frame.state.title) || "Switching to build agent",
+    mode: "block",
+    body: p.frame.status === "completed" ? text(p.frame.state.output) : undefined,
+  }
+}
+
+function runReviewExit(p: ToolProps<typeof ReviewExitTool>): ToolInline {
+  return {
+    icon: "→",
+    title: text(p.frame.state.title) || "Switching to review agent",
     mode: "block",
     body: p.frame.status === "completed" ? text(p.frame.state.output) : undefined,
   }
@@ -1225,6 +1236,16 @@ const TOOL_RULES = {
       final: false,
     },
     run: runPlanExit,
+    scroll: {
+      start: () => "",
+    },
+  },
+  review_exit: {
+    view: {
+      output: true,
+      final: false,
+    },
+    run: runReviewExit,
     scroll: {
       start: () => "",
     },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1181,6 +1181,7 @@ const layer = Layer.effect(
             Effect.provideService(RuntimeFlags.Service, flags),
             Effect.provideService(FSUtil.Service, fsys),
             Effect.provideService(Session.Service, sessions),
+            Effect.provideService(Config.Service, config),
           )
 
           const msg: SessionV1.Assistant = {

--- a/packages/opencode/src/session/prompt/review-reminder.txt
+++ b/packages/opencode/src/session/prompt/review-reminder.txt
@@ -1,0 +1,3 @@
+<system-reminder>
+A reviewer agent is configured for this session. When you have finished implementing and verifying your changes, call the review_exit tool to hand the session to the ${reviewer} agent for review. Only do this after completing implementation work; ignore this for questions or discussions that do not change code.
+</system-reminder>

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -4,6 +4,7 @@ import { ConfigWorkflowV1 } from "@opencode-ai/core/v1/config/workflow"
 import { Effect } from "effect"
 import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
+import { Permission } from "@/permission"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { InstanceState } from "@/effect/instance-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -13,6 +14,7 @@ import { Session } from "./session"
 import PROMPT_PLAN from "./prompt/plan.txt"
 import BUILD_SWITCH from "./prompt/build-switch.txt"
 import PLAN_MODE from "./prompt/plan-mode.txt"
+import REVIEW_REMINDER from "./prompt/review-reminder.txt"
 
 export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   messages: SessionV1.WithParts[]
@@ -27,10 +29,19 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   if (!userMessage) return input.messages
 
   const workflow = ConfigWorkflowV1.roles((yield* config.get()).workflow)
-  const reviewNote =
-    workflow.reviewer && input.agent.name === workflow.worker
-      ? `\n\nWhen you have finished implementing and verifying your changes, call the review_exit tool to hand the session to the ${workflow.reviewer} agent for review.`
-      : ""
+  // Re-injected every provider turn (never persisted) so the worker still hands
+  // off to the reviewer in resumed or compacted sessions where a one-time note
+  // would have scrolled out of context.
+  if (workflow.reviewer && Permission.evaluate("review_exit", "*", input.agent.permission).action === "allow") {
+    userMessage.parts.push({
+      id: PartID.ascending(),
+      messageID: userMessage.info.id,
+      sessionID: userMessage.info.sessionID,
+      type: "text",
+      text: REVIEW_REMINDER.replace("${reviewer}", () => workflow.reviewer!),
+      synthetic: true,
+    })
+  }
 
   if (!flags.experimentalPlanMode) {
     if (input.agent.name === workflow.planner) {
@@ -50,7 +61,7 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
         messageID: userMessage.info.id,
         sessionID: userMessage.info.sessionID,
         type: "text",
-        text: BUILD_SWITCH + reviewNote,
+        text: BUILD_SWITCH,
         synthetic: true,
       })
     }
@@ -67,10 +78,9 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
       messageID: userMessage.info.id,
       sessionID: userMessage.info.sessionID,
       type: "text",
-      text:
-        (exists
-          ? `${BUILD_SWITCH}\n\nA plan file exists at ${plan}. You should execute on the plan defined within it`
-          : BUILD_SWITCH) + reviewNote,
+      text: exists
+        ? `${BUILD_SWITCH}\n\nA plan file exists at ${plan}. You should execute on the plan defined within it`
+        : BUILD_SWITCH,
       synthetic: true,
     })
     userMessage.parts.push(part)

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -1,7 +1,9 @@
 import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ConfigWorkflowV1 } from "@opencode-ai/core/v1/config/workflow"
 import { Effect } from "effect"
 import { Agent } from "@/agent/agent"
+import { Config } from "@/config/config"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { InstanceState } from "@/effect/instance-state"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -20,11 +22,18 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   const flags = yield* RuntimeFlags.Service
   const fsys = yield* FSUtil.Service
   const sessions = yield* Session.Service
+  const config = yield* Config.Service
   const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
   if (!userMessage) return input.messages
 
+  const workflow = ConfigWorkflowV1.roles((yield* config.get()).workflow)
+  const reviewNote =
+    workflow.reviewer && input.agent.name === workflow.worker
+      ? `\n\nWhen you have finished implementing and verifying your changes, call the review_exit tool to hand the session to the ${workflow.reviewer} agent for review.`
+      : ""
+
   if (!flags.experimentalPlanMode) {
-    if (input.agent.name === "plan") {
+    if (input.agent.name === workflow.planner) {
       userMessage.parts.push({
         id: PartID.ascending(),
         messageID: userMessage.info.id,
@@ -34,14 +43,14 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
         synthetic: true,
       })
     }
-    const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-    if (wasPlan && input.agent.name === "build") {
+    const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === workflow.planner)
+    if (wasPlan && input.agent.name === workflow.worker) {
       userMessage.parts.push({
         id: PartID.ascending(),
         messageID: userMessage.info.id,
         sessionID: userMessage.info.sessionID,
         type: "text",
-        text: BUILD_SWITCH,
+        text: BUILD_SWITCH + reviewNote,
         synthetic: true,
       })
     }
@@ -49,7 +58,7 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   }
 
   const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
-  if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
+  if (input.agent.name !== workflow.planner && assistantMessage?.info.agent === workflow.planner) {
     const ctx = yield* InstanceState.context
     const plan = Session.plan(input.session, ctx)
     const exists = yield* fsys.existsSafe(plan)
@@ -58,16 +67,18 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
       messageID: userMessage.info.id,
       sessionID: userMessage.info.sessionID,
       type: "text",
-      text: exists
-        ? `${BUILD_SWITCH}\n\nA plan file exists at ${plan}. You should execute on the plan defined within it`
-        : BUILD_SWITCH,
+      text:
+        (exists
+          ? `${BUILD_SWITCH}\n\nA plan file exists at ${plan}. You should execute on the plan defined within it`
+          : BUILD_SWITCH) + reviewNote,
       synthetic: true,
     })
     userMessage.parts.push(part)
     return input.messages
   }
 
-  if (input.agent.name !== "plan" || assistantMessage?.info.agent === "plan") return input.messages
+  if (input.agent.name !== workflow.planner || assistantMessage?.info.agent === workflow.planner)
+    return input.messages
 
   const ctx = yield* InstanceState.context
   const plan = Session.plan(input.session, ctx)

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -2,6 +2,8 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { PlanExitTool } from "./plan"
+import { ReviewExitTool } from "./review"
+import { ConfigWorkflowV1 } from "@opencode-ai/core/v1/config/workflow"
 import { Session } from "@/session/session"
 import { QuestionTool } from "./question"
 import { ShellTool } from "./shell"
@@ -100,6 +102,7 @@ const layer = Layer.effect(
     const todo = yield* TodoWriteTool
     const lsptool = yield* LspTool
     const plan = yield* PlanExitTool
+    const review = yield* ReviewExitTool
     const webfetch = yield* WebFetchTool
     const websearch = yield* WebSearchTool
     const shell = yield* ShellTool
@@ -198,8 +201,9 @@ const layer = Layer.effect(
           }
         }
 
-        yield* config.get()
+        const cfg = yield* config.get()
         const questionEnabled = ["app", "cli", "desktop"].includes(flags.client) || flags.enableQuestionTool
+        const reviewerConfigured = !!ConfigWorkflowV1.roles(cfg.workflow).reviewer
 
         const tool = yield* Effect.all({
           invalid: Tool.init(invalid),
@@ -218,6 +222,7 @@ const layer = Layer.effect(
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          review: Tool.init(review),
           ...(codeModeTool ? { execute: Tool.init(codeModeTool) } : {}),
         })
 
@@ -241,6 +246,7 @@ const layer = Layer.effect(
             ...(tool.execute ? [tool.execute] : []),
             ...(flags.experimentalLspTool ? [tool.lsp] : []),
             ...(flags.experimentalPlanMode && flags.client === "cli" ? [tool.plan] : []),
+            ...(reviewerConfigured ? [tool.review] : []),
           ],
           task: tool.task,
           read: tool.read,

--- a/packages/opencode/src/tool/review-exit.txt
+++ b/packages/opencode/src/tool/review-exit.txt
@@ -1,0 +1,13 @@
+Use this tool when you have finished implementing and verifying your changes and the work is ready for review.
+
+This tool will ask the user if they want to hand the session off to the review agent to review the implementation.
+
+Call this tool:
+- After you have completed every item of the approved plan or requested change
+- After you have verified your work (tests, typechecks) where possible
+- When you have nothing left to implement
+
+Do NOT call this tool:
+- While parts of the implementation are still unfinished
+- If verification surfaced failures you have not addressed
+- If the user has indicated they want changes before a review

--- a/packages/opencode/src/tool/review.ts
+++ b/packages/opencode/src/tool/review.ts
@@ -1,28 +1,29 @@
 import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { ConfigWorkflowV1 } from "@opencode-ai/core/v1/config/workflow"
+import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
 import { Question } from "../question"
 import { Session } from "@/session/session"
-import { MessageV2 } from "../session/message-v2"
 import { Provider } from "@/provider/provider"
 import { InstanceState } from "@/effect/instance-state"
 import { MessageID, PartID } from "../session/schema"
-import EXIT_DESCRIPTION from "./plan-exit.txt"
+import EXIT_DESCRIPTION from "./review-exit.txt"
 
 export const Parameters = Schema.Struct({})
 
-export const PlanExitTool = Tool.define(
-  "plan_exit",
+export const ReviewExitTool = Tool.define(
+  "review_exit",
   Effect.gen(function* () {
     const session = yield* Session.Service
     const question = yield* Question.Service
     const provider = yield* Provider.Service
     const config = yield* Config.Service
     const agents = yield* Agent.Service
+    const fsys = yield* FSUtil.Service
 
     return {
       description: EXIT_DESCRIPTION,
@@ -32,18 +33,24 @@ export const PlanExitTool = Tool.define(
           const instance = yield* InstanceState.context
           const info = yield* session.get(ctx.sessionID)
           const cfg = yield* config.get()
-          const worker = ConfigWorkflowV1.roles(cfg.workflow).worker
-          const plan = path.relative(instance.worktree, Session.plan(info, instance))
+          const reviewer = ConfigWorkflowV1.roles(cfg.workflow).reviewer
+          if (!reviewer)
+            return {
+              title: "No reviewer configured",
+              output:
+                "No workflow reviewer is configured, so there is no review agent to hand off to. Continue without a review.",
+              metadata: {},
+            }
           const answers = yield* question.ask({
             sessionID: ctx.sessionID,
             questions: [
               {
-                question: `Plan at ${plan} is complete. Would you like to switch to the ${worker} agent and start implementing?`,
-                header: `${worker.charAt(0).toUpperCase() + worker.slice(1)} Agent`,
+                question: `Implementation is complete. Would you like to switch to the ${reviewer} agent to review the changes?`,
+                header: "Review Agent",
                 custom: false,
                 options: [
-                  { label: "Yes", description: `Switch to ${worker} agent and start implementing the plan` },
-                  { label: "No", description: "Stay with plan agent to continue refining the plan" },
+                  { label: "Yes", description: `Switch to ${reviewer} agent and review the implementation` },
+                  { label: "No", description: "Stay with the current agent to continue working" },
                 ],
               },
             ],
@@ -52,21 +59,25 @@ export const PlanExitTool = Tool.define(
 
           if (answers[0]?.[0] === "No") yield* new Question.RejectedError()
 
-          const workerAgent = yield* agents.get(worker)
+          const reviewerAgent = yield* agents.get(reviewer)
           const messages = yield* session.messages({ sessionID: ctx.sessionID }).pipe(Effect.orDie)
           const lastUser = messages.findLast((item) => item.info.role === "user" && item.info.model)
           const model =
-            workerAgent?.model ??
+            reviewerAgent?.model ??
             (lastUser?.info.role === "user" && lastUser.info.model
               ? lastUser.info.model
               : yield* provider.defaultModel())
+
+          const plan = Session.plan(info, instance)
+          const planExists = yield* fsys.existsSafe(plan)
+          const against = planExists ? ` against the plan at ${path.relative(instance.worktree, plan)}` : ""
 
           const msg: SessionV1.User = {
             id: MessageID.ascending(),
             sessionID: ctx.sessionID,
             role: "user",
             time: { created: Date.now() },
-            agent: worker,
+            agent: reviewer,
             model,
           }
           yield* session.updateMessage(msg)
@@ -75,13 +86,13 @@ export const PlanExitTool = Tool.define(
             messageID: msg.id,
             sessionID: ctx.sessionID,
             type: "text",
-            text: `The plan at ${plan} has been approved, you can now edit files. Execute the plan`,
+            text: `The implementation is complete. Review the changes made in this session${against} and report your findings.`,
             synthetic: true,
           } satisfies SessionV1.TextPart)
 
           return {
-            title: `Switching to ${worker} agent`,
-            output: `User approved switching to ${worker} agent. Wait for further instructions.`,
+            title: `Switching to ${reviewer} agent`,
+            output: `User approved switching to ${reviewer} agent for review. Wait for further instructions.`,
             metadata: {},
           }
         }).pipe(Effect.orDie),

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -749,6 +749,84 @@ it.instance(
       agent: {
         build: { disable: true },
         plan: { disable: true },
+        review: { disable: true },
+      },
+    },
+  },
+)
+
+it.instance("review agent is read-only and denies review_exit by default", () =>
+  Effect.gen(function* () {
+    const review = yield* load((svc) => svc.get("review"))
+    expect(review).toBeDefined()
+    expect(review?.mode).toBe("all")
+    expect(review?.native).toBe(true)
+    expect(evalPerm(review, "edit")).toBe("deny")
+    expect(evalPerm(review, "read")).toBe("allow")
+    expect(evalPerm(review, "review_exit")).toBe("deny")
+    expect(Permission.evaluate("task", "general", review!.permission).action).toBe("deny")
+  }),
+)
+
+it.instance("review_exit is denied everywhere without a workflow config", () =>
+  Effect.gen(function* () {
+    const build = yield* load((svc) => svc.get("build"))
+    expect(evalPerm(build, "review_exit")).toBe("deny")
+  }),
+)
+
+it.instance(
+  "workflow config allows review_exit for the default worker",
+  () =>
+    Effect.gen(function* () {
+      const build = yield* load((svc) => svc.get("build"))
+      const plan = yield* load((svc) => svc.get("plan"))
+      const review = yield* load((svc) => svc.get("review"))
+      expect(evalPerm(build, "review_exit")).toBe("allow")
+      expect(evalPerm(plan, "review_exit")).toBe("deny")
+      expect(evalPerm(review, "review_exit")).toBe("deny")
+    }),
+  {
+    config: {
+      workflow: {},
+    },
+  },
+)
+
+it.instance(
+  "workflow config maps roles to custom agents",
+  () =>
+    Effect.gen(function* () {
+      const impl = yield* load((svc) => svc.get("impl"))
+      const build = yield* load((svc) => svc.get("build"))
+      expect(evalPerm(impl, "review_exit")).toBe("allow")
+      expect(evalPerm(build, "review_exit")).toBe("deny")
+    }),
+  {
+    config: {
+      workflow: {
+        worker: "impl",
+        reviewer: "checker",
+      },
+      agent: {
+        impl: { description: "Implements plans", mode: "primary" },
+        checker: { description: "Reviews implementations", mode: "primary" },
+      },
+    },
+  },
+)
+
+it.instance(
+  "workflow reviewer pointing at a missing agent grants nothing",
+  () =>
+    Effect.gen(function* () {
+      const build = yield* load((svc) => svc.get("build"))
+      expect(evalPerm(build, "review_exit")).toBe("deny")
+    }),
+  {
+    config: {
+      workflow: {
+        reviewer: "does_not_exist",
       },
     },
   },

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1654,6 +1654,12 @@ export type ServerConfig = {
   cors?: Array<string>
 }
 
+export type WorkflowConfig = {
+  planner?: string
+  worker?: string
+  reviewer?: string
+}
+
 export type PermissionActionConfig = "ask" | "allow" | "deny"
 
 export type PermissionObjectConfig = {
@@ -1928,6 +1934,7 @@ export type Config = {
   model?: string
   small_model?: string
   default_agent?: string
+  workflow?: WorkflowConfig
   username?: string
   mode?: {
     build?: AgentConfig
@@ -1939,6 +1946,7 @@ export type Config = {
     build?: AgentConfig
     general?: AgentConfig
     explore?: AgentConfig
+    review?: AgentConfig
     title?: AgentConfig
     summary?: AgentConfig
     compaction?: AgentConfig

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -42,7 +42,7 @@ OpenCode comes with three built-in subagents, **General**, **Explore**, and **Sc
 
 ## Built-in
 
-OpenCode comes with two built-in primary agents and three built-in subagents.
+OpenCode comes with two built-in primary agents, three built-in subagents, and a review agent that works as either.
 
 ---
 
@@ -92,6 +92,14 @@ A read-only agent for external docs and dependency research. Use this when you n
 
 ---
 
+### Use review
+
+_Mode_: `all`
+
+A read-only agent that reviews implementations for correctness, completeness, and quality. It cannot modify files. Use it after a change is complete to verify the work against its requirements or plan, or wire it into a [workflow](#workflows) so the worker agent can hand the session off for review.
+
+---
+
 ### Use compaction
 
 _Mode_: `primary`
@@ -136,6 +144,46 @@ Hidden system agent that creates session summaries. It runs automatically and is
    - `session_parent` (default: **Up**) to return to the parent session
 
    This lets you switch between the main conversation and specialized subagent work.
+
+---
+
+## Workflows
+
+You can chain agents into a planner → worker → reviewer workflow, with each role running on its own model. Map the roles to agents with the `workflow` config, and give each agent its own model with the per-agent `model` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "workflow": {
+    "planner": "plan",
+    "worker": "build",
+    "reviewer": "review"
+  },
+  "agent": {
+    "plan": {
+      "model": "anthropic/claude-opus-4-8"
+    },
+    "build": {
+      "model": "zai/glm-4.7"
+    },
+    "review": {
+      "model": "openai/gpt-5.2-codex"
+    }
+  }
+}
+```
+
+All roles are optional and default to `plan`, `build`, and `review`. An empty `"workflow": {}` enables the defaults. You can also point a role at a custom agent.
+
+Here's how the chain works:
+
+1. The **planner** explores the codebase and writes a plan. Switch to the worker with **Tab** when the plan is ready — with `OPENCODE_EXPERIMENTAL_PLAN_MODE` enabled the planner offers the switch itself once the plan is complete.
+2. The **worker** implements the plan using its own configured model. When a reviewer is configured, the worker gets a `review_exit` tool and is reminded to call it once the implementation is verified.
+3. The **reviewer** is a read-only agent that inspects the changes, checks them against the plan, and reports findings by severity.
+
+Each handoff asks for your confirmation first, and you can keep working with any agent after a handoff — the workflow guides the session, it doesn't lock it.
+
+The reviewer stage only activates when a `workflow` key is present in your config. Without it, sessions behave exactly as before.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes # — no issue yet; I'm happy to open one describing the feature if maintainers want it tracked separately.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an opt-in `workflow` config that maps planner/worker/reviewer roles to agents, so a plan -> implement -> review chain can run each stage on its own model (via the existing per-agent `model` overrides):

```jsonc
{
  "workflow": {}, // defaults: planner=plan, worker=build, reviewer=review
  "agent": {
    "plan": { "model": "anthropic/claude-opus-4-8" },
    "build": { "model": "opencode/glm-4.7" },
    "review": { "model": "openai/gpt-5.2-codex" }
  }
}
```

Why this shape: the pieces mostly existed already. Per-agent models are resolved with `input.model ?? agent.model ?? currentModel` in `session/prompt.ts`, and `plan_exit` already hands a session from plan to build via a synthetic user message. This PR generalizes that handoff to the configured worker (also fixing it to switch to the worker's configured model — previously it hardcoded `build` and kept the planner's model, which contradicts the resolution order above), adds a read-only built-in `review` agent, and adds a `review_exit` tool that mirrors `plan_exit` for the worker -> reviewer handoff.

Safety of the default path: `review_exit` is denied by default for every agent and only granted to the configured worker when a `workflow` key with a valid reviewer exists, so nothing changes for existing configs. It's also denied in non-interactive `opencode run` (same as `plan_exit`, since it asks a confirmation question). Role names resolve through one helper (`ConfigWorkflowV1.roles`) used by the agent registry, both handoff tools, and the session reminders, so the pieces can't disagree about who the worker is.

### How did you verify your code works?

- New tests: 5 agent-registry tests for the `review_exit` permission gating (default deny, grant via `workflow: {}`, custom role mapping, missing reviewer grants nothing) and the review agent's read-only ruleset; 4 unit tests for `ConfigWorkflowV1.roles` defaults/overrides.
- Existing suites: `test/agent`, `test/session`, `test/config`, `test/tool` pass locally (one pre-existing `write.test.ts` file-permission failure reproduces on a clean checkout, unrelated).
- `bun typecheck` clean in `packages/core`, `packages/opencode`, `packages/sdk/js`.
- Ran the TUI from source against a test project with the config above: the review agent appears in the Tab cycle and each agent runs on its configured model when switching.

### Screenshots / recordings

The UI surface is small: a `review` agent in the Tab cycle and CLI rendering for the `review_exit` handoff (same block style as `plan_exit`). Can add a recording of the full chain if helpful.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
