### PR TITLE
feat(session): support admit-only synthetic messages

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -154,6 +154,7 @@ export type Endpoint4_12Input = {
   readonly text: Endpoint4_12Request["payload"]["text"]
   readonly description?: Endpoint4_12Request["payload"]["description"]
   readonly metadata?: Endpoint4_12Request["payload"]["metadata"]
+  readonly resume?: Endpoint4_12Request["payload"]["resume"]
 }
 export type Endpoint4_12Output = EffectValue<ReturnType<RawClient["server.session"]["session.synthetic"]>>
 export type SessionSyntheticOperation<E = never> = (input: Endpoint4_12Input) => Effect.Effect<Endpoint4_12Output, E>

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -209,11 +209,17 @@ type Endpoint4_12Input = {
   readonly text: Endpoint4_12Request["payload"]["text"]
   readonly description?: Endpoint4_12Request["payload"]["description"]
   readonly metadata?: Endpoint4_12Request["payload"]["metadata"]
+  readonly resume?: Endpoint4_12Request["payload"]["resume"]
 }
 const Endpoint4_12 = (raw: RawClient["server.session"]) => (input: Endpoint4_12Input) =>
   raw["session.synthetic"]({
     params: { sessionID: input["sessionID"] },
-    payload: { text: input["text"], description: input["description"], metadata: input["metadata"] },
+    payload: {
+      text: input["text"],
+      description: input["description"],
+      metadata: input["metadata"],
+      resume: input["resume"],
+    },
   }).pipe(Effect.mapError(mapClientError))
 
 type Endpoint4_13Request = Parameters<RawClient["server.session"]["session.shell"]>[0]

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -538,7 +538,12 @@ export function make(options: ClientOptions) {
           {
             method: "POST",
             path: `/api/session/${encodeURIComponent(input.sessionID)}/synthetic`,
-            body: { text: input["text"], description: input["description"], metadata: input["metadata"] },
+            body: {
+              text: input["text"],
+              description: input["description"],
+              metadata: input["metadata"],
+              resume: input["resume"],
+            },
             successStatus: 204,
             declaredStatuses: [404, 400, 401],
             empty: true,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -856,17 +856,26 @@ export type SessionSyntheticInput = {
     readonly text: string
     readonly description?: string | null
     readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly resume?: boolean | null
   }["text"]
   readonly description?: {
     readonly text: string
     readonly description?: string | null
     readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly resume?: boolean | null
   }["description"]
   readonly metadata?: {
     readonly text: string
     readonly description?: string | null
     readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly resume?: boolean | null
   }["metadata"]
+  readonly resume?: {
+    readonly text: string
+    readonly description?: string | null
+    readonly metadata?: { readonly [x: string]: JsonValue }
+    readonly resume?: boolean | null
+  }["resume"]
 }
 
 export type SessionSyntheticOutput = void

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -243,6 +243,7 @@ export interface Interface {
     text: string
     description?: string
     metadata?: Record<string, unknown>
+    resume?: boolean
   }) => Effect.Effect<void, NotFoundError>
   readonly revert: {
     readonly stage: (input: {
@@ -682,6 +683,7 @@ const layer = Layer.effect(
           description: input.description,
           metadata: input.metadata,
         })
+        if (input.resume === false) return
         yield* execution
           .resume(input.sessionID)
           .pipe(Effect.ignore, Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -344,6 +344,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           text: Schema.String,
           description: Schema.String.pipe(Schema.optional),
           metadata: SessionMessage.Synthetic.fields.metadata,
+          resume: Schema.Boolean.pipe(Schema.optional),
         }),
         success: HttpApiSchema.NoContent,
         error: SessionNotFoundError,

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -329,6 +329,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
               text: ctx.payload.text,
               description: ctx.payload.description,
               metadata: ctx.payload.metadata,
+              resume: ctx.payload.resume,
             })
             .pipe(
               Effect.catchTag("Session.NotFoundError", (error) =>


### PR DESCRIPTION
## Summary
- add an optional `resume` flag to the V2 synthetic message endpoint
- persist synthetic messages without resuming execution when `resume` is false
- regenerate promise and Effect clients

## Verification
- `bun typecheck` in `packages/protocol`
- `bun typecheck` in `packages/client` was attempted but killed by the host memory limit