### PR TITLE
fix(desktop): skip stale remote session restore

### DIFF
--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -90,9 +90,26 @@ function getLastActiveUrl(windowID: string) {
   if (typeof localStorage !== "object") return "/"
   try {
     const value = localStorage.getItem(windowLastActiveUrlKey(windowID))
-    if (value?.startsWith("/") && !value.startsWith("//")) return value
+    if (value?.startsWith("/") && !value.startsWith("//") && !isStaleWindowsRemoteSessionUrl(value)) return value
   } catch {}
   return "/"
+}
+
+function isStaleWindowsRemoteSessionUrl(value: string) {
+  if (!navigator.userAgent.includes("Windows")) return false
+  const match = value.match(/^\/([^/]+)\/session(?:\/|$)/)
+  if (!match) return false
+  const directory = decodeRouteSegment(match[1])
+  return directory?.startsWith("/") ?? false
+}
+
+function decodeRouteSegment(value: string) {
+  try {
+    const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/"))
+    return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)))
+  } catch {
+    return undefined
+  }
 }
 
 function setLastActiveUrl(windowID: string, value: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #23958 (unrelated)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a Desktop startup restore issue on Windows where a previously opened remote/WSL session could be restored as a local session.

- Detects stale legacy session URLs on Windows.
- Checks whether the encoded session directory is a Unix-style absolute path like `/home/user/project`.
- Skips restoring that URL when it cannot be a native Windows local path.
- Falls back to the home screen instead of asking the local sidecar to open `C:/home/...`.
- Leaves modern `/server/.../session/...` routes unchanged.
- Leaves normal Windows local session restore unchanged.

This works because the failing sessions were remote sessions stored in the old directory-based route format. On Windows, those remote Linux paths were being interpreted as local Windows paths, causing local “Session not found” / missing directory errors.

**New Flow With the new guard:**

- Saved value is missing: returns /.
- Saved value does not start with /: returns /.
- Saved value starts with //: returns /.
- Saved value is a normal app URL like /, /new-session, /server/.../session/...: returns that saved URL.
- Saved value is a legacy session URL like /<encoded-dir>/session/<id> and not Windows: returns that saved URL.
- Saved value is a legacy session URL on Windows and decoded directory is a Windows path like C:\dev\project: returns that saved URL.
- Saved value is a legacy session URL on Windows and decoded directory is a Unix path like /home/user/project: returns /.
- Saved value is malformed and decoding fails: returns the saved URL, because the guard cannot prove it is stale.

### How did you verify your code works?

- Ran `bun typecheck` from `packages/desktop`.
- Commit hook also ran repo typecheck successfully.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
