### PR TITLE
feat(opencode): add runtime model override for task tool subagents

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -119,6 +119,7 @@ const layer = Layer.effect(
         const defaults = Permission.fromConfig({
           "*": "allow",
           doom_loop: "ask",
+          model_override: "ask",
           external_directory: {
             "*": "ask",
             ...Object.fromEntries(whitelistedDirs.map((dir) => [dir, "allow"])),

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,6 +10,7 @@ import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
+import { Provider } from "@/provider/provider"
 import { Effect, Exit, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -49,6 +50,10 @@ const BaseParameterFields = {
       "This should only be set if you mean to resume a previous task (you can pass a prior task_id and the task will continue the same subagent session as before instead of creating a fresh one)",
   }),
   command: Schema.optional(Schema.String).annotate({ description: "The command that triggered this task" }),
+  model: Schema.optional(Schema.String).annotate({
+    description:
+      'Override the subagent model for this invocation (format: "provider/model-id"). Takes priority over the subagent\'s configured model. Requires model_override permission.',
+  }),
 }
 
 const BaseParameters = Schema.Struct(BaseParameterFields)
@@ -118,6 +123,28 @@ export const TaskTool = Tool.define(
         return yield* Effect.fail(new Error(`Unknown agent type: ${params.subagent_type} is not a valid agent type`))
       }
 
+      let overrideModel: ReturnType<typeof Provider.parseModel> | undefined
+      if (params.model) {
+        const trimmed = params.model.trim()
+        const slashIndex = trimmed.indexOf("/")
+        if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+          return yield* Effect.fail(
+            new Error(`Invalid model format: "${params.model}". Expected "provider/model-id".`),
+          )
+        }
+        yield* ctx.ask({
+          permission: "model_override",
+          patterns: [trimmed],
+          always: [],
+          metadata: {
+            description: params.description,
+            subagent_type: params.subagent_type,
+            model: trimmed,
+          },
+        })
+        overrideModel = Provider.parseModel(trimmed)
+      }
+
       const session = params.task_id
         ? yield* sessions.get(SessionID.make(params.task_id)).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
         : undefined
@@ -164,7 +191,7 @@ export const TaskTool = Tool.define(
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
       const variant = msg.info.variant
 
-      const model = next.model ?? {
+      const model = overrideModel ?? next.model ?? {
         modelID: msg.info.modelID,
         providerID: msg.info.providerID,
       }
@@ -192,7 +219,7 @@ export const TaskTool = Tool.define(
             modelID: model.modelID,
             providerID: model.providerID,
           },
-          variant: next.model ? undefined : variant,
+          variant: overrideModel || next.model ? undefined : variant,
           agent: next.name,
           parts,
         })

--- a/packages/opencode/src/tool/task.txt
+++ b/packages/opencode/src/tool/task.txt
@@ -17,3 +17,4 @@ Usage notes:
 5. The agent's outputs should generally be trusted
 6. Clearly tell the agent whether you expect it to write code or just to do research (search, file reads, web fetches, etc.), since it is not aware of the user's intent. Tell it how to verify its work if possible (e.g., relevant test commands).
 7. If the agent description mentions that it should be used proactively, then you should try your best to use it without the user having to ask for it first. Use your judgement.
+8. You can override the subagent's model for a specific invocation by passing a model parameter in "provider/model-id" format (e.g. "anthropic/claude-sonnet-4"). This lets you pick a different model than the subagent's default — useful for cost optimization or capability matching. The override requires model_override permission.

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -456,6 +456,309 @@ describe("tool.task", () => {
     },
   )
 
+  it.instance(
+    "uses the subagent's configured model instead of the parent's",
+    () =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+        const result = yield* def.execute(
+          {
+            description: "run custom model agent",
+            prompt: "do something",
+            subagent_type: "custom-model-agent",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(seen?.model).toEqual({
+          providerID: ProviderV2.ID.make("test"),
+          modelID: ModelV2.ID.make("different-model"),
+        })
+        expect(seen?.variant).toBeUndefined()
+        expect(result.metadata.model).toEqual({
+          providerID: ProviderV2.ID.make("test"),
+          modelID: ModelV2.ID.make("different-model"),
+        })
+      }),
+    {
+      config: {
+        agent: {
+          "custom-model-agent": {
+            description: "Agent with a custom model",
+            mode: "subagent",
+            model: "test/different-model",
+          },
+        },
+      },
+    },
+  )
+
+  it.instance(
+    "uses a subagent model from a different provider than the parent",
+    () =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+        yield* def.execute(
+          {
+            description: "run cross-provider agent",
+            prompt: "do something",
+            subagent_type: "cross-provider-agent",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(seen?.model).toEqual({
+          providerID: ProviderV2.ID.make("other-provider"),
+          modelID: ModelV2.ID.make("other-model"),
+        })
+        expect(seen?.variant).toBeUndefined()
+      }),
+    {
+      config: {
+        agent: {
+          "cross-provider-agent": {
+            description: "Agent using a different provider",
+            mode: "subagent",
+            model: "other-provider/other-model",
+          },
+        },
+      },
+    },
+  )
+
+  it.instance("falls back to the parent model when the subagent has no model configured", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      let seen: SessionPrompt.PromptInput | undefined
+      const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+      const result = yield* def.execute(
+        {
+          description: "run general agent",
+          prompt: "do something",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(seen?.model).toEqual({
+        providerID: ref.providerID,
+        modelID: ref.modelID,
+      })
+      expect(seen?.variant).toBe("xhigh")
+      expect(result.metadata.model).toEqual({
+        providerID: ref.providerID,
+        modelID: ref.modelID,
+      })
+    }),
+  )
+
+  it.instance(
+    "uses the runtime model override when provided",
+    () =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+        const result = yield* def.execute(
+          {
+            description: "run with override",
+            prompt: "do something",
+            subagent_type: "general",
+            model: "test/override-model",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(seen?.model).toEqual({
+          providerID: ProviderV2.ID.make("test"),
+          modelID: ModelV2.ID.make("override-model"),
+        })
+        expect(seen?.variant).toBeUndefined()
+        expect(result.metadata.model).toEqual({
+          providerID: ProviderV2.ID.make("test"),
+          modelID: ModelV2.ID.make("override-model"),
+        })
+      }),
+    {
+      config: {
+        permission: {
+          model_override: "allow",
+        },
+      },
+    },
+  )
+
+  it.instance(
+    "runtime model override takes priority over the subagent's configured model",
+    () =>
+      Effect.gen(function* () {
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+        yield* def.execute(
+          {
+            description: "run with override",
+            prompt: "do something",
+            subagent_type: "custom-model-agent",
+            model: "test/override-model",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        expect(seen?.model).toEqual({
+          providerID: ProviderV2.ID.make("test"),
+          modelID: ModelV2.ID.make("override-model"),
+        })
+        expect(seen?.variant).toBeUndefined()
+      }),
+    {
+      config: {
+        permission: {
+          model_override: "allow",
+        },
+        agent: {
+          "custom-model-agent": {
+            description: "Agent with a custom model",
+            mode: "subagent",
+            model: "test/different-model",
+          },
+        },
+      },
+    },
+  )
+
+  it.instance("rejects an invalid model override format", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const promptOps = stubOps()
+
+      const exit = yield* def
+        .execute(
+          {
+            description: "run with bad model",
+            prompt: "do something",
+            subagent_type: "general",
+            model: "no-slash-here",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit)).toBe(true)
+    }),
+  )
+
+  it.instance("asks for model_override permission when a model is specified", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const calls: Array<{ permission: string; patterns: readonly string[] }> = []
+      const promptOps = stubOps()
+
+      yield* def.execute(
+        {
+          description: "run with override",
+          prompt: "do something",
+          subagent_type: "general",
+          model: "test/override-model",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: (input) =>
+            Effect.sync(() => {
+              calls.push({ permission: input.permission, patterns: input.patterns })
+            }),
+        },
+      )
+
+      const override = calls.find((c) => c.permission === "model_override")
+      expect(override).toBeDefined()
+      expect(override?.patterns).toEqual(["test/override-model"])
+    }),
+  )
+
   it.instance("rejects background execution when the experiment is disabled", () =>
     Effect.gen(function* () {
       const { chat, assistant } = yield* seed()


### PR DESCRIPTION
### Issue for this PR

Closes #17595, #32730

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `model` parameter to the task tool so a primary agent can pick a subagent model at runtime using `provider/model-id` format.

Model priority: explicit `model` param → subagent configured `model` frontmatter → parent assistant message model.

Explicit overrides are gated behind a new `model_override` permission (defaults to `ask`) to prevent prompt-injection escalation to expensive models.

### How did you verify your code works?

- 25 tests in `test/tool/task.test.ts` (7 new) — all pass
- `bunx tsc --noEmit` clean on changed files
- Tests cover: per-agent model resolution, cross-provider models, parent fallback, variant clearing, runtime override, override priority over configured model, invalid format rejection, permission prompting

### Screenshots / recordings

N/A — backend logic change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Note: #29447 implements the same feature but has been waiting for review since May. This is an independent implementation.