### PR TITLE
test(tui): cover patch diff display aliases

### DIFF
--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -122,6 +122,8 @@ describe("TUI inline tool wrapping", () => {
     // Legacy tool names normalize to their renamed views.
     expect(toolDisplay("bash")).toBe("shell")
     expect(toolDisplay("task")).toBe("subagent")
+    expect(toolDisplay("apply_patch")).toBe("patch")
+    expect(toolDisplay("patch")).toBe("patch")
     expect(toolDisplay("plugin_tool")).toBe("generic")
   })
 


### PR DESCRIPTION
## Summary

Adds focused regression coverage that both the canonical `patch` tool name and legacy `apply_patch` transcripts select the structured patch diff renderer.

The implementation landed concurrently in `5db320b02d` while #35809 was being investigated. This PR locks down the compatibility behavior.

Closes #35809.

## Verification

- `bun run test test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- `bun typecheck` from `packages/tui`
- repository pre-push typecheck