### PR TITLE
fix(core): provide PluginHooks in plugin test layer

### DIFF
--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -47,6 +47,7 @@ export const PluginTestLayer = AppNodeBuilder.build(
     CommandV2.node,
     Integration.node,
     PluginRuntime.node,
+    PluginHooks.node,
     Reference.node,
     SkillV2.node,
     ToolHooks.node,


### PR DESCRIPTION
## Summary
- add `PluginHooks.node` to `PluginTestLayer`
- fixes CI failures where `PluginHost.make` required `@opencode/v2/PluginHooks`

## Testing
- `bun test test/plugin/provider-gitlab.test.ts test/plugin.test.ts test/plugin/promise.test.ts test/plugin/provider-openai.test.ts` in `packages/core`