### PR TITLE
fix(tui): prevent stale shell counts

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -114,6 +114,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     const sessionRefreshApplied = new Map<string, number>()
     const sessionUsage = new Map<string, { generation: number; cost: number; tokens: SessionV2Info["tokens"] }>()
     let connectionGeneration = 0
+    let shellGeneration = 0
     let statusChanges: Set<string> | undefined
     let bootstrapping: Promise<void> | undefined
 
@@ -758,6 +759,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           )
           break
         case "shell.created":
+          shellGeneration++
           setStore("location", locationKey(event.location ?? defaultLocation()), (data) => ({
             ...data,
             shell: { ...data?.shell, [event.data.info.id]: event.data.info },
@@ -765,6 +767,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
           break
         case "shell.exited":
         case "shell.deleted":
+          shellGeneration++
           if (event.location) {
             setStore("location", locationKey(event.location), (data) => ({
               ...data,
@@ -932,12 +935,14 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             .map((data) => data.shell?.[id])
             .find((shell) => shell !== undefined)
         },
-        async refresh(ref?: LocationRef) {
-          const result = await sdk.api.shell.list({ location: locationQuery(ref) })
-          const key = locationKey(result.location)
+        async refresh(ref?: LocationRef): Promise<void> {
+          const generation = shellGeneration
+          const response = await sdk.api.shell.list({ location: locationQuery(ref) })
+          if (generation !== shellGeneration) return result.shell.refresh(ref)
+          const key = locationKey(response.location)
           setStore("location", key, {
             ...store.location[key],
-            shell: Object.fromEntries(mutable(result.data).map((info) => [info.id, info])),
+            shell: Object.fromEntries(mutable(response.data).map((info) => [info.id, info])),
           })
         },
       },

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -9,7 +9,7 @@ import { ProjectProvider } from "../../../src/context/project"
 import { SDKProvider } from "../../../src/context/sdk"
 import { DataProvider, useData } from "../../../src/context/data"
 import { createSessionRows, type SessionRow } from "../../../src/routes/session/rows"
-import { createApi, createClient, createEventStream, createFetch, directory, json } from "../../fixture/tui-sdk"
+import { createApi, createClient, createEventStream, createFetch, directory, json, worktree } from "../../fixture/tui-sdk"
 import { TestTuiContexts } from "../../fixture/tui-environment"
 
 async function wait(fn: () => boolean, timeout = 2000) {
@@ -1447,6 +1447,66 @@ test("keeps shell state scoped to location", async () => {
     })
     await wait(() => data.shell.list({ directory: other }).some((shell) => shell.id === "sh_live_other"))
     expect(data.shell.list().map((shell) => shell.id)).toEqual(["sh_default"])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("retries a shell refresh when a lifecycle event races its response", async () => {
+  const events = createEventStream()
+  let requests = 0
+  let resolveFirst!: (response: Response) => void
+  const first = new Promise<Response>((resolve) => {
+    resolveFirst = resolve
+  })
+  const location = { directory, project: { id: "proj_test", directory: worktree } }
+  const shell = {
+    id: "sh_stale",
+    status: "running" as const,
+    command: "bun test",
+    cwd: directory,
+    shell: "/bin/sh",
+    file: "/tmp/opencode-shell",
+    metadata: { sessionID: "ses_default" },
+    time: { started: 1 },
+  }
+  const calls = createFetch((url) => {
+    if (url.pathname !== "/api/shell") return
+    requests++
+    if (requests === 1) return first
+    return json({ location, data: [] })
+  }, events)
+  let data!: ReturnType<typeof useData>
+
+  function Probe() {
+    data = useData()
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <SDKProvider client={createClient(calls.fetch)} api={createApi(calls.fetch)}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </SDKProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await wait(() => requests === 1)
+    emitEvent(events, {
+      id: "evt_shell_exited",
+      created: 0,
+      type: "shell.exited",
+      data: { id: "sh_stale", exit: 0, status: "exited" },
+    })
+    resolveFirst(json({ location, data: [shell] }))
+
+    await wait(() => requests === 2)
+    expect(data.shell.list()).toEqual([])
   } finally {
     app.renderer.destroy()
   }


### PR DESCRIPTION
## Summary

- retry shell snapshot refreshes when lifecycle events arrive in flight
- prevent an older HTTP response from restoring shells that already exited
- cover the startup race with a regression test

## Root cause

The TUI stores running shells from both the live event stream and `/api/shell`. During startup, a `shell.exited` event could arrive before an older shell-list response completed. The event removed the shell, then the stale response inserted it again, leaving a phantom running-shell count until reconnect.

## Verification

- `bun run test test/cli/tui/data.test.tsx`
- `bun typecheck` in `packages/tui`
- full pre-push workspace typecheck