### PR TITLE
fix(desktop): apply stale remote session fallback on all platforms

### DIFF
--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -90,13 +90,12 @@ function getLastActiveUrl(windowID: string) {
   if (typeof localStorage !== "object") return "/"
   try {
     const value = localStorage.getItem(windowLastActiveUrlKey(windowID))
-    if (value?.startsWith("/") && !value.startsWith("//") && !isStaleWindowsRemoteSessionUrl(value)) return value
+    if (value?.startsWith("/") && !value.startsWith("//") && !isStaleRemoteSessionUrl(value)) return value
   } catch {}
   return "/"
 }
 
-function isStaleWindowsRemoteSessionUrl(value: string) {
-  if (!navigator.userAgent.includes("Windows")) return false
+function isStaleRemoteSessionUrl(value: string) {
   const match = value.match(/^\/([^/]+)\/session(?:\/|$)/)
   if (!match) return false
   const directory = decodeRouteSegment(match[1])

--- a/packages/desktop/src/renderer/index.tsx
+++ b/packages/desktop/src/renderer/index.tsx
@@ -90,9 +90,26 @@ function getLastActiveUrl(windowID: string) {
   if (typeof localStorage !== "object") return "/"
   try {
     const value = localStorage.getItem(windowLastActiveUrlKey(windowID))
-    if (value?.startsWith("/") && !value.startsWith("//")) return value
+    if (value?.startsWith("/") && !value.startsWith("//") && !isStaleWindowsRemoteSessionUrl(value)) return value
   } catch {}
   return "/"
+}
+
+function isStaleWindowsRemoteSessionUrl(value: string) {
+  if (!navigator.userAgent.includes("Windows")) return false
+  const match = value.match(/^\/([^/]+)\/session(?:\/|$)/)
+  if (!match) return false
+  const directory = decodeRouteSegment(match[1])
+  return directory?.startsWith("/") ?? false
+}
+
+function decodeRouteSegment(value: string) {
+  try {
+    const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/"))
+    return new TextDecoder().decode(Uint8Array.from(binary, (char) => char.charCodeAt(0)))
+  } catch {
+    return undefined
+  }
 }
 
 function setLastActiveUrl(windowID: string, value: string) {


### PR DESCRIPTION
### Issue for this PR

Closes #25131
Closes #32473

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #35790 added stale remote session URL detection to prevent the desktop app from crashing on startup when the persisted last-active URL references a session that no longer exists. However, it only applied the fix on Windows (gated by `navigator.userAgent.includes("Windows")`).

The same crash happens on macOS and Linux when switching between remote servers — the localStorage retains a session URL from the previous server, and the new server returns 404.

This PR removes the Windows-only guard so `getLastActiveUrl()` falls back to `/` (home) on all platforms when a stale remote session URL pattern is detected.

### How did you verify your code works?

- Built the desktop app locally on macOS (Apple Silicon)
- Launched with a stale remote session URL in localStorage
- Confirmed it falls back to home instead of crashing with NotFoundError
- Typecheck passes (`bun typecheck`)

### Screenshots / recordings

_N/A — no UI change, crash prevention only._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR