### PR TITLE
test(core): add request-driven runner scenarios

### DIFF
--- a/packages/core/test/lib/runner-scenario.ts
+++ b/packages/core/test/lib/runner-scenario.ts
@@ -14,9 +14,9 @@ class RunnerEndedError extends Error {
   }
 }
 
-class RunnerScenarioUsedError extends Error {
+class RunnerScenarioActiveError extends Error {
   constructor() {
-    super("RunnerScenario.run may only be called once")
+    super("RunnerScenario.run is already active")
   }
 }
 
@@ -48,29 +48,41 @@ export interface RunnerLLMCall {
   }
 }
 
+interface CallState {
+  readonly generation: number
+  readonly status: "pending" | "responded" | "closed"
+}
+
 interface State {
-  readonly started: boolean
   readonly accepting: boolean
-  readonly ended: boolean
+  readonly active: number | undefined
+  readonly nextGeneration: number
   readonly nextID: number
-  readonly calls: ReadonlyMap<number, "pending" | "responded" | "closed">
+  readonly calls: ReadonlyMap<number, CallState>
   readonly requests: ReadonlyArray<LLMRequest>
 }
 
 type Registration =
-  | { readonly _tag: "Registered"; readonly id: number }
+  | { readonly _tag: "Registered"; readonly id: number; readonly generation: number }
   | { readonly _tag: "Unexpected"; readonly error: Error }
 
 interface PendingCall {
+  readonly _tag: "Call"
+  readonly generation: number
   readonly id: number
   readonly call: RunnerLLMCall
 }
 
+interface RunnerEnd {
+  readonly _tag: "End"
+  readonly generation: number
+}
+
 interface RunnerLLMInternal {
   readonly llm: RunnerLLM
-  readonly begin: Effect.Effect<void, RunnerScenarioUsedError>
-  readonly finishInteraction: Effect.Effect<void, Error>
-  readonly end: Effect.Effect<void>
+  readonly begin: Effect.Effect<number, RunnerScenarioActiveError>
+  readonly finishInteraction: (generation: number) => Effect.Effect<void, Error>
+  readonly end: (generation: number) => Effect.Effect<void>
 }
 
 export interface RunnerLLM {
@@ -115,11 +127,11 @@ const toolCall = (
 }
 
 const makeRunnerLLM = Effect.gen(function* () {
-  const calls = yield* Queue.unbounded<PendingCall, Cause.Done>()
+  const calls = yield* Queue.unbounded<PendingCall | RunnerEnd>()
   const state = yield* Ref.make<State>({
-    started: false,
     accepting: false,
-    ended: false,
+    active: undefined,
+    nextGeneration: 1,
     nextID: 1,
     calls: new Map(),
     requests: [],
@@ -133,8 +145,9 @@ const makeRunnerLLM = Effect.gen(function* () {
     Effect.uninterruptible(
       Effect.gen(function* () {
         const pending = yield* Ref.modify(state, (current) => {
-          if (current.calls.get(id) !== "pending") return [false, current]
-          return [true, { ...current, calls: new Map(current.calls).set(id, "responded") }]
+          const call = current.calls.get(id)
+          if (call?.status !== "pending") return [false, current]
+          return [true, { ...current, calls: new Map(current.calls).set(id, { ...call, status: "responded" }) }]
         })
         if (!pending) return yield* Effect.fail(new RunnerLLMResponseClosedError(id))
         yield* Deferred.succeed(response, stream)
@@ -147,7 +160,7 @@ const makeRunnerLLM = Effect.gen(function* () {
         Effect.gen(function* () {
           const response = yield* Deferred.make<Stream.Stream<LLMEvent, LLMError>>()
           const registered = yield* Ref.modify<State, Registration>(state, (current) => {
-            if (!current.accepting) {
+            if (!current.accepting || current.active === undefined) {
               const error = new RunnerLLMRequestError(current.nextID)
               return [
                 { _tag: "Unexpected" as const, error },
@@ -155,11 +168,14 @@ const makeRunnerLLM = Effect.gen(function* () {
               ]
             }
             return [
-              { _tag: "Registered" as const, id: current.nextID },
+              { _tag: "Registered" as const, id: current.nextID, generation: current.active },
               {
                 ...current,
                 nextID: current.nextID + 1,
-                calls: new Map(current.calls).set(current.nextID, "pending"),
+                calls: new Map(current.calls).set(current.nextID, {
+                  generation: current.active,
+                  status: "pending",
+                }),
                 requests: [...current.requests, request],
               },
             ]
@@ -167,6 +183,8 @@ const makeRunnerLLM = Effect.gen(function* () {
           if (registered._tag === "Unexpected") return yield* Effect.fail(registered.error)
           const reply = (stream: Stream.Stream<LLMEvent, LLMError>) => respond(registered.id, response, stream)
           yield* Queue.offer(calls, {
+            _tag: "Call",
+            generation: registered.generation,
             id: registered.id,
             call: {
               request,
@@ -182,11 +200,11 @@ const makeRunnerLLM = Effect.gen(function* () {
           })
           return yield* restore(Deferred.await(response)).pipe(
             Effect.onInterrupt(() =>
-              Ref.update(state, (current) =>
-                current.calls.get(registered.id) === "pending"
-                  ? { ...current, calls: new Map(current.calls).set(registered.id, "closed") }
-                  : current,
-              ),
+              Ref.update(state, (current) => {
+                const call = current.calls.get(registered.id)
+                if (call?.status !== "pending") return current
+                return { ...current, calls: new Map(current.calls).set(registered.id, { ...call, status: "closed" }) }
+              }),
             ),
           )
         }),
@@ -195,11 +213,12 @@ const makeRunnerLLM = Effect.gen(function* () {
 
   const next = (): Effect.Effect<RunnerLLMCall, Error> =>
     Effect.gen(function* () {
-      if ((yield* Ref.get(state)).ended) return yield* Effect.fail(new RunnerEndedError())
-      const pending = yield* Queue.take(calls).pipe(Effect.mapError(() => new RunnerEndedError()))
-      const current = yield* Ref.get(state)
-      if (current.ended) return yield* Effect.fail(new RunnerEndedError())
-      if (current.calls.get(pending.id) === "pending") return pending.call
+      const generation = (yield* Ref.get(state)).active
+      if (generation === undefined) return yield* Effect.fail(new RunnerEndedError())
+      const pending = yield* Queue.take(calls)
+      if (pending.generation !== generation) return yield* next()
+      if (pending._tag === "End") return yield* Effect.fail(new RunnerEndedError())
+      if ((yield* Ref.get(state)).calls.get(pending.id)?.status === "pending") return pending.call
       return yield* next()
     })
 
@@ -216,22 +235,44 @@ const makeRunnerLLM = Effect.gen(function* () {
       next,
       requests: Ref.get(state).pipe(Effect.map((state) => state.requests)),
     },
-    begin: Ref.modify<State, Effect.Effect<void, RunnerScenarioUsedError>>(state, (current) =>
-      current.started
-        ? [Effect.fail(new RunnerScenarioUsedError()), current]
-        : [Effect.void, { ...current, started: true, accepting: true }],
+    begin: Ref.modify<State, Effect.Effect<number, RunnerScenarioActiveError>>(state, (current) =>
+      current.active !== undefined
+        ? [Effect.fail(new RunnerScenarioActiveError()), current]
+        : [
+            Effect.succeed(current.nextGeneration),
+            {
+              ...current,
+              accepting: true,
+              active: current.nextGeneration,
+              nextGeneration: current.nextGeneration + 1,
+            },
+          ],
     ).pipe(Effect.flatten),
-    finishInteraction: Effect.gen(function* () {
-      const unanswered = yield* Ref.modify(state, (current) => [
-        [...current.calls].find(([, status]) => status === "pending")?.[0],
-        { ...current, accepting: false },
-      ])
-      if (unanswered !== undefined) return yield* Effect.fail(new RunnerLLMRequestError(unanswered))
-    }),
-    end: Effect.gen(function* () {
-      yield* Ref.update(state, (current) => ({ ...current, accepting: false, ended: true }))
-      yield* Queue.end(calls)
-    }),
+    finishInteraction: (generation) =>
+      Effect.gen(function* () {
+        const unanswered = yield* Ref.modify(state, (current) => [
+          [...current.calls].find(([, call]) => call.generation === generation && call.status === "pending")?.[0],
+          current.active === generation ? { ...current, accepting: false } : current,
+        ])
+        if (unanswered !== undefined) return yield* Effect.fail(new RunnerLLMRequestError(unanswered))
+      }),
+    end: (generation) =>
+      Effect.gen(function* () {
+        yield* Ref.update(state, (current) => ({
+          ...current,
+          accepting: current.active === generation ? false : current.accepting,
+          active: current.active === generation ? undefined : current.active,
+          calls: new Map(
+            [...current.calls].map(([id, call]) => [
+              id,
+              call.generation === generation && call.status === "pending"
+                ? { ...call, status: "closed" as const }
+                : call,
+            ]),
+          ),
+        }))
+        yield* Queue.offer(calls, { _tag: "End", generation })
+      }),
   } satisfies RunnerLLMInternal
 })
 
@@ -253,13 +294,13 @@ export namespace RunnerScenario {
       ): Effect.Effect<A, RunError | E | Error, RunRequirements | R> =>
         Effect.uninterruptibleMask((restore) =>
           Effect.gen(function* () {
-            yield* internal.begin
-            const runner = yield* start(internal.llm).pipe(Effect.ensuring(internal.end), Effect.forkChild)
+            const generation = yield* internal.begin
+            const runner = yield* start(internal.llm).pipe(Effect.ensuring(internal.end(generation)), Effect.forkChild)
             return yield* restore(
               Effect.gen(function* () {
                 const interactionExit = yield* Effect.gen(interaction).pipe(Effect.exit)
                 if (Exit.isSuccess(interactionExit)) {
-                  yield* internal.finishInteraction
+                  yield* internal.finishInteraction(generation)
                   yield* Fiber.join(runner)
                   return interactionExit.value
                 }
@@ -267,7 +308,7 @@ export namespace RunnerScenario {
                 if (Option.isSome(error) && error.value instanceof RunnerEndedError) yield* Fiber.join(runner)
                 return yield* Effect.failCause(interactionExit.cause)
               }),
-            ).pipe(Effect.ensuring(Fiber.interrupt(runner).pipe(Effect.andThen(internal.end))))
+            ).pipe(Effect.ensuring(Fiber.interrupt(runner).pipe(Effect.andThen(internal.end(generation)))))
           }),
         )
       return {

--- a/packages/core/test/lib/runner-scenario.ts
+++ b/packages/core/test/lib/runner-scenario.ts
@@ -1,0 +1,278 @@
+import {
+  LLMClient,
+  LLMEvent,
+  type LLMClientShape,
+  type LLMClientService,
+  type LLMError,
+  type LLMRequest,
+} from "@opencode-ai/llm"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Option, Queue, Ref, Stream } from "effect"
+
+class RunnerEndedError extends Error {
+  constructor() {
+    super("Runner completed before the next LLM request")
+  }
+}
+
+class RunnerScenarioUsedError extends Error {
+  constructor() {
+    super("RunnerScenario.run may only be called once")
+  }
+}
+
+class RunnerLLMRequestError extends Error {
+  constructor(readonly id: number) {
+    super(`Runner LLM request #${id} was not handled by the interaction`)
+  }
+}
+
+class RunnerLLMResponseClosedError extends Error {
+  constructor(readonly id: number) {
+    super(`Runner LLM request #${id} is no longer awaiting a response`)
+  }
+}
+
+export interface RunnerLLMCall {
+  readonly request: LLMRequest
+  readonly respond: {
+    readonly stop: () => Effect.Effect<void, Error>
+    readonly text: (text: string, options?: { readonly id?: string }) => Effect.Effect<void, Error>
+    readonly toolCall: (
+      name: string,
+      input: unknown,
+      options?: { readonly id?: string; readonly providerExecuted?: boolean },
+    ) => Effect.Effect<void, Error>
+    readonly events: (...events: ReadonlyArray<LLMEvent>) => Effect.Effect<void, Error>
+    readonly stream: (stream: Stream.Stream<LLMEvent, LLMError>) => Effect.Effect<void, Error>
+    readonly fail: (error: LLMError) => Effect.Effect<void, Error>
+  }
+}
+
+interface State {
+  readonly started: boolean
+  readonly accepting: boolean
+  readonly ended: boolean
+  readonly nextID: number
+  readonly calls: ReadonlyMap<number, "pending" | "responded" | "closed">
+  readonly requests: ReadonlyArray<LLMRequest>
+}
+
+type Registration =
+  | { readonly _tag: "Registered"; readonly id: number }
+  | { readonly _tag: "Unexpected"; readonly error: Error }
+
+interface PendingCall {
+  readonly id: number
+  readonly call: RunnerLLMCall
+}
+
+interface RunnerLLMInternal {
+  readonly llm: RunnerLLM
+  readonly begin: Effect.Effect<void, RunnerScenarioUsedError>
+  readonly finishInteraction: Effect.Effect<void, Error>
+  readonly end: Effect.Effect<void>
+}
+
+export interface RunnerLLM {
+  readonly layer: Layer.Layer<LLMClientService>
+  readonly next: () => Effect.Effect<RunnerLLMCall, Error>
+  readonly requests: Effect.Effect<ReadonlyArray<LLMRequest>>
+}
+
+const events = (...events: ReadonlyArray<LLMEvent>) => Stream.fromIterable(events)
+
+const stop = () =>
+  events(
+    LLMEvent.stepStart({ index: 0 }),
+    LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+    LLMEvent.finish({ reason: "stop" }),
+  )
+
+const text = (value: string, options?: { readonly id?: string }) => {
+  const id = options?.id ?? "text"
+  return events(
+    LLMEvent.stepStart({ index: 0 }),
+    LLMEvent.textStart({ id }),
+    LLMEvent.textDelta({ id, text: value }),
+    LLMEvent.textEnd({ id }),
+    LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+    LLMEvent.finish({ reason: "stop" }),
+  )
+}
+
+const toolCall = (
+  name: string,
+  input: unknown,
+  options?: { readonly id?: string; readonly providerExecuted?: boolean },
+) => {
+  const id = options?.id ?? `call-${name}`
+  return events(
+    LLMEvent.stepStart({ index: 0 }),
+    LLMEvent.toolCall({ id, name, input, providerExecuted: options?.providerExecuted }),
+    LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+    LLMEvent.finish({ reason: "tool-calls" }),
+  )
+}
+
+const makeRunnerLLM = Effect.gen(function* () {
+  const calls = yield* Queue.unbounded<PendingCall, Cause.Done>()
+  const state = yield* Ref.make<State>({
+    started: false,
+    accepting: false,
+    ended: false,
+    nextID: 1,
+    calls: new Map(),
+    requests: [],
+  })
+
+  const respond = (
+    id: number,
+    response: Deferred.Deferred<Stream.Stream<LLMEvent, LLMError>>,
+    stream: Stream.Stream<LLMEvent, LLMError>,
+  ) =>
+    Effect.uninterruptible(
+      Effect.gen(function* () {
+        const pending = yield* Ref.modify(state, (current) => {
+          if (current.calls.get(id) !== "pending") return [false, current]
+          return [true, { ...current, calls: new Map(current.calls).set(id, "responded") }]
+        })
+        if (!pending) return yield* Effect.fail(new RunnerLLMResponseClosedError(id))
+        yield* Deferred.succeed(response, stream)
+      }),
+    )
+
+  const stream = (request: LLMRequest) =>
+    Stream.unwrap(
+      Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          const response = yield* Deferred.make<Stream.Stream<LLMEvent, LLMError>>()
+          const registered = yield* Ref.modify<State, Registration>(state, (current) => {
+            if (!current.accepting) {
+              const error = new RunnerLLMRequestError(current.nextID)
+              return [
+                { _tag: "Unexpected" as const, error },
+                { ...current, nextID: current.nextID + 1, requests: [...current.requests, request] },
+              ]
+            }
+            return [
+              { _tag: "Registered" as const, id: current.nextID },
+              {
+                ...current,
+                nextID: current.nextID + 1,
+                calls: new Map(current.calls).set(current.nextID, "pending"),
+                requests: [...current.requests, request],
+              },
+            ]
+          })
+          if (registered._tag === "Unexpected") return yield* Effect.fail(registered.error)
+          const reply = (stream: Stream.Stream<LLMEvent, LLMError>) => respond(registered.id, response, stream)
+          yield* Queue.offer(calls, {
+            id: registered.id,
+            call: {
+              request,
+              respond: {
+                stop: () => reply(stop()),
+                text: (value, options) => reply(text(value, options)),
+                toolCall: (name, input, options) => reply(toolCall(name, input, options)),
+                events: (...input) => reply(events(...input)),
+                stream: reply,
+                fail: (error) => reply(Stream.fail(error)),
+              },
+            },
+          })
+          return yield* restore(Deferred.await(response)).pipe(
+            Effect.onInterrupt(() =>
+              Ref.update(state, (current) =>
+                current.calls.get(registered.id) === "pending"
+                  ? { ...current, calls: new Map(current.calls).set(registered.id, "closed") }
+                  : current,
+              ),
+            ),
+          )
+        }),
+      ),
+    )
+
+  const next = (): Effect.Effect<RunnerLLMCall, Error> =>
+    Effect.gen(function* () {
+      if ((yield* Ref.get(state)).ended) return yield* Effect.fail(new RunnerEndedError())
+      const pending = yield* Queue.take(calls).pipe(Effect.mapError(() => new RunnerEndedError()))
+      const current = yield* Ref.get(state)
+      if (current.ended) return yield* Effect.fail(new RunnerEndedError())
+      if (current.calls.get(pending.id) === "pending") return pending.call
+      return yield* next()
+    })
+
+  return {
+    llm: {
+      layer: Layer.succeed(
+        LLMClient.Service,
+        LLMClient.Service.of({
+          prepare: () => Effect.die("RunnerLLM.prepare is not implemented"),
+          stream: stream as LLMClientShape["stream"],
+          generate: () => Effect.die("RunnerLLM.generate is not implemented"),
+        }),
+      ),
+      next,
+      requests: Ref.get(state).pipe(Effect.map((state) => state.requests)),
+    },
+    begin: Ref.modify<State, Effect.Effect<void, RunnerScenarioUsedError>>(state, (current) =>
+      current.started
+        ? [Effect.fail(new RunnerScenarioUsedError()), current]
+        : [Effect.void, { ...current, started: true, accepting: true }],
+    ).pipe(Effect.flatten),
+    finishInteraction: Effect.gen(function* () {
+      const unanswered = yield* Ref.modify(state, (current) => [
+        [...current.calls].find(([, status]) => status === "pending")?.[0],
+        { ...current, accepting: false },
+      ])
+      if (unanswered !== undefined) return yield* Effect.fail(new RunnerLLMRequestError(unanswered))
+    }),
+    end: Effect.gen(function* () {
+      yield* Ref.update(state, (current) => ({ ...current, accepting: false, ended: true }))
+      yield* Queue.end(calls)
+    }),
+  } satisfies RunnerLLMInternal
+})
+
+export interface RunnerScenario<RunError, RunRequirements> {
+  readonly llm: RunnerLLM
+  readonly run: <A, E, R>(
+    interaction: () => Effect.gen.Return<A, E, R>,
+  ) => Effect.Effect<A, RunError | E | Error, RunRequirements | R>
+}
+
+export namespace RunnerScenario {
+  export const make = <RunResult, RunError, RunRequirements>(
+    start: (llm: RunnerLLM) => Effect.Effect<RunResult, RunError, RunRequirements>,
+  ): Effect.Effect<RunnerScenario<RunError, RunRequirements>> =>
+    Effect.gen(function* () {
+      const internal = yield* makeRunnerLLM
+      const run = <A, E, R>(
+        interaction: () => Effect.gen.Return<A, E, R>,
+      ): Effect.Effect<A, RunError | E | Error, RunRequirements | R> =>
+        Effect.uninterruptibleMask((restore) =>
+          Effect.gen(function* () {
+            yield* internal.begin
+            const runner = yield* start(internal.llm).pipe(Effect.ensuring(internal.end), Effect.forkChild)
+            return yield* restore(
+              Effect.gen(function* () {
+                const interactionExit = yield* Effect.gen(interaction).pipe(Effect.exit)
+                if (Exit.isSuccess(interactionExit)) {
+                  yield* internal.finishInteraction
+                  yield* Fiber.join(runner)
+                  return interactionExit.value
+                }
+                const error = Cause.findErrorOption(interactionExit.cause)
+                if (Option.isSome(error) && error.value instanceof RunnerEndedError) yield* Fiber.join(runner)
+                return yield* Effect.failCause(interactionExit.cause)
+              }),
+            ).pipe(Effect.ensuring(Fiber.interrupt(runner).pipe(Effect.andThen(internal.end))))
+          }),
+        )
+      return {
+        llm: internal.llm,
+        run,
+      }
+    })
+}

--- a/packages/core/test/runner-scenario.test.ts
+++ b/packages/core/test/runner-scenario.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect } from "bun:test"
+import { LLM, LLMError, LLMEvent, Model, TransportReason } from "@opencode-ai/llm"
+import * as OpenAIChat from "@opencode-ai/llm/protocols/openai-chat"
+import { Deferred, Effect, Fiber, Stream } from "effect"
+import { it } from "./lib/effect"
+import { RunnerScenario } from "./lib/runner-scenario"
+
+const model = Model.make({ id: "fake-model", provider: "fake", route: OpenAIChat.route })
+const request = (text: string) => LLM.request({ model, prompt: text })
+const textOf = (events: ReadonlyArray<LLMEvent>) => events.filter(LLMEvent.is.textDelta).map((event) => event.text)
+
+describe("RunnerScenario", () => {
+  it.effect("drives provider requests in execution order", () =>
+    Effect.gen(function* () {
+      const output: LLMEvent[][] = []
+      const scenario = yield* RunnerScenario.make((llm) =>
+        Effect.gen(function* () {
+          output.push(Array.from(yield* LLM.stream(request("Echo this")).pipe(Stream.runCollect)))
+          output.push(Array.from(yield* LLM.stream(request("Continue")).pipe(Stream.runCollect)))
+        }).pipe(Effect.provide(llm.layer)),
+      )
+
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(first.request.messages[0]?.content).toEqual([{ type: "text", text: "Echo this" }])
+        yield* first.respond.toolCall("echo", { text: "hello" })
+
+        const second = yield* scenario.llm.next()
+        expect(second.request.messages[0]?.content).toEqual([{ type: "text", text: "Continue" }])
+        yield* second.respond.text("Done")
+      })
+
+      expect(output[0]?.find(LLMEvent.is.toolCall)).toMatchObject({ name: "echo", input: { text: "hello" } })
+      expect(textOf(output[1] ?? [])).toEqual(["Done"])
+    }),
+  )
+
+  it.effect("pauses the runner until the pending request receives a response", () =>
+    Effect.gen(function* () {
+      const completed = yield* Deferred.make<void>()
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Wait")).pipe(
+          Stream.runDrain,
+          Effect.andThen(Deferred.succeed(completed, undefined)),
+          Effect.provide(llm.layer),
+        ),
+      )
+
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(Deferred.isDoneUnsafe(completed)).toBe(false)
+        yield* call.respond.stop()
+      })
+
+      expect(Deferred.isDoneUnsafe(completed)).toBe(true)
+    }),
+  )
+
+  it.effect("accepts raw failing streams for lifecycle edge cases", () =>
+    Effect.gen(function* () {
+      const failure = new LLMError({
+        module: "test",
+        method: "stream",
+        reason: new TransportReason({ message: "unavailable" }),
+      })
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Fail")).pipe(Stream.runDrain, Effect.provide(llm.layer)),
+      )
+
+      expect(
+        yield* scenario
+          .run(function* () {
+            const call = yield* scenario.llm.next()
+            yield* call.respond.stream(
+              Stream.concat(Stream.make(LLMEvent.stepStart({ index: 0 })), Stream.fail(failure)),
+            )
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
+    }),
+  )
+
+  it.effect("fails when an interaction leaves a request unanswered", () =>
+    Effect.gen(function* () {
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Wait")).pipe(Stream.runDrain, Effect.provide(llm.layer)),
+      )
+
+      const failure = yield* scenario
+        .run(function* () {
+          yield* scenario.llm.next()
+        })
+        .pipe(Effect.flip)
+
+      expect(failure).toMatchObject({ message: "Runner LLM request #1 was not handled by the interaction" })
+    }),
+  )
+
+  it.effect("fails when the runner starts another request before the interaction finishes", () =>
+    Effect.gen(function* () {
+      const scenario = yield* RunnerScenario.make((llm) =>
+        Effect.gen(function* () {
+          yield* LLM.stream(request("First")).pipe(Stream.runDrain)
+          yield* LLM.stream(request("Unexpected")).pipe(Stream.runDrain)
+        }).pipe(Effect.provide(llm.layer)),
+      )
+
+      const failure = yield* scenario
+        .run(function* () {
+          const call = yield* scenario.llm.next()
+          yield* call.respond.stop()
+        })
+        .pipe(Effect.flip)
+
+      expect(failure).toMatchObject({ message: "Runner LLM request #2 was not handled by the interaction" })
+    }),
+  )
+
+  it.effect("rejects a second response to the same request", () =>
+    Effect.gen(function* () {
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Once")).pipe(Stream.runDrain, Effect.provide(llm.layer)),
+      )
+      let duplicate: Error | undefined
+
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        yield* call.respond.stop()
+        duplicate = yield* call.respond.stop().pipe(Effect.flip, Effect.orDie)
+      })
+      expect(duplicate?.message).toBe("Runner LLM request #1 is no longer awaiting a response")
+    }),
+  )
+
+  it.effect("does not wait for the runner after a duplicate response", () =>
+    Effect.gen(function* () {
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Once")).pipe(Stream.runDrain, Effect.andThen(Effect.never), Effect.provide(llm.layer)),
+      )
+
+      expect(
+        yield* scenario
+          .run(function* () {
+            const call = yield* scenario.llm.next()
+            yield* call.respond.stop()
+            yield* call.respond.stop()
+          })
+          .pipe(Effect.flip),
+      ).toMatchObject({ message: "Runner LLM request #1 is no longer awaiting a response" })
+    }),
+  )
+
+  it.effect("surfaces a runner failure while waiting for its next request", () =>
+    Effect.gen(function* () {
+      const failure = new Error("runner failed")
+      const scenario = yield* RunnerScenario.make(() => Effect.fail<Error>(failure))
+
+      expect(
+        yield* scenario
+          .run(function* () {
+            yield* scenario.llm.next()
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
+    }),
+  )
+
+  it.effect("preserves a runner failure when its pending request closes", () =>
+    Effect.gen(function* () {
+      const fail = yield* Deferred.make<void>()
+      const closed = yield* Deferred.make<void>()
+      const failure = new Error("runner failed")
+      const scenario = yield* RunnerScenario.make((llm) =>
+        Effect.raceFirst(
+          LLM.stream(request("Fail pending")).pipe(
+            Stream.runDrain,
+            Effect.ensuring(Deferred.succeed(closed, undefined)),
+          ),
+          Deferred.await(fail).pipe(Effect.andThen(Effect.fail(failure))),
+        ).pipe(Effect.provide(llm.layer)),
+      )
+
+      expect(
+        yield* scenario
+          .run(function* () {
+            const call = yield* scenario.llm.next()
+            yield* Deferred.succeed(fail, undefined)
+            yield* Deferred.await(closed)
+            expect((yield* call.respond.stop().pipe(Effect.flip)).message).toBe(
+              "Runner LLM request #1 is no longer awaiting a response",
+            )
+            yield* scenario.llm.next()
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
+    }),
+  )
+
+  it.effect("rejects a stale response after the runner closes a request", () =>
+    Effect.gen(function* () {
+      const release = yield* Deferred.make<void>()
+      const closed = yield* Deferred.make<void>()
+      const scenario = yield* RunnerScenario.make((llm) =>
+        Effect.raceFirst(
+          LLM.stream(request("Close pending")).pipe(
+            Stream.runDrain,
+            Effect.ensuring(Deferred.succeed(closed, undefined)),
+          ),
+          Deferred.await(release),
+        ).pipe(Effect.provide(llm.layer)),
+      )
+
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        yield* Deferred.succeed(release, undefined)
+        yield* Deferred.await(closed)
+        expect((yield* call.respond.stop().pipe(Effect.flip)).message).toBe(
+          "Runner LLM request #1 is no longer awaiting a response",
+        )
+      })
+    }),
+  )
+
+  it.effect("interrupts a runner that hangs after its final response", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>()
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Hang")).pipe(
+          Stream.runDrain,
+          Effect.andThen(Deferred.succeed(started, undefined)),
+          Effect.andThen(Effect.never),
+          Effect.provide(llm.layer),
+        ),
+      )
+      const run = yield* scenario
+        .run(function* () {
+          const call = yield* scenario.llm.next()
+          yield* call.respond.stop()
+        })
+        .pipe(Effect.forkChild)
+      yield* Deferred.await(started)
+
+      yield* Fiber.interrupt(run)
+
+      expect(run.pollUnsafe()).toBeDefined()
+    }),
+  )
+
+  it.effect("rejects running one scenario twice", () =>
+    Effect.gen(function* () {
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Once")).pipe(Stream.runDrain, Effect.provide(llm.layer)),
+      )
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.stop()
+      })
+      const failure = yield* scenario.run(function* (): Effect.gen.Return<void> {}).pipe(Effect.exit)
+      expect(failure._tag).toBe("Failure")
+      if (failure._tag !== "Failure") throw new Error("Expected second run to fail")
+      const error = failure.cause.reasons.find((reason) => reason._tag === "Fail")
+      expect(error?._tag).toBe("Fail")
+      if (error?._tag !== "Fail") throw new Error("Expected a typed failure")
+      expect(error.error).toMatchObject({ message: "RunnerScenario.run may only be called once" })
+    }),
+  )
+})

--- a/packages/core/test/runner-scenario.test.ts
+++ b/packages/core/test/runner-scenario.test.ts
@@ -224,11 +224,13 @@ describe("RunnerScenario", () => {
   it.effect("interrupts a runner that hangs after its final response", () =>
     Effect.gen(function* () {
       const started = yield* Deferred.make<void>()
+      const interrupted = yield* Deferred.make<void>()
       const scenario = yield* RunnerScenario.make((llm) =>
         LLM.stream(request("Hang")).pipe(
           Stream.runDrain,
           Effect.andThen(Deferred.succeed(started, undefined)),
           Effect.andThen(Effect.never),
+          Effect.onInterrupt(() => Deferred.succeed(interrupted, undefined)),
           Effect.provide(llm.layer),
         ),
       )
@@ -242,11 +244,12 @@ describe("RunnerScenario", () => {
 
       yield* Fiber.interrupt(run)
 
+      expect(Deferred.isDoneUnsafe(interrupted)).toBe(true)
       expect(run.pollUnsafe()).toBeDefined()
     }),
   )
 
-  it.effect("rejects running one scenario twice", () =>
+  it.effect("runs one scenario sequentially while retaining request history", () =>
     Effect.gen(function* () {
       const scenario = yield* RunnerScenario.make((llm) =>
         LLM.stream(request("Once")).pipe(Stream.runDrain, Effect.provide(llm.layer)),
@@ -254,13 +257,35 @@ describe("RunnerScenario", () => {
       yield* scenario.run(function* () {
         yield* (yield* scenario.llm.next()).respond.stop()
       })
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.stop()
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(2)
+    }),
+  )
+
+  it.effect("rejects concurrent runs of one scenario", () =>
+    Effect.gen(function* () {
+      const scenario = yield* RunnerScenario.make((llm) =>
+        LLM.stream(request("Once")).pipe(Stream.runDrain, Effect.provide(llm.layer)),
+      )
+      const active = yield* scenario
+        .run(function* () {
+          yield* scenario.llm.next()
+          yield* Effect.never
+        })
+        .pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+
       const failure = yield* scenario.run(function* (): Effect.gen.Return<void> {}).pipe(Effect.exit)
       expect(failure._tag).toBe("Failure")
-      if (failure._tag !== "Failure") throw new Error("Expected second run to fail")
+      if (failure._tag !== "Failure") throw new Error("Expected concurrent run to fail")
       const error = failure.cause.reasons.find((reason) => reason._tag === "Fail")
       expect(error?._tag).toBe("Fail")
       if (error?._tag !== "Fail") throw new Error("Expected a typed failure")
-      expect(error.error).toMatchObject({ message: "RunnerScenario.run may only be called once" })
+      expect(error.error).toMatchObject({ message: "RunnerScenario.run is already active" })
+      yield* Fiber.interrupt(active)
     }),
   )
 })

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2785,7 +2785,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  scenarioIt("durably settles local tool failures before continuing", (scenario) =>
+  scenarioIt("durably rejects tools unavailable for the request", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -2793,10 +2793,9 @@ describe("SessionRunnerLLM", () => {
 
       yield* scenario.run(function* () {
         yield* (yield* scenario.llm.next()).respond.toolCall("missing", {}, { id: "call-missing" })
-        yield* (yield* scenario.llm.next()).respond.text("Recovered", { id: "text-after-error" })
       })
 
-      expect(yield* scenario.llm.requests).toHaveLength(2)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Call missing" },
         {
@@ -2805,11 +2804,10 @@ describe("SessionRunnerLLM", () => {
             {
               type: "tool",
               id: "call-missing",
-              state: { status: "error", error: { message: "Unknown tool: missing" } },
+              state: { status: "error", error: { message: "Tool is not available for this request: missing" } },
             },
           ],
         },
-        { type: "assistant", finish: "stop", content: [{ type: "text", text: "Recovered" }] },
       ])
     }),
   )

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -62,9 +62,11 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { Location } from "@opencode-ai/core/location"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { Cause, DateTime, Deferred, Effect, Exit, Fiber, Layer, Schema, Stream } from "effect"
+import type { Scope } from "effect/Scope"
 import { TestClock } from "effect/testing"
 import { asc, eq } from "drizzle-orm"
-import { testEffect } from "./lib/effect"
+import { it as effectIt, testEffect } from "./lib/effect"
+import { RunnerScenario } from "./lib/runner-scenario"
 
 const requests: LLMRequest[] = []
 let response: LLMEvent[] = []
@@ -267,9 +269,9 @@ const config = Layer.succeed(
       ]),
   }),
 )
-const runnerLayer = AppNodeBuilder.build(SessionRunnerLLM.node, [
+const runnerLayerWith = (clientLayer: typeof client) => AppNodeBuilder.build(SessionRunnerLLM.node, [
   [Snapshot.node, Snapshot.noopLayer],
-  [LayerNodePlatform.llmClient, client],
+  [LayerNodePlatform.llmClient, clientLayer],
   [SessionRunnerModel.node, models],
   [InstructionBuiltIns.node, systemContext],
   [InstructionDiscovery.node, instructionContext],
@@ -281,7 +283,7 @@ const runnerLayer = AppNodeBuilder.build(SessionRunnerLLM.node, [
   [McpGuidance.node, mcpGuidance],
   [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
 ])
-const execution = Layer.effect(
+const executionWith = (runnerLayer: ReturnType<typeof runnerLayerWith>) => Layer.effect(
   SessionExecution.Service,
   Effect.gen(function* () {
     const sessionRunner = yield* SessionRunner.Service
@@ -297,8 +299,10 @@ const execution = Layer.effect(
     })
   }),
 ).pipe(Layer.provide(runnerLayer))
-const it = testEffect(
-  AppNodeBuilder.build(
+const testLayerWith = (clientLayer: typeof client) => {
+  const runnerLayer = runnerLayerWith(clientLayer)
+  const execution = executionWith(runnerLayer)
+  return AppNodeBuilder.build(
     LayerNode.group([
       Database.node,
       EventV2.node,
@@ -322,7 +326,7 @@ const it = testEffect(
       SessionV2.node,
     ]),
     [
-      [LayerNodePlatform.llmClient, client],
+      [LayerNodePlatform.llmClient, clientLayer],
       [PermissionV2.node, permission],
       [SessionRunnerModel.node, models],
       [InstructionBuiltIns.node, systemContext],
@@ -335,10 +339,26 @@ const it = testEffect(
       [Config.node, config],
       [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
     ],
-  ),
-)
+  )
+}
+const testLayer = testLayerWith(client)
+const it = testEffect(testLayer)
 const sessionID = SessionV2.ID.make("ses_runner_test")
 const otherSessionID = SessionV2.ID.make("ses_runner_other")
+const makeSessionScenario = () =>
+  RunnerScenario.make(() => SessionV2.Service.use((session) => session.resume(sessionID)))
+type SessionScenario = Effect.Success<ReturnType<typeof makeSessionScenario>>
+type TestServices = Layer.Success<typeof testLayer>
+const scenarioIt = <A, E>(
+  name: string,
+  body: (scenario: SessionScenario) => Effect.Effect<A, E, TestServices | Scope>,
+) =>
+  effectIt.effect(name, () =>
+    Effect.gen(function* () {
+      const scenario = yield* makeSessionScenario()
+      return yield* body(scenario).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
+    }),
+  )
 
 const insertSession = (id: SessionV2.ID) =>
   Effect.gen(function* () {
@@ -725,55 +745,50 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("starts a real runner turn after default prompt recording", () =>
+  scenarioIt("starts a real runner turn after default prompt recording", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
-      requests.length = 0
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = []
 
       const message = yield* session.prompt({
         sessionID,
         prompt: PromptInput.Prompt.make({ text: "Run automatically" }),
       })
-      yield* session.wait(sessionID)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
 
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.messages({ sessionID })).toMatchObject([
         { id: message.id, type: "user", text: "Run automatically" },
       ])
     }),
   )
 
-  it.effect("streams one request with registry definitions from chronological V2 user history", () =>
+  scenarioIt("streams one request with registry definitions from chronological V2 user history", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-      requests.length = 0
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = []
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.model).toBe(model)
+        expect(call.request.tools.map((tool) => tool.name)).toEqual(["echo", "defect", "storefail"])
+        expect(call.request.messages.map((message) => ({ role: message.role, content: message.content }))).toEqual([
+          { role: "user", content: [{ type: "text", text: "First" }] },
+          { role: "user", content: [{ type: "text", text: "Second" }] },
+        ])
+        yield* call.respond.events()
+      })
 
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.model).toBe(model)
-      expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(["echo", "defect", "storefail"])
-      expect(requests[0]?.messages.map((message) => ({ role: message.role, content: message.content }))).toEqual([
-        { role: "user", content: [{ type: "text", text: "First" }] },
-        { role: "user", content: [{ type: "text", text: "Second" }] },
-      ])
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.messages({ sessionID })).toHaveLength(2)
     }),
   )
 
-  it.effect("retries the first provider turn after system context becomes available", () =>
+  scenarioIt("retries the first provider turn after system context becomes available", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -786,13 +801,12 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "First" }),
         resume: false,
       })
-      requests.length = 0
 
       const exit = yield* session.resume(sessionID).pipe(Effect.exit)
 
       expect(Exit.isFailure(exit)).toBe(true)
       if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Instructions.InitializationBlocked)
-      expect(requests).toHaveLength(0)
+      expect(yield* scenario.llm.requests).toHaveLength(0)
       expect(yield* SessionInput.hasPending(db, sessionID, "steer")).toBe(true)
       expect(
         yield* db
@@ -804,53 +818,59 @@ describe("SessionRunnerLLM", () => {
 
       systemUnavailable = false
       yield* session.prompt({ id: messageID, sessionID, prompt: PromptInput.Prompt.make({ text: "First" }) })
-      yield* session.wait(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user"])
+        yield* call.respond.events()
+      })
 
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.messages.map((message) => message.role)).toEqual(["user"])
+      expect(yield* scenario.llm.requests).toHaveLength(1)
     }),
   )
 
-  it.effect("interrupts a source Location runner after a Session moves", () =>
+  scenarioIt("interrupts a source Location runner after a Session moves", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       const { db } = yield* Database.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
 
-      yield* events.publish(SessionEvent.Moved, {
-        sessionID,
-        location: Location.Ref.make({ directory: AbsolutePath.make("/moved") }),
+      const exit = yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.events()
+        yield* session.wait(sessionID)
+
+        yield* events.publish(SessionEvent.Moved, {
+          sessionID,
+          location: Location.Ref.make({ directory: AbsolutePath.make("/moved") }),
+        })
+        expect(
+          yield* db
+            .select()
+            .from(InstructionCheckpointTable)
+            .where(eq(InstructionCheckpointTable.session_id, sessionID))
+            .get(),
+        ).toBeUndefined()
+
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        return yield* session.resume(sessionID).pipe(Effect.exit)
       })
-      expect(
-        yield* db
-          .select()
-          .from(InstructionCheckpointTable)
-          .where(eq(InstructionCheckpointTable.session_id, sessionID))
-          .get(),
-      ).toBeUndefined()
-
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      const exit = yield* session.resume(sessionID).pipe(Effect.exit)
 
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true)
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* SessionInput.hasPending(db, sessionID, "steer")).toBe(true)
     }),
   )
 
-  it.effect("copies the context checkpoint to a fork", () =>
+  scenarioIt("copies the context checkpoint to a fork", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const { db } = yield* Database.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
-      response = []
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
 
       const forked = yield* session.fork({ sessionID })
 
@@ -872,30 +892,32 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("heals an undecodable stored applied record by re-announcing context", () =>
+  scenarioIt("heals an undecodable stored applied record by re-announcing context", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const { db } = yield* Database.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
-      response = []
-      yield* session.resume(sessionID)
-      yield* db
-        .update(InstructionCheckpointTable)
-        .set({ snapshot: { invalid: { value: "bad" } } })
-        .where(eq(InstructionCheckpointTable.session_id, sessionID))
-        .run()
-        .pipe(Effect.orDie)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      requests.length = 0
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* db
+          .update(InstructionCheckpointTable)
+          .set({ snapshot: { invalid: { value: "bad" } } })
+          .where(eq(InstructionCheckpointTable.session_id, sessionID))
+          .run()
+          .pipe(Effect.orDie)
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      yield* session.resume(sessionID)
+        const second = yield* scenario.llm.next()
+        // Comparison state was lost, so every source re-announces as new.
+        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(second.request.messages.at(1)?.content).toEqual([{ type: "text", text: "Initial context" }])
+        yield* second.respond.events()
+      })
 
-      // Comparison state was lost, so every source re-announces as new.
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-      expect(requests[0]?.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-      expect(requests[0]?.messages.at(1)?.content).toEqual([{ type: "text", text: "Initial context" }])
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       const healed = yield* db
         .select({ snapshot: InstructionCheckpointTable.snapshot })
         .from(InstructionCheckpointTable)
@@ -906,25 +928,26 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("reuses one durable baseline after the context producer changes", () =>
+  scenarioIt("reuses one durable baseline after the context producer changes", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      systemBaseline = "Changed context"
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        systemBaseline = "Changed context"
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
-        [defaultSystem, "Initial context"],
-        [defaultSystem, "Initial context"],
-      ])
-      expect(requests[1]?.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-      expect(requests[1]?.messages.at(1)?.content).toEqual([{ type: "text", text: "Changed context" }])
+        const second = yield* scenario.llm.next()
+        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(second.request.messages.at(1)?.content).toEqual([{ type: "text", text: "Changed context" }])
+        yield* second.respond.events()
+      })
+
       expect(yield* session.messages({ sessionID })).toHaveLength(3)
       const { db } = yield* Database.Service
       expect(
@@ -940,25 +963,25 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("uses the selected model family prompt when the agent does not override it", () =>
+  scenarioIt("uses the selected model family prompt when the agent does not override it", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       currentModel = Model.make({ id: "gpt-5", provider: "openai", route: OpenAIChat.route })
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = fragmentFixture("text", "text-provider-prompt", ["Done"]).completeEvents
-      yield* session.resume(sessionID)
-
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual([
-        expect.stringContaining("You are OpenCode, You and the user share the same workspace"),
-        "Initial context",
-      ])
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([
+          expect.stringContaining("You are OpenCode, You and the user share the same workspace"),
+          "Initial context",
+        ])
+        yield* call.respond.text("Done", { id: "text-provider-prompt" })
+      })
     }),
   )
 
-  it.effect("uses the selected model family prompt when the agent system override is empty", () =>
+  scenarioIt("uses the selected model family prompt when the agent system override is empty", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       currentModel = Model.make({ id: "gpt-5", provider: "openai", route: OpenAIChat.route })
@@ -972,18 +995,18 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = fragmentFixture("text", "text-empty-agent-system", ["Done"]).completeEvents
-      yield* session.resume(sessionID)
-
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual([
-        expect.stringContaining("You are OpenCode, You and the user share the same workspace"),
-        "Initial context",
-      ])
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([
+          expect.stringContaining("You are OpenCode, You and the user share the same workspace"),
+          "Initial context",
+        ])
+        yield* call.respond.text("Done", { id: "text-empty-agent-system" })
+      })
     }),
   )
 
-  it.effect("includes the effective default agent system before durable context", () =>
+  scenarioIt("includes the effective default agent system before durable context", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const agent = yield* AgentV2.Service
@@ -996,15 +1019,15 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = fragmentFixture("text", "text-build", ["Done"]).completeEvents
-      yield* session.resume(sessionID)
-
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Build agent instructions", "Initial context"])
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual(["Build agent instructions", "Initial context"])
+        yield* call.respond.text("Done", { id: "text-build" })
+      })
     }),
   )
 
-  it.effect("uses the configured default agent system for omitted-agent sessions", () =>
+  scenarioIt("uses the configured default agent system for omitted-agent sessions", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const agent = yield* AgentV2.Service
@@ -1022,16 +1045,17 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = fragmentFixture("text", "text-reviewer", ["Done"]).completeEvents
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual(["Reviewer instructions", "Initial context"])
+        yield* call.respond.text("Done", { id: "text-reviewer" })
+      })
 
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Reviewer instructions", "Initial context"])
       expect((yield* session.messages({ sessionID }))[0]).toMatchObject({ type: "assistant", agent: "reviewer" })
     }),
   )
 
-  it.effect("uses only the agent prompt and durable baseline as system parts", () =>
+  scenarioIt("uses only the agent prompt and durable baseline as system parts", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const agent = yield* AgentV2.Service
@@ -1044,15 +1068,15 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = fragmentFixture("text", "text-no-system", ["Done"]).completeEvents
-      yield* session.resume(sessionID)
-
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Build agent instructions", "Initial context"])
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual(["Build agent instructions", "Initial context"])
+        yield* call.respond.text("Done", { id: "text-no-system" })
+      })
     }),
   )
 
-  it.effect("uses an explicitly selected non-build agent system", () =>
+  scenarioIt("uses an explicitly selected non-build agent system", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const { db } = yield* Database.Service
@@ -1072,16 +1096,17 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = fragmentFixture("text", "text-selected", ["Done"]).completeEvents
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual(["Reviewer instructions", "Initial context"])
+        yield* call.respond.text("Done", { id: "text-selected" })
+      })
 
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Reviewer instructions", "Initial context"])
       expect((yield* session.messages({ sessionID }))[0]).toMatchObject({ type: "assistant", agent: "reviewer" })
     }),
   )
 
-  it.effect("updates selected-agent skill guidance after an agent switch", () =>
+  scenarioIt("updates selected-agent skill guidance after an agent switch", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -1089,26 +1114,32 @@ describe("SessionRunnerLLM", () => {
       skillBaselines.set(AgentV2.ID.make("build"), "Build skills")
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      skillBaselines.set(AgentV2.ID.make("reviewer"), "Reviewer skills")
-      yield* events.publish(SessionEvent.AgentSelected, {
-        sessionID,
-        agent: "reviewer",
-      })
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(first.request.system.map((part) => part.text)).toEqual([
+          defaultSystem,
+          "Initial context\n\nBuild skills",
+        ])
+        skillBaselines.set(AgentV2.ID.make("reviewer"), "Reviewer skills")
+        yield* events.publish(SessionEvent.AgentSelected, {
+          sessionID,
+          agent: "reviewer",
+        })
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
-        [defaultSystem, "Initial context\n\nBuild skills"],
-        [defaultSystem, "Initial context\n\nBuild skills"],
-      ])
-      expect(systemTexts(requests[1]!)).toContainEqual(expect.stringContaining("Reviewer skills"))
+        const second = yield* scenario.llm.next()
+        expect(second.request.system.map((part) => part.text)).toEqual([
+          defaultSystem,
+          "Initial context\n\nBuild skills",
+        ])
+        expect(systemTexts(second.request)).toContainEqual(expect.stringContaining("Reviewer skills"))
+        yield* second.respond.events()
+      })
     }),
   )
 
-  it.effect("keeps the sampled agent when selection changes during observation", () =>
+  scenarioIt("keeps the sampled agent when selection changes during observation", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -1128,17 +1159,18 @@ describe("SessionRunnerLLM", () => {
       })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-
-      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
-        [defaultSystem, "Initial context\n\nBuild skills"],
-      ])
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([
+          defaultSystem,
+          "Initial context\n\nBuild skills",
+        ])
+        yield* call.respond.events()
+      })
     }),
   )
 
-  it.effect("keeps the sampled model when selection changes during model resolution", () =>
+  scenarioIt("keeps the sampled model when selection changes during model resolution", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -1156,38 +1188,40 @@ describe("SessionRunnerLLM", () => {
       })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      expect(requests.map((request) => request.model)).toEqual([model])
-      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
-        [defaultSystem, "Initial context"],
-      ])
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.model).toBe(model)
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* call.respond.events()
+      })
     }),
   )
 
-  it.effect("admits removed context as a chronological System message", () =>
+  scenarioIt("admits removed context as a chronological System message", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      systemRemoved = true
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        systemRemoved = true
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      expect(requests[1]?.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-      expect(requests[1]?.messages.at(1)?.content).toEqual([
-        { type: "text", text: "System context source removed: test/context" },
-      ])
+        const second = yield* scenario.llm.next()
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(second.request.messages.at(1)?.content).toEqual([
+          { type: "text", text: "System context source removed: test/context" },
+        ])
+        yield* second.respond.events()
+      })
+
       expect(yield* session.messages({ sessionID })).toHaveLength(3)
     }),
   )
 
-  it.effect("renders API context entries through the belief lifecycle", () =>
+  scenarioIt("renders API context entries through the belief lifecycle", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -1195,120 +1229,136 @@ describe("SessionRunnerLLM", () => {
       yield* contextEntries.put({ sessionID, key: "deploy-target", value: "production" })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        // String values render verbatim inside the tagged block at baseline.
+        expect(first.request.system.map((part) => part.text)).toEqual([
+          defaultSystem,
+          ["Initial context", "", '<context key="deploy-target">', "production", "</context>"].join("\n"),
+        ])
 
-      // String values render verbatim inside the tagged block at baseline.
-      expect(requests[0]?.system.map((part) => part.text)).toEqual([
-        defaultSystem,
-        ["Initial context", "", '<context key="deploy-target">', "production", "</context>"].join("\n"),
-      ])
+        // Non-string JSON pretty-prints; the change narrates as a System update.
+        yield* contextEntries.put({ sessionID, key: "deploy-target", value: { region: "us-east-1" } })
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      // Non-string JSON pretty-prints; the change narrates as a System update.
-      yield* contextEntries.put({ sessionID, key: "deploy-target", value: { region: "us-east-1" } })
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
+        const second = yield* scenario.llm.next()
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(second.request.messages.at(1)?.content).toEqual([
+          {
+            type: "text",
+            text: [
+              'The context under "deploy-target" changed and supersedes the previous value:',
+              '<context key="deploy-target">',
+              "{",
+              '  "region": "us-east-1"',
+              "}",
+              "</context>",
+            ].join("\n"),
+          },
+        ])
+        expect(yield* contextEntries.list(sessionID)).toEqual([
+          { key: "deploy-target", value: { region: "us-east-1" } },
+        ])
 
-      expect(requests[1]?.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-      expect(requests[1]?.messages.at(1)?.content).toEqual([
-        {
-          type: "text",
-          text: [
-            'The context under "deploy-target" changed and supersedes the previous value:',
-            '<context key="deploy-target">',
-            "{",
-            '  "region": "us-east-1"',
-            "}",
-            "</context>",
-          ].join("\n"),
-        },
-      ])
-      expect(yield* contextEntries.list(sessionID)).toEqual([{ key: "deploy-target", value: { region: "us-east-1" } }])
+        // Deleting the row announces removal through the stored removal text.
+        yield* contextEntries.remove({ sessionID, key: "deploy-target" })
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
+        yield* second.respond.events()
 
-      // Deleting the row announces removal through the stored removal text.
-      yield* contextEntries.remove({ sessionID, key: "deploy-target" })
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-      yield* session.resume(sessionID)
+        const third = yield* scenario.llm.next()
+        expect(third.request.messages.map((message) => message.role)).toEqual([
+          "user",
+          "system",
+          "user",
+          "system",
+          "user",
+        ])
+        expect(third.request.messages.at(-2)?.content).toEqual([
+          { type: "text", text: 'The context under "deploy-target" no longer applies. Disregard it.' },
+        ])
+        yield* third.respond.events()
+      })
 
-      expect(requests[2]?.messages.map((message) => message.role)).toEqual(["user", "system", "user", "system", "user"])
-      expect(requests[2]?.messages.at(-2)?.content).toEqual([
-        { type: "text", text: 'The context under "deploy-target" no longer applies. Disregard it.' },
-      ])
       expect(yield* contextEntries.list(sessionID)).toEqual([])
     }),
   )
 
-  it.effect("keeps the baseline and chronological System updates after a model switch", () =>
+  scenarioIt("keeps the baseline and chronological System updates after a model switch", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      systemBaseline = "Changed context"
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
-      yield* events.publish(SessionEvent.ModelSelected, {
-        sessionID,
-        model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
-      })
-      systemBaseline = "Replacement context"
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        systemBaseline = "Changed context"
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
-        [defaultSystem, "Initial context"],
-        [defaultSystem, "Initial context"],
-        [defaultSystem, "Initial context"],
-      ])
-      expect(requests[1]?.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-      expect(requests[2]?.messages.filter((message) => message.role === "system")).toHaveLength(2)
-      expect((yield* session.context(sessionID)).map((message) => message.type)).toEqual([
-        "user",
-        "system",
-        "user",
-        "model-switched",
-        "system",
-        "user",
-      ])
-      yield* replaySessionProjection(sessionID)
-      expect(yield* session.messages({ sessionID })).toHaveLength(6)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fourth" }), resume: false })
-      yield* session.resume(sessionID)
+        const second = yield* scenario.llm.next()
+        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        yield* events.publish(SessionEvent.ModelSelected, {
+          sessionID,
+          model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
+        })
+        systemBaseline = "Replacement context"
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
+        yield* second.respond.events()
+
+        const third = yield* scenario.llm.next()
+        expect(third.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(third.request.messages.filter((message) => message.role === "system")).toHaveLength(2)
+        expect((yield* session.context(sessionID)).map((message) => message.type)).toEqual([
+          "user",
+          "system",
+          "user",
+          "model-switched",
+          "system",
+          "user",
+        ])
+        yield* replaySessionProjection(sessionID)
+        expect(yield* session.messages({ sessionID })).toHaveLength(6)
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fourth" }), resume: false })
+        yield* third.respond.events()
+
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
     }),
   )
 
-  it.effect("preserves the baseline while context is temporarily unavailable", () =>
+  scenarioIt("preserves the baseline while context is temporarily unavailable", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      yield* events.publish(SessionEvent.ModelSelected, {
-        sessionID,
-        model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
-      })
-      systemUnavailable = true
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
-      systemUnavailable = false
-      systemBaseline = "Replacement context"
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* events.publish(SessionEvent.ModelSelected, {
+          sessionID,
+          model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
+        })
+        systemUnavailable = true
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
-        [defaultSystem, "Initial context"],
-        [defaultSystem, "Initial context"],
-        [defaultSystem, "Initial context"],
-      ])
+        const second = yield* scenario.llm.next()
+        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        systemUnavailable = false
+        systemBaseline = "Replacement context"
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
+        yield* second.respond.events()
+
+        const third = yield* scenario.llm.next()
+        expect(third.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* third.respond.events()
+      })
     }),
   )
 
@@ -1763,38 +1813,24 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("continues with reloaded history after durably settling one local tool call", () =>
+  scenarioIt("continues with reloaded history after durably settling one local tool call", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Echo this" }), resume: false })
 
-      requests.length = 0
       authorizations.length = 0
       executions.length = 0
-      streamGate = undefined
-      streamStarted = undefined
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-echo", name: "echo", input: { text: "hello" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.textStart({ id: "text-final" }),
-          LLMEvent.textDelta({ id: "text-final", text: "Done" }),
-          LLMEvent.textEnd({ id: "text-final" }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* first.respond.toolCall("echo", { text: "hello" }, { id: "call-echo" })
 
-      yield* session.resume(sessionID)
+        const second = yield* scenario.llm.next()
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+        yield* second.respond.text("Done", { id: "text-final" })
+      })
 
-      expect(requests).toHaveLength(2)
-      expect(requests[1]?.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       expect(authorizations).toMatchObject([{ sessionID, toolCallID: "call-echo" }])
       expect(executions).toEqual(["hello"])
       const context = yield* session.context(sessionID)
@@ -2181,40 +2217,24 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("steers an active provider turn with newly recorded prompts", () =>
+  scenarioIt("steers an active provider turn with newly recorded prompts", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(userTexts(first.request)).toEqual(["Start working"])
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Change direction" }) })
+        yield* first.respond.stop()
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Change direction" }) })
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(first)
-      streamGate = undefined
-      streamStarted = undefined
-      yield* Effect.yieldNow
+        const second = yield* scenario.llm.next()
+        expect(userTexts(second.request)).toEqual(["Start working", "Change direction"])
+        yield* second.respond.stop()
+      })
 
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[0]!)).toEqual(["Start working"])
-      expect(userTexts(requests[1]!)).toEqual(["Start working", "Change direction"])
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       expect((yield* session.context(sessionID)).map((message) => message.type)).toEqual([
         "user",
         "assistant",
@@ -3759,7 +3779,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("projects raw provider stream failures as terminal assistant step failures", () =>
+  scenarioIt("projects raw provider stream failures as terminal assistant step failures", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3769,9 +3789,14 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
       const failure = invalidRequest()
-      responseStream = Stream.fail(failure)
 
-      expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
+      expect(
+        yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.fail(failure)
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
       yield* replaySessionProjection(sessionID)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Fail raw stream durably" },

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2226,38 +2226,22 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("joins concurrent resume calls into one active provider run", () =>
+  scenarioIt("joins concurrent resume calls into one active provider run", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Run once" }), resume: false })
 
-      requests.length = 0
-      responses = undefined
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.textStart({ id: "text-once" }),
-        LLMEvent.textDelta({ id: "text-once", text: "Once" }),
-        LLMEvent.textEnd({ id: "text-once" }),
-        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-        LLMEvent.finish({ reason: "stop" }),
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        const second = yield* session.resume(sessionID).pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        expect(yield* scenario.llm.requests).toHaveLength(1)
+        yield* call.respond.text("Once", { id: "text-once" })
+        yield* Fiber.join(second)
+      })
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      const second = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Effect.yieldNow
-
-      expect(requests).toHaveLength(1)
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(first)
-      yield* Fiber.join(second)
-      streamGate = undefined
-      streamStarted = undefined
-
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Run once" },
         { type: "assistant", finish: "stop", content: [{ type: "text", text: "Once" }] },
@@ -2292,191 +2276,153 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("promotes queued input after continuation ends", () =>
+  scenarioIt("promotes queued input after continuation ends", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-echo", name: "echo", input: { text: "hello" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(userTexts(first.request)).toEqual(["Start working"])
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Wait until continuation ends" }),
+          delivery: "queue",
+        })
+        yield* first.respond.toolCall("echo", { text: "hello" }, { id: "call-echo" })
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Wait until continuation ends" }),
-        delivery: "queue",
+        const second = yield* scenario.llm.next()
+        expect(userTexts(second.request)).toEqual(["Start working"])
+        yield* second.respond.stop()
+
+        const third = yield* scenario.llm.next()
+        expect(userTexts(third.request)).toEqual(["Start working", "Wait until continuation ends"])
+        yield* third.respond.stop()
       })
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(first)
-      streamGate = undefined
-      streamStarted = undefined
 
-      expect(requests).toHaveLength(3)
-      expect(userTexts(requests[0]!)).toEqual(["Start working"])
-      expect(userTexts(requests[1]!)).toEqual(["Start working"])
-      expect(userTexts(requests[2]!)).toEqual(["Start working", "Wait until continuation ends"])
+      expect(yield* scenario.llm.requests).toHaveLength(3)
     }),
   )
 
-  it.effect("preserves durable queued input for a later wake after interruption", () =>
+  effectIt.effect("preserves durable queued input for a later wake after interruption", () =>
     Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      const { db } = yield* Database.Service
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Interrupt current work" }),
-        resume: false,
-      })
+      const interrupted = yield* Deferred.make<Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>>()
+      const retry = yield* Deferred.make<void>()
+      const scenario = yield* RunnerScenario.make(() =>
+        SessionV2.Service.use((session) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(interrupted, yield* session.resume(sessionID).pipe(Effect.exit))
+            yield* Deferred.await(retry)
+            yield* session.resume(sessionID)
+          }),
+        ),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        const { db } = yield* Database.Service
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Interrupt current work" }),
+          resume: false,
+        })
 
-      requests.length = 0
-      responses = [
-        [],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+        yield* scenario.run(function* () {
+          const first = yield* scenario.llm.next()
+          expect(userTexts(first.request)).toEqual(["Interrupt current work"])
+          yield* session.prompt({
+            sessionID,
+            prompt: PromptInput.Prompt.make({ text: "Run after interrupt" }),
+            delivery: "queue",
+          })
+          yield* session.interrupt(sessionID)
+          expect(yield* Deferred.await(interrupted)).toMatchObject({ _tag: "Failure" })
+          expect(yield* SessionInput.hasPending(db, sessionID, "queue")).toBe(true)
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Run after interrupt" }),
-        delivery: "queue",
-      })
-      yield* session.interrupt(sessionID)
-      expect(yield* Fiber.await(run)).toMatchObject({ _tag: "Failure" })
-      expect(requests).toHaveLength(1)
-      expect(yield* SessionInput.hasPending(db, sessionID, "queue")).toBe(true)
-      const resumed = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 2) yield* Effect.yieldNow
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(resumed)
-      streamGate = undefined
-      streamStarted = undefined
+          yield* Deferred.succeed(retry, undefined)
+          const second = yield* scenario.llm.next()
+          expect(userTexts(second.request)).toEqual(["Interrupt current work", "Run after interrupt"])
+          yield* second.respond.stop()
+        })
 
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[0]!)).toEqual(["Interrupt current work"])
-      expect(userTexts(requests[1]!)).toEqual(["Interrupt current work", "Run after interrupt"])
+        expect(yield* scenario.llm.requests).toHaveLength(2)
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
-  it.effect("preserves durable steering input for a later resume after interruption", () =>
+  effectIt.effect("preserves durable steering input for a later resume after interruption", () =>
     Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      const { db } = yield* Database.Service
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Interrupt current work" }),
-        resume: false,
-      })
+      const interrupted = yield* Deferred.make<Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>>()
+      const retry = yield* Deferred.make<void>()
+      const scenario = yield* RunnerScenario.make(() =>
+        SessionV2.Service.use((session) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(interrupted, yield* session.resume(sessionID).pipe(Effect.exit))
+            yield* Deferred.await(retry)
+            yield* session.resume(sessionID)
+          }),
+        ),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        const { db } = yield* Database.Service
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Interrupt current work" }),
+          resume: false,
+        })
 
-      requests.length = 0
-      responses = [
-        [],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+        yield* scenario.run(function* () {
+          const first = yield* scenario.llm.next()
+          expect(userTexts(first.request)).toEqual(["Interrupt current work"])
+          yield* session.prompt({
+            sessionID,
+            prompt: PromptInput.Prompt.make({ text: "Steer after interrupt" }),
+          })
+          yield* session.interrupt(sessionID)
+          expect(yield* Deferred.await(interrupted)).toMatchObject({ _tag: "Failure" })
+          expect(yield* SessionInput.hasPending(db, sessionID, "steer")).toBe(true)
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Steer after interrupt" }),
-      })
-      yield* session.interrupt(sessionID)
-      expect(yield* Fiber.await(run)).toMatchObject({ _tag: "Failure" })
-      expect(requests).toHaveLength(1)
-      expect(yield* SessionInput.hasPending(db, sessionID, "steer")).toBe(true)
+          yield* Deferred.succeed(retry, undefined)
+          const second = yield* scenario.llm.next()
+          expect(userTexts(second.request)).toEqual(["Interrupt current work", "Steer after interrupt"])
+          yield* second.respond.stop()
+        })
 
-      const resumed = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 2) yield* Effect.yieldNow
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(resumed)
-      streamGate = undefined
-      streamStarted = undefined
-
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[0]!)).toEqual(["Interrupt current work"])
-      expect(userTexts(requests[1]!)).toEqual(["Interrupt current work", "Steer after interrupt"])
+        expect(yield* scenario.llm.requests).toHaveLength(2)
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
-  it.effect("promotes queued inputs one at a time in FIFO order", () =>
+  scenarioIt("promotes queued inputs one at a time in FIFO order", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(userTexts(first.request)).toEqual(["Start working"])
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue first" }), delivery: "queue" })
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue second" }), delivery: "queue" })
+        yield* first.respond.stop()
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue first" }), delivery: "queue" })
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue second" }), delivery: "queue" })
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(first)
-      streamGate = undefined
-      streamStarted = undefined
+        const second = yield* scenario.llm.next()
+        expect(userTexts(second.request)).toEqual(["Start working", "Queue first"])
+        yield* second.respond.stop()
 
-      expect(requests).toHaveLength(3)
-      expect(userTexts(requests[0]!)).toEqual(["Start working"])
-      expect(userTexts(requests[1]!)).toEqual(["Start working", "Queue first"])
-      expect(userTexts(requests[2]!)).toEqual(["Start working", "Queue first", "Queue second"])
+        const third = yield* scenario.llm.next()
+        expect(userTexts(third.request)).toEqual(["Start working", "Queue first", "Queue second"])
+        yield* third.respond.stop()
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(3)
     }),
   )
 
-  it.effect("promotes queued input after steering continuation ends", () =>
+  scenarioIt("promotes queued input after steering continuation ends", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -2488,166 +2434,125 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(userTexts(first.request)).toEqual(["Start steering"])
+        yield* first.respond.stop()
 
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[0]!)).toEqual(["Start steering"])
-      expect(userTexts(requests[1]!)).toEqual(["Start steering", "Queue for later"])
-    }),
-  )
-
-  it.effect("promotes steers before the next queued input", () =>
-    Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
-
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      const firstGate = yield* Deferred.make<void>()
-      const secondGate = yield* Deferred.make<void>()
-      streamGate = firstGate
-
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 1) yield* Effect.yieldNow
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue first" }), delivery: "queue" })
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue second" }), delivery: "queue" })
-      streamGate = secondGate
-      yield* Deferred.succeed(firstGate, undefined)
-      while (requests.length < 2) yield* Effect.yieldNow
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Steer before next queued input" }) })
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Also steer before next queued input" }),
+        const second = yield* scenario.llm.next()
+        expect(userTexts(second.request)).toEqual(["Start steering", "Queue for later"])
+        yield* second.respond.stop()
       })
-      yield* Deferred.succeed(secondGate, undefined)
-      yield* Fiber.join(first)
-      streamGate = undefined
 
-      expect(requests).toHaveLength(4)
-      expect(userTexts(requests[0]!)).toEqual(["Start working"])
-      expect(userTexts(requests[1]!)).toEqual(["Start working", "Queue first"])
-      expect(userTexts(requests[2]!)).toEqual([
-        "Start working",
-        "Queue first",
-        "Steer before next queued input",
-        "Also steer before next queued input",
-      ])
-      expect(userTexts(requests[3]!)).toEqual([
-        "Start working",
-        "Queue first",
-        "Steer before next queued input",
-        "Also steer before next queued input",
-        "Queue second",
-      ])
+      expect(yield* scenario.llm.requests).toHaveLength(2)
     }),
   )
 
-  it.effect("coalesces multiple active steering prompts into one continuation turn", () =>
+  scenarioIt("promotes steers before the next queued input", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(userTexts(first.request)).toEqual(["Start working"])
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue first" }), delivery: "queue" })
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue second" }), delivery: "queue" })
+        yield* first.respond.stop()
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First steer" }) })
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second steer" }) })
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(first)
-      streamGate = undefined
-      streamStarted = undefined
-      yield* Effect.yieldNow
+        const second = yield* scenario.llm.next()
+        expect(userTexts(second.request)).toEqual(["Start working", "Queue first"])
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Steer before next queued input" }) })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Also steer before next queued input" }),
+        })
+        yield* second.respond.stop()
 
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[1]!)).toEqual(["Start working", "First steer", "Second steer"])
+        const third = yield* scenario.llm.next()
+        expect(userTexts(third.request)).toEqual([
+          "Start working",
+          "Queue first",
+          "Steer before next queued input",
+          "Also steer before next queued input",
+        ])
+        yield* third.respond.stop()
+
+        const fourth = yield* scenario.llm.next()
+        expect(userTexts(fourth.request)).toEqual([
+          "Start working",
+          "Queue first",
+          "Steer before next queued input",
+          "Also steer before next queued input",
+          "Queue second",
+        ])
+        yield* fourth.respond.stop()
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(4)
+    }),
+  )
+
+  scenarioIt("coalesces multiple active steering prompts into one continuation turn", (scenario) =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
+
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First steer" }) })
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second steer" }) })
+        yield* first.respond.stop()
+
+        const second = yield* scenario.llm.next()
+        expect(userTexts(second.request)).toEqual(["Start working", "First steer", "Second steer"])
+        yield* second.respond.stop()
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       yield* (yield* SessionExecution.Service).wake(sessionID)
-      yield* Effect.yieldNow
-      expect(requests).toHaveLength(2)
+      yield* session.wait(sessionID)
+      expect(yield* scenario.llm.requests).toHaveLength(2)
     }),
   )
 
-  it.effect("runs steering input accepted while the active provider turn fails", () =>
+  effectIt.effect("runs steering input accepted while the active provider turn fails", () =>
     Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
+      const failed = yield* Deferred.make<Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>>()
+      const scenario = yield* RunnerScenario.make(() =>
+        SessionV2.Service.use((session) =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(failed, yield* session.resume(sessionID).pipe(Effect.exit))
+            yield* session.wait(sessionID)
+          }),
+        ),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start working" }), resume: false })
+        const failure = invalidRequest()
 
-      requests.length = 0
-      responses = undefined
-      response = []
-      streamFailure = invalidRequest()
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+        yield* scenario.run(function* () {
+          const first = yield* scenario.llm.next()
+          yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Recover with this" }) })
+          yield* first.respond.fail(failure)
+          const exit = yield* Deferred.await(failed)
+          expect(Exit.isFailure(exit) && Cause.squash(exit.cause)).toBe(failure)
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Recover with this" }) })
-      yield* Deferred.succeed(streamGate, undefined)
-      expect(yield* Fiber.join(first).pipe(Effect.flip)).toBe(streamFailure)
+          const second = yield* scenario.llm.next()
+          expect(userTexts(second.request)).toEqual(["Start working", "Recover with this"])
+          yield* second.respond.stop()
+        })
 
-      streamFailure = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      yield* Effect.yieldNow
-
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[1]!)).toEqual(["Start working", "Recover with this"])
+        expect(yield* scenario.llm.requests).toHaveLength(2)
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
-  it.effect("durably fails local tools left running by a prior process before continuing", () =>
+  scenarioIt("durably fails local tools left running by a prior process before continuing", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -2684,12 +2589,13 @@ describe("SessionRunnerLLM", () => {
         input: { text: "stale" },
         executed: false,
       })
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+        yield* call.respond.events()
+      })
 
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Recover interrupted tool" },
         {
@@ -2709,7 +2615,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("durably fails hosted tools left running by a prior process before continuing inline", () =>
+  scenarioIt("durably fails hosted tools left running by a prior process before continuing inline", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -2747,25 +2653,26 @@ describe("SessionRunnerLLM", () => {
         executed: true,
         state: { itemId: "call-hosted-interrupted" },
       })
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "assistant"])
+        expect(call.request.messages[1]?.content).toMatchObject([
+          {
+            type: "tool-call",
+            id: "call-hosted-interrupted",
+            providerExecuted: true,
+            providerMetadata: { fake: { itemId: "call-hosted-interrupted" } },
+          },
+          { type: "tool-result", id: "call-hosted-interrupted", providerExecuted: true, result: { type: "error" } },
+        ])
+        yield* call.respond.events()
+      })
 
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.messages.map((message) => message.role)).toEqual(["user", "assistant"])
-      expect(requests[0]?.messages[1]?.content).toMatchObject([
-        {
-          type: "tool-call",
-          id: "call-hosted-interrupted",
-          providerExecuted: true,
-          providerMetadata: { fake: { itemId: "call-hosted-interrupted" } },
-        },
-        { type: "tool-result", id: "call-hosted-interrupted", providerExecuted: true, result: { type: "error" } },
-      ])
+      expect(yield* scenario.llm.requests).toHaveLength(1)
     }),
   )
 
-  it.effect("durably fails pending tool input left by a prior process before continuing", () =>
+  scenarioIt("durably fails pending tool input left by a prior process before continuing", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -2789,12 +2696,13 @@ describe("SessionRunnerLLM", () => {
         callID: "call-pending-interrupted",
         name: "echo",
       })
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+        yield* call.respond.events()
+      })
 
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Recover interrupted tool input" },
         { type: "assistant", content: [{ type: "tool", id: "call-pending-interrupted", state: { status: "error" } }] },
@@ -2802,57 +2710,79 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("promotes the first queued input when woken while idle", () =>
+  effectIt.effect("promotes the first queued input when woken while idle", () =>
     Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Wait in queue" }),
-        delivery: "queue",
-        resume: false,
-      })
+      const scenario = yield* RunnerScenario.make(() =>
+        Effect.gen(function* () {
+          const execution = yield* SessionExecution.Service
+          yield* execution.wake(sessionID)
+          yield* execution.awaitIdle(sessionID)
+        }),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Wait in queue" }),
+          delivery: "queue",
+          resume: false,
+        })
 
-      requests.length = 0
-      yield* (yield* SessionExecution.Service).wake(sessionID)
-      yield* Effect.yieldNow
+        yield* scenario.run(function* () {
+          const call = yield* scenario.llm.next()
+          expect(userTexts(call.request)).toEqual(["Wait in queue"])
+          yield* call.respond.events()
+        })
 
-      expect(requests).toHaveLength(1)
-      expect(userTexts(requests[0]!)).toEqual(["Wait in queue"])
+        expect(yield* scenario.llm.requests).toHaveLength(1)
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
-  it.effect("retries inbox input after prompt projection rolls back", () =>
+  effectIt.effect("retries inbox input after prompt projection rolls back", () =>
     Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      const events = yield* EventV2.Service
       const defect = new Error("fail after prompt promotion")
       let fail = true
-      yield* events.project(SessionEvent.PromptPromoted, () => (fail ? Effect.die(defect) : Effect.void))
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Recover promoted input" }),
-        resume: false,
-      })
+      const rolledBack = yield* Deferred.make<unknown>()
+      const retry = yield* Deferred.make<void>()
+      const scenario = yield* RunnerScenario.make(() =>
+        Effect.gen(function* () {
+          const session = yield* SessionV2.Service
+          yield* Deferred.succeed(
+            rolledBack,
+            yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed)),
+          )
+          yield* Deferred.await(retry)
+          const execution = yield* SessionExecution.Service
+          yield* execution.wake(sessionID)
+          yield* execution.awaitIdle(sessionID)
+        }),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        const events = yield* EventV2.Service
+        yield* events.project(SessionEvent.PromptPromoted, () => (fail ? Effect.die(defect) : Effect.void))
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Recover promoted input" }),
+          resume: false,
+        })
 
-      expect(yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed))).toBe(defect)
-      fail = false
-      requests.length = 0
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-        LLMEvent.finish({ reason: "stop" }),
-      ]
-
-      yield* (yield* SessionExecution.Service).wake(sessionID)
-      while (requests.length === 0) yield* Effect.yieldNow
-
-      expect(userTexts(requests[0]!)).toEqual(["Recover promoted input"])
+        yield* scenario.run(function* () {
+          expect(yield* Deferred.await(rolledBack)).toBe(defect)
+          fail = false
+          yield* Deferred.succeed(retry, undefined)
+          const call = yield* scenario.llm.next()
+          expect(userTexts(call.request)).toEqual(["Recover promoted input"])
+          yield* call.respond.stop()
+        })
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
-  it.effect("does not strand a committed promotion when a post-commit listener defects", () =>
+  scenarioIt("does not strand a committed promotion when a post-commit listener defects", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -2868,11 +2798,13 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      requests.length = 0
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(userTexts(call.request)).toEqual(["Run committed promotion"])
+        yield* call.respond.events()
+      })
 
-      expect(requests).toHaveLength(1)
-      expect(userTexts(requests[0]!)).toEqual(["Run committed promotion"])
+      expect(yield* scenario.llm.requests).toHaveLength(1)
     }),
   )
 
@@ -2913,68 +2845,93 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("bounds 64-character session prompt cache keys", () =>
+  effectIt.effect("bounds 64-character session prompt cache keys", () =>
     Effect.gen(function* () {
-      yield* setup
       const longSessionID = SessionV2.ID.make(`ses_${"a".repeat(64)}`)
       const otherLongSessionID = SessionV2.ID.make(`ses_${"b".repeat(64)}`)
-      yield* insertSession(longSessionID)
-      yield* insertSession(otherLongSessionID)
-      const session = yield* SessionV2.Service
-      yield* session.prompt({
-        sessionID: longSessionID,
-        prompt: PromptInput.Prompt.make({ text: "Run long session" }),
-        resume: false,
-      })
-      yield* session.prompt({
-        sessionID: otherLongSessionID,
-        prompt: PromptInput.Prompt.make({ text: "Run other long session" }),
-        resume: false,
-      })
+      const scenario = yield* RunnerScenario.make(() =>
+        SessionV2.Service.use((session) =>
+          session.resume(longSessionID).pipe(Effect.andThen(session.resume(otherLongSessionID))),
+        ),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        yield* insertSession(longSessionID)
+        yield* insertSession(otherLongSessionID)
+        const session = yield* SessionV2.Service
+        yield* session.prompt({
+          sessionID: longSessionID,
+          prompt: PromptInput.Prompt.make({ text: "Run long session" }),
+          resume: false,
+        })
+        yield* session.prompt({
+          sessionID: otherLongSessionID,
+          prompt: PromptInput.Prompt.make({ text: "Run other long session" }),
+          resume: false,
+        })
 
-      requests.length = 0
-      yield* session.resume(longSessionID)
-      yield* session.resume(otherLongSessionID)
+        yield* scenario.run(function* () {
+          yield* (yield* scenario.llm.next()).respond.events()
+          yield* (yield* scenario.llm.next()).respond.events()
+        })
 
-      const keys = requests.map((request) => request.providerOptions?.openai?.promptCacheKey)
-      expect(keys).toEqual([longSessionID.slice(4), otherLongSessionID.slice(4)])
-      expect(keys.every((key) => typeof key === "string" && key.length === 64)).toBe(true)
-      expect(keys[0]).not.toBe(keys[1])
+        const keys = (yield* scenario.llm.requests).map(
+          (request) => request.providerOptions?.openai?.promptCacheKey,
+        )
+        expect(keys).toEqual([longSessionID.slice(4), otherLongSessionID.slice(4)])
+        expect(keys.every((key) => typeof key === "string" && key.length === 64)).toBe(true)
+        expect(keys[0]).not.toBe(keys[1])
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
-  it.effect("fans out one failed run and allows a later retry", () =>
+  effectIt.effect("fans out one failed run and allows a later retry", () =>
     Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Retry after failure" }),
-        resume: false,
-      })
+      const join = yield* Deferred.make<void>()
+      const joined = yield* Deferred.make<
+        readonly [
+          Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>,
+          Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>,
+        ]
+      >()
+      const retry = yield* Deferred.make<void>()
+      const scenario = yield* RunnerScenario.make(() =>
+        SessionV2.Service.use((session) =>
+          Effect.gen(function* () {
+            const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
+            yield* Deferred.await(join)
+            const second = yield* session.resume(sessionID).pipe(Effect.forkChild)
+            yield* Deferred.succeed(joined, yield* Effect.all([Fiber.await(first), Fiber.await(second)]))
+            yield* Deferred.await(retry)
+            yield* session.resume(sessionID)
+          }),
+        ),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Retry after failure" }),
+          resume: false,
+        })
+        const failure = invalidRequest()
 
-      requests.length = 0
-      responses = undefined
-      response = []
-      streamFailure = invalidRequest()
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+        yield* scenario.run(function* () {
+          const first = yield* scenario.llm.next()
+          yield* Deferred.succeed(join, undefined)
+          yield* Effect.yieldNow
+          expect(yield* scenario.llm.requests).toHaveLength(1)
+          yield* first.respond.fail(failure)
+          const [firstExit, secondExit] = yield* Deferred.await(joined)
+          expect(secondExit).toEqual(firstExit)
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      const second = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Effect.yieldNow
+          yield* Deferred.succeed(retry, undefined)
+          yield* (yield* scenario.llm.next()).respond.events()
+        })
 
-      expect(requests).toHaveLength(1)
-      yield* Deferred.succeed(streamGate, undefined)
-      const [firstExit, secondExit] = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
-      expect(secondExit).toEqual(firstExit)
-
-      streamFailure = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      yield* session.resume(sessionID)
-      expect(requests).toHaveLength(2)
+        expect(yield* scenario.llm.requests).toHaveLength(2)
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test"
 import {
-  LLMClient,
   LLMError,
   LLMEvent,
   Model,
@@ -8,7 +7,7 @@ import {
   TransportReason,
   InvalidRequestReason,
   RateLimitReason,
-  type LLMClientShape,
+  type LLMClientService,
   type LLMRequest,
 } from "@opencode-ai/llm"
 import * as OpenAIChat from "@opencode-ai/llm/protocols/openai-chat"
@@ -65,46 +64,14 @@ import { Cause, DateTime, Deferred, Effect, Exit, Fiber, Layer, Schema, Stream }
 import type { Scope } from "effect/Scope"
 import { TestClock } from "effect/testing"
 import { asc, eq } from "drizzle-orm"
-import { it as effectIt, testEffect } from "./lib/effect"
+import { it as effectIt } from "./lib/effect"
 import { RunnerScenario } from "./lib/runner-scenario"
 
-const requests: LLMRequest[] = []
-let response: LLMEvent[] = []
-let responses: LLMEvent[][] | undefined
-let responseStream: Stream.Stream<LLMEvent, LLMError> | undefined
-let streamGate: Deferred.Deferred<void> | undefined
-let streamStarted: Deferred.Deferred<void> | undefined
-let streamFailure: LLMError | undefined
 let toolExecutionGate: Deferred.Deferred<void> | undefined
 let toolExecutionsStarted: Deferred.Deferred<void> | undefined
 let toolExecutionsReady = 5
 let activeToolExecutions = 0
 let maxActiveToolExecutions = 0
-const client = Layer.succeed(
-  LLMClient.Service,
-  LLMClient.Service.of({
-    prepare: () => Effect.die("unused"),
-    stream: ((request: LLMRequest) => {
-      requests.push(request)
-      if (responseStream) {
-        const stream = responseStream
-        responseStream = undefined
-        return stream
-      }
-      const events = streamFailure
-        ? Stream.fail(streamFailure)
-        : Stream.fromIterable(responses === undefined ? response : (responses.shift() ?? []))
-      if (!streamGate) return events
-      return Stream.unwrap(
-        (streamStarted ? Deferred.succeed(streamStarted, undefined) : Effect.void).pipe(
-          Effect.andThen(Deferred.await(streamGate)),
-          Effect.as(events),
-        ),
-      )
-    }) as unknown as LLMClientShape["stream"],
-    generate: () => Effect.die("unused"),
-  }),
-)
 const model = Model.make({ id: "fake-model", provider: "fake", route: OpenAIChat.route })
 const defaultSystem = SessionRunnerSystemPrompt.provider(model)
 const replacementModel = Model.make({ id: "replacement", provider: "fake", route: OpenAIChat.route })
@@ -269,37 +236,39 @@ const config = Layer.succeed(
       ]),
   }),
 )
-const runnerLayerWith = (clientLayer: typeof client) => AppNodeBuilder.build(SessionRunnerLLM.node, [
-  [Snapshot.node, Snapshot.noopLayer],
-  [LayerNodePlatform.llmClient, clientLayer],
-  [SessionRunnerModel.node, models],
-  [InstructionBuiltIns.node, systemContext],
-  [InstructionDiscovery.node, instructionContext],
-  [Location.node, Location.boundNode({ directory: AbsolutePath.make("/project") })],
-  [SkillGuidance.node, skillGuidance],
-  [ReferenceGuidance.node, referenceGuidance],
-  [PermissionV2.node, permission],
-  [Config.node, config],
-  [McpGuidance.node, mcpGuidance],
-  [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
-])
-const executionWith = (runnerLayer: ReturnType<typeof runnerLayerWith>) => Layer.effect(
-  SessionExecution.Service,
-  Effect.gen(function* () {
-    const sessionRunner = yield* SessionRunner.Service
-    const coordinator = yield* SessionRunCoordinator.make<SessionV2.ID, SessionRunner.RunError>({
-      drain: (sessionID, force) => sessionRunner.drain({ sessionID, force }),
-    })
-    return SessionExecution.Service.of({
-      active: coordinator.active,
-      resume: coordinator.run,
-      wake: coordinator.wake,
-      interrupt: coordinator.interrupt,
-      awaitIdle: coordinator.awaitIdle,
-    })
-  }),
-).pipe(Layer.provide(runnerLayer))
-const testLayerWith = (clientLayer: typeof client) => {
+const runnerLayerWith = (clientLayer: Layer.Layer<LLMClientService>) =>
+  AppNodeBuilder.build(SessionRunnerLLM.node, [
+    [Snapshot.node, Snapshot.noopLayer],
+    [LayerNodePlatform.llmClient, clientLayer],
+    [SessionRunnerModel.node, models],
+    [InstructionBuiltIns.node, systemContext],
+    [InstructionDiscovery.node, instructionContext],
+    [Location.node, Location.boundNode({ directory: AbsolutePath.make("/project") })],
+    [SkillGuidance.node, skillGuidance],
+    [ReferenceGuidance.node, referenceGuidance],
+    [PermissionV2.node, permission],
+    [Config.node, config],
+    [McpGuidance.node, mcpGuidance],
+    [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
+  ])
+const executionWith = (runnerLayer: ReturnType<typeof runnerLayerWith>) =>
+  Layer.effect(
+    SessionExecution.Service,
+    Effect.gen(function* () {
+      const sessionRunner = yield* SessionRunner.Service
+      const coordinator = yield* SessionRunCoordinator.make<SessionV2.ID, SessionRunner.RunError>({
+        drain: (sessionID, force) => sessionRunner.drain({ sessionID, force }),
+      })
+      return SessionExecution.Service.of({
+        active: coordinator.active,
+        resume: coordinator.run,
+        wake: coordinator.wake,
+        interrupt: coordinator.interrupt,
+        awaitIdle: coordinator.awaitIdle,
+      })
+    }),
+  ).pipe(Layer.provide(runnerLayer))
+const testLayerWith = (clientLayer: Layer.Layer<LLMClientService>) => {
   const runnerLayer = runnerLayerWith(clientLayer)
   const execution = executionWith(runnerLayer)
   return AppNodeBuilder.build(
@@ -341,14 +310,12 @@ const testLayerWith = (clientLayer: typeof client) => {
     ],
   )
 }
-const testLayer = testLayerWith(client)
-const it = testEffect(testLayer)
 const sessionID = SessionV2.ID.make("ses_runner_test")
 const otherSessionID = SessionV2.ID.make("ses_runner_other")
 const makeSessionScenario = () =>
   RunnerScenario.make(() => SessionV2.Service.use((session) => session.resume(sessionID)))
 type SessionScenario = Effect.Success<ReturnType<typeof makeSessionScenario>>
-type TestServices = Layer.Success<typeof testLayer>
+type TestServices = Layer.Success<ReturnType<typeof testLayerWith>>
 const scenarioIt = <A, E>(
   name: string,
   body: (scenario: SessionScenario) => Effect.Effect<A, E, TestServices | Scope>,
@@ -380,7 +347,6 @@ const insertSession = (id: SessionV2.ID) =>
 
 const setup = Effect.gen(function* () {
   const { db } = yield* Database.Service
-  response = []
   systemBaseline = "Initial context"
   systemRemoved = false
   systemUnavailable = false
@@ -388,11 +354,6 @@ const setup = Effect.gen(function* () {
   modelResolveHook = Effect.void
   currentModel = model
   skillBaselines.clear()
-  responses = undefined
-  streamFailure = undefined
-  responseStream = undefined
-  streamGate = undefined
-  streamStarted = undefined
   toolExecutionGate = undefined
   toolExecutionsStarted = undefined
   toolExecutionsReady = 5
@@ -591,97 +552,8 @@ const fragmentFixture = (kind: FragmentKind, id: string, chunks: readonly string
   }
 }
 
-const verifyEphemeralDeltas = (kind: FragmentKind) =>
-  Effect.gen(function* () {
-    yield* setup
-    requests.length = 0
-    const session = yield* SessionV2.Service
-    const prompt = `Stream ${kind}`
-    const chunks = Array.from({ length: 32 }, (_, index) => `${index},`)
-    const fixture = fragmentFixture(kind, fragmentID(kind, "many"), chunks)
-    const expectedContext = [{ type: "user", text: prompt }, fixture.expectedAssistant]
-    yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: prompt }), resume: false })
-    const events = yield* EventV2.Service
-    const live = yield* events.subscribe(fixture.delta).pipe(Stream.take(32), Stream.runCollect, Effect.forkScoped)
-    yield* Effect.yieldNow
-    response = fixture.completeEvents
-
-    yield* session.resume(sessionID)
-
-    const { db } = yield* Database.Service
-    const deltas = yield* db
-      .select({ type: EventTable.type })
-      .from(EventTable)
-      .where(eq(EventTable.type, EventV2.versionedType(fixture.delta.type, 1)))
-      .all()
-      .pipe(Effect.orDie)
-    expect(Array.from(yield* Fiber.join(live))).toHaveLength(32)
-    expect(deltas).toHaveLength(0)
-    expect(yield* session.context(sessionID)).toMatchObject(expectedContext)
-
-    yield* replaySessionProjection(sessionID)
-
-    expect(yield* session.context(sessionID)).toMatchObject(expectedContext)
-  })
-
-const verifyPartialFlushOnFailure = (kind: FragmentKind) =>
-  Effect.gen(function* () {
-    yield* setup
-    requests.length = 0
-    const session = yield* SessionV2.Service
-    const prompt = `Fail after ${kind}`
-    const fixture = fragmentFixture(kind, fragmentID(kind, "partial"), ["Partial"])
-    const failure = providerUnavailable()
-    yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: prompt }), resume: false })
-    responseStream = Stream.concat(Stream.fromIterable(fixture.partialEvents), Stream.fail(failure))
-
-    expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
-    expect(yield* session.context(sessionID)).toMatchObject([
-      { type: "user", text: prompt },
-      {
-        type: "assistant",
-        finish: "error",
-        error: { type: "provider.transport", message: "Provider unavailable" },
-        content: [fixture.expectedContent],
-      },
-    ])
-    expect(requests).toHaveLength(1)
-  })
-
-const verifyPartialFlushOnInterruption = (kind: FragmentKind) =>
-  Effect.gen(function* () {
-    yield* setup
-    const session = yield* SessionV2.Service
-    const prompt = `Interrupt after ${kind}`
-    const fixture = fragmentFixture(kind, fragmentID(kind, "interrupted"), ["Partial"])
-    const streamed = yield* Deferred.make<void>()
-    yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: prompt }), resume: false })
-    responseStream = Stream.concat(
-      Stream.fromIterable(fixture.partialEvents),
-      Stream.fromEffect(Deferred.succeed(streamed, undefined)).pipe(Stream.flatMap(() => Stream.never)),
-    )
-
-    const runner = yield* SessionRunner.Service
-    const fiber = yield* runner.drain({ sessionID, force: true }).pipe(Effect.forkChild)
-    yield* Deferred.await(streamed)
-    yield* Fiber.interrupt(fiber)
-    expect(yield* session.context(sessionID)).toMatchObject([
-      { type: "user", text: prompt },
-      {
-        type: "assistant",
-        finish: "error",
-        error: { type: "aborted", message: "Step interrupted" },
-        content: [
-          kind === "tool input"
-            ? { type: "tool", id: fragmentID(kind, "interrupted"), state: { status: "error" } }
-            : fixture.expectedContent,
-        ],
-      },
-    ])
-  })
-
 describe("SessionRunnerLLM", () => {
-  it.effect("advertises and executes a location registered tool", () =>
+  scenarioIt("advertises and executes a location registered tool", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const registry = yield* ToolRegistry.Service
@@ -704,19 +576,12 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Use application context" }),
         resume: false,
       })
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-location", name: "location_context", input: { query: "hello" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [],
-      ]
-
-      yield* session.resume(sessionID)
-
-      expect(requests[0]?.tools.map((tool) => tool.name)).toContain("location_context")
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.tools.map((tool) => tool.name)).toContain("location_context")
+        yield* call.respond.toolCall("location_context", { query: "hello" }, { id: "call-location" })
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
       expect(contexts).toEqual([
         {
           sessionID,
@@ -1157,10 +1022,7 @@ describe("SessionRunnerLLM", () => {
 
       yield* scenario.run(function* () {
         const call = yield* scenario.llm.next()
-        expect(call.request.system.map((part) => part.text)).toEqual([
-          defaultSystem,
-          "Initial context\n\nBuild skills",
-        ])
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context\n\nBuild skills"])
         yield* call.respond.events()
       })
     }),
@@ -2114,10 +1976,7 @@ describe("SessionRunnerLLM", () => {
       yield* scenario.run(function* () {
         const first = yield* scenario.llm.next()
         yield* first.respond.stream(
-          Stream.concat(
-            initial,
-            Stream.unwrap(Deferred.await(providerGate).pipe(Effect.as(final))),
-          ),
+          Stream.concat(initial, Stream.unwrap(Deferred.await(providerGate).pipe(Effect.as(final)))),
         )
         yield* Deferred.await(executionsStarted)
 
@@ -2405,8 +2264,16 @@ describe("SessionRunnerLLM", () => {
       yield* scenario.run(function* () {
         const first = yield* scenario.llm.next()
         expect(userTexts(first.request)).toEqual(["Start working"])
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue first" }), delivery: "queue" })
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue second" }), delivery: "queue" })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Queue first" }),
+          delivery: "queue",
+        })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Queue second" }),
+          delivery: "queue",
+        })
         yield* first.respond.stop()
 
         const second = yield* scenario.llm.next()
@@ -2457,13 +2324,24 @@ describe("SessionRunnerLLM", () => {
       yield* scenario.run(function* () {
         const first = yield* scenario.llm.next()
         expect(userTexts(first.request)).toEqual(["Start working"])
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue first" }), delivery: "queue" })
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Queue second" }), delivery: "queue" })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Queue first" }),
+          delivery: "queue",
+        })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Queue second" }),
+          delivery: "queue",
+        })
         yield* first.respond.stop()
 
         const second = yield* scenario.llm.next()
         expect(userTexts(second.request)).toEqual(["Start working", "Queue first"])
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Steer before next queued input" }) })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Steer before next queued input" }),
+        })
         yield* session.prompt({
           sessionID,
           prompt: PromptInput.Prompt.make({ text: "Also steer before next queued input" }),
@@ -2749,10 +2627,7 @@ describe("SessionRunnerLLM", () => {
       const scenario = yield* RunnerScenario.make(() =>
         Effect.gen(function* () {
           const session = yield* SessionV2.Service
-          yield* Deferred.succeed(
-            rolledBack,
-            yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed)),
-          )
+          yield* Deferred.succeed(rolledBack, yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed)))
           yield* Deferred.await(retry)
           const execution = yield* SessionExecution.Service
           yield* execution.wake(sessionID)
@@ -2808,40 +2683,39 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("runs different sessions concurrently", () =>
+  effectIt.effect("runs different sessions concurrently", () =>
     Effect.gen(function* () {
-      yield* setup
-      yield* insertSession(otherSessionID)
-      const session = yield* SessionV2.Service
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Run first" }), resume: false })
-      yield* session.prompt({
-        sessionID: otherSessionID,
-        prompt: PromptInput.Prompt.make({ text: "Run second" }),
-        resume: false,
-      })
+      const scenario = yield* RunnerScenario.make(() =>
+        SessionV2.Service.use((session) =>
+          Effect.all([session.resume(sessionID), session.resume(otherSessionID)], {
+            concurrency: "unbounded",
+            discard: true,
+          }),
+        ),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        yield* insertSession(otherSessionID)
+        const session = yield* SessionV2.Service
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Run first" }), resume: false })
+        yield* session.prompt({
+          sessionID: otherSessionID,
+          prompt: PromptInput.Prompt.make({ text: "Run second" }),
+          resume: false,
+        })
 
-      requests.length = 0
-      responses = undefined
-      response = []
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+        yield* scenario.run(function* () {
+          const first = yield* scenario.llm.next()
+          const second = yield* scenario.llm.next()
+          expect(
+            [first, second].map((call) => call.request.providerOptions?.openai?.promptCacheKey).toSorted(),
+          ).toEqual([sessionID, otherSessionID].toSorted())
+          yield* first.respond.events()
+          yield* second.respond.events()
+        })
 
-      const first = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      streamStarted = yield* Deferred.make<void>()
-      const second = yield* session.resume(otherSessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-
-      expect(requests).toHaveLength(2)
-      expect(requests.map((request) => request.providerOptions?.openai?.promptCacheKey)).toEqual([
-        sessionID,
-        otherSessionID,
-      ])
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(first)
-      yield* Fiber.join(second)
-      streamGate = undefined
-      streamStarted = undefined
+        expect(yield* scenario.llm.requests).toHaveLength(2)
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
@@ -2875,9 +2749,7 @@ describe("SessionRunnerLLM", () => {
           yield* (yield* scenario.llm.next()).respond.events()
         })
 
-        const keys = (yield* scenario.llm.requests).map(
-          (request) => request.providerOptions?.openai?.promptCacheKey,
-        )
+        const keys = (yield* scenario.llm.requests).map((request) => request.providerOptions?.openai?.promptCacheKey)
         expect(keys).toEqual([longSessionID.slice(4), otherLongSessionID.slice(4)])
         expect(keys.every((key) => typeof key === "string" && key.length === 64)).toBe(true)
         expect(keys[0]).not.toBe(keys[1])
@@ -2888,12 +2760,13 @@ describe("SessionRunnerLLM", () => {
   effectIt.effect("fans out one failed run and allows a later retry", () =>
     Effect.gen(function* () {
       const join = yield* Deferred.make<void>()
-      const joined = yield* Deferred.make<
-        readonly [
-          Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>,
-          Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>,
-        ]
-      >()
+      const joined =
+        yield* Deferred.make<
+          readonly [
+            Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>,
+            Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>,
+          ]
+        >()
       const retry = yield* Deferred.make<void>()
       const scenario = yield* RunnerScenario.make(() =>
         SessionV2.Service.use((session) =>
@@ -3412,53 +3285,61 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("durably fails blocked local tools when interrupted while awaiting settlement", () =>
+  effectIt.effect("durably fails blocked local tools when interrupted while awaiting settlement", () =>
     Effect.gen(function* () {
-      yield* setup
-      const session = yield* SessionV2.Service
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Interrupt tool settlement" }),
-        resume: false,
-      })
-      executions.length = 0
-      toolExecutionGate = yield* Deferred.make<void>()
-      toolExecutionsStarted = yield* Deferred.make<void>()
-      toolExecutionsReady = 1
-      const executionsStarted = toolExecutionsStarted
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({ id: "call-await-interrupt", name: "echo", input: { text: "blocked" } }),
-        LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-        LLMEvent.finish({ reason: "tool-calls" }),
-      ]
+      const scenario = yield* RunnerScenario.make(() =>
+        SessionRunner.Service.use((runner) => runner.drain({ sessionID, force: true })),
+      )
+      yield* Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Interrupt tool settlement" }),
+          resume: false,
+        })
+        executions.length = 0
+        const executionGate = yield* Deferred.make<void>()
+        const executionsStarted = yield* Deferred.make<void>()
+        toolExecutionGate = executionGate
+        toolExecutionsStarted = executionsStarted
+        toolExecutionsReady = 1
 
-      const runner = yield* SessionRunner.Service
-      const run = yield* runner.drain({ sessionID, force: true }).pipe(Effect.forkChild)
-      yield* Deferred.await(executionsStarted)
-      yield* Fiber.interrupt(run)
-      toolExecutionGate = undefined
-      toolExecutionsStarted = undefined
+        const run = yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.toolCall(
+              "echo",
+              { text: "blocked" },
+              { id: "call-await-interrupt" },
+            )
+            yield* Effect.never
+          })
+          .pipe(Effect.forkChild)
+        yield* Deferred.await(executionsStarted)
+        yield* Fiber.interrupt(run)
+        toolExecutionGate = undefined
+        toolExecutionsStarted = undefined
 
-      expect(yield* Fiber.await(run)).toMatchObject({ _tag: "Failure" })
-      expect(yield* session.context(sessionID)).toMatchObject([
-        { type: "user", text: "Interrupt tool settlement" },
-        {
-          type: "assistant",
-          finish: "error",
-          error: { type: "aborted", message: "Step interrupted" },
-          content: [
-            {
-              type: "tool",
-              id: "call-await-interrupt",
-              state: { status: "error", error: { type: "aborted", message: "Tool execution interrupted" } },
-            },
-          ],
-        },
-      ])
-      const eventTypes = yield* recordedEventTypes(sessionID)
-      expect(eventTypes).toContain("session.step.failed.1")
-      expect(eventTypes).not.toContain("session.step.ended.1")
+        expect(yield* Fiber.await(run)).toMatchObject({ _tag: "Failure" })
+        expect(yield* session.context(sessionID)).toMatchObject([
+          { type: "user", text: "Interrupt tool settlement" },
+          {
+            type: "assistant",
+            finish: "error",
+            error: { type: "aborted", message: "Step interrupted" },
+            content: [
+              {
+                type: "tool",
+                id: "call-await-interrupt",
+                state: { status: "error", error: { type: "aborted", message: "Tool execution interrupted" } },
+              },
+            ],
+          },
+        ])
+        const eventTypes = yield* recordedEventTypes(sessionID)
+        expect(eventTypes).toContain("session.step.failed.1")
+        expect(eventTypes).not.toContain("session.step.ended.1")
+      }).pipe(Effect.provide(testLayerWith(scenario.llm.layer)))
     }),
   )
 
@@ -3544,16 +3425,14 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fail durably" }), resume: false })
 
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.stepStart({ index: 0 }),
-                LLMEvent.providerError({ message: "Provider unavailable" }),
-              )
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.providerError({ message: "Provider unavailable" }),
+            )
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("Provider unavailable")
 
       expect(yield* scenario.llm.requests).toHaveLength(1)
@@ -3571,15 +3450,13 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fail before step" }), resume: false })
 
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.providerError({ message: "Provider unavailable" }),
-              )
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.providerError({ message: "Provider unavailable" }),
+            )
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("Provider unavailable")
 
       expect(yield* scenario.llm.requests).toHaveLength(1)
@@ -3646,20 +3523,18 @@ describe("SessionRunnerLLM", () => {
       const started = (toolExecutionsStarted = yield* Deferred.make<void>())
       toolExecutionsReady = 1
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.stepStart({ index: 0 }),
-                LLMEvent.toolCall({ id: "call-before-content-filter", name: "echo", input: { text: "settled" } }),
-                LLMEvent.stepFinish({ index: 0, reason: "content-filter" }),
-                LLMEvent.finish({ reason: "content-filter" }),
-              )
-              yield* Deferred.await(started)
-              yield* Deferred.succeed(gate, undefined)
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.toolCall({ id: "call-before-content-filter", name: "echo", input: { text: "settled" } }),
+              LLMEvent.stepFinish({ index: 0, reason: "content-filter" }),
+              LLMEvent.finish({ reason: "content-filter" }),
+            )
+            yield* Deferred.await(started)
+            yield* Deferred.succeed(gate, undefined)
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("Provider blocked the response")
       toolExecutionGate = undefined
       toolExecutionsStarted = undefined
@@ -3689,19 +3564,17 @@ describe("SessionRunnerLLM", () => {
       })
 
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.stepStart({ index: 0 }),
-                LLMEvent.textStart({ id: "text-partial" }),
-                LLMEvent.textDelta({ id: "text-partial", text: "Partial" }),
-                LLMEvent.textEnd({ id: "text-partial" }),
-                LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
-              )
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.textStart({ id: "text-partial" }),
+              LLMEvent.textDelta({ id: "text-partial", text: "Partial" }),
+              LLMEvent.textEnd({ id: "text-partial" }),
+              LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
+            )
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("prompt too long")
 
       expect(yield* scenario.llm.requests).toHaveLength(1)
@@ -3899,19 +3772,17 @@ describe("SessionRunnerLLM", () => {
       const started = (toolExecutionsStarted = yield* Deferred.make<void>())
       toolExecutionsReady = 1
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.stepStart({ index: 0 }),
-                LLMEvent.toolCall({ id: "call-before-provider-error", name: "echo", input: { text: "settled" } }),
-                LLMEvent.providerError({ message: "Provider unavailable" }),
-              )
-              yield* Deferred.await(started)
-              yield* Deferred.succeed(gate, undefined)
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.toolCall({ id: "call-before-provider-error", name: "echo", input: { text: "settled" } }),
+              LLMEvent.providerError({ message: "Provider unavailable" }),
+            )
+            yield* Deferred.await(started)
+            yield* Deferred.succeed(gate, undefined)
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("Provider unavailable")
       toolExecutionGate = undefined
       toolExecutionsStarted = undefined
@@ -3940,22 +3811,20 @@ describe("SessionRunnerLLM", () => {
       })
 
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.stepStart({ index: 0 }),
-                LLMEvent.toolCall({
-                  id: "call-hosted-provider-error",
-                  name: "web_search",
-                  input: { query: "effect" },
-                  providerExecuted: true,
-                }),
-                LLMEvent.providerError({ message: "Provider unavailable" }),
-              )
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.toolCall({
+                id: "call-hosted-provider-error",
+                name: "web_search",
+                input: { query: "effect" },
+                providerExecuted: true,
+              }),
+              LLMEvent.providerError({ message: "Provider unavailable" }),
+            )
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("Provider unavailable")
 
       expect(yield* scenario.llm.requests).toHaveLength(1)
@@ -3988,17 +3857,15 @@ describe("SessionRunnerLLM", () => {
       })
 
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.stepStart({ index: 0 }),
-                LLMEvent.toolCall({ id: "call-defect-provider-error", name: "defect", input: {} }),
-                LLMEvent.providerError({ message: "Provider unavailable" }),
-              )
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.toolCall({ id: "call-defect-provider-error", name: "defect", input: {} }),
+              LLMEvent.providerError({ message: "Provider unavailable" }),
+            )
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("Provider unavailable")
 
       const context = yield* session.context(sessionID)
@@ -4025,21 +3892,19 @@ describe("SessionRunnerLLM", () => {
       })
 
       expect(
-        (
-          yield* scenario
-            .run(function* () {
-              yield* (yield* scenario.llm.next()).respond.events(
-                LLMEvent.stepStart({ index: 0 }),
-                LLMEvent.toolCall({
-                  id: "call-hosted-eof",
-                  name: "web_search",
-                  input: { query: "effect" },
-                  providerExecuted: true,
-                }),
-              )
-            })
-            .pipe(Effect.flip)
-        ).message,
+        (yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.toolCall({
+                id: "call-hosted-eof",
+                name: "web_search",
+                input: { query: "effect" },
+                providerExecuted: true,
+              }),
+            )
+          })
+          .pipe(Effect.flip)).message,
       ).toBe("Provider did not return a tool result")
       const assistant = requireAssistant(yield* session.context(sessionID))
       const events = yield* recordedStepSettlementEvents(sessionID, assistant.id)
@@ -4408,7 +4273,12 @@ describe("SessionRunnerLLM", () => {
           LLMEvent.toolInputStart({ id: "call-parsed", name: "web_search" }),
           LLMEvent.toolInputDelta({ id: "call-parsed", name: "web_search", text: '{"query":"hello"}' }),
           LLMEvent.toolInputEnd({ id: "call-parsed", name: "web_search" }),
-          LLMEvent.toolCall({ id: "call-parsed", name: "web_search", input: { query: "hello" }, providerExecuted: true }),
+          LLMEvent.toolCall({
+            id: "call-parsed",
+            name: "web_search",
+            input: { query: "hello" },
+            providerExecuted: true,
+          }),
           LLMEvent.stepFinish({ index: 0, reason: "stop" }),
           LLMEvent.finish({ reason: "stop" }),
         )

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -3633,21 +3633,26 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("projects provider errors as terminal assistant step failures", () =>
+  scenarioIt("projects provider errors as terminal assistant step failures", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fail durably" }), resume: false })
 
-      requests.length = 0
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = [LLMEvent.stepStart({ index: 0 }), LLMEvent.providerError({ message: "Provider unavailable" })]
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.providerError({ message: "Provider unavailable" }),
+              )
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider unavailable")
 
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("Provider unavailable")
-
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Fail durably" },
         { type: "assistant", finish: "error", error: { type: "provider.unknown", message: "Provider unavailable" } },
@@ -3655,18 +3660,25 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("projects provider errors emitted before assistant step start", () =>
+  scenarioIt("projects provider errors emitted before assistant step start", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fail before step" }), resume: false })
 
-      requests.length = 0
-      response = [LLMEvent.providerError({ message: "Provider unavailable" })]
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.providerError({ message: "Provider unavailable" }),
+              )
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider unavailable")
 
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("Provider unavailable")
-
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Fail before step" },
         { type: "assistant", finish: "error", error: { type: "provider.unknown", message: "Provider unavailable" } },
@@ -3674,24 +3686,30 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("projects content-filter finishes as visible terminal failures", () =>
+  scenarioIt("projects content-filter finishes as visible terminal failures", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Blocked response" }), resume: false })
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.textStart({ id: "partial" }),
-        LLMEvent.textDelta({ id: "partial", text: "Partial" }),
-        LLMEvent.stepFinish({
-          index: 0,
-          reason: "content-filter",
-          usage: { nonCachedInputTokens: 8, outputTokens: 3, reasoningTokens: 1 },
-        }),
-        LLMEvent.finish({ reason: "content-filter" }),
-      ]
-
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("Provider blocked the response")
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.textStart({ id: "partial" }),
+                LLMEvent.textDelta({ id: "partial", text: "Partial" }),
+                LLMEvent.stepFinish({
+                  index: 0,
+                  reason: "content-filter",
+                  usage: { nonCachedInputTokens: 8, outputTokens: 3, reasoningTokens: 1 },
+                }),
+                LLMEvent.finish({ reason: "content-filter" }),
+              )
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider blocked the response")
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user" },
         {
@@ -3711,7 +3729,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("settles a local tool before one content-filter step failure", () =>
+  scenarioIt("settles a local tool before one content-filter step failure", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3720,20 +3738,25 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Tool before blocked response" }),
         resume: false,
       })
-      toolExecutionGate = yield* Deferred.make<void>()
-      toolExecutionsStarted = yield* Deferred.make<void>()
+      const gate = (toolExecutionGate = yield* Deferred.make<void>())
+      const started = (toolExecutionsStarted = yield* Deferred.make<void>())
       toolExecutionsReady = 1
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({ id: "call-before-content-filter", name: "echo", input: { text: "settled" } }),
-        LLMEvent.stepFinish({ index: 0, reason: "content-filter" }),
-        LLMEvent.finish({ reason: "content-filter" }),
-      ]
-
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(toolExecutionsStarted)
-      yield* Deferred.succeed(toolExecutionGate, undefined)
-      expect((yield* Fiber.join(run).pipe(Effect.flip)).message).toBe("Provider blocked the response")
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.toolCall({ id: "call-before-content-filter", name: "echo", input: { text: "settled" } }),
+                LLMEvent.stepFinish({ index: 0, reason: "content-filter" }),
+                LLMEvent.finish({ reason: "content-filter" }),
+              )
+              yield* Deferred.await(started)
+              yield* Deferred.succeed(gate, undefined)
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider blocked the response")
       toolExecutionGate = undefined
       toolExecutionsStarted = undefined
 
@@ -3751,7 +3774,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("does not recover context overflow after durable assistant output", () =>
+  scenarioIt("does not recover context overflow after durable assistant output", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3761,17 +3784,23 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      requests.length = 0
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.textStart({ id: "text-partial" }),
-        LLMEvent.textDelta({ id: "text-partial", text: "Partial" }),
-        LLMEvent.textEnd({ id: "text-partial" }),
-        LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
-      ]
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("prompt too long")
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.textStart({ id: "text-partial" }),
+                LLMEvent.textDelta({ id: "text-partial", text: "Partial" }),
+                LLMEvent.textEnd({ id: "text-partial" }),
+                LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
+              )
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("prompt too long")
 
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Fail after output" },
         {
@@ -3810,23 +3839,23 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("retries eligible pre-output failures after exponential backoff", () =>
+  scenarioIt("retries eligible pre-output failures after exponential backoff", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Retry transport" }), resume: false })
-      requests.length = 0
-      responseStream = Stream.fail(providerUnavailable())
-      response = fragmentFixture("text", "retry-success", ["Recovered"]).completeEvents
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 1) yield* Effect.yieldNow
-      yield* TestClock.adjust("1999 millis")
-      expect(requests).toHaveLength(1)
-      yield* TestClock.adjust("1 millis")
-      yield* Fiber.join(run)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.fail(providerUnavailable())
+        yield* TestClock.adjust("1999 millis")
+        expect(yield* scenario.llm.requests).toHaveLength(1)
+        yield* TestClock.adjust("1 millis")
+        yield* (yield* scenario.llm.next()).respond.events(
+          ...fragmentFixture("text", "retry-success", ["Recovered"]).completeEvents,
+        )
+      })
 
-      expect(requests).toHaveLength(2)
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       const eventTypes = yield* recordedEventTypes(sessionID)
       expect(eventTypes).toContain("session.retry.scheduled.1")
       expect(eventTypes.filter((type) => type === "session.step.started.1")).toHaveLength(2)
@@ -3839,41 +3868,44 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("uses a larger provider retry-after delay", () =>
+  scenarioIt("uses a larger provider retry-after delay", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Retry rate limit" }), resume: false })
-      requests.length = 0
-      responseStream = Stream.fail(rateLimited(5_000))
-      response = fragmentFixture("text", "retry-after-success", ["Recovered"]).completeEvents
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 1) yield* Effect.yieldNow
-      yield* TestClock.adjust("4999 millis")
-      expect(requests).toHaveLength(1)
-      yield* TestClock.adjust("1 millis")
-      yield* Fiber.join(run)
-      expect(requests).toHaveLength(2)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.fail(rateLimited(5_000))
+        yield* TestClock.adjust("4999 millis")
+        expect(yield* scenario.llm.requests).toHaveLength(1)
+        yield* TestClock.adjust("1 millis")
+        yield* (yield* scenario.llm.next()).respond.events(
+          ...fragmentFixture("text", "retry-after-success", ["Recovered"]).completeEvents,
+        )
+      })
+      expect(yield* scenario.llm.requests).toHaveLength(2)
     }),
   )
 
-  it.effect("stops after five total retry attempts", () =>
+  scenarioIt("stops after five total retry attempts", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Exhaust retries" }), resume: false })
-      requests.length = 0
-      streamFailure = providerUnavailable()
+      const failure = providerUnavailable()
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 1) yield* Effect.yieldNow
-      for (const [index, delay] of [2_000, 4_000, 8_000, 16_000].entries()) {
-        yield* TestClock.adjust(delay)
-        while (requests.length < index + 2) yield* Effect.yieldNow
-      }
-      expect(yield* Fiber.join(run).pipe(Effect.flip)).toBe(streamFailure)
-      expect(requests).toHaveLength(5)
+      expect(
+        yield* scenario
+          .run(function* () {
+            for (const delay of [2_000, 4_000, 8_000, 16_000]) {
+              yield* (yield* scenario.llm.next()).respond.fail(failure)
+              yield* TestClock.adjust(delay)
+            }
+            yield* (yield* scenario.llm.next()).respond.fail(failure)
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
+      expect(yield* scenario.llm.requests).toHaveLength(5)
 
       const database = (yield* Database.Service).db
       const retries = yield* database
@@ -3894,7 +3926,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("counts retry attempts against the agent step allowance", () =>
+  scenarioIt("counts retry attempts against the agent step allowance", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const agents = yield* AgentV2.Service
@@ -3909,17 +3941,19 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Bound retries by steps" }),
         resume: false,
       })
-      requests.length = 0
       const failure = providerUnavailable()
-      responseStream = Stream.fail(failure)
-      streamFailure = failure
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 1) yield* Effect.yieldNow
-      yield* TestClock.adjust("2 seconds")
-      expect(yield* Fiber.join(run).pipe(Effect.flip)).toBe(failure)
+      expect(
+        yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.fail(failure)
+            yield* TestClock.adjust("2 seconds")
+            yield* (yield* scenario.llm.next()).respond.fail(failure)
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
 
-      expect(requests).toHaveLength(2)
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       const eventTypes = yield* recordedEventTypes(sessionID)
       expect(eventTypes.filter((type) => type === "session.step.started.1")).toHaveLength(2)
       expect(eventTypes.filter((type) => type === "session.retry.scheduled.1")).toHaveLength(1)
@@ -3927,22 +3961,26 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("does not retry non-eligible provider failures", () =>
+  scenarioIt("does not retry non-eligible provider failures", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Do not retry" }), resume: false })
-      requests.length = 0
       const failure = invalidRequest()
-      streamFailure = failure
 
-      expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
-      expect(requests).toHaveLength(1)
+      expect(
+        yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.fail(failure)
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
     }),
   )
 
-  it.effect("does not continue automatically after a provider error follows a local tool call", () =>
+  scenarioIt("does not continue automatically after a provider error follows a local tool call", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3952,25 +3990,29 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      requests.length = 0
       const executionCount = executions.length
-      toolExecutionGate = yield* Deferred.make<void>()
-      toolExecutionsStarted = yield* Deferred.make<void>()
+      const gate = (toolExecutionGate = yield* Deferred.make<void>())
+      const started = (toolExecutionsStarted = yield* Deferred.make<void>())
       toolExecutionsReady = 1
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({ id: "call-before-provider-error", name: "echo", input: { text: "settled" } }),
-        LLMEvent.providerError({ message: "Provider unavailable" }),
-      ]
-
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(toolExecutionsStarted)
-      yield* Deferred.succeed(toolExecutionGate, undefined)
-      expect((yield* Fiber.join(run).pipe(Effect.flip)).message).toBe("Provider unavailable")
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.toolCall({ id: "call-before-provider-error", name: "echo", input: { text: "settled" } }),
+                LLMEvent.providerError({ message: "Provider unavailable" }),
+              )
+              yield* Deferred.await(started)
+              yield* Deferred.succeed(gate, undefined)
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider unavailable")
       toolExecutionGate = undefined
       toolExecutionsStarted = undefined
 
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(executions.slice(executionCount)).toEqual(["settled"])
       const context = yield* session.context(sessionID)
       const assistant = requireAssistant(context)
@@ -3983,7 +4025,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("durably fails a hosted tool when its provider errors before returning a result", () =>
+  scenarioIt("durably fails a hosted tool when its provider errors before returning a result", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3993,21 +4035,26 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      requests.length = 0
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({
-          id: "call-hosted-provider-error",
-          name: "web_search",
-          input: { query: "effect" },
-          providerExecuted: true,
-        }),
-        LLMEvent.providerError({ message: "Provider unavailable" }),
-      ]
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.toolCall({
+                  id: "call-hosted-provider-error",
+                  name: "web_search",
+                  input: { query: "effect" },
+                  providerExecuted: true,
+                }),
+                LLMEvent.providerError({ message: "Provider unavailable" }),
+              )
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider unavailable")
 
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("Provider unavailable")
-
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       const context = yield* session.context(sessionID)
       expect(context).toMatchObject([
         { type: "user", text: "Fail hosted tool durably" },
@@ -4026,7 +4073,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("preserves a tool defect before provider failure settlement", () =>
+  scenarioIt("preserves a tool defect before provider failure settlement", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -4035,13 +4082,20 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Defect while provider fails" }),
         resume: false,
       })
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({ id: "call-defect-provider-error", name: "defect", input: {} }),
-        LLMEvent.providerError({ message: "Provider unavailable" }),
-      ]
 
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("Provider unavailable")
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.toolCall({ id: "call-defect-provider-error", name: "defect", input: {} }),
+                LLMEvent.providerError({ message: "Provider unavailable" }),
+              )
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider unavailable")
 
       const context = yield* session.context(sessionID)
       const assistant = requireAssistant(context)
@@ -4056,7 +4110,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("durably fails a hosted tool left unresolved at normal provider EOF", () =>
+  scenarioIt("durably fails a hosted tool left unresolved at normal provider EOF", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -4065,17 +4119,24 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Fail hosted tool at EOF" }),
         resume: false,
       })
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({
-          id: "call-hosted-eof",
-          name: "web_search",
-          input: { query: "effect" },
-          providerExecuted: true,
-        }),
-      ]
 
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("Provider did not return a tool result")
+      expect(
+        (
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.events(
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.toolCall({
+                  id: "call-hosted-eof",
+                  name: "web_search",
+                  input: { query: "effect" },
+                  providerExecuted: true,
+                }),
+              )
+            })
+            .pipe(Effect.flip)
+        ).message,
+      ).toBe("Provider did not return a tool result")
       const assistant = requireAssistant(yield* session.context(sessionID))
       const events = yield* recordedStepSettlementEvents(sessionID, assistant.id)
       expect(events.map((event) => event.type)).toEqual([
@@ -4101,7 +4162,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("fails an unresolved hosted tool before one clean step end", () =>
+  scenarioIt("fails an unresolved hosted tool before one clean step end", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -4110,19 +4171,20 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Settle hosted tool before ending" }),
         resume: false,
       })
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({
-          id: "call-hosted-clean-end",
-          name: "web_search",
-          input: { query: "effect" },
-          providerExecuted: true,
-        }),
-        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-        LLMEvent.finish({ reason: "stop" }),
-      ]
 
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.events(
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolCall({
+            id: "call-hosted-clean-end",
+            name: "web_search",
+            input: { query: "effect" },
+            providerExecuted: true,
+          }),
+          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+          LLMEvent.finish({ reason: "stop" }),
+        )
+      })
 
       const assistant = requireAssistant(yield* session.context(sessionID))
       const events = yield* recordedStepSettlementEvents(sessionID, assistant.id)
@@ -4138,7 +4200,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("settles unresolved local and hosted tools before one raw provider failure", () =>
+  scenarioIt("settles unresolved local and hosted tools before one raw provider failure", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -4149,25 +4211,33 @@ describe("SessionRunnerLLM", () => {
       })
       const failure = invalidRequest()
       const providerFailed = yield* Deferred.make<void>()
-      toolExecutionGate = yield* Deferred.make<void>()
-      responseStream = Stream.concat(
-        Stream.fromIterable([
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-local-raw-failure", name: "defect", input: {} }),
-          LLMEvent.toolCall({
-            id: "call-hosted-raw-failure-pair",
-            name: "web_search",
-            input: { query: "effect" },
-            providerExecuted: true,
-          }),
-        ]),
-        Stream.fromEffect(Deferred.succeed(providerFailed, undefined)).pipe(Stream.flatMap(() => Stream.fail(failure))),
-      )
+      const gate = (toolExecutionGate = yield* Deferred.make<void>())
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(providerFailed)
-      yield* Deferred.succeed(toolExecutionGate, undefined)
-      expect(yield* Fiber.join(run).pipe(Effect.flip)).toBe(failure)
+      expect(
+        yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.stream(
+              Stream.concat(
+                Stream.fromIterable([
+                  LLMEvent.stepStart({ index: 0 }),
+                  LLMEvent.toolCall({ id: "call-local-raw-failure", name: "defect", input: {} }),
+                  LLMEvent.toolCall({
+                    id: "call-hosted-raw-failure-pair",
+                    name: "web_search",
+                    input: { query: "effect" },
+                    providerExecuted: true,
+                  }),
+                ]),
+                Stream.fromEffect(Deferred.succeed(providerFailed, undefined)).pipe(
+                  Stream.flatMap(() => Stream.fail(failure)),
+                ),
+              ),
+            )
+            yield* Deferred.await(providerFailed)
+            yield* Deferred.succeed(gate, undefined)
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
       toolExecutionGate = undefined
 
       const assistant = requireAssistant(yield* session.context(sessionID))
@@ -4186,7 +4256,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("durably fails a hosted tool left unresolved by a raw provider stream failure", () =>
+  scenarioIt("durably fails a hosted tool left unresolved by a raw provider stream failure", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -4195,23 +4265,29 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Fail hosted tool on raw failure" }),
         resume: false,
       })
-      requests.length = 0
       const failure = providerUnavailable()
-      responseStream = Stream.concat(
-        Stream.fromIterable([
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({
-            id: "call-hosted-raw-failure",
-            name: "web_search",
-            input: { query: "effect" },
-            providerExecuted: true,
-          }),
-        ]),
-        Stream.fail(failure),
-      )
 
-      expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
-      expect(requests).toHaveLength(1)
+      expect(
+        yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.stream(
+              Stream.concat(
+                Stream.fromIterable([
+                  LLMEvent.stepStart({ index: 0 }),
+                  LLMEvent.toolCall({
+                    id: "call-hosted-raw-failure",
+                    name: "web_search",
+                    input: { query: "effect" },
+                    providerExecuted: true,
+                  }),
+                ]),
+                Stream.fail(failure),
+              ),
+            )
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       const assistant = requireAssistant(yield* session.context(sessionID))
       const events = yield* recordedStepSettlementEvents(sessionID, assistant.id)
       expect(events.map((event) => event.type)).toEqual([
@@ -4236,50 +4312,46 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("rejects a second text start before the open fragment ends", () =>
+  scenarioIt("rejects a second text start before the open fragment ends", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Two blocks" }), resume: false })
 
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.textStart({ id: "text-1" }),
-        LLMEvent.textStart({ id: "text-2" }),
-      ]
-
-      const defect = yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed))
+      const defect = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.events(
+            LLMEvent.stepStart({ index: 0 }),
+            LLMEvent.textStart({ id: "text-1" }),
+            LLMEvent.textStart({ id: "text-2" }),
+          )
+        })
+        .pipe(Effect.catchDefect(Effect.succeed))
       expect(defect).toBeInstanceOf(Error)
       if (!(defect instanceof Error)) return
       expect(defect.message).toBe("text start before end: text-2")
     }),
   )
 
-  it.effect("projects sequential text fragments as separate content parts", () =>
+  scenarioIt("projects sequential text fragments as separate content parts", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Two blocks" }), resume: false })
 
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.textStart({ id: "text-1" }),
-        LLMEvent.textDelta({ id: "text-1", text: "First" }),
-        LLMEvent.textEnd({ id: "text-1" }),
-        LLMEvent.textStart({ id: "text-2" }),
-        LLMEvent.textDelta({ id: "text-2", text: "Second" }),
-        LLMEvent.textEnd({ id: "text-2" }),
-        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-        LLMEvent.finish({ reason: "stop" }),
-      ]
-
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.events(
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.textStart({ id: "text-1" }),
+          LLMEvent.textDelta({ id: "text-1", text: "First" }),
+          LLMEvent.textEnd({ id: "text-1" }),
+          LLMEvent.textStart({ id: "text-2" }),
+          LLMEvent.textDelta({ id: "text-2", text: "Second" }),
+          LLMEvent.textEnd({ id: "text-2" }),
+          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+          LLMEvent.finish({ reason: "stop" }),
+        )
+      })
 
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Two blocks" },
@@ -4295,34 +4367,128 @@ describe("SessionRunnerLLM", () => {
   )
 
   for (const kind of fragmentKinds) {
-    it.effect(`broadcasts provider ${kind} deltas without storing projection rewrites`, () =>
-      verifyEphemeralDeltas(kind),
+    scenarioIt(`broadcasts provider ${kind} deltas without storing projection rewrites`, (scenario) =>
+      Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        const prompt = `Stream ${kind}`
+        const chunks = Array.from({ length: 32 }, (_, index) => `${index},`)
+        const fixture = fragmentFixture(kind, fragmentID(kind, "many"), chunks)
+        const expectedContext = [{ type: "user", text: prompt }, fixture.expectedAssistant]
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: prompt }), resume: false })
+        const events = yield* EventV2.Service
+        const live = yield* events.subscribe(fixture.delta).pipe(Stream.take(32), Stream.runCollect, Effect.forkScoped)
+        yield* Effect.yieldNow
+
+        yield* scenario.run(function* () {
+          yield* (yield* scenario.llm.next()).respond.events(...fixture.completeEvents)
+        })
+
+        const { db } = yield* Database.Service
+        const deltas = yield* db
+          .select({ type: EventTable.type })
+          .from(EventTable)
+          .where(eq(EventTable.type, EventV2.versionedType(fixture.delta.type, 1)))
+          .all()
+          .pipe(Effect.orDie)
+        expect(Array.from(yield* Fiber.join(live))).toHaveLength(32)
+        expect(deltas).toHaveLength(0)
+        expect(yield* session.context(sessionID)).toMatchObject(expectedContext)
+
+        yield* replaySessionProjection(sessionID)
+
+        expect(yield* session.context(sessionID)).toMatchObject(expectedContext)
+      }),
     )
 
-    it.effect(`durably closes partial ${kind} when the provider stream fails`, () => verifyPartialFlushOnFailure(kind))
+    scenarioIt(`durably closes partial ${kind} when the provider stream fails`, (scenario) =>
+      Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        const prompt = `Fail after ${kind}`
+        const fixture = fragmentFixture(kind, fragmentID(kind, "partial"), ["Partial"])
+        const failure = providerUnavailable()
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: prompt }), resume: false })
 
-    it.effect(`durably closes partial ${kind} when the provider stream is interrupted`, () =>
-      verifyPartialFlushOnInterruption(kind),
+        expect(
+          yield* scenario
+            .run(function* () {
+              yield* (yield* scenario.llm.next()).respond.stream(
+                Stream.concat(Stream.fromIterable(fixture.partialEvents), Stream.fail(failure)),
+              )
+            })
+            .pipe(Effect.flip),
+        ).toBe(failure)
+        expect(yield* session.context(sessionID)).toMatchObject([
+          { type: "user", text: prompt },
+          {
+            type: "assistant",
+            finish: "error",
+            error: { type: "provider.transport", message: "Provider unavailable" },
+            content: [fixture.expectedContent],
+          },
+        ])
+        expect(yield* scenario.llm.requests).toHaveLength(1)
+      }),
+    )
+
+    scenarioIt(`durably closes partial ${kind} when the provider stream is interrupted`, (scenario) =>
+      Effect.gen(function* () {
+        yield* setup
+        const session = yield* SessionV2.Service
+        const prompt = `Interrupt after ${kind}`
+        const fixture = fragmentFixture(kind, fragmentID(kind, "interrupted"), ["Partial"])
+        const streamed = yield* Deferred.make<void>()
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: prompt }), resume: false })
+
+        yield* scenario
+          .run(function* () {
+            yield* (yield* scenario.llm.next()).respond.stream(
+              Stream.concat(
+                Stream.fromIterable(fixture.partialEvents),
+                Stream.fromEffect(Deferred.succeed(streamed, undefined)).pipe(Stream.flatMap(() => Stream.never)),
+              ),
+            )
+            yield* Deferred.await(streamed)
+            yield* session.interrupt(sessionID)
+          })
+          .pipe(Effect.exit)
+        expect(yield* session.context(sessionID)).toMatchObject([
+          { type: "user", text: prompt },
+          {
+            type: "assistant",
+            finish: "error",
+            error: { type: "aborted", message: "Step interrupted" },
+            content: [
+              kind === "tool input"
+                ? { type: "tool", id: fragmentID(kind, "interrupted"), state: { status: "error" } }
+                : fixture.expectedContent,
+            ],
+          },
+        ])
+      }),
     )
   }
 
-  it.effect("rejects duplicate streamed text starts", () =>
+  scenarioIt("rejects duplicate streamed text starts", (scenario) =>
     Effect.gen(function* () {
       yield* setup
-      const session = yield* SessionV2.Service
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = [LLMEvent.textStart({ id: "text-1" }), LLMEvent.textStart({ id: "text-1" })]
 
-      const defect = yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed))
+      const defect = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.events(
+            LLMEvent.textStart({ id: "text-1" }),
+            LLMEvent.textStart({ id: "text-1" }),
+          )
+        })
+        .pipe(Effect.catchDefect(Effect.succeed))
       expect(defect).toBeInstanceOf(Error)
       if (!(defect instanceof Error)) return
       expect(defect.message).toBe("Duplicate text start: text-1")
     }),
   )
 
-  it.effect("transitions streamed raw tool input to parsed called input", () =>
+  scenarioIt("transitions streamed raw tool input to parsed called input", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -4332,20 +4498,17 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolInputStart({ id: "call-parsed", name: "web_search" }),
-        LLMEvent.toolInputDelta({ id: "call-parsed", name: "web_search", text: '{"query":"hello"}' }),
-        LLMEvent.toolInputEnd({ id: "call-parsed", name: "web_search" }),
-        LLMEvent.toolCall({ id: "call-parsed", name: "web_search", input: { query: "hello" }, providerExecuted: true }),
-        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-        LLMEvent.finish({ reason: "stop" }),
-      ]
-
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.events(
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolInputStart({ id: "call-parsed", name: "web_search" }),
+          LLMEvent.toolInputDelta({ id: "call-parsed", name: "web_search", text: '{"query":"hello"}' }),
+          LLMEvent.toolInputEnd({ id: "call-parsed", name: "web_search" }),
+          LLMEvent.toolCall({ id: "call-parsed", name: "web_search", input: { query: "hello" }, providerExecuted: true }),
+          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+          LLMEvent.finish({ reason: "stop" }),
+        )
+      })
 
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Call provider tool" },
@@ -4357,16 +4520,17 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("rejects malformed streamed tool input ordering", () =>
+  scenarioIt("rejects malformed streamed tool input ordering", (scenario) =>
     Effect.gen(function* () {
       yield* setup
-      const session = yield* SessionV2.Service
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = [LLMEvent.toolInputDelta({ id: "call-1", name: "read", text: "{}" })]
 
-      const defect = yield* session.resume(sessionID).pipe(Effect.catchDefect(Effect.succeed))
+      const defect = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.events(
+            LLMEvent.toolInputDelta({ id: "call-1", name: "read", text: "{}" }),
+          )
+        })
+        .pipe(Effect.catchDefect(Effect.succeed))
       expect(defect).toBeInstanceOf(Error)
       if (!(defect instanceof Error)) return
       expect(defect.message).toBe("Tool input delta before start: call-1")

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -431,15 +431,11 @@ const rateLimited = (retryAfterMs?: number) =>
 const setupOverflowRecovery = Effect.gen(function* () {
   yield* setup
   const session = yield* SessionV2.Service
-  response = fragmentFixture("text", "text-earlier", ["Earlier answer"]).completeEvents
   yield* session.prompt({
     sessionID,
     prompt: PromptInput.Prompt.make({ text: "Earlier question ".repeat(700) }),
     resume: false,
   })
-  yield* session.resume(sessionID)
-  currentModel = recoveryModel
-  requests.length = 0
   return session
 })
 
@@ -1362,215 +1358,210 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("rebuilds the baseline directly after completed compaction", () =>
+  scenarioIt("rebuilds the baseline directly after completed compaction", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      yield* events.publish(SessionEvent.Compaction.Started, {
-        sessionID,
-        reason: "manual",
-      })
-      yield* events.publish(SessionEvent.Compaction.Ended, {
-        sessionID,
-        reason: "manual",
-        text: "summary",
-        recent: "",
-      })
-      systemBaseline = "Replacement context"
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* events.publish(SessionEvent.Compaction.Started, {
+          sessionID,
+          reason: "manual",
+        })
+        yield* events.publish(SessionEvent.Compaction.Ended, {
+          sessionID,
+          reason: "manual",
+          text: "summary",
+          recent: "",
+        })
+        systemBaseline = "Replacement context"
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
-        [defaultSystem, "Initial context"],
-        [defaultSystem, "Replacement context"],
-      ])
-      yield* replaySessionProjection(sessionID)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-      yield* session.resume(sessionID)
+        const second = yield* scenario.llm.next()
+        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Replacement context"])
+        yield* replaySessionProjection(sessionID)
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
+        yield* second.respond.events()
+
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
     }),
   )
 
-  it.effect("runs one durable compaction barrier before later steer and queued prompts", () =>
+  scenarioIt("runs one durable compaction barrier before later steer and queued prompts", (scenario) =>
     Effect.gen(function* () {
       yield* setup
-      requests.length = 0
       currentModel = recoveryModel
       const session = yield* SessionV2.Service
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
-      responses = [
-        fragmentFixture("text", "text-active", ["Active complete"]).completeEvents,
-        [LLMEvent.textDelta({ id: "summary", text: "durable summary" })],
-        fragmentFixture("text", "text-steer", ["Steer complete"]).completeEvents,
-        fragmentFixture("text", "text-queue", ["Queue complete"]).completeEvents,
-      ]
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Active work" }), resume: false })
-      const active = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
 
-      const first = yield* session.compact({ sessionID })
-      const second = yield* session.compact({ sessionID })
-      expect(second.id).toBe(first.id)
-      expect(yield* SessionInput.pendingCompaction((yield* Database.Service).db, sessionID)).toMatchObject({
-        id: first.id,
-      })
-      expect((yield* session.messages({ sessionID })).find((message) => message.id === first.id)).toMatchObject({
-        type: "compaction",
-        status: "queued",
+      yield* scenario.run(function* () {
+        const active = yield* scenario.llm.next()
+        const first = yield* session.compact({ sessionID })
+        const second = yield* session.compact({ sessionID })
+        expect(second.id).toBe(first.id)
+        expect(yield* SessionInput.pendingCompaction((yield* Database.Service).db, sessionID)).toMatchObject({
+          id: first.id,
+        })
+        expect((yield* session.messages({ sessionID })).find((message) => message.id === first.id)).toMatchObject({
+          type: "compaction",
+          status: "queued",
+        })
+
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Steer after compaction" }),
+          resume: false,
+        })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Queue after compaction" }),
+          delivery: "queue",
+          resume: false,
+        })
+        expect(yield* SessionInput.hasPending((yield* Database.Service).db, sessionID, "steer")).toBe(false)
+        yield* active.respond.text("Active complete", { id: "text-active" })
+
+        const compaction = yield* scenario.llm.next()
+        expect(userTexts(compaction.request)[0]).toContain("Create a new anchored summary")
+        yield* compaction.respond.events(LLMEvent.textDelta({ id: "summary", text: "durable summary" }))
+
+        const steer = yield* scenario.llm.next()
+        expect(userTexts(steer.request)).toContain("Steer after compaction")
+        yield* steer.respond.text("Steer complete", { id: "text-steer" })
+
+        const queue = yield* scenario.llm.next()
+        expect(userTexts(queue.request)).toContain("Queue after compaction")
+        yield* queue.respond.text("Queue complete", { id: "text-queue" })
+
+        expect(yield* SessionInput.pendingCompaction((yield* Database.Service).db, sessionID)).toBeUndefined()
+        expect((yield* session.messages({ sessionID })).find((message) => message.id === first.id)).toMatchObject({
+          type: "compaction",
+          status: "completed",
+          summary: "durable summary",
+        })
       })
 
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Steer after compaction" }),
-        resume: false,
-      })
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Queue after compaction" }),
-        delivery: "queue",
-        resume: false,
-      })
-      expect(yield* SessionInput.hasPending((yield* Database.Service).db, sessionID, "steer")).toBe(false)
-
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(active)
-
-      expect(requests).toHaveLength(4)
-      expect(userTexts(requests[1])[0]).toContain("Create a new anchored summary")
-      expect(userTexts(requests[2])).toContain("Steer after compaction")
-      expect(userTexts(requests[3])).toContain("Queue after compaction")
-      expect(yield* SessionInput.pendingCompaction((yield* Database.Service).db, sessionID)).toBeUndefined()
-      expect((yield* session.messages({ sessionID })).find((message) => message.id === first.id)).toMatchObject({
-        type: "compaction",
-        status: "completed",
-        summary: "durable summary",
-      })
+      expect(yield* scenario.llm.requests).toHaveLength(4)
     }),
   )
 
-  it.effect("releases queued prompts when durable compaction fails", () =>
+  scenarioIt("releases queued prompts when durable compaction fails", (scenario) =>
     Effect.gen(function* () {
       yield* setup
-      requests.length = 0
       currentModel = recoveryModel
       const session = yield* SessionV2.Service
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
-      responses = [
-        fragmentFixture("text", "text-active-failure", ["Active complete"]).completeEvents,
-        [],
-        fragmentFixture("text", "text-after-failure", ["Continued"]).completeEvents,
-      ]
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Active work" }), resume: false })
-      const active = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
 
-      const compaction = yield* session.compact({ sessionID })
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Continue after failure" }),
-        delivery: "queue",
-        resume: false,
-      })
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(active)
+      yield* scenario.run(function* () {
+        const active = yield* scenario.llm.next()
+        const compaction = yield* session.compact({ sessionID })
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Continue after failure" }),
+          delivery: "queue",
+          resume: false,
+        })
+        yield* active.respond.text("Active complete", { id: "text-active-failure" })
 
-      expect(requests).toHaveLength(3)
-      expect(userTexts(requests[2])).toContain("Continue after failure")
-      expect(yield* SessionInput.pendingCompaction((yield* Database.Service).db, sessionID)).toBeUndefined()
-      expect((yield* session.messages({ sessionID })).find((message) => message.id === compaction.id)).toMatchObject({
-        type: "compaction",
-        status: "failed",
+        yield* (yield* scenario.llm.next()).respond.events()
+        const continued = yield* scenario.llm.next()
+        expect(userTexts(continued.request)).toContain("Continue after failure")
+        yield* continued.respond.text("Continued", { id: "text-after-failure" })
+
+        expect(yield* SessionInput.pendingCompaction((yield* Database.Service).db, sessionID)).toBeUndefined()
+        expect((yield* session.messages({ sessionID })).find((message) => message.id === compaction.id)).toMatchObject({
+          type: "compaction",
+          status: "failed",
+        })
       })
+
+      expect(yield* scenario.llm.requests).toHaveLength(3)
     }),
   )
 
-  it.effect("automatically compacts into a completed summary and retained recent turn", () =>
+  scenarioIt("automatically compacts into a completed summary and retained recent turn", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
-      response = fragmentFixture("text", "text-first", ["Earlier answer"]).completeEvents
       yield* session.prompt({
         sessionID,
         prompt: PromptInput.Prompt.make({ text: "Earlier question ".repeat(180) }),
         resume: false,
       })
-      yield* session.resume(sessionID)
 
-      currentModel = compactModel
-      requests.length = 0
-      responses = [
-        fragmentFixture("text", "text-summary", ["## Objective\n- Preserve the task"]).completeEvents,
-        fragmentFixture("text", "text-final", ["Continued"]).completeEvents,
-      ]
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Recent exact request ".repeat(180) }),
-        resume: false,
+      yield* scenario.run(function* () {
+        const earlier = yield* scenario.llm.next()
+        currentModel = compactModel
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Recent exact request ".repeat(180) }),
+          resume: false,
+        })
+        yield* earlier.respond.text("Earlier answer", { id: "text-first" })
+
+        const summary = yield* scenario.llm.next()
+        expect(userTexts(summary.request)[0]).toContain("## Objective")
+        yield* summary.respond.text("## Objective\n- Preserve the task", { id: "text-summary" })
+
+        const continued = yield* scenario.llm.next()
+        expect(userTexts(continued.request)).toHaveLength(1)
+        expect(userTexts(continued.request)[0]).toContain("<summary>\n## Objective\n- Preserve the task\n</summary>")
+        expect(userTexts(continued.request)[0]).toContain(`[User]: ${"Recent exact request ".repeat(180)}`)
+        yield* session.prompt({
+          sessionID,
+          prompt: PromptInput.Prompt.make({ text: "Newest exact request ".repeat(180) }),
+          resume: false,
+        })
+        yield* continued.respond.text("Continued", { id: "text-final" })
+
+        const updatedSummary = yield* scenario.llm.next()
+        expect(userTexts(updatedSummary.request)[0]).toContain(
+          "<previous-summary>\n## Objective\n- Preserve the task\n</previous-summary>",
+        )
+        expect(userTexts(updatedSummary.request)[0]).toContain("Recent exact request")
+        yield* updatedSummary.respond.text("## Objective\n- Preserve the updated task", { id: "text-summary-2" })
+
+        yield* (yield* scenario.llm.next()).respond.text("Continued again", { id: "text-final-2" })
+        expect((yield* (yield* SessionStore.Service).context(sessionID))[0]).toMatchObject({
+          type: "compaction",
+          summary: "## Objective\n- Preserve the updated task",
+        })
       })
-      yield* session.resume(sessionID)
 
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[0])[0]).toContain("## Objective")
-      expect(userTexts(requests[1])).toHaveLength(1)
-      expect(userTexts(requests[1])[0]).toContain("<summary>\n## Objective\n- Preserve the task\n</summary>")
-      expect(userTexts(requests[1])[0]).toContain(`[User]: ${"Recent exact request ".repeat(180)}`)
-
-      const context = yield* (yield* SessionStore.Service).context(sessionID)
-      expect(context.map((message) => message.type)).toEqual(["compaction", "assistant"])
-      expect(context[0]).toMatchObject({
-        type: "compaction",
-        summary: "## Objective\n- Preserve the task",
-      })
-
-      requests.length = 0
-      executions.length = 0
-      responses = [
-        fragmentFixture("text", "text-summary-2", ["## Objective\n- Preserve the updated task"]).completeEvents,
-        fragmentFixture("text", "text-final-2", ["Continued again"]).completeEvents,
-      ]
-      yield* session.prompt({
-        sessionID,
-        prompt: PromptInput.Prompt.make({ text: "Newest exact request ".repeat(180) }),
-        resume: false,
-      })
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(2)
-      expect(userTexts(requests[0])[0]).toContain(
-        "<previous-summary>\n## Objective\n- Preserve the task\n</previous-summary>",
-      )
-      expect(userTexts(requests[0])[0]).toContain("Recent exact request")
-      expect((yield* (yield* SessionStore.Service).context(sessionID))[0]).toMatchObject({
-        type: "compaction",
-        summary: "## Objective\n- Preserve the updated task",
-      })
+      expect(yield* scenario.llm.requests).toHaveLength(5)
     }),
   )
 
-  it.effect("forces one compaction and retries after provider context overflow", () =>
+  scenarioIt("forces one compaction and retries after provider context overflow", (scenario) =>
     Effect.gen(function* () {
       const session = yield* setupOverflowRecovery
-      responses = [
-        [
+      yield* scenario.run(function* () {
+        const earlier = yield* scenario.llm.next()
+        currentModel = recoveryModel
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
+        yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
+
+        yield* (yield* scenario.llm.next()).respond.events(
           LLMEvent.stepStart({ index: 0 }),
           LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
-        ],
-        fragmentFixture("text", "text-summary", ["## Objective\n- Recover overflow"]).completeEvents,
-        fragmentFixture("text", "text-final", ["Recovered"]).completeEvents,
-      ]
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-      yield* session.resume(sessionID)
+        )
 
-      expect(requests).toHaveLength(3)
-      expect(userTexts(requests[1])[0]).toContain("## Objective")
-      expect(userTexts(requests[2])[0]).toContain("<summary>\n## Objective\n- Recover overflow\n</summary>")
+        const summary = yield* scenario.llm.next()
+        expect(userTexts(summary.request)[0]).toContain("## Objective")
+        yield* summary.respond.text("## Objective\n- Recover overflow", { id: "text-summary" })
+
+        const recovered = yield* scenario.llm.next()
+        expect(userTexts(recovered.request)[0]).toContain("<summary>\n## Objective\n- Recover overflow\n</summary>")
+        yield* recovered.respond.text("Recovered", { id: "text-final" })
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(4)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "compaction", summary: "## Objective\n- Recover overflow" },
         { type: "assistant", finish: "stop" },
@@ -1583,22 +1574,35 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("persists a second context overflow after one recovery", () =>
+  scenarioIt("persists a second context overflow after one recovery", (scenario) =>
     Effect.gen(function* () {
       const session = yield* setupOverflowRecovery
       const overflow = () => [
         LLMEvent.stepStart({ index: 0 }),
         LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
       ]
-      responses = [
-        overflow(),
-        fragmentFixture("text", "text-summary", ["## Objective\n- Recover once"]).completeEvents,
-        overflow(),
-      ]
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("prompt too long")
+      expect(
+        (yield* scenario
+          .run(function* () {
+            const earlier = yield* scenario.llm.next()
+            currentModel = recoveryModel
+            yield* session.prompt({
+              sessionID,
+              prompt: PromptInput.Prompt.make({ text: "Continue" }),
+              resume: false,
+            })
+            yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
 
-      expect(requests).toHaveLength(3)
+            yield* (yield* scenario.llm.next()).respond.events(...overflow())
+            yield* (yield* scenario.llm.next()).respond.text("## Objective\n- Recover once", {
+              id: "text-summary",
+            })
+            yield* (yield* scenario.llm.next()).respond.events(...overflow())
+          })
+          .pipe(Effect.flip)).message,
+      ).toBe("prompt too long")
+
+      expect(yield* scenario.llm.requests).toHaveLength(4)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "compaction" },
         { type: "assistant", finish: "error", error: { message: "prompt too long" } },
@@ -1606,27 +1610,32 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("recovers once from a raw context overflow failure", () =>
+  scenarioIt("recovers once from a raw context overflow failure", (scenario) =>
     Effect.gen(function* () {
       const session = yield* setupOverflowRecovery
-      responseStream = Stream.fail(
-        new LLMError({
-          module: "test",
-          method: "stream",
-          reason: new InvalidRequestReason({
-            message: "prompt too long",
-            classification: "context-overflow",
-          }),
-        }),
-      )
-      responses = [
-        fragmentFixture("text", "text-summary", ["## Objective\n- Recover raw overflow"]).completeEvents,
-        fragmentFixture("text", "text-final", ["Recovered"]).completeEvents,
-      ]
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const earlier = yield* scenario.llm.next()
+        currentModel = recoveryModel
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
+        yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
 
-      expect(requests).toHaveLength(3)
+        yield* (yield* scenario.llm.next()).respond.fail(
+          new LLMError({
+            module: "test",
+            method: "stream",
+            reason: new InvalidRequestReason({
+              message: "prompt too long",
+              classification: "context-overflow",
+            }),
+          }),
+        )
+        yield* (yield* scenario.llm.next()).respond.text("## Objective\n- Recover raw overflow", {
+          id: "text-summary",
+        })
+        yield* (yield* scenario.llm.next()).respond.text("Recovered", { id: "text-final" })
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(4)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "compaction", summary: "## Objective\n- Recover raw overflow" },
         { type: "assistant", finish: "stop" },
@@ -1634,17 +1643,32 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("publishes the original overflow when recovery summarization fails", () =>
+  scenarioIt("publishes the original overflow when recovery summarization fails", (scenario) =>
     Effect.gen(function* () {
       const session = yield* setupOverflowRecovery
-      responses = [
-        [LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" })],
-        [LLMEvent.providerError({ message: "summary unavailable" })],
-      ]
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-      expect((yield* session.resume(sessionID).pipe(Effect.flip)).message).toBe("prompt too long")
+      expect(
+        (yield* scenario
+          .run(function* () {
+            const earlier = yield* scenario.llm.next()
+            currentModel = recoveryModel
+            yield* session.prompt({
+              sessionID,
+              prompt: PromptInput.Prompt.make({ text: "Continue" }),
+              resume: false,
+            })
+            yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
 
-      expect(requests).toHaveLength(2)
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
+            )
+            yield* (yield* scenario.llm.next()).respond.events(
+              LLMEvent.providerError({ message: "summary unavailable" }),
+            )
+          })
+          .pipe(Effect.flip)).message,
+      ).toBe("prompt too long")
+
+      expect(yield* scenario.llm.requests).toHaveLength(3)
       const context = yield* session.context(sessionID)
       expect(context.some((message) => message.type === "compaction")).toBe(false)
       expect(context.slice(-2)).toMatchObject([
@@ -1654,61 +1678,68 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("interrupts overflow recovery while the summary provider is running", () =>
+  scenarioIt("interrupts overflow recovery while the summary provider is running", (scenario) =>
     Effect.gen(function* () {
       const session = yield* setupOverflowRecovery
-      responses = [
-        [LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" })],
-        fragmentFixture("text", "text-summary", ["## Objective\n- Interrupted"]).completeEvents,
-      ]
-      const firstGate = yield* Deferred.make<void>()
-      const summaryGate = yield* Deferred.make<void>()
-      streamGate = firstGate
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (requests.length < 1) yield* Effect.yieldNow
-      streamGate = summaryGate
-      yield* Deferred.succeed(firstGate, undefined)
-      while (requests.length < 2) yield* Effect.yieldNow
+      const exit = yield* scenario
+        .run(function* () {
+          const earlier = yield* scenario.llm.next()
+          currentModel = recoveryModel
+          yield* session.prompt({
+            sessionID,
+            prompt: PromptInput.Prompt.make({ text: "Continue" }),
+            resume: false,
+          })
+          yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
 
-      yield* session.interrupt(sessionID)
-      expect(yield* Fiber.await(run)).toMatchObject({ _tag: "Failure" })
-      streamGate = undefined
-      expect(requests).toHaveLength(2)
+          yield* (yield* scenario.llm.next()).respond.events(
+            LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
+          )
+          yield* (yield* scenario.llm.next()).respond.stream(Stream.never)
+          yield* session.interrupt(sessionID)
+        })
+        .pipe(Effect.exit)
+
+      expect(exit).toMatchObject({ _tag: "Failure" })
+      expect(yield* scenario.llm.requests).toHaveLength(3)
       expect((yield* session.context(sessionID)).some((message) => message.type === "compaction")).toBe(false)
     }),
   )
 
-  it.effect("rebaselines after compaction from the last-applied belief while unobservable", () =>
+  scenarioIt("rebaselines after compaction from the last-applied belief while unobservable", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      requests.length = 0
-      response = []
-      yield* session.resume(sessionID)
-      systemBaseline = "Changed context"
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-      yield* session.resume(sessionID)
-      yield* events.publish(SessionEvent.Compaction.Started, {
-        sessionID,
-        reason: "manual",
-      })
-      yield* events.publish(SessionEvent.Compaction.Ended, {
-        sessionID,
-        reason: "manual",
-        text: "summary",
-        recent: "",
-      })
-      systemUnavailable = true
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        systemBaseline = "Changed context"
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+        yield* first.respond.events()
 
-      // The rebaseline proceeds while the source is unobservable, restating the model's belief.
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual([defaultSystem, "Changed context"])
-      expect(systemTexts(requests.at(-1)!)).not.toContain("Changed context")
+        const second = yield* scenario.llm.next()
+        yield* events.publish(SessionEvent.Compaction.Started, {
+          sessionID,
+          reason: "manual",
+        })
+        yield* events.publish(SessionEvent.Compaction.Ended, {
+          sessionID,
+          reason: "manual",
+          text: "summary",
+          recent: "",
+        })
+        systemUnavailable = true
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
+        yield* second.respond.events()
+
+        const third = yield* scenario.llm.next()
+        // The rebaseline proceeds while the source is unobservable, restating the model's belief.
+        expect(third.request.system.map((part) => part.text)).toEqual([defaultSystem, "Changed context"])
+        expect(systemTexts(third.request)).not.toContain("Changed context")
+        yield* third.respond.events()
+      })
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2935,35 +2935,18 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("durably settles local tool failures before continuing", () =>
+  scenarioIt("durably settles local tool failures before continuing", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Call missing" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-missing", name: "missing", input: {} }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.textStart({ id: "text-after-error" }),
-          LLMEvent.textDelta({ id: "text-after-error", text: "Recovered" }),
-          LLMEvent.textEnd({ id: "text-after-error" }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = undefined
-      streamStarted = undefined
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.toolCall("missing", {}, { id: "call-missing" })
+        yield* (yield* scenario.llm.next()).respond.text("Recovered", { id: "text-after-error" })
+      })
 
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(2)
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Call missing" },
         {
@@ -2981,34 +2964,20 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("returns unexpected local tool defects to the model and continues", () =>
+  scenarioIt("returns unexpected local tool defects to the model and continues", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Call defect" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-defect", name: "defect", input: {} }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.textStart({ id: "text-after-defect" }),
-          LLMEvent.textDelta({ id: "text-after-defect", text: "Recovered" }),
-          LLMEvent.textEnd({ id: "text-after-defect" }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.toolCall("defect", {}, { id: "call-defect" })
+        const second = yield* scenario.llm.next()
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+        yield* second.respond.text("Recovered", { id: "text-after-defect" })
+      })
 
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(2)
-      expect(requests[1]?.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       const context = yield* session.context(sessionID)
       expect(context).toMatchObject([
         { type: "user", text: "Call defect" },
@@ -3037,7 +3006,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("returns policy-blocked tools to the model and continues", () =>
+  scenarioIt("returns policy-blocked tools to the model and continues", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3055,24 +3024,12 @@ describe("SessionRunnerLLM", () => {
       })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Call blocked" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-blocked", name: "blocked", input: {} }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.toolCall("blocked", {}, { id: "call-blocked" })
+        yield* (yield* scenario.llm.next()).respond.stop()
+      })
 
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(2)
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Call blocked" },
         {
@@ -3086,7 +3043,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("interrupts runner continuation when permission approval is declined", () =>
+  scenarioIt("interrupts runner continuation when permission approval is declined", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3101,19 +3058,15 @@ describe("SessionRunnerLLM", () => {
       })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Call declined" }), resume: false })
 
-      requests.length = 0
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({ id: "call-declined", name: "declined", input: {} }),
-        LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-        LLMEvent.finish({ reason: "tool-calls" }),
-      ]
-
-      const exit = yield* session.resume(sessionID).pipe(Effect.exit)
+      const exit = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.toolCall("declined", {}, { id: "call-declined" })
+        })
+        .pipe(Effect.exit)
 
       expect(exit._tag).toBe("Failure")
       if (exit._tag === "Failure") expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Call declined" },
         {
@@ -3130,7 +3083,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("returns permission corrections to the model and continues", () =>
+  scenarioIt("returns permission corrections to the model and continues", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3148,24 +3101,12 @@ describe("SessionRunnerLLM", () => {
       })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Call corrected" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-corrected", name: "corrected", input: {} }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.toolCall("corrected", {}, { id: "call-corrected" })
+        yield* (yield* scenario.llm.next()).respond.stop()
+      })
 
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(2)
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Call corrected" },
         {
@@ -3179,27 +3120,20 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("fails the drain when tool output persistence fails", () =>
+  scenarioIt("fails the drain when tool output persistence fails", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Call storefail" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-storefail", name: "storefail", input: {} }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [],
-      ]
-
-      const exit = yield* session.resume(sessionID).pipe(Effect.exit)
+      const exit = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.toolCall("storefail", {}, { id: "call-storefail" })
+        })
+        .pipe(Effect.exit)
 
       expect(Exit.isFailure(exit)).toBe(true)
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Call storefail" },
         {
@@ -3224,7 +3158,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("preserves permission rejection and stops before continuation", () =>
+  scenarioIt("preserves permission rejection and stops before continuation", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3250,21 +3184,14 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Reject permission" }),
         resume: false,
       })
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-permission", name: "permissionfail", input: {} }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [LLMEvent.stepStart({ index: 0 }), LLMEvent.stepFinish({ index: 0, reason: "stop" })],
-      ]
-
-      const exit = yield* session.resume(sessionID).pipe(Effect.exit)
+      const exit = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.toolCall("permissionfail", {}, { id: "call-permission" })
+        })
+        .pipe(Effect.exit)
 
       expect(exit._tag).toBe("Failure")
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user" },
         {
@@ -3293,7 +3220,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("interrupts runner continuation when a question is cancelled", () =>
+  scenarioIt("interrupts runner continuation when a question is cancelled", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3308,23 +3235,15 @@ describe("SessionRunnerLLM", () => {
       })
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Ask then stop" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-question", name: "question", input: {} }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [],
-      ]
-
-      const run = yield* session.resume(sessionID).pipe(Effect.exit, Effect.forkChild)
-      const exit = yield* Fiber.join(run)
+      const exit = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.toolCall("question", {}, { id: "call-question" })
+        })
+        .pipe(Effect.exit)
 
       expect(exit._tag).toBe("Failure")
       if (exit._tag === "Failure") expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true)
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Ask then stop" },
         {
@@ -3341,7 +3260,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("awaits started local tools before surfacing provider stream failure", () =>
+  scenarioIt("awaits started local tools before surfacing provider stream failure", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3352,20 +3271,31 @@ describe("SessionRunnerLLM", () => {
       })
       const failure = providerUnavailable()
       toolExecutionGate = yield* Deferred.make<void>()
-      responseStream = Stream.concat(
-        Stream.fromIterable([
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-before-failure", name: "echo", input: { text: "settle" } }),
-        ]),
-        Stream.fail(failure),
-      )
+      toolExecutionsStarted = yield* Deferred.make<void>()
+      toolExecutionsReady = 1
+      const executionGate = toolExecutionGate
+      const executionsStarted = toolExecutionsStarted
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (executions.length === 0) yield* Effect.yieldNow
-      yield* Effect.yieldNow
-      yield* Deferred.succeed(toolExecutionGate, undefined)
-      expect(yield* Fiber.join(run).pipe(Effect.flip)).toBe(failure)
+      expect(
+        yield* scenario
+          .run(function* () {
+            const call = yield* scenario.llm.next()
+            yield* call.respond.stream(
+              Stream.concat(
+                Stream.fromIterable([
+                  LLMEvent.stepStart({ index: 0 }),
+                  LLMEvent.toolCall({ id: "call-before-failure", name: "echo", input: { text: "settle" } }),
+                ]),
+                Stream.fail(failure),
+              ),
+            )
+            yield* Deferred.await(executionsStarted)
+            yield* Deferred.succeed(executionGate, undefined)
+          })
+          .pipe(Effect.flip),
+      ).toBe(failure)
       toolExecutionGate = undefined
+      toolExecutionsStarted = undefined
 
       const context = yield* session.context(sessionID)
       expect(context).toMatchObject([
@@ -3387,7 +3317,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("durably fails blocked local tools when a provider turn is interrupted", () =>
+  scenarioIt("durably fails blocked local tools when a provider turn is interrupted", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3398,20 +3328,30 @@ describe("SessionRunnerLLM", () => {
       })
       executions.length = 0
       toolExecutionGate = yield* Deferred.make<void>()
-      responseStream = Stream.concat(
-        Stream.fromIterable([
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-before-interrupt", name: "echo", input: { text: "blocked" } }),
-        ]),
-        Stream.never,
-      )
+      toolExecutionsStarted = yield* Deferred.make<void>()
+      toolExecutionsReady = 1
+      const executionsStarted = toolExecutionsStarted
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      while (executions.length === 0) yield* Effect.yieldNow
-      yield* session.interrupt(sessionID)
+      const exit = yield* scenario
+        .run(function* () {
+          const call = yield* scenario.llm.next()
+          yield* call.respond.stream(
+            Stream.concat(
+              Stream.fromIterable([
+                LLMEvent.stepStart({ index: 0 }),
+                LLMEvent.toolCall({ id: "call-before-interrupt", name: "echo", input: { text: "blocked" } }),
+              ]),
+              Stream.never,
+            ),
+          )
+          yield* Deferred.await(executionsStarted)
+          yield* session.interrupt(sessionID)
+        })
+        .pipe(Effect.exit)
       toolExecutionGate = undefined
+      toolExecutionsStarted = undefined
 
-      expect(yield* Fiber.await(run)).toMatchObject({ _tag: "Failure" })
+      expect(exit).toMatchObject({ _tag: "Failure" })
       yield* session.interrupt(sessionID)
       const context = yield* session.context(sessionID)
       expect(context).toMatchObject([
@@ -3441,15 +3381,10 @@ describe("SessionRunnerLLM", () => {
         { type: "user", text: "Interrupt blocked tool" },
         { type: "assistant", content: [{ type: "tool", id: "call-before-interrupt", state: { status: "error" } }] },
       ])
-      requests.length = 0
-      responseStream = undefined
-      response = []
-      yield* session.resume(sessionID)
-      expect(requests[0]?.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
     }),
   )
 
-  it.effect("interrupts a blocked provider turn without local tool execution", () =>
+  scenarioIt("interrupts a blocked provider turn without local tool execution", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
@@ -3458,20 +3393,16 @@ describe("SessionRunnerLLM", () => {
         prompt: PromptInput.Prompt.make({ text: "Interrupt provider" }),
         resume: false,
       })
-      requests.length = 0
-      response = []
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.interrupt(sessionID)
-      const exit = yield* Fiber.await(run)
-      streamGate = undefined
-      streamStarted = undefined
+      const exit = yield* scenario
+        .run(function* () {
+          yield* (yield* scenario.llm.next()).respond.stream(Stream.never)
+          yield* session.interrupt(sessionID)
+        })
+        .pipe(Effect.exit)
 
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBeTrue()
-      expect(requests).toHaveLength(1)
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Interrupt provider" },
         { type: "assistant", finish: "error", error: { type: "aborted", message: "Step interrupted" } },
@@ -3494,6 +3425,7 @@ describe("SessionRunnerLLM", () => {
       toolExecutionGate = yield* Deferred.make<void>()
       toolExecutionsStarted = yield* Deferred.make<void>()
       toolExecutionsReady = 1
+      const executionsStarted = toolExecutionsStarted
       response = [
         LLMEvent.stepStart({ index: 0 }),
         LLMEvent.toolCall({ id: "call-await-interrupt", name: "echo", input: { text: "blocked" } }),
@@ -3503,9 +3435,10 @@ describe("SessionRunnerLLM", () => {
 
       const runner = yield* SessionRunner.Service
       const run = yield* runner.drain({ sessionID, force: true }).pipe(Effect.forkChild)
-      yield* Deferred.await(toolExecutionsStarted)
+      yield* Deferred.await(executionsStarted)
       yield* Fiber.interrupt(run)
       toolExecutionGate = undefined
+      toolExecutionsStarted = undefined
 
       expect(yield* Fiber.await(run)).toMatchObject({ _tag: "Failure" })
       expect(yield* session.context(sessionID)).toMatchObject([
@@ -3529,7 +3462,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("forces a text response on an agent's configured final step", () =>
+  scenarioIt("forces a text response on an agent's configured final step", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const agents = yield* AgentV2.Service
@@ -3545,33 +3478,23 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      requests.length = 0
       executions.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-terminal", name: "echo", input: { text: "done" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-forbidden", name: "echo", input: { text: "forbidden" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-      ]
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        expect(first.request.toolChoice).toBeUndefined()
+        yield* first.respond.toolCall("echo", { text: "done" }, { id: "call-terminal" })
 
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(2)
-      expect(requests[0]?.toolChoice).toBeUndefined()
-      expect(requests[1]?.toolChoice).toMatchObject({ type: "none" })
-      expect(requests[1]?.tools).toEqual([])
-      expect(requests[1]?.messages.at(-1)).toMatchObject({
-        role: "assistant",
-        content: [{ type: "text", text: expect.stringContaining("MAXIMUM STEPS REACHED") }],
+        const second = yield* scenario.llm.next()
+        expect(second.request.toolChoice).toMatchObject({ type: "none" })
+        expect(second.request.tools).toEqual([])
+        expect(second.request.messages.at(-1)).toMatchObject({
+          role: "assistant",
+          content: [{ type: "text", text: expect.stringContaining("MAXIMUM STEPS REACHED") }],
+        })
+        yield* second.respond.toolCall("echo", { text: "forbidden" }, { id: "call-forbidden" })
       })
+
+      expect(yield* scenario.llm.requests).toHaveLength(2)
       expect(executions).toEqual(["done"])
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Finish at the limit" },
@@ -3581,7 +3504,7 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("resets the configured step allowance when steering input promotes", () =>
+  scenarioIt("resets the configured step allowance when steering input promotes", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const agents = yield* AgentV2.Service
@@ -3593,42 +3516,23 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Start work" }), resume: false })
 
-      requests.length = 0
       executions.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-before-steer", name: "echo", input: { text: "before" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-after-steer", name: "echo", input: { text: "after" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-          LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      streamGate = yield* Deferred.make<void>()
-      streamStarted = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Change direction" }) })
+        yield* first.respond.toolCall("echo", { text: "before" }, { id: "call-before-steer" })
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(streamStarted)
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Change direction" }) })
-      yield* Deferred.succeed(streamGate, undefined)
-      yield* Fiber.join(run)
-      streamGate = undefined
-      streamStarted = undefined
+        const second = yield* scenario.llm.next()
+        expect(second.request.toolChoice).toBeUndefined()
+        expect(second.request.tools).not.toEqual([])
+        yield* second.respond.toolCall("echo", { text: "after" }, { id: "call-after-steer" })
 
-      expect(requests).toHaveLength(3)
-      expect(requests[1]?.toolChoice).toBeUndefined()
-      expect(requests[1]?.tools).not.toEqual([])
-      expect(requests[2]?.toolChoice).toMatchObject({ type: "none" })
+        const third = yield* scenario.llm.next()
+        expect(third.request.toolChoice).toMatchObject({ type: "none" })
+        yield* third.respond.stop()
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(3)
       expect(executions).toEqual(["before", "after"])
     }),
   )

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -389,16 +389,21 @@ const rateLimited = (retryAfterMs?: number) =>
     reason: new RateLimitReason({ message: "Rate limited", retryAfterMs }),
   })
 
-const setupOverflowRecovery = Effect.gen(function* () {
-  yield* setup
-  const session = yield* SessionV2.Service
-  yield* session.prompt({
-    sessionID,
-    prompt: PromptInput.Prompt.make({ text: "Earlier question ".repeat(700) }),
-    resume: false,
+const setupOverflowRecovery = (scenario: SessionScenario) =>
+  Effect.gen(function* () {
+    yield* setup
+    const session = yield* SessionV2.Service
+    yield* session.prompt({
+      sessionID,
+      prompt: PromptInput.Prompt.make({ text: "Earlier question ".repeat(700) }),
+      resume: false,
+    })
+    yield* scenario.run(function* () {
+      yield* (yield* scenario.llm.next()).respond.text("Earlier answer", { id: "text-earlier" })
+    })
+    currentModel = recoveryModel
+    return session
   })
-  return session
-})
 
 const messageTexts = (request: LLMRequest, role: "user" | "system") =>
   request.messages.flatMap((message) =>
@@ -663,7 +668,11 @@ describe("SessionRunnerLLM", () => {
         resume: false,
       })
 
-      const exit = yield* session.resume(sessionID).pipe(Effect.exit)
+      const exit = yield* scenario
+        .run(function* () {
+          yield* scenario.llm.next()
+        })
+        .pipe(Effect.exit)
 
       expect(Exit.isFailure(exit)).toBe(true)
       if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Instructions.InitializationBlocked)
@@ -697,25 +706,28 @@ describe("SessionRunnerLLM", () => {
       const { db } = yield* Database.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
-      const exit = yield* scenario.run(function* () {
+      yield* scenario.run(function* () {
         yield* (yield* scenario.llm.next()).respond.events()
-        yield* session.wait(sessionID)
-
-        yield* events.publish(SessionEvent.Moved, {
-          sessionID,
-          location: Location.Ref.make({ directory: AbsolutePath.make("/moved") }),
-        })
-        expect(
-          yield* db
-            .select()
-            .from(InstructionCheckpointTable)
-            .where(eq(InstructionCheckpointTable.session_id, sessionID))
-            .get(),
-        ).toBeUndefined()
-
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        return yield* session.resume(sessionID).pipe(Effect.exit)
       })
+
+      yield* events.publish(SessionEvent.Moved, {
+        sessionID,
+        location: Location.Ref.make({ directory: AbsolutePath.make("/moved") }),
+      })
+      expect(
+        yield* db
+          .select()
+          .from(InstructionCheckpointTable)
+          .where(eq(InstructionCheckpointTable.session_id, sessionID))
+          .get(),
+      ).toBeUndefined()
+
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
+      const exit = yield* scenario
+        .run(function* () {
+          yield* scenario.llm.next()
+        })
+        .pipe(Effect.exit)
 
       expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true)
       expect(yield* scenario.llm.requests).toHaveLength(1)
@@ -760,22 +772,23 @@ describe("SessionRunnerLLM", () => {
       const { db } = yield* Database.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        yield* db
-          .update(InstructionCheckpointTable)
-          .set({ snapshot: { invalid: { value: "bad" } } })
-          .where(eq(InstructionCheckpointTable.session_id, sessionID))
-          .run()
-          .pipe(Effect.orDie)
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
+      yield* db
+        .update(InstructionCheckpointTable)
+        .set({ snapshot: { invalid: { value: "bad" } } })
+        .where(eq(InstructionCheckpointTable.session_id, sessionID))
+        .run()
+        .pipe(Effect.orDie)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
         // Comparison state was lost, so every source re-announces as new.
-        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-        expect(second.request.messages.at(1)?.content).toEqual([{ type: "text", text: "Initial context" }])
-        yield* second.respond.events()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(call.request.messages.at(1)?.content).toEqual([{ type: "text", text: "Initial context" }])
+        yield* call.respond.events()
       })
 
       expect(yield* scenario.llm.requests).toHaveLength(2)
@@ -796,17 +809,19 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        systemBaseline = "Changed context"
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* call.respond.events()
+      })
+      systemBaseline = "Changed context"
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-        expect(second.request.messages.at(1)?.content).toEqual([{ type: "text", text: "Changed context" }])
-        yield* second.respond.events()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(call.request.messages.at(1)?.content).toEqual([{ type: "text", text: "Changed context" }])
+        yield* call.respond.events()
       })
 
       expect(yield* session.messages({ sessionID })).toHaveLength(3)
@@ -976,26 +991,22 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        expect(first.request.system.map((part) => part.text)).toEqual([
-          defaultSystem,
-          "Initial context\n\nBuild skills",
-        ])
-        skillBaselines.set(AgentV2.ID.make("reviewer"), "Reviewer skills")
-        yield* events.publish(SessionEvent.AgentSelected, {
-          sessionID,
-          agent: "reviewer",
-        })
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context\n\nBuild skills"])
+        yield* call.respond.events()
+      })
+      skillBaselines.set(AgentV2.ID.make("reviewer"), "Reviewer skills")
+      yield* events.publish(SessionEvent.AgentSelected, {
+        sessionID,
+        agent: "reviewer",
+      })
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.system.map((part) => part.text)).toEqual([
-          defaultSystem,
-          "Initial context\n\nBuild skills",
-        ])
-        expect(systemTexts(second.request)).toContainEqual(expect.stringContaining("Reviewer skills"))
-        yield* second.respond.events()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context\n\nBuild skills"])
+        expect(systemTexts(call.request)).toContainEqual(expect.stringContaining("Reviewer skills"))
+        yield* call.respond.events()
       })
     }),
   )
@@ -1062,17 +1073,18 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        systemRemoved = true
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
+      systemRemoved = true
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-        expect(second.request.messages.at(1)?.content).toEqual([
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(call.request.messages.at(1)?.content).toEqual([
           { type: "text", text: "System context source removed: test/context" },
         ])
-        yield* second.respond.events()
+        yield* call.respond.events()
       })
 
       expect(yield* session.messages({ sessionID })).toHaveLength(3)
@@ -1088,21 +1100,23 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
+        const call = yield* scenario.llm.next()
         // String values render verbatim inside the tagged block at baseline.
-        expect(first.request.system.map((part) => part.text)).toEqual([
+        expect(call.request.system.map((part) => part.text)).toEqual([
           defaultSystem,
           ["Initial context", "", '<context key="deploy-target">', "production", "</context>"].join("\n"),
         ])
+        yield* call.respond.events()
+      })
 
-        // Non-string JSON pretty-prints; the change narrates as a System update.
-        yield* contextEntries.put({ sessionID, key: "deploy-target", value: { region: "us-east-1" } })
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+      // Non-string JSON pretty-prints; the change narrates as a System update.
+      yield* contextEntries.put({ sessionID, key: "deploy-target", value: { region: "us-east-1" } })
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-        expect(second.request.messages.at(1)?.content).toEqual([
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        expect(call.request.messages.at(1)?.content).toEqual([
           {
             type: "text",
             text: [
@@ -1115,27 +1129,27 @@ describe("SessionRunnerLLM", () => {
             ].join("\n"),
           },
         ])
-        expect(yield* contextEntries.list(sessionID)).toEqual([
-          { key: "deploy-target", value: { region: "us-east-1" } },
-        ])
+        yield* call.respond.events()
+      })
+      expect(yield* contextEntries.list(sessionID)).toEqual([{ key: "deploy-target", value: { region: "us-east-1" } }])
 
-        // Deleting the row announces removal through the stored removal text.
-        yield* contextEntries.remove({ sessionID, key: "deploy-target" })
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-        yield* second.respond.events()
+      // Deleting the row announces removal through the stored removal text.
+      yield* contextEntries.remove({ sessionID, key: "deploy-target" })
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
 
-        const third = yield* scenario.llm.next()
-        expect(third.request.messages.map((message) => message.role)).toEqual([
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual([
           "user",
           "system",
           "user",
           "system",
           "user",
         ])
-        expect(third.request.messages.at(-2)?.content).toEqual([
+        expect(call.request.messages.at(-2)?.content).toEqual([
           { type: "text", text: 'The context under "deploy-target" no longer applies. Disregard it.' },
         ])
-        yield* third.respond.events()
+        yield* call.respond.events()
       })
 
       expect(yield* contextEntries.list(sessionID)).toEqual([])
@@ -1150,39 +1164,45 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        systemBaseline = "Changed context"
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* call.respond.events()
+      })
+      systemBaseline = "Changed context"
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
-        yield* events.publish(SessionEvent.ModelSelected, {
-          sessionID,
-          model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
-        })
-        systemBaseline = "Replacement context"
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-        yield* second.respond.events()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "system", "user"])
+        yield* call.respond.events()
+      })
+      yield* events.publish(SessionEvent.ModelSelected, {
+        sessionID,
+        model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
+      })
+      systemBaseline = "Replacement context"
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
 
-        const third = yield* scenario.llm.next()
-        expect(third.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        expect(third.request.messages.filter((message) => message.role === "system")).toHaveLength(2)
-        expect((yield* session.context(sessionID)).map((message) => message.type)).toEqual([
-          "user",
-          "system",
-          "user",
-          "model-switched",
-          "system",
-          "user",
-        ])
-        yield* replaySessionProjection(sessionID)
-        expect(yield* session.messages({ sessionID })).toHaveLength(6)
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fourth" }), resume: false })
-        yield* third.respond.events()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(call.request.messages.filter((message) => message.role === "system")).toHaveLength(2)
+        yield* call.respond.events()
+      })
+      expect((yield* session.context(sessionID)).map((message) => message.type)).toEqual([
+        "user",
+        "system",
+        "user",
+        "model-switched",
+        "system",
+        "user",
+      ])
+      yield* replaySessionProjection(sessionID)
+      expect(yield* session.messages({ sessionID })).toHaveLength(6)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Fourth" }), resume: false })
 
+      yield* scenario.run(function* () {
         yield* (yield* scenario.llm.next()).respond.events()
       })
     }),
@@ -1196,26 +1216,30 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        yield* events.publish(SessionEvent.ModelSelected, {
-          sessionID,
-          model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
-        })
-        systemUnavailable = true
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* call.respond.events()
+      })
+      yield* events.publish(SessionEvent.ModelSelected, {
+        sessionID,
+        model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
+      })
+      systemUnavailable = true
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        systemUnavailable = false
-        systemBaseline = "Replacement context"
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-        yield* second.respond.events()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* call.respond.events()
+      })
+      systemUnavailable = false
+      systemBaseline = "Replacement context"
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
 
-        const third = yield* scenario.llm.next()
-        expect(third.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        yield* third.respond.events()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* call.respond.events()
       })
     }),
   )
@@ -1228,28 +1252,32 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        expect(first.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
-        yield* events.publish(SessionEvent.Compaction.Started, {
-          sessionID,
-          reason: "manual",
-        })
-        yield* events.publish(SessionEvent.Compaction.Ended, {
-          sessionID,
-          reason: "manual",
-          text: "summary",
-          recent: "",
-        })
-        systemBaseline = "Replacement context"
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        yield* call.respond.events()
+      })
+      yield* events.publish(SessionEvent.Compaction.Started, {
+        sessionID,
+        reason: "manual",
+      })
+      yield* events.publish(SessionEvent.Compaction.Ended, {
+        sessionID,
+        reason: "manual",
+        text: "summary",
+        recent: "",
+      })
+      systemBaseline = "Replacement context"
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Replacement context"])
-        yield* replaySessionProjection(sessionID)
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-        yield* second.respond.events()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Replacement context"])
+        yield* call.respond.events()
+      })
+      yield* replaySessionProjection(sessionID)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
 
+      yield* scenario.run(function* () {
         yield* (yield* scenario.llm.next()).respond.events()
       })
     }),
@@ -1358,15 +1386,16 @@ describe("SessionRunnerLLM", () => {
       })
 
       yield* scenario.run(function* () {
-        const earlier = yield* scenario.llm.next()
-        currentModel = compactModel
-        yield* session.prompt({
-          sessionID,
-          prompt: PromptInput.Prompt.make({ text: "Recent exact request ".repeat(180) }),
-          resume: false,
-        })
-        yield* earlier.respond.text("Earlier answer", { id: "text-first" })
+        yield* (yield* scenario.llm.next()).respond.text("Earlier answer", { id: "text-first" })
+      })
+      currentModel = compactModel
+      yield* session.prompt({
+        sessionID,
+        prompt: PromptInput.Prompt.make({ text: "Recent exact request ".repeat(180) }),
+        resume: false,
+      })
 
+      yield* scenario.run(function* () {
         const summary = yield* scenario.llm.next()
         expect(userTexts(summary.request)[0]).toContain("## Objective")
         yield* summary.respond.text("## Objective\n- Preserve the task", { id: "text-summary" })
@@ -1375,13 +1404,15 @@ describe("SessionRunnerLLM", () => {
         expect(userTexts(continued.request)).toHaveLength(1)
         expect(userTexts(continued.request)[0]).toContain("<summary>\n## Objective\n- Preserve the task\n</summary>")
         expect(userTexts(continued.request)[0]).toContain(`[User]: ${"Recent exact request ".repeat(180)}`)
-        yield* session.prompt({
-          sessionID,
-          prompt: PromptInput.Prompt.make({ text: "Newest exact request ".repeat(180) }),
-          resume: false,
-        })
         yield* continued.respond.text("Continued", { id: "text-final" })
+      })
+      yield* session.prompt({
+        sessionID,
+        prompt: PromptInput.Prompt.make({ text: "Newest exact request ".repeat(180) }),
+        resume: false,
+      })
 
+      yield* scenario.run(function* () {
         const updatedSummary = yield* scenario.llm.next()
         expect(userTexts(updatedSummary.request)[0]).toContain(
           "<previous-summary>\n## Objective\n- Preserve the task\n</previous-summary>",
@@ -1402,13 +1433,9 @@ describe("SessionRunnerLLM", () => {
 
   scenarioIt("forces one compaction and retries after provider context overflow", (scenario) =>
     Effect.gen(function* () {
-      const session = yield* setupOverflowRecovery
+      const session = yield* setupOverflowRecovery(scenario)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
       yield* scenario.run(function* () {
-        const earlier = yield* scenario.llm.next()
-        currentModel = recoveryModel
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-        yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
-
         yield* (yield* scenario.llm.next()).respond.events(
           LLMEvent.stepStart({ index: 0 }),
           LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
@@ -1438,7 +1465,8 @@ describe("SessionRunnerLLM", () => {
 
   scenarioIt("persists a second context overflow after one recovery", (scenario) =>
     Effect.gen(function* () {
-      const session = yield* setupOverflowRecovery
+      const session = yield* setupOverflowRecovery(scenario)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
       const overflow = () => [
         LLMEvent.stepStart({ index: 0 }),
         LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
@@ -1446,15 +1474,6 @@ describe("SessionRunnerLLM", () => {
       expect(
         (yield* scenario
           .run(function* () {
-            const earlier = yield* scenario.llm.next()
-            currentModel = recoveryModel
-            yield* session.prompt({
-              sessionID,
-              prompt: PromptInput.Prompt.make({ text: "Continue" }),
-              resume: false,
-            })
-            yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
-
             yield* (yield* scenario.llm.next()).respond.events(...overflow())
             yield* (yield* scenario.llm.next()).respond.text("## Objective\n- Recover once", {
               id: "text-summary",
@@ -1474,13 +1493,9 @@ describe("SessionRunnerLLM", () => {
 
   scenarioIt("recovers once from a raw context overflow failure", (scenario) =>
     Effect.gen(function* () {
-      const session = yield* setupOverflowRecovery
+      const session = yield* setupOverflowRecovery(scenario)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
       yield* scenario.run(function* () {
-        const earlier = yield* scenario.llm.next()
-        currentModel = recoveryModel
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-        yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
-
         yield* (yield* scenario.llm.next()).respond.fail(
           new LLMError({
             module: "test",
@@ -1507,19 +1522,11 @@ describe("SessionRunnerLLM", () => {
 
   scenarioIt("publishes the original overflow when recovery summarization fails", (scenario) =>
     Effect.gen(function* () {
-      const session = yield* setupOverflowRecovery
+      const session = yield* setupOverflowRecovery(scenario)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
       expect(
         (yield* scenario
           .run(function* () {
-            const earlier = yield* scenario.llm.next()
-            currentModel = recoveryModel
-            yield* session.prompt({
-              sessionID,
-              prompt: PromptInput.Prompt.make({ text: "Continue" }),
-              resume: false,
-            })
-            yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
-
             yield* (yield* scenario.llm.next()).respond.events(
               LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
             )
@@ -1542,18 +1549,10 @@ describe("SessionRunnerLLM", () => {
 
   scenarioIt("interrupts overflow recovery while the summary provider is running", (scenario) =>
     Effect.gen(function* () {
-      const session = yield* setupOverflowRecovery
+      const session = yield* setupOverflowRecovery(scenario)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
       const exit = yield* scenario
         .run(function* () {
-          const earlier = yield* scenario.llm.next()
-          currentModel = recoveryModel
-          yield* session.prompt({
-            sessionID,
-            prompt: PromptInput.Prompt.make({ text: "Continue" }),
-            resume: false,
-          })
-          yield* earlier.respond.text("Earlier answer", { id: "text-earlier" })
-
           yield* (yield* scenario.llm.next()).respond.events(
             LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" }),
           )
@@ -1576,31 +1575,33 @@ describe("SessionRunnerLLM", () => {
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "First" }), resume: false })
 
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        systemBaseline = "Changed context"
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
-        yield* first.respond.events()
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
+      systemBaseline = "Changed context"
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Second" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        yield* events.publish(SessionEvent.Compaction.Started, {
-          sessionID,
-          reason: "manual",
-        })
-        yield* events.publish(SessionEvent.Compaction.Ended, {
-          sessionID,
-          reason: "manual",
-          text: "summary",
-          recent: "",
-        })
-        systemUnavailable = true
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
-        yield* second.respond.events()
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
+      yield* events.publish(SessionEvent.Compaction.Started, {
+        sessionID,
+        reason: "manual",
+      })
+      yield* events.publish(SessionEvent.Compaction.Ended, {
+        sessionID,
+        reason: "manual",
+        text: "summary",
+        recent: "",
+      })
+      systemUnavailable = true
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Third" }), resume: false })
 
-        const third = yield* scenario.llm.next()
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
         // The rebaseline proceeds while the source is unobservable, restating the model's belief.
-        expect(third.request.system.map((part) => part.text)).toEqual([defaultSystem, "Changed context"])
-        expect(systemTexts(third.request)).not.toContain("Changed context")
-        yield* third.respond.events()
+        expect(call.request.system.map((part) => part.text)).toEqual([defaultSystem, "Changed context"])
+        expect(systemTexts(call.request)).not.toContain("Changed context")
+        yield* call.respond.events()
       })
     }),
   )
@@ -1805,69 +1806,56 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Think first" }), resume: false })
 
-      const streamed = yield* Deferred.make<void>()
-      const release = yield* Deferred.make<void>()
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        yield* first.respond.stream(
-          Stream.concat(
-            Stream.fromIterable([
-              LLMEvent.stepStart({ index: 0 }),
-              LLMEvent.reasoningStart({ id: "reasoning-anthropic" }),
-              LLMEvent.reasoningDelta({ id: "reasoning-anthropic", text: "Signed thought" }),
-              LLMEvent.reasoningEnd({
-                id: "reasoning-anthropic",
-                providerMetadata: { fake: { signature: "sig_1" }, anthropic: { ignored: true } },
-              }),
-              LLMEvent.reasoningStart({
-                id: "reasoning-openai",
-                providerMetadata: {
-                  fake: { itemId: "rs_1", reasoningEncryptedContent: null },
-                  openai: { ignored: true },
-                },
-              }),
-              LLMEvent.reasoningDelta({ id: "reasoning-openai", text: "Encrypted thought" }),
-              LLMEvent.reasoningEnd({
-                id: "reasoning-openai",
-                providerMetadata: {
-                  fake: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
-                  openai: { ignored: true },
-                },
-              }),
-              LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-              LLMEvent.finish({ reason: "stop" }),
-            ]),
-            Stream.unwrap(
-              Deferred.succeed(streamed, undefined).pipe(
-                Effect.andThen(Deferred.await(release)),
-                Effect.as(Stream.empty),
-              ),
-            ),
-          ),
+        yield* (yield* scenario.llm.next()).respond.events(
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.reasoningStart({ id: "reasoning-anthropic" }),
+          LLMEvent.reasoningDelta({ id: "reasoning-anthropic", text: "Signed thought" }),
+          LLMEvent.reasoningEnd({
+            id: "reasoning-anthropic",
+            providerMetadata: { fake: { signature: "sig_1" }, anthropic: { ignored: true } },
+          }),
+          LLMEvent.reasoningStart({
+            id: "reasoning-openai",
+            providerMetadata: {
+              fake: { itemId: "rs_1", reasoningEncryptedContent: null },
+              openai: { ignored: true },
+            },
+          }),
+          LLMEvent.reasoningDelta({ id: "reasoning-openai", text: "Encrypted thought" }),
+          LLMEvent.reasoningEnd({
+            id: "reasoning-openai",
+            providerMetadata: {
+              fake: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
+              openai: { ignored: true },
+            },
+          }),
+          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+          LLMEvent.finish({ reason: "stop" }),
         )
-        yield* Deferred.await(streamed)
-        yield* replaySessionProjection(sessionID)
+      })
+      yield* replaySessionProjection(sessionID)
 
-        expect(yield* session.context(sessionID)).toMatchObject([
-          { type: "user", text: "Think first" },
-          {
-            type: "assistant",
-            content: [
-              { type: "reasoning", text: "Signed thought", state: { signature: "sig_1" } },
-              {
-                type: "reasoning",
-                text: "Encrypted thought",
-                state: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
-              },
-            ],
-          },
-        ])
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user", text: "Think first" },
+        {
+          type: "assistant",
+          content: [
+            { type: "reasoning", text: "Signed thought", state: { signature: "sig_1" } },
+            {
+              type: "reasoning",
+              text: "Encrypted thought",
+              state: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
+            },
+          ],
+        },
+      ])
 
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-        yield* Deferred.succeed(release, undefined)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.messages[1]?.content).toEqual([
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages[1]?.content).toEqual([
           { type: "reasoning", text: "Signed thought", providerMetadata: { fake: { signature: "sig_1" } } },
           {
             type: "reasoning",
@@ -1875,8 +1863,10 @@ describe("SessionRunnerLLM", () => {
             providerMetadata: { fake: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
           },
         ])
-        yield* second.respond.events()
+        yield* call.respond.events()
       })
+
+      expect(yield* scenario.llm.requests).toHaveLength(2)
     }),
   )
 
@@ -1886,48 +1876,35 @@ describe("SessionRunnerLLM", () => {
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Search first" }), resume: false })
 
-      const streamed = yield* Deferred.make<void>()
-      const release = yield* Deferred.make<void>()
       yield* scenario.run(function* () {
-        const first = yield* scenario.llm.next()
-        yield* first.respond.stream(
-          Stream.concat(
-            Stream.fromIterable([
-              LLMEvent.stepStart({ index: 0 }),
-              LLMEvent.toolCall({
-                id: "hosted-search",
-                name: "web_search",
-                input: { query: "Effect" },
-                providerExecuted: true,
-                providerMetadata: { fake: { itemId: "hosted-search" }, openai: { ignored: true } },
-              }),
-              LLMEvent.toolResult({
-                id: "hosted-search",
-                name: "web_search",
-                result: { type: "json", value: [{ title: "Effect" }] },
-                providerExecuted: true,
-                providerMetadata: { fake: { blockType: "web_search_tool_result" }, anthropic: { ignored: true } },
-              }),
-              LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-              LLMEvent.finish({ reason: "stop" }),
-            ]),
-            Stream.unwrap(
-              Deferred.succeed(streamed, undefined).pipe(
-                Effect.andThen(Deferred.await(release)),
-                Effect.as(Stream.empty),
-              ),
-            ),
-          ),
+        yield* (yield* scenario.llm.next()).respond.events(
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolCall({
+            id: "hosted-search",
+            name: "web_search",
+            input: { query: "Effect" },
+            providerExecuted: true,
+            providerMetadata: { fake: { itemId: "hosted-search" }, openai: { ignored: true } },
+          }),
+          LLMEvent.toolResult({
+            id: "hosted-search",
+            name: "web_search",
+            result: { type: "json", value: [{ title: "Effect" }] },
+            providerExecuted: true,
+            providerMetadata: { fake: { blockType: "web_search_tool_result" }, anthropic: { ignored: true } },
+          }),
+          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+          LLMEvent.finish({ reason: "stop" }),
         )
-        yield* Deferred.await(streamed)
-        yield* replaySessionProjection(sessionID)
+      })
+      yield* replaySessionProjection(sessionID)
 
-        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-        yield* Deferred.succeed(release, undefined)
+      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
 
-        const second = yield* scenario.llm.next()
-        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"])
-        expect(second.request.messages[1]?.content).toMatchObject([
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"])
+        expect(call.request.messages[1]?.content).toMatchObject([
           {
             type: "tool-call",
             id: "hosted-search",
@@ -1945,8 +1922,10 @@ describe("SessionRunnerLLM", () => {
             providerMetadata: { fake: { blockType: "web_search_tool_result" } },
           },
         ])
-        yield* second.respond.events()
+        yield* call.respond.events()
       })
+
+      expect(yield* scenario.llm.requests).toHaveLength(2)
     }),
   )
 
@@ -2767,7 +2746,6 @@ describe("SessionRunnerLLM", () => {
             Exit.Exit<void, SessionRunner.RunError | SessionV2.NotFoundError>,
           ]
         >()
-      const retry = yield* Deferred.make<void>()
       const scenario = yield* RunnerScenario.make(() =>
         SessionV2.Service.use((session) =>
           Effect.gen(function* () {
@@ -2775,8 +2753,6 @@ describe("SessionRunnerLLM", () => {
             yield* Deferred.await(join)
             const second = yield* session.resume(sessionID).pipe(Effect.forkChild)
             yield* Deferred.succeed(joined, yield* Effect.all([Fiber.await(first), Fiber.await(second)]))
-            yield* Deferred.await(retry)
-            yield* session.resume(sessionID)
           }),
         ),
       )
@@ -2798,8 +2774,9 @@ describe("SessionRunnerLLM", () => {
           yield* first.respond.fail(failure)
           const [firstExit, secondExit] = yield* Deferred.await(joined)
           expect(secondExit).toEqual(firstExit)
+        })
 
-          yield* Deferred.succeed(retry, undefined)
+        yield* scenario.run(function* () {
           yield* (yield* scenario.llm.next()).respond.events()
         })
 
@@ -3254,6 +3231,14 @@ describe("SessionRunnerLLM", () => {
         { type: "user", text: "Interrupt blocked tool" },
         { type: "assistant", content: [{ type: "tool", id: "call-before-interrupt", state: { status: "error" } }] },
       ])
+
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "tool"])
+        yield* call.respond.events()
+      })
+
+      expect(yield* scenario.llm.requests).toHaveLength(2)
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1743,65 +1743,62 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("projects reasoning and tool events without executing or continuing tools", () =>
+  scenarioIt("projects reasoning and tool events without executing or continuing tools", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Use tools" }), resume: false })
 
-      requests.length = 0
-      responses = undefined
-      streamGate = undefined
-      streamStarted = undefined
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.reasoningStart({ id: "reasoning-1" }),
-        LLMEvent.reasoningDelta({ id: "reasoning-1", text: "Think" }),
-        LLMEvent.reasoningEnd({ id: "reasoning-1" }),
-        LLMEvent.toolInputStart({ id: "call-error", name: "write" }),
-        LLMEvent.toolInputDelta({ id: "call-error", name: "write", text: '{"path":"README.md"}' }),
-        LLMEvent.toolInputEnd({ id: "call-error", name: "write" }),
-        LLMEvent.toolCall({ id: "call-error", name: "write", input: { path: "README.md" }, providerExecuted: true }),
-        LLMEvent.toolError({ id: "call-error", name: "write", message: "Denied" }),
-        LLMEvent.toolResult({ id: "call-error", name: "write", result: { type: "error", value: "Denied" } }),
-        LLMEvent.toolCall({
-          id: "call-provider",
-          name: "web_search",
-          input: { query: "hello" },
-          providerExecuted: true,
-          providerMetadata: { fake: { source: "provider" } },
-        }),
-        LLMEvent.toolResult({
-          id: "call-provider",
-          name: "web_search",
-          result: {
-            type: "content",
-            value: [
-              { type: "text", text: "Hello" },
-              { type: "file", uri: "data:image/png;base64,aGVsbG8=", mime: "image/png", name: "hello.png" },
-            ],
-          },
-          providerExecuted: true,
-          providerMetadata: { fake: { source: "provider" } },
-        }),
-        LLMEvent.stepFinish({
-          index: 0,
-          reason: "tool-calls",
-          usage: {
-            inputTokens: 10,
-            nonCachedInputTokens: 8,
-            outputTokens: 4,
-            reasoningTokens: 1,
-            cacheReadInputTokens: 2,
-          },
-        }),
-        LLMEvent.finish({ reason: "tool-calls" }),
-      ]
+      yield* scenario.run(function* () {
+        const call = yield* scenario.llm.next()
+        expect(call.request.tools.map((tool) => tool.name)).toEqual(["echo", "defect", "storefail"])
+        yield* call.respond.events(
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.reasoningStart({ id: "reasoning-1" }),
+          LLMEvent.reasoningDelta({ id: "reasoning-1", text: "Think" }),
+          LLMEvent.reasoningEnd({ id: "reasoning-1" }),
+          LLMEvent.toolInputStart({ id: "call-error", name: "write" }),
+          LLMEvent.toolInputDelta({ id: "call-error", name: "write", text: '{"path":"README.md"}' }),
+          LLMEvent.toolInputEnd({ id: "call-error", name: "write" }),
+          LLMEvent.toolCall({ id: "call-error", name: "write", input: { path: "README.md" }, providerExecuted: true }),
+          LLMEvent.toolError({ id: "call-error", name: "write", message: "Denied" }),
+          LLMEvent.toolResult({ id: "call-error", name: "write", result: { type: "error", value: "Denied" } }),
+          LLMEvent.toolCall({
+            id: "call-provider",
+            name: "web_search",
+            input: { query: "hello" },
+            providerExecuted: true,
+            providerMetadata: { fake: { source: "provider" } },
+          }),
+          LLMEvent.toolResult({
+            id: "call-provider",
+            name: "web_search",
+            result: {
+              type: "content",
+              value: [
+                { type: "text", text: "Hello" },
+                { type: "file", uri: "data:image/png;base64,aGVsbG8=", mime: "image/png", name: "hello.png" },
+              ],
+            },
+            providerExecuted: true,
+            providerMetadata: { fake: { source: "provider" } },
+          }),
+          LLMEvent.stepFinish({
+            index: 0,
+            reason: "tool-calls",
+            usage: {
+              inputTokens: 10,
+              nonCachedInputTokens: 8,
+              outputTokens: 4,
+              reasoningTokens: 1,
+              cacheReadInputTokens: 2,
+            },
+          }),
+          LLMEvent.finish({ reason: "tool-calls" }),
+        )
+      })
 
-      yield* session.resume(sessionID)
-
-      expect(requests).toHaveLength(1)
-      expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(["echo", "defect", "storefail"])
+      expect(yield* scenario.llm.requests).toHaveLength(1)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Use tools" },
         {
@@ -1896,40 +1893,41 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("reloads a model switch before a tool-driven continuation turn", () =>
+  scenarioIt("reloads a model switch before a tool-driven continuation turn", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       const events = yield* EventV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Echo this" }), resume: false })
 
-      requests.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "call-echo", name: "echo", input: { text: "hello" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
+      const executionGate = yield* Deferred.make<void>()
+      const executionsStarted = yield* Deferred.make<void>()
+      toolExecutionGate = executionGate
+      toolExecutionsStarted = executionsStarted
+      toolExecutionsReady = 1
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* first.respond.toolCall("echo", { text: "hello" }, { id: "call-echo" })
+        yield* Deferred.await(executionsStarted)
+        yield* events.publish(SessionEvent.ModelSelected, {
+          sessionID,
+          model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
+        })
+        systemBaseline = "Replacement context"
+        yield* Deferred.succeed(executionGate, undefined)
+
+        const second = yield* scenario.llm.next()
+        expect(second.request.model).toBe(replacementModel)
+        expect(second.request.system.map((part) => part.text)).toEqual([defaultSystem, "Initial context"])
+        expect(systemTexts(second.request)).toContain("Replacement context")
+        yield* second.respond.events(
           LLMEvent.stepStart({ index: 0 }),
           LLMEvent.stepFinish({ index: 0, reason: "stop" }),
           LLMEvent.finish({ reason: "stop" }),
-        ],
-      ]
-      toolExecutionGate = yield* Deferred.make<void>()
-      toolExecutionsStarted = yield* Deferred.make<void>()
-      toolExecutionsReady = 1
-      const run = yield* Effect.forkChild(session.resume(sessionID))
-      yield* Deferred.await(toolExecutionsStarted)
-      yield* events.publish(SessionEvent.ModelSelected, {
-        sessionID,
-        model: { id: ModelV2.ID.make("replacement"), providerID: ProviderV2.ID.make("fake") },
+        )
       })
-      systemBaseline = "Replacement context"
-      yield* Deferred.succeed(toolExecutionGate, undefined)
-      yield* Fiber.join(run)
 
+      const requests = yield* scenario.llm.requests
       expect(requests.map((request) => request.model)).toEqual([model, replacementModel])
       expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
         [defaultSystem, "Initial context"],
@@ -1939,140 +1937,169 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("restores durable reasoning provider metadata in a second-turn request", () =>
+  scenarioIt("restores durable reasoning provider metadata in a second-turn request", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Think first" }), resume: false })
 
-      requests.length = 0
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.reasoningStart({ id: "reasoning-anthropic" }),
-        LLMEvent.reasoningDelta({ id: "reasoning-anthropic", text: "Signed thought" }),
-        LLMEvent.reasoningEnd({
-          id: "reasoning-anthropic",
-          providerMetadata: { fake: { signature: "sig_1" }, anthropic: { ignored: true } },
-        }),
-        LLMEvent.reasoningStart({
-          id: "reasoning-openai",
-          providerMetadata: {
-            fake: { itemId: "rs_1", reasoningEncryptedContent: null },
-            openai: { ignored: true },
+      const streamed = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* first.respond.stream(
+          Stream.concat(
+            Stream.fromIterable([
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.reasoningStart({ id: "reasoning-anthropic" }),
+              LLMEvent.reasoningDelta({ id: "reasoning-anthropic", text: "Signed thought" }),
+              LLMEvent.reasoningEnd({
+                id: "reasoning-anthropic",
+                providerMetadata: { fake: { signature: "sig_1" }, anthropic: { ignored: true } },
+              }),
+              LLMEvent.reasoningStart({
+                id: "reasoning-openai",
+                providerMetadata: {
+                  fake: { itemId: "rs_1", reasoningEncryptedContent: null },
+                  openai: { ignored: true },
+                },
+              }),
+              LLMEvent.reasoningDelta({ id: "reasoning-openai", text: "Encrypted thought" }),
+              LLMEvent.reasoningEnd({
+                id: "reasoning-openai",
+                providerMetadata: {
+                  fake: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
+                  openai: { ignored: true },
+                },
+              }),
+              LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+              LLMEvent.finish({ reason: "stop" }),
+            ]),
+            Stream.unwrap(
+              Deferred.succeed(streamed, undefined).pipe(
+                Effect.andThen(Deferred.await(release)),
+                Effect.as(Stream.empty),
+              ),
+            ),
+          ),
+        )
+        yield* Deferred.await(streamed)
+        yield* replaySessionProjection(sessionID)
+
+        expect(yield* session.context(sessionID)).toMatchObject([
+          { type: "user", text: "Think first" },
+          {
+            type: "assistant",
+            content: [
+              { type: "reasoning", text: "Signed thought", state: { signature: "sig_1" } },
+              {
+                type: "reasoning",
+                text: "Encrypted thought",
+                state: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
+              },
+            ],
           },
-        }),
-        LLMEvent.reasoningDelta({ id: "reasoning-openai", text: "Encrypted thought" }),
-        LLMEvent.reasoningEnd({
-          id: "reasoning-openai",
-          providerMetadata: {
-            fake: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
-            openai: { ignored: true },
+        ])
+
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
+        yield* Deferred.succeed(release, undefined)
+
+        const second = yield* scenario.llm.next()
+        expect(second.request.messages[1]?.content).toEqual([
+          { type: "reasoning", text: "Signed thought", providerMetadata: { fake: { signature: "sig_1" } } },
+          {
+            type: "reasoning",
+            text: "Encrypted thought",
+            providerMetadata: { fake: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
           },
-        }),
-        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-        LLMEvent.finish({ reason: "stop" }),
-      ]
-      yield* session.resume(sessionID)
-      yield* replaySessionProjection(sessionID)
-
-      expect(yield* session.context(sessionID)).toMatchObject([
-        { type: "user", text: "Think first" },
-        {
-          type: "assistant",
-          content: [
-            { type: "reasoning", text: "Signed thought", state: { signature: "sig_1" } },
-            {
-              type: "reasoning",
-              text: "Encrypted thought",
-              state: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" },
-            },
-          ],
-        },
-      ])
-
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-      response = []
-      yield* session.resume(sessionID)
-
-      expect(requests[1]?.messages[1]?.content).toEqual([
-        { type: "reasoning", text: "Signed thought", providerMetadata: { fake: { signature: "sig_1" } } },
-        {
-          type: "reasoning",
-          text: "Encrypted thought",
-          providerMetadata: { fake: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
-        },
-      ])
+        ])
+        yield* second.respond.events()
+      })
     }),
   )
 
-  it.effect("replays durable provider-executed tool results inline in a second-turn request", () =>
+  scenarioIt("replays durable provider-executed tool results inline in a second-turn request", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Search first" }), resume: false })
 
-      requests.length = 0
-      response = [
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.toolCall({
-          id: "hosted-search",
-          name: "web_search",
-          input: { query: "Effect" },
-          providerExecuted: true,
-          providerMetadata: { fake: { itemId: "hosted-search" }, openai: { ignored: true } },
-        }),
-        LLMEvent.toolResult({
-          id: "hosted-search",
-          name: "web_search",
-          result: { type: "json", value: [{ title: "Effect" }] },
-          providerExecuted: true,
-          providerMetadata: { fake: { blockType: "web_search_tool_result" }, anthropic: { ignored: true } },
-        }),
-        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
-        LLMEvent.finish({ reason: "stop" }),
-      ]
-      yield* session.resume(sessionID)
-      yield* replaySessionProjection(sessionID)
+      const streamed = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* first.respond.stream(
+          Stream.concat(
+            Stream.fromIterable([
+              LLMEvent.stepStart({ index: 0 }),
+              LLMEvent.toolCall({
+                id: "hosted-search",
+                name: "web_search",
+                input: { query: "Effect" },
+                providerExecuted: true,
+                providerMetadata: { fake: { itemId: "hosted-search" }, openai: { ignored: true } },
+              }),
+              LLMEvent.toolResult({
+                id: "hosted-search",
+                name: "web_search",
+                result: { type: "json", value: [{ title: "Effect" }] },
+                providerExecuted: true,
+                providerMetadata: { fake: { blockType: "web_search_tool_result" }, anthropic: { ignored: true } },
+              }),
+              LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+              LLMEvent.finish({ reason: "stop" }),
+            ]),
+            Stream.unwrap(
+              Deferred.succeed(streamed, undefined).pipe(
+                Effect.andThen(Deferred.await(release)),
+                Effect.as(Stream.empty),
+              ),
+            ),
+          ),
+        )
+        yield* Deferred.await(streamed)
+        yield* replaySessionProjection(sessionID)
 
-      yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
-      response = []
-      yield* session.resume(sessionID)
+        yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Continue" }), resume: false })
+        yield* Deferred.succeed(release, undefined)
 
-      expect(requests[1]?.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"])
-      expect(requests[1]?.messages[1]?.content).toMatchObject([
-        {
-          type: "tool-call",
-          id: "hosted-search",
-          name: "web_search",
-          input: { query: "Effect" },
-          providerExecuted: true,
-          providerMetadata: { fake: { itemId: "hosted-search" } },
-        },
-        {
-          type: "tool-result",
-          id: "hosted-search",
-          name: "web_search",
-          result: { type: "json", value: [{ title: "Effect" }] },
-          providerExecuted: true,
-          providerMetadata: { fake: { blockType: "web_search_tool_result" } },
-        },
-      ])
+        const second = yield* scenario.llm.next()
+        expect(second.request.messages.map((message) => message.role)).toEqual(["user", "assistant", "user"])
+        expect(second.request.messages[1]?.content).toMatchObject([
+          {
+            type: "tool-call",
+            id: "hosted-search",
+            name: "web_search",
+            input: { query: "Effect" },
+            providerExecuted: true,
+            providerMetadata: { fake: { itemId: "hosted-search" } },
+          },
+          {
+            type: "tool-result",
+            id: "hosted-search",
+            name: "web_search",
+            result: { type: "json", value: [{ title: "Effect" }] },
+            providerExecuted: true,
+            providerMetadata: { fake: { blockType: "web_search_tool_result" } },
+          },
+        ])
+        yield* second.respond.events()
+      })
     }),
   )
 
-  it.effect("starts recorded local tools eagerly and awaits settlement before continuing", () =>
+  scenarioIt("starts recorded local tools eagerly and awaits settlement before continuing", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Echo five times" }), resume: false })
 
-      requests.length = 0
       executions.length = 0
-      toolExecutionGate = yield* Deferred.make<void>()
-      toolExecutionsStarted = yield* Deferred.make<void>()
+      const executionGate = yield* Deferred.make<void>()
+      const executionsStarted = yield* Deferred.make<void>()
+      toolExecutionGate = executionGate
+      toolExecutionsStarted = executionsStarted
       const providerGate = yield* Deferred.make<void>()
-      response = []
-      responses = undefined
       const initial = Stream.fromIterable([
         LLMEvent.stepStart({ index: 0 }),
         ...Array.from({ length: 5 }, (_, index) =>
@@ -2083,72 +2110,62 @@ describe("SessionRunnerLLM", () => {
         LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
         LLMEvent.finish({ reason: "tool-calls" }),
       ])
-      streamGate = undefined
-      responseStream = Stream.concat(
-        initial,
-        Stream.fromEffect(Deferred.await(providerGate)).pipe(Stream.flatMap(() => final)),
-      )
 
-      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
-      yield* Deferred.await(toolExecutionsStarted)
+      yield* scenario.run(function* () {
+        const first = yield* scenario.llm.next()
+        yield* first.respond.stream(
+          Stream.concat(
+            initial,
+            Stream.unwrap(Deferred.await(providerGate).pipe(Effect.as(final))),
+          ),
+        )
+        yield* Deferred.await(executionsStarted)
 
-      expect(executions).toHaveLength(5)
-      expect(maxActiveToolExecutions).toBe(5)
-      expect(yield* session.context(sessionID)).toMatchObject([
-        { type: "user", text: "Echo five times" },
-        {
-          type: "assistant",
-          content: Array.from({ length: 5 }, (_, index) => ({
-            type: "tool",
-            id: `call-echo-${index}`,
-            state: { status: "running", input: { text: `${index}` } },
-          })),
-        },
-      ])
+        expect(executions).toHaveLength(5)
+        expect(maxActiveToolExecutions).toBe(5)
+        expect(yield* session.context(sessionID)).toMatchObject([
+          { type: "user", text: "Echo five times" },
+          {
+            type: "assistant",
+            content: Array.from({ length: 5 }, (_, index) => ({
+              type: "tool",
+              id: `call-echo-${index}`,
+              state: { status: "running", input: { text: `${index}` } },
+            })),
+          },
+        ])
 
-      yield* Deferred.succeed(providerGate, undefined)
-      yield* Effect.yieldNow
-      expect(requests).toHaveLength(1)
+        yield* Deferred.succeed(providerGate, undefined)
+        yield* Effect.yieldNow
+        expect(yield* scenario.llm.requests).toHaveLength(1)
 
-      yield* Deferred.succeed(toolExecutionGate, undefined)
-      yield* Fiber.join(run)
+        yield* Deferred.succeed(executionGate, undefined)
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
       toolExecutionGate = undefined
       toolExecutionsStarted = undefined
 
       expect(executions).toHaveLength(5)
       expect(maxActiveToolExecutions).toBe(5)
-      expect(requests).toHaveLength(2)
+      expect(yield* scenario.llm.requests).toHaveLength(2)
     }),
   )
 
-  it.effect("settles repeated provider-local tool call IDs against their owning assistant messages", () =>
+  scenarioIt("settles repeated provider-local tool call IDs against their owning assistant messages", (scenario) =>
     Effect.gen(function* () {
       yield* setup
       const session = yield* SessionV2.Service
       yield* session.prompt({ sessionID, prompt: PromptInput.Prompt.make({ text: "Echo twice" }), resume: false })
 
-      requests.length = 0
       executions.length = 0
-      responses = [
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "tool_0", name: "echo", input: { text: "first" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [
-          LLMEvent.stepStart({ index: 0 }),
-          LLMEvent.toolCall({ id: "tool_0", name: "echo", input: { text: "second" } }),
-          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
-          LLMEvent.finish({ reason: "tool-calls" }),
-        ],
-        [],
-      ]
-
-      yield* session.resume(sessionID)
+      yield* scenario.run(function* () {
+        yield* (yield* scenario.llm.next()).respond.toolCall("echo", { text: "first" }, { id: "tool_0" })
+        yield* (yield* scenario.llm.next()).respond.toolCall("echo", { text: "second" }, { id: "tool_0" })
+        yield* (yield* scenario.llm.next()).respond.events()
+      })
 
       expect(executions).toEqual(["first", "second"])
-      expect(requests).toHaveLength(3)
+      expect(yield* scenario.llm.requests).toHaveLength(3)
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Echo twice" },
         {


### PR DESCRIPTION
## Summary

- add a request-driven `RunnerScenario` test DSL around the real `LLMClient` boundary
- migrate V2 runner tests from shared mutable response queues to linear `next()` / `respond` interactions
- preserve explicit resume boundaries, raw stream failure coverage, concurrency behavior, and replay assertions
- remove the order-dependent legacy runner LLM harness

## Verification

- `bun run test test/session-runner.test.ts test/runner-scenario.test.ts test/session-runner-recorded.test.ts` (119 passed)
- `bun run test test/session-runner.test.ts --randomize --rerun-each 3` (315 passed)
- `bun run test test/runner-scenario.test.ts --randomize --rerun-each 100` (1300 passed)
- `bun typecheck` in `packages/core`
- pre-push workspace typecheck (31 packages passed)
