### PR TITLE
fix(tool): decode webfetch bodies using declared charset via iconv-lite

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -634,6 +634,7 @@
         "google-auth-library": "10.5.0",
         "gray-matter": "4.0.3",
         "htmlparser2": "8.0.2",
+        "iconv-lite": "0.7.3",
         "ignore": "7.0.5",
         "immer": "11.1.4",
         "jsonc-parser": "3.3.1",
@@ -3983,7 +3984,7 @@
 
     "iconv-corefoundation": ["iconv-corefoundation@1.1.7", "", { "dependencies": { "cli-truncate": "^2.1.0", "node-addon-api": "^1.6.3" }, "os": "darwin" }, "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ=="],
 
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -6341,11 +6342,15 @@
 
     "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
 
+    "minipass-fetch/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
     "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "motion/framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
+
+    "mysql2/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "nitro/h3": ["h3@2.0.1-rc.5", "", { "dependencies": { "rou3": "^0.7.9", "srvx": "^0.9.1" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"] }, "sha512-qkohAzCab0nLzXNm78tBjZDvtKMTmtygS8BJLT3VPczAQofdqlFXDPkXdLMJN4r05+xqneG8snZJ0HgkERCZTg=="],
 
@@ -6770,6 +6775,8 @@
     "@modelcontextprotocol/sdk/express/serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "@modelcontextprotocol/sdk/express/type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "@modelcontextprotocol/sdk/raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "@octokit/auth-app/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@11.0.3", "", { "dependencies": { "@octokit/types": "^16.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag=="],
 
@@ -7308,6 +7315,8 @@
     "@jsx-email/cli/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@jsx-email/cli/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@modelcontextprotocol/sdk/express/body-parser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "@modelcontextprotocol/sdk/express/type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -125,6 +125,7 @@
     "google-auth-library": "10.5.0",
     "gray-matter": "4.0.3",
     "htmlparser2": "8.0.2",
+    "iconv-lite": "0.7.3",
     "ignore": "7.0.5",
     "immer": "11.1.4",
     "jsonc-parser": "3.3.1",

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Parser } from "htmlparser2"
 import * as Tool from "./tool"
 import TurndownService from "turndown"
+import iconv from "iconv-lite"
 import DESCRIPTION from "./webfetch.txt"
 import { isImageAttachment } from "@/util/media"
 
@@ -123,7 +124,7 @@ export const WebFetchTool = Tool.define(
             }
           }
 
-          const content = new TextDecoder().decode(arrayBuffer)
+          const content = decodeBody(arrayBuffer, contentType)
 
           // Handle content based on requested format and actual content type
           switch (params.format) {
@@ -154,6 +155,40 @@ export const WebFetchTool = Tool.define(
     }
   }),
 )
+
+// Parse the `charset` parameter from a Content-Type header value, e.g.
+// "text/html; charset=windows-1251" -> "windows-1251". Returns undefined when
+// no charset is declared so callers can fall back to UTF-8. (#35752)
+function charsetFromContentType(contentType: string): string | undefined {
+  const match = /charset\s*=\s*"?([^\s;"]+)/i.exec(contentType)
+  return match?.[1]
+}
+
+// Decode a response body honouring the charset declared in Content-Type.
+// `TextDecoder` defaults to UTF-8 and Bun's build only supports a handful of
+// labels (utf-8, shift_jis, gb18030, big5, euc-kr) — it throws on common
+// legacy encodings like windows-1251 (Russian legal sites such as
+// garant.ru/consultant.ru), so without this those pages come back garbled.
+// iconv-lite covers the long tail Bun's TextDecoder can't. (#35752)
+function decodeBody(body: BufferSource, contentType: string): string {
+  const charset = charsetFromContentType(contentType)
+  if (charset) {
+    // UTF-8 is the hot path and Bun's native TextDecoder handles it directly.
+    if (/^utf-?8$/i.test(charset)) {
+      return new TextDecoder("utf-8").decode(body)
+    }
+    if (iconv.encodingExists(charset)) {
+      return iconv.decode(Buffer.from(body as ArrayBuffer), charset)
+    }
+    // Unknown/unsupported label — best-effort native attempt, then UTF-8.
+    try {
+      return new TextDecoder(charset).decode(body)
+    } catch {
+      // fall through to UTF-8
+    }
+  }
+  return new TextDecoder().decode(body)
+}
 
 function extractTextFromHTML(html: string) {
   let text = ""

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -116,4 +116,34 @@ describe("tool.webfetch", () => {
         }),
     ),
   )
+
+  it.instance("decodes non-UTF-8 charset declared in Content-Type", () =>
+    withFetch(
+      () =>
+        // "Привет" encoded in windows-1251 (Cyrillic А-я occupy 0xC0-0xFF).
+        // Under the previous UTF-8-only decode this byte sequence is invalid
+        // and yields replacement characters. (#35752)
+        new Response(new Uint8Array([0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2]), {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=windows-1251" },
+        }),
+      (url) =>
+        Effect.gen(function* () {
+          const result = yield* exec({ url: new URL("/win1251.txt", url).toString(), format: "text" })
+          expect(result.output).toBe("Привет")
+        }),
+    ),
+  )
+
+  it.instance("falls back to UTF-8 for unsupported charset labels", () =>
+    withFetch(
+      () =>
+        new Response("hello", { status: 200, headers: { "content-type": "text/plain; charset=x-not-real" } }),
+      (url) =>
+        Effect.gen(function* () {
+          const result = yield* exec({ url: new URL("/unknown.txt", url).toString(), format: "text" })
+          expect(result.output).toBe("hello")
+        }),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #35752

### Type of change

- [x] Bug fix

### What does this PR do?

`webfetch` decoded every response body as UTF-8 (`new TextDecoder().decode(body)`), ignoring the `charset` in the `Content-Type` header even though it was already being read. Pages served as `windows-1251` (common for Russian legal sites such as `base.garant.ru`) came back as replacement characters.

This parses the charset from `Content-Type` and decodes with it. Because Bun's `TextDecoder` only supports a handful of labels (utf-8, shift_jis, gb18030, big5, euc-kr) and throws on common legacy encodings like `windows-1251`, the non-UTF-8 path uses `iconv-lite`. utf-8 stays on the fast native `TextDecoder` path; unknown/unsupported charset labels fall back to UTF-8 (the previous behavior) rather than failing the fetch.

I understand why this works: the charset was being read but discarded (`contentType.split(";")[0]`), so the fix is to keep it and feed it to a decoder that actually supports it. `iconv-lite` is needed specifically because Bun's built-in `TextDecoder` cannot decode `windows-1251` — I verified `new TextDecoder("windows-1251")` throws `ERR_ENCODING_NOT_SUPPORTED` in `oven/bun:1.3.14`, while `iconv.decode(buf, "win1251")` decodes correctly.

Adds `iconv-lite` as a direct dependency of `packages/opencode`. It was already present transitively (several versions resolve in the lockfile); this promotes it to a declared dep of the package that uses it.

### How did you verify your code works?

- `bun test test/tool/webfetch.test.ts` in `oven/bun:1.3.14` — 6/6 pass, including two new cases: decodes `windows-1251` bytes (`Привет`) correctly via iconv-lite, and falls back to UTF-8 for an unsupported charset label.
- `bunx tsgo --noEmit` (the package's `typecheck` script) — 0 errors.
- `bun install` updates `bun.lock` for the new dep.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
