### PR TITLE
feat: add browser tool powered by browser-use

### DIFF
--- a/packages/core/src/uv.ts
+++ b/packages/core/src/uv.ts
@@ -1,0 +1,126 @@
+import path from "path"
+import { Context, Effect, Layer, Stream } from "effect"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import { CrossSpawnSpawner } from "./cross-spawn-spawner"
+import { makeGlobalNode } from "./effect/app-node"
+import { httpClient } from "./effect/app-node-platform"
+import { FSUtil } from "./fs-util"
+import { Global } from "./global"
+import { which } from "./util/which"
+
+export namespace UvBinary {
+  const VERSION = "0.11.28"
+  const PLATFORM = {
+    "arm64-darwin": { platform: "aarch64-apple-darwin", extension: "tar.gz" },
+    "arm64-linux": { platform: "aarch64-unknown-linux-gnu", extension: "tar.gz" },
+    "x64-darwin": { platform: "x86_64-apple-darwin", extension: "tar.gz" },
+    "x64-linux": { platform: "x86_64-unknown-linux-musl", extension: "tar.gz" },
+    "arm64-win32": { platform: "aarch64-pc-windows-msvc", extension: "zip" },
+    "ia32-win32": { platform: "i686-pc-windows-msvc", extension: "zip" },
+    "x64-win32": { platform: "x86_64-pc-windows-msvc", extension: "zip" },
+  } as const
+
+  interface Interface {
+    readonly filepath: Effect.Effect<string, Error>
+  }
+
+  export class Service extends Context.Service<Service, Interface>()("@opencode/UvBinary") {}
+
+  const layer = Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const http = HttpClient.filterStatusOk(yield* HttpClient.HttpClient)
+      const spawner = yield* ChildProcessSpawner
+
+      const run = Effect.fnUntraced(function* (command: string, args: string[]) {
+        const handle = yield* spawner.spawn(ChildProcess.make(command, args, { extendEnv: true, stdin: "ignore" }))
+        const [stdout, stderr, code] = yield* Effect.all(
+          [
+            Stream.mkString(Stream.decodeText(handle.stdout)),
+            Stream.mkString(Stream.decodeText(handle.stderr)),
+            handle.exitCode,
+          ],
+          { concurrency: "unbounded" },
+        )
+        return { stdout, stderr, code }
+      }, Effect.scoped)
+
+      const extract = Effect.fnUntraced(function* (
+        archive: string,
+        config: (typeof PLATFORM)[keyof typeof PLATFORM],
+        target: string,
+      ) {
+        const dir = yield* fs.makeTempDirectoryScoped({ directory: Global.Path.bin, prefix: "uv-" })
+
+        if (config.extension === "zip") {
+          const shell = (yield* Effect.sync(() => which("powershell.exe") ?? which("pwsh.exe"))) ?? "powershell.exe"
+          const result = yield* run(shell, [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath '${archive.replaceAll("'", "''")}' -DestinationPath '${dir.replaceAll("'", "''")}' -Force`,
+          ])
+          if (result.code !== 0)
+            throw new Error(result.stderr.trim() || result.stdout.trim() || `uv extraction failed with code ${result.code}`)
+        }
+
+        if (config.extension === "tar.gz") {
+          const result = yield* run("tar", ["-xzf", archive, "-C", dir])
+          if (result.code !== 0)
+            throw new Error(result.stderr.trim() || result.stdout.trim() || `uv extraction failed with code ${result.code}`)
+        }
+
+        // tar.gz archives nest the binaries under uv-<target>/; zip archives are flat
+        const extracted =
+          config.extension === "zip" ? path.join(dir, "uv.exe") : path.join(dir, `uv-${config.platform}`, "uv")
+        if (!(yield* fs.isFile(extracted))) throw new Error(`uv archive did not contain executable: ${extracted}`)
+
+        yield* fs.copyFile(extracted, target)
+        if (process.platform !== "win32") yield* fs.chmod(target, 0o755)
+      }, Effect.scoped)
+
+      return Service.of({
+        filepath: yield* Effect.cached(
+          Effect.gen(function* () {
+            const system = yield* Effect.sync(() => which(process.platform === "win32" ? "uv.exe" : "uv"))
+            if (system && (yield* fs.isFile(system).pipe(Effect.orDie))) return system
+
+            const target = path.join(Global.Path.bin, `uv${process.platform === "win32" ? ".exe" : ""}`)
+            if (yield* fs.isFile(target).pipe(Effect.orDie)) return target
+
+            const platformKey = `${process.arch}-${process.platform}` as keyof typeof PLATFORM
+            const config = PLATFORM[platformKey]
+            if (!config) throw new Error(`unsupported platform for uv: ${platformKey}`)
+
+            const filename = `uv-${config.platform}.${config.extension}`
+            const url = `https://github.com/astral-sh/uv/releases/download/${VERSION}/${filename}`
+            const archive = path.join(Global.Path.bin, filename)
+
+            yield* Effect.logInfo("downloading uv", { url })
+            yield* fs.ensureDir(Global.Path.bin).pipe(Effect.orDie)
+            const bytes = yield* HttpClientRequest.get(url).pipe(
+              http.execute,
+              Effect.flatMap((response) => response.arrayBuffer),
+              Effect.mapError((cause) => (cause instanceof Error ? cause : new Error(String(cause)))),
+            )
+            if (bytes.byteLength === 0) throw new Error(`failed to download uv from ${url}`)
+
+            yield* fs.writeWithDirs(archive, new Uint8Array(bytes))
+            yield* extract(archive, config, target)
+            yield* fs.remove(archive, { force: true }).pipe(Effect.ignore)
+            return target
+          }),
+        ),
+      })
+    }),
+  )
+
+  export const node = makeGlobalNode({
+    service: Service,
+    layer: layer,
+    deps: [FSUtil.node, httpClient, CrossSpawnSpawner.node],
+  })
+}

--- a/packages/opencode/src/tool/browser.ts
+++ b/packages/opencode/src/tool/browser.ts
@@ -1,0 +1,118 @@
+import { Effect, Schema, Stream } from "effect"
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import { UvBinary } from "@opencode-ai/core/uv"
+import { InstanceState } from "@/effect/instance-state"
+import * as Tool from "./tool"
+import DESCRIPTION from "./browser.txt"
+
+const DEFAULT_TIMEOUT = 2 * 60 * 1000
+const MAX_TIMEOUT = 10 * 60 * 1000
+
+export const Parameters = Schema.Struct({
+  script: Schema.String.annotate({
+    description:
+      "Python script to run against the browser. Helpers like new_tab(), page_info(), capture_screenshot(), click_at_xy(), and js() are pre-imported; use print() to return data.",
+  }),
+  timeout: Schema.optional(Schema.Number).annotate({ description: "Optional timeout in seconds (max 600)" }),
+})
+
+export const BrowserTool = Tool.define(
+  "browser",
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner
+    const uv = yield* UvBinary.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          yield* ctx.ask({
+            permission: "browser",
+            patterns: ["*"],
+            always: ["*"],
+            metadata: {
+              script: params.script,
+            },
+          })
+
+          const timeout = Math.min((params.timeout ?? DEFAULT_TIMEOUT / 1000) * 1000, MAX_TIMEOUT)
+          const directory = yield* InstanceState.directory
+
+          let output = ""
+          const exit = yield* Effect.scoped(
+            Effect.gen(function* () {
+              const spawn = (command: string, args: string[]) =>
+                spawner.spawn(
+                  ChildProcess.make(command, args, {
+                    cwd: directory,
+                    extendEnv: true,
+                    stdin: Stream.make(params.script).pipe(Stream.encodeText),
+                  }),
+                )
+
+              // Prefer an installed browser-use, then a system uvx; as a last
+              // resort download uv itself (same on-demand provisioning as
+              // ripgrep) and run the package through it. uv caches the
+              // package after the first call.
+              const handle = yield* spawn("browser-use", []).pipe(
+                Effect.catch(() => spawn("uvx", ["browser-use"])),
+                Effect.catch(() =>
+                  uv.filepath.pipe(Effect.flatMap((bin) => spawn(bin, ["tool", "run", "browser-use"]))),
+                ),
+                Effect.mapError(
+                  (cause) =>
+                    new Error(
+                      `Failed to start the browser-use CLI: ${cause instanceof Error ? cause.message : String(cause)}`,
+                    ),
+                ),
+              )
+
+              yield* Effect.forkScoped(
+                Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+                  Effect.sync(() => {
+                    output += chunk
+                  }),
+                ),
+              )
+
+              const abort = Effect.callback<void>((resume) => {
+                if (ctx.abort.aborted) return resume(Effect.void)
+                const handler = () => resume(Effect.void)
+                ctx.abort.addEventListener("abort", handler, { once: true })
+                return Effect.sync(() => ctx.abort.removeEventListener("abort", handler))
+              })
+
+              const exit = yield* Effect.raceAll([
+                handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
+                abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
+                Effect.sleep(`${timeout} millis`).pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+              ])
+
+              if (exit.kind !== "exit") {
+                yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
+              }
+
+              return exit
+            }),
+          )
+
+          const title = params.script.split("\n")[0] ?? ""
+          if (exit.kind === "abort") throw new Error("Browser script was aborted")
+          if (exit.kind === "timeout") {
+            throw new Error(`Browser script timed out after ${timeout / 1000} seconds\n${output}`.trim())
+          }
+
+          const body = output.trim() || "(no output)"
+          return {
+            title,
+            output: exit.code === 0 ? body : `browser-use exited with code ${exit.code}\n${body}`,
+            metadata: {
+              exitCode: exit.code,
+            },
+          }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)

--- a/packages/opencode/src/tool/browser.txt
+++ b/packages/opencode/src/tool/browser.txt
@@ -1,0 +1,24 @@
+# Control a real web browser
+
+Runs a Python script against a live browser via the browser-use CLI. Helpers are pre-imported; arbitrary Python is allowed (variables, loops, imports, multiple statements), and anything written to stdout with print() becomes the tool result. The daemon, browser, and tabs persist across calls within a session, so later calls continue from the current page state. Nothing needs to be installed: if browser-use is missing it is provisioned automatically, so the first call may take longer.
+
+Use this tool when the task needs a live, rendered page:
+- Verifying UI changes end-to-end, or testing a local dev server.
+- Reproducing a reported bug in a web app.
+- Filling forms or completing multi-step interactions.
+- Pages that require JavaScript to render, or an existing logged-in session.
+- The user asks you to look at, click through, or test a website.
+
+Do not use it for content that merely needs to be read: prefer `webfetch` for static pages, articles, and documentation. Do not enter credentials: on login walls, stop and ask the user.
+
+Pre-imported helpers:
+  - new_tab(url) - open a URL in a new tab (use this for the first navigation)
+  - goto_url(url) - navigate the current tab
+  - page_info() - current URL, title, and tab list
+  - wait_for_load() - wait for the page to finish loading after navigation
+  - capture_screenshot() - capture a screenshot to understand visible state
+  - click_at_xy(x, y) - click at pixel coordinates from the latest screenshot
+  - js(code) - run JavaScript in the page for DOM inspection or extraction
+  - ensure_real_tab() - make sure a regular tab is focused before acting
+
+Screenshot first to understand visible state, act (click/type/navigate), then screenshot again to verify. Keep scripts short and check the result between steps rather than scripting long sequences blindly.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -1,6 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { UvBinary } from "@opencode-ai/core/uv"
 import { PlanExitTool } from "./plan"
 import { Session } from "@/session/session"
 import { QuestionTool } from "./question"
@@ -26,6 +27,7 @@ import { Plugin } from "../plugin"
 import { Provider } from "@/provider/provider"
 
 import { WebSearchTool } from "./websearch"
+import { BrowserTool } from "./browser"
 import { LspTool } from "./lsp"
 import * as Truncate from "./truncate"
 import { ApplyPatchTool } from "./apply_patch"
@@ -102,6 +104,7 @@ const layer = Layer.effect(
     const plan = yield* PlanExitTool
     const webfetch = yield* WebFetchTool
     const websearch = yield* WebSearchTool
+    const browser = yield* BrowserTool
     const shell = yield* ShellTool
     const globtool = yield* GlobTool
     const writetool = yield* WriteTool
@@ -213,6 +216,7 @@ const layer = Layer.effect(
           fetch: Tool.init(webfetch),
           todo: Tool.init(todo),
           search: Tool.init(websearch),
+          browser: Tool.init(browser),
           skill: Tool.init(skilltool),
           patch: Tool.init(patchtool),
           question: Tool.init(question),
@@ -236,6 +240,7 @@ const layer = Layer.effect(
             tool.fetch,
             tool.todo,
             tool.search,
+            tool.browser,
             tool.skill,
             tool.patch,
             ...(tool.execute ? [tool.execute] : []),
@@ -444,6 +449,7 @@ export const node = LayerNode.make({
     MCP.node,
     Database.node,
     Ripgrep.node,
+    UvBinary.node,
   ],
 })
 

--- a/packages/opencode/test/tool/browser.test.ts
+++ b/packages/opencode/test/tool/browser.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer } from "effect"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { Config } from "@/config/config"
+import { BrowserTool } from "../../src/tool/browser"
+import { provideInstance, testInstanceStoreLayer } from "../fixture/fixture"
+import { Agent } from "../../src/agent/agent"
+import { Truncate } from "@/tool/truncate"
+import { SessionID, MessageID } from "../../src/session/schema"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { UvBinary } from "@opencode-ai/core/uv"
+import { Plugin } from "../../src/plugin"
+import { testEffect } from "../lib/effect"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+
+// Stub UvBinary so the download tier never hits the network in tests.
+const uvBinaryStub = Layer.effect(
+  UvBinary.Service,
+  Effect.sync(() =>
+    UvBinary.Service.of({
+      filepath: Effect.sync(() => path.join(uvStubDir, "uv")),
+    }),
+  ),
+)
+
+const browserLayer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+    ]),
+  ),
+  uvBinaryStub,
+  testInstanceStoreLayer,
+)
+const it = testEffect(browserLayer)
+
+const ctx = {
+  sessionID: SessionID.make("ses_test"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+const projectRoot = path.join(__dirname, "../..")
+
+const run = Effect.fn("BrowserToolTest.run")(function* (args: { script: string; timeout?: number }) {
+  const info = yield* BrowserTool
+  const tool = yield* info.init()
+  return yield* tool.execute(args, ctx)
+})
+
+// Stub browser-use binary: echoes stdin back, exits nonzero when asked.
+let stubDir: string
+const originalPath = process.env.PATH
+
+let uvxStubDir: string
+let uvStubDir: string
+
+beforeAll(async () => {
+  stubDir = await fs.mkdtemp(path.join(os.tmpdir(), "browser-tool-test-"))
+  const stub = path.join(stubDir, "browser-use")
+  await fs.writeFile(stub, `#!/bin/sh\nscript=$(cat)\nif [ "$script" = "fail" ]; then echo boom; exit 3; fi\nprintf 'RAN:%s' "$script"\n`)
+  await fs.chmod(stub, 0o755)
+
+  uvxStubDir = await fs.mkdtemp(path.join(os.tmpdir(), "browser-tool-uvx-test-"))
+  const uvx = path.join(uvxStubDir, "uvx")
+  await fs.writeFile(uvx, `#!/bin/sh\n[ "$1" = "browser-use" ] || exit 9\nprintf 'UVX:%s' "$(cat)"\n`)
+  await fs.chmod(uvx, 0o755)
+
+  uvStubDir = await fs.mkdtemp(path.join(os.tmpdir(), "browser-tool-uv-test-"))
+  const uv = path.join(uvStubDir, "uv")
+  await fs.writeFile(uv, `#!/bin/sh\n[ "$1" = "tool" ] && [ "$2" = "run" ] && [ "$3" = "browser-use" ] || exit 9\nprintf 'UV:%s' "$(cat)"\n`)
+  await fs.chmod(uv, 0o755)
+
+  process.env.PATH = `${stubDir}${path.delimiter}${originalPath}`
+})
+
+afterAll(async () => {
+  process.env.PATH = originalPath
+  await fs.rm(stubDir, { recursive: true, force: true })
+  await fs.rm(uvxStubDir, { recursive: true, force: true })
+  await fs.rm(uvStubDir, { recursive: true, force: true })
+})
+
+describe.skipIf(process.platform === "win32")("tool.browser", () => {
+  it.live("pipes the script to browser-use stdin and returns stdout", () =>
+    provideInstance(projectRoot)(
+      Effect.gen(function* () {
+        const result = yield* run({ script: "print(2+2)" })
+        expect(result.output).toBe("RAN:print(2+2)")
+        expect(Number(result.metadata.exitCode)).toBe(0)
+        expect(result.title).toBe("print(2+2)")
+      }),
+    ),
+  )
+
+  it.live("reports a nonzero exit code in the output", () =>
+    provideInstance(projectRoot)(
+      Effect.gen(function* () {
+        const result = yield* run({ script: "fail" })
+        expect(Number(result.metadata.exitCode)).toBe(3)
+        expect(result.output).toContain("browser-use exited with code 3")
+        expect(result.output).toContain("boom")
+      }),
+    ),
+  )
+
+  it.live("falls back to uvx when browser-use is not on PATH", () =>
+    provideInstance(projectRoot)(
+      Effect.gen(function* () {
+        const previous = process.env.PATH
+        process.env.PATH = `${uvxStubDir}${path.delimiter}/usr/bin${path.delimiter}/bin`
+        try {
+          const result = yield* run({ script: "print(1)" })
+          expect(result.output).toBe("UVX:print(1)")
+        } finally {
+          process.env.PATH = previous
+        }
+      }),
+    ),
+  )
+
+  it.live("falls back to the provisioned uv when neither browser-use nor uvx is on PATH", () =>
+    provideInstance(projectRoot)(
+      Effect.gen(function* () {
+        const previous = process.env.PATH
+        process.env.PATH = `/usr/bin${path.delimiter}/bin`
+        try {
+          const result = yield* run({ script: "print(2)" })
+          expect(result.output).toBe("UV:print(2)")
+        } finally {
+          process.env.PATH = previous
+        }
+      }),
+    ),
+  )
+})

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -118,6 +118,15 @@ describe("tool.registry", () => {
     }),
   )
 
+  it.instance("exposes browser", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const ids = yield* registry.ids()
+
+      expect(ids).toContain("browser")
+    }),
+  )
+
   withCodeMode.instance("exposes execute when code mode is enabled", () =>
     Effect.gen(function* () {
       const registry = yield* ToolRegistry.Service


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Gives the agent a built-in `browser` tool, so it can open pages, click, run JavaScript, and pull content out of a real browser. The agent can only `webfetch` pages. This returns static HTML and means the agent cannot interact with anything.

The `browser` tool is useful, as the agent can now:

- **Test what it builds.** After writing a web app, the agent can open it, click through it, read console errors, and fix what it finds.
- **Use the web.** Docs, issue trackers, and dashboards are JS-rendered; `webfetch` sees an empty shell, and a browser sees the page.

The tool uses the [Browser Use CLI](https://github.com/browser-use/browser-use) (3.0). The CLI lets the model run short Python scripts inside a managed browser session.

**Solution:**

- **New `BrowserTool`** in `packages/opencode/src/tool/browser.ts`. The model sends a short Python script using pre-imported helpers (`new_tab`, `js`, `click_at_xy`, …); the tool pipes it to `browser-use` over stdin and returns stdout. The CLI's daemon keeps the browser session alive between calls, so tabs and page state persist even though each call is a short-lived process.
- **Provisioning copies ripgrep** (`packages/core/src/ripgrep/binary.ts`): use `browser-use` from PATH if the user has it; otherwise `uvx browser-use`; otherwise download the uv binary into `Global.Path.bin` (new `UvBinary` service, a near-mirror of `RipgrepBinary`) and run the package through it. Nothing runs or installs until the first browser call.
- **Wired through the existing gates:** the tool registry, and the standard permission prompt on every call (`browser` permission, script shown as metadata). The tool description steers the model to keep preferring `webfetch` for static content.

### How did you verify your code works?

- `bun test`: new `test/tool/browser.test.ts` exercises the real execute path against stub binaries — stdin piping, output capture, nonzero exit codes, and both fallback tiers (uvx, provisioned uv). Registry test asserts the tool is exposed. All pass, typecheck and oxlint clean.
- Manually via `bun dev .`: GPT-5.5 used the tool unprompted for a web task — navigated, extracted content with `js()`, reused page state across calls, and correctly switched to `webfetch` for static article pages.
- Verified the uv release archive layouts (tar.gz nests `uv-<target>/`, Windows zips are flat) against the real 0.11.28 assets before writing the extract step.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR