### PR TITLE
docs: add Vestige as a local MCP memory server example

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Vestige](https://github.com/samvallad33/vestige)                                          | Local MCP memory server that persists context across sessions   |
 
 ---
 

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -110,6 +110,23 @@ And to use it I can add `use the mcp_everything tool` to my prompts.
 use the mcp_everything tool to add the number 3 and 4
 ```
 
+Or add [`Vestige`](https://github.com/samvallad33/vestige) to give opencode persistent memory that lives across sessions, stored locally on your machine.
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "vestige": {
+      "type": "local",
+      "command": ["npx", "-y", "-p", "vestige-mcp-server@latest", "vestige-mcp"],
+      "enabled": true,
+    },
+  },
+}
+```
+
+It exposes tools for saving and recalling decisions, preferences, and past fixes, so opencode does not start from scratch each session.
+
 ---
 
 #### Options


### PR DESCRIPTION
### Issue for this PR

Closes #31402

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Vestige to the docs as a local MCP server example, in two spots: a `type: "local"` config block in the MCP servers page right after the `mcp_everything` example, and one row in the ecosystem Projects table.

Vestige is a local-first memory server that runs over stdio. It lets opencode keep memory across sessions (decisions, preferences, past fixes) without a cloud account, since everything stays on the user's machine. I kept the example minimal and matched the shape of the existing `mcp_everything` block so it reads consistently with the rest of the section.

### How did you verify your code works?

Ran the exact command from the config block. `npx -y -p vestige-mcp-server@latest vestige-mcp` boots v2.2.1 and completes the MCP `initialize` handshake over stdio (returns `serverInfo` and `capabilities`, protocol `2024-11-05`). The npm package `vestige-mcp-server@2.2.1` ships the `vestige-mcp` binary the command calls. Docs only, so no app behavior changes.

### Screenshots / recordings

Not a UI change, docs only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
