### PR TITLE
fix(skill): correct MCP local server env key to environment in customize-opencode

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -112,7 +112,7 @@ Every field is optional.
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp"],
       "enabled": true,
-      "env": {}
+      "environment": {}
     },
     "remote-thing": {
       "type": "remote",
@@ -371,7 +371,7 @@ Special object-shaped (not callbacks): `tool: { my_tool: { ... } }`,
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp"],
       "enabled": true,
-      "env": { "BROWSER": "chromium" }
+      "environment": { "BROWSER": "chromium" }
     },
     "github": {
       "type": "remote",

--- a/packages/core/test/plugin/skill.test.ts
+++ b/packages/core/test/plugin/skill.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { Effect } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { SkillPlugin } from "@opencode-ai/core/plugin/skill"
 import { SkillV2 } from "@opencode-ai/core/skill"
 import { testEffect } from "../lib/effect"
 import { host } from "./host"
+
+// Regression: the skill previously used "env" which is stripped by the schema parser.
+// The correct field is "environment" (matches McpLocalConfig schema and mcp/index.ts runtime).
+test("customize-opencode skill uses correct 'environment' key for MCP local server env vars", () => {
+  const content = readFileSync(
+    join(import.meta.dir, "../../src/plugin/skill/customize-opencode.md"),
+    "utf-8",
+  )
+  expect(content).not.toMatch(/"env":\s*\{/)
+  expect(content).toContain('"environment"')
+})
 
 const it = testEffect(AppNodeBuilder.build(SkillV2.node))
 


### PR DESCRIPTION
### Issue for this PR

Closes #35860

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The built-in `customize-opencode` skill showed `"env"` as the key for MCP local server environment variables in two example blocks. The config schema (`packages/core/src/config/mcp.ts`) and the runtime (`packages/opencode/src/mcp/index.ts:342`) both use `"environment"`. The config loader strips unknown keys without warning, so users copying the example had their env vars silently dropped — no error, just absent subprocess environment variables.

Two changes in one file:

```diff
-      "env": {}
+      "environment": {}
```

```diff
-      "env": { "BROWSER": "chromium" }
+      "environment": { "BROWSER": "chromium" }
```

### How did you verify your code works?

- `bun test test/plugin/skill.test.ts` from `packages/core` — 1 pass, 0 fail
- `bun run typecheck` (turbo, all 30 packages) — 30 successful, 0 errors
- Confirmed `"environment"` matches the field name in `packages/core/src/config/mcp.ts:12` and what `mcp/index.ts:342` reads at runtime

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR