### PR TITLE
fix: prevent headless run startup deadlock from effect fiber re-entrancy

### DIFF
--- a/patches/effect@4.0.0-beta.83.patch
+++ b/patches/effect@4.0.0-beta.83.patch
@@ -1,3 +1,23 @@
+diff --git a/node_modules/effect/.bun-tag-5b59820d26c13f3c b/.bun-tag-5b59820d26c13f3c
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/internal/effect.js b/dist/internal/effect.js
+index 052c8e0ad2ff8007f4fc828dd577ff78e0129b10..89e9390d67c11ffa5e14b377b81e28c9e5b1b6f7 100644
+--- a/dist/internal/effect.js
++++ b/dist/internal/effect.js
+@@ -720,7 +720,11 @@ const callbackOptions = /*#__PURE__*/makePrimitive({
+       if (resumed) return;
+       resumed = true;
+       if (yielded) {
+-        fiber.evaluate(effect);
++        // fix(run-init-deadlock): resume via the fiber's own dispatcher instead of
++        // re-entering runLoop inline on the completer's stack. Inline resume builds a
++        // nested tower under startImmediately forks; a second re-entry then strands the
++        // re-parked fiber via the runLoop re-entrancy guard (a lost wakeup).
++        fiber.currentDispatcher.scheduleTask(() => fiber.evaluate(effect), 0);
+       } else {
+         yielded = effect;
+       }
 diff --git a/dist/unstable/httpapi/HttpApiSchema.js b/dist/unstable/httpapi/HttpApiSchema.js
 index ecb6603d1ee4e89e92174b3a1100e8c9c720b3f3..08b832b6b3e9e4d10df156eca36b16f571f67f6e 100644
 --- a/dist/unstable/httpapi/HttpApiSchema.js


### PR DESCRIPTION
### Issue for this PR

Closes #35870 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run` intermittently hangs at startup (~40% of cold starts under load, ~0% idle): it reaches instance-ready, then idles forever before creating the session. `InstanceStore.load` parks the main fiber on the boot `Deferred`, and `effect@4.0.0-beta.83` resumes it inline on the completer's stack (`internal/effect.ts:1031`). Under the `startImmediately` boot fork the continuation runs nested, re-parks on the op-yield budget, and a second re-entry strands the fiber through the `runLoop` re-entrancy guard (`:634`).

One line, in the existing `patches/effect@4.0.0-beta.83.patch`: schedule the async resume on the fiber's own dispatcher instead of resuming inline, so it can't run nested on the completer's stack.

```js
// internal/effect.ts:1031 — was: fiber.evaluate(effect)
fiber.currentDispatcher.scheduleTask(() => fiber.evaluate(effect), 0)
```

### How did you verify your code works?

A standalone repro of the mechanism strands 100% of runs before the change and 0% after. The app-side alternatives (`startImmediately: false`, an inserted `yieldNow`) don't fix it. `opencode run` still replies normally (exit 0). A reviewer can confirm by running the repro with and without the patch, or by hammering `opencode run` cold starts under load.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

