### PR TITLE
fix(mcp): forward piped stderr from local MCP servers to error diagnostics

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -337,6 +337,10 @@ const layer = Layer.effect(
       }
     })
 
+    // Tracks the last stderr output from each MCP server for diagnostics.
+    // Keyed by server name; cleared on successful connection.
+    const stderrBuffers = new Map<string, string>()
+
     const connectLocal = Effect.fn("MCP.connectLocal")(function* (
       key: string,
       mcp: ConfigMCPV1.Info & { type: "local" },
@@ -356,15 +360,31 @@ const layer = Layer.effect(
         },
       })
 
+      // Capture stderr from the MCP server process for diagnostics.
+      // Without this, startup errors (e.g. missing files, bad config) are
+      // silently lost and the user only sees "Connection closed".
+      const MAX_STDERR_BYTES = 4096
+      let stderrTail = ""
+      const stderrStream = transport.stderr
+      if (stderrStream) {
+        stderrStream.on("data", (chunk: Buffer) => {
+          const text = chunk.toString()
+          stderrTail = (stderrTail + text).slice(-MAX_STDERR_BYTES)
+        })
+      }
+
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       return yield* connectTransport(transport, connectTimeout).pipe(
-        Effect.map((client): { client: MCPClient | undefined; status: Status } => ({
-          client,
-          status: { status: "connected" },
-        })),
+        Effect.map((client): { client: MCPClient | undefined; status: Status } => {
+          stderrBuffers.delete(key)
+          return { client, status: { status: "connected" } }
+        }),
         Effect.catch((error): Effect.Effect<{ client: MCPClient | undefined; status: Status }> => {
           const msg = error instanceof Error ? error.message : String(error)
-          return Effect.succeed({ client: undefined, status: { status: "failed", error: msg } })
+          const stderr = stderrTail.trim()
+          if (stderr) stderrBuffers.set(key, stderr)
+          const detail = stderr ? `${msg}\nServer stderr: ${stderr}` : msg
+          return Effect.succeed({ client: undefined, status: { status: "failed", error: detail } })
         }),
       )
     })
@@ -445,9 +465,11 @@ const layer = Layer.effect(
         delete s.clients[name]
         delete s.defs[name]
         delete s.instructions[name]
-        s.status[name] = { status: "failed", error: "Connection closed" }
+        const stderr = stderrBuffers.get(name)?.trim()
+        const error = stderr ? `Connection closed\nServer stderr: ${stderr}` : "Connection closed"
+        s.status[name] = { status: "failed", error }
         bridge.fork(
-          Effect.logWarning("MCP connection closed", { server: name }).pipe(
+          Effect.logWarning("MCP connection closed", { server: name, ...(stderr ? { stderr } : {}) }).pipe(
             Effect.andThen(events.publish(ToolsChanged, { server: name })),
             Effect.ignore,
           ),


### PR DESCRIPTION
### Issue for this PR

Closes #35719

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a local MCP server is spawned with `stderr: "pipe"`, nothing ever reads from the pipe. If the server writes startup errors or crash output to stderr and then exits, the user only sees the generic "Connection closed" message with no actionable context.

This adds a bounded (4KB) stderr listener on the transport's stderr stream. When a connection fails or the `onclose` handler fires, the buffered stderr is appended to the error string that's already surfaced in the TUI status. The buffer is cleared on successful connection to avoid stale data.

The fix is intentionally minimal: no new UI, no new dependencies — just plumbing that already-piped stderr into the existing error path.

### How did you verify your code works?

1. Configured an MCP server with a deliberately broken source path → confirmed the error status now shows the upstream "failed to read file: ..." message.
2. Configured a valid MCP server → confirmed stderr buffer is cleared and behavior is identical to before.
3. Verified the 4KB cap works by writing >4KB to stderr in a test harness and checking only the tail is retained.

### Screenshots / recordings

_N/A — no UI changes. The stderr context appears in the existing error status string._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR