### PR TITLE
fix(app): prevent session model overwrite on tab switch

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1508,6 +1508,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     current: props.controls.agents.current,
     style: control(),
     onSelect: (value) => {
+      if (value === props.controls.agents.current) return
       props.controls.agents.select(value)
       restoreFocus()
     },
@@ -1694,6 +1695,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                               <MenuV2.RadioGroup
                                 value={props.controls.model.selection.variant.current() ?? "default"}
                                 onChange={(value) => {
+                                  const current = props.controls.model.selection.variant.current() ?? "default"
+                                  if (value === current) return
                                   props.controls.model.selection.variant.set(value === "default" ? undefined : value)
                                   restoreFocus()
                                 }}
@@ -1934,6 +1937,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                             options={props.controls.agents.options}
                             current={props.controls.agents.current}
                             onSelect={(value) => {
+                              if (value === props.controls.agents.current) return
                               props.controls.agents.select(value)
                               restoreFocus()
                             }}
@@ -2043,6 +2047,8 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                                 current={props.controls.model.selection.variant.current() ?? "default"}
                                 label={(x) => (x === "default" ? language.t("common.default") : x)}
                                 onSelect={(value) => {
+                                  const current = props.controls.model.selection.variant.current() ?? "default"
+                                  if (value === current) return
                                   props.controls.model.selection.variant.set(value === "default" ? undefined : value)
                                   restoreFocus()
                                 }}

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -199,10 +199,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             variant: item.variant ?? null,
           })
           const prev = scope()
+          const agentChanged = item.name !== prev?.agent
           const next = {
             agent: item.name,
-            model: item.model ?? prev?.model,
-            variant: item.variant ?? prev?.variant,
+            model: agentChanged ? (item.model ?? prev?.model) : prev?.model,
+            variant: agentChanged ? (item.variant ?? prev?.variant) : prev?.variant,
           } satisfies State
           const session = id()
           if (session) {

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -124,6 +124,7 @@ export function Select<T>(props: SelectProps<T> & Omit<ButtonProps, "children">)
         </Kobalte.Item>
       )}
       onChange={(v) => {
+        if (v === local.current) return
         local.onSelect?.(v ?? undefined)
         stop()
       }}


### PR DESCRIPTION
Kobalte Select auto-fires onChange when its controlled value prop changes externally (e.g. switching session tabs), which spuriously triggered agent.set/variant.set. The agent's configured default model then overwrote the user-selected model in saved.session[sessionID], causing all sessions in the same workspace to silently revert to the same default model.

Three-layer fix:
- ui/select.tsx: skip onSelect when new value equals current value
- app/prompt-input.tsx: guard all 4 agent/variant onSelect callbacks
- app/local.tsx: agent.set preserves prev model/variant when agent unchanged, so even a spurious trigger cannot overwrite user selection

### Issue for this PR

Closes #35899

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
切换会话时，模型选择器的 Select 组件会错误触发 onChange，导致 agent.set 把插件配置的默认模型覆盖了用户选的模型。修复了三层：Select 组件本身加守卫、回调处加守卫、agent.set 函数内部也加守卫，确保用户选中的模型不会被覆盖。

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
在Web应用上测试:两个使用不同模型的会话，反复切换它们，每个会话保留自己的模型。
### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
