### PR TITLE
fix(event): remove directory filter from SSE stream for worktree sessions

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -34,8 +34,7 @@ function eventResponse(events: EventV2.Interface) {
     const stream = Stream.fromQueue(queue).pipe(
       Stream.filter(
         (event) =>
-          event.location?.directory === instance.directory &&
-          (event.location.workspaceID === undefined || event.location.workspaceID === workspaceID),
+          event.location?.workspaceID === undefined || event.location.workspaceID === workspaceID,
       ),
       Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
     )


### PR DESCRIPTION
### Issue for this PR

Closes #35917

### Type of change

- [x] Bug fix

### What does this PR do?

The SSE event handler filters events by `event.location?.directory === instance.directory`. When a session runs inside a git worktree, the working directory differs from the configured instance directory. All events fail the filter and are silently dropped — the TUI receives no tool completions, message streaming, or permission prompts.

The fix removes the `directory` filter condition. The `workspaceID` filter is retained, which correctly scopes events to the current workspace regardless of directory path. Added `?.' null-safety to the `workspaceID` access since the directory guard that previously implied `location` is defined is gone.

### How did you verify your code works?

Built and deployed locally on v1.17.9. Verified that worktree sessions receive SSE events (tool completions, message parts, permission prompts) after the fix. Non-worktree sessions are unaffected — the `workspaceID` filter still scopes correctly.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR