### PR TITLE
test(tui): cover streaming shell state

### DIFF
--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -1770,6 +1770,14 @@ test("settles pending tools when a live failure arrives", async () => {
         name: "bash",
       },
     })
+    await wait(() => {
+      const assistant = sync.session.message.get("session-1", "msg_explicit_assistant_9")
+      return (
+        assistant?.type === "assistant" &&
+        assistant.content[0]?.type === "tool" &&
+        assistant.content[0].state.status === "streaming"
+      )
+    })
     emitEvent(events, {
       id: "evt_called_1",
       created: 0,


### PR DESCRIPTION
## Summary
- assert live shell tool input starts in the `streaming` state
- guard against restoring the legacy `pending` state that crashes shell rendering without structured metadata

## Test
- `bun test test/cli/tui/data.test.tsx --timeout 30000 --only-failures --test-name-pattern "settles pending tools"`