### PR TITLE
fix(provider): detect max-token request overflow errors from non-OpenAI providers

### DIFF
--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -20,6 +20,35 @@ export class ResponseStreamError extends Error {
   }
 }
 
+// Adapted from overflow detection patterns in:
+// https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/utils/overflow.ts
+const OVERFLOW_PATTERNS = [
+  /prompt is too long/i, // Anthropic
+  /input is too long for requested model/i, // Amazon Bedrock
+  /exceeds the context window/i, // OpenAI (Completions + Responses API message text)
+  /(?:tokens? in (?:request|input|prompt|context)|(?:request|input|prompt|context) tokens?|input token count).*?(?:more than|greater than|exceeds?|exceeded).*?(?:max(?:imum)?(?: number of)? tokens?(?: allowed)?|token limit)/i, // Conservative request-token overflow variants
+  /input token count.*exceeds the maximum/i, // Google (Gemini)
+  /maximum prompt length is \d+/i, // xAI (Grok)
+  /reduce the length of the messages/i, // Groq
+  /maximum context length is \d+ tokens/i, // OpenRouter, DeepSeek, vLLM
+  /exceeds the limit of \d+/i, // GitHub Copilot
+  /exceeds the available context size/i, // llama.cpp server
+  /greater than the context length/i, // LM Studio
+  /context window exceeds limit/i, // MiniMax
+  /exceeded model token limit/i, // Kimi For Coding, Moonshot
+  /context[_ ]length[_ ]exceeded/i, // Generic fallback
+  /request entity too large/i, // HTTP 413
+  /context length is only \d+ tokens/i, // vLLM
+  /input length.*exceeds.*context length/i, // vLLM
+  /prompt too long; exceeded (?:max )?context length/i, // Ollama explicit overflow error
+  /too large for model with \d+ maximum context length/i, // Mistral
+  /model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
+]
+
+function normalizeOverflowText(message: string) {
+  return message.toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim()
+}
+
 function isOpenAiErrorRetryable(e: APICallError) {
   const status = e.statusCode
   if (!status) return e.isRetryable
@@ -29,6 +58,16 @@ function isOpenAiErrorRetryable(e: APICallError) {
 
 // Providers not reliably handled in this function:
 // - z.ai: can accept overflow silently (needs token-count/context-window checks)
+function isOverflow(message: string) {
+  const normalized = normalizeOverflowText(message)
+  if (OVERFLOW_PATTERNS.some((p) => p.test(message) || p.test(normalized))) return true
+
+  // Providers/status patterns handled outside of regex list:
+  // - Cerebras: often returns "400 (no body)" / "413 (no body)"
+  // - Mistral: often returns "400 (no body)" / "413 (no body)"
+  return /^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message)
+}
+
 function message(providerID: ProviderV2.ID, e: APICallError) {
   return iife(() => {
     const msg = e.message
@@ -165,7 +204,13 @@ export type ParsedAPICallError =
 export function parseAPICallError(input: { providerID: ProviderV2.ID; error: APICallError }): ParsedAPICallError {
   const m = message(input.providerID, input.error)
   const body = json(input.error.responseBody)
-  if (isContextOverflow(m) || input.error.statusCode === 413 || body?.error?.code === "context_length_exceeded") {
+  if (
+    isContextOverflow(m) ||
+    isOverflow(m) ||
+    (input.error.responseBody ? isOverflow(input.error.responseBody) : false) ||
+    input.error.statusCode === 413 ||
+    body?.error?.code === "context_length_exceeded"
+  ) {
     return {
       type: "context_overflow",
       message: m,

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1468,6 +1468,31 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("detects request max-token overflow API call errors", () => {
+    const cases = [
+      "tokens in request more than max tokens allowed",
+      "Input token count exceeded maximum number of tokens allowed",
+    ]
+
+    cases.forEach((message) => {
+      const result = MessageV2.fromError(
+        new APICallError({
+          message,
+          url: "https://example.com",
+          requestBodyValues: {},
+          statusCode: 400,
+          responseHeaders: { "content-type": "application/json" },
+          isRetryable: false,
+        }),
+        { providerID },
+      )
+
+      expect(MessageV2.ContextOverflowError.isInstance(result)).toBe(true)
+      if (!MessageV2.ContextOverflowError.isInstance(result)) throw new Error("expected ContextOverflowError")
+      expect(result.data.message).toBe(message)
+    })
+  })
+
   test("detects context overflow from context_length_exceeded code in response body", () => {
     const error = new APICallError({
       message: "Request failed",
@@ -1502,6 +1527,27 @@ describe("session.message-v2.fromError", () => {
     )
     expect(SessionV1.ContextOverflowError.isInstance(result)).toBe(false)
     expect(SessionV1.APIError.isInstance(result)).toBe(true)
+  })
+
+  test("does not classify max_tokens setting errors as context overflow", () => {
+    const message = "max_tokens must be less than or equal to 4096"
+    const result = MessageV2.fromError(
+      new APICallError({
+        message,
+        url: "https://example.com",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseHeaders: { "content-type": "application/json" },
+        responseBody: JSON.stringify({ error: { message } }),
+        isRetryable: false,
+      }),
+      { providerID },
+    )
+
+    expect(MessageV2.ContextOverflowError.isInstance(result)).toBe(false)
+    expect(MessageV2.APIError.isInstance(result)).toBe(true)
+    if (!MessageV2.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.message).toContain(message)
   })
 
   test("serializes unknown inputs", () => {

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -191,6 +191,23 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
   })
 
+  test("does not retry request max-token overflow API call errors", () => {
+    const error = MessageV2.fromError(
+      new APICallError({
+        message: "tokens in request more than max tokens allowed",
+        url: "https://example.com",
+        requestBodyValues: {},
+        statusCode: 400,
+        responseHeaders: { "content-type": "application/json" },
+        isRetryable: false,
+      }),
+      { providerID },
+    )
+
+    expect(MessageV2.ContextOverflowError.isInstance(error)).toBe(true)
+    expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
+  })
+
   test("retries 500 errors even when isRetryable is false", () => {
     const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
       new SessionV1.APIError({


### PR DESCRIPTION
### Issue for this PR

Closes #35918

### Type of change

- [x] Bug fix

### What does this PR do?

Context overflow errors from non-OpenAI providers (GLM/Z.AI, Moonshot, DeepSeek, etc.) are not detected by the current error classifier. The existing `isContextOverflow` from `@opencode-ai/llm` covers OpenAI-style phrasing but misses provider-specific variants like `"tokens in request more than max tokens allowed"` (GLM) or `"exceeded model token limit"` (Moonshot).

This PR adds a conservative `OVERFLOW_PATTERNS` regex array and an `isOverflow()` helper that detects overflow across 18+ provider-specific error formats. It also checks `responseBody` for overflow indicators (some providers embed the error in the response body rather than the message).

The patterns are deliberately conservative — multi-word sequences like `more than max tokens` — to avoid false positives from `max_tokens` parameter validation errors.

Changes:
- `packages/opencode/src/provider/error.ts`: Added `OVERFLOW_PATTERNS`, `isOverflow()`, and integrated both `isContextOverflow` (upstream) and `isOverflow` (new) into the overflow check in `parseAPICallError`
- `packages/opencode/test/session/retry.test.ts`: Tests verifying overflow errors are classified correctly and not retried
- `packages/opencode/test/session/message-v2.test.ts`: Tests for new overflow variants and a non-overflow `max_tokens` validation case

### How did you verify your code works?

- Unit tests pass: `bun test test/session/retry.test.ts` and `bun test test/session/message-v2.test.ts`
- Verified on local deployment with GLM 5.1 (200K context) — overflow at ~190K tokens correctly triggers compaction instead of retry loops
- Verified that `max_tokens` output-limit errors do NOT trigger compaction (no false positives)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR