### PR TITLE
fix(core): preserve prompt attachment order

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -173,19 +173,25 @@ function toLLMMessage(message: SessionMessage.Info, model: ModelV2.Ref, provider
       return []
     case "user":
       const files = message.files ?? []
+      const attachments = files.flatMap((file): ContentPart[] => {
+        if (file.mime === "text/plain") return [textAttachment(file)]
+        if (file.mime === "application/x-directory") return [directoryAttachment(file)]
+        if (imageMimes.has(file.mime)) return [media(file)]
+        return []
+      })
+      const firstTextAttachment = message.text === "" ? attachments.findIndex((part) => part.type === "text") : -1
+      const content: ContentPart[] = [
+        ...(message.text === "" ? [] : [{ type: "text" as const, text: message.text }]),
+        ...attachments.map((part, index) =>
+          part.type === "text" && index !== firstTextAttachment ? { ...part, text: `\n\n${part.text}` } : part,
+        ),
+      ]
+      if (content.length === 0) return []
       return [
         Message.make({
           id: message.id,
           role: "user",
-          content: [
-            { type: "text", text: message.text },
-            ...files.flatMap((file): ContentPart[] => {
-              if (file.mime === "text/plain") return [textAttachment(file)]
-              if (file.mime === "application/x-directory") return [directoryAttachment(file)]
-              if (imageMimes.has(file.mime)) return [media(file)]
-              return []
-            }),
-          ],
+          content,
           metadata: {
             ...message.metadata,
             ...(message.agents?.length ? { agents: message.agents } : {}),

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -59,6 +59,26 @@ const directoryAttachment = (file: FileAttachment): ContentPart => ({
   },
 })
 
+const attachmentContent = (file: FileAttachment): ContentPart[] => {
+  if (file.mime === "text/plain") return [textAttachment(file)]
+  if (file.mime === "application/x-directory") return [directoryAttachment(file)]
+  if (imageMimes.has(file.mime)) return [media(file)]
+  return []
+}
+
+function separateTextParts(parts: ContentPart[]) {
+  let seenText = false
+  return parts.map((part) => {
+    if (part.type !== "text") return part
+    if (!seenText) {
+      seenText = true
+      return part
+    }
+    // OpenAI Chat flattens text-only content without adding a delimiter.
+    return { ...part, text: `\n\n${part.text}` }
+  })
+}
+
 const decodeToolInput = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
 
 const providerMetadata = (
@@ -172,20 +192,10 @@ function toLLMMessage(message: SessionMessage.Info, model: ModelV2.Ref, provider
     case "model-switched":
       return []
     case "user":
-      const files = message.files ?? []
-      const attachments = files.flatMap((file): ContentPart[] => {
-        if (file.mime === "text/plain") return [textAttachment(file)]
-        if (file.mime === "application/x-directory") return [directoryAttachment(file)]
-        if (imageMimes.has(file.mime)) return [media(file)]
-        return []
-      })
-      const firstTextAttachment = message.text === "" ? attachments.findIndex((part) => part.type === "text") : -1
-      const content: ContentPart[] = [
-        ...(message.text === "" ? [] : [{ type: "text" as const, text: message.text }]),
-        ...attachments.map((part, index) =>
-          part.type === "text" && index !== firstTextAttachment ? { ...part, text: `\n\n${part.text}` } : part,
-        ),
-      ]
+      const content = separateTextParts([
+        ...(message.text === "" ? [] : [Message.text(message.text)]),
+        ...(message.files ?? []).flatMap(attachmentContent),
+      ])
       if (content.length === 0) return []
       return [
         Message.make({

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -21,45 +21,43 @@ const media = (file: FileAttachment): ContentPart => ({
   metadata: file.description === undefined ? undefined : { description: file.description },
 })
 
-const textAttachment = (file: FileAttachment) =>
-  Message.make({
-    role: "user",
-    content: [
-      `Attached file: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")}`,
-      file.description === undefined ? undefined : `Description: ${file.description}`,
-      "",
-      Buffer.from(file.data, "base64").toString("utf8"),
-    ]
-      .filter((line): line is string => line !== undefined)
-      .join("\n"),
-    metadata: {
-      attachment: {
-        source: file.source,
-        name: file.name,
-        description: file.description,
-      },
+const textAttachment = (file: FileAttachment): ContentPart => ({
+  type: "text",
+  text: [
+    `Attached file: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")}`,
+    file.description === undefined ? undefined : `Description: ${file.description}`,
+    "",
+    Buffer.from(file.data, "base64").toString("utf8"),
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n"),
+  metadata: {
+    attachment: {
+      source: file.source,
+      name: file.name,
+      description: file.description,
     },
-  })
+  },
+})
 
-const directoryAttachment = (file: FileAttachment) =>
-  Message.make({
-    role: "user",
-    content: [
-      `Attached directory: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "directory")}`,
-      file.description === undefined ? undefined : `Description: ${file.description}`,
-      file.data.length === 0 ? undefined : "",
-      file.data.length === 0 ? undefined : Buffer.from(file.data, "base64").toString("utf8"),
-    ]
-      .filter((line): line is string => line !== undefined)
-      .join("\n"),
-    metadata: {
-      attachment: {
-        source: file.source,
-        name: file.name,
-        description: file.description,
-      },
+const directoryAttachment = (file: FileAttachment): ContentPart => ({
+  type: "text",
+  text: [
+    `Attached directory: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "directory")}`,
+    file.description === undefined ? undefined : `Description: ${file.description}`,
+    file.data.length === 0 ? undefined : "",
+    file.data.length === 0 ? undefined : Buffer.from(file.data, "base64").toString("utf8"),
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n"),
+  metadata: {
+    attachment: {
+      source: file.source,
+      name: file.name,
+      description: file.description,
     },
-  })
+  },
+})
 
 const decodeToolInput = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
 
@@ -176,14 +174,17 @@ function toLLMMessage(message: SessionMessage.Info, model: ModelV2.Ref, provider
     case "user":
       const files = message.files ?? []
       return [
-        ...files.filter((file) => file.mime === "text/plain").map(textAttachment),
-        ...files.filter((file) => file.mime === "application/x-directory").map(directoryAttachment),
         Message.make({
           id: message.id,
           role: "user",
           content: [
             { type: "text", text: message.text },
-            ...files.filter((file) => imageMimes.has(file.mime)).map(media),
+            ...files.flatMap((file): ContentPart[] => {
+              if (file.mime === "text/plain") return [textAttachment(file)]
+              if (file.mime === "application/x-directory") return [directoryAttachment(file)]
+              if (imageMimes.has(file.mime)) return [media(file)]
+              return []
+            }),
           ],
           metadata: {
             ...message.metadata,

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -23,14 +23,14 @@ const media = (file: FileAttachment): ContentPart => ({
 
 const textAttachment = (file: FileAttachment): ContentPart => ({
   type: "text",
-  text: [
+  text: `\n\n${[
     `Attached file: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")}`,
     file.description === undefined ? undefined : `Description: ${file.description}`,
     "",
     Buffer.from(file.data, "base64").toString("utf8"),
   ]
     .filter((line): line is string => line !== undefined)
-    .join("\n"),
+    .join("\n")}`,
   metadata: {
     attachment: {
       source: file.source,
@@ -42,14 +42,14 @@ const textAttachment = (file: FileAttachment): ContentPart => ({
 
 const directoryAttachment = (file: FileAttachment): ContentPart => ({
   type: "text",
-  text: [
+  text: `\n\n${[
     `Attached directory: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "directory")}`,
     file.description === undefined ? undefined : `Description: ${file.description}`,
     file.data.length === 0 ? undefined : "",
     file.data.length === 0 ? undefined : Buffer.from(file.data, "base64").toString("utf8"),
   ]
     .filter((line): line is string => line !== undefined)
-    .join("\n"),
+    .join("\n")}`,
   metadata: {
     attachment: {
       source: file.source,
@@ -64,19 +64,6 @@ const attachmentContent = (file: FileAttachment): ContentPart[] => {
   if (file.mime === "application/x-directory") return [directoryAttachment(file)]
   if (imageMimes.has(file.mime)) return [media(file)]
   return []
-}
-
-function separateTextParts(parts: ContentPart[]) {
-  let seenText = false
-  return parts.map((part) => {
-    if (part.type !== "text") return part
-    if (!seenText) {
-      seenText = true
-      return part
-    }
-    // OpenAI Chat flattens text-only content without adding a delimiter.
-    return { ...part, text: `\n\n${part.text}` }
-  })
 }
 
 const decodeToolInput = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
@@ -192,10 +179,10 @@ function toLLMMessage(message: SessionMessage.Info, model: ModelV2.Ref, provider
     case "model-switched":
       return []
     case "user":
-      const content = separateTextParts([
+      const content = [
         ...(message.text === "" ? [] : [Message.text(message.text)]),
         ...(message.files ?? []).flatMap(attachmentContent),
-      ])
+      ]
       if (content.length === 0) return []
       return [
         Message.make({

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -172,7 +172,7 @@ Recent work
         { type: "text", text: "Review this file" },
         {
           type: "text",
-          text: "Attached file: main.ts\n\nexport const value = 1",
+          text: "\n\nAttached file: main.ts\n\nexport const value = 1",
           metadata: { attachment: { source: file.source, name: "main.ts" } },
         },
       ],
@@ -204,7 +204,7 @@ Recent work
       { type: "text", text: "Review this file" },
       {
         type: "text",
-        text: "Attached file: inline.txt\n\ninline content",
+        text: "\n\nAttached file: inline.txt\n\ninline content",
       },
     ])
   })
@@ -237,7 +237,7 @@ Recent work
         { type: "text", text: "Review this directory" },
         {
           type: "text",
-          text: "Attached directory: src/\n\nlib/\nindex.ts",
+          text: "\n\nAttached directory: src/\n\nlib/\nindex.ts",
           metadata: { attachment: { source: directory.source, name: "src/" } },
         },
       ],
@@ -274,9 +274,34 @@ Recent work
     expect(messages).toHaveLength(1)
     expect(messages[0]?.content.map((part) => (part.type === "text" ? part.text : part.type))).toEqual([
       "Review these attachments",
-      "Attached directory: src/\n\nindex.ts",
-      "Attached file: main.ts\n\nexport const value = 1",
+      "\n\nAttached directory: src/\n\nindex.ts",
+      "\n\nAttached file: main.ts\n\nexport const value = 1",
     ])
+  })
+
+  test("omits empty prompt text before an attachment", () => {
+    const messages = toLLMMessages(
+      [
+        SessionMessage.User.make({
+          id: id("user-attachment-only"),
+          type: "user",
+          text: "",
+          files: [
+            FileAttachment.make({
+              data: Base64.make(Buffer.from("index.ts").toString("base64")),
+              mime: "application/x-directory",
+              source: { type: "uri", uri: "file:///project/src" },
+              name: "src/",
+            }),
+          ],
+          time: { created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.content).toMatchObject([{ type: "text", text: "Attached directory: src/\n\nindex.ts" }])
   })
 
   test("uses materialized image data as provider media and drops unsupported attachments", () => {

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -301,7 +301,7 @@ Recent work
     )
 
     expect(messages).toHaveLength(1)
-    expect(messages[0]?.content).toMatchObject([{ type: "text", text: "Attached directory: src/\n\nindex.ts" }])
+    expect(messages[0]?.content).toMatchObject([{ type: "text", text: "\n\nAttached directory: src/\n\nindex.ts" }])
   })
 
   test("uses materialized image data as provider media and drops unsupported attachments", () => {

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -144,7 +144,7 @@ Recent work
     ])
   })
 
-  test("lowers text attachments as separate user messages", () => {
+  test("lowers text attachments after the prompt in one user message", () => {
     const file = FileAttachment.make({
       data: Base64.make(Buffer.from("export const value = 1").toString("base64")),
       mime: "text/plain",
@@ -164,21 +164,18 @@ Recent work
       model,
     )
 
-    expect(messages).toHaveLength(2)
+    expect(messages).toHaveLength(1)
     expect(messages[0]).toMatchObject({
+      id: id("user-text-file"),
       role: "user",
       content: [
+        { type: "text", text: "Review this file" },
         {
           type: "text",
           text: "Attached file: main.ts\n\nexport const value = 1",
+          metadata: { attachment: { source: file.source, name: "main.ts" } },
         },
       ],
-      metadata: { attachment: { source: file.source, name: "main.ts" } },
-    })
-    expect(messages[1]).toMatchObject({
-      id: id("user-text-file"),
-      role: "user",
-      content: [{ type: "text", text: "Review this file" }],
     })
   })
 
@@ -203,7 +200,8 @@ Recent work
       model,
     )
 
-    expect(messages[0]?.content).toEqual([
+    expect(messages[0]?.content).toMatchObject([
+      { type: "text", text: "Review this file" },
       {
         type: "text",
         text: "Attached file: inline.txt\n\ninline content",
@@ -231,13 +229,54 @@ Recent work
       model,
     )
 
-    expect(messages).toHaveLength(2)
+    expect(messages).toHaveLength(1)
     expect(messages[0]).toMatchObject({
+      id: id("user-directory"),
       role: "user",
-      content: [{ type: "text", text: "Attached directory: src/\n\nlib/\nindex.ts" }],
-      metadata: { attachment: { source: directory.source, name: "src/" } },
+      content: [
+        { type: "text", text: "Review this directory" },
+        {
+          type: "text",
+          text: "Attached directory: src/\n\nlib/\nindex.ts",
+          metadata: { attachment: { source: directory.source, name: "src/" } },
+        },
+      ],
     })
-    expect(messages[1]?.content).toEqual([{ type: "text", text: "Review this directory" }])
+  })
+
+  test("preserves attachment order after the prompt", () => {
+    const messages = toLLMMessages(
+      [
+        SessionMessage.User.make({
+          id: id("user-mixed-files"),
+          type: "user",
+          text: "Review these attachments",
+          files: [
+            FileAttachment.make({
+              data: Base64.make(Buffer.from("index.ts").toString("base64")),
+              mime: "application/x-directory",
+              source: { type: "uri", uri: "file:///project/src" },
+              name: "src/",
+            }),
+            FileAttachment.make({
+              data: Base64.make(Buffer.from("export const value = 1").toString("base64")),
+              mime: "text/plain",
+              source: { type: "uri", uri: "file:///project/main.ts" },
+              name: "main.ts",
+            }),
+          ],
+          time: { created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.content.map((part) => (part.type === "text" ? part.text : part.type))).toEqual([
+      "Review these attachments",
+      "Attached directory: src/\n\nindex.ts",
+      "Attached file: main.ts\n\nexport const value = 1",
+    ])
   })
 
   test("uses materialized image data as provider media and drops unsupported attachments", () => {


### PR DESCRIPTION
## Summary
- lower each user prompt and its supported attachments into one LLM user message
- keep prompt text first and preserve the submitted attachment order
- retain attachment metadata on the corresponding content parts

## Testing
- `bun test test/session-runner-message.test.ts`
- `bun typecheck`