### PR TITLE
feat(opencode): add built-in Pkl LSP support

### DIFF
--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -55,6 +55,7 @@ export const builtinServerIds = [
   "gleam",
   "clojure-lsp",
   "nixd",
+  "pkl",
   "tinymist",
   "haskell-language-server",
   "julials",

--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -65,6 +65,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".pm": "perl",
   ".pm6": "perl6",
   ".php": "php",
+  ".pkl": "pkl",
   ".ps1": "powershell",
   ".psm1": "powershell",
   ".pug": "jade",

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1864,6 +1864,26 @@ export const Nixd: Info = {
   },
 }
 
+export const Pkl: Info = {
+  id: "pkl",
+  extensions: [".pkl"],
+  root: NearestRoot(["PklProject", "pkl.project", "pkl.toml", "flake.nix", ".git"]),
+  async spawn(root) {
+    const pklLsp = which("pkl-lsp")
+    if (!pklLsp) {
+      return
+    }
+    return {
+      process: spawn(pklLsp, ["--stdio"], {
+        cwd: root,
+        env: {
+          ...process.env,
+        },
+      }),
+    }
+  },
+}
+
 export const Tinymist: Info = {
   id: "tinymist",
   extensions: [".typ", ".typc"],

--- a/packages/opencode/test/config/lsp.test.ts
+++ b/packages/opencode/test/config/lsp.test.ts
@@ -22,6 +22,11 @@ describe("ConfigLSPV1.Info refinement", () => {
       expect(decodeEffect(input)).toEqual(input)
     })
 
+    test("pkl builtin with no extensions passes", () => {
+      const input = { pkl: { command: ["pkl-lsp", "--stdio"] } }
+      expect(decodeEffect(input)).toEqual(input)
+    })
+
     test("custom server WITH extensions passes", () => {
       const input = {
         "my-lsp": { command: ["my-lsp-bin"], extensions: [".ml"] },

--- a/packages/opencode/test/lsp/index.test.ts
+++ b/packages/opencode/test/lsp/index.test.ts
@@ -7,6 +7,7 @@ import { Config } from "@/config/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { LSP } from "@/lsp/lsp"
 import * as LSPServer from "@/lsp/server"
+import { LANGUAGE_EXTENSIONS } from "@/lsp/language"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestInstance } from "../fixture/fixture"
 import { awaitWithTimeout, testEffect } from "../lib/effect"
@@ -26,6 +27,12 @@ const disabledDownloadIt = testEffect(
 )
 
 describe("lsp.spawn", () => {
+  it.effect("maps PKL files to the pkl language id", () =>
+    Effect.sync(() => {
+      expect(LANGUAGE_EXTENSIONS[".pkl"]).toBe("pkl")
+    }),
+  )
+
   it.instance(
     "does not spawn builtin LSP for files outside instance",
     () =>
@@ -223,6 +230,29 @@ describe("lsp.spawn", () => {
             expect(pyright.mock.calls[0]?.[2]).toMatchObject({ disableLspDownload: true })
           } finally {
             pyright.mockRestore()
+          }
+        }),
+      ),
+    { config: { lsp: true } },
+  )
+
+  it.instance(
+    "would spawn builtin PKL LSP for PKL files when lsp is true",
+    () =>
+      LSP.Service.use((lsp) =>
+        Effect.gen(function* () {
+          const dir = (yield* TestInstance).directory
+          const spy = spyOn(LSPServer.Pkl, "spawn").mockResolvedValue(undefined)
+
+          try {
+            yield* lsp.hover({
+              file: path.join(dir, "config.pkl"),
+              line: 0,
+              character: 0,
+            })
+            expect(spy).toHaveBeenCalledTimes(1)
+          } finally {
+            spy.mockRestore()
           }
         }),
       ),

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -34,6 +34,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` command available                                 |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` dependency in project                               |
 | php intelephense   | .php                                                                | Auto-installs for PHP projects                               |
+| pkl                | .pkl                                                                | `pkl-lsp` command available                                  |
 | prisma             | .prisma                                                             | `prisma` command available                                   |
 | pyright            | .py, .pyi                                                           | `pyright` dependency installed                               |
 | razor              | .razor, .cshtml                                                     | `.NET SDK` and VS Code C# extension installed                |


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation

### What does this PR do?

Adds Pkl as a built-in LSP. OpenCode now recognizes `.pkl` files, accepts `pkl` in the built-in LSP config, and starts `pkl-lsp --stdio` when the command is available.

The built-in LSP docs and focused tests were updated with the new entry.

### How did you verify your code works?

- `git diff --check`
- `bun test --timeout 30000 test/config/lsp.test.ts test/lsp/index.test.ts` from `packages/opencode`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
