### PR TITLE
fix(app): render cold-loaded session timelines

### DIFF
--- a/OWNER_OPENCODE_FORK_UPDATE.md
+++ b/OWNER_OPENCODE_FORK_UPDATE.md
@@ -1,0 +1,127 @@
+# Updating owner-opencode From Upstream
+
+This repository is a fork mirror of upstream OpenCode used by the `owner` repo as a submodule at:
+
+```text
+apps/forge-ui/vendor/opencode
+```
+
+Do not use a GitHub pull request to update the fork from upstream. A PR from upstream into the fork can show a very large diff, may compare the wrong direction, and can fail with permission errors because GitHub treats it as a cross-repository PR. Update the fork with local git instead.
+
+Important: updating and pushing this fork is not enough for Forge UI to use the new code. The `owner` repo pins `apps/forge-ui/vendor/opencode` to a specific submodule commit. Changes only take effect in Forge UI after the `owner` repo updates that submodule pointer and commits the new gitlink.
+
+## Repositories
+
+- Fork repo: `https://github.com/owner/owner-opencode.git`
+- Upstream repo: `https://github.com/anomalyco/opencode.git`
+- Default branch: `dev`
+- Parent repo that pins this fork as a submodule: `/Users/aidan/Desktop/work/code/owner`
+- Fork checkout: `/Users/aidan/Desktop/work/code/owner-opencode`
+
+## Safe Fork Update Workflow
+
+Run these commands from `/Users/aidan/Desktop/work/code/owner-opencode`.
+
+```bash
+git status --short --branch
+git remote -v
+```
+
+The working tree should be clean before rebasing. Ensure `origin` points to `owner/owner-opencode` and `upstream` points to `anomalyco/opencode`.
+
+```bash
+git remote add upstream https://github.com/anomalyco/opencode.git
+```
+
+If `upstream` already exists, skip that command.
+
+Fetch upstream and inspect counts without loading the full diff:
+
+```bash
+git fetch upstream dev
+git rev-list --left-right --count upstream/dev...dev
+git log --oneline upstream/dev..dev
+```
+
+The first number is commits present only in upstream. The second number is commits present only in the fork. Review the fork-only commit list before rebasing.
+
+Rebase the fork onto upstream:
+
+```bash
+git checkout dev
+git rebase upstream/dev
+```
+
+If a fork-only bug-fix commit conflicts heavily with rewritten upstream code, inspect only that commit's patch and the conflicted regions:
+
+```bash
+git show --stat --oneline <commit>
+git show --format= --unified=30 <commit> -- <specific-file>
+rg -n "^(<<<<<<<|=======|>>>>>>>)" <conflicted-files>
+```
+
+If upstream has already replaced the affected area and the local fix is obsolete, skip the commit:
+
+```bash
+git rebase --skip
+```
+
+Only hand-port a local fix when the current upstream source still has the same bug. Do not preserve stale fork logic just to keep a fork commit.
+
+Verify the result:
+
+```bash
+git status --short --branch
+git rev-parse dev upstream/dev origin/dev
+git rev-list --left-right --count upstream/dev...dev
+```
+
+When satisfied, update the fork remote:
+
+```bash
+git push --force-with-lease origin dev
+```
+
+Use `--force-with-lease`, not plain `--force`, so the push fails if someone else updated `origin/dev` after the last fetch.
+
+## Updating The Parent Submodule Pin
+
+Pushing `owner-opencode` does not update the version used by `owner` or Forge UI. The parent repo records a specific submodule commit, so it remains pinned until the gitlink is changed and committed in `/Users/aidan/Desktop/work/code/owner`.
+
+Run these commands from `/Users/aidan/Desktop/work/code/owner`.
+
+```bash
+git status --short --branch
+git submodule status --recursive
+git ls-tree HEAD apps/forge-ui/vendor/opencode
+```
+
+Then update the submodule checkout to the desired fork commit:
+
+```bash
+cd apps/forge-ui/vendor/opencode
+git fetch origin dev
+git checkout origin/dev
+git rev-parse HEAD
+cd /Users/aidan/Desktop/work/code/owner
+git status --short
+```
+
+The parent repo should now show `apps/forge-ui/vendor/opencode` as modified. That is the submodule gitlink update.
+
+Commit the parent repo pointer change:
+
+```bash
+git add apps/forge-ui/vendor/opencode
+git commit -m "chore(forge-ui): update opencode submodule"
+```
+
+Do not expect submodule updates to appear as normal file diffs in the parent repo. The parent commit stores only the new submodule commit SHA.
+
+## Notes For Agents
+
+- Avoid loading the full upstream-vs-fork diff when upstream is hundreds of commits ahead.
+- Prefer commit counts, commit lists, `git show --stat`, and targeted file inspection.
+- Do not push until local `dev` has been checked against `upstream/dev`.
+- Do not update the parent repo submodule pin until the fork remote has the target commit.
+- The submodule checkout is often detached; that is normal.

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -596,7 +596,8 @@ export function createServerSession(client: OpencodeClient, options?: { retry?: 
         applied = true
       })
       .finally(() => {
-        if (!applied && generations.get(sessionID) === active && messageLoads.get(sessionID) === load) {
+        const owns = messageLoads.get(sessionID) === load
+        if (!applied && generations.get(sessionID) === active && owns) {
           for (const messageID of load.orphanParents) {
             if (!orphanParts.get(sessionID)?.has(messageID)) continue
             setData(produce((draft) => deleteMessageParts(draft, messageID)))
@@ -604,8 +605,13 @@ export function createServerSession(client: OpencodeClient, options?: { retry?: 
           }
           if (orphanParts.get(sessionID)?.size === 0) orphanParts.delete(sessionID)
         }
-        if (messageLoads.get(sessionID) === load) messageLoads.delete(sessionID)
-        if (generations.get(sessionID) === active) setMeta("loading", sessionID, false)
+        if (owns) messageLoads.delete(sessionID)
+        // Release the loading flag whenever this load still owns the slot, even if
+        // the generation changed mid-load. Gating this on the generation alone let
+        // `loading` stick true forever after a generation change, which made every
+        // later load (including a forced one) no-op at the `meta.loading` guard and
+        // left the session's transcript permanently blank.
+        if (owns || generations.get(sessionID) === active) setMeta("loading", sessionID, false)
       })
   }
 

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -512,12 +512,19 @@ export function MessageTimeline(props: {
   }
 
   let measuredSessionKey = sessionKey()
+  let measuredRowCount = timelineRows().length
   createEffect(() => {
     const key = sessionKey()
-    timelineRows().length
-    if (measuredSessionKey !== key) {
+    const rowCount = timelineRows().length
+    const sessionChanged = measuredSessionKey !== key
+    const firstRowsLoaded = measuredRowCount === 0 && rowCount > 0
+
+    if (sessionChanged || firstRowsLoaded) {
       measuredSessionKey = key
+      measuredRowCount = rowCount
       virtualizer.measure()
+    } else {
+      measuredRowCount = rowCount
     }
     maybeAnchorBottom()
   })

--- a/packages/app/src/pages/session/timeline/model.ts
+++ b/packages/app/src/pages/session/timeline/model.ts
@@ -1,11 +1,14 @@
 import type { Message, UserMessage } from "@opencode-ai/sdk/v2"
-import { createMemo, createResource, onCleanup, untrack, type Accessor } from "solid-js"
+import { createEffect, createMemo, createResource, onCleanup, untrack, type Accessor } from "solid-js"
 import { useServerSync } from "@/context/server-sync"
 import { useSync } from "@/context/sync"
 import { same } from "@/utils/same"
 
 const emptyUserMessages: UserMessage[] = []
 const sessionFreshness = 15_000
+const coldLoadMessageLimit = 200
+const coldLoadHistoryAttempts = 10
+const coldLoadHistoryRetryDelay = 25
 
 export function createTimelineModel(input: {
   sessionID: Accessor<string | undefined>
@@ -44,9 +47,11 @@ export function createTimelineModel(input: {
       // and re-drive it until the session's messages are in the store (or the view
       // moves on).
       for (let attempt = 0; attempt < 5; attempt++) {
-        await sync().session.sync(id, { force: true })
+        await sync().session.sync(id, { force: true, messageLimit: coldLoadMessageLimit })
         if (input.sessionID() !== id) return
-        if (untrack(() => sync().data.message[id] !== undefined)) return
+        const loaded = await ensureRenderableHistory(id)
+        if (input.sessionID() !== id) return
+        if (loaded) return
       }
     },
   )
@@ -73,6 +78,11 @@ export function createTimelineModel(input: {
   const loading = createMemo(() => {
     const id = input.sessionID()
     return id ? sync().session.history.loading(id) : false
+  })
+  createEffect(() => {
+    const id = input.sessionID()
+    if (!id || userMessages().length > 0 || !more() || loading()) return
+    void ensureRenderableHistory(id)
   })
   const loadOlder = async (options?: { before?: () => void; after?: (done: boolean) => void }) => {
     return loadOlderTimeline({
@@ -102,6 +112,24 @@ export function createTimelineModel(input: {
     if (refreshTimer !== undefined) window.clearTimeout(refreshTimer)
     refreshFrame = undefined
     refreshTimer = undefined
+  }
+
+  async function ensureRenderableHistory(id: string) {
+    for (let attempt = 0; attempt < coldLoadHistoryAttempts; attempt++) {
+      const messages = untrack(() => sync().data.message[id])
+      if (messages === undefined) return false
+      if (selectUserMessages(messages).length > 0) return true
+      if (sync().session.history.loading(id)) {
+        await new Promise((resolve) => window.setTimeout(resolve, coldLoadHistoryRetryDelay))
+        if (input.sessionID() !== id) return false
+        continue
+      }
+      if (!sync().session.history.more(id)) return true
+
+      await sync().session.history.loadMore(id)
+      if (input.sessionID() !== id) return false
+    }
+    return true
   }
 }
 

--- a/packages/app/src/pages/session/timeline/model.ts
+++ b/packages/app/src/pages/session/timeline/model.ts
@@ -18,7 +18,7 @@ export function createTimelineModel(input: {
 
   const [resource] = createResource(
     () => input.sessionID(),
-    (id) => {
+    async (id) => {
       clearRefresh()
       if (!id) return
 
@@ -36,7 +36,18 @@ export function createTimelineModel(input: {
         }, 0)
       })
 
-      return sync().session.sync(id)
+      if (cached) return sync().session.sync(id)
+
+      // Cold load for the session being viewed. A concurrent background load can
+      // be deduped by the shared in-flight map or dropped on a generation change,
+      // which leaves the transcript permanently blank with no retry. Force a load
+      // and re-drive it until the session's messages are in the store (or the view
+      // moves on).
+      for (let attempt = 0; attempt < 5; attempt++) {
+        await sync().session.sync(id, { force: true })
+        if (input.sessionID() !== id) return
+        if (untrack(() => sync().data.message[id] !== undefined)) return
+      }
     },
   )
   const messages = createMemo(() => {


### PR DESCRIPTION
## Summary
- Request a fuller initial message page for cold session loads so timeline rows include user messages immediately.
- Keep loading older history reactively when a selected session has no user messages yet.
- Remeasure the virtualized timeline when rows first arrive after an empty render.

## Test plan
- Hard reloaded Forge task `tsk-8JGCKjfPoz8S` with eight tasks/workspaces in the sidebar and verified the transcript rendered.
- Verified expected transcript text, 5 message rows, and 6 timeline rows in the browser.
- Ran `yarn workspace forge-ui typecheck` from the parent Owner repo.
- Ran `yarn workspace forge-ui test` from the parent Owner repo.


Made with [Cursor](https://cursor.com)