### PR TITLE
fix(app): prevent context provider crash on direct session route

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -59,7 +59,7 @@ import { createSessionLineage } from "@/pages/session/session-lineage"
 import { SessionPage, SessionRouteErrorBoundary, TargetSessionRouteContent } from "@/pages/session"
 import { NewHome, LegacyHome } from "@/pages/home"
 
-const NewSession = lazy(() => import("@/pages/new-session"))
+import NewSession from "@/pages/new-session"
 
 const SessionRoute = () => {
   const settings = useSettings()


### PR DESCRIPTION
### Issue for this PR

Closes #30898

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Loading a session page directly via a route URL causes a `ServerSync context must be used within a context provider` crash. This occurs because the lazy-loaded `NewSession` route chunk gets compiled with a separate instance of the main bundle graph, creating duplicate context provider records.

This PR replaces the lazy-loaded import of `NewSession` in `packages/app/src/app.tsx` with a static import, ensuring they share the same bundled module graph during route hydration.

### How did you verify your code works?

- Navigated directly to a session URL (e.g., `/<encoded-project-path>/session/<session-id>`) in a fresh browser session.
- Verified that the page loads cleanly without hitting the SolidJS error boundary.
- Verified compilation with `bun --cwd packages/app typecheck`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR