### PR TITLE
docs: add PostHog observability plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -51,6 +51,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                             |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                           |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                           |
+| [opencode-posthog-observability](https://github.com/KlimentP/opencode-posthog-observability)       | Send AI observability telemetry from OpenCode sessions to PostHog                                  |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |


### PR DESCRIPTION
### Issue for this PR

N/A - adds an ecosystem plugin listing; there is no associated issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-posthog-observability` to the ecosystem plugin list. The plugin sends OpenCode session observability telemetry to PostHog, and this change makes it discoverable alongside the other community plugins.

This is a single documentation-row addition following the existing ecosystem table format.

### How did you verify your code works?

Checked the Markdown table locally and confirmed the repository link and description use the same format as the surrounding plugin entries.

### Screenshots / recordings

N/A - documentation-only change with no UI behavior change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
