### PR TITLE
feat(desktop): add provider connection tip

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
         "shiki": "catalog:",
         "solid-js": "catalog:",
         "solid-list": "catalog:",
+        "solid-presence": "0.2.0",
         "tailwindcss": "catalog:",
       },
       "devDependencies": {
@@ -5103,7 +5104,7 @@
 
     "solid-list": ["solid-list@0.3.0", "", { "dependencies": { "@corvu/utils": "~0.4.0" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-t4hx/F/l8Vmq+ib9HtZYl7Z9F1eKxq3eKJTXlvcm7P7yI4Z8O7QSOOEVHb/K6DD7M0RxzVRobK/BS5aSfLRwKg=="],
 
-    "solid-presence": ["solid-presence@0.1.8", "", { "dependencies": { "@corvu/utils": "~0.4.0" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA=="],
+    "solid-presence": ["solid-presence@0.2.0", "", { "dependencies": { "@corvu/utils": "~0.4.2" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-YM92o+jvpzX3XGaD4rLYmq/Kc2ZVh47GSCLEufHBFQQIurvZTs8SoGJxO8BJGNDxBKdcS8F3dYhW1SDXp4BNjA=="],
 
     "solid-prevent-scroll": ["solid-prevent-scroll@0.1.10", "", { "dependencies": { "@corvu/utils": "~0.4.1" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-KplGPX2GHiWJLZ6AXYRql4M127PdYzfwvLJJXMkO+CMb8Np4VxqDAg5S8jLdwlEuBis/ia9DKw2M8dFx5u8Mhw=="],
 
@@ -5916,6 +5917,8 @@
     "@jsx-email/cli/vite": ["vite@4.5.14", "", { "dependencies": { "esbuild": "^0.18.10", "postcss": "^8.4.27", "rollup": "^3.27.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@types/node": ">= 14", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g=="],
 
     "@jsx-email/doiuse-email/htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
+
+    "@kobalte/core/solid-presence": ["solid-presence@0.1.8", "", { "dependencies": { "@corvu/utils": "~0.4.0" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-pWGtXUFWYYUZNbg5YpG5vkQJyOtzn2KXhxYaMx/4I+lylTLYkITOLevaCwMRN+liCVk0pqB6EayLWojNqBFECA=="],
 
     "@malept/flatpak-bundler/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -88,6 +88,7 @@
     "shiki": "catalog:",
     "solid-js": "catalog:",
     "solid-list": "catalog:",
+    "solid-presence": "0.2.0",
     "tailwindcss": "catalog:"
   }
 }

--- a/packages/app/src/components/session/session-new-design-view.tsx
+++ b/packages/app/src/components/session/session-new-design-view.tsx
@@ -2,7 +2,7 @@ import type { JSX } from "solid-js"
 import { WordmarkV2 } from "@opencode-ai/ui/v2/wordmark-v2"
 import { NEW_SESSION_CONTENT_WIDTH } from "@/pages/session/new-session-layout"
 
-export function NewSessionDesignView(props: { children: JSX.Element }) {
+export function NewSessionDesignView(props: { children: JSX.Element; footer?: JSX.Element }) {
   return (
     <div data-component="session-new-design" class="relative size-full overflow-hidden bg-v2-background-bg-deep ">
       <div class="absolute inset-x-0 top-[25.375%] flex justify-center px-6">
@@ -11,6 +11,7 @@ export function NewSessionDesignView(props: { children: JSX.Element }) {
           <div class="mt-8">{props.children}</div>
         </div>
       </div>
+      {props.footer}
     </div>
   )
 }

--- a/packages/app/src/components/session/session-new-design-view.tsx
+++ b/packages/app/src/components/session/session-new-design-view.tsx
@@ -2,7 +2,7 @@ import type { JSX } from "solid-js"
 import { WordmarkV2 } from "@opencode-ai/ui/v2/wordmark-v2"
 import { NEW_SESSION_CONTENT_WIDTH } from "@/pages/session/new-session-layout"
 
-export function NewSessionDesignView(props: { children: JSX.Element; footer?: JSX.Element }) {
+export function NewSessionDesignView(props: { children: JSX.Element }) {
   return (
     <div data-component="session-new-design" class="relative size-full overflow-hidden bg-v2-background-bg-deep ">
       <div class="absolute inset-x-0 top-[25.375%] flex justify-center px-6">
@@ -11,7 +11,6 @@ export function NewSessionDesignView(props: { children: JSX.Element; footer?: JS
           <div class="mt-8">{props.children}</div>
         </div>
       </div>
-      {props.footer}
     </div>
   )
 }

--- a/packages/app/src/components/settings-dialog.tsx
+++ b/packages/app/src/components/settings-dialog.tsx
@@ -4,7 +4,7 @@ import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 
-export function useSettingsDialog() {
+export function useSettingsDialog(defaultValue?: string) {
   const dialog = useDialog()
   const params = useParams<{ id?: string }>()
   let run = 0
@@ -14,7 +14,7 @@ export function useSettingsDialog() {
     dead = true
   })
 
-  return (defaultValue?: string) => {
+  return () => {
     const current = ++run
     const sessionID = params.id
     void import("@/components/settings-v2").then((module) => {

--- a/packages/app/src/components/settings-dialog.tsx
+++ b/packages/app/src/components/settings-dialog.tsx
@@ -14,12 +14,12 @@ export function useSettingsDialog() {
     dead = true
   })
 
-  return () => {
+  return (defaultValue?: string) => {
     const current = ++run
     const sessionID = params.id
     void import("@/components/settings-v2").then((module) => {
       if (dead || run !== current) return
-      void dialog.show(() => <module.DialogSettings sessionID={sessionID} />)
+      void dialog.show(() => <module.DialogSettings sessionID={sessionID} defaultValue={defaultValue} />)
     })
   }
 }

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -548,6 +548,7 @@ export const dict = {
   "home.sessions.group.today": "اليوم",
   "home.sessions.group.yesterday": "أمس",
   "home.sessions.group.older": "الأقدم",
+  "home.providerTip": "اتصل بأكثر من 75 مزودًا لاستخدام نماذج أخرى، بما فيها Claude وGPT وGemini وغيرها",
   "session.tab.session": "جلسة",
   "session.tab.review": "مراجعة",
   "session.tab.context": "سياق",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -552,6 +552,7 @@ export const dict = {
   "home.sessions.group.today": "Hoje",
   "home.sessions.group.yesterday": "Ontem",
   "home.sessions.group.older": "Mais antigas",
+  "home.providerTip": "Conecte-se a mais de 75 provedores para usar outros modelos, incluindo Claude, GPT, Gemini e muito mais",
   "session.tab.session": "Sessão",
   "session.tab.review": "Revisão",
   "session.tab.context": "Contexto",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -603,6 +603,7 @@ export const dict = {
   "home.sessions.group.today": "Danas",
   "home.sessions.group.yesterday": "Jučer",
   "home.sessions.group.older": "Starije",
+  "home.providerTip": "Povežite se s više od 75 pružalaca usluga kako biste koristili druge modele, uključujući Claude, GPT, Gemini i druge",
 
   "session.tab.session": "Sesija",
   "session.tab.review": "Pregled",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -600,6 +600,7 @@ export const dict = {
   "home.sessions.group.today": "I dag",
   "home.sessions.group.yesterday": "I går",
   "home.sessions.group.older": "Ældre",
+  "home.providerTip": "Opret forbindelse til mere end 75 udbydere for at bruge andre modeller, herunder Claude, GPT, Gemini og flere",
 
   "session.tab.session": "Session",
   "session.tab.review": "Gennemgang",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -560,6 +560,7 @@ export const dict = {
   "home.sessions.group.today": "Heute",
   "home.sessions.group.yesterday": "Gestern",
   "home.sessions.group.older": "Älter",
+  "home.providerTip": "Verbinde dich mit über 75 Anbietern, um weitere Modelle wie Claude, GPT, Gemini und andere zu nutzen",
   "session.tab.session": "Sitzung",
   "session.tab.review": "Überprüfung",
   "session.tab.context": "Kontext",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -622,6 +622,7 @@ export const dict = {
   "home.sessions.group.today": "Today",
   "home.sessions.group.yesterday": "Yesterday",
   "home.sessions.group.older": "Older",
+  "home.providerTip": "Connect to 75+ providers to use other models, including Claude, GPT, Gemini, etc",
 
   "session.tab.session": "Session",
   "session.tab.review": "Review",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -604,6 +604,7 @@ export const dict = {
   "home.sessions.group.today": "Hoy",
   "home.sessions.group.yesterday": "Ayer",
   "home.sessions.group.older": "Anteriores",
+  "home.providerTip": "Conéctate a más de 75 proveedores para usar otros modelos, como Claude, GPT, Gemini y muchos más",
 
   "session.tab.session": "Sesión",
   "session.tab.review": "Revisión",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -557,6 +557,7 @@ export const dict = {
   "home.sessions.group.today": "Aujourd'hui",
   "home.sessions.group.yesterday": "Hier",
   "home.sessions.group.older": "Plus anciennes",
+  "home.providerTip": "Connectez-vous à plus de 75 fournisseurs pour utiliser d’autres modèles, notamment Claude, GPT, Gemini, etc.",
   "session.tab.session": "Session",
   "session.tab.review": "Revue",
   "session.tab.context": "Contexte",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -550,6 +550,7 @@ export const dict = {
   "home.sessions.group.today": "今日",
   "home.sessions.group.yesterday": "昨日",
   "home.sessions.group.older": "それ以前",
+  "home.providerTip": "75以上のプロバイダーに接続して、Claude、GPT、Geminiなどの他のモデルを利用できます",
   "session.tab.session": "セッション",
   "session.tab.review": "レビュー",
   "session.tab.context": "コンテキスト",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -950,6 +950,7 @@ export const dict = {
   "home.sessions.group.today": "오늘",
   "home.sessions.group.yesterday": "어제",
   "home.sessions.group.older": "이전",
+  "home.providerTip": "75개 이상의 제공업체에 연결하여 Claude, GPT, Gemini 등의 다른 모델을 사용하세요",
 
   "session.tab.unknown": "알 수 없는 세션",
   "session.error.notFound": "이 세션을 찾을 수 없습니다",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -1043,6 +1043,7 @@ export const dict = {
   "home.sessions.group.today": "I dag",
   "home.sessions.group.yesterday": "I går",
   "home.sessions.group.older": "Eldre",
+  "home.providerTip": "Koble til over 75 leverandører for å bruke andre modeller, inkludert Claude, GPT, Gemini og flere",
 
   "session.tab.unknown": "Ukjent sesjon",
   "session.error.notFound": "Denne sesjonen finnes ikke",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -553,6 +553,7 @@ export const dict = {
   "home.sessions.group.today": "Dzisiaj",
   "home.sessions.group.yesterday": "Wczoraj",
   "home.sessions.group.older": "Starsze",
+  "home.providerTip": "Połącz się z ponad 75 dostawcami, aby korzystać z innych modeli, w tym Claude, GPT, Gemini i innych",
   "session.tab.session": "Sesja",
   "session.tab.review": "Przegląd",
   "session.tab.context": "Kontekst",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -604,6 +604,7 @@ export const dict = {
   "home.sessions.group.today": "Сегодня",
   "home.sessions.group.yesterday": "Вчера",
   "home.sessions.group.older": "Ранее",
+  "home.providerTip": "Подключитесь к более чем 75 провайдерам, чтобы использовать другие модели, включая Claude, GPT, Gemini и другие",
 
   "session.tab.session": "Сессия",
   "session.tab.review": "Обзор",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -599,6 +599,7 @@ export const dict = {
   "home.sessions.group.today": "วันนี้",
   "home.sessions.group.yesterday": "เมื่อวาน",
   "home.sessions.group.older": "ก่อนหน้านี้",
+  "home.providerTip": "เชื่อมต่อกับผู้ให้บริการกว่า 75 รายเพื่อใช้โมเดลอื่นๆ รวมถึง Claude, GPT, Gemini และอีกมากมาย",
 
   "session.tab.session": "เซสชัน",
   "session.tab.review": "ตรวจสอบ",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -608,6 +608,7 @@ export const dict = {
   "home.sessions.group.today": "Bugün",
   "home.sessions.group.yesterday": "Dün",
   "home.sessions.group.older": "Daha eski",
+  "home.providerTip": "Claude, GPT, Gemini ve diğer modelleri kullanmak için 75'ten fazla sağlayıcıya bağlanın",
 
   "session.tab.session": "Oturum",
   "session.tab.review": "İnceleme",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -626,6 +626,7 @@ export const dict = {
   "home.sessions.group.today": "Сьогодні",
   "home.sessions.group.yesterday": "Учора",
   "home.sessions.group.older": "Раніше",
+  "home.providerTip": "Підключіться до понад 75 провайдерів, щоб використовувати інші моделі, зокрема Claude, GPT, Gemini та інші",
 
   "session.tab.session": "Сесія",
   "session.tab.review": "Огляд",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -600,6 +600,7 @@ export const dict = {
   "home.sessions.group.today": "今天",
   "home.sessions.group.yesterday": "昨天",
   "home.sessions.group.older": "更早",
+  "home.providerTip": "连接 75 个以上的提供商，使用 Claude、GPT、Gemini 等其他模型",
 
   "session.tab.session": "会话",
   "session.tab.review": "审查",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -595,6 +595,7 @@ export const dict = {
   "home.sessions.group.today": "今天",
   "home.sessions.group.yesterday": "昨天",
   "home.sessions.group.older": "更早",
+  "home.providerTip": "連接 75 個以上的供應商，使用 Claude、GPT、Gemini 等其他模型",
 
   "session.tab.session": "工作階段",
   "session.tab.review": "審查",

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -1,4 +1,4 @@
-import { Show, createEffect, createMemo, createResource, onCleanup, untrack } from "solid-js"
+import { Show, createEffect, createMemo, createResource, createSignal, onCleanup, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Portal } from "solid-js/web"
 import { useSearchParams } from "@solidjs/router"
@@ -29,6 +29,7 @@ import { useTitlebarRightMount } from "@/components/titlebar"
 import { useProviders } from "@/hooks/use-providers"
 import { useSettingsDialog } from "@/components/settings-dialog"
 import { Persist, persisted } from "@/utils/persist"
+import createPresence from "solid-presence"
 
 const workspaceBarEnabled = import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"
 const providerTipDismissalDuration = 30 * 24 * 60 * 60 * 1000
@@ -122,15 +123,7 @@ export default function NewSessionPage() {
       <div class="flex-1 min-h-0 flex flex-col gap-2 p-2">
         <div class="@container relative flex flex-col min-h-0 h-full flex-1">
           <div class="flex-1 min-h-0 overflow-hidden rounded-[10px]">
-            <NewSessionDesignView
-              footer={
-                <ProviderTip
-                  ready={() => serverSync().child(sdk().directory)[0].provider_ready}
-                  connected={() => providers.paid().length > 0}
-                  openProviders={openProviderSettings}
-                />
-              }
-            >
+            <NewSessionDesignView>
               <div class={NEW_SESSION_CONTENT_WIDTH}>
                 <Show
                   when={prompt.ready() || promptReady()}
@@ -191,6 +184,11 @@ export default function NewSessionPage() {
                 </Show>
               </div>
             </NewSessionDesignView>
+            <ProviderTip
+              ready={() => serverSync().child(sdk().directory)[0].provider_ready}
+              connected={() => providers.paid().length > 0}
+              openProviders={openProviderSettings}
+            />
           </div>
         </div>
       </div>
@@ -204,62 +202,39 @@ function ProviderTip(props: { ready: () => boolean; connected: () => boolean; op
     Persist.global("new-session.provider-tip"),
     createStore({ dismissedAt: 0 }),
   )
-  const [state, setState] = createStore({ dismissing: false, now: Date.now() })
-  let dismissTimer: ReturnType<typeof setTimeout> | undefined
   const visible = createMemo(
     () =>
-      state.dismissing ||
-      (props.ready() &&
-        persistedReady() &&
-        !props.connected() &&
-        state.now - persistedState.dismissedAt >= providerTipDismissalDuration),
+      props.ready() &&
+      persistedReady() &&
+      !props.connected() &&
+      Date.now() - persistedState.dismissedAt >= providerTipDismissalDuration,
   )
 
-  createEffect(() => {
-    if (!persistedReady()) return
-    const remaining = persistedState.dismissedAt + providerTipDismissalDuration - state.now
-    if (remaining <= 0) return
-    const timer = setTimeout(() => setState("now", Date.now()), Math.min(remaining, 2_147_483_647))
-    onCleanup(() => clearTimeout(timer))
-  })
-
-  onCleanup(() => {
-    if (dismissTimer) clearTimeout(dismissTimer)
-  })
-
   function dismiss() {
-    if (state.dismissing) return
-    const dismissedAt = Date.now()
-    setState("dismissing", true)
-    setState("now", dismissedAt)
-    setPersistedState("dismissedAt", dismissedAt)
-    dismissTimer = setTimeout(completeDismissal, providerTipExitDuration + 50)
+    setPersistedState("dismissedAt", Date.now())
   }
 
-  function completeDismissal() {
-    if (!state.dismissing) return
-    if (dismissTimer) clearTimeout(dismissTimer)
-    dismissTimer = undefined
-    setState("dismissing", false)
-  }
+  const [ref, setRef] = createSignal<HTMLDivElement>()
+  const presence = createPresence({
+    show: () => visible(),
+    element: () => ref() ?? null,
+  })
 
   return (
-    <Show when={visible()}>
+    <Show when={presence.present()}>
       <div class="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center px-10">
         <div
+          ref={setRef}
           data-component="provider-tip"
+          data-visible={visible()}
           class="group/provider-tip pointer-events-auto relative flex h-6 max-w-full items-center transition-[opacity,transform] duration-[250ms] ease-[cubic-bezier(0.215,0.61,0.355,1)] motion-reduce:transition-none"
           classList={{
-            "opacity-0 [transform:translate3d(0,24px,0)] will-change-[transform,opacity]": state.dismissing,
-          }}
-          onTransitionEnd={(event) => {
-            if (event.target === event.currentTarget && event.propertyName === "transform") completeDismissal()
+            "data-[visible=false]:animate-out fade-out slide-out-to-bottom-4": true,
           }}
         >
           <button
             type="button"
             class="flex h-6 min-w-0 items-center rounded-[4px] pl-1.5 text-[13px] leading-none tracking-[-0.04px] text-v2-text-text-faint transition-[background-color,color] duration-150 ease-in-out hover:bg-v2-overlay-simple-overlay-hover hover:text-v2-text-text-muted focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:text-v2-text-text-muted focus-visible:outline-none"
-            disabled={state.dismissing}
             onClick={props.openProviders}
           >
             <span class="truncate">{language.t("home.providerTip")}</span>
@@ -267,23 +242,21 @@ function ProviderTip(props: { ready: () => boolean; connected: () => boolean; op
               <IconV2 name="chevron-down" size="small" class="-rotate-90" />
             </span>
           </button>
-          <Show when={!state.dismissing}>
-            <TooltipV2
-              class="hover-reveal absolute left-full top-0 flex h-6 w-7 items-center justify-end delay-0 duration-0 group-hover/provider-tip:delay-[250ms] group-hover/provider-tip:duration-150 group-hover/provider-tip:opacity-100 focus-within:delay-0 focus-within:duration-0 focus-within:opacity-100"
-              placement="top"
-              openDelay={1000}
-              value={language.t("common.dismiss")}
+          <TooltipV2
+            class="hover-reveal absolute left-full top-0 flex h-6 w-7 items-center justify-end delay-0 duration-0 group-hover/provider-tip:delay-[250ms] group-hover/provider-tip:duration-150 group-hover/provider-tip:opacity-100 focus-within:delay-0 focus-within:duration-0 focus-within:opacity-100"
+            placement="top"
+            openDelay={1000}
+            value={language.t("common.dismiss")}
+          >
+            <button
+              type="button"
+              class="flex size-6 items-center justify-center rounded-[4px] text-v2-icon-icon-muted transition-[background-color,color] duration-150 ease-in-out hover:bg-v2-overlay-simple-overlay-hover hover:text-v2-icon-icon-base focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:text-v2-icon-icon-base focus-visible:outline-none"
+              aria-label={language.t("common.dismiss")}
+              onClick={dismiss}
             >
-              <button
-                type="button"
-                class="flex size-6 items-center justify-center rounded-[4px] text-v2-icon-icon-muted transition-[background-color,color] duration-150 ease-in-out hover:bg-v2-overlay-simple-overlay-hover hover:text-v2-icon-icon-base focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:text-v2-icon-icon-base focus-visible:outline-none"
-                aria-label={language.t("common.dismiss")}
-                onClick={dismiss}
-              >
-                <IconV2 name="xmark-small" />
-              </button>
-            </TooltipV2>
-          </Show>
+              <IconV2 name="xmark-small" />
+            </button>
+          </TooltipV2>
         </div>
       </div>
     </Show>

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -1,8 +1,10 @@
-import { Show, createEffect, createMemo, createResource, untrack } from "solid-js"
+import { Show, createEffect, createMemo, createResource, onCleanup, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Portal } from "solid-js/web"
 import { useSearchParams } from "@solidjs/router"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { NewSessionDesignView } from "@/components/session"
 import { PromptInput } from "@/components/prompt-input"
 import { StatusPopoverV2 } from "@/components/status-popover"
@@ -24,8 +26,13 @@ import { useComposerCommands } from "@/pages/session/use-composer-commands"
 import { NEW_SESSION_CONTENT_WIDTH } from "@/pages/session/new-session-layout"
 import { PromptWorkspaceSelector } from "@/components/prompt-workspace-selector"
 import { useTitlebarRightMount } from "@/components/titlebar"
+import { useProviders } from "@/hooks/use-providers"
+import { useSettingsDialog } from "@/components/settings-dialog"
+import { Persist, persisted } from "@/utils/persist"
 
 const workspaceBarEnabled = import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"
+const providerTipDismissalDuration = 30 * 24 * 60 * 60 * 1000
+const providerTipExitDuration = 250
 
 /**
  * The `/new-session` draft page. Unlike `session.tsx`, this only renders the prompt
@@ -40,6 +47,8 @@ export default function NewSessionPage() {
   const comments = useComments()
   const language = useLanguage()
   const settings = useSettings()
+  const providers = useProviders(() => sdk().directory)
+  const openSettings = useSettingsDialog()
   const route = useSessionKey()
   const [searchParams, setSearchParams] = useSearchParams<{ draftId?: string; prompt?: string }>()
 
@@ -113,7 +122,15 @@ export default function NewSessionPage() {
       <div class="flex-1 min-h-0 flex flex-col gap-2 p-2">
         <div class="@container relative flex flex-col min-h-0 h-full flex-1">
           <div class="flex-1 min-h-0 overflow-hidden rounded-[10px]">
-            <NewSessionDesignView>
+            <NewSessionDesignView
+              footer={
+                <ProviderTip
+                  ready={() => serverSync().child(sdk().directory)[0].provider_ready}
+                  connected={() => providers.connected().length > 0}
+                  openProviders={() => openSettings("providers")}
+                />
+              }
+            >
               <div class={NEW_SESSION_CONTENT_WIDTH}>
                 <Show
                   when={prompt.ready() || promptReady()}
@@ -178,5 +195,93 @@ export default function NewSessionPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+function ProviderTip(props: { ready: () => boolean; connected: () => boolean; openProviders: () => void }) {
+  const language = useLanguage()
+  const [persistedState, setPersistedState, , persistedReady] = persisted(
+    Persist.global("new-session.provider-tip"),
+    createStore({ dismissedAt: 0 }),
+  )
+  const [state, setState] = createStore({ dismissing: false, now: Date.now() })
+  let dismissTimer: ReturnType<typeof setTimeout> | undefined
+  const visible = createMemo(
+    () =>
+      props.ready() &&
+      persistedReady() &&
+      !props.connected() &&
+      state.now - persistedState.dismissedAt >= providerTipDismissalDuration,
+  )
+
+  createEffect(() => {
+    if (!persistedReady()) return
+    const remaining = persistedState.dismissedAt + providerTipDismissalDuration - state.now
+    if (remaining <= 0) return
+    const timer = setTimeout(() => setState("now", Date.now()), Math.min(remaining, 2_147_483_647))
+    onCleanup(() => clearTimeout(timer))
+  })
+
+  onCleanup(() => {
+    if (dismissTimer) clearTimeout(dismissTimer)
+  })
+
+  function dismiss() {
+    if (state.dismissing) return
+    setState("dismissing", true)
+    dismissTimer = setTimeout(completeDismissal, providerTipExitDuration + 50)
+  }
+
+  function completeDismissal() {
+    if (!state.dismissing) return
+    if (dismissTimer) clearTimeout(dismissTimer)
+    dismissTimer = undefined
+    setPersistedState("dismissedAt", Date.now())
+  }
+
+  return (
+    <Show when={visible()}>
+      <div class="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center px-10">
+        <div
+          data-component="provider-tip"
+          class="group/provider-tip pointer-events-auto relative flex h-6 max-w-full items-center transition-[opacity,transform] duration-[250ms] ease-[cubic-bezier(0.215,0.61,0.355,1)] motion-reduce:transition-none"
+          classList={{
+            "opacity-0 [transform:translate3d(0,24px,0)] will-change-[transform,opacity]": state.dismissing,
+          }}
+          onTransitionEnd={(event) => {
+            if (event.target === event.currentTarget && event.propertyName === "transform") completeDismissal()
+          }}
+        >
+          <button
+            type="button"
+            class="flex h-6 min-w-0 items-center rounded-[4px] pl-1.5 text-[13px] leading-none tracking-[-0.04px] text-v2-text-text-faint transition-[background-color,color] duration-150 ease-in-out hover:bg-v2-overlay-simple-overlay-hover hover:text-v2-text-text-muted focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:text-v2-text-text-muted focus-visible:outline-none"
+            disabled={state.dismissing}
+            onClick={props.openProviders}
+          >
+            <span class="truncate">{language.t("home.providerTip")}</span>
+            <span class="flex size-6 shrink-0 items-center justify-center" aria-hidden="true">
+              <IconV2 name="chevron-down" size="small" class="-rotate-90" />
+            </span>
+          </button>
+          <Show when={!state.dismissing}>
+            <TooltipV2
+              class="hover-reveal absolute left-full top-0 flex h-6 w-7 items-center justify-end delay-0 duration-0 group-hover/provider-tip:delay-[250ms] group-hover/provider-tip:duration-150 group-hover/provider-tip:opacity-100 focus-within:delay-0 focus-within:duration-0 focus-within:opacity-100"
+              placement="top"
+              openDelay={1000}
+              value={language.t("common.dismiss")}
+            >
+              <button
+                type="button"
+                class="flex size-6 items-center justify-center rounded-[4px] text-v2-icon-icon-muted transition-[background-color,color] duration-150 ease-in-out hover:bg-v2-overlay-simple-overlay-hover hover:text-v2-icon-icon-base focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:text-v2-icon-icon-base focus-visible:outline-none"
+                aria-label={language.t("common.dismiss")}
+                onClick={dismiss}
+              >
+                <IconV2 name="xmark-small" />
+              </button>
+            </TooltipV2>
+          </Show>
+        </div>
+      </div>
+    </Show>
   )
 }

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -48,7 +48,7 @@ export default function NewSessionPage() {
   const language = useLanguage()
   const settings = useSettings()
   const providers = useProviders(() => sdk().directory)
-  const openSettings = useSettingsDialog()
+  const openProviderSettings = useSettingsDialog("providers")
   const route = useSessionKey()
   const [searchParams, setSearchParams] = useSearchParams<{ draftId?: string; prompt?: string }>()
 
@@ -126,8 +126,8 @@ export default function NewSessionPage() {
               footer={
                 <ProviderTip
                   ready={() => serverSync().child(sdk().directory)[0].provider_ready}
-                  connected={() => providers.connected().length > 0}
-                  openProviders={() => openSettings("providers")}
+                  connected={() => providers.paid().length > 0}
+                  openProviders={openProviderSettings}
                 />
               }
             >
@@ -208,10 +208,11 @@ function ProviderTip(props: { ready: () => boolean; connected: () => boolean; op
   let dismissTimer: ReturnType<typeof setTimeout> | undefined
   const visible = createMemo(
     () =>
-      props.ready() &&
-      persistedReady() &&
-      !props.connected() &&
-      state.now - persistedState.dismissedAt >= providerTipDismissalDuration,
+      state.dismissing ||
+      (props.ready() &&
+        persistedReady() &&
+        !props.connected() &&
+        state.now - persistedState.dismissedAt >= providerTipDismissalDuration),
   )
 
   createEffect(() => {
@@ -229,6 +230,7 @@ function ProviderTip(props: { ready: () => boolean; connected: () => boolean; op
   function dismiss() {
     if (state.dismissing) return
     setState("dismissing", true)
+    setPersistedState("dismissedAt", Date.now())
     dismissTimer = setTimeout(completeDismissal, providerTipExitDuration + 50)
   }
 
@@ -236,7 +238,7 @@ function ProviderTip(props: { ready: () => boolean; connected: () => boolean; op
     if (!state.dismissing) return
     if (dismissTimer) clearTimeout(dismissTimer)
     dismissTimer = undefined
-    setPersistedState("dismissedAt", Date.now())
+    setState("dismissing", false)
   }
 
   return (

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -229,8 +229,10 @@ function ProviderTip(props: { ready: () => boolean; connected: () => boolean; op
 
   function dismiss() {
     if (state.dismissing) return
+    const dismissedAt = Date.now()
     setState("dismissing", true)
-    setPersistedState("dismissedAt", Date.now())
+    setState("now", dismissedAt)
+    setPersistedState("dismissedAt", dismissedAt)
     dismissTimer = setTimeout(completeDismissal, providerTipExitDuration + 50)
   }
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds the provider connection tip from the Q3 desktop design to the new-session screen. The tip appears after provider data loads when no paid or external provider is connected, opens the Providers settings tab, and can be dismissed for 30 days. Its hover, tooltip, and exit behavior follow the Figma interaction notes.

### How did you verify your code works?

- `bun typecheck` from `packages/app`
- `bun run build` from `packages/app`
- Repository pre-push typecheck across all participating packages
- Manually exercised hover, tooltip, dismissal, and exit animation states

### Screenshots / recordings

https://github.com/user-attachments/assets/86b4ebe0-e04a-4cae-9764-bb84a652ba13

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._