### PR TITLE
feat(app): fix descender clipping

### DIFF
--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -474,7 +474,7 @@ export function ModelSelectorPopoverV2(props: {
                                 }}
                                 onSelect={() => selectModel(item)}
                               >
-                                <span class="min-w-0 truncate">{item.name}</span>
+                                <span class="min-w-0 truncate leading-5">{item.name}</span>
                                 <Show when={isFree(item.provider.id, item.cost)}>
                                   <TagV2 class="shrink-0">{language.t("model.tag.free")}</TagV2>
                                 </Show>

--- a/packages/ui/src/v2/components/button-v2.css
+++ b/packages/ui/src/v2/components/button-v2.css
@@ -14,7 +14,7 @@
   font-style: normal;
   font-weight: 530;
   font-size: 13px;
-  line-height: 1;
+  line-height: 20px;
   color: var(--v2-text-text-base);
   text-shadow: none;
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
### Issue for this PR
N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Updates line height from 16px to 20px for text in `button-v2` and `dialog-select-model` so descenders don't get clipped.

### How did you verify your code works?
- Ran the app locally and verified the updated UI manually
- Ran type checks locally (`bun turbo typecheck`)

### Screenshots / recordings
N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
