### PR TITLE
feat(app): add Run button to titlebar for project startup commands

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -25,6 +25,10 @@ import { readSessionTabsRemovedDetail, SESSION_TABS_REMOVED_EVENT } from "@/comp
 import { useGlobal } from "@/context/global"
 import { ServerConnection, useServer } from "@/context/server"
 import { tabKey, useTabs } from "@/context/tabs"
+import { useServerSync } from "@/context/server-sync"
+import { useSDK } from "@/context/sdk"
+import { defaultTitle } from "@/context/terminal-title"
+import { decode64 } from "@/utils/base64"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "./command-tooltip-keybind"
 
@@ -444,6 +448,60 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
 
             const [tabsAreOverflowing, setTabsAreOverflowing] = createSignal(false)
 
+            const getCurrentProject = () => {
+              const route = layout.route()
+              if (route.type === "session" || route.type === "draft") {
+                const conn = global.servers
+                  .list()
+                  .find((item) => ServerConnection.key(item) === (route.server ?? server.key))
+                if (!conn) return undefined
+                const serverCtx = global.ensureServerCtx(conn)
+                const worktree = route.type === "session" && session()?.directory
+                  ? session()!.directory
+                  : route.type === "draft"
+                    ? global
+                        .ensureServerCtx(conn)
+                        .projects.list()
+                        .find((p) => p.worktree === decode64(params.dir ?? ""))?.worktree
+                    : undefined
+                if (!worktree) return undefined
+                return serverCtx.projects.list().find((p) => p.worktree === worktree)
+              }
+              return undefined
+            }
+
+            const runProjectCommand = async () => {
+              const project = getCurrentProject()
+              if (!project?.commands?.start) return
+              const route = layout.route()
+              const conn = global.servers
+                .list()
+                .find((item) => ServerConnection.key(item) === (route.server ?? server.key))
+              if (!conn) return
+              const sdk = global.ensureServerCtx(conn).sdk
+              const worktree = project.worktree
+
+              const pty = await sdk.client.pty
+                .create({
+                  body: {
+                    command: project.commands.start,
+                    cwd: worktree,
+                    title: `Run: ${project.commands.start}`,
+                  },
+                  query: { directory: worktree },
+                })
+                .catch((error: unknown) => {
+                  console.error("Failed to create terminal for run command", error)
+                  return undefined
+                })
+
+              if (!pty?.data) return
+              layout.terminal.open()
+            }
+
+            const currentProject = () => getCurrentProject()
+            const hasRunCommand = () => !!currentProject()?.commands?.start
+
             return (
               <div
                 class="h-full flex-1 overflow-hidden flex flex-row items-center gap-1.5 px-2 md:pr-3"
@@ -480,6 +538,20 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                     aria-pressed={layout.route().type === "home"}
                   />
                 </TooltipV2>
+
+                <Show when={hasRunCommand()}>
+                  <TooltipV2 placement="bottom" value={language.t("command.project.run")}>
+                    <IconButtonV2
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="shrink-0"
+                      icon={<IconV2 name="play" />}
+                      onClick={runProjectCommand}
+                      aria-label={language.t("command.project.run")}
+                    />
+                  </TooltipV2>
+                </Show>
 
                 <TitlebarTabStrip
                   tabs={tabsStore}

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -24,6 +24,7 @@ export const dict = {
   "command.project.previous": "المشروع السابق",
   "command.project.next": "المشروع التالي",
   "command.project.index": "التبديل إلى المشروع {{index}}",
+  "command.project.run": "تشغيل أمر التشغيل",
   "command.provider.connect": "اتصال بموفر",
   "command.server.switch": "تبديل الخادم",
   "command.settings.open": "فتح الإعدادات",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -24,6 +24,7 @@ export const dict = {
   "command.project.previous": "Projeto anterior",
   "command.project.next": "Próximo projeto",
   "command.project.index": "Alternar para o projeto {{index}}",
+  "command.project.run": "Executar comando de inicialização",
   "command.provider.connect": "Conectar provedor",
   "command.server.switch": "Trocar servidor",
   "command.settings.open": "Abrir configurações",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -26,6 +26,7 @@ export const dict = {
   "command.project.previous": "Prethodni projekat",
   "command.project.next": "Sljedeći projekat",
   "command.project.index": "Prebaci na projekat {{index}}",
+  "command.project.run": "Pokreni naredbu pokretanja",
   "command.provider.connect": "Poveži provajdera",
   "command.server.switch": "Promijeni server",
   "command.settings.open": "Otvori postavke",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -26,6 +26,7 @@ export const dict = {
   "command.project.previous": "Forrige projekt",
   "command.project.next": "Næste projekt",
   "command.project.index": "Skift til projekt {{index}}",
+  "command.project.run": "Kør opstarts kommando",
   "command.provider.connect": "Tilslut udbyder",
   "command.server.switch": "Skift server",
   "command.settings.open": "Åbn indstillinger",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -28,6 +28,7 @@ export const dict = {
   "command.project.previous": "Vorheriges Projekt",
   "command.project.next": "Nächstes Projekt",
   "command.project.index": "Zu Projekt {{index}} wechseln",
+  "command.project.run": "Startbefehl ausführen",
   "command.provider.connect": "Anbieter verbinden",
   "command.server.switch": "Server wechseln",
   "command.settings.open": "Einstellungen öffnen",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -26,6 +26,7 @@ export const dict = {
   "command.project.previous": "Previous project",
   "command.project.next": "Next project",
   "command.project.index": "Switch to project {{index}}",
+  "command.project.run": "Run startup command",
   "command.provider.connect": "Connect provider",
   "command.server.switch": "Switch server",
   "command.settings.open": "Open settings",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -26,6 +26,7 @@ export const dict = {
   "command.project.previous": "Proyecto anterior",
   "command.project.next": "Siguiente proyecto",
   "command.project.index": "Cambiar al proyecto {{index}}",
+  "command.project.run": "Ejecutar comando de inicio",
   "command.provider.connect": "Conectar proveedor",
   "command.server.switch": "Cambiar servidor",
   "command.settings.open": "Abrir ajustes",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -24,6 +24,7 @@ export const dict = {
   "command.project.previous": "Projet précédent",
   "command.project.next": "Projet suivant",
   "command.project.index": "Passer au projet {{index}}",
+  "command.project.run": "Exécuter la commande de démarrage",
   "command.provider.connect": "Connecter un fournisseur",
   "command.server.switch": "Changer de serveur",
   "command.settings.open": "Ouvrir les paramètres",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -24,6 +24,7 @@ export const dict = {
   "command.project.previous": "前のプロジェクト",
   "command.project.next": "次のプロジェクト",
   "command.project.index": "プロジェクト{{index}}に切り替え",
+  "command.project.run": "スタートアップコマンドを実行",
   "command.provider.connect": "プロバイダーに接続",
   "command.server.switch": "サーバーの切り替え",
   "command.settings.open": "設定を開く",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -852,6 +852,7 @@ export const dict = {
   "command.project.previous": "이전 프로젝트",
   "command.project.next": "다음 프로젝트",
   "command.project.index": "{{index}}번 프로젝트로 전환",
+  "command.project.run": "시작 명령 실행",
   "command.tab.reopenClosed": "닫은 탭 다시 열기",
   "model.tooltip.context.label": "컨텍스트",
   "model.tooltip.inputs": "입력",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -940,6 +940,7 @@ export const dict = {
   "command.project.previous": "Forrige prosjekt",
   "command.project.next": "Neste prosjekt",
   "command.project.index": "Bytt til prosjekt {{index}}",
+  "command.project.run": "Kjør oppstartskommando",
   "command.tab.reopenClosed": "Åpne lukket fane på nytt",
 
   "model.tooltip.context.label": "Kontekst",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -24,6 +24,7 @@ export const dict = {
   "command.project.previous": "Poprzedni projekt",
   "command.project.next": "Następny projekt",
   "command.project.index": "Przełącz na projekt {{index}}",
+  "command.project.run": "Uruchom polecenie startowe",
   "command.provider.connect": "Połącz dostawcę",
   "command.server.switch": "Przełącz serwer",
   "command.settings.open": "Otwórz ustawienia",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -26,6 +26,7 @@ export const dict = {
   "command.project.previous": "Предыдущий проект",
   "command.project.next": "Следующий проект",
   "command.project.index": "Переключиться на проект {{index}}",
+  "command.project.run": "Выполнить команду запуска",
   "command.provider.connect": "Подключить провайдера",
   "command.server.switch": "Переключить сервер",
   "command.settings.open": "Открыть настройки",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -26,6 +26,7 @@ export const dict = {
   "command.project.previous": "โปรเจกต์ก่อนหน้า",
   "command.project.next": "โปรเจกต์ถัดไป",
   "command.project.index": "สลับไปยังโปรเจกต์ {{index}}",
+  "command.project.run": "รันคำสั่งเริ่มต้น",
   "command.provider.connect": "เชื่อมต่อผู้ให้บริการ",
   "command.server.switch": "สลับเซิร์ฟเวอร์",
   "command.settings.open": "เปิดการตั้งค่า",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -30,6 +30,7 @@ export const dict = {
   "command.project.previous": "Önceki proje",
   "command.project.next": "Sonraki proje",
   "command.project.index": "{{index}} numaralı projeye geç",
+  "command.project.run": "Başlangıç komutunu çalıştır",
   "command.provider.connect": "Sağlayıcı bağla",
   "command.server.switch": "Sunucu değiştir",
   "command.settings.open": "Ayarları aç",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -26,6 +26,7 @@ export const dict = {
   "command.project.previous": "Попередній проєкт",
   "command.project.next": "Наступний проєкт",
   "command.project.index": "Перемкнути на проєкт {{index}}",
+  "command.project.run": "Виконати команду запуску",
   "command.provider.connect": "Підключити провайдера",
   "command.server.switch": "Перемкнути сервер",
   "command.settings.open": "Відкрити налаштування",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -31,7 +31,7 @@ export const dict = {
   "command.project.previous": "上一个项目",
   "command.project.next": "下一个项目",
   "command.project.index": "切换到项目 {{index}}",
-
+  "command.project.run": "运行启动命令",
   "command.provider.connect": "连接提供商",
 
   "command.server.switch": "切换服务器",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -30,6 +30,7 @@ export const dict = {
   "command.project.previous": "上一個專案",
   "command.project.next": "下一個專案",
   "command.project.index": "切換至專案 {{index}}",
+  "command.project.run": "執行啟動命令",
   "command.provider.connect": "連接提供者",
   "command.server.switch": "切換伺服器",
   "command.settings.open": "開啟設定",

--- a/packages/ui/src/v2/components/icon.tsx
+++ b/packages/ui/src/v2/components/icon.tsx
@@ -49,6 +49,10 @@ const icons = {
     viewBox: "0 0 16 16",
     body: `<path d="M8 2.88867V13.1109" stroke="currentColor" stroke-linejoin="round"/><path d="M2.88867 8H13.1109" stroke="currentColor" stroke-linejoin="round"/>`,
   },
+  play: {
+    viewBox: "0 0 16 16",
+    body: `<path d="M4.66675 3.77783V12.2223L12.8891 8.00006L4.66675 3.77783Z" fill="currentColor"/>`,
+  },
   "settings-gear": {
     viewBox: "0 0 16 16",
     body: `<path d="M7.99998 1.3335L14 4.66683V11.3335L7.99998 14.6668L2 11.3335V4.66683L7.99998 1.3335Z" stroke="currentColor"/><path d="M9.99998 8.00016C9.99998 9.10476 9.10458 10.0002 7.99998 10.0002C6.89538 10.0002 5.99998 9.10476 5.99998 8.00016C5.99998 6.89556 6.89538 6.00016 7.99998 6.00016C9.10458 6.00016 9.99998 6.89556 9.99998 8.00016Z" stroke="currentColor"/>`,


### PR DESCRIPTION
### Issue for this PR


### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a Run button to the titlebar that executes the project startup command. The button appears only when a project has a startup command configured in its settings.


### How did you verify your code works?

Reviewed the implementation for correct SDK API usage and consistent styling with existing buttons.
### Screenshots / recordings


i can't upload any screenshots or recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

