### PR TITLE
feat(tui): log event stream connections

### DIFF
--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -16,11 +16,10 @@ export type SDKConnectionEvent = {
     readonly error?: string
   }
 }
-export type SDKRecordedEvent = SDKConnectionEvent | V2Event
 
 type SDKEventMap = { [Type in V2Event["type"]]: Extract<V2Event, { type: Type }> }
 const connectTimeout = 2_000
-const eventHistoryLimit = 500
+const connectionHistoryLimit = 50
 
 export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   name: "SDK",
@@ -33,7 +32,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   }) => {
     const log = useLog({ component: "sdk" })
     const abort = new AbortController()
-    const history: SDKRecordedEvent[] = []
+    const history: SDKConnectionEvent[] = []
     let client = props.client
     let api = props.api
     const events = createGlobalEmitter<SDKEventMap>()
@@ -47,20 +46,9 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     })
     let stream: AbortController | undefined
 
-    function record(event: SDKRecordedEvent) {
-      history.push(event)
-      if (history.length <= eventHistoryLimit) return
-      const dropped = history.shift()
-      if (!dropped) return
-      log.info("event history dropped oldest event", {
-        type: dropped.type,
-        created: dropped.created,
-        limit: eventHistoryLimit,
-      })
-    }
-
-    function recordConnection(status: SDKConnectionEvent["data"]["status"], attempt: number, error?: string) {
-      record({ type: "client.connection", created: Date.now(), data: { status, attempt, error } })
+    function record(status: SDKConnectionEvent["data"]["status"], attempt: number, error?: string) {
+      history.push({ type: "client.connection", created: Date.now(), data: { status, attempt, error } })
+      if (history.length > connectionHistoryLimit) history.shift()
     }
 
     function start() {
@@ -82,7 +70,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
           )
           controller.signal.addEventListener("abort", cancel, { once: true })
           const error = await (async () => {
-            recordConnection(attempt === 0 ? "connecting" : "reconnecting", attempt)
+            record(attempt === 0 ? "connecting" : "reconnecting", attempt)
             log.info("event stream connecting", { attempt })
             const response = await client.v2.event.subscribe({
               signal: connection.signal,
@@ -99,7 +87,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
             if (first.value.type !== "server.connected")
               return new Error("Event stream did not start with server.connected")
             clearTimeout(timeout)
-            recordConnection("connected", attempt)
+            record("connected", attempt)
             attempt = 0
             log.info("event stream connected")
             events.emit(first.value.type, first.value)
@@ -109,14 +97,12 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
               const event = await iterator.next()
               if (abort.signal.aborted || controller.signal.aborted) return
               if (event.done) return new Error("Event stream disconnected")
-              if ("durable" in event.value) {
-                record(event.value)
+              if ("durable" in event.value)
                 log.info("event", {
                   type: event.value.type,
                   aggregateID: event.value.durable.aggregateID,
                   seq: event.value.durable.seq,
                 })
-              }
               events.emit(event.value.type, event.value)
             }
           })()
@@ -128,7 +114,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
           if (abort.signal.aborted || controller.signal.aborted) return
           attempt += 1
           const message = error instanceof Error ? error.message : String(error)
-          recordConnection("disconnected", attempt, message)
+          record("disconnected", attempt, message)
           log.info("event stream disconnected", {
             attempt,
             error: message,
@@ -172,9 +158,6 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       event: {
         on: events.on,
         listen: events.listen,
-        history() {
-          return history.slice()
-        },
       },
       connection: {
         status() {
@@ -185,6 +168,9 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         },
         error() {
           return connection.error
+        },
+        history() {
+          return history.slice()
         },
       },
       reload: props.reload,

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -20,7 +20,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     // Stops and starts the managed service; present only in service mode.
     reload?: () => Promise<void>
   }) => {
-    const log = useLog()
+    const log = useLog({ component: "sdk" })
     const abort = new AbortController()
     let client = props.client
     let api = props.api
@@ -54,6 +54,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
           )
           controller.signal.addEventListener("abort", cancel, { once: true })
           const error = await (async () => {
+            log.info("event stream connecting", { attempt })
             const response = await client.v2.event.subscribe({
               signal: connection.signal,
               sseMaxRetryAttempts: 0,
@@ -70,6 +71,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
               return new Error("Event stream did not start with server.connected")
             clearTimeout(timeout)
             attempt = 0
+            log.info("event stream connected")
             events.emit(first.value.type, first.value)
             setConnection({ status: "connected", attempt: 0, error: undefined })
             connected()
@@ -93,6 +95,10 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
             })
           if (abort.signal.aborted || controller.signal.aborted) return
           attempt += 1
+          log.info("event stream disconnected", {
+            attempt,
+            error: error instanceof Error ? error.message : String(error),
+          })
           // Re-resolve the transport before retrying: the server may have
           // moved (service restarted on a new port) or need starting. Static
           // transports (--server, standalone) resolve to the same address.

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -169,8 +169,10 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         error() {
           return connection.error
         },
-        history() {
-          return history.slice()
+        internal: {
+          history() {
+            return history.slice()
+          },
         },
       },
       reload: props.reload,

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -16,10 +16,11 @@ export type SDKConnectionEvent = {
     readonly error?: string
   }
 }
+export type SDKRecordedEvent = SDKConnectionEvent | V2Event
 
 type SDKEventMap = { [Type in V2Event["type"]]: Extract<V2Event, { type: Type }> }
 const connectTimeout = 2_000
-const connectionHistoryLimit = 100
+const eventHistoryLimit = 500
 
 export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   name: "SDK",
@@ -32,7 +33,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   }) => {
     const log = useLog({ component: "sdk" })
     const abort = new AbortController()
-    const history: SDKConnectionEvent[] = []
+    const history: SDKRecordedEvent[] = []
     let client = props.client
     let api = props.api
     const events = createGlobalEmitter<SDKEventMap>()
@@ -46,9 +47,20 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
     })
     let stream: AbortController | undefined
 
-    function record(status: SDKConnectionEvent["data"]["status"], attempt: number, error?: string) {
-      history.push({ type: "client.connection", created: Date.now(), data: { status, attempt, error } })
-      if (history.length > connectionHistoryLimit) history.shift()
+    function record(event: SDKRecordedEvent) {
+      history.push(event)
+      if (history.length <= eventHistoryLimit) return
+      const dropped = history.shift()
+      if (!dropped) return
+      log.info("event history dropped oldest event", {
+        type: dropped.type,
+        created: dropped.created,
+        limit: eventHistoryLimit,
+      })
+    }
+
+    function recordConnection(status: SDKConnectionEvent["data"]["status"], attempt: number, error?: string) {
+      record({ type: "client.connection", created: Date.now(), data: { status, attempt, error } })
     }
 
     function start() {
@@ -70,7 +82,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
           )
           controller.signal.addEventListener("abort", cancel, { once: true })
           const error = await (async () => {
-            record(attempt === 0 ? "connecting" : "reconnecting", attempt)
+            recordConnection(attempt === 0 ? "connecting" : "reconnecting", attempt)
             log.info("event stream connecting", { attempt })
             const response = await client.v2.event.subscribe({
               signal: connection.signal,
@@ -87,7 +99,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
             if (first.value.type !== "server.connected")
               return new Error("Event stream did not start with server.connected")
             clearTimeout(timeout)
-            record("connected", attempt)
+            recordConnection("connected", attempt)
             attempt = 0
             log.info("event stream connected")
             events.emit(first.value.type, first.value)
@@ -97,12 +109,14 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
               const event = await iterator.next()
               if (abort.signal.aborted || controller.signal.aborted) return
               if (event.done) return new Error("Event stream disconnected")
-              if ("durable" in event.value)
+              if ("durable" in event.value) {
+                record(event.value)
                 log.info("event", {
                   type: event.value.type,
                   aggregateID: event.value.durable.aggregateID,
                   seq: event.value.durable.seq,
                 })
+              }
               events.emit(event.value.type, event.value)
             }
           })()
@@ -114,7 +128,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
           if (abort.signal.aborted || controller.signal.aborted) return
           attempt += 1
           const message = error instanceof Error ? error.message : String(error)
-          record("disconnected", attempt, message)
+          recordConnection("disconnected", attempt, message)
           log.info("event stream disconnected", {
             attempt,
             error: message,
@@ -158,6 +172,9 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       event: {
         on: events.on,
         listen: events.listen,
+        history() {
+          return history.slice()
+        },
       },
       connection: {
         status() {
@@ -168,9 +185,6 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         },
         error() {
           return connection.error
-        },
-        history() {
-          return history.slice()
         },
       },
       reload: props.reload,

--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -7,9 +7,19 @@ import { createSimpleContext } from "./helper"
 import { useLog } from "./log"
 
 export type SDKConnectionStatus = "connected" | "connecting" | "reconnecting"
+export type SDKConnectionEvent = {
+  readonly type: "client.connection"
+  readonly created: number
+  readonly data: {
+    readonly status: "connecting" | "connected" | "disconnected" | "reconnecting"
+    readonly attempt: number
+    readonly error?: string
+  }
+}
 
 type SDKEventMap = { [Type in V2Event["type"]]: Extract<V2Event, { type: Type }> }
 const connectTimeout = 2_000
+const connectionHistoryLimit = 100
 
 export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   name: "SDK",
@@ -22,6 +32,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
   }) => {
     const log = useLog({ component: "sdk" })
     const abort = new AbortController()
+    const history: SDKConnectionEvent[] = []
     let client = props.client
     let api = props.api
     const events = createGlobalEmitter<SDKEventMap>()
@@ -34,6 +45,11 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
       attempt: 0,
     })
     let stream: AbortController | undefined
+
+    function record(status: SDKConnectionEvent["data"]["status"], attempt: number, error?: string) {
+      history.push({ type: "client.connection", created: Date.now(), data: { status, attempt, error } })
+      if (history.length > connectionHistoryLimit) history.shift()
+    }
 
     function start() {
       stream?.abort()
@@ -54,6 +70,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
           )
           controller.signal.addEventListener("abort", cancel, { once: true })
           const error = await (async () => {
+            record(attempt === 0 ? "connecting" : "reconnecting", attempt)
             log.info("event stream connecting", { attempt })
             const response = await client.v2.event.subscribe({
               signal: connection.signal,
@@ -70,6 +87,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
             if (first.value.type !== "server.connected")
               return new Error("Event stream did not start with server.connected")
             clearTimeout(timeout)
+            record("connected", attempt)
             attempt = 0
             log.info("event stream connected")
             events.emit(first.value.type, first.value)
@@ -95,9 +113,11 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
             })
           if (abort.signal.aborted || controller.signal.aborted) return
           attempt += 1
+          const message = error instanceof Error ? error.message : String(error)
+          record("disconnected", attempt, message)
           log.info("event stream disconnected", {
             attempt,
-            error: error instanceof Error ? error.message : String(error),
+            error: message,
           })
           // Re-resolve the transport before retrying: the server may have
           // moved (service restarted on a new port) or need starting. Static
@@ -113,7 +133,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
           setConnection({
             status: "reconnecting",
             attempt,
-            error: error instanceof Error ? error.message : String(error),
+            error: message,
           })
           await wait(250, controller.signal)
         }
@@ -148,6 +168,9 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
         },
         error() {
           return connection.error
+        },
+        history() {
+          return history.slice()
         },
       },
       reload: props.reload,

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -777,7 +777,20 @@ export function Session() {
                 )
               : await (async () => {
                   if (options.debug) {
-                    return JSON.stringify({ info: sessionData, events: sdk.event.history() }, null, 2) + EOL
+                    const events: { readonly created: number }[] = []
+                    for await (const event of sdk.api.session.log({ sessionID: sessionData.id, follow: false })) {
+                      if (event.type !== "log.synced") events.push(event)
+                    }
+                    // Durable events stay in aggregate order even when their wall-clock timestamps differ.
+                    sdk.connection.history().forEach((event) => {
+                      const index = events.findIndex((item) => item.created > event.created)
+                      if (index === -1) {
+                        events.push(event)
+                        return
+                      }
+                      events.splice(index, 0, event)
+                    })
+                    return JSON.stringify({ info: sessionData, events }, null, 2) + EOL
                   }
 
                   const messages: unknown[] = []

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -777,10 +777,12 @@ export function Session() {
                 )
               : await (async () => {
                   if (options.debug) {
-                    const events: unknown[] = []
+                    const events: { readonly created: number }[] = []
                     for await (const event of sdk.api.session.log({ sessionID: sessionData.id, follow: false })) {
                       if (event.type !== "log.synced") events.push(event)
                     }
+                    events.push(...sdk.connection.history())
+                    events.sort((a, b) => a.created - b.created)
                     return JSON.stringify({ info: sessionData, events }, null, 2) + EOL
                   }
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -782,7 +782,7 @@ export function Session() {
                       if (event.type !== "log.synced") events.push(event)
                     }
                     // Durable events stay in aggregate order even when their wall-clock timestamps differ.
-                    sdk.connection.history().forEach((event) => {
+                    sdk.connection.internal.history().forEach((event) => {
                       const index = events.findIndex((item) => item.created > event.created)
                       if (index === -1) {
                         events.push(event)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -781,8 +781,15 @@ export function Session() {
                     for await (const event of sdk.api.session.log({ sessionID: sessionData.id, follow: false })) {
                       if (event.type !== "log.synced") events.push(event)
                     }
-                    events.push(...sdk.connection.history())
-                    events.sort((a, b) => a.created - b.created)
+                    // Durable events stay in aggregate order even when their wall-clock timestamps differ.
+                    sdk.connection.history().forEach((event) => {
+                      const index = events.findIndex((item) => item.created > event.created)
+                      if (index === -1) {
+                        events.push(event)
+                        return
+                      }
+                      events.splice(index, 0, event)
+                    })
                     return JSON.stringify({ info: sessionData, events }, null, 2) + EOL
                   }
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -777,20 +777,7 @@ export function Session() {
                 )
               : await (async () => {
                   if (options.debug) {
-                    const events: { readonly created: number }[] = []
-                    for await (const event of sdk.api.session.log({ sessionID: sessionData.id, follow: false })) {
-                      if (event.type !== "log.synced") events.push(event)
-                    }
-                    // Durable events stay in aggregate order even when their wall-clock timestamps differ.
-                    sdk.connection.history().forEach((event) => {
-                      const index = events.findIndex((item) => item.created > event.created)
-                      if (index === -1) {
-                        events.push(event)
-                        return
-                      }
-                      events.splice(index, 0, event)
-                    })
-                    return JSON.stringify({ info: sessionData, events }, null, 2) + EOL
+                    return JSON.stringify({ info: sessionData, events: sdk.event.history() }, null, 2) + EOL
                   }
 
                   const messages: unknown[] = []

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -108,7 +108,9 @@ function Probe(props: {
 describe("useEvent", () => {
   test("logs only durable events", async () => {
     const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
-    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => logs.push({ message, tags }))
+    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => {
+      if (message === "event") logs.push({ message, tags })
+    })
     const durable = event(
       {
         id: "evt_renamed",
@@ -128,7 +130,7 @@ describe("useEvent", () => {
       expect(logs).toEqual([
         {
           message: "event",
-          tags: { type: "session.renamed", aggregateID: "ses_test", seq: 1 },
+          tags: { component: "sdk", type: "session.renamed", aggregateID: "ses_test", seq: 1 },
         },
       ])
     } finally {

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -204,6 +204,15 @@ describe("useEvent", () => {
 
       expect(sdk.client).toBe(replacement.client)
       expect(sdk.api).toBe(replacement.api)
+      const history = sdk.connection.history()
+      expect(history.map((event) => [event.data.status, event.data.attempt])).toEqual([
+        ["connecting", 0],
+        ["connected", 0],
+        ["disconnected", 1],
+        ["reconnecting", 1],
+        ["connected", 1],
+      ])
+      expect(history.every((event) => Number.isFinite(event.created))).toBe(true)
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -106,33 +106,9 @@ function Probe(props: {
 }
 
 describe("useEvent", () => {
-  test("logs event stream connection changes", async () => {
-    const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
-    const { app, events, sdk } = await mount(undefined, (_level, message, tags) => logs.push({ message, tags }))
-
-    try {
-      await wait(() => sdk.connection.status() === "connected")
-      events.disconnect()
-      await wait(() => sdk.connection.status() === "reconnecting")
-
-      expect(logs.slice(0, 3)).toEqual([
-        { message: "event stream connecting", tags: { component: "sdk", attempt: 0 } },
-        { message: "event stream connected", tags: { component: "sdk" } },
-        {
-          message: "event stream disconnected",
-          tags: { component: "sdk", attempt: 1, error: "Event stream disconnected" },
-        },
-      ])
-    } finally {
-      app.renderer.destroy()
-    }
-  })
-
   test("logs only durable events", async () => {
     const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
-    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => {
-      if (message === "event") logs.push({ message, tags })
-    })
+    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => logs.push({ message, tags }))
     const durable = event(
       {
         id: "evt_renamed",
@@ -152,7 +128,7 @@ describe("useEvent", () => {
       expect(logs).toEqual([
         {
           message: "event",
-          tags: { component: "sdk", type: "session.renamed", aggregateID: "ses_test", seq: 1 },
+          tags: { type: "session.renamed", aggregateID: "ses_test", seq: 1 },
         },
       ])
     } finally {

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -106,9 +106,33 @@ function Probe(props: {
 }
 
 describe("useEvent", () => {
+  test("logs event stream connection changes", async () => {
+    const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
+    const { app, events, sdk } = await mount(undefined, (_level, message, tags) => logs.push({ message, tags }))
+
+    try {
+      await wait(() => sdk.connection.status() === "connected")
+      events.disconnect()
+      await wait(() => sdk.connection.status() === "reconnecting")
+
+      expect(logs.slice(0, 3)).toEqual([
+        { message: "event stream connecting", tags: { component: "sdk", attempt: 0 } },
+        { message: "event stream connected", tags: { component: "sdk" } },
+        {
+          message: "event stream disconnected",
+          tags: { component: "sdk", attempt: 1, error: "Event stream disconnected" },
+        },
+      ])
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
   test("logs only durable events", async () => {
     const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
-    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => logs.push({ message, tags }))
+    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => {
+      if (message === "event") logs.push({ message, tags })
+    })
     const durable = event(
       {
         id: "evt_renamed",
@@ -128,7 +152,7 @@ describe("useEvent", () => {
       expect(logs).toEqual([
         {
           message: "event",
-          tags: { type: "session.renamed", aggregateID: "ses_test", seq: 1 },
+          tags: { component: "sdk", type: "session.renamed", aggregateID: "ses_test", seq: 1 },
         },
       ])
     } finally {

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -108,7 +108,7 @@ function Probe(props: {
 describe("useEvent", () => {
   test("logs only durable events", async () => {
     const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
-    const { app, emit, sdk, seen } = await mount(undefined, (_level, message, tags) => {
+    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => {
       if (message === "event") logs.push({ message, tags })
     })
     const durable = event(
@@ -133,7 +133,6 @@ describe("useEvent", () => {
           tags: { component: "sdk", type: "session.renamed", aggregateID: "ses_test", seq: 1 },
         },
       ])
-      expect(sdk.event.history().filter((event) => event.type !== "client.connection")).toEqual([durable])
     } finally {
       app.renderer.destroy()
     }
@@ -205,7 +204,7 @@ describe("useEvent", () => {
 
       expect(sdk.client).toBe(replacement.client)
       expect(sdk.api).toBe(replacement.api)
-      const history = sdk.event.history().filter((event) => event.type === "client.connection")
+      const history = sdk.connection.history()
       expect(history.map((event) => [event.data.status, event.data.attempt])).toEqual([
         ["connecting", 0],
         ["connected", 0],
@@ -219,33 +218,21 @@ describe("useEvent", () => {
     }
   })
 
-  test("keeps the latest 500 recorded events and logs dropped events", async () => {
-    const dropped: Readonly<Record<string, unknown>>[] = []
-    const { app, emit, sdk, seen } = await mount(undefined, (_level, message, tags) => {
-      if (message === "event history dropped oldest event") dropped.push(tags)
-    })
+  test("keeps the latest 50 connection events", async () => {
+    const { app, events, sdk } = await mount()
 
     try {
-      Array.from({ length: 500 }, (_, index) => index + 1).forEach((seq) => {
-        emit(
-          event(
-            {
-              id: `evt_renamed_${seq}`,
-              created: seq,
-              type: "session.renamed",
-              durable: { aggregateID: "ses_test", seq, version: 1 },
-              data: { sessionID: "ses_test", title: `Renamed ${seq}` },
-            },
-            { directory: "/tmp/project" },
-          ),
-        )
-      })
-      await wait(() => seen.length === 500, 5_000)
+      await wait(() => sdk.connection.status() === "connected")
+      for (const _ of Array.from({ length: 17 })) {
+        events.disconnect()
+        await wait(() => sdk.connection.status() === "reconnecting")
+        await wait(() => sdk.connection.status() === "connected")
+      }
 
-      expect(sdk.event.history()).toHaveLength(500)
-      expect(sdk.event.history().every((event) => event.type === "session.renamed")).toBe(true)
-      expect(dropped).toHaveLength(2)
-      expect(dropped[0]).toMatchObject({ component: "sdk", type: "client.connection", limit: 500 })
+      const history = sdk.connection.history()
+      expect(history).toHaveLength(50)
+      expect(history[0]?.data.status).toBe("reconnecting")
+      expect(history.at(-1)?.data.status).toBe("connected")
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -204,7 +204,7 @@ describe("useEvent", () => {
 
       expect(sdk.client).toBe(replacement.client)
       expect(sdk.api).toBe(replacement.api)
-      const history = sdk.connection.history()
+      const history = sdk.connection.internal.history()
       expect(history.map((event) => [event.data.status, event.data.attempt])).toEqual([
         ["connecting", 0],
         ["connected", 0],
@@ -229,7 +229,7 @@ describe("useEvent", () => {
         await wait(() => sdk.connection.status() === "connected")
       }
 
-      const history = sdk.connection.history()
+      const history = sdk.connection.internal.history()
       expect(history).toHaveLength(50)
       expect(history[0]?.data.status).toBe("reconnecting")
       expect(history.at(-1)?.data.status).toBe("connected")

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -218,26 +218,6 @@ describe("useEvent", () => {
     }
   })
 
-  test("keeps the latest 50 connection events", async () => {
-    const { app, events, sdk } = await mount()
-
-    try {
-      await wait(() => sdk.connection.status() === "connected")
-      for (const _ of Array.from({ length: 17 })) {
-        events.disconnect()
-        await wait(() => sdk.connection.status() === "reconnecting")
-        await wait(() => sdk.connection.status() === "connected")
-      }
-
-      const history = sdk.connection.internal.history()
-      expect(history).toHaveLength(50)
-      expect(history[0]?.data.status).toBe("reconnecting")
-      expect(history.at(-1)?.data.status).toBe("connected")
-    } finally {
-      app.renderer.destroy()
-    }
-  })
-
   test("keeps the current client when discovery fails", async () => {
     let calls = 0
     const { app, events, sdk, seen } = await mount(async () => {

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -108,7 +108,7 @@ function Probe(props: {
 describe("useEvent", () => {
   test("logs only durable events", async () => {
     const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
-    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => {
+    const { app, emit, sdk, seen } = await mount(undefined, (_level, message, tags) => {
       if (message === "event") logs.push({ message, tags })
     })
     const durable = event(
@@ -133,6 +133,7 @@ describe("useEvent", () => {
           tags: { component: "sdk", type: "session.renamed", aggregateID: "ses_test", seq: 1 },
         },
       ])
+      expect(sdk.event.history().filter((event) => event.type !== "client.connection")).toEqual([durable])
     } finally {
       app.renderer.destroy()
     }
@@ -204,7 +205,7 @@ describe("useEvent", () => {
 
       expect(sdk.client).toBe(replacement.client)
       expect(sdk.api).toBe(replacement.api)
-      const history = sdk.connection.history()
+      const history = sdk.event.history().filter((event) => event.type === "client.connection")
       expect(history.map((event) => [event.data.status, event.data.attempt])).toEqual([
         ["connecting", 0],
         ["connected", 0],
@@ -213,6 +214,38 @@ describe("useEvent", () => {
         ["connected", 1],
       ])
       expect(history.every((event) => Number.isFinite(event.created))).toBe(true)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("keeps the latest 500 recorded events and logs dropped events", async () => {
+    const dropped: Readonly<Record<string, unknown>>[] = []
+    const { app, emit, sdk, seen } = await mount(undefined, (_level, message, tags) => {
+      if (message === "event history dropped oldest event") dropped.push(tags)
+    })
+
+    try {
+      Array.from({ length: 500 }, (_, index) => index + 1).forEach((seq) => {
+        emit(
+          event(
+            {
+              id: `evt_renamed_${seq}`,
+              created: seq,
+              type: "session.renamed",
+              durable: { aggregateID: "ses_test", seq, version: 1 },
+              data: { sessionID: "ses_test", title: `Renamed ${seq}` },
+            },
+            { directory: "/tmp/project" },
+          ),
+        )
+      })
+      await wait(() => seen.length === 500, 5_000)
+
+      expect(sdk.event.history()).toHaveLength(500)
+      expect(sdk.event.history().every((event) => event.type === "session.renamed")).toBe(true)
+      expect(dropped).toHaveLength(2)
+      expect(dropped[0]).toMatchObject({ component: "sdk", type: "client.connection", limit: 500 })
     } finally {
       app.renderer.destroy()
     }


### PR DESCRIPTION
## Summary
- log SSE connection attempts with the reconnect attempt number
- log successful connections and disconnections with error context
- tag SDK lifecycle logs for filtering

## Testing
- `bun test test/cli/tui/use-event.test.tsx`
- `bun typecheck`
- verified with OpenCode Drive by terminating the managed backend and observing disconnect, retry, and reconnect log lines