### PR TITLE
fix(llm): map DeepSeek cache miss tokens

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -118,6 +118,8 @@ const OpenAIChatUsage = Schema.Struct({
   prompt_tokens: Schema.optional(Schema.Number),
   completion_tokens: Schema.optional(Schema.Number),
   total_tokens: Schema.optional(Schema.Number),
+  prompt_cache_hit_tokens: Schema.optional(Schema.Number),
+  prompt_cache_miss_tokens: Schema.optional(Schema.Number),
   prompt_tokens_details: optionalNull(
     Schema.Struct({
       cached_tokens: Schema.optional(Schema.Number),
@@ -390,14 +392,16 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
 // satisfied on both sides.
 const mapUsage = (usage: OpenAIChatEvent["usage"]): Usage | undefined => {
   if (!usage) return undefined
-  const cached = usage.prompt_tokens_details?.cached_tokens
+  const cached = usage.prompt_tokens_details?.cached_tokens ?? usage.prompt_cache_hit_tokens
+  const cacheWrite = usage.prompt_cache_miss_tokens
   const reasoning = usage.completion_tokens_details?.reasoning_tokens
-  const nonCached = ProviderShared.subtractTokens(usage.prompt_tokens, cached)
+  const nonCached = ProviderShared.subtractTokens(usage.prompt_tokens, ProviderShared.sumTokens(cached, cacheWrite))
   return new Usage({
     inputTokens: usage.prompt_tokens,
     outputTokens: usage.completion_tokens,
     nonCachedInputTokens: nonCached,
     cacheReadInputTokens: cached,
+    cacheWriteInputTokens: cacheWrite,
     reasoningTokens: reasoning,
     totalTokens: ProviderShared.totalTokens(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens),
     providerMetadata: { openai: usage },

--- a/packages/llm/test/provider/openai-compatible-chat.test.ts
+++ b/packages/llm/test/provider/openai-compatible-chat.test.ts
@@ -235,4 +235,46 @@ describe("OpenAI-compatible Chat route", () => {
       expect(response.events.at(-1)).toMatchObject({ type: "finish", reason: "stop" })
     }),
   )
+
+  it.effect("maps DeepSeek prompt cache hit and miss usage", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          dynamicResponse((input) =>
+            Effect.succeed(
+              input.respond(
+                sseEvents(
+                  deltaChunk({ role: "assistant", content: "Hello" }),
+                  deltaChunk({}, "stop"),
+                  usageChunk({
+                    prompt_tokens: 5,
+                    prompt_cache_hit_tokens: 3,
+                    prompt_cache_miss_tokens: 2,
+                    completion_tokens: 1,
+                    total_tokens: 6,
+                  }),
+                ),
+                { headers: { "content-type": "text/event-stream" } },
+              ),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.usage).toMatchObject({
+        inputTokens: 5,
+        nonCachedInputTokens: 0,
+        cacheReadInputTokens: 3,
+        cacheWriteInputTokens: 2,
+        outputTokens: 1,
+        totalTokens: 6,
+        providerMetadata: {
+          openai: {
+            prompt_cache_hit_tokens: 3,
+            prompt_cache_miss_tokens: 2,
+          },
+        },
+      })
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #35974

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

DeepSeek reports cache usage as top-level `usage.prompt_cache_hit_tokens` and `usage.prompt_cache_miss_tokens`. The OpenAI-compatible chat parser did not keep those fields, so DeepSeek cache misses always ended up as `cacheWriteInputTokens: undefined`.

This keeps those usage fields, maps hits to `cacheReadInputTokens`, maps misses to `cacheWriteInputTokens`, and computes fresh input tokens after subtracting both buckets. The added fixture covers a 5-token prompt with 3 cache-hit tokens and 2 cache-miss tokens.

### How did you verify your code works?

The new test fails on `origin/dev`: read/write cache fields are missing and `nonCachedInputTokens` stays at 5.

After the fix:

- `cd packages/llm && bun test --timeout 30000 test/provider/openai-compatible-chat.test.ts test/provider/openai-chat.test.ts`
- `bun --cwd packages/llm test`
- `bun --cwd packages/llm typecheck`
- `bun lint packages/llm/src/protocols/openai-chat.ts packages/llm/test/provider/openai-compatible-chat.test.ts`

### Screenshots / recordings

N/A, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

