### PR TITLE
fix(core): avoid per-file directory list rebuild

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -41,8 +41,15 @@ export const ripgrepLayer = Layer.effect(
           Effect.sync(() => {
             state.files.push(entry.path)
             const parts = entry.path.split("/")
-            parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
-            state.directories = Array.from(directories)
+            let prefix = ""
+            for (let index = 0; index < parts.length - 1; index++) {
+              const part = parts[index]
+              prefix = prefix ? `${prefix}/${part}` : part
+              const directory = prefix + path.sep
+              if (directories.has(directory)) continue
+              directories.add(directory)
+              state.directories.push(directory)
+            }
           }),
       })
       .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))

--- a/packages/core/test/filesystem/search.test.ts
+++ b/packages/core/test/filesystem/search.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Effect } from "effect"
+import { Deferred, Effect, Layer } from "effect"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Entry } from "@opencode-ai/core/filesystem"
+import { FileSystemSearch } from "@opencode-ai/core/filesystem/search"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Location } from "@opencode-ai/core/location"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
+import { location } from "../fixture/location"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
@@ -40,5 +45,47 @@ describe("Ripgrep", () => {
         expect(result[0]?.submatches[0]?.text).toBe("needle")
       }),
     ),
+  )
+})
+
+describe("FileSystemSearch", () => {
+  it.live("indexes unique parent directories from ripgrep entries", () =>
+    Effect.gen(function* () {
+      const indexed = yield* Deferred.make<"indexed">()
+      const entries = [
+        Entry.make({ path: RelativePath.make("src/index.ts"), type: "file" }),
+        Entry.make({ path: RelativePath.make("src/components/button.ts"), type: "file" }),
+        Entry.make({ path: RelativePath.make("src/components/card.ts"), type: "file" }),
+      ]
+      const fakeRipgrep = Layer.succeed(
+        Ripgrep.Service,
+        Ripgrep.Service.of({
+          find: (input) =>
+            Effect.gen(function* () {
+              yield* Effect.forEach(entries, (entry) => input.onEntry?.(entry) ?? Effect.void)
+              yield* Deferred.succeed(indexed, "indexed")
+              return entries
+            }),
+          glob: () => Effect.succeed([]),
+          grep: () => Effect.succeed([]),
+        }),
+      )
+      const activeLocation = Layer.succeed(
+        Location.Service,
+        Location.Service.of(location({ directory: AbsolutePath.make("/workspace") })),
+      )
+      const searchLayer = FileSystemSearch.ripgrepLayer.pipe(
+        Layer.provide(Layer.mergeAll(LayerNode.compile(FSUtil.node), activeLocation, fakeRipgrep)),
+      )
+
+      yield* Effect.gen(function* () {
+        const service = yield* FileSystemSearch.Service
+        expect(yield* Deferred.await(indexed).pipe(Effect.timeout("1 second"))).toBe("indexed")
+        const result = yield* service.find({ query: "src", type: "directory", limit: 10 })
+        expect(result.map((item) => item.path).sort()).toEqual(
+          [RelativePath.make("src" + path.sep), RelativePath.make("src/components" + path.sep)].sort(),
+        )
+      }).pipe(Effect.provide(searchLayer))
+    }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #35254

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops rebuilding the full directory array for every indexed file. New parent directories are appended once while preserving insertion order and search results.

### How did you verify your code works?

- `bun test test/filesystem/search.test.ts --timeout 30000` in `packages/core` (`3 pass`)
- `bun turbo typecheck --filter=@opencode-ai/core --concurrency=1`
- `bun lint packages/core/src/filesystem/search.ts packages/core/test/filesystem/search.test.ts` (`0 warnings`, `0 errors`)
- Pre-push `TURBO_CONCURRENCY=3 bun typecheck` (`30 tasks successful`)
- `git diff --check origin/dev...HEAD`
- 7 alternating runs with 20,000 files and 1,026 directories: median `163.92ms -> 10.80ms`; worst `184.41ms -> 15.08ms`

### Screenshots / recordings

N/A; non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
