### PR TITLE
fix(project): bound icon discovery scan

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -32,6 +32,21 @@ export const Event = {
 
 type Row = typeof ProjectTable.$inferSelect
 
+const ICON_DISCOVERY_PATHS = [
+  "favicon",
+  "public/favicon",
+  "public/assets/favicon",
+  "static/favicon",
+  "static/assets/favicon",
+  "assets/favicon",
+  "src/favicon",
+  "src/assets/favicon",
+  "app/favicon",
+  "resources/favicon",
+]
+const ICON_DISCOVERY_EXTENSIONS = ["ico", "png", "svg", "jpg", "jpeg", "webp"]
+const ICON_DISCOVERY_PATTERN = `{${ICON_DISCOVERY_PATHS.join(",")}}.{${ICON_DISCOVERY_EXTENSIONS.join(",")}}`
+
 export function fromRow(row: Row): Info {
   const icon =
     row.icon_url || row.icon_url_override || row.icon_color
@@ -315,7 +330,7 @@ const layer = Layer.effect(
       if (input.icon?.url) return
 
       const matches = yield* fs
-        .glob("**/favicon.{ico,png,svg,jpg,jpeg,webp}", {
+        .glob(ICON_DISCOVERY_PATTERN, {
           cwd: input.worktree,
           absolute: true,
           include: "file",

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -2,6 +2,7 @@ import { describe, expect } from "bun:test"
 import { Project } from "@/project/project"
 import { $ } from "bun"
 import path from "path"
+import fs from "fs/promises"
 import { tmpdirScoped } from "../fixture/fixture"
 import { GlobalBus } from "../../src/bus/global"
 import { Database } from "@opencode-ai/core/database/database"
@@ -431,6 +432,45 @@ describe("Project.discover", () => {
       expect(updated!.icon?.url).toStartWith("data:")
       expect(updated!.icon?.url).toContain("base64")
       expect(updated!.icon?.color).toBeUndefined()
+    }),
+  )
+
+  it.live("should discover favicon.png in public", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      const result = yield* project.fromDirectory(tmp)
+
+      const publicDir = path.join(tmp, "public")
+      const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      yield* Effect.promise(() => fs.mkdir(publicDir, { recursive: true }))
+      yield* Effect.promise(() => Bun.write(path.join(publicDir, "favicon.png"), pngData))
+
+      yield* project.discover(result.project)
+
+      const updated = yield* project.get(result.project.id)
+      expect(updated).toBeDefined()
+      expect(updated!.icon?.url).toStartWith("data:")
+      expect(updated!.icon?.url).toContain("base64")
+    }),
+  )
+
+  it.live("should not discover favicon in arbitrary nested directories", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      const result = yield* project.fromDirectory(tmp)
+
+      const nestedDir = path.join(tmp, "data", "free-runtime", "stale-leases", "one", "two", "three")
+      const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      yield* Effect.promise(() => fs.mkdir(nestedDir, { recursive: true }))
+      yield* Effect.promise(() => Bun.write(path.join(nestedDir, "favicon.png"), pngData))
+
+      yield* project.discover(result.project)
+
+      const updated = yield* project.get(result.project.id)
+      expect(updated).toBeDefined()
+      expect(updated!.icon).toBeUndefined()
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #29953

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Project icon discovery used a recursive `**/favicon.*` scan, which can walk an entire repository during project load. This bounds discovery to common icon locations such as the project root, `public`, `static`, `assets`, `src`, `app`, and `resources` while preserving normal favicon/project icon lookup.

Impact: icon lookup becomes a bounded set of glob paths instead of an unbounded worktree scan.

### How did you verify your code works?

- `bun --cwd packages/opencode test test/project/project.test.ts --timeout 30000`
- `bun --cwd packages/opencode typecheck`
- `bun lint packages/opencode/src/project/project.ts packages/opencode/test/project/project.test.ts`
- `git diff --check HEAD~1..HEAD`

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
