### PR TITLE
fix(skill): avoid symlink traversal during discovery

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -1,5 +1,6 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import path from "path"
+import fs from "fs/promises"
 import { Effect, Layer, Context, Schema } from "effect"
 import { NamedError } from "@opencode-ai/core/util/error"
 import type { Agent } from "@/agent/agent"
@@ -20,7 +21,6 @@ import { escapeHtml } from "@/util/html"
 
 const CLAUDE_EXTERNAL_DIR = ".claude"
 const AGENTS_EXTERNAL_DIR = ".agents"
-const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
 const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"
 const SKILL_PATTERN = "**/SKILL.md"
 
@@ -139,6 +139,31 @@ const add = Effect.fnUntraced(function* (state: State, match: string, events: Ev
   }
 })
 
+async function externalSkillFiles(root: string) {
+  const result: string[] = []
+  const skills = path.join(root, "skills")
+  const rootStat = await fs.lstat(root).catch(() => undefined)
+  if (!rootStat?.isDirectory()) return result
+  const skillsStat = await fs.lstat(skills).catch(() => undefined)
+  if (!skillsStat?.isDirectory()) return result
+
+  async function walk(dir: string) {
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => [])
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const full = path.join(dir, entry.name)
+      if (entry.isSymbolicLink()) continue
+      if (entry.isDirectory()) {
+        await walk(full)
+        continue
+      }
+      if (entry.isFile() && entry.name === "SKILL.md") result.push(full)
+    }
+  }
+
+  await walk(skills)
+  return result
+}
+
 const scan = Effect.fnUntraced(function* (
   state: ScanState,
   root: string,
@@ -170,6 +195,22 @@ const scan = Effect.fnUntraced(function* (
   }
 })
 
+const scanExternal = Effect.fnUntraced(function* (state: ScanState, root: string, scope: string) {
+  const matches = yield* Effect.tryPromise({
+    try: () => externalSkillFiles(root),
+    catch: (error) => error,
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.logError(`failed to scan ${scope} skills`, { dir: root, error: error }).pipe(Effect.as([] as string[])),
+    ),
+  )
+
+  for (const match of matches) {
+    state.matches.add(match)
+    state.dirs.add(path.dirname(match))
+  }
+})
+
 const discoverSkills = Effect.fnUntraced(function* (
   config: Config.Interface,
   discovery: Discovery.Interface,
@@ -189,8 +230,7 @@ const discoverSkills = Effect.fnUntraced(function* (
 
     for (const dir of externalDirs) {
       const root = path.join(global.home, dir)
-      if (!(yield* fsys.isDir(root))) continue
-      yield* scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "global" })
+      yield* scanExternal(state, root, "global")
     }
 
     const upDirs = yield* fsys
@@ -198,7 +238,7 @@ const discoverSkills = Effect.fnUntraced(function* (
       .pipe(Effect.catch(() => Effect.succeed([] as string[])))
 
     for (const root of upDirs) {
-      yield* scan(state, root, EXTERNAL_SKILL_PATTERN, { dot: true, scope: "project" })
+      yield* scanExternal(state, root, "project")
     }
   }
 

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -2,13 +2,8 @@ import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Effect, Layer } from "effect"
 import { Skill } from "../../src/skill"
-import { Discovery } from "../../src/skill/discovery"
 import { RuntimeFlags } from "../../src/effect/runtime-flags"
-import { EventV2Bridge } from "../../src/event-v2-bridge"
-import { Config } from "../../src/config/config"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
-import { FSUtil } from "@opencode-ai/core/fs-util"
-import { Global } from "@opencode-ai/core/global"
 import { provideInstance, provideTmpdirInstance, testInstanceStoreLayer, tmpdir } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
 import path from "path"
@@ -266,6 +261,55 @@ description: A skill in the .claude/skills directory.
           expect(item).toBeDefined()
           expect(item!.location).toContain(path.join(".claude", "skills", "claude-skill", "SKILL.md"))
         }),
+      { git: true },
+    ),
+  )
+
+  it.live("does not follow symlinked external skill directories", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        withHome(
+          dir,
+          Effect.gen(function* () {
+            yield* Effect.promise(async () => {
+              const skills = path.join(dir, ".claude", "skills")
+              const local = path.join(skills, "local-skill")
+              const linkedTarget = path.join(dir, "linked-target")
+
+              await fs.mkdir(local, { recursive: true })
+              await fs.mkdir(linkedTarget, { recursive: true })
+              await Bun.write(
+                path.join(local, "SKILL.md"),
+                `---
+name: local-skill
+description: A regular external skill.
+---
+
+# Local Skill
+`,
+              )
+              await Bun.write(
+                path.join(linkedTarget, "SKILL.md"),
+                `---
+name: linked-skill
+description: A linked external skill.
+---
+
+# Linked Skill
+`,
+              )
+              await fs.symlink(
+                linkedTarget,
+                path.join(skills, "linked-skill"),
+                process.platform === "win32" ? "junction" : "dir",
+              )
+            })
+
+            const skill = yield* Skill.Service
+            const list = (yield* skill.all()).filter((s) => s.location !== "<built-in>")
+            expect(list.map((s) => s.name).toSorted()).toEqual(["local-skill"])
+          }),
+        ),
       { git: true },
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #27027
Closes #27638

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

External skill discovery under `.claude` and `.agents` could traverse symlinked directories. That made startup vulnerable to huge or cyclic linked trees. This adds an explicit `lstat`/`readdir` walker for those external roots that skips symlink roots and nested symlink entries before recursing. Configured skill paths and URL-pulled skills keep the existing glob path.

Impact: symlinked external skill trees are skipped before traversal, avoiding pathological startup scans.

### How did you verify your code works?

- `bun test test/skill/skill.test.ts --timeout 30000` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun lint packages/opencode/src/skill/index.ts packages/opencode/test/skill/skill.test.ts`
- `git diff --check HEAD~1..HEAD`

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
