### PR TITLE
fix(session): separate active context tokens from usage totals

### DIFF
--- a/packages/app/src/components/session-context-usage.tsx
+++ b/packages/app/src/components/session-context-usage.tsx
@@ -12,7 +12,7 @@ import { useSync } from "@/context/sync"
 import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
 import { useSDK } from "@/context/sdk"
-import { getSessionContext, getSessionTokenTotal } from "@/components/session/session-context-metrics"
+import { getSessionContext } from "@/components/session/session-context-metrics"
 import { useSessionLayout } from "@/pages/session/session-layout"
 import { createSessionTabs } from "@/pages/session/helpers"
 import { useSettings } from "@/context/settings"
@@ -74,7 +74,6 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
   )
 
   const context = createMemo(() => getSessionContext(messages(), [...providers.all().values()]))
-  const tokens = createMemo(() => info()?.tokens)
   const cost = createMemo(() => {
     return usd().format(info()?.cost ?? 0)
   })
@@ -132,7 +131,7 @@ export function SessionContextUsage(props: SessionContextUsageProps) {
       <ContextTooltipRow name={language.t("context.usage.usage")} value={`${context()?.usage ?? 0}%`} />
       <ContextTooltipRow
         name={language.t("context.usage.tokens")}
-        value={getSessionTokenTotal(tokens())?.toLocaleString(language.intl()) ?? "0"}
+        value={context()?.total.toLocaleString(language.intl()) ?? "0"}
       />
     </div>
   )

--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -105,4 +105,24 @@ describe("getSessionContext", () => {
       }),
     ).toBe(150)
   })
+
+  test("keeps active context tokens separate from cumulative session totals", () => {
+    const messages = [
+      assistant("a1", { input: 120, output: 20, reasoning: 0, read: 4_000, write: 0 }, 0.5),
+      assistant("a2", { input: 500, output: 100, reasoning: 20, read: 600, write: 80 }, 0.75),
+    ]
+    const cumulative = {
+      input: 620,
+      output: 120,
+      reasoning: 20,
+      cache: { read: 41_000_000, write: 80 },
+    }
+
+    const ctx = getSessionContext(messages, [])
+
+    expect(ctx?.message.id).toBe("a2")
+    expect(ctx?.tokens.cache.read).toBe(600)
+    expect(ctx?.total).toBe(1_300)
+    expect(getSessionTokenTotal(cumulative)).toBe(41_000_840)
+  })
 })

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -20,21 +20,28 @@ type Context = {
   providerLabel: string
   modelLabel: string
   limit: number | undefined
+  tokens: AssistantMessage["tokens"]
+  total: number
   input: number
   usage: number | null
 }
 
-const tokenTotal = (msg: AssistantMessage) => {
-  return msg.tokens.input + msg.tokens.output + msg.tokens.reasoning + msg.tokens.cache.read + msg.tokens.cache.write
+const tokenTotal = (tokens: AssistantMessage["tokens"]) => {
+  return tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write
+}
+
+const messageTokenTotal = (msg: AssistantMessage) => {
+  return tokenTotal(msg.tokens)
 }
 
 const lastAssistantWithTokens = (messages: Message[]) => {
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i]
     if (msg.role !== "assistant") continue
-    if (tokenTotal(msg) <= 0) continue
+    if (messageTokenTotal(msg) <= 0) continue
     return msg
   }
+  return undefined
 }
 
 const build = (messages: Message[] = [], providers: Provider[] = []): Context | undefined => {
@@ -44,7 +51,7 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Context | 
   const provider = providers.find((item) => item.id === message.providerID)
   const model = provider?.models[message.modelID]
   const limit = model?.limit.context
-  const total = tokenTotal(message)
+  const total = messageTokenTotal(message)
 
   return {
     message,
@@ -53,6 +60,8 @@ const build = (messages: Message[] = [], providers: Provider[] = []): Context | 
     providerLabel: provider?.name ?? message.providerID,
     modelLabel: model?.name ?? message.modelID,
     limit,
+    tokens: message.tokens,
+    total,
     input: message.tokens.input,
     usage: limit ? Math.round((total / limit) * 100) : null,
   }
@@ -64,5 +73,5 @@ export function getSessionContext(messages: Message[] = [], providers: Provider[
 
 export function getSessionTokenTotal(tokens: Session["tokens"] | undefined) {
   if (!tokens) return undefined
-  return tokens.input + tokens.output + tokens.reasoning + tokens.cache.read + tokens.cache.write
+  return tokenTotal(tokens)
 }

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -15,7 +15,7 @@ import { useLanguage } from "@/context/language"
 import { useProviders } from "@/hooks/use-providers"
 import { useSDK } from "@/context/sdk"
 import { useSessionLayout } from "@/pages/session/session-layout"
-import { getSessionContext, getSessionTokenTotal } from "./session-context-metrics"
+import { getSessionContext } from "./session-context-metrics"
 import { estimateSessionContextBreakdown, type SessionContextBreakdownKey } from "./session-context-breakdown"
 import { createSessionContextFormatter } from "./session-context-format"
 
@@ -135,7 +135,7 @@ export function SessionContextTab() {
   )
 
   const ctx = createMemo(() => getSessionContext(messages(), [...providers.all().values()]))
-  const tokens = createMemo(() => info()?.tokens)
+  const tokens = createMemo(() => ctx()?.tokens)
   const formatter = createMemo(() => createSessionContextFormatter(language.intl()))
 
   const cost = createMemo(() => {
@@ -204,7 +204,7 @@ export function SessionContextTab() {
     { label: "context.stats.provider", value: providerLabel },
     { label: "context.stats.model", value: modelLabel },
     { label: "context.stats.limit", value: () => formatter().number(ctx()?.limit) },
-    { label: "context.stats.totalTokens", value: () => formatter().number(getSessionTokenTotal(tokens())) },
+    { label: "context.stats.totalTokens", value: () => formatter().number(ctx()?.total) },
     { label: "context.stats.usage", value: () => formatter().percent(ctx()?.usage) },
     { label: "context.stats.inputTokens", value: () => formatter().number(tokens()?.input) },
     { label: "context.stats.outputTokens", value: () => formatter().number(tokens()?.output) },


### PR DESCRIPTION
### Issue for this PR

Closes #30649
Closes #34712

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The context meter mixed active context size with cumulative usage totals, so large cache-read totals could make the UI report impossible context usage. This adds a shared session context metric helper and uses the latest assistant message's active context tokens for the meter/details while leaving cumulative cost accounting unchanged.

Impact: UI context usage reflects active model context instead of cumulative billing counters.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/components/session/session-context-metrics.test.ts` from `packages/app`
- `bun typecheck` from `packages/app`
- `bun lint packages/app/src/components/session/session-context-metrics.ts packages/app/src/components/session-context-usage.tsx packages/app/src/components/session/session-context-tab.tsx packages/app/src/components/session/session-context-metrics.test.ts`
- `git diff --check HEAD~1..HEAD`

### Screenshots / recordings

N/A, metric calculation change covered by tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
