### PR TITLE
fix(app): cap prompt history attachments

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -58,8 +58,10 @@ import {
   prependHistoryEntry,
   type PromptHistoryComment,
   type PromptHistoryEntry,
+  type PromptHistoryState,
   type PromptHistoryStoredEntry,
   promptLength,
+  sanitizePromptHistoryState,
 } from "./prompt-input/history"
 import { createPromptSubmit, type FollowupDraft } from "./prompt-input/submit"
 import { PromptPopover, type AtOption, type SlashCommand } from "./prompt-input/slash-popover"
@@ -120,8 +122,6 @@ export function createPromptInputHistory(): PromptInputHistory {
   return createPromptInputHistoryStore(normal, setNormal, shell, setShell)
 }
 
-type PromptHistoryState = { entries: PromptHistoryStoredEntry[] }
-
 function createPromptInputHistoryStore(
   normal: Store<PromptHistoryState>,
   setNormal: SetStoreFunction<PromptHistoryState>,
@@ -142,11 +142,11 @@ function createPromptInputHistoryStore(
 
 function createPersistedPromptInputHistory() {
   const [normal, setNormal] = persisted(
-    Persist.global("prompt-history", ["prompt-history.v1"]),
+    { ...Persist.global("prompt-history", ["prompt-history.v1"]), migrate: sanitizePromptHistoryState },
     createStore<PromptHistoryState>({ entries: [] }),
   )
   const [shell, setShell] = persisted(
-    Persist.global("prompt-history-shell", ["prompt-history-shell.v1"]),
+    { ...Persist.global("prompt-history-shell", ["prompt-history-shell.v1"]), migrate: sanitizePromptHistoryState },
     createStore<PromptHistoryState>({ entries: [] }),
   )
   return createPromptInputHistoryStore(normal, setNormal, shell, setShell)

--- a/packages/app/src/components/prompt-input/history.test.ts
+++ b/packages/app/src/components/prompt-input/history.test.ts
@@ -3,16 +3,24 @@ import type { Prompt } from "@/context/prompt"
 import {
   canNavigateHistoryAtCursor,
   clonePromptParts,
+  MAX_HISTORY_INLINE_DATA_URL_LENGTH,
   normalizePromptHistoryEntry,
   navigatePromptHistory,
   prependHistoryEntry,
   promptLength,
+  sanitizePromptHistoryState,
   type PromptHistoryComment,
+  type PromptHistoryEntry,
+  type PromptHistoryStoredEntry,
 } from "./history"
 
 const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
 const text = (value: string): Prompt => [{ type: "text", content: value, start: 0, end: value.length }]
+const oversizedDataUrl = (mime = "application/pdf") => {
+  const prefix = `data:${mime};base64,`
+  return prefix + "A".repeat(MAX_HISTORY_INLINE_DATA_URL_LENGTH - prefix.length + 1)
+}
 const comment = (id: string, value = "note"): PromptHistoryComment => ({
   id,
   path: "src/a.ts",
@@ -22,6 +30,18 @@ const comment = (id: string, value = "note"): PromptHistoryComment => ({
   origin: "review",
   preview: "const a = 1",
 })
+
+function firstHistoryEntry(entries: PromptHistoryStoredEntry[]) {
+  const entry = entries[0]
+  if (!entry) throw new Error("expected history entry")
+  return entry
+}
+
+function expectHistoryState(value: unknown): asserts value is { entries: PromptHistoryEntry[] } {
+  if (!value || typeof value !== "object" || !("entries" in value) || !Array.isArray(value.entries)) {
+    throw new Error("expected history state")
+  }
+}
 
 describe("prompt-input history", () => {
   test("prependHistoryEntry skips empty prompt and deduplicates consecutive entries", () => {
@@ -39,6 +59,85 @@ describe("prompt-input history", () => {
 
     const dedupedComments = prependHistoryEntry(commentsOnly, DEFAULT_PROMPT, [comment("c1")])
     expect(dedupedComments).toBe(commentsOnly)
+  })
+
+  test("prependHistoryEntry skips oversized inline data-url attachments while keeping text", () => {
+    const added = prependHistoryEntry([], [
+      { type: "text", content: "review this", start: 0, end: 11 },
+      {
+        type: "image",
+        id: "pdf_1",
+        filename: "paper.pdf",
+        mime: "application/pdf",
+        dataUrl: oversizedDataUrl(),
+      },
+    ])
+    const entry = normalizePromptHistoryEntry(firstHistoryEntry(added))
+
+    expect(entry.prompt).toEqual([{ type: "text", content: "review this", start: 0, end: 11 }])
+  })
+
+  test("prependHistoryEntry keeps small inline data-url attachments", () => {
+    const added = prependHistoryEntry([], [
+      { type: "text", content: "see image", start: 0, end: 9 },
+      {
+        type: "image",
+        id: "img_1",
+        filename: "image.png",
+        mime: "image/png",
+        dataUrl: "data:image/png;base64,AAA",
+      },
+    ])
+    const entry = normalizePromptHistoryEntry(firstHistoryEntry(added))
+
+    expect(entry.prompt).toMatchObject([
+      { type: "text", content: "see image" },
+      { type: "image", filename: "image.png", dataUrl: "data:image/png;base64,AAA" },
+    ])
+  })
+
+  test("sanitizePromptHistoryState removes oversized persisted data urls", () => {
+    const migrated = sanitizePromptHistoryState({
+      entries: [
+        {
+          prompt: [
+            { type: "text", content: "old entry", start: 0, end: 9 },
+            {
+              type: "image",
+              id: "pdf_1",
+              filename: "paper.pdf",
+              mime: "application/pdf",
+              dataUrl: oversizedDataUrl(),
+            },
+            {
+              type: "file",
+              path: "paper.pdf",
+              content: "@paper.pdf",
+              start: 10,
+              end: 20,
+              url: oversizedDataUrl(),
+            },
+          ],
+          comments: [comment("c1")],
+        },
+      ],
+    })
+    expectHistoryState(migrated)
+
+    expect(migrated.entries).toHaveLength(1)
+    expect(migrated.entries[0]?.comments).toEqual([comment("c1")])
+    expect(migrated.entries[0]?.prompt).toEqual([
+      { type: "text", content: "old entry", start: 0, end: 9 },
+      {
+        type: "file",
+        path: "paper.pdf",
+        content: "@paper.pdf",
+        start: 10,
+        end: 20,
+        selection: undefined,
+        url: undefined,
+      },
+    ])
   })
 
   test("navigatePromptHistory restores saved prompt when moving down from newest", () => {

--- a/packages/app/src/components/prompt-input/history.ts
+++ b/packages/app/src/components/prompt-input/history.ts
@@ -4,6 +4,7 @@ import type { SelectedLineRange } from "@/context/file"
 const DEFAULT_PROMPT: Prompt = [{ type: "text", content: "", start: 0, end: 0 }]
 
 export const MAX_HISTORY = 100
+export const MAX_HISTORY_INLINE_DATA_URL_LENGTH = 64 * 1024
 
 export type PromptHistoryComment = {
   id: string
@@ -21,6 +22,7 @@ export type PromptHistoryEntry = {
 }
 
 export type PromptHistoryStoredEntry = Prompt | PromptHistoryEntry
+export type PromptHistoryState = { entries: PromptHistoryStoredEntry[] }
 
 export function canNavigateHistoryAtCursor(direction: "up" | "down", text: string, cursor: number, inHistory = false) {
   const position = Math.max(0, Math.min(cursor, text.length))
@@ -41,6 +43,38 @@ export function clonePromptParts(prompt: Prompt): Prompt {
       selection: part.selection ? { ...part.selection } : undefined,
     }
   })
+}
+
+function isInlineDataUrl(value: string | undefined): value is string {
+  return value?.startsWith("data:") === true
+}
+
+export function sanitizePromptForHistory(prompt: Prompt): Prompt {
+  const result: Prompt = []
+  let remainingDataUrlLength = MAX_HISTORY_INLINE_DATA_URL_LENGTH
+  const keepInlineDataUrl = (value: string | undefined) => {
+    if (!isInlineDataUrl(value)) return true
+    if (value.length > remainingDataUrlLength) return false
+    remainingDataUrlLength -= value.length
+    return true
+  }
+
+  for (const part of prompt) {
+    if (part.type === "text" || part.type === "agent") {
+      result.push({ ...part })
+      continue
+    }
+    if (part.type === "image") {
+      if (keepInlineDataUrl(part.dataUrl)) result.push({ ...part })
+      continue
+    }
+    result.push({
+      ...part,
+      selection: part.selection ? { ...part.selection } : undefined,
+      url: keepInlineDataUrl(part.url) ? part.url : undefined,
+    })
+  }
+  return result
 }
 
 function cloneSelection(selection: SelectedLineRange): SelectedLineRange {
@@ -72,6 +106,54 @@ export function normalizePromptHistoryEntry(entry: PromptHistoryStoredEntry): Pr
   }
 }
 
+export function sanitizePromptHistoryEntry(entry: PromptHistoryStoredEntry): PromptHistoryEntry {
+  const normalized = normalizePromptHistoryEntry(entry)
+  return {
+    prompt: sanitizePromptForHistory(normalized.prompt),
+    comments: clonePromptHistoryComments(normalized.comments),
+  }
+}
+
+function hasHistoryContent(entry: PromptHistoryEntry) {
+  const text = entry.prompt
+    .map((part) => ("content" in part ? part.content : ""))
+    .join("")
+    .trim()
+  const hasImages = entry.prompt.some((part) => part.type === "image")
+  const hasComments = entry.comments.some((comment) => !!comment.comment.trim())
+  return !!text || hasImages || hasComments
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isPromptHistoryStoredEntry(value: unknown): value is PromptHistoryStoredEntry {
+  if (Array.isArray(value)) return true
+  return isRecord(value) && Array.isArray(value.prompt) && Array.isArray(value.comments)
+}
+
+function sanitizePromptHistoryEntries(entries: unknown[]) {
+  return entries.flatMap((entry) => {
+    if (!isPromptHistoryStoredEntry(entry)) return []
+    try {
+      const sanitized = sanitizePromptHistoryEntry(entry)
+      return hasHistoryContent(sanitized) ? [sanitized] : []
+    } catch {
+      return []
+    }
+  })
+}
+
+export function sanitizePromptHistoryState(value: unknown): unknown {
+  if (Array.isArray(value)) return { entries: sanitizePromptHistoryEntries(value) }
+  if (!isRecord(value) || !Array.isArray(value.entries)) return value
+  return {
+    ...value,
+    entries: sanitizePromptHistoryEntries(value.entries),
+  }
+}
+
 export function promptLength(prompt: Prompt) {
   return prompt.reduce((len, part) => len + ("content" in part ? part.content.length : 0), 0)
 }
@@ -82,16 +164,17 @@ export function prependHistoryEntry(
   comments: PromptHistoryComment[] = [],
   max = MAX_HISTORY,
 ) {
+  const sanitizedPrompt = sanitizePromptForHistory(prompt)
   const text = prompt
     .map((part) => ("content" in part ? part.content : ""))
     .join("")
     .trim()
-  const hasImages = prompt.some((part) => part.type === "image")
+  const hasImages = sanitizedPrompt.some((part) => part.type === "image")
   const hasComments = comments.some((comment) => !!comment.comment.trim())
   if (!text && !hasImages && !hasComments) return entries
 
   const entry = {
-    prompt: clonePromptParts(prompt),
+    prompt: sanitizedPrompt,
     comments: clonePromptHistoryComments(comments),
   } satisfies PromptHistoryEntry
   const last = entries[0]


### PR DESCRIPTION
### Issue for this PR

Closes #34215

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prompt history could persist inline data URLs from attachments, which made the global persisted state grow by megabytes. This caps persisted inline attachment URLs to 64 KiB per history entry, drops oversized data URLs, preserves text/comment metadata, and sanitizes existing prompt history state on load.

Impact: future prompt history entries no longer retain large base64 attachment payloads.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/components/prompt-input/history.test.ts` from `packages/app`
- `bun typecheck` from `packages/app`
- `bun lint packages/app/src/components/prompt-input/history.ts packages/app/src/components/prompt-input/history.test.ts packages/app/src/components/prompt-input.tsx`
- `git diff --check HEAD~1..HEAD`

### Screenshots / recordings

N/A, persistence/data-size change covered by tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
