### PR TITLE
fix(session): preserve cache prefix across mode switch

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -8,7 +8,7 @@ import {
   isContextOverflowFailure,
   type ProviderErrorEvent,
 } from "@opencode-ai/llm"
-import { Cause, DateTime, Effect, FiberSet, Layer, Option, Semaphore, Stream } from "effect"
+import { Cause, DateTime, Effect, FiberSet, Layer, Option, Schema, Semaphore, Stream } from "effect"
 import { AgentV2 } from "../../agent"
 import { Config } from "../../config"
 import { Database } from "../../database/database"
@@ -165,10 +165,31 @@ const layer = Layer.effect(
     const continueAfterOverflowCompaction = (step: number) =>
       new TurnTransitionError({ _tag: "ContinueAfterOverflowCompaction", step })
 
+    const agentSystemContext = (agent: AgentV2.Selection) => {
+      if (!agent.info?.system) return SystemContext.empty
+      return SystemContext.make({
+        key: SystemContext.Key.make("session/agent-system"),
+        codec: Schema.String,
+        load: Effect.succeed(agent.info.system),
+        baseline: String,
+        update: (_previous, current) => current,
+        removed: () =>
+          "Selected-agent system instructions are no longer active. Disregard any earlier selected-agent system instructions.",
+      })
+    }
+
     const loadSystemContext = (agent: AgentV2.Selection) =>
-      Effect.all([systemContext.load(), skillGuidance.load(agent), referenceGuidance.load()], {
-        concurrency: "unbounded",
-      }).pipe(Effect.map(SystemContext.combine))
+      Effect.all(
+        [
+          Effect.succeed(agentSystemContext(agent)),
+          systemContext.load(),
+          skillGuidance.load(agent),
+          referenceGuidance.load(),
+        ],
+        {
+          concurrency: "unbounded",
+        },
+      ).pipe(Effect.map(SystemContext.combine))
 
     const runTurnAttempt = Effect.fn("SessionRunner.runTurn")(function* (
       sessionID: SessionSchema.ID,
@@ -205,7 +226,7 @@ const layer = Layer.effect(
       const request = LLM.request({
         model,
         providerOptions: { openai: { promptCacheKey } },
-        system: [agent.info?.system, system.baseline]
+        system: [system.baseline]
           .filter((part): part is string => part !== undefined && part.length > 0)
           .map(SystemPart.make),
         messages: [...toLLMMessages(context, model), ...(isLastStep ? [Message.assistant(MAX_STEPS_PROMPT)] : [])],

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -796,7 +796,7 @@ describe("SessionRunnerLLM", () => {
       response = fragmentFixture("text", "text-build", ["Done"]).completeEvents
       yield* session.resume(sessionID)
 
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Build agent instructions", "Initial context"])
+      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Build agent instructions\n\nInitial context"])
     }),
   )
 
@@ -822,7 +822,7 @@ describe("SessionRunnerLLM", () => {
       response = fragmentFixture("text", "text-reviewer", ["Done"]).completeEvents
       yield* session.resume(sessionID)
 
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Reviewer instructions", "Initial context"])
+      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Reviewer instructions\n\nInitial context"])
       expect((yield* session.messages({ sessionID }))[0]).toMatchObject({ type: "assistant", agent: "reviewer" })
     }),
   )
@@ -851,8 +851,43 @@ describe("SessionRunnerLLM", () => {
       response = fragmentFixture("text", "text-selected", ["Done"]).completeEvents
       yield* session.resume(sessionID)
 
-      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Reviewer instructions", "Initial context"])
+      expect(requests.at(-1)?.system.map((part) => part.text)).toEqual(["Reviewer instructions\n\nInitial context"])
       expect((yield* session.messages({ sessionID }))[0]).toMatchObject({ type: "assistant", agent: "reviewer" })
+    }),
+  )
+
+  it.effect("preserves the cached system prefix when switching from plan to build", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const agents = yield* AgentV2.Service
+      yield* agents.transform((editor) => {
+        editor.update(AgentV2.ID.make("build"), (agent) => {
+          agent.system = "Build agent instructions"
+          agent.mode = "primary"
+        })
+        editor.update(AgentV2.ID.make("plan"), (agent) => {
+          agent.system = undefined
+          agent.mode = "primary"
+        })
+      })
+      const session = yield* SessionV2.Service
+      yield* session.switchAgent({ sessionID, agent: "plan" })
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Draft a plan" }), resume: false })
+
+      requests.length = 0
+      response = fragmentFixture("text", "text-plan", ["Plan ready"]).completeEvents
+      yield* session.resume(sessionID)
+      yield* session.switchAgent({ sessionID, agent: "build" })
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Build it" }), resume: false })
+      response = fragmentFixture("text", "text-build", ["Done"]).completeEvents
+      yield* session.resume(sessionID)
+
+      expect(requests.map((request) => request.system.map((part) => part.text))).toEqual([
+        ["Initial context"],
+        ["Initial context"],
+      ])
+      expect(systemTexts(requests[1])).toEqual(["Build agent instructions"])
+      expect(userTexts(requests[1])).toEqual(["Draft a plan", "Build it"])
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #35708

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Switching modes changed the provider system prompt prefix, which can reduce prefix-cache locality for providers that cache stable prompt prefixes. This keeps the stable baseline system prompt in the request `system` field and moves agent-specific instructions into a keyed `SystemContext` update.

Impact: plan/build mode changes no longer rewrite the provider system prefix, improving cache locality for prefix-caching providers.

### How did you verify your code works?

- `bun test test/session-runner.test.ts --timeout 30000` from `packages/core`
- `bun typecheck` from `packages/core`
- `bun lint packages/core/src/session/runner/llm.ts packages/core/test/session-runner.test.ts`
- `git diff --check HEAD~1..HEAD`

### Screenshots / recordings

N/A, request-shaping change covered by tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
