### PR TITLE
fix(session): settle busy status after stream close

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -303,7 +303,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
           sessionID: ctx.params.sessionID,
         })
         .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
-      return HttpServerResponse.stream(Stream.make(JSON.stringify(message)).pipe(Stream.encodeText), {
+      const body = Stream.make(JSON.stringify(message)).pipe(Stream.encodeText)
+      const settledBody =
+        ctx.payload.noReply === true ? body : body.pipe(Stream.ensuring(runState.settle(ctx.params.sessionID)))
+      return HttpServerResponse.stream(settledBody, {
         contentType: "application/json",
       })
     })

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -11,6 +11,7 @@ import { SessionStatus } from "./status"
 export interface Interface {
   readonly assertNotBusy: (sessionID: SessionID) => Effect.Effect<void, Session.BusyError>
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+  readonly settle: (sessionID: SessionID) => Effect.Effect<void>
   readonly ensureRunning: (
     sessionID: SessionID,
     onInterrupt: Effect.Effect<SessionV1.WithParts>,
@@ -85,6 +86,16 @@ const layer = Layer.effect(
       yield* existing.cancel
     })
 
+    const settle = Effect.fn("SessionRunState.settle")(function* (sessionID: SessionID) {
+      const data = yield* InstanceState.get(state)
+      const existing = data.runners.get(sessionID)
+      if (existing?.busy) return
+      data.runners.delete(sessionID)
+      const current = yield* status.get(sessionID)
+      if (current.type === "idle") return
+      yield* status.set(sessionID, { type: "idle" })
+    })
+
     const ensureRunning = Effect.fn("SessionRunState.ensureRunning")(function* (
       sessionID: SessionID,
       onInterrupt: Effect.Effect<SessionV1.WithParts>,
@@ -104,7 +115,7 @@ const layer = Layer.effect(
         .pipe(Effect.catchTag("RunnerBusy", () => Effect.fail(busyError(sessionID))))
     })
 
-    return Service.of({ assertNotBusy, cancel, ensureRunning, startShell })
+    return Service.of({ assertNotBusy, cancel, settle, ensureRunning, startShell })
   }),
 )
 

--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -805,6 +805,34 @@ describe("HttpApi SDK", () => {
     ),
   )
 
+  serverPathParity("settles session status immediately after prompt stream completes", (serverPath) =>
+    withFakeLlm(serverPath, ({ sdk, llm }) =>
+      Effect.gen(function* () {
+        yield* llm.text("status settled", { usage: { input: 5, output: 3 } })
+        const session = yield* capture(() =>
+          sdk.session.create({
+            title: "status settles",
+            permission: [{ permission: "*", pattern: "*", action: "allow" }],
+          }),
+        )
+        const sessionID = String(record(session.data).id)
+        const prompt = yield* capture(() =>
+          sdk.session.prompt({
+            sessionID,
+            agent: "build",
+            model: { providerID: "test", modelID: "test-model" },
+            parts: [{ type: "text", text: "hello status" }],
+          }),
+        )
+        const status = yield* capture(() => sdk.session.status())
+
+        expect(prompt.status).toBe(200)
+        expect(status.status).toBe(200)
+        expect(record(status.data)[sessionID]).toBeUndefined()
+      }),
+    ),
+  )
+
   httpapi(
     "includes project skills in REST API prompt context",
     withFakeLlmProject("default", { setup: writeProjectSkill }, ({ sdk, llm }) =>

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1062,6 +1062,7 @@ it.instance(
       const prompt = yield* SessionPrompt.Service
       const sessions = yield* Session.Service
       const status = yield* SessionStatus.Service
+      const run = yield* SessionRunState.Service
 
       yield* llm.hang
 
@@ -1070,6 +1071,8 @@ it.instance(
 
       const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
       yield* llm.wait(1)
+      expect((yield* status.get(chat.id)).type).toBe("busy")
+      yield* run.settle(chat.id)
       expect((yield* status.get(chat.id)).type).toBe("busy")
       yield* prompt.cancel(chat.id)
       yield* Fiber.await(fiber)


### PR DESCRIPTION
### Issue for this PR

Closes #35472

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After a prompt stream closed, session status could remain busy until a later update even though the runner had already finished. This adds a guarded `SessionRunState.settle()` and ensures prompt response streams call it on close. The settle path is a no-op while a runner is genuinely still busy.

Impact: `/session/status` can return idle immediately after prompt stream completion instead of waiting for a later cleanup signal.

### How did you verify your code works?

- `bun test test/server/httpapi-sdk.test.ts -t "settles session status immediately after prompt stream completes" --timeout 30000` from `packages/opencode`
- `bun test --timeout 30000 test/session/prompt.test.ts -t "loop sets status to busy then idle"` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun lint packages/opencode/src/session/run-state.ts packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts packages/opencode/test/server/httpapi-sdk.test.ts packages/opencode/test/session/prompt.test.ts`
- `git diff --check HEAD~1..HEAD`

### Screenshots / recordings

N/A, API status behavior covered by tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
