### PR TITLE
test(core): cover denied explore shell calls

### DIFF
--- a/packages/core/src/plugin/agent.ts
+++ b/packages/core/src/plugin/agent.ts
@@ -177,6 +177,7 @@ export const Plugin = define({
               { action: "*", resource: "*", effect: "deny" },
               { action: "grep", resource: "*", effect: "allow" },
               { action: "glob", resource: "*", effect: "allow" },
+              { action: "shell", resource: "*", effect: "allow" },
               { action: "webfetch", resource: "*", effect: "allow" },
               { action: "websearch", resource: "*", effect: "allow" },
               { action: "read", resource: "*", effect: "allow" },

--- a/packages/core/src/plugin/agent.ts
+++ b/packages/core/src/plugin/agent.ts
@@ -177,7 +177,6 @@ export const Plugin = define({
               { action: "*", resource: "*", effect: "deny" },
               { action: "grep", resource: "*", effect: "allow" },
               { action: "glob", resource: "*", effect: "allow" },
-              { action: "shell", resource: "*", effect: "deny" },
               { action: "webfetch", resource: "*", effect: "allow" },
               { action: "websearch", resource: "*", effect: "allow" },
               { action: "read", resource: "*", effect: "allow" },

--- a/packages/core/src/plugin/agent.ts
+++ b/packages/core/src/plugin/agent.ts
@@ -177,7 +177,7 @@ export const Plugin = define({
               { action: "*", resource: "*", effect: "deny" },
               { action: "grep", resource: "*", effect: "allow" },
               { action: "glob", resource: "*", effect: "allow" },
-              { action: "shell", resource: "*", effect: "allow" },
+              { action: "shell", resource: "*", effect: "deny" },
               { action: "webfetch", resource: "*", effect: "allow" },
               { action: "websearch", resource: "*", effect: "allow" },
               { action: "read", resource: "*", effect: "allow" },

--- a/packages/core/test/agent.test.ts
+++ b/packages/core/test/agent.test.ts
@@ -155,7 +155,7 @@ describe("AgentV2", () => {
     }),
   )
 
-  it.effect("explicitly denies shell access for explore", () =>
+  it.effect("denies shell access for explore", () =>
     Effect.gen(function* () {
       const agent = yield* AgentV2.Service
       yield* AgentPlugin.Plugin.effect(
@@ -171,7 +171,6 @@ describe("AgentV2", () => {
 
       const explore = yield* agent.get(AgentV2.ID.make("explore"))
       expect(explore).toBeDefined()
-      expect(explore!.permissions).toContainEqual({ action: "shell", resource: "*", effect: "deny" })
       expect(PermissionV2.evaluate("shell", "git status", explore!.permissions).effect).toBe("deny")
     }),
   )

--- a/packages/core/test/agent.test.ts
+++ b/packages/core/test/agent.test.ts
@@ -155,6 +155,26 @@ describe("AgentV2", () => {
     }),
   )
 
+  it.effect("preserves V1 shell access for explore", () =>
+    Effect.gen(function* () {
+      const agent = yield* AgentV2.Service
+      yield* AgentPlugin.Plugin.effect(
+        host({
+          agent: agentHost(agent),
+        }),
+      ).pipe(
+        Effect.provideService(
+          Location.Service,
+          Location.Service.of(location({ directory: AbsolutePath.make("/project") })),
+        ),
+      )
+
+      const explore = yield* agent.get(AgentV2.ID.make("explore"))
+      expect(explore).toBeDefined()
+      expect(PermissionV2.evaluate("shell", "git status", explore!.permissions).effect).toBe("allow")
+    }),
+  )
+
   it.effect("denies the subagent tool for built-in subagents", () =>
     Effect.gen(function* () {
       const agent = yield* AgentV2.Service

--- a/packages/core/test/agent.test.ts
+++ b/packages/core/test/agent.test.ts
@@ -155,7 +155,7 @@ describe("AgentV2", () => {
     }),
   )
 
-  it.effect("preserves V1 shell access for explore", () =>
+  it.effect("explicitly denies shell access for explore", () =>
     Effect.gen(function* () {
       const agent = yield* AgentV2.Service
       yield* AgentPlugin.Plugin.effect(
@@ -171,7 +171,8 @@ describe("AgentV2", () => {
 
       const explore = yield* agent.get(AgentV2.ID.make("explore"))
       expect(explore).toBeDefined()
-      expect(PermissionV2.evaluate("shell", "git status", explore!.permissions).effect).toBe("allow")
+      expect(explore!.permissions).toContainEqual({ action: "shell", resource: "*", effect: "deny" })
+      expect(PermissionV2.evaluate("shell", "git status", explore!.permissions).effect).toBe("deny")
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2795,6 +2795,59 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("safely rejects provider calls for tools excluded by permissions", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      const agents = yield* AgentV2.Service
+      const registry = yield* ToolRegistry.Service
+      const executions: string[] = []
+      yield* agents.transform((editor) =>
+        editor.update(AgentV2.ID.make("build"), (agent) => {
+          agent.permissions.push({ action: "shell", resource: "*", effect: "deny" })
+        }),
+      )
+      yield* registry.register({
+        shell: Tool.make({
+          description: "Run a shell command",
+          input: Schema.Struct({ command: Schema.String }),
+          output: Schema.Struct({}),
+          execute: ({ command }) =>
+            Effect.sync(() => {
+              executions.push(command)
+              return {}
+            }),
+        }),
+      })
+      yield* admit(session, "Call shell")
+
+      responses = [
+        reply.tool("call-shell", "shell", { command: "git status" }),
+        reply.text("Recovered", "text-after-shell-error"),
+      ]
+      yield* session.resume(sessionID)
+
+      expect(requests[0]?.tools.map((tool) => tool.name)).not.toContain("shell")
+      expect(executions).toEqual([])
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user", text: "Call shell" },
+        {
+          type: "assistant",
+          content: [
+            {
+              type: "tool",
+              id: "call-shell",
+              state: {
+                status: "error",
+                error: { type: "tool.unknown", message: "Unknown tool: shell" },
+              },
+            },
+          ],
+        },
+        { type: "assistant", finish: "stop", content: [{ type: "text", text: "Recovered" }] },
+      ])
+    }),
+  )
+
   it.effect("returns unexpected local tool defects to the model and continues", () =>
     Effect.gen(function* () {
       const session = yield* setup


### PR DESCRIPTION
## Summary
- verify the built-in Explore agent's default wildcard policy denies a fully unavailable `shell` tool
- verify a provider-emitted call to a permission-excluded tool is never executed
- verify the call becomes a durable unknown-tool failure and the Session continues normally

This is test-only coverage for the separate unadvertised-tool path. It does **not** address #35806: that incident involved an advertised `shell` tool with narrow resource allows, a correctly rejected command, and cleanup racing with a concurrent streamed `glob` call. PR #36067 fixes that race.

The legacy `bash` name is not registered in V2 and remains unavailable.

## Testing
- `bun test --only-failures ./test/agent.test.ts` (10 passed)
- `bun run test session-runner.test.ts` (111 passed)
- all GitHub CI checks pass