### PR TITLE
fix(runtime): upgrade Bun to fix NAPI crash on exit

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -1,6 +1,10 @@
 name: "Setup Bun"
-description: "Setup Bun with caching and install dependencies"
+description: "Resolve the channel Bun toolchain, install it, and install dependencies"
 inputs:
+  cross-compile:
+    description: "Pre-cache matching Bun runtimes for all compile targets"
+    required: false
+    default: "false"
   install-flags:
     description: "Additional flags to pass to 'bun install'"
     required: false
@@ -15,53 +19,111 @@ runs:
       with:
         node-version: "24"
 
-    - name: Get baseline download URL
+    - name: Resolve Bun toolchain
+      id: resolve
+      shell: bash
+      env:
+        GITHUB_BASE_REF: ${{ github.base_ref }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        GITHUB_WORKFLOW: ${{ github.workflow }}
+      run: node "$GITHUB_ACTION_PATH/resolve.mjs"
+
+    - name: Resolve Bun download URL
       id: bun-url
       shell: bash
+      env:
+        SELECTOR: ${{ steps.resolve.outputs.selector }}
+        BASE_URL: ${{ steps.resolve.outputs.base-url }}
       run: |
-        if [ "$RUNNER_ARCH" = "X64" ]; then
-          V=$(node -p "require('./package.json').packageManager.split('@')[1]")
-          case "$RUNNER_OS" in
-            macOS)   OS=darwin ;;
-            Linux)   OS=linux ;;
-            Windows) OS=windows ;;
-          esac
-          echo "url=https://github.com/oven-sh/bun/releases/download/bun-v${V}/bun-${OS}-x64-baseline.zip" >> "$GITHUB_OUTPUT"
+        if [ "$RUNNER_ARCH" != "X64" ]; then
+          exit
         fi
+        case "$RUNNER_OS" in
+          macOS) OS=darwin ;;
+          Linux) OS=linux ;;
+          Windows) OS=windows ;;
+        esac
+        SUFFIX=-baseline
+        if [ "$SELECTOR" = "canary" ] && [ "$OS" = "darwin" ]; then
+          SUFFIX=
+        fi
+        echo "url=${BASE_URL}/bun-${OS}-x64${SUFFIX}.zip" >> "$GITHUB_OUTPUT"
 
     - name: Setup Bun
+      id: bun
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
-        bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
+        bun-version: ${{ steps.resolve.outputs.selector }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
+
+    - name: Verify Bun toolchain
+      id: metadata
+      shell: bash
+      env:
+        SELECTOR: ${{ steps.resolve.outputs.selector }}
+      run: |
+        VERSION=$(bun --version)
+        REVISION=$(bun --revision)
+        COMPILE_VERSION=$(echo "$VERSION" | sed 's/^\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
+        if [ "$SELECTOR" = "canary" ]; then
+          echo "$REVISION" | grep -q canary
+        elif [ "${REVISION%%+*}" != "$SELECTOR" ]; then
+          echo "Expected Bun $SELECTOR, got $REVISION" >&2
+          exit 1
+        fi
+        echo "OPENCODE_BUN_VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
+        echo "compile-version=$COMPILE_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Get cache directory
       id: cache
       shell: bash
-      run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
+      run: |
+        DIR=$(bun pm cache)
+        echo "dir=$DIR" >> "$GITHUB_OUTPUT"
+        # bun build --compile only finds pre-cached target runtimes through this path.
+        echo "BUN_INSTALL_CACHE_DIR=$DIR" >> "$GITHUB_ENV"
 
     - name: Restore Bun dependencies
       id: bun-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.metadata.outputs.revision }}-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
-          ${{ runner.os }}-bun-
+          ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.metadata.outputs.revision }}-
+
+    - name: Pre-cache Bun cross-compile runtimes
+      if: inputs.cross-compile == 'true' && steps.resolve.outputs.selector == 'canary'
+      shell: bash
+      run: >-
+        bash "$GITHUB_ACTION_PATH/cache-targets.sh"
+        "${{ steps.resolve.outputs.selector }}"
+        "${{ steps.resolve.outputs.base-url }}"
+        "${{ steps.metadata.outputs.compile-version }}"
+        "${{ steps.metadata.outputs.revision }}"
+        "${{ steps.cache.outputs.dir }}"
 
     - name: Install setuptools for distutils compatibility
       run: python3 -m pip install setuptools || pip install setuptools || true
       shell: bash
 
     - name: Install dependencies
+      env:
+        SELECTOR: ${{ steps.resolve.outputs.selector }}
       run: |
         # Workaround for patched peer variants
         # e.g. ./patches/ for standard-openapi
         # https://github.com/oven-sh/bun/issues/28147
+        FROZEN=
+        if [ "$SELECTOR" = "canary" ]; then
+          FROZEN=--frozen-lockfile
+        fi
         if [ "$RUNNER_OS" = "Windows" ]; then
-          bun install --linker hoisted ${{ inputs.install-flags }}
+          bun install $FROZEN --linker hoisted ${{ inputs.install-flags }}
         else
-          bun install ${{ inputs.install-flags }}
+          bun install $FROZEN ${{ inputs.install-flags }}
         fi
       shell: bash
 
@@ -70,4 +132,4 @@ runs:
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-bun-${{ steps.metadata.outputs.revision }}-${{ hashFiles('**/bun.lock') }}

--- a/.github/actions/setup-bun/cache-targets.sh
+++ b/.github/actions/setup-bun/cache-targets.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+selector="$1"
+base_url="$2"
+version="$3"
+revision="$4"
+cache="$5"
+temp="$(mktemp -d)"
+trap 'rm -rf "$temp"' EXIT
+
+targets=(
+  linux-aarch64 linux-x64 linux-x64-baseline
+  linux-aarch64-musl linux-x64-musl linux-x64-musl-baseline
+  darwin-aarch64 darwin-x64
+  windows-aarch64 windows-x64 windows-x64-baseline
+)
+if [[ "$selector" != "canary" ]]; then
+  targets+=(darwin-x64-baseline)
+fi
+
+mkdir -p "$cache"
+for target in "${targets[@]}"; do
+  curl -fsSL "${base_url}/bun-${target}.zip" -o "$temp/bun.zip"
+  unzip -qo "$temp/bun.zip" -d "$temp"
+  binary="bun"
+  [[ "$target" == windows-* ]] && binary="bun.exe"
+  source="$temp/bun-${target}/${binary}"
+  grep -aFq "$revision" "$source"
+  install -m 755 "$source" "$cache/bun-${target}-v${version}"
+  rm -rf "$temp/bun-${target}" "$temp/bun.zip"
+done

--- a/.github/actions/setup-bun/resolve.mjs
+++ b/.github/actions/setup-bun/resolve.mjs
@@ -1,0 +1,35 @@
+import fs from "node:fs"
+import path from "node:path"
+const exact = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+
+function output(name, value) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`)
+}
+
+const config = JSON.parse(fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, "bun-versions.json"), "utf8"))
+const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"))
+const target = process.env.GITHUB_BASE_REF || process.env.GITHUB_REF_NAME
+const release =
+  process.env.GITHUB_WORKFLOW === "publish" &&
+  (event.inputs?.bump || (event.inputs?.version && !event.inputs.version.startsWith("0.0.0-")))
+const channel =
+  process.env.GITHUB_WORKFLOW === "beta" || target === "beta"
+    ? "beta"
+    : release || target === "production"
+      ? "prod"
+      : "dev"
+const selector = config[channel]
+
+if (!selector) throw new Error(`Unknown Bun channel: ${channel}`)
+if (selector !== "canary" && !exact.test(selector)) throw new Error(`Invalid Bun selector for ${channel}: ${selector}`)
+
+const pkg = JSON.parse(fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, "package.json"), "utf8"))
+if (pkg.packageManager !== `bun@${config.dev}`) throw new Error("packageManager must match the dev Bun version")
+
+output("selector", selector)
+output(
+  "base-url",
+  selector === "canary"
+    ? "https://github.com/oven-sh/bun/releases/download/canary"
+    : `https://github.com/oven-sh/bun/releases/download/bun-v${selector}`,
+)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,6 +78,8 @@ jobs:
           fetch-tags: true
 
       - uses: ./.github/actions/setup-bun
+        with:
+          cross-compile: "true"
 
       - name: Setup git committer
         id: committer

--- a/bun-versions.json
+++ b/bun-versions.json
@@ -1,0 +1,5 @@
+{
+  "dev": "1.3.14",
+  "beta": "canary",
+  "prod": "canary"
+}

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,0 +1,2 @@
+.build
+.build-*

--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -4,6 +4,7 @@ import { $ } from "bun"
 import fs from "fs"
 import { rm } from "fs/promises"
 import path from "path"
+import { createRequire } from "module"
 import { Script } from "@opencode-ai/script"
 import { createSolidTransformPlugin } from "@opentui/solid/bun-plugin"
 import pkg from "../package.json"
@@ -20,6 +21,7 @@ const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 const sourcemapsFlag = process.argv.includes("--sourcemaps")
 const plugin = createSolidTransformPlugin()
+const canary = Bun.spawnSync([process.execPath, "--revision"]).stdout.toString().includes("-canary.")
 
 const allTargets: {
   os: string
@@ -41,19 +43,33 @@ const allTargets: {
   { os: "win32", arch: "x64", avx2: false },
 ]
 
-const targets = singleFlag
-  ? allTargets.filter((item) => {
-      if (item.os !== process.platform || item.arch !== process.arch) return false
-      if (item.avx2 === false) return baselineFlag
-      return item.abi === undefined
-    })
-  : allTargets
+const targets = (
+  singleFlag
+    ? allTargets.filter((item) => {
+        if (item.os !== process.platform || item.arch !== process.arch) return false
+        if (item.avx2 === false) return baselineFlag
+        return item.abi === undefined
+      })
+    : allTargets
+).filter((item) => !(canary && item.os === "darwin" && item.arch === "x64" && item.avx2 === false))
 
-if (!skipInstall) await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
+if (!skipInstall) await $`bun install --no-save --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
 
-const localParserWorker = path.resolve(dir, "node_modules/@opentui/core/parser.worker.js")
-const rootParserWorker = path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js")
-const parserWorker = fs.realpathSync(fs.existsSync(localParserWorker) ? localParserWorker : rootParserWorker)
+const localParserWorker = "./.build/parser.worker.js"
+const installedParserWorker = fs.realpathSync(
+  fs.existsSync(path.resolve(dir, "node_modules/@opentui/core/parser.worker.js"))
+    ? path.resolve(dir, "node_modules/@opentui/core/parser.worker.js")
+    : path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js"),
+)
+await fs.promises.mkdir(path.dirname(path.resolve(dir, localParserWorker)), { recursive: true })
+await fs.promises.copyFile(installedParserWorker, path.resolve(dir, localParserWorker))
+const parserWorkerPlugin: Bun.BunPlugin = {
+  name: "local-parser-worker",
+  setup(build) {
+    const require = createRequire(installedParserWorker)
+    build.onResolve({ filter: /^web-tree-sitter(?:\/.*)?$/ }, (args) => ({ path: require.resolve(args.path) }))
+  },
+}
 
 for (const item of targets) {
   const target = [
@@ -68,9 +84,9 @@ for (const item of targets) {
   const name = target.replace(binary, "cli")
   console.log(`building ${name}`)
   const result = await Bun.build({
-    entrypoints: ["./src/index.ts", parserWorker],
+    entrypoints: ["./src/index.ts", localParserWorker],
     tsconfig: "./tsconfig.json",
-    plugins: [plugin],
+    plugins: [plugin, parserWorkerPlugin],
     external: ["node-gyp"],
     format: "esm",
     minify: true,
@@ -96,7 +112,7 @@ for (const item of targets) {
       FFF_LIBC: item.os === "linux" ? `'${item.abi ?? "gnu"}'` : "undefined",
       OTUI_TREE_SITTER_WORKER_PATH:
         (item.os === "win32" ? '"B:/~BUN/root/' : '"/$bunfs/root/') +
-        path.relative(dir, parserWorker).replaceAll("\\", "/") +
+        path.relative(dir, localParserWorker).replaceAll("\\", "/") +
         '"',
       ...(item.os === "linux" ? { "process.env.OPENTUI_LIBC": JSON.stringify(item.abi ?? "glibc") } : {}),
     },

--- a/packages/opencode/.gitignore
+++ b/packages/opencode/.gitignore
@@ -6,3 +6,4 @@ app.log
 script/build-*.ts
 temporary-*.md
 .artifacts
+.build

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -3,6 +3,7 @@
 import { $ } from "bun"
 import fs from "fs"
 import path from "path"
+import { createRequire } from "module"
 import { fileURLToPath } from "url"
 import { createSolidTransformPlugin } from "@opentui/solid/bun-plugin"
 
@@ -23,6 +24,7 @@ const skipInstall = process.argv.includes("--skip-install")
 const sourcemapsFlag = process.argv.includes("--sourcemaps")
 const plugin = createSolidTransformPlugin()
 const skipEmbedWebUi = process.argv.includes("--skip-embed-web-ui")
+const canary = Bun.spawnSync([process.execPath, "--revision"]).stdout.toString().includes("-canary.")
 
 const createEmbeddedWebUIBundle = async () => {
   console.log(`Building Web UI to embed in the binary`)
@@ -113,34 +115,54 @@ const allTargets: {
   },
 ]
 
-const targets = singleFlag
-  ? allTargets.filter((item) => {
-      if (item.os !== process.platform || item.arch !== process.arch) {
-        return false
-      }
+const targets = (
+  singleFlag
+    ? allTargets.filter((item) => {
+        if (item.os !== process.platform || item.arch !== process.arch) {
+          return false
+        }
 
-      // When building for the current platform, prefer a single native binary by default.
-      // Baseline binaries require additional Bun artifacts and can be flaky to download.
-      if (item.avx2 === false) {
-        return baselineFlag
-      }
+        // When building for the current platform, prefer a single native binary by default.
+        // Baseline binaries require additional Bun artifacts and can be flaky to download.
+        if (item.avx2 === false) {
+          return baselineFlag
+        }
 
-      // also skip abi-specific builds for the same reason
-      if (item.abi !== undefined) {
-        return false
-      }
+        // also skip abi-specific builds for the same reason
+        if (item.abi !== undefined) {
+          return false
+        }
 
-      return true
-    })
-  : allTargets
+        return true
+      })
+    : allTargets
+)
+  // Bun does not publish a current Darwin x64 baseline canary, so we must not publish one either
+  .filter((item) => !(canary && item.os === "darwin" && item.arch === "x64" && item.avx2 === false))
 
 await $`rm -rf dist`
 
+const localParserWorker = "./.build/parser.worker.js"
+const installedParserWorker = fs.realpathSync(
+  fs.existsSync(path.resolve(dir, "node_modules/@opentui/core/parser.worker.js"))
+    ? path.resolve(dir, "node_modules/@opentui/core/parser.worker.js")
+    : path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js"),
+)
+await fs.promises.mkdir(path.dirname(path.resolve(dir, localParserWorker)), { recursive: true })
+await fs.promises.copyFile(installedParserWorker, path.resolve(dir, localParserWorker))
+const parserWorkerPlugin: Bun.BunPlugin = {
+  name: "local-parser-worker",
+  setup(build) {
+    const require = createRequire(installedParserWorker)
+    build.onResolve({ filter: /^web-tree-sitter(?:\/.*)?$/ }, (args) => ({ path: require.resolve(args.path) }))
+  },
+}
+
 const binaries: Record<string, string> = {}
 if (!skipInstall) {
-  await $`bun install --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
-  await $`bun install --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
-  await $`bun install --os="*" --cpu="*" @ff-labs/fff-bun@${pkg.dependencies["@ff-labs/fff-bun"]}`
+  await $`bun install --no-save --os="*" --cpu="*" @opentui/core@${pkg.dependencies["@opentui/core"]}`
+  await $`bun install --no-save --os="*" --cpu="*" @parcel/watcher@${pkg.dependencies["@parcel/watcher"]}`
+  await $`bun install --no-save --os="*" --cpu="*" @ff-labs/fff-bun@${pkg.dependencies["@ff-labs/fff-bun"]}`
 }
 for (const item of targets) {
   const name = [
@@ -156,19 +178,16 @@ for (const item of targets) {
   console.log(`building ${name}`)
   await $`mkdir -p dist/${name}/bin`
 
-  const localPath = path.resolve(dir, "node_modules/@opentui/core/parser.worker.js")
-  const rootPath = path.resolve(dir, "../../node_modules/@opentui/core/parser.worker.js")
-  const parserWorker = fs.realpathSync(fs.existsSync(localPath) ? localPath : rootPath)
   const workerPath = "./src/cli/tui/worker.ts"
 
   // Use platform-specific bunfs root path based on target OS
   const bunfsRoot = item.os === "win32" ? "B:/~BUN/root/" : "/$bunfs/root/"
-  const workerRelativePath = path.relative(dir, parserWorker).replaceAll("\\", "/")
+  const workerRelativePath = path.relative(dir, localParserWorker).replaceAll("\\", "/")
 
   await Bun.build({
     conditions: ["bun", "node"],
     tsconfig: "./tsconfig.json",
-    plugins: [plugin],
+    plugins: [plugin, parserWorkerPlugin],
     external: ["node-gyp"],
     format: "esm",
     minify: true,
@@ -185,7 +204,7 @@ for (const item of targets) {
       windows: {},
     },
     files: embeddedFileMap ? { "opencode-web-ui.gen.ts": embeddedFileMap } : {},
-    entrypoints: ["./src/index.ts", parserWorker, workerPath, ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
+    entrypoints: ["./src/index.ts", localParserWorker, workerPath, ...(embeddedFileMap ? ["opencode-web-ui.gen.ts"] : [])],
     define: {
       FFF_LIBC: JSON.stringify(item.abi === "musl" ? "musl" : "gnu"),
       OPENCODE_VERSION: `'${Script.version}'`,


### PR DESCRIPTION
## Summary

Upgrades Bun to canary for stable builds to fix the NAPI crash that occurs on exit across all platforms (Windows, macOS, Linux).

Fixes #28046
Fixes #31563

## Root Cause

The crash is caused by an upstream Bun bug where NAPI finalizer tasks crash during GC sweep at exit:

- **Issue**: [oven-sh/bun#32144](https://github.com/oven-sh/bun/issues/32144)
- **Fix commit**: [`7146d69`](https://github.com/oven-sh/bun/commit/7146d69) - "jsc: drain cleanup hooks in global_exit so deferred napi finalizers don't leak" (merged 2026-06-12)

The fix is in Bun's main branch but not yet in any stable release (latest stable is still 1.3.14).

## Changes

- Add `bun-versions.json` to control Bun version per channel (dev/beta/prod)
- Set `prod` channel to use `canary` (contains the NAPI fix)
- Update `setup-bun` action to resolve channel-specific Bun toolchain
- Add cross-compile runtime caching for canary builds
- Update build scripts to handle canary-specific limitations:
  - Darwin x64 baseline not published for canary
  - Use `--no-save` to prevent lockfile churn with cross-platform installs
- Add `.gitignore` entries for build artifacts

## Platforms Affected

- Windows
- macOS  
- Linux

## Testing

- [ ] Build opencode with the new Bun version
- [ ] Run a session, perform some work, exit cleanly
- [ ] Verify no NAPI panic on shutdown

## Notes

Once Bun 1.3.15 (or a later stable release containing the fix) is released, `bun-versions.json` can be updated to use the stable version instead of canary.