### PR TITLE
fix(core): extract zips with tar on Windows instead of Expand-Archive

### DIFF
--- a/packages/core/src/ripgrep/binary.ts
+++ b/packages/core/src/ripgrep/binary.ts
@@ -55,27 +55,15 @@ export namespace RipgrepBinary {
       ) {
         const dir = yield* fs.makeTempDirectoryScoped({ directory: Global.Path.bin, prefix: "ripgrep-" })
 
-        if (config.extension === "zip") {
-          const shell = (yield* Effect.sync(() => which("powershell.exe") ?? which("pwsh.exe"))) ?? "powershell.exe"
-          const result = yield* run(shell, [
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath '${archive.replaceAll("'", "''")}' -DestinationPath '${dir.replaceAll("'", "''")}' -Force`,
-          ])
-          if (result.code !== 0)
-            throw new Error(
-              result.stderr.trim() || result.stdout.trim() || `ripgrep extraction failed with code ${result.code}`,
-            )
-        }
-
-        if (config.extension === "tar.gz") {
-          const result = yield* run("tar", ["-xzf", archive, "-C", dir])
-          if (result.code !== 0)
-            throw new Error(
-              result.stderr.trim() || result.stdout.trim() || `ripgrep extraction failed with code ${result.code}`,
-            )
-        }
+        // zip is extracted with tar too: Windows ships bsdtar as tar.exe since
+        // Windows 10 1803 (Bun needs 1809+) and it reads zip natively. PowerShell's
+        // Expand-Archive can't be used: module autoload fails when powershell.exe
+        // is spawned from the Bun-compiled binary (#24291).
+        const result = yield* run("tar", [config.extension === "zip" ? "-xf" : "-xzf", archive, "-C", dir])
+        if (result.code !== 0)
+          throw new Error(
+            result.stderr.trim() || result.stdout.trim() || `ripgrep extraction failed with code ${result.code}`,
+          )
 
         const extracted = path.join(
           dir,

--- a/packages/opencode/src/util/archive.ts
+++ b/packages/opencode/src/util/archive.ts
@@ -1,13 +1,15 @@
+import fs from "fs/promises"
 import path from "path"
 import * as Process from "./process"
 
 export async function extractZip(zipPath: string, destDir: string) {
   if (process.platform === "win32") {
-    const winZipPath = path.resolve(zipPath)
+    // tar.exe (bsdtar) ships with Windows 10 1803+ (Bun needs 1809+) and extracts
+    // zip natively. PowerShell's Expand-Archive can't be used: module autoload
+    // fails when powershell.exe is spawned from the Bun-compiled binary (#24291).
     const winDestDir = path.resolve(destDir)
-    // $global:ProgressPreference suppresses PowerShell's blue progress bar popup
-    const cmd = `$global:ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path '${winZipPath}' -DestinationPath '${winDestDir}' -Force`
-    await Process.run(["powershell", "-NoProfile", "-NonInteractive", "-Command", cmd])
+    await fs.mkdir(winDestDir, { recursive: true })
+    await Process.run(["tar", "-xf", path.resolve(zipPath), "-C", winDestDir])
     return
   }
 


### PR DESCRIPTION
### Issue for this PR

Closes #24291

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, zip extraction (the ripgrep download and LSP server installs) shells out to PowerShell's `Expand-Archive`. When opencode runs as the Bun-compiled binary, `powershell.exe` fails to autoload `Microsoft.PowerShell.Archive` ("the module could not be loaded"), which breaks the `skill` and `glob` tools.

The fix swaps both PowerShell call sites for Windows' built-in `tar.exe`. Why this works: Windows has shipped bsdtar since Windows 10 1803 and Bun requires 1809+, so `tar` is always present on any machine that can run opencode, and bsdtar reads zip archives natively — no PowerShell process, no module autoload, so the Bun environment issue can't be hit. This also matches the tar.gz extraction path already used on macOS/Linux.

- `packages/core/src/ripgrep/binary.ts`: zip and tar.gz now share one `tar` invocation (`-xf` vs `-xzf`)
- `packages/opencode/src/util/archive.ts`: same swap; adds an explicit mkdir for the destination (`Expand-Archive` created it implicitly, `tar -C` does not) and removes the single-quote interpolation that broke on paths containing `'`

### How did you verify your code works?

- On Windows 11: extracted a ripgrep-layout zip with nested dirs, spaces and apostrophes in file names via the exact `tar -xf <zip> -C <dest>` invocation; re-extracted over existing files to confirm overwrite parity with `-Force`; exit 0 and correct contents both times.
- `bun run typecheck` passes in `packages/core` and `packages/opencode`; full pre-push turbo typecheck green (30/30).

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR