### PR TITLE
fix(opencode): strip carriage returns from question prompt text

### DIFF
--- a/packages/opencode/src/question/index.ts
+++ b/packages/opencode/src/question/index.ts
@@ -97,7 +97,7 @@ const layer = Layer.effect(
       const info: Request = {
         id,
         sessionID: input.sessionID,
-        questions: input.questions,
+        questions: input.questions.map(sanitizeQuestion),
         tool: input.tool,
       }
       pending.set(id, { info, deferred })
@@ -157,5 +157,25 @@ const layer = Layer.effect(
 )
 
 export const node = LayerNode.make({ service: Service, layer: layer, deps: [EventV2Bridge.node] })
+
+// Models sometimes emit carriage returns in question/option text, which the TUI
+// renderer treats as hard line breaks (every word on its own line). Normalize CR
+// out of the body and collapse newlines in short labels before the data is stored
+// and broadcast to every render surface (TUI, footer, web, scrollback).
+function sanitizeQuestion(info: Info): Info {
+  return {
+    ...info,
+    question: info.question.replace(/\r\n?/g, "\n"),
+    header: collapse(info.header),
+    options: info.options.map((o) => ({
+      label: collapse(o.label),
+      description: collapse(o.description),
+    })),
+  }
+}
+
+function collapse(text: string): string {
+  return text.replace(/\s*[\r\n]+\s*/g, " ").trim()
+}
 
 export * as Question from "."


### PR DESCRIPTION
Fixes #36040

### Problem

Some model providers emit carriage-return (`\r`) characters inside the `question`/ask tool's header, question body, and option `label`/`description`. The TUI's opentui renderer treats a bare `\r` as a hard line break, so the prompt renders with nearly every word on its own line (very visible with CJK text).

### Fix

Normalize the strings in `Question.ask` (`packages/opencode/src/question/index.ts`) — the single ingress where question data is minted and broadcast via the `question.asked` event to every render surface (TUI, CLI footer, web dock, scrollback). Fixing it here covers all consumers with one change instead of patching each renderer.

- The multi-line **question body** only has `\r` normalized to `\n`, preserving intentional line breaks.
- The short **header / label / description** fields (annotated as very short labels) collapse surrounding whitespace/newlines to single spaces.

```ts
questions: input.questions.map(sanitizeQuestion),
// ...
function sanitizeQuestion(info: Info): Info {
  return {
    ...info,
    question: info.question.replace(/\r\n?/g, "\n"),
    header: collapse(info.header),
    options: info.options.map((o) => ({
      label: collapse(o.label),
      description: collapse(o.description),
    })),
  }
}

function collapse(text: string): string {
  return text.replace(/\s*[\r\n]+\s*/g, " ").trim()
}
```

### Why this layer (and not schema / opentui)

- **Not the schema package.** This is runtime string normalization, not a wire/storage contract — the schema package guide explicitly keeps runtime behavior out of contract definitions. The active runtime path also uses the frozen `question-v1` subtree, which current code must not modify.
- **Not opentui.** That's a separate upstream renderer and would only fix the terminal, not the CLI/web string consumers.
- **`Question.ask` is the correct choke point** — it already builds the `Request` payload that every surface reads. This also mirrors existing precedent: several surfaces already do their own `\r\n?` normalization (e.g. the prompt textarea, and app-side row/message rendering).

### Notes

- Unicode line separators U+2028/U+2029 are not handled here; there's no evidence any provider emits them and `\r` is the observed real-world cause. Easy to extend the regexes if that ever surfaces.

### Testing

Verified the normalization against the reported input (CR after every word/segment): headers/labels collapse to single-spaced text and the question body keeps intentional newlines while dropping stray `\r`.

> Note: I couldn't run the full `bun typecheck` locally because `bun install` was blocked by GitHub rate-limiting on a git dependency (`ghostty-web`) in my environment. The change is a small, self-contained TypeScript edit and field types match the `Question.Info` contract; happy to adjust if CI flags anything.
