### PR TITLE
docs: add @aiand/opencode-plugin to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [@aiand/opencode-plugin](https://github.com/aiandlabs/aiand-opencode-plugin)                       | Adds ai& as a provider — live model catalog and API-key login via the ai& gateway                  |
 
 ---
 


### PR DESCRIPTION
Adds [`@aiand/opencode-plugin`](https://github.com/aiandlabs/aiand-opencode-plugin) to the Plugins table.

It registers [ai&](https://aiand.com) (an OpenAI-compatible inference platform) as a provider: routes to the ai& gateway, populates the model picker from ai&'s live public catalog, and adds an "ai& API Key" method to `opencode auth login`.

Published on npm with provenance: [`@aiand/opencode-plugin`](https://www.npmjs.com/package/@aiand/opencode-plugin).