### PR TITLE
fix(tui): batch streaming part deltas to keep TUI responsive during fast streams

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -167,6 +167,41 @@ export const {
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 
+    // Fast-streaming models emit message.part.delta faster than the renderer
+    // keeps up; applying every chunk synchronously starves input handling and
+    // freezes scrolling (#36043). Deltas accumulate per part field and flush
+    // together on a short interval instead.
+    const pendingDeltas = new Map<string, { messageID: string; partID: string; field: string; delta: string }>()
+    let deltaTimer: ReturnType<typeof setTimeout> | undefined
+    const dropPendingDeltas = (messageID: string, partID: string) => {
+      if (!pendingDeltas.size) return
+      const prefix = `${messageID}|${partID}|`
+      for (const key of pendingDeltas.keys()) if (key.startsWith(prefix)) pendingDeltas.delete(key)
+    }
+    const flushDeltas = () => {
+      deltaTimer = undefined
+      if (!pendingDeltas.size) return
+      batch(() => {
+        for (const pending of pendingDeltas.values()) {
+          const parts = store.part[pending.messageID]
+          if (!parts) continue
+          const result = search(parts, pending.partID, (p) => p.id)
+          if (!result.found) continue
+          setStore(
+            "part",
+            pending.messageID,
+            produce((draft) => {
+              const part = draft[result.index]
+              const field = pending.field as keyof typeof part
+              const existing = part[field] as string | undefined
+              ;(part[field] as string) = (existing ?? "") + pending.delta
+            }),
+          )
+        }
+        pendingDeltas.clear()
+      })
+    }
+
     event.subscribe((event, { directory, workspace }) => {
       switch (event.type) {
         case "server.instance.disposed":
@@ -368,6 +403,8 @@ export const {
           break
         }
         case "message.part.updated": {
+          // full snapshot supersedes any buffered deltas for this part
+          dropPendingDeltas(event.properties.part.messageID, event.properties.part.id)
           touchPart(event.properties.part.sessionID, event.properties.part.id)
           const parts = store.part[event.properties.part.messageID]
           if (!parts) {
@@ -395,16 +432,17 @@ export const {
           const result = search(parts, event.properties.partID, (p) => p.id)
           if (!result.found) break
           touchPart(event.properties.sessionID, event.properties.partID)
-          setStore(
-            "part",
-            event.properties.messageID,
-            produce((draft) => {
-              const part = draft[result.index]
-              const field = event.properties.field as keyof typeof part
-              const existing = part[field] as string | undefined
-              ;(part[field] as string) = (existing ?? "") + event.properties.delta
-            }),
-          )
+          const key = `${event.properties.messageID}|${event.properties.partID}|${event.properties.field}`
+          const pending = pendingDeltas.get(key)
+          if (pending) pending.delta += event.properties.delta
+          else
+            pendingDeltas.set(key, {
+              messageID: event.properties.messageID,
+              partID: event.properties.partID,
+              field: event.properties.field,
+              delta: event.properties.delta,
+            })
+          if (!deltaTimer) deltaTimer = setTimeout(flushDeltas, 40)
           break
         }
 


### PR DESCRIPTION
### Issue for this PR

Closes #36043

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Every `message.part.delta` SSE event was applied to the Solid store synchronously (`packages/tui/src/context/sync.tsx`), so each streamed chunk triggered reactivity and a re-render of the growing text part. Models with high chunk rates (GLM in my case) saturate the render loop, and queued input — scrolling in particular — stalls for several seconds, even in a brand-new conversation.

The fix accumulates deltas per part field in a small buffer and flushes them together every 40ms inside a single `batch()`. Why the final state is unchanged: flushing applies the concatenated delta exactly where the per-chunk appends would have landed, and a `message.part.updated` snapshot drops any buffered deltas for that part before reconciling (the snapshot already contains that text, so applying them afterwards would duplicate it). Removed parts/messages are skipped at flush time, same outcome as the previous per-chunk path.

### How did you verify your code works?

- `bun run typecheck` passes in `packages/tui`.
- `bun test` in `packages/tui`: no new failures vs a clean `dev` checkout on the same machine (dev fails 5, this branch fails 3 — the remaining ones are pre-existing environment-flaky tests: SIGHUP/title handling and home-path abbreviation on Windows).
- I am dogfooding this branch on the exact setup that reproduces #36043 (Windows 11 TUI + GLM) and will report back on the issue.

### Screenshots / recordings

Not a visual change — behavior fix (scroll responsiveness while streaming).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR