### PR TITLE
fix(tui): show permission prompts from nested subagent chains

### DIFF
--- a/packages/app/src/context/permission-auto-respond.test.ts
+++ b/packages/app/src/context/permission-auto-respond.test.ts
@@ -104,6 +104,45 @@ describe("autoRespondsPermission", () => {
 
     expect(autoRespondsPermission(autoAccept, sessions, permission("child"), directory)).toBe(true)
   })
+
+  test("inherits an ancestor's directory-scoped auto-accept across a grandchild", () => {
+    const directory = "/tmp/project"
+    // root → child → grandchild lineage
+    const sessions = [
+      session({ id: "root" }),
+      session({ id: "child", parentID: "root" }),
+      session({ id: "grandchild", parentID: "child" }),
+    ]
+    const autoAccept = {
+      [`${base64Encode(directory)}/root`]: true,
+    }
+
+    expect(autoRespondsPermission(autoAccept, sessions, permission("grandchild"), directory)).toBe(true)
+  })
+
+  test("inherits a root session's legacy auto-accept key from a grandchild", () => {
+    const sessions = [
+      session({ id: "root" }),
+      session({ id: "child", parentID: "root" }),
+      session({ id: "grandchild", parentID: "child" }),
+    ]
+
+    expect(autoRespondsPermission({ root: true }, sessions, permission("grandchild"), "/tmp/project")).toBe(true)
+  })
+
+  test("requires approval for a grandchild with no ancestor override", () => {
+    const sessions = [
+      session({ id: "root" }),
+      session({ id: "child", parentID: "root" }),
+      session({ id: "grandchild", parentID: "child" }),
+      session({ id: "unrelated" }),
+    ]
+    const autoAccept = {
+      unrelated: true,
+    }
+
+    expect(autoRespondsPermission(autoAccept, sessions, permission("grandchild"), "/tmp/project")).toBe(false)
+  })
 })
 
 describe("isDirectoryAutoAccepting", () => {

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -15,7 +15,7 @@
 // The tick counter prevents stale idle events from resolving the wrong turn.
 // We also re-check live session status before resolving an idle event so a
 // delayed idle from an older turn cannot complete a newer busy turn.
-import type { Event, GlobalEvent, OpencodeClient } from "@opencode-ai/sdk/v2"
+import type { Event, GlobalEvent, OpencodeClient, Session } from "@opencode-ai/sdk/v2"
 import { Context, Deferred, Effect, Exit, Layer, Scope, Stream } from "effect"
 import { makeRuntime } from "@/effect/run-service"
 import {
@@ -388,6 +388,42 @@ function traceTabs(trace: Trace | undefined, prev: FooterSubagentTab[], next: Fo
   }
 }
 
+const collectDescendantSessions = Effect.fn("RunStreamTransport.collectDescendantSessions")(function* (
+  sdk: OpencodeClient,
+  rootSessionID: string,
+) {
+  const visited = new Set<string>([rootSessionID])
+  const descendants: Session[] = []
+  let frontier = [rootSessionID]
+
+  while (frontier.length > 0) {
+    const levels = yield* Effect.all(
+      frontier.map((sessionID) =>
+        Effect.promise(() => sdk.session.children({ sessionID })).pipe(
+          Effect.map((item) => item.data ?? []),
+          Effect.orElseSucceed(() => []),
+        ),
+      ),
+      { concurrency: "unbounded" },
+    )
+
+    frontier = []
+    for (const children of levels) {
+      for (const child of children) {
+        if (visited.has(child.id)) {
+          continue
+        }
+
+        visited.add(child.id)
+        descendants.push(child)
+        frontier.push(child.id)
+      }
+    }
+  }
+
+  return descendants
+})
+
 function createLayer(input: StreamInput) {
   return Layer.fresh(
     Layer.effect(
@@ -684,14 +720,7 @@ function createLayer(input: StreamInput) {
                     : Math.max(input.replayLimit, SUBAGENT_BOOTSTRAP_LIMIT)
                   : SUBAGENT_BOOTSTRAP_LIMIT,
               ),
-              Effect.promise(() =>
-                input.sdk.session.children({
-                  sessionID: input.sessionID,
-                }),
-              ).pipe(
-                Effect.map((item) => item.data ?? []),
-                Effect.orElseSucceed(() => []),
-              ),
+              collectDescendantSessions(input.sdk, input.sessionID),
               Effect.promise(() => input.sdk.permission.list()).pipe(
                 Effect.map((item) => item.data ?? []),
                 Effect.orElseSucceed(() => []),

--- a/packages/opencode/src/cli/cmd/run/subagent-data.ts
+++ b/packages/opencode/src/cli/cmd/run/subagent-data.ts
@@ -798,6 +798,7 @@ export function reduceSubagentData(input: {
 }) {
   const event = input.event
 
+  let changed = false
   if (event.type === "message.part.updated") {
     const part = event.properties.part
     if (part.sessionID === input.sessionID) {
@@ -806,6 +807,10 @@ export function reduceSubagentData(input: {
       }
 
       return syncTaskTab(input.data, part)
+    }
+
+    if (part.type === "tool" && knownSession(input.data, part.sessionID)) {
+      changed = syncTaskTab(input.data, part)
     }
   }
 
@@ -871,6 +876,6 @@ export function reduceSubagentData(input: {
       event,
       thinking: input.thinking,
       limits: input.limits,
-    }) || cancelled
+    }) || cancelled || changed
   )
 }

--- a/packages/opencode/test/cli/run/stream.transport.test.ts
+++ b/packages/opencode/test/cli/run/stream.transport.test.ts
@@ -1399,6 +1399,132 @@ describe("run stream transport", () => {
     }
   })
 
+  test("bootstraps grandchild tabs and permissions from a nested subagent chain", async () => {
+    const src = eventFeed()
+    const ui = footer()
+    const transport = await createSessionTransport({
+      sdk: sdk({
+        stream: src.stream,
+        messages: async ({ sessionID }) => {
+          if (sessionID === "session-1") {
+            return ok([
+              assistantMessage({
+                sessionID: "session-1",
+                id: "msg-1",
+                parts: [
+                  runningTool({
+                    sessionID: "session-1",
+                    messageID: "msg-1",
+                    id: "task-1",
+                    callID: "call-1",
+                    tool: "task",
+                    body: {
+                      description: "Explore run folder",
+                      subagent_type: "explore",
+                    },
+                    metadata: {
+                      sessionId: "child-1",
+                    },
+                  }),
+                ],
+              }),
+            ])
+          }
+
+          if (sessionID === "child-1") {
+            return ok([
+              assistantMessage({
+                sessionID: "child-1",
+                id: "msg-child-1",
+                parts: [
+                  runningTool({
+                    sessionID: "child-1",
+                    messageID: "msg-child-1",
+                    id: "task-2",
+                    callID: "call-2",
+                    tool: "task",
+                    body: {
+                      description: "Grep for callers",
+                      subagent_type: "explore",
+                    },
+                    metadata: {
+                      sessionId: "grandchild-1",
+                    },
+                  }),
+                ],
+              }),
+            ])
+          }
+
+          return ok([
+            assistantMessage({
+              sessionID: "grandchild-1",
+              id: "msg-grandchild-1",
+              parts: [
+                runningTool({
+                  sessionID: "grandchild-1",
+                  messageID: "msg-grandchild-1",
+                  id: "grep-1",
+                  callID: "call-grep-1",
+                  tool: "grep",
+                  body: {
+                    pattern: "callers",
+                  },
+                }),
+              ],
+            }),
+          ])
+        },
+        children: async ({ sessionID }) => {
+          if (sessionID === "session-1") return ok([child("child-1")])
+          if (sessionID === "child-1") return ok([child("grandchild-1")])
+          return ok([])
+        },
+        permissions: async () =>
+          ok([
+            {
+              id: "perm-grandchild-1",
+              sessionID: "grandchild-1",
+              permission: "grep",
+              patterns: ["callers"],
+              metadata: {},
+              always: [],
+              tool: {
+                messageID: "msg-grandchild-1",
+                callID: "call-grep-1",
+              },
+            },
+          ]),
+      }),
+      sessionID: "session-1",
+      thinking: true,
+      limits: () => ({}),
+      footer: ui.api,
+    })
+
+    try {
+      const boot = await waitFor(() => {
+        const item = ui.events.findLast((event) => event.type === "stream.subagent")
+        const state = item?.type === "stream.subagent" ? item.state : undefined
+        return state?.tabs.some((tab) => tab.sessionID === "grandchild-1") &&
+          state.permissions.some((req) => req.id === "perm-grandchild-1")
+          ? state
+          : undefined
+      })
+
+      expect(boot.tabs.map((tab) => tab.sessionID).sort()).toEqual(["child-1", "grandchild-1"])
+      expect(boot.permissions).toEqual([
+        expect.objectContaining({
+          id: "perm-grandchild-1",
+          sessionID: "grandchild-1",
+        }),
+      ])
+    } finally {
+      src.close()
+      await transport.close()
+    }
+  })
+
   test("bootstraps child session output before selection", async () => {
     const ui = footer()
     const transport = await createSessionTransport({

--- a/packages/opencode/test/cli/run/subagent-data.test.ts
+++ b/packages/opencode/test/cli/run/subagent-data.test.ts
@@ -544,4 +544,64 @@ describe("run subagent data", () => {
       }),
     ])
   })
+
+  test("registers a grandchild tab when a known child session spawns a nested task", () => {
+    const data = createSubagentData()
+
+    bootstrapSubagentData({
+      data,
+      messages: [taskMessage("child-1", "running")],
+      children: [{ id: "child-1" }],
+      permissions: [],
+      questions: [],
+    })
+
+    const changed = reduce(data, {
+      type: "message.part.updated",
+      properties: {
+        part: {
+          id: "part-grandchild-1",
+          sessionID: "child-1",
+          messageID: "msg-child-1",
+          type: "tool",
+          callID: "call-grandchild-1",
+          tool: "task",
+          state: {
+            status: "running",
+            input: {
+              description: "Grep for callers",
+              subagent_type: "explore",
+            },
+            metadata: {
+              sessionId: "grandchild-1",
+            },
+            time: { start: 1 },
+          },
+        },
+      },
+    })
+
+    expect(changed).toBe(true)
+
+    const tabs = snapshotSubagentData(data).tabs
+    expect(tabs.map((tab) => tab.sessionID).sort()).toEqual(["child-1", "grandchild-1"])
+
+    reduce(data, {
+      type: "permission.asked",
+      properties: {
+        id: "perm-grandchild-1",
+        sessionID: "grandchild-1",
+        permission: "grep",
+        patterns: ["callers"],
+        metadata: {},
+        always: [],
+        tool: {
+          messageID: "msg-grandchild-1",
+          callID: "call-grep-1",
+        },
+      },
+    })
+
+    expect(snapshotSubagentData(data).permissions.map((item) => item.id)).toEqual(["perm-grandchild-1"])
+  })
 })

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -31,6 +31,7 @@ import type {
   AssistantMessage,
   Part,
   Provider,
+  Session,
   ToolPart,
   UserMessage,
   TextPart,
@@ -224,14 +225,14 @@ export function Session() {
         )
       : [],
   )
-  const permissions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.permission[x.id] ?? [])
+  const subtree = createMemo(() => {
+    // NOTE: 仅根会话收集整棵子树的权限/问题；子会话自身不重复收集（避免与父视图双重展示）
+    const s = session()
+    if (!s || s.parentID) return []
+    return collectSubtree(sync.data.session, s.id)
   })
-  const questions = createMemo(() => {
-    if (session()?.parentID) return []
-    return children().flatMap((x) => sync.data.question[x.id] ?? [])
-  })
+  const permissions = createMemo(() => subtree().flatMap((x) => sync.data.permission[x.id] ?? []))
+  const questions = createMemo(() => subtree().flatMap((x) => sync.data.question[x.id] ?? []))
   const visible = createMemo(() => !session()?.parentID && permissions().length === 0 && questions().length === 0)
   const disabled = createMemo(() => permissions().length > 0 || questions().length > 0)
 
@@ -2651,6 +2652,31 @@ export function toolDisplay(tool: string) {
 function recordValue(value: unknown): Record<string, unknown> | undefined {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return
   return value as Record<string, unknown>
+}
+
+export function collectSubtree(sessions: Session[], rootID: string): Session[] {
+  const root = sessions.find((item) => item.id === rootID)
+  if (!root) return []
+  const childrenByParent = new Map<string, Session[]>()
+  for (const item of sessions) {
+    if (!item.parentID) continue
+    const siblings = childrenByParent.get(item.parentID) ?? []
+    siblings.push(item)
+    childrenByParent.set(item.parentID, siblings)
+  }
+  const result = [root]
+  const visited = new Set([root.id])
+  const queue = [root]
+  while (queue.length > 0) {
+    const current = queue.shift()!
+    for (const child of childrenByParent.get(current.id) ?? []) {
+      if (visited.has(child.id)) continue
+      visited.add(child.id)
+      result.push(child)
+      queue.push(child)
+    }
+  }
+  return result
 }
 
 export function parseApplyPatchFiles(value: unknown) {

--- a/packages/tui/test/routes/session/collect-subtree.test.ts
+++ b/packages/tui/test/routes/session/collect-subtree.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2"
+import { collectSubtree } from "../../../src/routes/session"
+
+const s = (input: { id: string; parentID?: string }) =>
+  ({
+    id: input.id,
+    parentID: input.parentID,
+    title: input.id,
+  }) as Session
+
+describe("collectSubtree", () => {
+  test("returns only root when there are no children", () => {
+    const result = collectSubtree([s({ id: "root" })], "root")
+    expect(result.map((x) => x.id)).toEqual(["root"])
+  })
+
+  test("returns root with direct children", () => {
+    const sessions = [s({ id: "root" }), s({ id: "child-1", parentID: "root" }), s({ id: "child-2", parentID: "root" })]
+    const result = collectSubtree(sessions, "root")
+    expect(result.map((x) => x.id).sort()).toEqual(["child-1", "child-2", "root"])
+    expect(result[0].id).toBe("root")
+  })
+
+  test("returns the full chain for a three-level tree", () => {
+    const sessions = [
+      s({ id: "root" }),
+      s({ id: "child", parentID: "root" }),
+      s({ id: "grandchild", parentID: "child" }),
+    ]
+    const result = collectSubtree(sessions, "root")
+    expect(result.map((x) => x.id).sort()).toEqual(["child", "grandchild", "root"])
+    expect(result[0].id).toBe("root")
+  })
+
+  test("does not cross sibling branches", () => {
+    const sessions = [
+      s({ id: "root" }),
+      s({ id: "child-1", parentID: "root" }),
+      s({ id: "grandchild-1", parentID: "child-1" }),
+      s({ id: "child-2", parentID: "root" }),
+      s({ id: "grandchild-2", parentID: "child-2" }),
+    ]
+    expect(collectSubtree(sessions, "root").map((x) => x.id).sort()).toEqual(
+      ["child-1", "child-2", "grandchild-1", "grandchild-2", "root"],
+    )
+    expect(collectSubtree(sessions, "child-1").map((x) => x.id).sort()).toEqual(["child-1", "grandchild-1"])
+  })
+
+  test("includes root itself in the result", () => {
+    const sessions = [s({ id: "root" }), s({ id: "child", parentID: "root" })]
+    const ids = collectSubtree(sessions, "root").map((x) => x.id)
+    expect(ids).toContain("root")
+  })
+
+  test("returns empty array when root is missing", () => {
+    expect(collectSubtree([s({ id: "child", parentID: "root" })], "root")).toEqual([])
+  })
+
+  test("does not loop forever on a parentID cycle", () => {
+    const sessions = [
+      s({ id: "root", parentID: "child" }),
+      s({ id: "child", parentID: "root" }),
+    ]
+    const ids = collectSubtree(sessions, "root").map((x) => x.id)
+    expect(ids).toContain("root")
+    expect(ids).toContain("child")
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #13715

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Nested subagents (a subagent spawning its own subagent) could trigger a permission request that was never rendered in the UI, deadlocking the whole call chain. The TUI and CLI only tracked direct child sessions, so grandchild session events were silently dropped and the user had no way to approve the pending permission.

Root cause: both the TUI's permission collection and the CLI's subagent footer only looked one level deep in the session tree (direct children), instead of the full subtree. The permission events themselves were delivered correctly (SSE broadcast is not session-scoped) — the gap was purely in how the UI/CLI decided which sessions to display.

Changes:

- `packages/tui/src/routes/session/index.tsx`: collect the full session subtree (not just direct children) when gathering pending permissions/questions. Added a `collectSubtree` helper and a `subtree()` memo; the existing `children()` memo is left untouched since it's still used for tab navigation, which should stay direct-children-only.
- `packages/opencode/src/cli/cmd/run/stream.transport.ts`: bootstrap the CLI subagent footer with all descendants via a level-by-level BFS (`collectDescendantSessions`) instead of a single `session.children()` call, so a reconnect/cold start picks up grandchild sessions too.
- `packages/opencode/src/cli/cmd/run/subagent-data.ts`: in `reduceSubagentData`, register a grandchild tab when a known child session spawns a nested task, without skipping the child's own event tracking (previously the function returned early only for the root session's own task events).
- `packages/app/src/context/permission-auto-respond.test.ts`: added regression coverage for a three-level session chain. The auto-accept lookup already walks the full parent chain (`sessionLineage`), so no code change was needed there — just locking in the behavior with a test.

### How did you verify your code works?

- `bun run typecheck` passes in `packages/opencode`, `packages/tui`, and `packages/app`.
- Added unit tests: `collectSubtree` (single/three-level chains, sibling isolation, cycle guard), a bootstrap test asserting grandchild tabs/permissions surface after a level-by-level BFS, a live-event test asserting a grandchild tab is registered when a known child spawns a nested task, and three grandchild-lineage cases for `autoRespondsPermission`.
- Ran the targeted suites (`stream.transport.test.ts`, `subagent-data.test.ts`, `permission-auto-respond.test.ts`) plus the new test file — all passing, no regressions in existing cases.

### Screenshots / recordings

N/A — this fixes visibility of an existing permission prompt for deeper session nesting; no new UI surface.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
