### PR TITLE
fix(app): restore manage models spacing

### DIFF
--- a/packages/app/src/components/dialog-manage-models.test.ts
+++ b/packages/app/src/components/dialog-manage-models.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test"
+
+describe("DialogManageModelsV2 layout", () => {
+  test("keeps provider groups separated in the scroll panel", async () => {
+    const source = await Bun.file(new URL("./dialog-manage-models.tsx", import.meta.url)).text()
+
+    expect(source).toMatch(/class="[^"]*settings-v2-panel[^"]*settings-v2-models[^"]*gap-6[^"]*"/)
+  })
+})

--- a/packages/app/src/components/dialog-manage-models.tsx
+++ b/packages/app/src/components/dialog-manage-models.tsx
@@ -195,7 +195,7 @@ export const DialogManageModelsV2: Component = () => {
           </div>
         </div>
         <div data-slot="manage-models-scroll" class="relative min-h-0 flex-1">
-          <div class="settings-v2-panel settings-v2-models h-full px-4 pt-4 pb-4">
+          <div class="settings-v2-panel settings-v2-models h-full gap-6 px-4 pt-4 pb-4">
             <Show
               when={!list.grouped.loading}
               fallback={


### PR DESCRIPTION
### Issue for this PR

Closes #36056

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores the missing vertical gap between provider sections in the V2 session `Manage models` dialog.

The dialog reuses `settings-v2-models`, but unlike the full settings models page it renders inside `settings-v2-panel`, so it did not receive the `.settings-v2-tab-body.settings-v2-models` section gap. Adding `gap-6` to the dialog scroll panel keeps provider groups separated in the session flow too.

A focused regression test checks that the V2 manage-models scroll panel keeps the provider group gap class.

### How did you verify your code works?

- `bun test --preload ./happydom.ts ./src/components/dialog-manage-models.test.ts` from `packages/app`
- `bun typecheck` from `packages/app`
- `bun run build` from `packages/app`
- `bun run lint` from repo root: 0 errors, existing warnings only
- pre-push hook: `bun turbo typecheck` passed with Bun 1.3.14

- bun dev serve
- bun run --cwd packages/app dev
- check UI vertical gap is in right place

### Screenshots / recordings

Before:
<img width="2808" height="1442" alt="image" src="https://github.com/user-attachments/assets/11f2f574-e027-4da2-b69a-97721f1eab35" />


After:
<img width="2444" height="1432" alt="image" src="https://github.com/user-attachments/assets/6a7b7ff2-2d30-4b75-8202-fe06ae1b26d7" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR