### PR TITLE
fix(tui): use markdown renderer for reasoning content

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1766,10 +1766,9 @@ function ReasoningPart(props: {
         </box>
         <Show when={(!inMinimal() || expanded()) && summary().body}>
           <box paddingLeft={inMinimal() ? 2 : 0} marginTop={1}>
-            <code
-              filetype="markdown"
-              drawUnstyledText={false}
+            <markdown
               streaming={true}
+              internalBlockMode="top-level"
               syntaxStyle={syntax()}
               content={summary().body}
               conceal={ctx.conceal()}


### PR DESCRIPTION
### Issue for this PR

Closes #36037

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

ReasoningPart was using `<code filetype="markdown">` to render reasoning content, which caused each token to appear on its own line (one token per render line). Changed it to use `<markdown>` with `internalBlockMode="top-level"`, matching how TextPart already renders markdown content. This gives reasoning output proper flowing text display.

### How did you verify your code works?

- `tsgo --noEmit` passes from `packages/tui`
- Manual testing: reasoning content now renders as flowing markdown paragraphs instead of one token per line

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR