### PR TITLE
fix(tui): normalize carriage returns in question text

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2817,7 +2817,7 @@ export function parseQuestions(value: unknown) {
   if (!Array.isArray(value)) return []
   return value.flatMap((item) => {
     const question = stringValue(recordValue(item)?.question)
-    return question ? [{ question }] : []
+    return question ? [{ question: question.replace(/\r/g, "") }] : []
   })
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #36040

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some LLMs emit question strings containing `\r` (carriage return) characters. The `parseQuestions` function in the TUI split on newlines but did not strip `\r`, causing each word to render on its own line. Added `.replace(/\r/g, "")` to normalize the text before parsing.

### How did you verify your code works?

- `tsgo --noEmit` passes from `packages/tui`
- Manual testing: questions now display correctly as flowing text

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR