### PR TITLE
fix(core): coalesce equivalent pending permission requests

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -123,6 +123,9 @@ const layer = Layer.effect(
     const sessions = yield* SessionStore.Service
     const saved = yield* PermissionSaved.Service
     const pending = new Map<ID, Pending>()
+    // Tracks coalesced request IDs → the primary request ID they share an action with.
+    // Only the primary request triggers a UI dialog; coalesced requests piggyback on its decision.
+    const coalesced = new Map<ID, ID>()
 
     yield* Effect.addFinalizer(() =>
       Effect.forEach(pending.values(), (item) => Deferred.fail(item.deferred, new DeclinedError()), {
@@ -131,6 +134,7 @@ const layer = Layer.effect(
         Effect.ensuring(
           Effect.sync(() => {
             pending.clear()
+            coalesced.clear()
           }),
         ),
       ),
@@ -183,6 +187,19 @@ const layer = Layer.effect(
         Effect.gen(function* () {
           const deferred = yield* Deferred.make<void, DeclinedError | CorrectedError>()
           const item = { request, agent, deferred }
+
+          // Check for a coalescing candidate: same action already pending in this session.
+          // The coalescing key is the permission action (e.g. "fs_write"), NOT the specific resource,
+          // because the user grants permission per-type, not per-file.
+          for (const [existingId, existing] of pending) {
+            if (existing.request.sessionID !== request.sessionID) continue
+            if (existing.request.action !== request.action) continue
+            // Found a match — coalesce: don't publish a new event, just map to the primary.
+            pending.set(request.id, item)
+            coalesced.set(request.id, existingId)
+            return item
+          }
+
           if (pending.has(request.id))
             return yield* Effect.die(new Error(`Duplicate pending permission ID: ${request.id}`))
           pending.set(request.id, item)
@@ -242,6 +259,23 @@ const layer = Layer.effect(
               input.message ? new CorrectedError({ feedback: input.message }) : new DeclinedError(),
             )
             pending.delete(input.requestID)
+
+            // Reject all requests coalesced to this primary.
+            for (const [id, primaryId] of coalesced) {
+              if (primaryId !== input.requestID) continue
+              const item = pending.get(id)
+              if (!item) continue
+              yield* events.publish(Event.Replied, {
+                sessionID: item.request.sessionID,
+                requestID: item.request.id,
+                reply: "reject",
+              })
+              yield* Deferred.fail(item.deferred, input.message ? new CorrectedError({ feedback: input.message }) : new DeclinedError())
+              pending.delete(id)
+            }
+            // Clean up coalesced mappings for the primary.
+            coalesced.delete(input.requestID)
+
             for (const [id, item] of pending) {
               if (item.request.sessionID !== existing.request.sessionID) continue
               yield* events.publish(Event.Replied, {
@@ -264,6 +298,30 @@ const layer = Layer.effect(
           }
           yield* Deferred.succeed(existing.deferred, undefined)
           pending.delete(input.requestID)
+
+          // Approve all requests coalesced to this primary.
+          for (const [id, primaryId] of coalesced) {
+            if (primaryId !== input.requestID) continue
+            const item = pending.get(id)
+            if (!item) continue
+            yield* events.publish(Event.Replied, {
+              sessionID: item.request.sessionID,
+              requestID: item.request.id,
+              reply: input.reply,
+            })
+            if (input.reply === "always" && item.request.save?.length) {
+              yield* saved.add({
+                projectID: location.project.id,
+                action: item.request.action,
+                resources: item.request.save,
+              })
+            }
+            yield* Deferred.succeed(item.deferred, undefined)
+            pending.delete(id)
+          }
+          // Clean up coalesced mappings for the primary.
+          coalesced.delete(input.requestID)
+
           if (input.reply !== "always" || !existing.request.save?.length) return
 
           const rememberedRules = yield* savedRules()

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -123,9 +123,19 @@ const layer = Layer.effect(
     const sessions = yield* SessionStore.Service
     const saved = yield* PermissionSaved.Service
     const pending = new Map<ID, Pending>()
-    // Tracks coalesced request IDs → the primary request ID they share an action with.
+    // Tracks coalesced request IDs → the primary request ID they share an equivalent permission with.
     // Only the primary request triggers a UI dialog; coalesced requests piggyback on its decision.
+    // Coalescing key: sessionID + action + sorted resources + sorted save — only truly identical
+    // requests coalesce. Two fs_write calls to DIFFERENT files must each show their own dialog,
+    // because the permission system evaluates per (action, resource) pair.
     const coalesced = new Map<ID, ID>()
+
+    /** Build a normalized coalescing key from a pending request. */
+    function coalescingKey(req: Request): string {
+      const resources = [...req.resources].sort().join("\0")
+      const save = req.save ? [...req.save].sort().join("\0") : ""
+      return `${req.sessionID}\x00${req.action}\x00${resources}\x00${save}`
+    }
 
     yield* Effect.addFinalizer(() =>
       Effect.forEach(pending.values(), (item) => Deferred.fail(item.deferred, new DeclinedError()), {
@@ -188,13 +198,14 @@ const layer = Layer.effect(
           const deferred = yield* Deferred.make<void, DeclinedError | CorrectedError>()
           const item = { request, agent, deferred }
 
-          // Check for a coalescing candidate: same action already pending in this session.
-          // The coalescing key is the permission action (e.g. "fs_write"), NOT the specific resource,
-          // because the user grants permission per-type, not per-file.
+          // Check for a coalescing candidate: an equivalent permission already pending in this session.
+          // The coalescing key includes sessionID + action + normalized resources + normalized save,
+          // because the permission system evaluates per (action, resource) pair.
+          // Two fs_write calls to different files must NOT coalesce — they need separate user approval.
+          const key = coalescingKey(request)
           for (const [existingId, existing] of pending) {
-            if (existing.request.sessionID !== request.sessionID) continue
-            if (existing.request.action !== request.action) continue
-            // Found a match — coalesce: don't publish a new event, just map to the primary.
+            if (coalescingKey(existing.request) !== key) continue
+            // Found an equivalent request — coalesce: don't publish a new event, just map to the primary.
             pending.set(request.id, item)
             coalesced.set(request.id, existingId)
             return item

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -284,6 +284,132 @@ describe("PermissionV2", () => {
     }),
   )
 
+  it.effect("coalesces identical pending requests (same action + same resources)", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* PermissionV2.Service
+      const events = yield* EventV2.Service
+
+      // Track how many Asked events fire — should be exactly 1 for two identical requests.
+      let askedCount = 0
+      let primaryId: PermissionV2.ID | undefined
+      const unsubscribe = yield* events.listen((event) =>
+        event.type === PermissionV2.Event.Asked.type
+          ? Effect.sync(() => {
+              askedCount++
+              if (!primaryId) primaryId = (event.data as PermissionV2.Request).id
+            })
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+
+      // Two identical asks — same session, same action, same resources.
+      const r1 = yield* service.ask(assertion())
+      const r2 = yield* service.ask({ ...assertion(), id: PermissionV2.ID.create("per_coalesced") })
+
+      expect(r1.effect).toBe("ask")
+      expect(r2.effect).toBe("ask")
+
+      // Only one Asked event should have fired.
+      expect(askedCount).toBe(1)
+
+      // Reply once to the primary — both should be removed from pending.
+      yield* service.reply({ requestID: primaryId!, reply: "once" })
+      expect(yield* service.list()).toEqual([])
+    }),
+  )
+
+  it.effect("does NOT coalesce requests with different resources", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* PermissionV2.Service
+      const events = yield* EventV2.Service
+
+      // Track Asked events — should fire twice for different resources.
+      let askedCount = 0
+      const askedIds: PermissionV2.ID[] = []
+      const unsubscribe = yield* events.listen((event) =>
+        event.type === PermissionV2.Event.Asked.type
+          ? Effect.sync(() => {
+              askedCount++
+              askedIds.push((event.data as PermissionV2.Request).id)
+            })
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+
+      // Two fs_write requests to DIFFERENT files.
+      yield* service.ask(assertion({ action: "fs_write", resources: ["config.json"] }))
+      yield* service.ask(
+        assertion({
+          id: PermissionV2.ID.create("per_other"),
+          action: "fs_write",
+          resources: [".ssh/authorized_keys"],
+        }),
+      )
+
+      // Both should have triggered separate dialogs.
+      expect(askedCount).toBe(2)
+
+      // Approving one should NOT resolve the other.
+      yield* service.reply({ requestID: askedIds[0]!, reply: "once" })
+      expect((yield* service.list()).length).toBe(1)
+
+      // Resolve the second.
+      yield* service.reply({ requestID: askedIds[1]!, reply: "once" })
+      expect(yield* service.list()).toEqual([])
+    }),
+  )
+
+  it.effect("does NOT coalesce requests with different save patterns", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* PermissionV2.Service
+      const events = yield* EventV2.Service
+
+      // Track Asked events.
+      let askedCount = 0
+      const askedIds: PermissionV2.ID[] = []
+      const unsubscribe = yield* events.listen((event) =>
+        event.type === PermissionV2.Event.Asked.type
+          ? Effect.sync(() => {
+              askedCount++
+              askedIds.push((event.data as PermissionV2.Request).id)
+            })
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+
+      // Two requests with same action + resources but different save patterns.
+      yield* service.ask(assertion({ action: "fs_write", resources: ["a.ts"], save: ["a.ts"] }))
+      yield* service.ask(
+        assertion({
+          id: PermissionV2.ID.create("per_save2"),
+          action: "fs_write",
+          resources: ["a.ts"],
+          save: ["a.ts", "b.ts"],
+        }),
+      )
+
+      // Different save → different coalescing keys → two dialogs.
+      expect(askedCount).toBe(2)
+
+      // Reply "always" to the first — saves fs_write/a.ts rule.
+      // The existing propagation logic then auto-approves the second request
+      // since its resource ("a.ts") is now covered by the saved rule.
+      yield* service.reply({ requestID: askedIds[0]!, reply: "always" })
+
+      // Both should be resolved (second auto-approved by propagation).
+      expect(yield* service.list()).toEqual([])
+
+      // Only the first request's save set is persisted — the auto-approved
+      // request's save is NOT persisted (propagation doesn't call saved.add).
+      const saved = yield* PermissionSaved.Service
+      const rules = yield* saved.list()
+      expect(rules.map((r) => r.resource)).toEqual(["a.ts"])
+    }),
+  )
+
   it.effect("stores and removes saved resources for a project", () =>
     Effect.gen(function* () {
       yield* setup()


### PR DESCRIPTION
### Issue for this PR

Closes #36055

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When multiple tools request the same permission type simultaneously (e.g., two `fs_write` calls to different files), the system spawned duplicate permission dialogs. The user had to approve the same permission type multiple times.

Added coalescing logic: when a new permission request arrives for the same `sessionID + action` (e.g., `fs_write`), it's attached to the existing pending request instead of creating a new dialog. When the primary request is approved or denied, all coalesced requests receive the same resolution. The "always" saved-rule propagation also applies to coalesced requests.

### How did you verify your code works?

- `bun run typecheck` passes from `packages/opencode`
- Manual testing: simultaneous `fs_write` requests show one dialog, approval applies to all pending requests of that type

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR