### PR TITLE
fix(tui): cycle model variants from default

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -48,6 +48,19 @@ export function recentModels(
     .map((item) => ({ providerID: item.providerID, modelID: item.modelID }))
 }
 
+export function nextVariantInCycle(variants: string[], current: string | undefined) {
+  const cycleVariants = variants.filter((variant) => variant !== "default")
+  if (cycleVariants.length === 0) return null
+  if (!current || current === "default") {
+    return cycleVariants[0]
+  }
+  const index = cycleVariants.indexOf(current)
+  if (index === -1 || index === cycleVariants.length - 1) {
+    return undefined
+  }
+  return cycleVariants[index + 1]
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
@@ -388,19 +401,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             save()
           },
           cycle() {
-            const variants = this.list()
-            if (variants.length === 0) return
-            const current = this.current()
-            if (!current) {
-              this.set(variants[0])
-              return
-            }
-            const index = variants.indexOf(current)
-            if (index === -1 || index === variants.length - 1) {
-              this.set(undefined)
-              return
-            }
-            this.set(variants[index + 1])
+            const nextVariant = nextVariantInCycle(this.list(), this.current())
+            if (nextVariant === null) return
+            this.set(nextVariant)
           },
         },
       }

--- a/packages/tui/test/context/local.test.ts
+++ b/packages/tui/test/context/local.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { parseModel, recentModels } from "../../src/context/local"
+import { nextVariantInCycle, parseModel, recentModels } from "../../src/context/local"
 
 test("parses model IDs containing slashes", () => {
   expect(parseModel("provider/family/model")).toEqual({
@@ -19,4 +19,17 @@ test("moves a model to the front, deduplicates, and limits recents", () => {
     ...recent.slice(0, 5),
     ...recent.slice(6, 10),
   ])
+})
+
+test("cycles non-default variants when a default variant exists", () => {
+  const variants = ["high", "max", "default", "none"]
+
+  expect(nextVariantInCycle(variants, "default")).toBe("high")
+  expect(nextVariantInCycle(variants, "high")).toBe("max")
+  expect(nextVariantInCycle(variants, "max")).toBe("none")
+  expect(nextVariantInCycle(variants, "none")).toBeUndefined()
+})
+
+test("does not cycle when only the default variant exists", () => {
+  expect(nextVariantInCycle(["default"], "default")).toBeNull()
 })


### PR DESCRIPTION
### Issue for this PR

Closes #36095

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR fixes TUI variant cycling when a model defines a real variant named `default`. The cycle logic now uses a non-default cycle order internally, so `ctrl+t` moves through configured variants such as `high`, `max`, and `none` before returning to the default state.

The previous logic used the full variant list. Because `set(undefined)` stores `default`, a list like `high`, `max`, `default`, and `none` made the cycle jump from `default` to `none`, then back to `default`. The visible variant list and dialog behavior are unchanged.

### How did you verify your code works?

- Added regression coverage for `nextVariantInCycle` with `high`, `max`, `default`, and `none`.
- Verified the regression test fails with the old cycle behavior: `default` returned `none` instead of `high`.
- Ran `bun test test/context/local.test.ts` from `packages/tui`.
- Ran `bun typecheck` from `packages/tui`.
- Built the single Linux binary with `bun run build -- --single` from `packages/opencode` and confirmed the build smoke test passed.
- Manually verified that `ctrl+t` cycles through `default`, `high`, `max`, and `none` for the affected model.

### Screenshots / recordings

Not included. The change affects keyboard cycling behavior in the TUI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR