### PR TITLE
fix(opencode): skip falsy plugin hook returns instead of crashing provider listing

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -107,17 +107,30 @@ function getLegacyPlugins(mod: Record<string, unknown>) {
   return result
 }
 
+// Returns the specs of plugin entries that resolved to no hooks so the caller
+// can surface a warning. A falsy hooks entry must never reach the hooks array:
+// consumers dereference entries directly (e.g. hook.provider in the Provider
+// state build), so one undefined entry breaks provider listing for the whole
+// instance. Legacy modules are the common source — every function export is
+// loaded as a plugin, so a stray helper export lands here with an undefined
+// return value.
 async function applyPlugin(load: PluginLoader.Loaded, input: PluginInput, hooks: Hooks[]) {
+  const skipped: string[] = []
   const plugin = readV1Plugin(load.mod, load.spec, "server", "detect")
   if (plugin) {
     await resolvePluginId(load.source, load.spec, load.target, readPluginId(plugin.id, load.spec), load.pkg)
-    hooks.push(await (plugin as PluginModule).server(input, load.options))
-    return
+    const init = await (plugin as PluginModule).server(input, load.options)
+    if (init) hooks.push(init)
+    else skipped.push(load.spec)
+    return skipped
   }
 
   for (const server of getLegacyPlugins(load.mod)) {
-    hooks.push(await server(input, load.options))
+    const init = await server(input, load.options)
+    if (init) hooks.push(init)
+    else skipped.push(load.spec)
   }
+  return skipped
 }
 
 const layer = Layer.effect(
@@ -171,7 +184,10 @@ const layer = Layer.effect(
             Effect.tapError((error) => Effect.logError("failed to load internal plugin", { name: plugin.name, error })),
             Effect.option,
           )
-          if (init._tag === "Some") hooks.push(init.value)
+          if (init._tag === "Some") {
+            if (init.value) hooks.push(init.value)
+            else yield* Effect.logWarning("internal plugin returned no hooks", { name: plugin.name })
+          }
         }
 
         const plugins = flags.pure ? [] : (cfg.plugin_origins ?? [])
@@ -224,6 +240,13 @@ const layer = Layer.effect(
               return message
             },
           }).pipe(
+            Effect.tap((skipped) =>
+              skipped.length
+                ? Effect.logWarning("plugin returned no hooks — export a Plugin function or a PluginModule default", {
+                    path: load.spec,
+                  })
+                : Effect.void,
+            ),
             Effect.tapError((error) => Effect.logError("failed to load plugin", { path: load.spec, error })),
             Effect.catch(() => {
               // TODO: make proper events for this

--- a/packages/opencode/test/plugin/falsy-hooks.test.ts
+++ b/packages/opencode/test/plugin/falsy-hooks.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Npm } from "@opencode-ai/core/npm"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { Plugin } from "../../src/plugin/index"
+
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { AccountTest } from "../fake/account"
+import { AuthTest } from "../fake/auth"
+import { NpmTest } from "../fake/npm"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Plugin.node, CrossSpawnSpawner.node]), [
+    [Auth.node, AuthTest.empty],
+    [Account.node, AccountTest.empty],
+    [Npm.node, NpmTest.noop],
+    [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
+  ]),
+)
+
+function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const test = yield* TestInstance
+    const file = path.join(test.directory, "plugin.ts")
+    yield* Effect.all(
+      [
+        Effect.promise(() => Bun.write(file, source)),
+        Effect.promise(() =>
+          Bun.write(
+            path.join(test.directory, "opencode.json"),
+            JSON.stringify(
+              {
+                $schema: "https://opencode.ai/config.json",
+                plugin: [pathToFileURL(file).href],
+              },
+              null,
+              2,
+            ),
+          ),
+        ),
+      ],
+      { discard: true, concurrency: 2 },
+    )
+    return yield* self
+  })
+}
+
+const listHooks = Effect.gen(function* () {
+  const plugin = yield* Plugin.Service
+  yield* plugin.init()
+  return yield* plugin.list()
+})
+
+// A falsy entry in the hooks array breaks every consumer that dereferences
+// hook properties directly — most visibly the Provider state build
+// (hook.provider), which turns into a 500 from /config/providers and makes
+// the whole instance unusable. These tests pin down that plugin loading
+// never lets a falsy hook through.
+describe("plugin falsy hook returns", () => {
+  it.instance("legacy module: stray helper export resolving undefined is skipped, real plugin loads", () =>
+    withProject(
+      [
+        "// legacy shape: every function export is loaded as a plugin, so the",
+        "// helper below is called with (input, options) and returns undefined.",
+        "export function helper() {}",
+        "export const realPlugin = async () => ({",
+        "  async config(_cfg) {},",
+        "})",
+        "export default realPlugin",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        const hooks = yield* listHooks
+        expect(hooks.every(Boolean)).toBe(true)
+        // the real plugin's hooks made it in; only the helper was dropped
+        expect(hooks.some((hook) => typeof hook.config === "function")).toBe(true)
+      }),
+    ),
+  )
+
+  it.instance("v1 module: server() resolving undefined is skipped", () =>
+    withProject(
+      ["export default {", '  id: "demo.falsy-hooks",', "  server: async () => undefined,", "}", ""].join("\n"),
+      Effect.gen(function* () {
+        const hooks = yield* listHooks
+        expect(hooks.every(Boolean)).toBe(true)
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35772

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A plugin entry that resolves to no hooks gets pushed into the hooks array as-is in `applyPlugin`. The Provider state build later does `const p = hook.provider` (`provider/provider.ts:1372`) one line before its null-guard, so a single `undefined` entry 500s `GET /config/providers` and takes `opencode attach` and the web UI down with it — the error in #35772.

The easiest way to hit it: a stray helper export on a legacy-shaped plugin module. Every function export is loaded as a plugin, so the helper is called and its `undefined` return lands in the hooks array. That's how I hit it with my own plugin (identical on 1.16.2 and 1.17.x). A v1 module whose `server()` resolves `undefined` does the same. It also explains "happens with plugins removed": file-based plugins are auto-discovered from `{plugin,plugins}/*.{ts,js}` in every config dir, so a leftover file counts even with an empty `plugin` array.

Fix: skip falsy hook returns on the v1, legacy, and internal-plugin paths, and log a warning naming the plugin spec. I kept the guard at the source instead of adding `?.` at the consumers so the offending plugin gets named instead of silently ignored.

### How did you verify your code works?

- New `packages/opencode/test/plugin/falsy-hooks.test.ts` covers both module shapes; it fails 2/2 without the src change and passes with it. `bun test test/plugin/` and `test/provider/provider.test.ts` are green; `tsgo --noEmit` and prettier clean.
- Reproduced the crash end-to-end against a released `opencode serve` with a plugin carrying a stray helper export (`/config/providers` → 500 on every poll); removing the export restores 200. The loader guard itself is covered by the new tests.

### Screenshots / recordings

n/a — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
