### PR TITLE
fix(tui): highlight full repo:branch when branch name contains slashes

### DIFF
--- a/packages/tui/src/feature-plugins/sidebar/footer.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/footer.tsx
@@ -21,11 +21,10 @@ function View(props: { api: TuiPluginApi; sessionID: string }) {
     const dir = session?.directory || props.api.state.path.directory || paths.cwd
     const out = abbreviateHome(dir, paths.home)
     const branch = session?.directory === props.api.state.path.directory ? props.api.state.vcs?.branch : undefined
-    const text = branch ? out + ":" + branch : out
-    const list = text.split("/")
+    const list = out.split("/")
     return {
       parent: list.slice(0, -1).join("/"),
-      name: list.at(-1) ?? "",
+      name: (list.at(-1) ?? "") + (branch ? ":" + branch : ""),
     }
   })
 
@@ -65,7 +64,7 @@ function View(props: { api: TuiPluginApi; sessionID: string }) {
         </box>
       </Show>
       <text>
-        <span style={{ fg: theme().textMuted }}>{path().parent}/</span>
+        <span style={{ fg: theme().textMuted }}>{path().parent}{path().parent ? "/" : ""}</span>
         <span style={{ fg: theme().text }}>{path().name}</span>
       </text>
       <text fg={theme().textMuted}>


### PR DESCRIPTION
### Issue for this PR

Closes #36109

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The TUI sidebar highlights the current dir + branch at the bottom (e.g. `my-repo:main` in white, rest muted).

When the branch has a slash (e.g. `feature/new-endpoint`), only the part after the last `/` was highlighted. For `/path/to/my-repo:feature/new-endpoint` it highlighted just `new-endpoint` instead of the full `my-repo:feature/new-endpoint`.

Root cause: in `packages/tui/src/feature-plugins/sidebar/footer.tsx` the code did `out + ":" + branch` then `.split("/")` on the whole thing.

Fix: split the directory first, append `:branch` only to the last segment. Also made the trailing `/` conditional so `~` doesn't render as `/~`.

### How did you verify your code works?

- Created a test repo on branch `feature/new-endpoint`
- Ran `bun dev` against it
- Entered a session and checked the sidebar footer
- Full `scratch-repo:feature/new-endpoint` is now highlighted white
- `bun typecheck` passes in packages/tui
- Checked other cases: no branch, home dir, deeper slashes, path containing `:`

### Screenshots / recordings

Verified visually in the running TUI (Debian + tmux). No screenshot attached due to remote/headless setup.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
