### PR TITLE
fix(server): skip mdns probe listener

### DIFF
--- a/packages/opencode/src/server/mdns.ts
+++ b/packages/opencode/src/server/mdns.ts
@@ -17,6 +17,7 @@ export function publish(port: number, domain?: string) {
       host,
       port,
       txt: { path: "/" },
+      probe: false,
     })
 
     service.on("error", () => {})

--- a/packages/opencode/test/server/httpapi-mdns.test.ts
+++ b/packages/opencode/test/server/httpapi-mdns.test.ts
@@ -4,13 +4,16 @@ import { withTimeout } from "../../src/util/timeout"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances } from "../fixture/fixture"
 
-type Event = { kind: "publish"; port: number; name: string } | { kind: "unpublishAll" } | { kind: "destroy" }
+type Event =
+  | { kind: "publish"; port: number; name: string; probe: boolean | undefined }
+  | { kind: "unpublishAll" }
+  | { kind: "destroy" }
 const events: Event[] = []
 
 void mock.module("bonjour-service", () => ({
   Bonjour: class {
-    publish(opts: { port: number; name: string }) {
-      events.push({ kind: "publish", port: opts.port, name: opts.name })
+    publish(opts: { port: number; name: string; probe?: boolean }) {
+      events.push({ kind: "publish", port: opts.port, name: opts.name, probe: opts.probe })
       return { on: () => {} }
     }
     unpublishAll() {
@@ -60,9 +63,11 @@ describe("HttpApi Server.listen mDNS", () => {
       expect(published.length).toBe(1)
       expect(published[0]!.port).toBe(listener.port)
       expect(published[0]!.name).toBe(`opencode-${listener.port}`)
+      expect(published[0]!.probe).toBe(false)
     } finally {
       await withTimeout(listener.stop(true), 10_000, "timed out stopping mdns listener")
     }
+
     expect(events.some((e) => e.kind === "unpublishAll")).toBe(true)
     expect(events.some((e) => e.kind === "destroy")).toBe(true)
   })


### PR DESCRIPTION
Closes #35499

## Summary
- disable bonjour-service probing for the opencode mDNS advertisement
- keep the existing publish/unpublish lifecycle intact
- assert the publish call opts out of probing in the mDNS server test

## Verification
- `git diff --check`
- `bun test test/server/httpapi-mdns.test.ts --timeout 60000` *(blocked locally: Bun isolated install cannot resolve `@modelcontextprotocol/sdk/client/index.js` from the worktree)*
- `bun typecheck` *(blocked locally by pre-existing `src/tool/registry.ts` type errors)*
- pre-push `bun turbo typecheck` *(blocked locally by Windows resource exhaustion in tsgo / console-support)*