### PR TITLE
fix(copilot): handle zero billing batch size

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -99,7 +99,7 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
         : undefined
   const prices = remote.billing?.token_prices
   // Copilot prices are AIC per billing batch; OpenCode stores USD per million tokens.
-  const usdPerMillion = prices ? 10_000 / prices.batch_size : 0
+  const usdPerMillion = prices && prices.batch_size > 0 ? 10_000 / prices.batch_size : 0
 
   const model: CopilotModel = {
     id: key,

--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -1,8 +1,6 @@
 import type { Model } from "@opencode-ai/sdk/v2"
 import { Option, Schema } from "effect"
 
-const billingNumber = Schema.optional(Schema.NullOr(Schema.Finite))
-
 const item = Schema.Struct({
   model_picker_enabled: Schema.Boolean,
   id: Schema.String,
@@ -16,38 +14,30 @@ const item = Schema.Struct({
     }),
   ),
   billing: Schema.optional(
-    Schema.NullOr(
-      Schema.Struct({
-        token_prices: Schema.optional(
-          Schema.NullOr(
-            Schema.Struct({
-              batch_size: billingNumber,
-              default: Schema.optional(
-                Schema.NullOr(
-                  Schema.Struct({
-                    cache_price: billingNumber,
-                    input_price: billingNumber,
-                    output_price: billingNumber,
-                  }),
-                ),
-              ),
-            }),
-          ),
-        ),
-      }),
-    ),
+    Schema.Struct({
+      token_prices: Schema.optional(
+        Schema.Struct({
+          batch_size: Schema.Number,
+          default: Schema.Struct({
+            cache_price: Schema.Number,
+            input_price: Schema.Number,
+            output_price: Schema.Number,
+          }),
+        }),
+      ),
+    }),
   ),
   capabilities: Schema.Struct({
     family: Schema.String,
     limits: Schema.optional(
       Schema.Struct({
-        max_context_window_tokens: Schema.optional(Schema.Finite),
-        max_output_tokens: Schema.optional(Schema.Finite),
-        max_prompt_tokens: Schema.optional(Schema.Finite),
+        max_context_window_tokens: Schema.optional(Schema.Number),
+        max_output_tokens: Schema.optional(Schema.Number),
+        max_prompt_tokens: Schema.optional(Schema.Number),
         vision: Schema.optional(
           Schema.Struct({
-            max_prompt_image_size: Schema.Finite,
-            max_prompt_images: Schema.Finite,
+            max_prompt_image_size: Schema.Number,
+            max_prompt_images: Schema.Number,
             supported_media_types: Schema.Array(Schema.String),
           }),
         ),
@@ -55,8 +45,8 @@ const item = Schema.Struct({
     ),
     supports: Schema.Struct({
       adaptive_thinking: Schema.optional(Schema.Boolean),
-      max_thinking_budget: Schema.optional(Schema.Finite),
-      min_thinking_budget: Schema.optional(Schema.Finite),
+      max_thinking_budget: Schema.optional(Schema.Number),
+      min_thinking_budget: Schema.optional(Schema.Number),
       reasoning_effort: Schema.optional(Schema.Array(Schema.String)),
       streaming: Schema.optional(Schema.Boolean),
       structured_outputs: Schema.optional(Schema.Boolean),
@@ -108,7 +98,8 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
         ? "chat"
         : undefined
   const prices = remote.billing?.token_prices
-  const batch = prices?.batch_size
+  // Copilot prices are AIC per billing batch; OpenCode stores USD per million tokens.
+  const usdPerMillion = prices && prices.batch_size > 0 ? 10_000 / prices.batch_size : 0
 
   const model: CopilotModel = {
     id: key,
@@ -151,10 +142,10 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
     family: prev?.family ?? remote.capabilities.family,
     name: prev?.name ?? remote.name,
     cost: {
-      input: convertCost(prices?.default?.input_price, batch),
-      output: convertCost(prices?.default?.output_price, batch),
+      input: (prices?.default.input_price ?? 0) * usdPerMillion,
+      output: (prices?.default.output_price ?? 0) * usdPerMillion,
       cache: {
-        read: convertCost(prices?.default?.cache_price, batch),
+        read: (prices?.default.cache_price ?? 0) * usdPerMillion,
         // `/models` exposes cached-input reads only; per-request billing accounts for cache writes.
         write: 0,
       },
@@ -208,14 +199,6 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
   }
 
   return model
-}
-
-// Copilot prices are AIC per billing batch; OpenCode stores USD per million tokens.
-function convertCost(value: number | null | undefined, batch: number | null | undefined) {
-  if (value === null || value === undefined || value < 0 || batch === null || batch === undefined || batch <= 0)
-    return 0
-  const result = (value / batch) * 10_000
-  return Number.isFinite(result) ? result : 0
 }
 
 function usable(item: Item): item is SelectableItem {

--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -1,6 +1,8 @@
 import type { Model } from "@opencode-ai/sdk/v2"
 import { Option, Schema } from "effect"
 
+const billingNumber = Schema.optional(Schema.NullOr(Schema.Finite))
+
 const item = Schema.Struct({
   model_picker_enabled: Schema.Boolean,
   id: Schema.String,
@@ -14,30 +16,38 @@ const item = Schema.Struct({
     }),
   ),
   billing: Schema.optional(
-    Schema.Struct({
-      token_prices: Schema.optional(
-        Schema.Struct({
-          batch_size: Schema.Number,
-          default: Schema.Struct({
-            cache_price: Schema.Number,
-            input_price: Schema.Number,
-            output_price: Schema.Number,
-          }),
-        }),
-      ),
-    }),
+    Schema.NullOr(
+      Schema.Struct({
+        token_prices: Schema.optional(
+          Schema.NullOr(
+            Schema.Struct({
+              batch_size: billingNumber,
+              default: Schema.optional(
+                Schema.NullOr(
+                  Schema.Struct({
+                    cache_price: billingNumber,
+                    input_price: billingNumber,
+                    output_price: billingNumber,
+                  }),
+                ),
+              ),
+            }),
+          ),
+        ),
+      }),
+    ),
   ),
   capabilities: Schema.Struct({
     family: Schema.String,
     limits: Schema.optional(
       Schema.Struct({
-        max_context_window_tokens: Schema.optional(Schema.Number),
-        max_output_tokens: Schema.optional(Schema.Number),
-        max_prompt_tokens: Schema.optional(Schema.Number),
+        max_context_window_tokens: Schema.optional(Schema.Finite),
+        max_output_tokens: Schema.optional(Schema.Finite),
+        max_prompt_tokens: Schema.optional(Schema.Finite),
         vision: Schema.optional(
           Schema.Struct({
-            max_prompt_image_size: Schema.Number,
-            max_prompt_images: Schema.Number,
+            max_prompt_image_size: Schema.Finite,
+            max_prompt_images: Schema.Finite,
             supported_media_types: Schema.Array(Schema.String),
           }),
         ),
@@ -45,8 +55,8 @@ const item = Schema.Struct({
     ),
     supports: Schema.Struct({
       adaptive_thinking: Schema.optional(Schema.Boolean),
-      max_thinking_budget: Schema.optional(Schema.Number),
-      min_thinking_budget: Schema.optional(Schema.Number),
+      max_thinking_budget: Schema.optional(Schema.Finite),
+      min_thinking_budget: Schema.optional(Schema.Finite),
       reasoning_effort: Schema.optional(Schema.Array(Schema.String)),
       streaming: Schema.optional(Schema.Boolean),
       structured_outputs: Schema.optional(Schema.Boolean),
@@ -98,8 +108,7 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
         ? "chat"
         : undefined
   const prices = remote.billing?.token_prices
-  // Copilot prices are AIC per billing batch; OpenCode stores USD per million tokens.
-  const usdPerMillion = prices && prices.batch_size > 0 ? 10_000 / prices.batch_size : 0
+  const batch = prices?.batch_size
 
   const model: CopilotModel = {
     id: key,
@@ -142,10 +151,10 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
     family: prev?.family ?? remote.capabilities.family,
     name: prev?.name ?? remote.name,
     cost: {
-      input: (prices?.default.input_price ?? 0) * usdPerMillion,
-      output: (prices?.default.output_price ?? 0) * usdPerMillion,
+      input: convertCost(prices?.default?.input_price, batch),
+      output: convertCost(prices?.default?.output_price, batch),
       cache: {
-        read: (prices?.default.cache_price ?? 0) * usdPerMillion,
+        read: convertCost(prices?.default?.cache_price, batch),
         // `/models` exposes cached-input reads only; per-request billing accounts for cache writes.
         write: 0,
       },
@@ -199,6 +208,14 @@ function build(key: string, remote: SelectableItem, url: string, prev?: Model): 
   }
 
   return model
+}
+
+// Copilot prices are AIC per billing batch; OpenCode stores USD per million tokens.
+function convertCost(value: number | null | undefined, batch: number | null | undefined) {
+  if (value === null || value === undefined || value < 0 || batch === null || batch === undefined || batch <= 0)
+    return 0
+  const result = (value / batch) * 10_000
+  return Number.isFinite(result) ? result : 0
 }
 
 function usable(item: Item): item is SelectableItem {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1071,11 +1071,17 @@ export type ConfigProvidersResult = Types.DeepMutable<Schema.Schema.Type<typeof 
 
 export function toPublicInfo(provider: Info): Info {
   return JSON.parse(
-    JSON.stringify(provider, (_, value) => {
-      if (typeof value === "function" || typeof value === "symbol" || value === undefined) return undefined
-      if (typeof value === "bigint") return value.toString()
-      return value
-    }),
+    JSON.stringify(
+      {
+        ...provider,
+        models: Object.fromEntries(Object.entries(provider.models).filter(([, model]) => Schema.is(Model)(model))),
+      },
+      (_, value) => {
+        if (typeof value === "function" || typeof value === "symbol" || value === undefined) return undefined
+        if (typeof value === "bigint") return value.toString()
+        return value
+      },
+    ),
   )
 }
 

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -187,6 +187,60 @@ test("converts Copilot AIC token prices to USD per million tokens", async () => 
   expect(models["ignored-non-chat-record"]).toBeUndefined()
 })
 
+test("uses zero cost when Copilot reports a zero billing batch size", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "mercury-alpha",
+              name: "Mercury Alpha",
+              version: "mercury-alpha-2026-07-09",
+              billing: {
+                token_prices: {
+                  batch_size: 0,
+                  default: {
+                    input_price: 0,
+                    output_price: 0,
+                    cache_price: 0,
+                  },
+                },
+              },
+              capabilities: {
+                family: "mercury",
+                limits: {
+                  max_context_window_tokens: 128000,
+                  max_output_tokens: 16384,
+                  max_prompt_tokens: 128000,
+                },
+                supports: {
+                  streaming: true,
+                  tool_calls: true,
+                },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const model = (await CopilotModels.get("https://api.githubcopilot.com")).models["mercury-alpha"]
+
+  expect(model.cost).toEqual({
+    input: 0,
+    output: 0,
+    cache: {
+      read: 0,
+      write: 0,
+    },
+  })
+  expect(JSON.stringify(model)).not.toContain("null")
+})
+
 test("records Copilot advertised responses endpoint for non-GPT model IDs", async () => {
   globalThis.fetch = mock(() =>
     Promise.resolve(

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -187,7 +187,7 @@ test("converts Copilot AIC token prices to USD per million tokens", async () => 
   expect(models["ignored-non-chat-record"]).toBeUndefined()
 })
 
-test("uses finite zero costs when Copilot reports invalid billing metadata", async () => {
+test("uses zero cost when Copilot reports a zero billing batch size", async () => {
   globalThis.fetch = mock(() =>
     Promise.resolve(
       new Response(
@@ -204,40 +204,12 @@ test("uses finite zero costs when Copilot reports invalid billing metadata", asy
                   default: {
                     input_price: 0,
                     output_price: 0,
-                    cache_price: null,
+                    cache_price: 0,
                   },
                 },
               },
               capabilities: {
                 family: "mercury",
-                limits: {
-                  max_context_window_tokens: 128000,
-                  max_output_tokens: 16384,
-                  max_prompt_tokens: 128000,
-                },
-                supports: {
-                  streaming: true,
-                  tool_calls: true,
-                },
-              },
-            },
-            {
-              model_picker_enabled: true,
-              id: "overflow-model",
-              name: "Overflow Model",
-              version: "overflow-model-2026-07-09",
-              billing: {
-                token_prices: {
-                  batch_size: Number.MIN_VALUE,
-                  default: {
-                    input_price: Number.MAX_VALUE,
-                    output_price: -1,
-                    cache_price: 1,
-                  },
-                },
-              },
-              capabilities: {
-                family: "test",
                 limits: {
                   max_context_window_tokens: 128000,
                   max_output_tokens: 16384,
@@ -256,9 +228,7 @@ test("uses finite zero costs when Copilot reports invalid billing metadata", asy
     ),
   ) as unknown as typeof fetch
 
-  const models = (await CopilotModels.get("https://api.githubcopilot.com")).models
-  const model = models["mercury-alpha"]
-  const overflow = models["overflow-model"]
+  const model = (await CopilotModels.get("https://api.githubcopilot.com")).models["mercury-alpha"]
 
   expect(model.cost).toEqual({
     input: 0,
@@ -268,9 +238,7 @@ test("uses finite zero costs when Copilot reports invalid billing metadata", asy
       write: 0,
     },
   })
-  expect(overflow.cost).toEqual(model.cost)
   expect(JSON.stringify(model)).not.toContain("null")
-  expect(JSON.stringify(overflow)).not.toContain("null")
 })
 
 test("records Copilot advertised responses endpoint for non-GPT model IDs", async () => {

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -187,7 +187,7 @@ test("converts Copilot AIC token prices to USD per million tokens", async () => 
   expect(models["ignored-non-chat-record"]).toBeUndefined()
 })
 
-test("uses zero cost when Copilot reports a zero billing batch size", async () => {
+test("uses finite zero costs when Copilot reports invalid billing metadata", async () => {
   globalThis.fetch = mock(() =>
     Promise.resolve(
       new Response(
@@ -204,12 +204,40 @@ test("uses zero cost when Copilot reports a zero billing batch size", async () =
                   default: {
                     input_price: 0,
                     output_price: 0,
-                    cache_price: 0,
+                    cache_price: null,
                   },
                 },
               },
               capabilities: {
                 family: "mercury",
+                limits: {
+                  max_context_window_tokens: 128000,
+                  max_output_tokens: 16384,
+                  max_prompt_tokens: 128000,
+                },
+                supports: {
+                  streaming: true,
+                  tool_calls: true,
+                },
+              },
+            },
+            {
+              model_picker_enabled: true,
+              id: "overflow-model",
+              name: "Overflow Model",
+              version: "overflow-model-2026-07-09",
+              billing: {
+                token_prices: {
+                  batch_size: Number.MIN_VALUE,
+                  default: {
+                    input_price: Number.MAX_VALUE,
+                    output_price: -1,
+                    cache_price: 1,
+                  },
+                },
+              },
+              capabilities: {
+                family: "test",
                 limits: {
                   max_context_window_tokens: 128000,
                   max_output_tokens: 16384,
@@ -228,7 +256,9 @@ test("uses zero cost when Copilot reports a zero billing batch size", async () =
     ),
   ) as unknown as typeof fetch
 
-  const model = (await CopilotModels.get("https://api.githubcopilot.com")).models["mercury-alpha"]
+  const models = (await CopilotModels.get("https://api.githubcopilot.com")).models
+  const model = models["mercury-alpha"]
+  const overflow = models["overflow-model"]
 
   expect(model.cost).toEqual({
     input: 0,
@@ -238,7 +268,9 @@ test("uses zero cost when Copilot reports a zero billing batch size", async () =
       write: 0,
     },
   })
+  expect(overflow.cost).toEqual(model.cost)
   expect(JSON.stringify(model)).not.toContain("null")
+  expect(JSON.stringify(overflow)).not.toContain("null")
 })
 
 test("records Copilot advertised responses endpoint for non-GPT model IDs", async () => {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1426,6 +1426,32 @@ test("models.dev normalization fills required response fields", () => {
   expect(model.release_date).toBe("")
 })
 
+test("public provider info omits invalid models", () => {
+  const provider = Provider.fromModelsDevProvider({
+    id: "test",
+    name: "Test",
+    env: [],
+    models: {
+      valid: {
+        id: "valid",
+        name: "Valid",
+        cost: { input: 1, output: 1 },
+        limit: { context: 128_000, output: 16_000 },
+      },
+    },
+  } as unknown as ModelsDev.Provider)
+  provider.models.invalid = {
+    ...provider.models.valid,
+    id: ModelV2.ID.make("invalid"),
+    cost: { ...provider.models.valid.cost, input: Number.NaN },
+  }
+
+  const result = Provider.toPublicInfo(provider)
+
+  expect(result.models.valid).toBeDefined()
+  expect(result.models.invalid).toBeUndefined()
+})
+
 it.instance("model variants are generated for reasoning models", () =>
   Effect.gen(function* () {
     yield* set("ANTHROPIC_API_KEY", "test-api-key")


### PR DESCRIPTION
## Summary
- handle GitHub Copilot models with a zero billing batch size without producing `NaN` costs
- validate provider models independently before public serialization
- omit an invalid model instead of failing the entire provider list

## Testing
- `bun test test/plugin/github-copilot-models.test.ts`
- `bun test test/provider/provider.test.ts --test-name-pattern "public provider info omits invalid models"`
- `bun typecheck`
- verified the development `/provider` endpoint returns finite zero costs for `github-copilot/mercury-alpha`