### PR TITLE
fix: show selected mini agent in footer

### DIFF
--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -388,7 +388,7 @@ export function RunFooterView(props: RunFooterViewProps) {
       return "EXIT"
     }
 
-    return shell() ? "SHELL" : "BUILD"
+    return shell() ? "SHELL" : props.agent.toUpperCase()
   })
   const modeColor = createMemo(() => {
     if (exiting()) {

--- a/packages/opencode/test/cli/run/footer.view.test.tsx
+++ b/packages/opencode/test/cli/run/footer.view.test.tsx
@@ -164,6 +164,7 @@ async function renderFooter(
     width?: number
     height?: number
     state?: Partial<FooterState>
+    agent?: string
     onCycle?: () => void
     onSubmit?: (prompt: RunPrompt) => boolean
   } = {},
@@ -199,7 +200,7 @@ async function renderFooter(
           theme={input.theme ?? (() => RUN_THEME_FALLBACK)}
           tuiConfig={config}
           backgroundSubagents={input.backgroundSubagents ?? true}
-          agent="opencode"
+          agent={input.agent ?? "Build"}
           onSubmit={input.onSubmit ?? (() => true)}
           onPermissionReply={() => {}}
           onQuestionReply={() => {}}
@@ -307,6 +308,19 @@ test("direct footer composer area does not adopt footer surface", async () => {
     await app.renderOnce()
 
     expect(area.backgroundColor.toInts()).not.toEqual(surface.toInts())
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct footer statusline uses selected agent label", async () => {
+  const app = await renderFooter({ agent: "Plan" })
+
+  try {
+    await app.renderOnce()
+
+    expect(app.captureCharFrame()).toContain("PLAN")
+    expect(app.captureCharFrame()).not.toContain("BUILD")
   } finally {
     app.cleanup()
   }


### PR DESCRIPTION
## Summary

- show the selected mini-mode agent in the statusline instead of always showing `BUILD`
- add a footer render test covering `--agent plan` style labels

Fixes #36121.

## Test

- `bun test test/cli/run/footer.view.test.tsx --timeout 30000`
- `bun typecheck`
- pre-push hook: `bun turbo typecheck`