### PR TITLE
fix(llm): preserve nested OpenAI stream errors

### DIFF
--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -230,6 +230,7 @@ const OpenAIResponsesEvent = Schema.Struct({
   code: Schema.optional(Schema.String),
   message: Schema.optional(Schema.String),
   param: Schema.optional(Schema.String),
+  error: Schema.optional(OpenAIResponsesErrorPayload),
 })
 type OpenAIResponsesEvent = Schema.Schema.Type<typeof OpenAIResponsesEvent>
 
@@ -899,7 +900,7 @@ const onResponseFinish = (state: ParserState, event: OpenAIResponsesEvent): Step
 // the bare message — production rate limits and context-length failures used
 // to be indistinguishable from generic stream drops.
 const providerErrorMessage = (event: OpenAIResponsesEvent, fallback: string): string => {
-  const nested = event.response?.error ?? undefined
+  const nested = event.error ?? event.response?.error ?? undefined
   const message = event.message || nested?.message || undefined
   const code = event.code || nested?.code || undefined
   if (message && code) return `${code}: ${message}`
@@ -907,7 +908,7 @@ const providerErrorMessage = (event: OpenAIResponsesEvent, fallback: string): st
 }
 
 const providerError = (event: OpenAIResponsesEvent, fallback: string) => {
-  const code = event.code || event.response?.error?.code || undefined
+  const code = event.code || event.error?.code || event.response?.error?.code || undefined
   const message = providerErrorMessage(event, fallback)
   return LLMEvent.providerError({
     message,

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -198,11 +198,11 @@ const OpenAIResponsesStreamItem = Schema.Struct({
 })
 type OpenAIResponsesStreamItem = Schema.Schema.Type<typeof OpenAIResponsesStreamItem>
 
-// OpenAI Responses surfaces provider failures in two related shapes. The
-// streaming `error` event carries the details at the top level
-// (`{ type: "error", code, message, param, sequence_number }`), while
-// `response.failed` carries them under `response.error`. We capture both so
-// the parser can surface a useful provider-error message in either path.
+// The Responses schema puts streaming error details at the top level and
+// response failures under `response.error`. The official SDK also recognizes
+// an event-level HTTP-style `error` envelope, so accept all three shapes here.
+// https://github.com/openai/openai-openapi/blob/5162af98d3147432c14680df789e8e12d4891e6b/openapi.yaml#L67234-L67382
+// https://github.com/openai/openai-node/blob/61539248cbe04665de68a71e6fd878127ae4db87/src/core/streaming.ts#L58-L85
 const OpenAIResponsesErrorPayload = Schema.Struct({
   code: optionalNull(Schema.String),
   message: optionalNull(Schema.String),
@@ -227,10 +227,10 @@ const OpenAIResponsesEvent = Schema.Struct({
       [Schema.Record(Schema.String, Schema.Unknown)],
     ),
   ),
-  code: Schema.optional(Schema.String),
+  code: optionalNull(Schema.String),
   message: Schema.optional(Schema.String),
-  param: Schema.optional(Schema.String),
-  error: Schema.optional(OpenAIResponsesErrorPayload),
+  param: optionalNull(Schema.String),
+  error: optionalNull(OpenAIResponsesErrorPayload),
 })
 type OpenAIResponsesEvent = Schema.Schema.Type<typeof OpenAIResponsesEvent>
 

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -1443,7 +1443,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("surfaces error event details even when they arrive nested under response.error", () =>
+  it.effect("surfaces error event details nested under response.error", () =>
     Effect.gen(function* () {
       // Some OpenAI-compatible proxies and older SDK versions wrap the
       // top-level error fields into a nested `response.error` payload
@@ -1456,6 +1456,29 @@ describe("OpenAI Responses route", () => {
             sseEvents({
               type: "error",
               response: { error: { code: "context_length_exceeded", message: "prompt too long" } },
+            }),
+          ),
+        ),
+      )
+
+      expect(response.events).toEqual([
+        {
+          type: "provider-error",
+          message: "context_length_exceeded: prompt too long",
+          classification: "context-overflow",
+        },
+      ])
+    }),
+  )
+
+  it.effect("surfaces error event details nested under error", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              type: "error",
+              error: { code: "context_length_exceeded", message: "prompt too long" },
             }),
           ),
         ),

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -1478,7 +1478,13 @@ describe("OpenAI Responses route", () => {
           fixedResponse(
             sseEvents({
               type: "error",
-              error: { code: "context_length_exceeded", message: "prompt too long" },
+              sequence_number: 2,
+              error: {
+                type: "invalid_request_error",
+                code: "context_length_exceeded",
+                message: "prompt too long",
+                param: "input",
+              },
             }),
           ),
         ),
@@ -1491,6 +1497,36 @@ describe("OpenAI Responses route", () => {
           classification: "context-overflow",
         },
       ])
+    }),
+  )
+
+  it.effect("accepts nullable fields in spec-compliant error events", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              type: "error",
+              code: null,
+              message: "Something went wrong",
+              param: null,
+              sequence_number: 1,
+            }),
+          ),
+        ),
+      )
+
+      expect(response.events).toEqual([{ type: "provider-error", message: "Something went wrong" }])
+    }),
+  )
+
+  it.effect("falls back to a stable default when error is null", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(fixedResponse(sseEvents({ type: "error", error: null }))),
+      )
+
+      expect(response.events).toEqual([{ type: "provider-error", message: "OpenAI Responses stream error" }])
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #36118

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves OpenAI Responses SSE error details when the event arrives as:

```json
{ "type": "error", "error": { "code": "...", "message": "..." } }
```

The stream parser already handled top-level `code`/`message` and `response.error`; this adds the missing top-level `error` object shape so provider errors keep their code/message and context-overflow classification.

@rekram1-node tagging you since you have recent ownership in the LLM/provider area. Could you assign #36118 to me if this direction looks right?

### How did you verify your code works?

- Added a regression test for `type: "error"` with nested `error.code` / `error.message`.
- Ran `git diff --check`.
- Attempted the focused Bun test from `packages/llm`, but dependency install is blocked in this environment by a 403 while resolving `ghostty-web@github:anomalyco/ghostty-web#513463a6f...`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally where possible
- [x] I have not included unrelated changes in this PR
