### PR TITLE
fix(server): await catalog readiness for reads

### DIFF
--- a/packages/server/src/handlers/model.ts
+++ b/packages/server/src/handlers/model.ts
@@ -8,10 +8,27 @@ import { response } from "../location"
 
 export const ModelHandler = HttpApiBuilder.group(Api, "server.model", (handlers) =>
   Effect.gen(function* () {
+    const plugins = yield* PluginSupervisor.Service
+    const awaitCatalog = Effect.fn(function* () {
+      yield* plugins.flush.pipe(
+        Effect.timeoutOrElse({
+          duration: "5 seconds",
+          orElse: () =>
+            Effect.fail(
+              new ServiceUnavailableError({
+                message: "Model catalog initialization timed out",
+                service: "model.catalog",
+              }),
+            ),
+        }),
+      )
+    })
+
     return handlers
       .handle(
         "model.list",
         Effect.fn(function* () {
+          yield* awaitCatalog()
           const catalog = yield* Catalog.Service
           return yield* response(catalog.model.available())
         }),
@@ -19,19 +36,7 @@ export const ModelHandler = HttpApiBuilder.group(Api, "server.model", (handlers)
       .handle(
         "model.default",
         Effect.fn(function* () {
-          const plugins = yield* PluginSupervisor.Service
-          yield* plugins.flush.pipe(
-            Effect.timeoutOrElse({
-              duration: "5 seconds",
-              orElse: () =>
-                Effect.fail(
-                  new ServiceUnavailableError({
-                    message: "Model catalog initialization timed out",
-                    service: "model.catalog",
-                  }),
-                ),
-            }),
-          )
+          yield* awaitCatalog()
           const catalog = yield* Catalog.Service
           return yield* response(catalog.model.default())
         }),

--- a/packages/server/src/handlers/provider.ts
+++ b/packages/server/src/handlers/provider.ts
@@ -1,16 +1,34 @@
 import { Catalog } from "@opencode-ai/core/catalog"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
-import { ProviderNotFoundError } from "@opencode-ai/protocol/errors"
+import { ProviderNotFoundError, ServiceUnavailableError } from "@opencode-ai/protocol/errors"
 import { response } from "../location"
 
 export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (handlers) =>
   Effect.gen(function* () {
+    const plugins = yield* PluginSupervisor.Service
+    const awaitCatalog = Effect.fn(function* () {
+      yield* plugins.flush.pipe(
+        Effect.timeoutOrElse({
+          duration: "5 seconds",
+          orElse: () =>
+            Effect.fail(
+              new ServiceUnavailableError({
+                message: "Provider catalog initialization timed out",
+                service: "provider.catalog",
+              }),
+            ),
+        }),
+      )
+    })
+
     return handlers
       .handle(
         "provider.list",
         Effect.fn(function* () {
+          yield* awaitCatalog()
           const catalog = yield* Catalog.Service
           return yield* response(catalog.provider.available())
         }),
@@ -18,6 +36,7 @@ export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (han
       .handle(
         "provider.get",
         Effect.fn(function* (ctx) {
+          yield* awaitCatalog()
           const catalog = yield* Catalog.Service
           const provider = yield* catalog.provider.get(ctx.params.providerID)
           if (!provider)


### PR DESCRIPTION
### Issue for this PR

Closes #36117

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

During a managed-service restart, the public catalog read endpoints can return `200 OK` with an intermediate provider/model snapshot while catalog-producing plugins are still activating. The TUI can then bootstrap from that partial state, show unrelated models.dev entries, omit configured models, and keep the invalid picker state even after the catalog finishes loading.

Root cause: `/api/model`, `/api/provider`, and `/api/provider/{providerID}` read provider/catalog state directly, while `/api/model/default` already goes through the existing bounded plugin-readiness barrier.

This PR makes the public catalog read handlers use that same readiness path before returning successful snapshots:

- `/api/model` waits for catalog readiness before reading models.
- `/api/provider` and `/api/provider/{providerID}` wait for plugin readiness before reading provider availability.
- Readiness timeout remains explicit via `ServiceUnavailableError` instead of returning a successful partial catalog.

@kitlangton, tagging you since you authored #36117 and the incident/repro. If this matches the intended direction, could you assign/link the issue or clear the stale `needs:issue` label?

### How did you verify your code works?

- Ran `git diff --check`.
- Attempted the linked focused regression command from `packages/server`; this branch does not currently include `test/catalog-readiness.test.ts`, so Bun reported that the filter matched no files.
- Attempted `bun run typecheck` from `packages/server`; blocked locally because dependencies/tooling are unavailable (`tsgo: command not found`) after the repo dependency install is blocked by the private/403 `ghostty-web` dependency.
- Automated PR checks currently pass, including `check-standards` and `check-compliance`; the `needs:issue` label appears stale even though this body has `Closes #36117` in the required issue section.

### Risk / reviewer notes

Focused server-read behavior change. It should only affect cold-start/restart windows where catalog state is not ready yet: instead of returning a successful partial snapshot, reads wait for readiness or return the existing explicit service-unavailable timeout. Warm-path catalog reads should keep the same response shape.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally where possible
- [x] I have not included unrelated changes in this PR
