### PR TITLE
fix(opencode): expose max reasoning effort for GPT-5.6+ models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -520,6 +520,7 @@ const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_1_EFFORTS = ["none", ...WIDELY_SUPPORTED_EFFORTS]
 const OPENAI_GPT5_2_PLUS_EFFORTS = [...OPENAI_GPT5_1_EFFORTS, "xhigh"]
+const OPENAI_GPT5_6_PLUS_EFFORTS = [...OPENAI_GPT5_2_PLUS_EFFORTS, "max"]
 const OPENAI_GPT5_PRO_EFFORTS = ["high"]
 const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
 const OPENAI_GPT5_CHAT_EFFORTS = ["medium"]
@@ -551,6 +552,7 @@ function versionedGpt5ReasoningEfforts(apiId: string) {
   const version = gpt5Version(apiId)
   if (version === undefined) return undefined
   if (version === 1) return OPENAI_GPT5_1_EFFORTS
+  if (version >= 6) return OPENAI_GPT5_6_PLUS_EFFORTS
   return OPENAI_GPT5_2_PLUS_EFFORTS
 }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4007,6 +4007,12 @@ describe("ProviderTransform.variants", () => {
       },
       { id: "gpt-5.4-pro", releaseDate: "2026-03-05", efforts: ["medium", "high", "xhigh"] },
       { id: "gpt-5.5-pro", releaseDate: "2026-04-23", efforts: ["medium", "high", "xhigh"] },
+      { id: "gpt-5.6", releaseDate: "2026-07-02", efforts: ["none", "low", "medium", "high", "xhigh", "max"] },
+      {
+        id: "gpt-5.6-terra",
+        releaseDate: "2026-07-02",
+        efforts: ["none", "low", "medium", "high", "xhigh", "max"],
+      },
       { id: "gpt-5-codex", releaseDate: "2025-09-23", efforts: ["low", "medium", "high"] },
       { id: "gpt-5.1-codex", releaseDate: "2025-11-13", efforts: ["low", "medium", "high"] },
       { id: "gpt-5.1-codex-max", releaseDate: "2025-11-13", efforts: ["low", "medium", "high", "xhigh"] },


### PR DESCRIPTION
OpenAI's `reasoning_options` for GPT-5.6 family models (gpt-5.6, gpt-5.6-terra, gpt-5.6-luna, gpt-5.6-sol) include `max` but OpenCode was capping at `xhigh`.

### Changes

- Add `OPENAI_GPT5_6_PLUS_EFFORTS` constant extending the 2+ set with `max`
- Update `versionedGpt5ReasoningEfforts` to return the new set for version >= 6
- Add test coverage for gpt-5.6 and gpt-5.6-terra