### PR TITLE
fix(opencode): expose max reasoning effort for GPT-5.6+ models

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -520,6 +520,7 @@ const WIDELY_SUPPORTED_EFFORTS = ["low", "medium", "high"]
 const OPENAI_EFFORTS = ["none", "minimal", ...WIDELY_SUPPORTED_EFFORTS, "xhigh"]
 const OPENAI_GPT5_1_EFFORTS = ["none", ...WIDELY_SUPPORTED_EFFORTS]
 const OPENAI_GPT5_2_PLUS_EFFORTS = [...OPENAI_GPT5_1_EFFORTS, "xhigh"]
+const OPENAI_GPT5_6_PLUS_EFFORTS = [...OPENAI_GPT5_2_PLUS_EFFORTS, "max"]
 const OPENAI_GPT5_PRO_EFFORTS = ["high"]
 const OPENAI_GPT5_PRO_2_PLUS_EFFORTS = ["medium", "high", "xhigh"]
 const OPENAI_GPT5_CHAT_EFFORTS = ["medium"]
@@ -551,6 +552,7 @@ function versionedGpt5ReasoningEfforts(apiId: string) {
   const version = gpt5Version(apiId)
   if (version === undefined) return undefined
   if (version === 1) return OPENAI_GPT5_1_EFFORTS
+  if (version >= 6) return OPENAI_GPT5_6_PLUS_EFFORTS
   return OPENAI_GPT5_2_PLUS_EFFORTS
 }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4007,6 +4007,12 @@ describe("ProviderTransform.variants", () => {
       },
       { id: "gpt-5.4-pro", releaseDate: "2026-03-05", efforts: ["medium", "high", "xhigh"] },
       { id: "gpt-5.5-pro", releaseDate: "2026-04-23", efforts: ["medium", "high", "xhigh"] },
+      { id: "gpt-5.6", releaseDate: "2026-07-02", efforts: ["none", "low", "medium", "high", "xhigh", "max"] },
+      {
+        id: "gpt-5.6-terra",
+        releaseDate: "2026-07-02",
+        efforts: ["none", "low", "medium", "high", "xhigh", "max"],
+      },
       { id: "gpt-5-codex", releaseDate: "2025-09-23", efforts: ["low", "medium", "high"] },
       { id: "gpt-5.1-codex", releaseDate: "2025-11-13", efforts: ["low", "medium", "high"] },
       { id: "gpt-5.1-codex-max", releaseDate: "2025-11-13", efforts: ["low", "medium", "high", "xhigh"] },


### PR DESCRIPTION
### Issue for this PR

Closes #36141

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI's `reasoning_options` for GPT-5.6 family models (gpt-5.6, gpt-5.6-terra, gpt-5.6-luna, gpt-5.6-sol) include `max` as a valid reasoning effort, but `versionedGpt5ReasoningEfforts` in `transform.ts` returns `OPENAI_GPT5_2_PLUS_EFFORTS` for all versions >= 2, which caps at `xhigh`.

The fix adds a dedicated `OPENAI_GPT5_6_PLUS_EFFORTS` constant that extends the 2+ set with `max`, and a `version >= 6` check in `versionedGpt5ReasoningEfforts` to use it. Only GPT-5.6+ models are affected — earlier versions keep their existing effort sets unchanged.

### How did you verify your code works?

- Ran `bun test test/provider/transform.test.ts` — 295 tests pass (0 failures)
- Added test cases for `gpt-5.6` and `gpt-5.6-terra` that assert the full effort set `["none", "low", "medium", "high", "xhigh", "max"]`

### Screenshots / recordings

_N/A — no UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR