### PR TITLE
docs: expand LM Studio local provider guidance

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1447,6 +1447,16 @@ In this example:
 - `options.baseURL` is the endpoint for the local server.
 - `models` is a map of model IDs to their configurations. The model name will be displayed in the model selection list.
 
+opencode does not auto-discover models from the endpoint, so each model you want must be listed under `models`. Each model ID must match the `id` returned by `GET /v1/models` — run `curl http://127.0.0.1:1234/v1/models` to list the ids currently available in LM Studio.
+
+#### Tips for reliable local use
+
+- **Match the context limit.** Set each model's `limit.context` (and `limit.output`) to the context length the model is actually loaded with in LM Studio. If it's set too high, prompts can exceed the loaded window and error or get truncated; if it's set too low, opencode compacts the conversation earlier than necessary. LM Studio's native `GET /api/v0/models` endpoint reports both `loaded_context_length` and `max_context_length`.
+- **Loading and saved settings.** With just-in-time (JIT) model loading enabled, the first request auto-loads the model using LM Studio's default load settings, and an already-loaded model ignores a request's load config. To use your saved per-model settings (context length, GPU offload, etc.), load the model in LM Studio before starting opencode, or disable JIT loading. Consider raising LM Studio's idle TTL so the model isn't evicted mid-session.
+- **Use a tool-capable model.** Agentic use requires a model that supports tool calling. `GET /api/v0/models` lists a `capabilities` array for each model — prefer models that include `tool_use`.
+- **Bound runaway loops.** opencode does not cap agentic iterations by default. If a local model gets stuck repeating tool calls, set a step limit on the agents you use, for example `"agent": { "build": { "steps": 40 } }`.
+- **Reduce repetition.** opencode does not send a repetition or frequency penalty, so set one in LM Studio — a small repeat penalty (such as 1.05) together with a non-zero temperature helps avoid loops.
+
 ---
 
 ### Moonshot AI


### PR DESCRIPTION
### Issue for this PR

Closes #36138

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The LM Studio section in `providers.mdx` only had a minimal config snippet. This adds a short "Tips for reliable local use" list covering the things that actually trip people up:

- Models must be listed manually (opencode does not auto-discover); each ID must match `GET /v1/models`.
- `limit.context` should match the model's loaded context, because it drives opencode's auto-compaction - too high overflows the backend, too low compacts early.
- With just-in-time loading, a request auto-loads the model with default settings, and an already-loaded model ignores a request's load config; so load the model first (or disable JIT) to keep your saved settings.
- Prefer a tool-capable model (LM Studio's `/api/v0/models` lists a `capabilities` array with `tool_use`).
- Set `agent.steps` to bound loops - opencode has no default iteration cap.
- Set a repetition penalty in LM Studio, since opencode does not send one.

These reflect documented LM Studio API behavior and opencode's existing config fields; no code paths change.

### How did you verify your code works?

Docs-only change. The additions use only Markdown constructs already used elsewhere in `providers.mdx` (bullet lists, inline code, `---` dividers) and were reviewed against the surrounding section for consistent style. No application code is touched.

### Screenshots / recordings

N/A - not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR