### PR TITLE
feat: add OPENCODE_SUBAGENT_MODEL env var to override subagent model

### DIFF
--- a/packages/opencode/src/effect/runtime-flags.ts
+++ b/packages/opencode/src/effect/runtime-flags.ts
@@ -54,6 +54,7 @@ export class Service extends ConfigService.Service<Service>()("@opencode/Runtime
   experimentalNativeLlm: bool("OPENCODE_EXPERIMENTAL_NATIVE_LLM"),
   experimentalWebSockets: bool("OPENCODE_EXPERIMENTAL_WEBSOCKETS"),
   client: Config.string("OPENCODE_CLIENT").pipe(Config.withDefault("cli")),
+  subagentModel: Config.string("OPENCODE_SUBAGENT_MODEL").pipe(Config.option),
 }) {}
 
 export type Info = Context.Service.Shape<typeof Service>

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,7 +10,8 @@ import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
-import { Effect, Exit, Schema, Scope } from "effect"
+import { Provider } from "../provider/provider.js"
+import { Effect, Exit, Option, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Database } from "@opencode-ai/core/database/database"
@@ -164,10 +165,12 @@ export const TaskTool = Tool.define(
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
       const variant = msg.info.variant
 
-      const model = next.model ?? {
-        modelID: msg.info.modelID,
-        providerID: msg.info.providerID,
-      }
+      const model =
+        Option.getOrUndefined(Option.map(flags.subagentModel, Provider.parseModel)) ??
+        next.model ?? {
+          modelID: msg.info.modelID,
+          providerID: msg.info.providerID,
+        }
       const metadata = {
         parentSessionId: ctx.sessionID,
         sessionId: nextSession.id,


### PR DESCRIPTION
### Issue for this PR

Closes #36147

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `OPENCODE_SUBAGENT_MODEL` env var to pin a specific model for subagents spawned via the task tool, independent of the main session model.

Without this, subagents inherit the parent session's model. If the main session is running a heavy model, every spawned subagent also runs on it - spiking costs when a session fans out to multiple agents. This lets you keep a capable model for the primary session while routing subagents to a cheaper one.

Mirrors `CLAUDE_CODE_SUBAGENT_MODEL` from Claude Code. Priority: env var > agent config model > parent session model.

**Usage:**
```
OPENCODE_SUBAGENT_MODEL=anthropic/claude-haiku-4-5-20251001 opencode
```

### How did you verify your code works?

Built from source and ran a session with `OPENCODE_SUBAGENT_MODEL` set, confirmed subagents used the overridden model. Also verified existing behavior is unchanged without the env var.

### Screenshots / recordings

_N/A - no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR