### PR TITLE
fix(tui): handle session search fetch failures without crashing

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -35,16 +35,23 @@ export function DialogSessionList() {
   const [searchResults] = createResource(search, async (query) => {
     if (!query) return
     const location = data.location.default()
-    const response = await sdk.api.session.list({
-      search: query,
-      limit: 50,
-      order: "desc",
-      parentID: null,
-      directory: location.directory,
-      workspace: location.workspaceID,
-    })
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- generated client output is readonly; session list UI reuses legacy mutable session types.
-    return { query, sessions: structuredClone(response.data) as SessionInfo[] }
+    try {
+      const response = await sdk.api.session.list({
+        search: query,
+        limit: 50,
+        order: "desc",
+        parentID: null,
+        directory: location.directory,
+        workspace: location.workspaceID,
+      })
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- generated client output is readonly; session list UI reuses legacy mutable session types.
+      return { query, sessions: structuredClone(response.data) as SessionInfo[] }
+    } catch (error) {
+      // A transient transport failure must degrade search, not crash the TUI
+      // through the root ErrorBoundary when the errored resource is read.
+      toast.show({ message: errorMessage(error), variant: "error", duration: 5000 })
+      return { query, sessions: [] as SessionInfo[] }
+    }
   })
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))


### PR DESCRIPTION
Fixes #36148

Typing in the session list dialog's search box fires a `createResource` fetcher calling `sdk.api.session.list(...)`. When the underlying `fetch` rejects before an HTTP response (server restarting, socket dropped after sleep/wake), the generated client throws `ClientError("Transport")`. The fetcher had no error handling, so Solid rethrew the stored rejection when the `sessions` memo read `searchResults()`, and the only `ErrorBoundary` (app root) rendered the crash screen, killing the whole TUI.

This wraps the fetcher in try/catch, matching the pattern used by sibling dialogs (`dialog-fork.tsx`, `dialog-message.tsx`): toast the error via `errorMessage` and return empty results, so a transient connection blip degrades search instead of crashing.

- `bun typecheck` passes in `packages/tui`