### PR TITLE
docs: add Unforgit to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |
+| [Unforgit](https://github.com/MiguelMedeiros/unforgit)                                                     | Repository-scoped persistent memory for OpenCode via MCP and AGENTS.md project integration        |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                         |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control          |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                    |


### PR DESCRIPTION
## Summary

Adds Unforgit to the OpenCode ecosystem plugins list.

Unforgit provides repository-scoped persistent memory for coding agents via MCP and project-level OpenCode configuration (`opencode.json` + `AGENTS.md`).

## Verification

From the Unforgit repo:

- `pnpm test` -> 224 tests passed
- `pnpm build` -> passed
- `pnpm lint` -> 0 errors

OpenCode integration generated by Unforgit:

```bash
npm install -g unforgit
cd your-project
unforgit init --ide opencode
```

Generated files:

- `opencode.json`
- `AGENTS.md`
