### PR TITLE
docs: add opencode-codex-rate-limit-reset to ecosystem of plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-codex-rate-limit-reset](https://github.com/nexxai/opencode-codex-rate-limit-reset)       | View and redeem your Codex rate limit resets                                                       |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

n/a

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the opencode-codex-rate-limit-reset plugin to the ecosystem documentation

### How did you verify your code works?

I viewed the `ecosystem.mdx` file in a Markdown viewer to confirm that the table is laid out correctly

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR