### PR TITLE
fix(core): narrow ecosystem config watches

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -197,7 +197,7 @@ const layer = Layer.effect(
               start: location.directory,
               stop: location.project.directory,
             })
-          .pipe(Effect.orDie)
+            .pipe(Effect.orDie)
 
       // We load certain files from a few other folders in the ecosystem
       const claude = [
@@ -235,7 +235,7 @@ const layer = Layer.effect(
       const supplementary = yield* Effect.forEach(directories, loadDirectory).pipe(Effect.orDie)
       return {
         entries: [...claude, ...agents, ...(supplementary[0] ?? []), ...direct, ...supplementary.slice(1).flat()],
-        directories: [...directories, ...claude.map((entry) => entry.path), ...agents.map((entry) => entry.path)],
+        directories,
         files: directPaths,
       }
     })

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -934,4 +934,54 @@ describe("Config", () => {
       }),
     ),
   )
+
+  it.live("discovers ecosystem skill directories without watching them as config", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const global = path.join(tmp.path, "global")
+          const project = path.join(tmp.path, "project")
+          const globalAgents = path.join(global, "home", ".agents")
+          const globalClaude = path.join(global, "home", ".claude")
+          const projectAgents = path.join(project, ".agents")
+          const projectClaude = path.join(project, ".claude")
+          yield* Effect.promise(() =>
+            Promise.all(
+              [global, project, globalAgents, globalClaude, projectAgents, projectClaude].map((directory) =>
+                fs.mkdir(directory, { recursive: true }),
+              ),
+            ),
+          )
+          const targets: Watcher.WatchInput[] = []
+          const watcher = Layer.succeed(
+            Watcher.Service,
+            Watcher.Service.of({
+              subscribe: (input) => {
+                targets.push(input)
+                return Stream.empty
+              },
+            }),
+          )
+
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const entries = yield* config.entries()
+
+            expect(entries.filter((entry) => entry.type === "agents").map((entry) => entry.path)).toEqual([
+              AbsolutePath.make(globalAgents),
+              AbsolutePath.make(projectAgents),
+            ])
+            expect(entries.filter((entry) => entry.type === "claude").map((entry) => entry.path)).toEqual([
+              AbsolutePath.make(globalClaude),
+              AbsolutePath.make(projectClaude),
+            ])
+            expect(targets).toEqual([{ path: AbsolutePath.make(global), type: "directory" }])
+          }).pipe(Effect.provide(testLayer(project, global, project, undefined, watcher)))
+        }),
+      ),
+    ),
+  )
 })


### PR DESCRIPTION
## Summary

- keep discovered `.claude` and `.agents` directories as ecosystem skill sources
- exclude those directories from recursive config watcher targets
- cover discovery and watcher targeting together with a config regression test

This prevents unrelated operational writes below ecosystem directories from publishing `config.updated` and reloading every plugin generation. Skill content changes remain covered by the existing location watcher and skill cache invalidation path.

Closes #36173

## Verification

- `bun run test test/config/config.test.ts` from `packages/core` (19 passed)
- `bun typecheck` from `packages/core`
- push hook: workspace `bun turbo typecheck --concurrency=3` (31 packages passed)
- `bunx prettier --check packages/core/src/config.ts packages/core/test/config/config.test.ts`