### PR TITLE
fix(tui): preserve initial user message on new session hydration

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1088,6 +1088,17 @@ export function Prompt(props: PromptProps) {
       })
     } else {
       move.startSubmit()
+      sync.session.optimisticUserMessage({
+        sessionID,
+        text: inputText,
+        parts: [...editorParts, ...nonTextParts],
+        agent: agent.name,
+        model: {
+          providerID: selectedModel.providerID,
+          modelID: selectedModel.modelID,
+          variant,
+        },
+      })
       sdk.client.session
         .prompt(
           {
@@ -1108,6 +1119,7 @@ export function Prompt(props: PromptProps) {
           { throwOnError: true },
         )
         .catch((error) => {
+          sync.session.clearOptimisticUserMessage(sessionID)
           toast.show({
             title: "Failed to send prompt",
             message: errorMessage(error),
@@ -1128,15 +1140,14 @@ export function Prompt(props: PromptProps) {
     setStore("extmarkToPartIndex", new Map())
     props.onSubmit?.()
 
-    // temporary hack to make sure the message is sent
     if (!props.sessionID) {
       if (editorParts.length > 0) editor.preserveSelectionFromNewSession()
-      setTimeout(() => {
+      queueMicrotask(() => {
         route.navigate({
           type: "session",
           sessionID,
         })
-      }, 50)
+      })
     }
     input.clear()
     if (finishMoveProgress) move.finishSubmit()

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -144,6 +144,32 @@ export const {
     const fullSyncedSessions = new Set<string>()
     const syncingSessions = new Map<string, Promise<void>>()
     const hydratingSessions = new Map<string, { messages: Set<string>; parts: Set<string> }>()
+    const optimisticBySession = new Map<string, string>()
+
+    function clearOptimisticUserMessage(sessionID: string) {
+      const messageID = optimisticBySession.get(sessionID)
+      if (!messageID) return
+      optimisticBySession.delete(sessionID)
+      const messages = store.message[sessionID]
+      if (messages) {
+        const match = search(messages, messageID, (m) => m.id)
+        if (match.found) {
+          setStore(
+            "message",
+            sessionID,
+            produce((draft) => {
+              draft.splice(match.index, 1)
+            }),
+          )
+        }
+      }
+      setStore(
+        "part",
+        produce((draft) => {
+          delete draft[messageID]
+        }),
+      )
+    }
     const touchMessage = (sessionID: string, messageID: string) => {
       hydratingSessions.get(sessionID)?.messages.add(messageID)
     }
@@ -313,6 +339,12 @@ export const {
         }
 
         case "message.updated": {
+          if (event.properties.info.role === "user") {
+            const optimisticID = optimisticBySession.get(event.properties.info.sessionID)
+            if (optimisticID && optimisticID !== event.properties.info.id) {
+              clearOptimisticUserMessage(event.properties.info.sessionID)
+            }
+          }
           touchMessage(event.properties.info.sessionID, event.properties.info.id)
           const messages = store.message[event.properties.info.sessionID]
           if (!messages) {
@@ -605,6 +637,8 @@ export const {
                 if (!match.found) draft.session.splice(match.index, 0, session.data!)
                 draft.todo[sessionID] = todo.data ?? []
                 const currentMessages = draft.message[sessionID] ?? []
+                const optimisticID = optimisticBySession.get(sessionID)
+                const optimisticIDs = optimisticID ? new Set([optimisticID]) : new Set<string>()
                 const infos = (messages.data ?? []).flatMap((message) => {
                   if (!tracker.messages.has(message.info.id)) return [message.info]
                   const current = currentMessages.find((item) => item.id === message.info.id)
@@ -612,7 +646,9 @@ export const {
                 })
                 infos.push(
                   ...currentMessages.filter(
-                    (message) => tracker.messages.has(message.id) && !infos.some((item) => item.id === message.id),
+                    (message) =>
+                      (tracker.messages.has(message.id) || optimisticIDs.has(message.id)) &&
+                      !infos.some((item) => item.id === message.id),
                   ),
                 )
                 const removed = infos.slice(0, -100)
@@ -658,6 +694,63 @@ export const {
           syncingSessions.set(sessionID, task)
           return task
         },
+        optimisticUserMessage(input: {
+          sessionID: string
+          text: string
+          parts?: Array<Omit<Part, "id" | "sessionID" | "messageID">>
+          agent: string
+          model: {
+            providerID: string
+            modelID: string
+            variant?: string
+          }
+        }) {
+          clearOptimisticUserMessage(input.sessionID)
+          const messageID = `opt_${crypto.randomUUID()}`
+          optimisticBySession.set(input.sessionID, messageID)
+          const created = Date.now()
+          const message: Message = {
+            id: messageID,
+            sessionID: input.sessionID,
+            role: "user",
+            time: { created },
+            agent: input.agent,
+            model: input.model,
+          }
+          const parts: Part[] = [
+            ...(input.parts ?? []).map(
+              (part) =>
+                ({
+                  ...part,
+                  id: `opt_${crypto.randomUUID()}`,
+                  sessionID: input.sessionID,
+                  messageID,
+                }) as Part,
+            ),
+            {
+              id: `opt_${crypto.randomUUID()}`,
+              sessionID: input.sessionID,
+              messageID,
+              type: "text",
+              text: input.text,
+            },
+          ]
+          const messages = store.message[input.sessionID]
+          if (!messages) {
+            setStore("message", input.sessionID, [message])
+          } else {
+            setStore(
+              "message",
+              input.sessionID,
+              produce((draft) => {
+                draft.push(message)
+              }),
+            )
+          }
+          setStore("part", messageID, parts)
+          return messageID
+        },
+        clearOptimisticUserMessage,
       },
       bootstrap,
     }

--- a/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
@@ -260,3 +260,67 @@ test("a message removed during hydration does not regain stale parts", async () 
     app.renderer.destroy()
   }
 })
+
+test("optimistic user message survives new session hydration race", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  const userText = "What is Rust?"
+  let resolveMessages!: (response: Response) => void
+  const messages = new Promise<Response>((resolve) => {
+    resolveMessages = resolve
+  })
+  let requested = false
+  const { app, emit, sync } = await mount((url) => {
+    if (url.pathname === `/session/${sessionID}`) return json(session)
+    if (url.pathname === `/session/${sessionID}/message`) {
+      requested = true
+      return messages
+    }
+    if (url.pathname === `/session/${sessionID}/todo` || url.pathname === `/session/${sessionID}/diff`) return json([])
+    return undefined
+  }, tmp.path)
+
+  try {
+    sync.session.optimisticUserMessage({
+      sessionID,
+      text: userText,
+      agent: "build",
+      model: { providerID: "test", modelID: "model" },
+    })
+
+    const hydrate = sync.session.sync(sessionID)
+    await wait(() => requested)
+    emit(global({ id: "evt_message", type: "message.updated", properties: { sessionID, info: assistant } }))
+    emit(
+      global({
+        id: "evt_part",
+        type: "message.part.updated",
+        properties: {
+          sessionID,
+          time: 2,
+          part: { id: partID, sessionID, messageID, type: "text", text: "Hi! How can I help you?" },
+        },
+      }),
+    )
+    await wait(() => sync.data.part[messageID]?.[0]?.type === "text")
+
+    resolveMessages(
+      json([
+        {
+          info: assistant,
+          parts: [{ id: partID, sessionID, messageID, type: "text", text: "Hi! How can I help you?" }],
+        },
+      ]),
+    )
+    await hydrate
+
+    const userMessages = (sync.data.message[sessionID] ?? []).filter((message) => message.role === "user")
+    expect(userMessages).toHaveLength(1)
+    const userParts = sync.data.part[userMessages[0]!.id] ?? []
+    expect(userParts.some((part) => part.type === "text" && part.text === userText)).toBe(true)
+    expect(sync.data.part[messageID][0]).toMatchObject({ text: "Hi! How can I help you?" })
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35988

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On a new session's first prompt, the TUI navigates to the session view and runs `session.sync()` before the server has persisted the user message. Hydration can complete with only the assistant reply, so the user bubble never appears.

This adds an optimistic user message in the sync store at submit time, keeps it through hydration merge, and removes it when the real `message.updated` arrives (or on prompt failure).

### How did you verify your code works?

- `cd packages/tui && bun test test/cli/cmd/tui/sync-live-hydration.test.tsx`
- `cd packages/tui && bun test`
- `cd packages/tui && bun run typecheck`

Added regression test: `optimistic user message survives new session hydration race`.

### Screenshots / recordings

No recording yet — race is timing-dependent. Happy to add one with a slow MCP config if needed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR