### PR TITLE
fix(app): timeline width jumps around when review panel is open/closed

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -483,7 +483,7 @@ export default function Page() {
     if (desktopSessionResizeOpen()) return `${sessionPanelResizedWidth()}px`
     return `calc(100% - ${layout.fileTree.width()}px)`
   })
-  const centered = createMemo(() => isDesktop() && !desktopReviewOpen())
+  const centered = createMemo(() => isDesktop() && (newSessionDesign() || !desktopReviewOpen()))
   const desktopV2PanelLayout = createMemo(() =>
     sessionPanelLayout({
       review: desktopV2ReviewOpen(),


### PR DESCRIPTION
### Issue for this PR

Closes #6234234

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Fixes bug where the timeline width switched between fixed (breakpoint) and unconditionally full width, depending on whether the review panel was open or not. 

### How did you verify your code works?
- Ran the app locally and verified the updated UI manually
- Ran type checks locally (bun turbo typecheck)

### Screenshots / recordings
Before

https://github.com/user-attachments/assets/71484ddc-857b-4cff-a56f-f2246dcf5c25

After

https://github.com/user-attachments/assets/aac6247b-0014-4119-b312-dd5aa1ed804c

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
