### PR TITLE
refactor(core): remove temporary locationServiceMapLayer constant

### DIFF
--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -144,5 +144,3 @@ export function buildLocationServiceMap(
   )
 }
 
-// This is temporary for backwards compatibility
-export const locationServiceMapLayer = buildLocationServiceMap()

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -27,7 +27,7 @@ import * as OtelTracer from "@effect/opentelemetry/Tracer"
 import { AbsolutePath, type DeepMutable } from "@opencode-ai/core/schema"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
-import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { LocationServiceMap, buildLocationServiceMap } from "@opencode-ai/core/location-services"
 import { Reference } from "@opencode-ai/core/reference"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Location } from "@opencode-ai/core/location"
@@ -434,7 +434,7 @@ const layer = Layer.effect(
 
 const locationServiceMapNode = LayerNode.make({
   service: LocationServiceMap.Service,
-  layer: locationServiceMapLayer,
+  layer: buildLocationServiceMap(),
   deps: [],
 })
 

--- a/packages/opencode/src/cli/cmd/debug/file.ts
+++ b/packages/opencode/src/cli/cmd/debug/file.ts
@@ -1,7 +1,7 @@
 import { EOL } from "os"
 import { Effect } from "effect"
 import { FileSystem } from "@opencode-ai/core/filesystem"
-import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { LocationServiceMap, buildLocationServiceMap } from "@opencode-ai/core/location-services"
 import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { effectCmd } from "../../effect-cmd"
@@ -10,7 +10,7 @@ import { cmd } from "../cmd"
 const filesystem = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(
     Effect.provide(LocationServiceMap.Service.get(Location.Ref.make({ directory: AbsolutePath.make(process.cwd()) }))),
-    Effect.provide(locationServiceMapLayer),
+    Effect.provide(buildLocationServiceMap()),
   )
 
 const FileSearchCommand = effectCmd({

--- a/packages/opencode/src/cli/cmd/debug/v2.ts
+++ b/packages/opencode/src/cli/cmd/debug/v2.ts
@@ -1,7 +1,7 @@
 import { EOL } from "os"
 import { Effect } from "effect"
 import { Catalog } from "@opencode-ai/core/catalog"
-import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { LocationServiceMap, buildLocationServiceMap } from "@opencode-ai/core/location-services"
 import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { effectCmd } from "../../effect-cmd"
@@ -37,6 +37,6 @@ export const V2Command = effectCmd({
           }),
         ),
       ),
-      Effect.provide(locationServiceMapLayer),
+      Effect.provide(buildLocationServiceMap()),
     ),
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -1,6 +1,6 @@
 import * as InstanceState from "@/effect/instance-state"
 import { FileSystem } from "@opencode-ai/core/filesystem"
-import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { LocationServiceMap, buildLocationServiceMap } from "@opencode-ai/core/location-services"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Location } from "@opencode-ai/core/location"
@@ -136,4 +136,4 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
       .handle("content", content)
       .handle("status", status)
   }),
-).pipe(Layer.provide(locationServiceMapLayer))
+).pipe(Layer.provide(buildLocationServiceMap()))

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/pty.ts
@@ -6,7 +6,7 @@ import { Pty } from "@opencode-ai/core/pty"
 import { PtyProtocol } from "@opencode-ai/core/pty/protocol"
 import { PtyID } from "@opencode-ai/core/pty/schema"
 import { PtyTicket } from "@opencode-ai/core/pty/ticket"
-import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { LocationServiceMap, buildLocationServiceMap } from "@opencode-ai/core/location-services"
 import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { ShellSelect } from "@opencode-ai/core/shell/select"
@@ -158,7 +158,7 @@ export const ptyHandlers = HttpApiBuilder.group(InstanceHttpApi, "pty", (handler
       .handle("remove", remove)
       .handle("connectToken", connectToken)
   }),
-).pipe(Layer.provide(locationServiceMapLayer))
+).pipe(Layer.provide(buildLocationServiceMap()))
 
 export const ptyConnectHandlers = HttpApiBuilder.group(PtyConnectApi, "pty-connect", (handlers) =>
   Effect.gen(function* () {
@@ -270,4 +270,4 @@ export const ptyConnectHandlers = HttpApiBuilder.group(PtyConnectApi, "pty-conne
       }),
     )
   }),
-).pipe(Layer.provide(locationServiceMapLayer))
+).pipe(Layer.provide(buildLocationServiceMap()))

--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -19,7 +19,7 @@ import { Permission } from "@/permission"
 import { Skill } from "@/skill"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Location } from "@opencode-ai/core/location"
-import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { LocationServiceMap, buildLocationServiceMap } from "@opencode-ai/core/location-services"
 import { Reference } from "@opencode-ai/core/reference"
 import { MCP } from "@/mcp"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
@@ -132,7 +132,7 @@ const layer = Layer.effect(
 
 const locationServiceMapNode = LayerNode.make({
   service: LocationServiceMap.Service,
-  layer: locationServiceMapLayer,
+  layer: buildLocationServiceMap(),
   deps: [],
 })
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -55,7 +55,7 @@ import { reply, TestLLMServer } from "../lib/llm-server"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
-import { LocationServiceMap, locationServiceMapLayer } from "@opencode-ai/core/location-services"
+import { LocationServiceMap, buildLocationServiceMap } from "@opencode-ai/core/location-services"
 
 const summary = Layer.succeed(
   SessionSummary.Service,
@@ -689,7 +689,7 @@ noLLMServer.instance.skip(
         Effect.provide(
           LayerNode.compile(SessionV2.node, [
             [SessionExecution.node, SessionExecution.noopLayer],
-            [LocationServiceMap.node, locationServiceMapLayer],
+            [LocationServiceMap.node, buildLocationServiceMap()],
           ]),
         ),
       )


### PR DESCRIPTION
### Issue for this PR

N/A — refactor PR (refactor PRs skip issue requirement per contributing guidelines)

### Type of change

- [x] Refactor

### What does this PR do?

Removes the temporary `locationServiceMapLayer` constant from `location-services.ts`. All call sites migrate to the `buildLocationServiceMap()` factory. The constant was marked "temporary for backwards compatibility" and its usage was already partially migrated upstream.

### How did you verify your code works?

`bun typecheck` in `packages/core` and `packages/opencode` (0 errors). All 8 remaining call sites migrated; `git grep locationServiceMapLayer` returns nothing.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR