### PR TITLE
fix(llm): inject _noop tool for all providers when messages contain tool history

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -157,11 +157,9 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
     for (const key of Object.keys(tools)) tools[key] = { ...tools[key], strict: false }
   }
   if (
-    input.model.providerID.includes("github-copilot") &&
     Object.keys(tools).length === 0 &&
     hasToolCalls(input.messages)
   ) {
-    // Copilot needs a tools field when replaying prior tool calls, even if no tools are currently enabled.
     tools["_noop"] = aiTool({
       description: "Do not call this tool. It exists only for API compatibility and must never be invoked.",
       inputSchema: jsonSchema({


### PR DESCRIPTION
### Issue for this PR

Closes #34089

### Type of change

- [x] Bug fix

### What does this PR do?

Bedrock (and other providers) requires a `toolConfig` when messages contain `toolUse`/`toolResult` content blocks, even if no active tools are being used. Previously the `_noop` tool injection was limited to `github-copilot`, but the underlying constraint affects Compaction on Bedrock-backed providers too (e.g. Portkey), resulting in "toolConfig field must be defined" errors.

Removes the `github-copilot`-specific guard so the `_noop` tool is injected whenever messages contain prior tool calls but no current tools are active.

### How did you verify your code works?

`bun typecheck` in `packages/opencode` (0 errors on `v2`). The change is a 2-line removal (guard condition + comment); the `_noop` injection and `hasToolCalls` logic are unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR