### PR TITLE
fix(core,tui): bound HTML provider bodies in retry notices

### DIFF
--- a/packages/core/src/session/to-session-error.ts
+++ b/packages/core/src/session/to-session-error.ts
@@ -8,29 +8,49 @@ import { ToolOutputStore } from "../tool-output-store"
 import { AgentNotFoundError, StepFailedError, UserInterruptedError } from "./error"
 import { SessionRunnerModel } from "./runner/model"
 
+const HTML_DOCUMENT = /<(?:!doctype\s+html|html|head|body)(?:\s|>)/i
+const HTTP_STATUS = /\bHTTP\s+(\d{3})\b/i
+const STATUS_CODE = /\b([45]\d{2})\b/
+
+/** Bound provider HTML/nginx bodies so retry notices stay human-readable in the TUI. */
+export function sanitizeErrorMessage(message: string, status?: number): string {
+  if (!HTML_DOCUMENT.test(message)) return message
+  const code = status ?? Number(message.match(HTTP_STATUS)?.[1] ?? message.match(STATUS_CODE)?.[1] ?? NaN)
+  if (Number.isFinite(code) && code >= 500) return `Provider temporarily unavailable (HTTP ${code})`
+  if (Number.isFinite(code)) return `Provider request failed (HTTP ${code})`
+  return "Provider request failed"
+}
+
+function message(value: string, status?: number) {
+  return sanitizeErrorMessage(value, status)
+}
+
 export function toSessionError(cause: unknown): SessionError.Error {
   if (cause instanceof LLMError) {
     switch (cause.reason._tag) {
       case "RateLimit":
-        return { type: "provider.rate-limit", message: cause.reason.message }
+        return { type: "provider.rate-limit", message: message(cause.reason.message) }
       case "Authentication":
-        return { type: "provider.auth", message: cause.reason.message }
+        return { type: "provider.auth", message: message(cause.reason.message) }
       case "QuotaExceeded":
-        return { type: "provider.quota", message: cause.reason.message }
+        return { type: "provider.quota", message: message(cause.reason.message) }
       case "ContentPolicy":
-        return { type: "provider.content-filter", message: cause.reason.message }
+        return { type: "provider.content-filter", message: message(cause.reason.message) }
       case "Transport":
-        return { type: "provider.transport", message: cause.reason.message }
+        return { type: "provider.transport", message: message(cause.reason.message) }
       case "ProviderInternal":
-        return { type: "provider.internal", message: cause.reason.message }
+        return {
+          type: "provider.internal",
+          message: message(cause.reason.message, cause.reason.status),
+        }
       case "InvalidProviderOutput":
-        return { type: "provider.invalid-output", message: cause.reason.message }
+        return { type: "provider.invalid-output", message: message(cause.reason.message) }
       case "InvalidRequest":
-        return { type: "provider.invalid-request", message: cause.reason.message }
+        return { type: "provider.invalid-request", message: message(cause.reason.message) }
       case "NoRoute":
-        return { type: "provider.no-route", message: cause.reason.message }
+        return { type: "provider.no-route", message: message(cause.reason.message) }
       case "UnknownProvider":
-        return { type: "provider.unknown", message: cause.reason.message }
+        return { type: "provider.unknown", message: message(cause.reason.message) }
       default: {
         const exhaustive: never = cause.reason
         return exhaustive
@@ -40,9 +60,11 @@ export function toSessionError(cause: unknown): SessionError.Error {
   if (cause instanceof PermissionV2.BlockedError) return { type: "permission.rejected", message: cause.message }
   if (cause instanceof QuestionV2.RejectedError) return { type: "aborted", message: cause.message }
   if (cause instanceof ToolFailure || cause instanceof Tool.Failure)
-    return cause.error === undefined ? { type: "tool.execution", message: cause.message } : toSessionError(cause.error)
+    return cause.error === undefined
+      ? { type: "tool.execution", message: message(cause.message) }
+      : toSessionError(cause.error)
   if (cause instanceof StepFailedError) return cause.error
-  if (cause instanceof AgentNotFoundError) return { type: "unknown", message: cause.message }
+  if (cause instanceof AgentNotFoundError) return { type: "unknown", message: message(cause.message) }
   if (cause instanceof UserInterruptedError) return { type: "aborted", message: cause.message }
   if (
     cause instanceof SessionRunnerModel.ModelNotSelectedError ||
@@ -50,8 +72,11 @@ export function toSessionError(cause: unknown): SessionError.Error {
     cause instanceof SessionRunnerModel.VariantUnavailableError ||
     cause instanceof SessionRunnerModel.UnsupportedPackageError
   )
-    return { type: "provider.no-route", message: cause.message }
-  if (cause instanceof Integration.AuthorizationError) return { type: "provider.auth", message: cause.message }
-  if (cause instanceof ToolOutputStore.StorageError) return { type: "unknown", message: cause.message }
-  return { type: "unknown", message: cause instanceof Error ? cause.message : String(cause) }
+    return { type: "provider.no-route", message: message(cause.message) }
+  if (cause instanceof Integration.AuthorizationError) return { type: "provider.auth", message: message(cause.message) }
+  if (cause instanceof ToolOutputStore.StorageError) return { type: "unknown", message: message(cause.message) }
+  return {
+    type: "unknown",
+    message: message(cause instanceof Error ? cause.message : String(cause)),
+  }
 }

--- a/packages/core/test/session-error.test.ts
+++ b/packages/core/test/session-error.test.ts
@@ -17,10 +17,35 @@ import {
 } from "@opencode-ai/llm"
 import { PermissionV2 } from "@opencode-ai/core/permission"
 import { Tool } from "@opencode-ai/plugin/v2/effect/tool"
-import { toSessionError } from "@opencode-ai/core/session/to-session-error"
+import { sanitizeErrorMessage, toSessionError } from "@opencode-ai/core/session/to-session-error"
 import { SessionRunnerRetry } from "@opencode-ai/core/session/runner/retry"
 
 const llm = (reason: LLMError["reason"]) => new LLMError({ module: "test", method: "stream", reason })
+
+describe("sanitizeErrorMessage", () => {
+  test("bounds html provider bodies for 503 retry notices", () => {
+    const html = `<html>
+<head><title>503 Service Temporarily Unavailable</title></head>
+<body>
+<center><h1>503 Service Temporarily Unavailable</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>`
+    expect(sanitizeErrorMessage(`Provider request failed with HTTP 503: ${html}`)).toBe(
+      "Provider temporarily unavailable (HTTP 503)",
+    )
+    expect(
+      toSessionError(llm(new ProviderInternalReason({ message: `Provider request failed with HTTP 503: ${html}`, status: 503 }))),
+    ).toEqual({
+      type: "provider.internal",
+      message: "Provider temporarily unavailable (HTTP 503)",
+    })
+  })
+
+  test("leaves plain text messages unchanged", () => {
+    expect(sanitizeErrorMessage("Service unavailable")).toBe("Service unavailable")
+  })
+})
 
 describe("toSessionError", () => {
   test("maps every LLM reason to the open wire type", () => {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1678,15 +1678,26 @@ function AssistantMessage(props: { message: SessionMessageAssistant; last: boole
   )
 }
 
+export function formatRetryNotice(attempt: number, error: { message: string; type: string }) {
+  // Defense in depth: core already sanitizes HTML bodies, but bound multi-line markup if it
+  // still reaches the TUI so a single nginx page cannot dominate the transcript.
+  const message = error.message.includes("<")
+    ? error.message
+        .replace(/<[^>]+>/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 120) || error.type
+    : error.message
+  return `Retry attempt ${attempt} scheduled: ${message} [${error.type}]`
+}
+
 function AssistantRetry(props: { retry: SessionMessageAssistant["retry"] }) {
   const { theme } = useTheme()
   return (
     <Show when={props.retry}>
       {(retry) => (
         <box paddingLeft={3} marginTop={1}>
-          <text fg={theme.textMuted}>
-            Retry attempt {retry().attempt} scheduled: {retry().error.message} [{retry().error.type}]
-          </text>
+          <text fg={theme.textMuted}>{formatRetryNotice(retry().attempt, retry().error)}</text>
         </box>
       )}
     </Show>


### PR DESCRIPTION
## Summary

When a provider returns an nginx-style HTML `503` body, V2 retry notices previously rendered the full markup inline:

```text
Retry attempt 3 scheduled: Provider request failed with HTTP 503: <html>...
```

## Changes

- Add `sanitizeErrorMessage` and apply it in `toSessionError` for provider/session wire messages
- Map HTML + 5xx bodies to `Provider temporarily unavailable (HTTP NNN)`
- Add defense-in-depth stripping in the TUI `AssistantRetry` formatter
- Cover the 503 HTML case in `session-error.test.ts`

Closes #35640

## Test plan

- [x] `bun test test/session-error.test.ts` in `packages/core` (5 pass)
- [ ] Manually trigger a 503 HTML provider failure and confirm the TUI retry line is bounded