### PR TITLE
fix(tui): show only background work in prompt footer

### DIFF
--- a/packages/core/src/tool/shell.ts
+++ b/packages/core/src/tool/shell.ts
@@ -196,7 +196,12 @@ export const Plugin = {
                   command: input.command,
                   cwd: target.canonical,
                   timeout,
-                  metadata: { sessionID: context.sessionID },
+                  metadata: {
+                    sessionID: context.sessionID,
+                    // Tag intentional background launches so the TUI footer can distinguish
+                    // observation-only shells from foreground blocking work.
+                    background: input.background === true,
+                  },
                 })
 
                 const settleShell = Effect.fn("ShellTool.settleShell")(function* () {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -163,15 +163,27 @@ export function Prompt(props: PromptProps) {
   const dialog = useDialog()
   const toast = useToast()
   const status = createMemo(() => data.session.status(props.sessionID ?? ""))
+  // Footer live-work counts are for work moved out of the main turn. While this session is
+  // busy, running descendants/shells are the blocking work the user is already watching, so
+  // counting them only produces flicker.
+  const showBackgroundWork = createMemo(() => Boolean(props.sessionID) && status() === "idle")
   const activeSubagents = createMemo(() => {
-    if (!props.sessionID) return 0
+    if (!showBackgroundWork()) return 0
     return data.session
-      .family(props.sessionID)
+      .family(props.sessionID!)
       .filter((id) => id !== props.sessionID && data.session.status(id) === "running").length
   })
-  const runningShells = createMemo(
-    () => data.shell.list(currentLocation()).filter((shell) => shell.metadata.sessionID === props.sessionID).length,
-  )
+  const runningShells = createMemo(() => {
+    if (!showBackgroundWork()) return 0
+    return data.shell
+      .list(currentLocation())
+      .filter((shell) => {
+        if (shell.metadata.sessionID !== props.sessionID) return false
+        // Prefer an explicit background tag when present; otherwise treat idle-parent shells
+        // as background observation candidates (mid-flight backgrounding may omit the tag).
+        return shell.metadata.background !== false
+      }).length
+  })
   const history = usePromptHistory()
   const stash = usePromptStash()
   const keymap = useOpencodeKeymap()


### PR DESCRIPTION
## Summary

The V2 prompt footer showed `N subagent · N shell` for foreground blocking work as well as backgrounded work. That duplicated the turn the user is already watching and flickered as tools start/finish.

## Changes

- Count footer subagents/shells only while the parent session is `idle` (background observation mode)
- Tag intentional `background: true` shell launches in shell metadata for future filtering
- Leave blocking-turn UI unchanged

Closes #35260

## Test plan

- [ ] Start a foreground subagent/shell and confirm the footer does **not** show live-work counts while the parent is busy
- [ ] Background the work (or launch with `background: true`) and confirm counts appear once the parent is idle
- [ ] Confirm background composer tabs still list running children