### PR TITLE
fix(tui): unify pending tool styling

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2042,8 +2042,7 @@ function InlineTool(props: {
     if (permission()) return theme.warning
     if (failed()) return theme.error
     if (hover() && props.onClick) return theme.text
-    if (props.complete) return theme.textMuted
-    return theme.text
+    return theme.textMuted
   })
 
   return (
@@ -2103,13 +2102,7 @@ export function InlineToolRow(props: {
         <Match when={true}>
           <Show
             fallback={
-              <text
-                paddingLeft={3}
-                fg={props.color}
-                attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
-              >
-                ~ {props.pending}
-              </text>
+              <Spinner color={props.color}>{props.pending}</Spinner>
             }
             when={props.complete || props.failed}
           >


### PR DESCRIPTION
## Summary

- replace tilde-prefixed pending tool labels with the existing animated spinner
- render pending tool activity with the same muted treatment as grouped exploration
- preserve warning, failure, and hover colors

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- repository pre-push typecheck (31 packages)
- exercised loading and failure transitions through `opencode-drive` recordings