### PR TITLE
docs: add Unforgit to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |
+| [Unforgit](https://github.com/MiguelMedeiros/unforgit)                                                     | Repository-scoped persistent memory for OpenCode via MCP and AGENTS.md project integration        |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                         |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control          |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                    |


### PR DESCRIPTION
### Issue for this PR

Closes #36295

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Unforgit to the ecosystem plugins table.

Unforgit provides repository-scoped memory for OpenCode via MCP. Its CLI can generate the OpenCode project files (`opencode.json` and `AGENTS.md`).

### How did you verify your code works?

Docs-only table entry.

Verified the submitted diff only changes `packages/web/src/content/docs/ecosystem.mdx`.

The Unforgit integration is tested in the Unforgit repo with:

- `unforgit init --ide opencode`
- `pnpm test`
- `pnpm build`
- `pnpm lint`

### Screenshots / recordings

N/A — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
