### PR TITLE
fix(opencode): send Codex-compatible OAuth request identity headers

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -12,6 +12,8 @@ const ISSUER = "https://auth.openai.com"
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 const OAUTH_PORT = 1455
 const OAUTH_POLLING_SAFETY_MARGIN_MS = 3000
+const CODEX_ORIGINATOR = "codex_cli_rs"
+const CODEX_USER_AGENT = `codex_cli_rs/0.0.0 (OpenCode/${InstallationVersion}) (${os.platform()} ${os.release()})`
 const ALLOWED_MODELS = new Set(["gpt-5.5", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"])
 const DISALLOWED_MODELS = new Set(["gpt-5.5-pro"])
 
@@ -539,8 +541,8 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
     },
     "chat.headers": async (input, output) => {
       if (input.model.providerID !== "openai") return
-      output.headers.originator = "opencode"
-      output.headers["User-Agent"] = `opencode/${InstallationVersion} (${os.platform()} ${os.release()}; ${os.arch()})`
+      output.headers.originator = CODEX_ORIGINATOR
+      output.headers["User-Agent"] = CODEX_USER_AGENT
       output.headers["session-id"] = input.sessionID
       // Temporary fetch-layer hack: title generation currently shares the conversation
       // session ID, so the OpenAI plugin marks it for HTTP fallback until transport

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import os from "os"
 import {
   CodexAuthPlugin,
   parseJwtClaims,
@@ -147,6 +149,18 @@ describe("plugin.codex", () => {
     expect(disabledOptions.fetch).toBeUndefined()
     expect(enabledOptions.fetch).toBeFunction()
     await enabled.dispose?.()
+  })
+
+  test("sends Codex-compatible request identity headers", async () => {
+    const hooks = await CodexAuthPlugin({} as never)
+    const output = { headers: {} as Record<string, string> }
+
+    await hooks["chat.headers"]?.({ model: { providerID: "openai" } } as never, output)
+
+    expect(output.headers.originator).toBe("codex_cli_rs")
+    expect(output.headers["User-Agent"]).toBe(
+      `codex_cli_rs/0.0.0 (OpenCode/${InstallationVersion}) (${os.platform()} ${os.release()})`,
+    )
   })
 
   test("deduplicates concurrent Codex token refreshes", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #36140

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Codex OAuth requests were identifying themselves as OpenCode instead of the Codex CLI. This could cause Codex requests to be rejected or unavailable.

This changes the request headers to use the Codex-compatible identity:

- `originator: codex_cli_rs`
- `User-Agent: codex_cli_rs/0.0.0 (OpenCode/<version>)`

It also adds a regression test covering these headers.

### How did you verify your code works?

- Ran the plugin doing the same change as PoC successfully.
- Added automatic test.

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR