### PR TITLE
feat(llm): support GPT-5.6 prompt cache new options

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -40,6 +40,13 @@ import { Snapshot } from "../../snapshot"
 import { makeLocationNode } from "../../effect/app-node"
 import { llmClient } from "../../effect/app-node-platform"
 
+const GPT56_PROMPT_CACHE_OPTIONS = { mode: "implicit", ttl: "30m" } as const
+
+const promptCacheOptions = (model: { readonly provider: string; readonly id: string }) =>
+  model.provider === "openai" && /(?:^|[/.])gpt-5\.6(?:$|[-_/.])/.test(model.id.toLowerCase())
+    ? GPT56_PROMPT_CACHE_OPTIONS
+    : undefined
+
 /**
  * Runs one durable coding-agent Session until it settles.
  *
@@ -202,9 +209,15 @@ const layer = Layer.effect(
       const isLastStep = agent.info?.steps !== undefined && currentStep >= agent.info.steps
       const toolMaterialization = isLastStep ? undefined : yield* tools.materialize(agent.info?.permissions)
       const promptCacheKey = /^ses_[0-9a-f]{64}$/.test(session.id) ? session.id.slice(4) : session.id
+      const promptCache = promptCacheOptions(model)
       const request = LLM.request({
         model,
-        providerOptions: { openai: { promptCacheKey } },
+        providerOptions: {
+          openai: {
+            promptCacheKey,
+            ...(promptCache ? { promptCacheOptions: promptCache } : {}),
+          },
+        },
         system: [agent.info?.system, system.baseline]
           .filter((part): part is string => part !== undefined && part.length > 0)
           .map(SystemPart.make),

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2484,6 +2484,38 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("adds GPT-5.6 family prompt cache options for OpenAI models", () =>
+    Effect.gen(function* () {
+      yield* setup
+      currentModel = Model.make({ id: "gpt-5.6-luna", provider: "openai", route: OpenAIChat.route })
+      const session = yield* SessionV2.Service
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Run with GPT-5.6 cache" }), resume: false })
+
+      requests.length = 0
+      yield* session.resume(sessionID)
+
+      expect(requests[0]?.providerOptions?.openai).toMatchObject({
+        promptCacheKey: sessionID,
+        promptCacheOptions: { mode: "implicit", ttl: "30m" },
+      })
+    }),
+  )
+
+  it.effect("keeps GPT-5.5 session prompt cache behavior unchanged", () =>
+    Effect.gen(function* () {
+      yield* setup
+      currentModel = Model.make({ id: "gpt-5.5", provider: "openai", route: OpenAIChat.route })
+      const session = yield* SessionV2.Service
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Run with GPT-5.5 cache" }), resume: false })
+
+      requests.length = 0
+      yield* session.resume(sessionID)
+
+      expect(requests[0]?.providerOptions?.openai?.promptCacheKey).toBe(sessionID)
+      expect(requests[0]?.providerOptions?.openai?.promptCacheOptions).toBeUndefined()
+    }),
+  )
+
   it.effect("fans out one failed run and allows a later retry", () =>
     Effect.gen(function* () {
       yield* setup

--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -97,6 +97,8 @@ export const bodyFields = {
   stream_options: Schema.optional(Schema.Struct({ include_usage: Schema.Boolean })),
   store: Schema.optional(Schema.Boolean),
   reasoning_effort: Schema.optional(OpenAIOptions.OpenAIReasoningEffort),
+  prompt_cache_key: Schema.optional(Schema.String),
+  prompt_cache_options: Schema.optional(OpenAIOptions.OpenAIPromptCacheOptions),
   max_tokens: Schema.optional(Schema.Number),
   temperature: Schema.optional(Schema.Number),
   top_p: Schema.optional(Schema.Number),
@@ -121,6 +123,7 @@ const OpenAIChatUsage = Schema.Struct({
   prompt_tokens_details: optionalNull(
     Schema.Struct({
       cached_tokens: Schema.optional(Schema.Number),
+      cache_write_tokens: Schema.optional(Schema.Number),
     }),
   ),
   completion_tokens_details: optionalNull(
@@ -332,11 +335,15 @@ const lowerMessages = Effect.fn("OpenAIChat.lowerMessages")(function* (request: 
 
 const lowerOptions = Effect.fn("OpenAIChat.lowerOptions")(function* (request: LLMRequest) {
   const store = OpenAIOptions.store(request)
+  const promptCacheKey = OpenAIOptions.promptCacheKey(request)
+  const promptCacheOptions = OpenAIOptions.promptCacheOptions(request)
   const reasoningEffort = OpenAIOptions.reasoningEffort(request)
   if (reasoningEffort && !OpenAIOptions.isReasoningEffort(reasoningEffort))
     return yield* invalid(`OpenAI Chat does not support reasoning effort ${reasoningEffort}`)
   return {
     ...(store !== undefined ? { store } : {}),
+    ...(promptCacheKey ? { prompt_cache_key: promptCacheKey } : {}),
+    ...(promptCacheOptions ? { prompt_cache_options: promptCacheOptions } : {}),
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
   }
 })
@@ -391,13 +398,15 @@ const mapFinishReason = (reason: string | null | undefined): FinishReason => {
 const mapUsage = (usage: OpenAIChatEvent["usage"]): Usage | undefined => {
   if (!usage) return undefined
   const cached = usage.prompt_tokens_details?.cached_tokens
+  const cacheWrite = usage.prompt_tokens_details?.cache_write_tokens
   const reasoning = usage.completion_tokens_details?.reasoning_tokens
-  const nonCached = ProviderShared.subtractTokens(usage.prompt_tokens, cached)
+  const nonCached = ProviderShared.subtractTokens(ProviderShared.subtractTokens(usage.prompt_tokens, cached), cacheWrite)
   return new Usage({
     inputTokens: usage.prompt_tokens,
     outputTokens: usage.completion_tokens,
     nonCachedInputTokens: nonCached,
     cacheReadInputTokens: cached,
+    cacheWriteInputTokens: cacheWrite,
     reasoningTokens: reasoning,
     totalTokens: ProviderShared.totalTokens(usage.prompt_tokens, usage.completion_tokens, usage.total_tokens),
     providerMetadata: { openai: usage },

--- a/packages/llm/src/protocols/openai-responses.ts
+++ b/packages/llm/src/protocols/openai-responses.ts
@@ -132,6 +132,7 @@ const OpenAIResponsesCoreFields = {
   store: Schema.optional(Schema.Boolean),
   service_tier: Schema.optional(OpenAIOptions.OpenAIServiceTier),
   prompt_cache_key: Schema.optional(Schema.String),
+  prompt_cache_options: Schema.optional(OpenAIOptions.OpenAIPromptCacheOptions),
   include: optionalArray(OpenAIOptions.OpenAIResponseIncludable),
   reasoning: Schema.optional(
     Schema.Struct({
@@ -167,7 +168,12 @@ const encodeWebSocketMessage = Schema.encodeSync(Schema.fromJsonString(OpenAIRes
 
 const OpenAIResponsesUsage = Schema.Struct({
   input_tokens: Schema.optional(Schema.Number),
-  input_tokens_details: optionalNull(Schema.Struct({ cached_tokens: Schema.optional(Schema.Number) })),
+  input_tokens_details: optionalNull(
+    Schema.Struct({
+      cached_tokens: Schema.optional(Schema.Number),
+      cache_write_tokens: Schema.optional(Schema.Number),
+    }),
+  ),
   output_tokens: Schema.optional(Schema.Number),
   output_tokens_details: optionalNull(Schema.Struct({ reasoning_tokens: Schema.optional(Schema.Number) })),
   total_tokens: Schema.optional(Schema.Number),
@@ -456,6 +462,7 @@ const lowerMessages = Effect.fn("OpenAIResponses.lowerMessages")(function* (requ
 const lowerOptions = Effect.fn("OpenAIResponses.lowerOptions")(function* (request: LLMRequest) {
   const store = OpenAIOptions.store(request)
   const promptCacheKey = OpenAIOptions.promptCacheKey(request)
+  const promptCacheOptions = OpenAIOptions.promptCacheOptions(request)
   const effort = OpenAIOptions.reasoningEffort(request)
   if (effort && !OpenAIOptions.isReasoningEffort(effort))
     return yield* invalid(`OpenAI Responses does not support reasoning effort ${effort}`)
@@ -468,6 +475,7 @@ const lowerOptions = Effect.fn("OpenAIResponses.lowerOptions")(function* (reques
     ...(instructions ? { instructions } : {}),
     ...(store !== undefined ? { store } : {}),
     ...(promptCacheKey ? { prompt_cache_key: promptCacheKey } : {}),
+    ...(promptCacheOptions ? { prompt_cache_options: promptCacheOptions } : {}),
     ...(include ? { include } : {}),
     ...(effort || summary ? { reasoning: { effort, summary } } : {}),
     ...(verbosity ? { text: { verbosity } } : {}),
@@ -507,13 +515,15 @@ const fromRequest = Effect.fn("OpenAIResponses.fromRequest")(function* (request:
 const mapUsage = (usage: OpenAIResponsesUsage | null | undefined) => {
   if (!usage) return undefined
   const cached = usage.input_tokens_details?.cached_tokens
+  const cacheWrite = usage.input_tokens_details?.cache_write_tokens
   const reasoning = usage.output_tokens_details?.reasoning_tokens
-  const nonCached = ProviderShared.subtractTokens(usage.input_tokens, cached)
+  const nonCached = ProviderShared.subtractTokens(ProviderShared.subtractTokens(usage.input_tokens, cached), cacheWrite)
   return new Usage({
     inputTokens: usage.input_tokens,
     outputTokens: usage.output_tokens,
     nonCachedInputTokens: nonCached,
     cacheReadInputTokens: cached,
+    cacheWriteInputTokens: cacheWrite,
     reasoningTokens: reasoning,
     totalTokens: ProviderShared.totalTokens(usage.input_tokens, usage.output_tokens, usage.total_tokens),
     providerMetadata: { openai: usage },

--- a/packages/llm/src/protocols/utils/openai-options.ts
+++ b/packages/llm/src/protocols/utils/openai-options.ts
@@ -22,17 +22,28 @@ export const OpenAIResponseIncludables = [
 export type OpenAIResponseIncludable = (typeof OpenAIResponseIncludables)[number]
 export const OpenAIServiceTiers = ["auto", "default", "flex", "priority"] as const
 export type OpenAIServiceTier = (typeof OpenAIServiceTiers)[number]
+export const OpenAIPromptCacheModes = ["implicit", "explicit"] as const
+export type OpenAIPromptCacheMode = (typeof OpenAIPromptCacheModes)[number]
+export const OpenAIPromptCacheTTLs = ["30m"] as const
+export type OpenAIPromptCacheTTL = (typeof OpenAIPromptCacheTTLs)[number]
 
 const REASONING_EFFORTS = new Set<string>(ReasoningEfforts)
 const OPENAI_REASONING_EFFORTS = new Set<string>(OpenAIReasoningEfforts)
 const TEXT_VERBOSITY = new Set<string>(["low", "medium", "high"])
 const INCLUDABLES = new Set<string>(OpenAIResponseIncludables)
 const SERVICE_TIERS = new Set<string>(OpenAIServiceTiers)
+const PROMPT_CACHE_MODES = new Set<string>(OpenAIPromptCacheModes)
+const PROMPT_CACHE_TTLS = new Set<string>(OpenAIPromptCacheTTLs)
 
 export const OpenAIReasoningEffort = Schema.Literals(OpenAIReasoningEfforts)
 export const OpenAITextVerbosity = TextVerbosity
 export const OpenAIResponseIncludable = Schema.Literals(OpenAIResponseIncludables)
 export const OpenAIServiceTier = Schema.Literals(OpenAIServiceTiers)
+export const OpenAIPromptCacheOptions = Schema.Struct({
+  mode: Schema.optional(Schema.Literals(OpenAIPromptCacheModes)),
+  ttl: Schema.optional(Schema.Literals(OpenAIPromptCacheTTLs)),
+})
+export type OpenAIPromptCacheOptions = Schema.Schema.Type<typeof OpenAIPromptCacheOptions>
 
 const isAnyReasoningEffort = (effort: unknown): effort is ReasoningEffort =>
   typeof effort === "string" && REASONING_EFFORTS.has(effort)
@@ -73,6 +84,22 @@ export const include = (request: LLMRequest): ReadonlyArray<OpenAIResponseInclud
 export const promptCacheKey = (request: LLMRequest) => {
   const value = options(request)?.promptCacheKey
   return typeof value === "string" ? value : undefined
+}
+
+export const promptCacheOptions = (request: LLMRequest): OpenAIPromptCacheOptions | undefined => {
+  const value = options(request)?.promptCacheOptions
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const input = value as Record<string, unknown>
+  const mode =
+    typeof input.mode === "string" && PROMPT_CACHE_MODES.has(input.mode)
+      ? (input.mode as OpenAIPromptCacheMode)
+      : undefined
+  const ttl =
+    typeof input.ttl === "string" && PROMPT_CACHE_TTLS.has(input.ttl)
+      ? (input.ttl as OpenAIPromptCacheTTL)
+      : undefined
+  if (!mode && !ttl) return undefined
+  return { mode, ttl }
 }
 
 export const textVerbosity = (request: LLMRequest) => {

--- a/packages/llm/src/providers/openai-options.ts
+++ b/packages/llm/src/providers/openai-options.ts
@@ -4,10 +4,16 @@ import type { OpenAIResponseIncludable, OpenAIServiceTier } from "../protocols/u
 
 export type { OpenAIResponseIncludable, OpenAIServiceTier } from "../protocols/utils/openai-options"
 
+export interface OpenAIPromptCacheOptionsInput {
+  readonly mode?: "implicit" | "explicit"
+  readonly ttl?: "30m"
+}
+
 export interface OpenAIOptionsInput {
   readonly [key: string]: unknown
   readonly store?: boolean
   readonly promptCacheKey?: string
+  readonly promptCacheOptions?: OpenAIPromptCacheOptionsInput
   readonly reasoningEffort?: ReasoningEffort
   readonly reasoningSummary?: "auto"
   // OpenAI Responses `include` wire field. Mirrors the official SDK's
@@ -30,6 +36,7 @@ const openAIProviderOptions = (options: OpenAIOptionsInput | undefined): Provide
     definedEntries({
       store: options?.store,
       promptCacheKey: options?.promptCacheKey,
+      promptCacheOptions: options?.promptCacheOptions,
       reasoningEffort: options?.reasoningEffort,
       reasoningSummary: options?.reasoningSummary,
       include: options?.include,
@@ -40,6 +47,9 @@ const openAIProviderOptions = (options: OpenAIOptionsInput | undefined): Provide
   if (Object.keys(openai).length === 0) return undefined
   return { openai }
 }
+
+export const isGPT56Family = (modelID: string) =>
+  /(?:^|[/.])gpt-5\.6(?:$|[-_/.])/.test(modelID.toLowerCase())
 
 export const gpt5DefaultOptions = (
   modelID: string,
@@ -63,16 +73,23 @@ export const gpt5DefaultOptions = (
   })
 }
 
+const gpt56DefaultOptions = (modelID: string): ProviderOptions | undefined =>
+  isGPT56Family(modelID) ? openAIProviderOptions({ promptCacheOptions: { mode: "implicit", ttl: "30m" } }) : undefined
+
 export const openAIDefaultOptions = (
   modelID: string,
-  options: { readonly textVerbosity?: boolean } = {},
+  options: { readonly textVerbosity?: boolean; readonly promptCaching?: boolean } = {},
 ): ProviderOptions | undefined =>
-  mergeProviderOptions(openAIProviderOptions({ store: false }), gpt5DefaultOptions(modelID, options))
+  mergeProviderOptions(
+    openAIProviderOptions({ store: false }),
+    gpt5DefaultOptions(modelID, options),
+    options.promptCaching === true ? gpt56DefaultOptions(modelID) : undefined,
+  )
 
 export const withOpenAIOptions = <Options extends { readonly providerOptions?: OpenAIProviderOptionsInput }>(
   modelID: string,
   options: Options,
-  defaults: { readonly textVerbosity?: boolean } = {},
+  defaults: { readonly textVerbosity?: boolean; readonly promptCaching?: boolean } = {},
 ): Omit<Options, "providerOptions"> & { readonly providerOptions?: ProviderOptions } => {
   return {
     ...options,

--- a/packages/llm/src/providers/openai.ts
+++ b/packages/llm/src/providers/openai.ts
@@ -40,10 +40,15 @@ export const configure = (input: Config = {}) => {
   const chatRoute = configuredRoute(OpenAIChat.route, input)
   const modelDefaults = defaults(input)
   const responses = (id: string | ModelID) =>
-    responsesRoute.with(withOpenAIOptions(id, modelDefaults, { textVerbosity: true })).model({ id })
+    responsesRoute.with(withOpenAIOptions(id, modelDefaults, { textVerbosity: true, promptCaching: true })).model({
+      id,
+    })
   const responsesWebSocket = (id: string | ModelID) =>
-    responsesWebSocketRoute.with(withOpenAIOptions(id, modelDefaults, { textVerbosity: true })).model({ id })
-  const chat = (id: string | ModelID) => chatRoute.with(withOpenAIOptions(id, modelDefaults)).model({ id })
+    responsesWebSocketRoute
+      .with(withOpenAIOptions(id, modelDefaults, { textVerbosity: true, promptCaching: true }))
+      .model({ id })
+  const chat = (id: string | ModelID) =>
+    chatRoute.with(withOpenAIOptions(id, modelDefaults, { promptCaching: true })).model({ id })
 
   return {
     id,

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -98,12 +98,35 @@ describe("OpenAI Chat route", () => {
         LLM.request({
           model: OpenAI.configure({ baseURL: "https://api.openai.test/v1/", apiKey: "test" }).chat("gpt-4o-mini"),
           prompt: "think",
-          providerOptions: { openai: { reasoningEffort: "low" } },
+          providerOptions: {
+            openai: {
+              promptCacheKey: "session_123",
+              promptCacheOptions: { mode: "explicit", ttl: "30m" },
+              reasoningEffort: "low",
+            },
+          },
         }),
       )
 
       expect(prepared.body.store).toBe(false)
+      expect(prepared.body.prompt_cache_key).toBe("session_123")
+      expect(prepared.body.prompt_cache_options).toEqual({ mode: "explicit", ttl: "30m" })
       expect(prepared.body.reasoning_effort).toBe("low")
+    }),
+  )
+
+  it.effect("enables GPT-5.6 family prompt cache options by default", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          model: OpenAI.configure({ baseURL: "https://api.openai.test/v1/", apiKey: "test" }).chat("gpt-5.6-luna"),
+          prompt: "think",
+          providerOptions: { openai: { promptCacheKey: "session_123" } },
+        }),
+      )
+
+      expect(prepared.body.prompt_cache_key).toBe("session_123")
+      expect(prepared.body.prompt_cache_options).toEqual({ mode: "implicit", ttl: "30m" })
     }),
   )
 
@@ -486,7 +509,7 @@ describe("OpenAI Chat route", () => {
           prompt_tokens: 5,
           completion_tokens: 2,
           total_tokens: 7,
-          prompt_tokens_details: { cached_tokens: 1 },
+          prompt_tokens_details: { cached_tokens: 1, cache_write_tokens: 2 },
           completion_tokens_details: { reasoning_tokens: 0 },
         }),
       )
@@ -494,8 +517,9 @@ describe("OpenAI Chat route", () => {
       const usage = new Usage({
         inputTokens: 5,
         outputTokens: 2,
-        nonCachedInputTokens: 4,
+        nonCachedInputTokens: 2,
         cacheReadInputTokens: 1,
+        cacheWriteInputTokens: 2,
         reasoningTokens: 0,
         totalTokens: 7,
         providerMetadata: {
@@ -503,7 +527,7 @@ describe("OpenAI Chat route", () => {
             prompt_tokens: 5,
             completion_tokens: 2,
             total_tokens: 7,
-            prompt_tokens_details: { cached_tokens: 1 },
+            prompt_tokens_details: { cached_tokens: 1, cache_write_tokens: 2 },
             completion_tokens_details: { reasoning_tokens: 0 },
           },
         },

--- a/packages/llm/test/provider/openai-responses.test.ts
+++ b/packages/llm/test/provider/openai-responses.test.ts
@@ -555,6 +555,7 @@ describe("OpenAI Responses route", () => {
           providerOptions: {
             openai: {
               promptCacheKey: "session_123",
+              promptCacheOptions: { mode: "implicit", ttl: "30m" },
               reasoningEffort: "high",
               reasoningSummary: "auto",
               include: ["reasoning.encrypted_content"],
@@ -565,9 +566,40 @@ describe("OpenAI Responses route", () => {
 
       expect(prepared.body.store).toBe(false)
       expect(prepared.body.prompt_cache_key).toBe("session_123")
+      expect(prepared.body.prompt_cache_options).toEqual({ mode: "implicit", ttl: "30m" })
       expect(prepared.body.include).toEqual(["reasoning.encrypted_content"])
       expect(prepared.body.reasoning).toEqual({ effort: "high", summary: "auto" })
       expect(prepared.body.text).toEqual({ verbosity: "low" })
+    }),
+  )
+
+  it.effect("enables GPT-5.6 family prompt cache options by default", () =>
+    Effect.gen(function* () {
+      yield* Effect.forEach(["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-fast"], (id) =>
+        Effect.gen(function* () {
+          const prepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(
+            LLM.request({
+              model: OpenAI.configure({ baseURL: "https://api.openai.test/v1/", apiKey: "test" }).model(id),
+              prompt: "think",
+              providerOptions: { openai: { promptCacheKey: "session_123" } },
+            }),
+          )
+
+          expect(prepared.body.prompt_cache_key).toBe("session_123")
+          expect(prepared.body.prompt_cache_options).toEqual({ mode: "implicit", ttl: "30m" })
+        }),
+      )
+
+      const prepared = yield* LLMClient.prepare<OpenAIResponses.OpenAIResponsesBody>(
+        LLM.request({
+          model: OpenAI.configure({ baseURL: "https://api.openai.test/v1/", apiKey: "test" }).model("gpt-5.5"),
+          prompt: "think",
+          providerOptions: { openai: { promptCacheKey: "session_123" } },
+        }),
+      )
+
+      expect(prepared.body.prompt_cache_key).toBe("session_123")
+      expect(prepared.body).not.toHaveProperty("prompt_cache_options")
     }),
   )
 
@@ -705,7 +737,7 @@ describe("OpenAI Responses route", () => {
               input_tokens: 5,
               output_tokens: 2,
               total_tokens: 7,
-              input_tokens_details: { cached_tokens: 1 },
+              input_tokens_details: { cached_tokens: 1, cache_write_tokens: 2 },
               output_tokens_details: { reasoning_tokens: 0 },
             },
           },
@@ -715,8 +747,9 @@ describe("OpenAI Responses route", () => {
       const usage = new Usage({
         inputTokens: 5,
         outputTokens: 2,
-        nonCachedInputTokens: 4,
+        nonCachedInputTokens: 2,
         cacheReadInputTokens: 1,
+        cacheWriteInputTokens: 2,
         reasoningTokens: 0,
         totalTokens: 7,
         providerMetadata: {
@@ -724,7 +757,7 @@ describe("OpenAI Responses route", () => {
             input_tokens: 5,
             output_tokens: 2,
             total_tokens: 7,
-            input_tokens_details: { cached_tokens: 1 },
+            input_tokens_details: { cached_tokens: 1, cache_write_tokens: 2 },
             output_tokens_details: { reasoning_tokens: 0 },
           },
         },

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -21,6 +21,11 @@ export const OUTPUT_TOKEN_MAX = 32_000
 // needed for stateless multi-turn reasoning (store: false). Hoisted so every
 // branch that requests it stays in lockstep.
 const INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"] as const
+const GPT56_PROMPT_CACHE_OPTIONS = { mode: "implicit", ttl: "30m" } as const
+
+function isGPT56Family(modelID: string) {
+  return /(?:^|[/.])gpt-5\.6(?:$|[-_/.])/.test(modelID.toLowerCase())
+}
 
 export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
@@ -1146,6 +1151,9 @@ export function options(input: {
       input.providerOptions?.setCacheKey)
   ) {
     result["promptCacheKey"] = input.sessionID
+  }
+  if (input.model.providerID === "openai" && isGPT56Family(input.model.api.id)) {
+    result["promptCacheOptions"] = GPT56_PROMPT_CACHE_OPTIONS
   }
 
   if (input.model.providerID === "meta" && input.model.api.npm === "@ai-sdk/openai") {

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -82,7 +82,7 @@ export function stream(input: StreamInput): StreamResult {
   // ProviderTransform.providerOptions builds AI-SDK-shaped options for the
   // selected SDK key (e.g. "openai") and the native LLM SDK reads the same
   // keys via OpenAIOptions.* (store, reasoningEffort, reasoningSummary,
-  // include, textVerbosity, promptCacheKey). Both sides intentionally use
+  // include, textVerbosity, promptCacheKey, promptCacheOptions). Both sides intentionally use
   // OpenAI's official wire field names, so this is identity, not translation
   // — if a field ever needs to differ between the two surfaces, the
   // translation belongs here, not split across both packages.

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -361,6 +361,34 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.include).toEqual(["reasoning.encrypted_content"])
   })
 
+  test("gpt-5.6 family should use implicit prompt cache options", () => {
+    const options = ["gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.6-fast"].map((id) =>
+      ProviderTransform.options({ model: createGpt5Model(id), sessionID, providerOptions: {} }),
+    )
+
+    expect(options.map((item) => item.promptCacheKey)).toEqual([
+      sessionID,
+      sessionID,
+      sessionID,
+      sessionID,
+      sessionID,
+    ])
+    expect(options.map((item) => item.promptCacheOptions)).toEqual([
+      { mode: "implicit", ttl: "30m" },
+      { mode: "implicit", ttl: "30m" },
+      { mode: "implicit", ttl: "30m" },
+      { mode: "implicit", ttl: "30m" },
+      { mode: "implicit", ttl: "30m" },
+    ])
+  })
+
+  test("gpt-5.5 should keep old prompt cache behavior", () => {
+    const result = ProviderTransform.options({ model: createGpt5Model("gpt-5.5"), sessionID, providerOptions: {} })
+
+    expect(result.promptCacheKey).toBe(sessionID)
+    expect(result.promptCacheOptions).toBeUndefined()
+  })
+
   test("Bedrock Mantle gpt-5.5 uses OpenAI Responses defaults", () => {
     const model = {
       ...createGpt5Model("openai.gpt-5.5"),


### PR DESCRIPTION
### Issue for this PR

Closes #36318

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds GPT-5.6 prompt caching support while keeping older OpenAI models on their existing behavior.

For the GPT-5.6 family, including `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, and suffix-style variants like `gpt-5.6-fast`, opencode now sends OpenAI request-wide prompt cache options:

```ts
promptCacheOptions: { mode: implicit, ttl: 30m }
```

That lowers to OpenAI wire field:

```json
prompt_cache_options: { mode: implicit, ttl: 30m }
```

The existing `prompt_cache_key` behavior remains in place. GPT-5.5 and older models do not receive `prompt_cache_options`, so they keep the old cache behavior.

This also parses `cache_write_tokens` in OpenAI usage responses so cache writes are counted separately from cached reads and normal input tokens.

OpenAI docs: https://developers.openai.com/api/docs/guides/prompt-caching

### How did you verify your code works?

Ran these locally:

- `bun test` from `packages/llm` — all tests pass.
- `bun typecheck` from `packages/llm` — passes.
- `bun test test/session-runner.test.ts` from `packages/core` — all tests pass.
- `bun typecheck` from `packages/core` — passes.
- `bun test --timeout 60000 test/provider/transform.test.ts` from `packages/opencode` — all tests pass.


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR