### PR TITLE
refactor(core): combine git discovery queries

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -190,15 +190,15 @@ const layer = Layer.effect(
 
       const cwd = path.dirname(dotgit)
       const git = run(cwd, proc)
-      const topLevel = yield* git(["rev-parse", "--show-toplevel"])
-      const gitDir = yield* git(["rev-parse", "--git-dir"])
-      const commonDir = yield* git(["rev-parse", "--git-common-dir"])
-      if (gitDir.exitCode !== 0 || commonDir.exitCode !== 0) return undefined
+      const result = yield* git(["rev-parse", "--show-toplevel", "--git-dir", "--git-common-dir"])
+      if (result.exitCode !== 0) return undefined
+      const [topLevel, gitDir, commonDir] = result.text.replace(/[\r\n]+$/, "").split(/\r?\n/)
+      if (!gitDir || !commonDir) return undefined
 
       return new Repository({
-        worktree: AbsolutePath.make(topLevel.exitCode === 0 ? resolvePath(cwd, topLevel.text) : cwd),
-        gitDirectory: AbsolutePath.make(resolvePath(cwd, gitDir.text)),
-        commonDirectory: AbsolutePath.make(resolvePath(cwd, commonDir.text)),
+        worktree: AbsolutePath.make(resolvePath(cwd, topLevel)),
+        gitDirectory: AbsolutePath.make(resolvePath(cwd, gitDir)),
+        commonDirectory: AbsolutePath.make(resolvePath(cwd, commonDir)),
       })
     })
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -189,14 +189,12 @@ const layer = Layer.effect(
       if (!dotgit) return undefined
 
       const cwd = path.dirname(dotgit)
-      const git = run(cwd, proc)
-      const result = yield* git(["rev-parse", "--show-toplevel", "--git-dir", "--git-common-dir"])
-      if (result.exitCode !== 0) return undefined
-      const [topLevel, gitDir, commonDir] = result.text.replace(/[\r\n]+$/, "").split(/\r?\n/)
+      const result = yield* run(cwd, proc)(["rev-parse", "--git-dir", "--git-common-dir", "--show-toplevel"])
+      const [gitDir, commonDir, topLevel] = result.text.split(/\r?\n/)
       if (!gitDir || !commonDir) return undefined
 
       return new Repository({
-        worktree: AbsolutePath.make(resolvePath(cwd, topLevel)),
+        worktree: AbsolutePath.make(topLevel ? resolvePath(cwd, topLevel) : cwd),
         gitDirectory: AbsolutePath.make(resolvePath(cwd, gitDir)),
         commonDirectory: AbsolutePath.make(resolvePath(cwd, commonDir)),
       })

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -13,6 +13,26 @@ import { testEffect } from "./lib/effect"
 const it = testEffect(LayerNode.compile(Git.node))
 
 describe("Git", () => {
+  it.live("discovers repository metadata without a work tree", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+      )
+      yield* Effect.promise(async () => {
+        await initRepo(root.path)
+        await $`git config core.bare true`.cwd(root.path).quiet()
+      })
+      const directory = AbsolutePath.make(yield* Effect.promise(() => fs.realpath(root.path)))
+      const git = yield* Git.Service
+      const repository = yield* git.repo.discover(directory)
+
+      expect(repository?.worktree).toBe(directory)
+      expect(repository?.gitDirectory).toBe(AbsolutePath.make(path.join(directory, ".git")))
+      expect(repository?.commonDirectory).toBe(repository?.gitDirectory)
+    }),
+  )
+
   it.live("clones a remote and reads checkout metadata", () =>
     withRemote((fixture) =>
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- combine Git repository discovery metadata into one `git rev-parse` subprocess
- preserve discovery when Git directory metadata is available but the repository has no work tree
- add live coverage for the worktree-less fallback

## Context

After #36290 removed eager Snapshot discovery from Location acquisition, Git discovery remained a smaller measured first-use cost. `Git.repo.discover()` previously launched three sequential subprocesses after locating `.git`:

```text
git rev-parse --show-toplevel
git rev-parse --git-dir
git rev-parse --git-common-dir
```

This PR asks Git for the same metadata in one process:

```text
git rev-parse --git-dir --git-common-dir --show-toplevel
```

The required Git and common directories are emitted first. If `--show-toplevel` fails because the repository has no work tree, discovery retains the previous behavior by using the discovered `.git` parent as `worktree`. Discovery still returns `undefined` when the required directory fields are unavailable.

## Benchmark

An alternating 20-run benchmark executed discovery metadata queries concurrently across five repositories. It used three warmups and compared the previous three-process sequence with the combined command in alternating order.

| Operation | Median | Spread |
| --- | ---: | ---: |
| Three sequential queries | 33.2 ms | 31.2-35.3 ms |
| One combined query | 11.5 ms | 10.9-12.7 ms |

The combined query reduced the measured batch median by 65%. An earlier run before rebasing measured `23.3 ms → 12.2 ms` (-48%), so the direction is durable across both runs.

This deliberately does not change the preceding filesystem ascent or add cross-call discovery caching. Those are separate behaviors and were not needed to test the subprocess-count hypothesis.

## Compatibility

- normal repositories retain canonical worktree, Git directory, and common directory resolution
- linked worktrees retain distinct Git directories and shared common directories
- repositories whose `.git` metadata is present but whose work tree is disabled retain the previous `cwd` worktree fallback
- failed required Git/common-directory discovery still returns `undefined`

## Verification

- `bun typecheck` from `packages/core`: passed
- `bun run test test/git.test.ts test/snapshot.test.ts` from `packages/core`: 10 passed
- push-hook repository typecheck: 31 packages passed

Follow-up to #36285 and #36290.
