### PR TITLE
docs: add toll402 plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [toll402-opencode](https://github.com/alexclowe/toll402-agent-plugins)                             | Find, compare, and safely integrate curated x402 services through six read-only tools              |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #36325

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the published `toll402-opencode` package to the ecosystem plugin table. It gives OpenCode six read-only tools for finding, comparing, and preparing integrations for curated x402 services.

### How did you verify your code works?

Confirmed npm version `1.0.0`, installed it from the public registry in a clean directory, and loaded all six tools.

### Screenshots / recordings

Not applicable; this is a documentation-only table entry.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
