### PR TITLE
fix(tui): fork messages with agent attachments

### DIFF
--- a/packages/tui/src/routes/session/dialog-fork.tsx
+++ b/packages/tui/src/routes/session/dialog-fork.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createSignal, onMount, Show } from "solid-js"
+import { unwrap } from "solid-js/store"
 import { useData } from "../../context/data"
 import { useRoute } from "../../context/route"
 import { useSDK } from "../../context/sdk"
@@ -38,7 +39,7 @@ export function DialogFork(props: { sessionID: string; messageID?: string; onMov
                 description: file.description,
                 mention: file.mention,
               })),
-              agents: structuredClone(message.agents ?? []),
+              agents: structuredClone(unwrap(message.agents ?? [])),
               pasted: [],
             }
           : undefined,


### PR DESCRIPTION
Closes #36323

## Summary
- unwrap Solid store-backed agent attachments before cloning them into the fork prompt
- allow successful message forks to navigate and close the dialog instead of throwing `DataCloneError`

## Testing
- `bun typecheck` in `packages/tui`
- `bun test` in `packages/tui`
- repository pre-push typecheck hook