### PR TITLE
feat(tui): show pending command resolution

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -52,6 +52,7 @@ import { useLocation } from "../../context/location"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { contextUsage } from "../../util/session"
 import { abbreviateHome } from "../../runtime"
+import { usePromptRef } from "../../context/prompt"
 
 registerOpencodeSpinner()
 
@@ -167,6 +168,7 @@ export function Prompt(props: PromptProps) {
   const config = useConfig().data
   const dialog = useDialog()
   const toast = useToast()
+  const promptRef = usePromptRef()
   const status = createMemo(() => data.session.status(props.sessionID ?? ""))
   const activeSubagents = createMemo(() => {
     if (!props.sessionID) return 0
@@ -1085,16 +1087,18 @@ export function Prompt(props: PromptProps) {
       const restOfInput = firstLineEnd === -1 ? "" : inputText.slice(firstLineEnd + 1)
       const args = firstLineArgs.join(" ") + (restOfInput ? "\n" + restOfInput : "")
 
-      void client.api.session
-        .command({
-          sessionID,
-          command: command.slice(1),
-          arguments: args,
-          agent: agent.id,
-          model: { providerID: selectedModel.providerID, id: selectedModel.modelID, variant },
-          files: store.prompt.files,
-          agents: store.prompt.agents,
-        })
+      void promptRef.command
+        .track(() =>
+          client.api.session.command({
+            sessionID,
+            command: command.slice(1),
+            arguments: args,
+            agent: agent.id,
+            model: { providerID: selectedModel.providerID, id: selectedModel.modelID, variant },
+            files: store.prompt.files,
+            agents: store.prompt.agents,
+          }),
+        )
         .catch((error) => {
           toast.show({ title: "Failed to run command", message: errorMessage(error), variant: "error" })
         })
@@ -1558,6 +1562,11 @@ export function Prompt(props: PromptProps) {
         <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
           <box flexGrow={1} flexShrink={1} minWidth={0}>
             <Switch>
+              <Match when={promptRef.command.pending}>
+                <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
+                  <Spinner color={themeV2.hue.accent(500)}>Resolving command...</Spinner>
+                </box>
+              </Match>
               <Match when={status() === "running"}>
                 <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
                   <box marginLeft={1}>

--- a/packages/tui/src/context/prompt.tsx
+++ b/packages/tui/src/context/prompt.tsx
@@ -1,10 +1,13 @@
 import { createSimpleContext } from "./helper"
 import type { PromptRef } from "../component/prompt"
+import { createSignal } from "solid-js"
 
 export const { use: usePromptRef, provider: PromptRefProvider } = createSimpleContext({
   name: "PromptRef",
   init: () => {
     let current: PromptRef | undefined
+    let commandID = 0
+    const [commands, setCommands] = createSignal<number[]>([])
 
     return {
       get current() {
@@ -12,6 +15,20 @@ export const { use: usePromptRef, provider: PromptRefProvider } = createSimpleCo
       },
       set(ref: PromptRef | undefined) {
         current = ref
+      },
+      command: {
+        get pending() {
+          return commands().length > 0
+        },
+        async track<T>(request: () => Promise<T>) {
+          const id = commandID++
+          setCommands((commands) => [...commands, id])
+          try {
+            return await request()
+          } finally {
+            setCommands((commands) => commands.filter((command) => command !== id))
+          }
+        },
       },
     }
   },

--- a/packages/tui/test/prompt/command-pending.test.tsx
+++ b/packages/tui/test/prompt/command-pending.test.tsx
@@ -1,29 +1,25 @@
 /** @jsxImportSource @opentui/solid */
 import { TextareaRenderable } from "@opentui/core"
-import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
-import { testRender, useRenderer } from "@opentui/solid"
+import { testRender } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import path from "node:path"
-import { createSignal, onCleanup, Show, type Setter } from "solid-js"
+import { createEffect, createSignal, Show, type Setter } from "solid-js"
 import { Prompt, type PromptRef } from "../../src/component/prompt"
-import { TuiConfigProvider } from "../../src/config/v1"
+import { ConfigProvider } from "../../src/config"
 import { ArgsProvider } from "../../src/context/args"
+import { ClientProvider } from "../../src/context/client"
 import { ClipboardProvider } from "../../src/context/clipboard"
 import { DataProvider, useData } from "../../src/context/data"
 import { EditorContextProvider } from "../../src/context/editor"
 import { ExitProvider } from "../../src/context/exit"
-import { KVProvider } from "../../src/context/kv"
+import { Keymap } from "../../src/context/keymap"
 import { LocalProvider } from "../../src/context/local"
-import { LocationProvider } from "../../src/context/location"
+import { LocationProvider, useLocation } from "../../src/context/location"
 import { PermissionProvider } from "../../src/context/permission"
 import { PromptRefProvider, usePromptRef } from "../../src/context/prompt"
-import { ProjectProvider } from "../../src/context/project"
 import { RouteProvider } from "../../src/context/route"
-import { SDKProvider } from "../../src/context/sdk"
-import { SyncProvider } from "../../src/context/sync"
 import { ThemeProvider } from "../../src/context/theme"
-import { OpencodeKeymapProvider, registerOpencodeKeymap } from "../../src/keymap"
 import { FrecencyProvider } from "../../src/prompt/frecency"
 import { PromptHistoryProvider } from "../../src/prompt/history"
 import { PromptStashProvider } from "../../src/prompt/stash"
@@ -32,7 +28,7 @@ import { Toast, ToastProvider } from "../../src/ui/toast"
 import { tmpdir } from "../fixture/fixture"
 import { TestTuiContexts } from "../fixture/tui-environment"
 import { createTuiResolvedConfig } from "../fixture/tui-runtime"
-import { createApi, createClient, createEventStream, createFetch, directory, json } from "../fixture/tui-sdk"
+import { createApi, createEventStream, createFetch, directory, json } from "../fixture/tui-client"
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -141,6 +137,8 @@ async function mountPrompt(root: string) {
 
   function Content() {
     data = useData()
+    const location = useLocation()
+    createEffect(() => location.set(data?.location.default()))
     return (
       <box width="100%" flexDirection="column">
         <Prompt
@@ -155,56 +153,45 @@ async function mountPrompt(root: string) {
   }
 
   function Harness() {
-    const renderer = useRenderer()
-    const keymap = createDefaultOpenTuiKeymap(renderer)
-    const off = registerOpencodeKeymap(keymap, renderer, config)
-    onCleanup(off)
-
     return (
       <TestTuiContexts directory={directory} paths={{ home: root, state, worktree: "/tmp/opencode" }}>
         <ExitProvider exit={() => {}}>
           <ClipboardProvider value={{}}>
-            <OpencodeKeymapProvider keymap={keymap}>
-              <ArgsProvider>
-                <KVProvider>
+            <ArgsProvider>
+              <ConfigProvider config={config}>
+                <Keymap.Provider>
                   <ToastProvider>
                     <RouteProvider initialRoute={{ type: "session", sessionID: "ses_test" }}>
-                      <TuiConfigProvider config={config}>
-                        <SDKProvider client={createClient(transport.fetch)} api={createApi(transport.fetch)}>
-                          <PermissionProvider>
-                            <ProjectProvider>
-                              <SyncProvider>
-                                <DataProvider>
-                                  <ThemeProvider mode="dark" source={{ discover: () => Promise.resolve({}) }}>
-                                    <LocalProvider>
-                                      <PromptStashProvider>
-                                        <DialogProvider>
-                                          <FrecencyProvider>
-                                            <PromptHistoryProvider>
-                                              <PromptRefProvider>
-                                                <EditorContextProvider integration={{}}>
-                                                  <LocationProvider location={{ directory }}>
-                                                    <Content />
-                                                  </LocationProvider>
-                                                </EditorContextProvider>
-                                              </PromptRefProvider>
-                                            </PromptHistoryProvider>
-                                          </FrecencyProvider>
-                                        </DialogProvider>
-                                      </PromptStashProvider>
-                                    </LocalProvider>
-                                  </ThemeProvider>
-                                </DataProvider>
-                              </SyncProvider>
-                            </ProjectProvider>
-                          </PermissionProvider>
-                        </SDKProvider>
-                      </TuiConfigProvider>
+                      <ClientProvider api={createApi(transport.fetch)}>
+                        <PermissionProvider>
+                          <DataProvider>
+                            <LocationProvider>
+                              <ThemeProvider mode="dark" source={{ discover: () => Promise.resolve({}) }}>
+                                <LocalProvider>
+                                  <PromptStashProvider>
+                                    <DialogProvider>
+                                      <FrecencyProvider>
+                                        <PromptHistoryProvider>
+                                          <PromptRefProvider>
+                                            <EditorContextProvider integration={{}}>
+                                              <Content />
+                                            </EditorContextProvider>
+                                          </PromptRefProvider>
+                                        </PromptHistoryProvider>
+                                      </FrecencyProvider>
+                                    </DialogProvider>
+                                  </PromptStashProvider>
+                                </LocalProvider>
+                              </ThemeProvider>
+                            </LocationProvider>
+                          </DataProvider>
+                        </PermissionProvider>
+                      </ClientProvider>
                     </RouteProvider>
                   </ToastProvider>
-                </KVProvider>
-              </ArgsProvider>
-            </OpencodeKeymapProvider>
+                </Keymap.Provider>
+              </ConfigProvider>
+            </ArgsProvider>
           </ClipboardProvider>
         </ExitProvider>
       </TestTuiContexts>

--- a/packages/tui/test/prompt/command-pending.test.tsx
+++ b/packages/tui/test/prompt/command-pending.test.tsx
@@ -1,0 +1,335 @@
+/** @jsxImportSource @opentui/solid */
+import { TextareaRenderable } from "@opentui/core"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { createSignal, onCleanup, Show, type Setter } from "solid-js"
+import { Prompt, type PromptRef } from "../../src/component/prompt"
+import { TuiConfigProvider } from "../../src/config/v1"
+import { ArgsProvider } from "../../src/context/args"
+import { ClipboardProvider } from "../../src/context/clipboard"
+import { DataProvider, useData } from "../../src/context/data"
+import { EditorContextProvider } from "../../src/context/editor"
+import { ExitProvider } from "../../src/context/exit"
+import { KVProvider } from "../../src/context/kv"
+import { LocalProvider } from "../../src/context/local"
+import { LocationProvider } from "../../src/context/location"
+import { PermissionProvider } from "../../src/context/permission"
+import { PromptRefProvider, usePromptRef } from "../../src/context/prompt"
+import { ProjectProvider } from "../../src/context/project"
+import { RouteProvider } from "../../src/context/route"
+import { SDKProvider } from "../../src/context/sdk"
+import { SyncProvider } from "../../src/context/sync"
+import { ThemeProvider } from "../../src/context/theme"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "../../src/keymap"
+import { FrecencyProvider } from "../../src/prompt/frecency"
+import { PromptHistoryProvider } from "../../src/prompt/history"
+import { PromptStashProvider } from "../../src/prompt/stash"
+import { DialogProvider } from "../../src/ui/dialog"
+import { Toast, ToastProvider } from "../../src/ui/toast"
+import { tmpdir } from "../fixture/fixture"
+import { TestTuiContexts } from "../fixture/tui-environment"
+import { createTuiResolvedConfig } from "../fixture/tui-runtime"
+import { createApi, createClient, createEventStream, createFetch, directory, json } from "../fixture/tui-sdk"
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+async function setupTracker() {
+  let prompt!: ReturnType<typeof usePromptRef>
+  let setMounted!: Setter<boolean>
+
+  function Status() {
+    prompt = usePromptRef()
+    return (
+      <Show when={prompt.command.pending}>
+        <text>Resolving command...</text>
+      </Show>
+    )
+  }
+
+  function View() {
+    const [mounted, set] = createSignal(true)
+    setMounted = set
+    return (
+      <box>
+        <Show when={mounted()}>
+          <Status />
+        </Show>
+      </box>
+    )
+  }
+
+  const app = await testRender(() => (
+    <PromptRefProvider>
+      <View />
+    </PromptRefProvider>
+  ))
+  await app.renderOnce()
+  return { app, prompt, setMounted }
+}
+
+async function mountPrompt(root: string) {
+  const state = path.join(root, "state")
+  await mkdir(state, { recursive: true })
+  await Promise.all([Bun.write(path.join(state, "kv.json"), "{}"), Bun.write(path.join(state, "model.json"), "{}")])
+
+  const requests: {
+    body: unknown
+    response: ReturnType<typeof deferred<Response>>
+  }[] = []
+  const events = createEventStream()
+  const location = { directory, project: { id: "proj_test", directory: "/tmp/opencode" } }
+  const transport = createFetch(async (url, request) => {
+    if (url.pathname === "/api/agent")
+      return json({
+        location,
+        data: [
+          {
+            id: "build",
+            name: "Build",
+            request: { headers: {}, body: {} },
+            mode: "primary",
+            hidden: false,
+            permissions: [],
+          },
+        ],
+      })
+    if (url.pathname === "/api/model")
+      return json({
+        location,
+        data: [
+          {
+            id: "model",
+            modelID: "model",
+            providerID: "provider",
+            name: "Test Model",
+            capabilities: {},
+            variants: [],
+            time: { released: 0 },
+            cost: [],
+            status: "active",
+            enabled: true,
+            limit: { context: 10_000, output: 1_000 },
+          },
+        ],
+      })
+    if (url.pathname === "/api/command")
+      return json({
+        location,
+        data: [{ name: "slow", template: "", description: "Slow command" }],
+      })
+    if (url.pathname === "/api/session/ses_test/command") {
+      const response = deferred<Response>()
+      requests.push({ body: await request.json(), response })
+      return response.promise
+    }
+    return undefined
+  }, events)
+  const config = createTuiResolvedConfig()
+  let prompt: PromptRef | undefined
+  let data: ReturnType<typeof useData> | undefined
+
+  function Content() {
+    data = useData()
+    return (
+      <box width="100%" flexDirection="column">
+        <Prompt
+          sessionID="ses_test"
+          ref={(value) => {
+            if (value) prompt = value
+          }}
+        />
+        <Toast />
+      </box>
+    )
+  }
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const off = registerOpencodeKeymap(keymap, renderer, config)
+    onCleanup(off)
+
+    return (
+      <TestTuiContexts directory={directory} paths={{ home: root, state, worktree: "/tmp/opencode" }}>
+        <ExitProvider exit={() => {}}>
+          <ClipboardProvider value={{}}>
+            <OpencodeKeymapProvider keymap={keymap}>
+              <ArgsProvider>
+                <KVProvider>
+                  <ToastProvider>
+                    <RouteProvider initialRoute={{ type: "session", sessionID: "ses_test" }}>
+                      <TuiConfigProvider config={config}>
+                        <SDKProvider client={createClient(transport.fetch)} api={createApi(transport.fetch)}>
+                          <PermissionProvider>
+                            <ProjectProvider>
+                              <SyncProvider>
+                                <DataProvider>
+                                  <ThemeProvider mode="dark" source={{ discover: () => Promise.resolve({}) }}>
+                                    <LocalProvider>
+                                      <PromptStashProvider>
+                                        <DialogProvider>
+                                          <FrecencyProvider>
+                                            <PromptHistoryProvider>
+                                              <PromptRefProvider>
+                                                <EditorContextProvider integration={{}}>
+                                                  <LocationProvider location={{ directory }}>
+                                                    <Content />
+                                                  </LocationProvider>
+                                                </EditorContextProvider>
+                                              </PromptRefProvider>
+                                            </PromptHistoryProvider>
+                                          </FrecencyProvider>
+                                        </DialogProvider>
+                                      </PromptStashProvider>
+                                    </LocalProvider>
+                                  </ThemeProvider>
+                                </DataProvider>
+                              </SyncProvider>
+                            </ProjectProvider>
+                          </PermissionProvider>
+                        </SDKProvider>
+                      </TuiConfigProvider>
+                    </RouteProvider>
+                  </ToastProvider>
+                </KVProvider>
+              </ArgsProvider>
+            </OpencodeKeymapProvider>
+          </ClipboardProvider>
+        </ExitProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { width: 100, height: 24, kittyKeyboard: true })
+  app.renderer.start()
+  await app.waitForFrame(
+    (frame) =>
+      frame.includes("Test Model") &&
+      data?.location.command.list()?.some((command) => command.name === "slow") === true,
+  )
+  if (!prompt) throw new Error("expected prompt ref")
+  const input = app.renderer.currentFocusedEditor
+  if (!(input instanceof TextareaRenderable)) throw new Error("expected focused prompt textarea")
+  return { app, input, prompt, requests }
+}
+
+function commandResponse(index: number) {
+  return json({
+    data: {
+      admittedSeq: index,
+      id: `msg_${index}`,
+      sessionID: "ses_test",
+      timeCreated: index,
+      type: "user",
+      data: { text: "Resolved command" },
+      delivery: "steer",
+    },
+  })
+}
+
+test("shows pending before a deferred command resolves across prompt remounts", async () => {
+  const { app, prompt, setMounted } = await setupTracker()
+  const request = deferred<void>()
+  const tracked = prompt.command.track(() => request.promise)
+
+  try {
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("Resolving command...")
+
+    setMounted(false)
+    await app.renderOnce()
+    setMounted(true)
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("Resolving command...")
+
+    request.resolve(undefined)
+    await tracked
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("submits through the command endpoint, clears input, and settles pending on success", async () => {
+  await using tmp = await tmpdir()
+  const harness = await mountPrompt(tmp.path)
+
+  try {
+    harness.prompt.set({ text: "/slow first argument", files: [], agents: [], pasted: [] })
+    expect(harness.input.plainText).toBe("/slow first argument")
+    harness.prompt.submit()
+    expect(harness.prompt.current.text).toBe("")
+    expect(harness.input.plainText).toBe("")
+
+    await harness.app.waitFor(() => harness.requests.length === 1)
+    expect(harness.requests[0]?.body).toMatchObject({
+      command: "slow",
+      arguments: "first argument",
+      agent: "build",
+      model: { providerID: "provider", id: "model" },
+    })
+    await harness.app.waitForFrame((frame) => frame.includes("Resolving command..."))
+
+    harness.requests[0]?.response.resolve(commandResponse(1))
+    await harness.app.waitForFrame((frame) => !frame.includes("Resolving command..."))
+  } finally {
+    harness.app.renderer.destroy()
+  }
+})
+
+test("clears pending and preserves the command error toast on rejection", async () => {
+  await using tmp = await tmpdir()
+  const harness = await mountPrompt(tmp.path)
+
+  try {
+    harness.prompt.set({ text: "/slow rejected", files: [], agents: [], pasted: [] })
+    harness.prompt.submit()
+    await harness.app.waitFor(() => harness.requests.length === 1)
+    await harness.app.waitForFrame((frame) => frame.includes("Resolving command..."))
+
+    harness.requests[0]?.response.reject(new Error("command failed"))
+    await harness.app.waitForFrame(
+      (frame) => frame.includes("Failed to run command") && !frame.includes("Resolving command..."),
+    )
+  } finally {
+    harness.app.renderer.destroy()
+  }
+})
+
+test("keeps the real pending UI visible until overlapping command requests settle", async () => {
+  await using tmp = await tmpdir()
+  const harness = await mountPrompt(tmp.path)
+
+  try {
+    harness.prompt.set({ text: "/slow first", files: [], agents: [], pasted: [] })
+    harness.prompt.submit()
+    expect(harness.prompt.current.text).toBe("")
+    await harness.app.waitFor(() => harness.requests.length === 1)
+
+    harness.prompt.set({ text: "/slow second", files: [], agents: [], pasted: [] })
+    harness.prompt.submit()
+    expect(harness.prompt.current.text).toBe("")
+    await harness.app.waitFor(() => harness.requests.length === 2)
+    await harness.app.waitForFrame((frame) => frame.includes("Resolving command..."))
+
+    harness.requests[0]?.response.resolve(commandResponse(1))
+    await harness.requests[0]?.response.promise
+    await Bun.sleep(10)
+    expect(harness.app.captureCharFrame()).toContain("Resolving command...")
+
+    harness.requests[1]?.response.resolve(commandResponse(2))
+    await harness.app.waitForFrame((frame) => !frame.includes("Resolving command..."))
+  } finally {
+    harness.app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #34860

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MCP-backed slash commands clear the composer before prompt resolution finishes, which leaves the TUI looking idle. This tracks outstanding command requests in the persistent prompt context and shows a spinner until they settle. Separate request IDs keep the indicator correct when commands overlap, and failure handling still uses the existing toast.

### How did you verify your code works?

- Focused pending-command tests: 4 passed
- Full TUI suite: 231 passed, 1 skipped
- Monorepo typecheck: 31 packages passed
- Prettier, Oxlint (0 errors), and git diff --check

### Screenshots / recordings

New TUI state: Resolving command...

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR