### PR TITLE
fix(core): unblock shell tool when a descendant keeps the stdio pipe …

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -96,6 +96,12 @@ const toPlatformError = (
 
 type ExitSignal = Deferred.Deferred<readonly [code: number | null, signal: NodeJS.Signals | null]>
 
+// After the spawned process exits, wait this long before forcing the output
+// streams to finish. A surviving descendant that inherited a stdio handle
+// keeps the pipe open so it never reaches EOF; this grace window lets any
+// final buffered output flush in the normal case before we unblock consumers.
+const EXIT_STREAM_GRACE_MS = 1000
+
 export const make = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
@@ -242,6 +248,7 @@ export const make = Effect.gen(function* () {
   const setupOutput = (
     command: ChildProcess.StandardCommand,
     proc: NodeChildProcess.ChildProcess,
+    signal: ExitSignal,
     out: ChildProcess.StdoutConfig,
     err: ChildProcess.StderrConfig,
   ) => {
@@ -257,6 +264,15 @@ export const make = Effect.gen(function* () {
           onError: (cause) => toPlatformError("fromReadable(stderr)", toError(cause), command),
         })
       : Stream.empty
+
+    // Once the process has exited, finish the output streams after a short
+    // grace period even if a surviving descendant kept an inherited stdio
+    // handle open (so the pipe never reaches EOF). Otherwise consumers such as
+    // `runStream` block forever waiting for the stream to end. The grace window
+    // lets any final buffered output flush in the normal case first.
+    const interruptOnExit = Deferred.await(signal).pipe(Effect.delay(EXIT_STREAM_GRACE_MS), Effect.asVoid)
+    if (proc.stdout) stdout = Stream.interruptWhen(stdout, interruptOnExit)
+    if (proc.stderr) stderr = Stream.interruptWhen(stderr, interruptOnExit)
 
     if (Sink.isSink(out.stream)) stdout = Stream.transduce(stdout, out.stream)
     if (Sink.isSink(err.stream)) stderr = Stream.transduce(stderr, err.stream)
@@ -275,6 +291,16 @@ export const make = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
+        // Complete as soon as the process terminates. Waiting for `close`
+        // instead would hang forever whenever a descendant keeps an inherited
+        // stdio handle open after the spawned process has already exited
+        // (e.g. a background server started by the command). That left the
+        // caller blocked indefinitely, defeating any timeout. `close` below
+        // remains as a fallback for the rare case where `exit` is missed.
+        if (!end) {
+          end = true
+          Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+        }
       })
       proc.on("close", (...args) => {
         if (end) return
@@ -403,7 +429,7 @@ export const make = Effect.gen(function* () {
           )
 
           const fd = yield* setupFds(command, proc, extra)
-          const out = setupOutput(command, proc, sout, serr)
+          const out = setupOutput(command, proc, signal, sout, serr)
           let ref = true
           return makeHandle({
             pid: ProcessId(proc.pid!),
@@ -431,7 +457,7 @@ export const make = Effect.gen(function* () {
               const attempt = send(sig).pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid)
               if (!opts?.forceKillAfter) return attempt
               return Effect.timeoutOrElse(attempt, {
-                duration: opts.forceKillAfter,
+                duration: opts?.forceKillAfter,
                 orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid),
               })
             },

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -6,11 +6,14 @@ import { Effect, Exit, Stream } from "effect"
 import type * as PlatformError from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppProcess } from "@opencode-ai/core/process"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { testEffect } from "../lib/effect"
 
 const live = LayerNode.compile(CrossSpawnSpawner.node)
 const fx = testEffect(live)
+const appLive = LayerNode.compile(AppProcess.node)
+const appFx = testEffect(appLive)
 
 function js(code: string, opts?: ChildProcess.CommandOptions) {
   return ChildProcess.make("node", ["-e", code], opts)
@@ -285,6 +288,30 @@ describe("cross-spawn spawner", () => {
         expect(running).toBe(false)
       }),
     )
+
+    fx.effect(
+      "does not block when a descendant keeps the stdio pipe open",
+      Effect.gen(function* () {
+        // Parent hangs and spawns a grandchild that inherits the stdio pipe
+        // and runs forever. The grandchild keeps the pipe write end open, so
+        // the parent's `close` event never fires. The caller must still return
+        // promptly when killed (regression test for the permanent-block bug).
+        const handle = yield* ChildProcess.make(
+          process.execPath,
+          [
+            "-e",
+            [
+              "const { spawn } = require('child_process')",
+              "spawn(process.execPath, ['-e', 'setInterval(() => {}, 1e9)'], { stdio: 'inherit' })",
+              "setInterval(() => {}, 1e9)",
+            ].join("\n"),
+          ],
+        )
+        const started = Date.now()
+        yield* handle.kill({ forceKillAfter: 500 })
+        expect(Date.now() - started).toBeLessThan(10_000)
+      }),
+    )
   })
 
   describe("error handling", () => {
@@ -420,6 +447,32 @@ describe("cross-spawn spawner", () => {
           ),
         )
         expect(code).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+    )
+  })
+
+  describe("runStream", () => {
+    appFx.effect(
+      "does not block when a descendant keeps the stdio pipe open",
+      Effect.gen(function* () {
+        if (process.platform !== "win32") return
+        // pwsh launches a background node that inherits the stdio pipe and
+        // survives, then pwsh exits immediately. The pipe never reaches EOF,
+        // which used to block runStream forever. It must finish after a grace.
+        const exit = yield* Effect.exit(
+          AppProcess.Service.use((svc) =>
+            svc
+              .runStream(
+                ChildProcess.make("pwsh", [
+                  "-NoProfile",
+                  "-Command",
+                  "Start-Process -FilePath node -ArgumentList '-e','setInterval(()=>{},1e9)' -WindowStyle Hidden; exit 0",
+                ]),
+              )
+              .pipe(Stream.runCollect),
+          ),
+        )
+        expect(Exit.isSuccess(exit)).toBe(true)
       }),
     )
   })


### PR DESCRIPTION
## Summary
On Windows, a shell command that launches a background process (e.g. a server
started via `Start-Process` / `pwsh`) can leave a surviving descendant that
inherited the stdio pipe handle. The pipe then never reaches EOF, so the
spawned process closes but its output streams do not end.

This blocked the shell tool (and any `runStream` consumer) forever, because
`runStream` concatenates the stdout stream with the exit-code tail and the
stdout stream never completes — defeating any timeout.

## Fix
- Complete the process signal on `exit` (not just `close`) so `exitCode`
  resolves as soon as the process terminates.
- Interrupt the stdout/stderr streams a short grace period (1s) after the
  process exits, so they finish even when a descendant holds the pipe open.
  The grace lets any final buffered output flush in the normal case first.

Normal command exit does not reap or kill processes the command intended to
start; only the blocked streams are unblocked.

## Test
- Added regression test: `runStream` completes when a `pwsh`-launched
  background `node` inherits the pipe and the parent exits (previously hung
  forever).
- Reproduced the real failure via the user's `restart_grok.ps1` (Store python
  server): the tool call now returns in ~2s instead of blocking indefinitely.

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
