### PR TITLE
fix(snapshot): fail closed when git check-ignore errors

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -120,7 +120,16 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
               stdin: encodeNulTerminatedPaths(checkIgnorePaths),
             },
           )
-          if (check.code !== 0 && check.code !== 1) return new Set<string>()
+          // git check-ignore: 0 = some ignored, 1 = none ignored; any other code is an error.
+          // Fail closed: treat every candidate as ignored so gitignored files cannot leak into
+          // snapshot patches and later be restored or deleted by /undo (see #28033).
+          if (check.code !== 0 && check.code !== 1) {
+            yield* Effect.logWarning("git check-ignore failed; treating all candidates as ignored", {
+              code: check.code,
+              stderr: check.stderr,
+            })
+            return new Set(files)
+          }
           return new Set(
             check.text
               .split("\0")


### PR DESCRIPTION
### Issue for this PR

Closes #28033

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Snapshot.ignore()` shells out to `git check-ignore`. Exit codes `0` / `1` are normal; any other code is an error.

**Bug (still present on `dev`):**

```ts
if (check.code !== 0 && check.code !== 1) return new Set<string>()
```

Returning an empty set means “nothing is ignored”. Callers then:

1. **`add()`** — skip dropping gitignored paths from the snapshot index  
2. **`patch()`** — keep gitignored paths in stored `Patch.files`  
3. **`revert()` / `/undo`** — may restore or **delete** those paths with no ignore filter  

So a transient `git check-ignore` failure (exit `128`, lock contention, path issues, etc.) can leak secrets into patches and delete user files on undo.

**Minimal fix:** on unexpected exit codes, fail closed — `return new Set(files)` (treat all candidates as ignored) — and log a warning with code/stderr. No API/behavior change on the normal `0`/`1` paths.

### How did you verify your code works?

- Confirmed on current `upstream/dev` that `packages/opencode/src/snapshot/index.ts` still returns `new Set<string>()` on non-0/non-1
- Traced consumers `add` / `patch` / `diffFull` which all use `ignore()` size or membership
- Diff is one-branch change only; success path of check-ignore is unchanged

### Screenshots / recordings

_N/A — non-UI_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Author

- GitHub: @1837620622 (传康Kk)
- Commit email: `35034498+1837620622@users.noreply.github.com`