### PR TITLE
fix(task): cancel subagent on any abnormal tool exit

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -321,7 +321,10 @@ export const TaskTool = Tool.define(
           }),
         (_, exit) =>
           Effect.gen(function* () {
-            if (Exit.hasInterrupts(exit))
+            // Cancel on any abnormal exit (interrupt, fail, or die). Limiting cleanup to
+            // interrupts left subagent sessions orphaned when Effect.orDie converted tool
+            // errors into defects, so the parent continued while the child kept running.
+            if (Exit.isFailure(exit))
               yield* Effect.all([cancel, background.cancel(nextSession.id)], { discard: true })
           }).pipe(
             Effect.ensuring(


### PR DESCRIPTION
### Issue for this PR

Closes #31787

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In `TaskTool`, the foreground subagent wait is wrapped in `Effect.acquireUseRelease`. Release previously only cleaned up on interrupt:

```ts
if (Exit.hasInterrupts(exit))
  yield* Effect.all([cancel, background.cancel(nextSession.id)], { discard: true })
```

**Bug:** tool failures become defects via `Effect.orDie` on `execute`. That exit is a **failure/defect**, not an interrupt, so:

1. `background.cancel(nextSession.id)` never runs  
2. The child session keeps running as an orphan  
3. The parent may retry / continue while the child still edits files → double work / races  

**Minimal fix:** cancel the child on **any** `Exit.isFailure` (interrupt, fail, or die). Successful completion and intentional background promotion stay on the success path and are not cancelled.

Does not change the framework-wide `Effect.orDie` in tool wrap (tracked separately); only closes the orphan hole in `task.ts`.

### How did you verify your code works?

- Confirmed on current `upstream/dev` that release still gates on `Exit.hasInterrupts` only
- Success path: completed wait / background promotion returns success → no cancel  
- Failure path: `status === "error"|"cancelled"` or defect → `Exit.isFailure` → cancel  
- Single-file, four-line behavioral change

### Screenshots / recordings

_N/A — non-UI_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Author

- GitHub: @1837620622 (传康Kk)
- Commit email: `35034498+1837620622@users.noreply.github.com`