### PR TITLE
fix(llm): stop dumping HTML gateway bodies into provider errors

### DIFF
--- a/packages/llm/src/route/executor.ts
+++ b/packages/llm/src/route/executor.ts
@@ -201,9 +201,15 @@ const responseBody = (body: string | void, request: HttpClientRequest.HttpClient
   return { body: redacted.slice(0, BODY_LIMIT), bodyTruncated: true }
 }
 
+// HTML/gateway error pages are useless (and noisy) in TUI retry notices (#35640).
+const isHtmlErrorBody = (body: string) => /^\s*<(!doctype\s+html|html[\s>])/i.test(body)
+
 const providerMessage = (status: number, body: { readonly body?: string }) => {
-  if (body.body && body.body.length <= 500) return `Provider request failed with HTTP ${status}: ${body.body}`
-  return `Provider request failed with HTTP ${status}`
+  const text = body.body
+  if (!text || text.length > 500 || isHtmlErrorBody(text)) {
+    return `Provider request failed with HTTP ${status}`
+  }
+  return `Provider request failed with HTTP ${status}: ${text}`
 }
 
 const responseHttp = (input: {

--- a/packages/llm/test/executor.test.ts
+++ b/packages/llm/test/executor.test.ts
@@ -265,6 +265,39 @@ describe("RequestExecutor", () => {
     ),
   )
 
+  it.effect("omits HTML error bodies from user-facing provider messages", () =>
+    Effect.gen(function* () {
+      const executor = yield* RequestExecutor.Service
+      const error = yield* executor.execute(request).pipe(Effect.flip)
+
+      expectLLMError(error)
+      expect(error.reason).toMatchObject({
+        _tag: "ProviderInternal",
+        status: 503,
+        message: "Provider request failed with HTTP 503",
+      })
+      expect(error.reason.message).not.toMatch(/<html/i)
+      expect(error.reason.message).not.toMatch(/nginx/i)
+    }).pipe(
+      Effect.provide(
+        responsesLayer([
+          new Response(
+            "<html>\n<head><title>503 Service Temporarily Unavailable</title></head>\n<body><center><h1>503 Service Temporarily Unavailable</h1></center><hr><center>nginx</center></body>\n</html>",
+            { status: 503, headers: { "retry-after-ms": "0" } },
+          ),
+          new Response(
+            "<html>\n<head><title>503 Service Temporarily Unavailable</title></head>\n<body><center><h1>503 Service Temporarily Unavailable</h1></center></body>\n</html>",
+            { status: 503, headers: { "retry-after-ms": "0" } },
+          ),
+          new Response(
+            "<html>\n<head><title>503 Service Temporarily Unavailable</title></head>\n<body><center><h1>503 Service Temporarily Unavailable</h1></center></body>\n</html>",
+            { status: 503 },
+          ),
+        ]),
+      ),
+    ),
+  )
+
   it.effect("marks 504 and 529 status responses retryable", () =>
     Effect.gen(function* () {
       const failWith = (status: number) =>

--- a/packages/opencode/src/provider/error.ts
+++ b/packages/opencode/src/provider/error.ts
@@ -29,11 +29,29 @@ function isOpenAiErrorRetryable(e: APICallError) {
 
 // Providers not reliably handled in this function:
 // - z.ai: can accept overflow silently (needs token-count/context-window checks)
+const isHtmlMarkup = (value: string) => /<!doctype\s+html|<html[\s>]/i.test(value)
+
 function message(providerID: ProviderV2.ID, e: APICallError) {
   return iife(() => {
     const msg = e.message
+
+    // Message may already embed an HTML error page (e.g. LLM executor appends body).
+    // Never surface raw markup in TUI/retry notices (#35640 / #15406).
+    if (isHtmlMarkup(msg)) {
+      if (e.statusCode === 401) {
+        return "Unauthorized: request was blocked by a gateway or proxy. Your authentication token may be missing or expired — try running `opencode auth login <your provider URL>` to re-authenticate."
+      }
+      if (e.statusCode === 403) {
+        return "Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource — check your account and provider settings."
+      }
+      if (e.statusCode === 502 || e.statusCode === 503 || e.statusCode === 504) {
+        return `Provider temporarily unavailable (HTTP ${e.statusCode})`
+      }
+      return e.statusCode ? `Provider request failed with HTTP ${e.statusCode}` : "Provider request failed"
+    }
+
     if (msg === "") {
-      if (e.responseBody) return e.responseBody
+      if (e.responseBody && !isHtmlMarkup(e.responseBody)) return e.responseBody
       if (e.statusCode) {
         const err = STATUS_CODES[e.statusCode]
         if (err) return err
@@ -56,12 +74,15 @@ function message(providerID: ProviderV2.ID, e: APICallError) {
 
     // If responseBody is HTML (e.g. from a gateway or proxy error page),
     // provide a human-readable message instead of dumping raw markup
-    if (/^\s*<!doctype|^\s*<html/i.test(e.responseBody)) {
+    if (isHtmlMarkup(e.responseBody)) {
       if (e.statusCode === 401) {
         return "Unauthorized: request was blocked by a gateway or proxy. Your authentication token may be missing or expired — try running `opencode auth login <your provider URL>` to re-authenticate."
       }
       if (e.statusCode === 403) {
         return "Forbidden: request was blocked by a gateway or proxy. You may not have permission to access this resource — check your account and provider settings."
+      }
+      if (e.statusCode === 502 || e.statusCode === 503 || e.statusCode === 504) {
+        return `Provider temporarily unavailable (HTTP ${e.statusCode})`
       }
       return msg
     }


### PR DESCRIPTION
### Issue for this PR

Closes #35640

### Type of change

- [x] Bug fix

### What does this PR do?

When a provider (or proxy) returns an HTML error page such as nginx **HTTP 503**, the V2 TUI retry notice prints the **entire HTML document** inline:

```text
Retry attempt 3 scheduled: Provider request failed with HTTP 503: <html>...
```

**Confirmed root causes:**

1. `packages/llm/src/route/executor.ts` — `providerMessage()` appends response bodies ≤ 500 characters with **no HTML detection**
2. `packages/opencode/src/provider/error.ts` — if HTML is already embedded in `APICallError.message`, the existing `responseBody` HTML guards never run

**Minimal fix (aligned with V1 #15406 intent):**

| Location | Change |
|----------|--------|
| `RequestExecutor.providerMessage` | Skip HTML / oversized bodies → `Provider request failed with HTTP {status}` |
| `ProviderError.message` | Detect HTML in message **or** body; 502/503/504 → `Provider temporarily unavailable (HTTP …)` |
| `executor.test.ts` | Regression: nginx-style 503 HTML never appears in `reason.message` |

Plain-text short bodies (e.g. `"busy"`) still surface as before.

### How did you verify your code works?

- Diff-reviewed against #35640 repro (`HTTP 503` + nginx HTML)
- Added executor test covering multi-retry 503 HTML responses
- Static review of ProviderError early-return path that previously leaked embedded HTML

### Author

- GitHub: @1837620622 (传康Kk)
- Commit email: `35034498+1837620622@users.noreply.github.com` (GitHub-verified)

### Checklist

- [x] Linked issue
- [x] No unrelated changes