### PR TITLE
fix(fs): refuse credential writes through symlinks

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -109,6 +109,28 @@ export namespace FSUtil {
 
       const writeJson = Effect.fn("FileSystem.writeJson")(function* (path: string, data: unknown, mode?: number) {
         const content = JSON.stringify(data, null, 2)
+        // Refuse symlink targets so credential/state writers (auth, mcp) cannot be redirected.
+        const isLink = yield* Effect.tryPromise({
+          try: async () => {
+            try {
+              return (await NFS.lstat(path)).isSymbolicLink()
+            } catch (e) {
+              if (typeof e === "object" && e !== null && "code" in e && (e as { code: string }).code === "ENOENT") {
+                return false
+              }
+              throw e
+            }
+          },
+          catch: (cause) => new FileSystemError({ method: "writeJson", cause }),
+        })
+        if (isLink) {
+          return yield* Effect.fail(
+            new FileSystemError({
+              method: "writeJson",
+              cause: new Error(`Refusing to write through symlink: ${path}`),
+            }),
+          )
+        }
         yield* fs.writeFileString(path, content)
         if (mode) yield* fs.chmod(path, mode)
       })

--- a/packages/opencode/src/util/filesystem.ts
+++ b/packages/opencode/src/util/filesystem.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, stat as statFile, writeFile } from "fs/promises"
+import { chmod, lstat, mkdir, readFile, stat as statFile, writeFile } from "fs/promises"
 import { createWriteStream, existsSync, statSync } from "fs"
 import { realpathSync } from "fs"
 import { dirname, isAbsolute, join, resolve as pathResolve, win32 } from "path"
@@ -58,7 +58,21 @@ function isEnoent(e: unknown): e is { code: "ENOENT" } {
   return typeof e === "object" && e !== null && "code" in e && (e as { code: string }).code === "ENOENT"
 }
 
+/** Refuse to write through an existing symlink (protects auth.json / credential stores). */
+async function assertNotSymlink(p: string): Promise<void> {
+  try {
+    const info = await lstat(p)
+    if (info.isSymbolicLink()) {
+      throw new Error(`Refusing to write through symlink: ${p}`)
+    }
+  } catch (e) {
+    if (isEnoent(e)) return
+    throw e
+  }
+}
+
 export async function write(p: string, content: string | Buffer | Uint8Array, mode?: number): Promise<void> {
+  await assertNotSymlink(p)
   try {
     if (mode) {
       await writeFile(p, content, { mode })

--- a/packages/opencode/test/util/filesystem.test.ts
+++ b/packages/opencode/test/util/filesystem.test.ts
@@ -308,6 +308,21 @@ describe("filesystem", () => {
     })
   })
 
+  describe("write()", () => {
+    test("refuses to write through a symlink", async () => {
+      if (process.platform === "win32") return
+      await using tmp = await tmpdir()
+      const target = path.join(tmp.path, "real.json")
+      const link = path.join(tmp.path, "link.json")
+      await fs.writeFile(target, "original")
+      await fs.symlink(target, link)
+
+      await expect(Filesystem.write(link, "hijacked", 0o600)).rejects.toThrow(/symlink/i)
+
+      expect(await fs.readFile(target, "utf-8")).toBe("original")
+    })
+  })
+
   describe("writeJson()", () => {
     test("writes JSON data", async () => {
       await using tmp = await tmpdir()


### PR DESCRIPTION
### Issue for this PR

Closes #36367

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Credential/state writers (`FSUtil.writeJson`, `Filesystem.write`) followed existing symlinks, so a replaced `auth.json` (or similar) could redirect writes outside the intended store.

Refuse writes through an existing symlink; leave the link target untouched. Regression test for `Filesystem.write`.

### How did you verify your code works?

- Added `filesystem.test.ts` case: write through symlink is rejected and target content unchanged
- Auth/MCP paths use `FSUtil.writeJson` which now has the same guard

### Screenshots / recordings

_N/A — non-UI_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR