### PR TITLE
fix(opencode): defer defaultAgent lookup in session summarize

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -276,8 +276,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     }) {
       yield* revertSvc.cleanup(yield* requireSession(ctx.params.sessionID))
       const messages = yield* SessionError.mapStorageNotFound(session.messages({ sessionID: ctx.params.sessionID }))
-      const defaultAgent = yield* agentSvc.defaultAgent()
-      const currentAgent = messages.findLast((message) => message.info.role === "user")?.info.agent ?? defaultAgent
+      // Prefer the last user message's agent. Only resolve defaultAgent when
+      // needed — default_agent configured as a subagent throws, which previously
+      // aborted /compact even when the session already had a valid agent.
+      const lastUserAgent = messages.findLast((message) => message.info.role === "user")?.info.agent
+      const currentAgent = lastUserAgent ?? (yield* agentSvc.defaultAgent())
 
       yield* compactSvc.create({
         sessionID: ctx.params.sessionID,


### PR DESCRIPTION
### Issue for this PR

Closes #29277

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`/compact` (and `POST /session/:id/summarize`) **silently fails** when `default_agent` is configured as a subagent.

**Root cause (still on `dev`):**

```ts
const defaultAgent = yield* agentSvc.defaultAgent()  // throws if subagent
const currentAgent = messages.findLast(...)?.info.agent ?? defaultAgent
```

`Agent.defaultAgent()` throws `"default agent X is a subagent"` **before** the last user-message agent fallback is considered. The TUI often ignores the API error, so compaction appears to do nothing.

**Minimal fix:** only resolve `defaultAgent()` when the session has no user-message agent:

```ts
const lastUserAgent = messages.findLast(...)?.info.agent
const currentAgent = lastUserAgent ?? (yield* agentSvc.defaultAgent())
```

When the session already has a valid agent (normal case after chatting), `/compact` works even if `default_agent` is a subagent. Empty sessions still surface the config error.

### Source evidence

- `packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts` — eager `defaultAgent()` in `summarize`
- `packages/opencode/src/agent/agent.ts` — `defaultInfo` throws when `mode === "subagent"`

### How did you verify your code works?

- Diff-reviewed against #29277 repro path
- Single-site change; success path when last user agent exists no longer calls `defaultAgent()`
- Empty-session path still falls through to `defaultAgent()` unchanged

### Author

- GitHub: @1837620622 (传康Kk)
- Commit email: `35034498+1837620622@users.noreply.github.com` (GitHub-verified noreply)

### Checklist

- [x] Linked issue (`Closes #29277`)
- [x] No unrelated changes