### PR TITLE
fix(runner): queue work when already running instead of discarding

### DIFF
--- a/packages/opencode/src/effect/runner.ts
+++ b/packages/opencode/src/effect/runner.ts
@@ -35,6 +35,7 @@ export type State<A, E> =
   | { readonly _tag: "Running"; readonly run: RunHandle<A, E> }
   | { readonly _tag: "Shell"; readonly shell: ShellHandle<A, E> }
   | { readonly _tag: "ShellThenRun"; readonly shell: ShellHandle<A, E>; readonly run: PendingHandle<A, E> }
+  | { readonly _tag: "RunningThenRun"; readonly run: RunHandle<A, E>; readonly pending: PendingHandle<A, E> }
 
 export const make = <A, E = never>(
   scope: Scope.Scope,
@@ -67,20 +68,35 @@ export const make = <A, E = never>(
   const idleIfCurrent = () =>
     SynchronizedRef.modify(ref, (st) => [st._tag === "Idle" ? idle : Effect.void, st] as const).pipe(Effect.flatten)
 
-  const finishRun = (id: number, done: Deferred.Deferred<A, E | Cancelled>, exit: Exit.Exit<A, E>) =>
-    SynchronizedRef.modify(
+  const finishRun = (
+    id: number,
+    done: Deferred.Deferred<A, E | Cancelled>,
+    exit: Exit.Exit<A, E>,
+  ): Effect.Effect<void> =>
+    SynchronizedRef.modifyEffect(
       ref,
-      (st) =>
-        [
-          Effect.gen(function* () {
-            if (st._tag === "Running" && st.run.id === id) yield* idle
-            yield* complete(done, exit)
-          }),
-          st._tag === "Running" && st.run.id === id ? ({ _tag: "Idle" } as const) : st,
-        ] as const,
+      Effect.fnUntraced(function* (st) {
+        if (st._tag === "Running" && st.run.id === id) {
+          return [
+            Effect.gen(function* () {
+              yield* idle
+              yield* complete(done, exit)
+            }),
+            { _tag: "Idle" } as const,
+          ] as const
+        }
+        if (st._tag === "RunningThenRun" && st.run.id === id) {
+          const run = yield* startRun(st.pending.work, st.pending.done)
+          return [complete(done, exit), { _tag: "Running", run } as const] as const
+        }
+        return [complete(done, exit), st] as const
+      }),
     ).pipe(Effect.flatten)
 
-  const startRun = (work: Effect.Effect<A, E>, done: Deferred.Deferred<A, E | Cancelled>) =>
+  const startRun = (
+    work: Effect.Effect<A, E>,
+    done: Deferred.Deferred<A, E | Cancelled>,
+  ): Effect.Effect<RunHandle<A, E>> =>
     Effect.gen(function* () {
       const id = next()
       const fiber = yield* work.pipe(
@@ -117,9 +133,18 @@ export const make = <A, E = never>(
       ref,
       Effect.fnUntraced(function* (st) {
         switch (st._tag) {
-          case "Running":
           case "ShellThenRun":
             return [awaitDone(st.run.done), st] as const
+          case "RunningThenRun":
+            return [awaitDone(st.pending.done), st] as const
+          case "Running": {
+            const pending = {
+              id: next(),
+              done: yield* Deferred.make<A, E | Cancelled>(),
+              work,
+            } satisfies PendingHandle<A, E>
+            return [awaitDone(pending.done), { _tag: "RunningThenRun", run: st.run, pending }] as const
+          }
           case "Shell": {
             const run = {
               id: next(),
@@ -194,6 +219,16 @@ export const make = <A, E = never>(
           Effect.gen(function* () {
             yield* stopShell(st.shell)
             yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
+            yield* idleIfCurrent()
+          }),
+          { _tag: "Idle" } as const,
+        ] as const
+      case "RunningThenRun":
+        return [
+          Effect.gen(function* () {
+            yield* Fiber.interrupt(st.run.fiber)
+            yield* Deferred.fail(st.run.done, new Cancelled()).pipe(Effect.asVoid)
+            yield* Deferred.fail(st.pending.done, new Cancelled()).pipe(Effect.asVoid)
             yield* idleIfCurrent()
           }),
           { _tag: "Idle" } as const,

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -52,7 +52,7 @@ describe("Runner", () => {
 
       expect(a).toBe("shared")
       expect(b).toBe("shared")
-      expect(yield* Ref.get(calls)).toBe(1)
+      expect(yield* Ref.get(calls)).toBe(2) // queued run also increments
     }),
   )
 
@@ -87,7 +87,7 @@ describe("Runner", () => {
   )
 
   it.live(
-    "second ensureRunning ignores new work if already running",
+    "second ensureRunning queues behind running and executes after",
     Effect.gen(function* () {
       const s = yield* Scope.Scope
       const runner = Runner.make<string>(s)
@@ -108,12 +108,98 @@ describe("Runner", () => {
       })
 
       expect(a).toBe("first-result")
-      expect(b).toBe("first-result")
-      expect(yield* Ref.get(ran)).toEqual(["first"])
+      expect(b).toBe("second-result")
+      expect(yield* Ref.get(ran)).toEqual(["first", "second"])
     }),
   )
 
   // --- cancel semantics ---
+
+  it.live(
+    "ensureRunning queues behind running and transitions through RunningThenRun",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const gate = yield* Deferred.make<void>()
+
+      const first = Deferred.await(gate).pipe(Effect.as("first"))
+      const second = Effect.succeed("second")
+
+      const a = yield* runner.ensureRunning(first).pipe(Effect.forkChild)
+      yield* waitForState(runner, "Running")
+
+      const b = yield* runner.ensureRunning(second).pipe(Effect.forkChild)
+      yield* waitForState(runner, "RunningThenRun")
+      expect(runner.state._tag).toBe("RunningThenRun")
+
+      yield* Deferred.succeed(gate, undefined)
+      yield* Fiber.await(a)
+
+      const exitB = yield* Fiber.await(b)
+      expect(Exit.isSuccess(exitB)).toBe(true)
+      if (Exit.isSuccess(exitB)) expect(exitB.value).toBe("second")
+      expect(runner.state._tag).toBe("Idle")
+    }),
+  )
+
+  it.live(
+    "third ensureRunning shares pending in RunningThenRun",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const gate = yield* Deferred.make<void>()
+      const calls = yield* Ref.make(0)
+
+      const first = Deferred.await(gate).pipe(Effect.as("first"))
+      const work = Effect.gen(function* () {
+        yield* Ref.update(calls, (n) => n + 1)
+        return "queued"
+      })
+
+      const a = yield* runner.ensureRunning(first).pipe(Effect.forkChild)
+      yield* waitForState(runner, "Running")
+
+      const b = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
+      yield* waitForState(runner, "RunningThenRun")
+
+      const c = yield* runner.ensureRunning(work).pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      expect(runner.state._tag).toBe("RunningThenRun")
+
+      yield* Deferred.succeed(gate, undefined)
+      yield* Fiber.await(a)
+
+      const [exitB, exitC] = yield* Effect.all([Fiber.await(b), Fiber.await(c)])
+      expect(Exit.isSuccess(exitB)).toBe(true)
+      expect(Exit.isSuccess(exitC)).toBe(true)
+      if (Exit.isSuccess(exitB)) expect(exitB.value).toBe("queued")
+      if (Exit.isSuccess(exitC)) expect(exitC.value).toBe("queued")
+    }),
+  )
+
+  it.live(
+    "cancel in RunningThenRun cancels both current and pending",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s, { onInterrupt: Effect.succeed("fallback") })
+      const gate = yield* Deferred.make<void>()
+
+      const a = yield* runner.ensureRunning(Deferred.await(gate).pipe(Effect.as("first"))).pipe(Effect.forkChild)
+      yield* waitForState(runner, "Running")
+
+      const b = yield* runner.ensureRunning(Effect.succeed("second")).pipe(Effect.forkChild)
+      yield* waitForState(runner, "RunningThenRun")
+
+      yield* runner.cancel
+      expect(runner.busy).toBe(false)
+
+      const [exitA, exitB] = yield* Effect.all([Fiber.await(a), Fiber.await(b)])
+      expect(Exit.isSuccess(exitA)).toBe(true)
+      expect(Exit.isSuccess(exitB)).toBe(true)
+      if (Exit.isSuccess(exitA)) expect(exitA.value).toBe("fallback")
+      if (Exit.isSuccess(exitB)) expect(exitB.value).toBe("fallback")
+    }),
+  )
 
   it.live(
     "cancel interrupts running work",

--- a/packages/opencode/test/effect/runner.test.ts
+++ b/packages/opencode/test/effect/runner.test.ts
@@ -178,6 +178,83 @@ describe("Runner", () => {
   )
 
   it.live(
+    // Regression guard for the lost-wakeup bug fixed in #36375 (refs #35066): a
+    // completing background subagent calls ensureRunning to notify the parent while
+    // it is still Running. Each such wakeup must survive, so the runner has to cycle
+    // Running -> RunningThenRun -> Running for every new arrival instead of dropping
+    // the queued work. Pre-fix the very first queued run never reached RunningThenRun.
+    "re-queues each run that arrives after the previous queued run is promoted",
+    Effect.gen(function* () {
+      const s = yield* Scope.Scope
+      const runner = Runner.make<string>(s)
+      const ran = yield* Ref.make<string[]>([])
+      const parentTurn = yield* Deferred.make<void>()
+      const firstQueued = yield* Deferred.make<void>()
+      // Set when the first notification finishes and captured when the second one
+      // starts, so the test proves the second is promoted only after the first has
+      // fully completed rather than merely after it began running.
+      const firstNotificationDone = yield* Ref.make(false)
+      const secondSawFirstDone = yield* Ref.make(false)
+
+      // Parent turn is in progress and stays Running until released.
+      const parent = yield* runner
+        .ensureRunning(
+          Effect.gen(function* () {
+            yield* Ref.update(ran, (a) => [...a, "parent"])
+            yield* Deferred.await(parentTurn)
+            return "parent"
+          }),
+        )
+        .pipe(Effect.forkChild)
+      yield* waitForState(runner, "Running")
+
+      // First notification arrives while the parent is still busy.
+      const wakeA = yield* runner
+        .ensureRunning(
+          Effect.gen(function* () {
+            yield* Ref.update(ran, (a) => [...a, "notify-a"])
+            yield* Deferred.await(firstQueued)
+            yield* Ref.set(firstNotificationDone, true)
+            return "notify-a"
+          }),
+        )
+        .pipe(Effect.forkChild)
+      yield* waitForState(runner, "RunningThenRun")
+
+      // Parent finishes; the queued notification is promoted to the running turn.
+      yield* Deferred.succeed(parentTurn, undefined)
+      yield* waitForState(runner, "Running")
+
+      // Second notification arrives while the promoted one is now running, forcing
+      // the runner back into RunningThenRun a second time.
+      const wakeB = yield* runner
+        .ensureRunning(
+          Effect.gen(function* () {
+            const firstDone = yield* Ref.get(firstNotificationDone)
+            yield* Ref.set(secondSawFirstDone, firstDone)
+            yield* Ref.update(ran, (a) => [...a, "notify-b"])
+            return "notify-b"
+          }),
+        )
+        .pipe(Effect.forkChild)
+      yield* waitForState(runner, "RunningThenRun")
+
+      // Release the first notification; the second must run after it completes, not be lost.
+      yield* Deferred.succeed(firstQueued, undefined)
+
+      const [valParent, valA, valB] = yield* Effect.all([Fiber.join(parent), Fiber.join(wakeA), Fiber.join(wakeB)])
+      expect(valParent).toBe("parent")
+      expect(valA).toBe("notify-a")
+      expect(valB).toBe("notify-b")
+      expect(yield* Ref.get(ran)).toEqual(["parent", "notify-a", "notify-b"])
+      // The second notification observed the first as completed, proving the runner
+      // promoted it only after the first queued run finished.
+      expect(yield* Ref.get(secondSawFirstDone)).toBe(true)
+      yield* waitForState(runner, "Idle")
+    }),
+  )
+
+  it.live(
     "cancel in RunningThenRun cancels both current and pending",
     Effect.gen(function* () {
       const s = yield* Scope.Scope


### PR DESCRIPTION
### Issue for this PR

Closes #35066

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a background subagent completes and calls `ops.prompt()` to notify the parent session, the parent's `Runner` is often still `Running` (processing the previous turn). The old `ensureRunning` discarded the new work item and just awaited the current run's completion — so the notification was lost and the parent session would hang until the user typed "continue".

**Root cause:** `Runner.ensureRunning` in `packages/opencode/src/effect/runner.ts` had this behavior when state was `Running`:

```ts
case "Running":
case "ShellThenRun":
  return [awaitDone(st.run.done), st] as const
```

It returned the existing run's deferred and threw away the new `work` argument. So if the parent was busy when the subagent finished, the `ops.prompt()` call that should have queued a new turn was silently dropped.

Commit dabf2dc01 ("remove the need for polling from experimental background agents" #29179) removed the old polling-based idle check (`resumeWhenIdle`), replacing it with a direct `ops.prompt()` call that races with `ensureRunning` — which is exactly where the race lives.

**Fix:** Add a `RunningThenRun` state to the Runner state machine (mirroring the existing `ShellThenRun` pattern):

1. `ensureRunning` when `Running`: store the new work as `pending`, transition to `RunningThenRun`, return a deferred that resolves when the pending work completes.
2. `finishRun` when `RunningThenRun`: when the current run finishes, start the pending work and transition back to `Running`.
3. `cancel` when `RunningThenRun`: interrupt both the current run's fiber and fail both deferreds (current + pending), then go idle.

**Why this approach over PR #35041:** PR #35041 (draft) moves the notification to the session completion path, but still has the same `ensureRunning` race — it doesn't fix the root cause. If the parent is busy when the notification fires, `ensureRunning` still discards the work. This PR fixes the root cause in the Runner itself, so all callers of `ensureRunning` (not just the subagent notification path) benefit.

### How did you verify your code works?

- Updated `"concurrent callers share the same run"` — now expects `calls=2` because the queued run also increments.
- Renamed `"second ensureRunning ignores new work"` → `"second ensureRunning queues behind running and executes after"` — now asserts the second work actually runs and returns its own result.
- Added 3 new tests:
  - `ensureRunning queues behind running and transitions through RunningThenRun`
  - `third ensureRunning shares pending in RunningThenRun`
  - `cancel in RunningThenRun cancels both current and pending`

```
runner.test.ts: 29 pass, 0 fail
prompt.test.ts + task.test.ts: 74 pass, 0 fail, 1 skip
typecheck (all 30 packages): pass
```

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR