### PR TITLE
fix(config): write valid JSON when auto-adding $schema to an empty config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -230,7 +230,7 @@ const layer = Layer.effect(
       yield* Effect.promise(() => resolveLoadedPlugins(data, options.path))
       if (!data.$schema) {
         data.$schema = "https://opencode.ai/config.json"
-        const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
+        const updated = patchJsonc(text, { $schema: "https://opencode.ai/config.json" })
         yield* fs.writeFileString(options.path, updated).pipe(Effect.catch(() => Effect.void))
       }
       return data

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -528,6 +528,19 @@ it.instance("preserves env variables when adding $schema to config", () =>
   ),
 )
 
+it.instance("writes valid JSON when adding $schema to a config with no other keys", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    // Empty object without $schema: auto-add must not leave a trailing comma (invalid strict JSON).
+    yield* FSUtil.use.writeWithDirs(path.join(test.directory, "opencode.json"), "{}")
+    yield* Config.use.get()
+
+    const content = yield* FSUtil.use.readFileString(path.join(test.directory, "opencode.json"))
+    expect(() => JSON.parse(content)).not.toThrow()
+    expect(JSON.parse(content).$schema).toBe("https://opencode.ai/config.json")
+  }),
+)
+
 it.instance("handles file inclusion substitution", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #36374

### Type of change

- [x] Bug fix

### What does this PR do?

When a loaded config lacks `$schema`, opencode auto-adds it and writes the file back. The injection used a regex that prepends `"$schema": "...",` after the opening brace, so for a config whose whole content is `{}` the result had a trailing comma (`{ "$schema": "...", }`) — invalid strict JSON. opencode re-reads it tolerantly via jsonc, but the file written to the user's `opencode.json` then fails any strict `JSON.parse` (IDE JSON language server, `jq`).

Fix: use the file's existing `patchJsonc` helper (jsonc-parser `modify`/`applyEdits`) instead of the regex, so the insertion is JSON-aware and always valid. Non-empty configs are unaffected.

### How did you verify your code works?

Added a regression test (writes `{}`, loads config, asserts the written-back file is valid strict JSON and has `$schema`). It fails on the current code (`JSON Parse error: Property name must be a string literal`) and passes with the fix. The full config test file shows no new failures; lint and typecheck are clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
