### PR TITLE
fix(app): skip agent.set when agent unchanged in Web UI

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -189,6 +189,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           setStore("current", undefined)
           return
         }
+        if (item.name === agent.current()?.name) return
 
         batch(() => {
           setStore("current", item.name)


### PR DESCRIPTION
### Issue for this PR

Closes #33402, #23666 (yeah, it's already marked as completed, but it's not for Web UI)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Problem**
Changing url (/:dir/session -> /:dir/session/:id or between sessions) causes the agent Select to re-render and call `agent.set` with the same agent. `agent.set` then overwrites the user's model selection with the agent's default model via `item.model ?? prev?.model`, since `item.model` is always truthy for agents with a configured model.

**Fix**
Early-return in `agent.set` when the agent hasn't changed.

### How did you verify your code works?

Verified on both `latest` and `dev` (with "Custom agents" setting toggled on) Web UI channels:
- Select model -> send first message -> model stays selected
- Switch agent (real change) -> model updates to agent default (intended)
- Switch between sessions in tabs -> each keeps its model

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._