### PR TITLE
refactor(app): remove promoting workaround

### DIFF
--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -80,7 +80,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const [store, setStore] = createStore<{
       current?: string
       draft?: State
-      promoting?: State
       last?: {
         type: "agent" | "model" | "variant"
         agent?: string
@@ -124,7 +123,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const scope = createMemo<State | undefined>(() => {
       const session = id()
-      if (!session) return store.draft ?? store.promoting
+      if (!session) return store.draft
       return saved.session[session] ?? handoff.get(handoffKey(serverSDK().scope, sdk().directory, session))
     })
 
@@ -137,13 +136,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       if (!next) return
       if (saved.session[session] !== undefined) {
         handoff.delete(key)
-        setStore("promoting", undefined)
         return
       }
 
       setSaved("session", session, clone(next))
       handoff.delete(key)
-      setStore("promoting", undefined)
     })
 
     const configuredModel = () => {
@@ -377,7 +374,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       session: {
         ready: savedReady,
         reset() {
-          setStore({ draft: undefined, promoting: undefined })
+          setStore("draft", undefined)
         },
         promote(dir: string, session: string, state?: State) {
           const next = clone(state ?? snapshot())
@@ -388,8 +385,6 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (dir === sdk().directory) {
             setSaved("session", session, next)
           }
-
-          setStore("promoting", next)
           setStore("draft", undefined)
         },
         restore(msg: { sessionID: string; agent: string; model: ModelKey }) {


### PR DESCRIPTION
### Issue for this PR

N/A — cleanup of workaround from #34466

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Commit e34822db6 (#34466) added an in-memory `promoting` state to
bridge the gap between `promote()` clearing `store.draft` and
`navigate()` updating the session ID.

Commit ea982c383 (#36182) wrapped `promote()` + `navigate()` in
`startTransition`, which batches both updates atomically. The
`promoting` workaround is no longer needed — `scope()` switches
directly from `store.draft` to `saved.session[session]` with no
intermediate state.

### How did you verify your code works?

Verified no flicker on both `latest` and `dev` Web UI channels when
sending the first message in a new session with a non-default model
selected.

### Screenshots / recordings


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR