### PR TITLE
fix(core): skip fff for aggregate locations

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -230,6 +230,13 @@ export const fffLayer = Layer.effect(
   }),
 )
 
-const layer = Layer.unwrap(Effect.sync(() => (Flag.OPENCODE_DISABLE_FFF || !Fff.available() ? ripgrepLayer : fffLayer)))
+const layer = Layer.unwrap(
+  Effect.gen(function* () {
+    if (Flag.OPENCODE_DISABLE_FFF || !Fff.available()) return ripgrepLayer
+    const location = yield* Location.Service
+    // Non-VCS locations can contain many repositories, so avoid eagerly content-indexing the entire aggregate tree.
+    return location.vcs ? fffLayer : ripgrepLayer
+  }),
+)
 
 export const node = makeLocationNode({ service: Service, layer, deps: [FSUtil.node, Location.node, Ripgrep.node] })


### PR DESCRIPTION
## Summary

- use FFF only for locations resolved to a VCS repository
- fall back to bounded ripgrep discovery for non-VCS aggregate directories
- prevent broad locations containing many nested repositories from eagerly content-indexing the entire tree

## Why ripgrep helps

Ripgrep also traverses the filesystem: the fallback runs `rg --files` once to populate file-name search. For non-VCS locations that discovery is capped at 100,000 entries.

The important difference is that FFF additionally reads file contents, builds and retains a bigram content index, and watches the tree for changes. Ripgrep does not build a persistent content index; content searches scan on demand. This change therefore replaces an unbounded eager content-indexing workload with bounded path discovery, rather than eliminating scanning entirely.

FFF supports `disableContentIndexing: true`, which may be a more targeted long-term option: retain FFF file discovery, ranking, and watching while making content grep search without the prebuilt index. It is not an obviously safer immediate fix for aggregate roots because FFF would still scan and watch the full tree. We should benchmark that mode separately for CPU, memory, watcher behavior, and grep latency before adopting it.

## Evidence

A live `next` service rooted at `/Users/kit/code/open-source` sustained 200-330% CPU and roughly 11 GB RSS. An 8-second process sample identified `fff_search::bigram_filter::BigramIndexBuilder::add_file_content` as the dominant runnable stack, while `lsof` showed it traversing nested repositories. This is the aggregate-directory variant of #32511: the prior upward-scan fix does not protect a broad `basePath` itself.

## Verification

- `bun typecheck` in `packages/core`
- `bun run test test/filesystem/search.test.ts` in `packages/core`
- repository-wide pre-push typecheck
