### PR TITLE
docs: add AI Conversation Analyzer to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [AI Conversation Analyzer](https://github.com/Conversation-analyzer/ai_conversation_analyzer) | Debug and inspect OpenCode sessions with timelines, analytics, and tool insights |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR
Closes #

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds a row to the Projects table in the ecosystem docs for AI Conversation Analyzer, a browser-based tool I built for inspecting OpenCode session JSON — timelines, tool call inspection, and token/latency analytics. No code changes, just the one table row in ecosystem.mdx.

Repo: https://github.com/Conversation-analyzer/ai_conversation_analyzer
Live demo: https://conversation-analyzer.github.io/

### How did you verify your code works?
Checked the markdown table renders correctly and the row matches the formatting/column widths of the existing entries.

### Screenshots / recordings
N/A — just a docs table addition, no UI change to the site.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR