### PR TITLE
fix(core): include child session id in background subagent start text

### DIFF
--- a/packages/core/src/tool/subagent.ts
+++ b/packages/core/src/tool/subagent.ts
@@ -12,8 +12,8 @@ import { Tool } from "./tool"
 export const name = "subagent"
 
 const NO_TEXT = "Subagent completed without a text response."
-const BACKGROUND_STARTED =
-  "The subagent is working in the background. You will be notified automatically when it finishes. DO NOT sleep, poll, or proactively check on its progress."
+const backgroundStarted = (sessionID: SessionSchema.ID) =>
+  `The subagent is working in the background (id: ${sessionID}). You will be notified automatically when it finishes. DO NOT sleep, poll, or proactively check on its progress.`
 
 export const Input = Schema.Struct({
   agent: Schema.String.annotate({ description: "The configured agent to run as the subagent" }),
@@ -168,7 +168,11 @@ export const Plugin = {
                 if (background) {
                   yield* runtime.job.background(info.id)
                   yield* notifyWhenDone(context.sessionID, child.id, input.description)
-                  return { sessionID: child.id, status: "running" as const, output: BACKGROUND_STARTED }
+                  return {
+                    sessionID: child.id,
+                    status: "running" as const,
+                    output: backgroundStarted(child.id),
+                  }
                 }
 
                 const result = yield* runtime.job.block({ id: child.id, sessionID: context.sessionID }).pipe(
@@ -180,7 +184,11 @@ export const Plugin = {
                 )
                 if (result?.type === "backgrounded") {
                   yield* notifyWhenDone(context.sessionID, child.id, input.description)
-                  return { sessionID: child.id, status: "running" as const, output: BACKGROUND_STARTED }
+                  return {
+                    sessionID: child.id,
+                    status: "running" as const,
+                    output: backgroundStarted(child.id),
+                  }
                 }
                 if (result?.info.status === "error")
                   return yield* new ToolFailure({ message: result.info.error ?? "Subagent failed" })

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -281,7 +281,10 @@ describe("SubagentTool", () => {
             },
           })
           const childID = outputSessionID(settled.output?.structured)
-          expect(settled.output?.structured).toMatchObject({ status: "running" })
+          expect(settled.output?.structured).toMatchObject({
+            status: "running",
+            output: expect.stringContaining(`id: ${childID}`),
+          })
 
           const admission = Array.from(yield* Fiber.join(admitted))[0]
           expect(admission?.data.input.data.text).toContain(`<subagent id="${childID}" state="completed"`)


### PR DESCRIPTION
## Summary
- Include the child session id in the background subagent tool result text so the parent model can match it to the later `<subagent id="..." state="completed">` synthetic notification.
- Cover the id in the background subagent test.

## Test plan
- [x] `bun test test/tool-subagent.test.ts` in `packages/core`
- [x] `bun typecheck` in `packages/core`