### PR TITLE
test(codemode): drop leftover $codemode references

### DIFF
--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -1,11 +1,11 @@
 # @opencode-ai/codemode
 
-CodeMode is a lightweight, JavaScript-like DSL for model-written orchestration programs, backed by a pure JavaScript
-tree-walking interpreter: program source is never handed to `eval`, `new Function`, or a VM. A program can only call
-the schema-described tools its host
-supplies: it can sequence calls, transform plain data, branch, loop, and run independent calls in parallel, without
-ambient filesystem, process, network, module, or application authority. Instead of many model round trips, the model
-writes one small program that does the orchestration in code.
+CodeMode is a lightweight, JavaScript-like DSL for model-written orchestration programs. Programs run inside
+CodeMode's own interpreter and are never executed as actual JavaScript, so the only thing a program can reach is the
+schema-described tool tree its host supplies. Within that boundary it can sequence tool calls, transform plain data,
+branch, loop, and run independent calls in parallel - with no ambient filesystem, process, network, module, or
+application authority. Instead of many model round trips, the model writes one small program that does the
+orchestration in code.
 
 The supported language and standard-library surface is documented exhaustively in the
 [interpreter support checklist](./interpreter-support.md).

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -1,7 +1,8 @@
 # @opencode-ai/codemode
 
 CodeMode is a lightweight, JavaScript-like DSL for model-written orchestration programs, backed by a pure JavaScript
-interpreter - no `eval`, no VM, no code generation. A program can only call the schema-described tools its host
+tree-walking interpreter: program source is never handed to `eval`, `new Function`, or a VM. A program can only call
+the schema-described tools its host
 supplies: it can sequence calls, transform plain data, branch, loop, and run independent calls in parallel, without
 ambient filesystem, process, network, module, or application authority. Instead of many model round trips, the model
 writes one small program that does the orchestration in code.

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -1,14 +1,14 @@
 # @opencode-ai/codemode
 
-CodeMode is a lightweight, JavaScript-like DSL for model-written orchestration programs. Programs run inside
-CodeMode's own interpreter and are never executed as actual JavaScript, so the only thing a program can reach is the
-schema-described tool tree its host supplies. Within that boundary it can sequence tool calls, transform plain data,
-branch, loop, and run independent calls in parallel - with no ambient filesystem, process, network, module, or
-application authority. Instead of many model round trips, the model writes one small program that does the
-orchestration in code.
+This is our take on code mode. Programs are written in a lightweight, JavaScript-like DSL and run in the package's
+own interpreter. They never execute as actual JavaScript, so there is no runtime to escape into. The interpreter
+itself can reach nothing; every effect a program has goes through a tool you explicitly supplied. The tradeoff is a
+bounded language rather than full JavaScript: the [interpreter support checklist](./interpreter-support.md) documents
+exactly what is supported.
 
-The supported language and standard-library surface is documented exhaustively in the
-[interpreter support checklist](./interpreter-support.md).
+[Cloudflare's post](https://blog.cloudflare.com/code-mode/) introduced the idea. Their implementation executes
+generated code in isolate sandboxes. We took a lighter route: a pure interpreter that runs wherever your application
+runs, no sandbox required.
 
 ## How it differs from JavaScript
 

--- a/packages/codemode/test/codemode.test.ts
+++ b/packages/codemode/test/codemode.test.ts
@@ -761,11 +761,6 @@ describe("CodeMode public contract", () => {
         "tools.thread.generateImage",
       )
     }
-
-    // The retired $codemode namespace is gone from the tools tree entirely.
-    const removed = await Effect.runPromise(runtime.execute(`return await tools.$codemode.search({ query: "file" })`))
-    expect(removed.ok).toBe(false)
-    if (!removed.ok) expect(removed.error.kind).toBe("UnknownTool")
   })
 
   test("search is a counted tool call: it burns maxToolCalls and fires the hooks", async () => {
@@ -1194,12 +1189,5 @@ describe("CodeMode public contract", () => {
       expect(result.error.message).toContain("timed out after 200ms")
     }
     expect(elapsedMs).toBeLessThan(3_000)
-  })
-
-  test("a host $codemode namespace is an ordinary namespace now that search is a built-in", async () => {
-    const runtime = CodeMode.make({ tools: { $codemode: { lookup } } })
-    const result = await Effect.runPromise(runtime.execute(`return await tools.$codemode.lookup({ id: "order_1" })`))
-    expect(result.ok).toBe(true)
-    if (result.ok) expect(result.value).toStrictEqual({ id: "order_1", status: "open" })
   })
 })

--- a/packages/codemode/test/enumeration.test.ts
+++ b/packages/codemode/test/enumeration.test.ts
@@ -52,10 +52,8 @@ describe("Object.keys over tool references", () => {
     expect(await value(`return Object.keys(tools.github.list_issues)`)).toEqual([])
   })
 
-  test("search is a global built-in function, not a tools namespace", async () => {
+  test("search is a global built-in function", async () => {
     expect(await value(`return typeof search`)).toBe("function")
-    const failure = await error(`return Object.keys(tools.$codemode)`)
-    expect(failure.kind).toBe("UnknownTool")
   })
 
   test("an unknown namespace is an UnknownTool error pointing at the discovery idioms", async () => {


### PR DESCRIPTION
Follow-up to #36450: removes the transitional $codemode assertions - the retired-namespace UnknownTool probes and the test asserting a host $codemode namespace is no longer reserved. The typeof-search check is kept as a plain built-in test.

787 tests pass, typecheck and prettier clean.