### PR TITLE
fix(opencode): preserve valid empty JSON config

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -230,7 +230,8 @@ const layer = Layer.effect(
       yield* Effect.promise(() => resolveLoadedPlugins(data, options.path))
       if (!data.$schema) {
         data.$schema = "https://opencode.ai/config.json"
-        const updated = text.replace(/^\s*\{/, '{\n  "$schema": "https://opencode.ai/config.json",')
+        const comma = Object.keys(parsed).length ? "," : ""
+        const updated = text.replace(/^\s*\{/, `{\n  "$schema": "https://opencode.ai/config.json"${comma}`)
         yield* fs.writeFileString(options.path, updated).pipe(Effect.catch(() => Effect.void))
       }
       return data

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -528,6 +528,19 @@ it.instance("preserves env variables when adding $schema to config", () =>
   ),
 )
 
+it.instance("adds $schema to an empty JSON config without a trailing comma", () =>
+  Effect.gen(function* () {
+    const test = yield* TestInstance
+    const file = path.join(test.directory, "opencode.json")
+    yield* FSUtil.use.writeWithDirs(file, "{}")
+
+    yield* Config.use.get()
+
+    const content = yield* FSUtil.use.readFileString(file)
+    expect(JSON.parse(content)).toEqual({ $schema: "https://opencode.ai/config.json" })
+  }),
+)
+
 it.instance("handles file inclusion substitution", () =>
   Effect.gen(function* () {
     const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #36374

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Avoids adding a dangling comma when `$schema` is inserted into an empty config object. The comma is now included only when the parsed config already has keys, so `{}` remains valid strict JSON after being rewritten.

### How did you verify your code works?

- `bun test test/config/config.test.ts` (97 passed)
- `bun typecheck` from `packages/opencode`
- Added a regression test that parses the rewritten file with `JSON.parse`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
