### PR TITLE
fix(tui): respect sidebar width threshold

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -247,7 +247,6 @@ export function Session() {
 
   const dimensions = useTerminalDimensions()
   const [sidebar, setSidebar] = kv.signal<"auto" | "hide">("sidebar", "auto")
-  const [sidebarOpen, setSidebarOpen] = createSignal(false)
   const [conceal, setConceal] = createSignal(true)
   const thinking = useThinkingMode()
   const thinkingMode = thinking.mode
@@ -263,7 +262,6 @@ export function Session() {
   const wide = createMemo(() => dimensions().width > 120)
   const sidebarVisible = createMemo(() => {
     if (session()?.parentID) return false
-    if (sidebarOpen()) return true
     if (sidebar() === "auto" && wide()) return true
     return false
   })
@@ -671,7 +669,6 @@ export function Session() {
         batch(() => {
           const isVisible = sidebarVisible()
           setSidebar(() => (isVisible ? "hide" : "auto"))
-          setSidebarOpen(!isVisible)
         })
         dialog.clear()
       },


### PR DESCRIPTION
### Issue for this PR

Closes #36417

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the temporary `sidebarOpen` override from the TUI session view. Sidebar visibility is now controlled by the persisted `auto` or `hide` setting and the existing terminal-width check, so enabling it cannot force the sidebar over content in a narrow terminal.

### How did you verify your code works?

- `bun typecheck` from `packages/tui`
- `bun test test/index.test.tsx`

### Screenshots / recordings

Not included. The change restores the existing narrow-terminal hidden state and does not introduce new UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
