### PR TITLE
feat(tui): paste clipboard on right click

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1091,8 +1091,15 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       flexDirection="column"
       backgroundColor={theme.background}
       onMouseDown={(evt) => {
-        if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
         if (evt.button !== MouseButton.RIGHT) return
+
+        if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) {
+          if (!promptRef.current?.focused) return
+          keymap.dispatchCommand("prompt.paste")
+          evt.preventDefault()
+          evt.stopPropagation()
+          return
+        }
 
         if (!Selection.copy(renderer, toast, clipboard)) return
         evt.preventDefault()


### PR DESCRIPTION
### Issue for this PR

Closes #36456

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes right-click dispatch the existing `prompt.paste` command when mouse capture is enabled and the prompt is focused. This supports clipboard text and images while preserving the experimental right-click copy behavior.

Unlike #32064, which is limited to Windows-specific terminal behavior, this fixes the default captured-mouse path reported on Linux and avoids pasting behind dialogs by requiring prompt focus.

### How did you verify your code works?

- `bun typecheck` from `packages/tui`
- `bun test test/app-lifecycle.test.tsx test/index.test.tsx` (3 passed)

### Screenshots / recordings

Not included. Clipboard insertion is an input interaction without a stable visual before/after state.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
