### PR TITLE
fix(core): settle malformed tool input on failure

### DIFF
--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -220,8 +220,31 @@ export const createLLMEventPublisher = (events: Pick<EventV2.Interface, "publish
     yield* flushFragments()
   })
 
+  const failTools = Effect.fnUntraced(function* (error: SessionError.Error, mode: "all" | "hosted" | "uncalled") {
+    let failed = false
+    for (const [callID, tool] of tools) {
+      if (
+        tool.settled ||
+        (mode === "hosted" && !tool.providerExecuted) ||
+        (mode === "uncalled" && tool.called)
+      )
+        continue
+      tool.settled = true
+      failed = true
+      yield* events.publish(SessionEvent.Tool.Failed, {
+        sessionID: input.sessionID,
+        assistantMessageID: tool.assistantMessageID,
+        callID,
+        error,
+        executed: tool.providerExecuted,
+      })
+    }
+    return failed
+  })
+
   const failAssistant = Effect.fnUntraced(function* (error: SessionError.Error, replace = false) {
     yield* flush()
+    yield* failTools(error, "uncalled")
     yield* startAssistant()
     if (replace || stepFailure === undefined) stepFailure = error
   })
@@ -245,20 +268,7 @@ export const createLLMEventPublisher = (events: Pick<EventV2.Interface, "publish
     error: SessionError.Error,
     hostedOnly = false,
   ) {
-    let failed = false
-    for (const [callID, tool] of tools) {
-      if (tool.settled || (hostedOnly && !tool.providerExecuted)) continue
-      tool.settled = true
-      failed = true
-      yield* events.publish(SessionEvent.Tool.Failed, {
-        sessionID: input.sessionID,
-        assistantMessageID: tool.assistantMessageID,
-        callID,
-        error,
-        executed: tool.providerExecuted,
-      })
-    }
-    return failed
+    return yield* failTools(error, hostedOnly ? "hosted" : "all")
   })
 
   const assistantMessageIDForTool = (callID: string) => {

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -6,6 +6,7 @@ import {
   Model,
   ToolFailure,
   TransportReason,
+  InvalidProviderOutputReason,
   InvalidRequestReason,
   RateLimitReason,
   type LLMClientShape,
@@ -716,7 +717,18 @@ const verifyPartialFlushOnFailure = (kind: FragmentKind) =>
         type: "assistant",
         finish: "error",
         error: { type: "provider.transport", message: "Provider unavailable" },
-        content: [fixture.expectedContent],
+        content: [
+          kind === "tool input"
+            ? {
+                type: "tool",
+                id: fragmentID(kind, "partial"),
+                state: {
+                  status: "error",
+                  error: { type: "provider.transport", message: "Provider unavailable" },
+                },
+              }
+            : fixture.expectedContent,
+        ],
       },
     ])
     expect(requests).toHaveLength(1)
@@ -3873,6 +3885,45 @@ describe("SessionRunnerLLM", () => {
       expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
       expect(requests).toHaveLength(1)
       expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
+    }),
+  )
+
+  it.effect("settles malformed streamed tool input before the provider failure", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      yield* admit(session, "Call a malformed tool")
+      const failure = new LLMError({
+        module: "test",
+        method: "stream",
+        reason: new InvalidProviderOutputReason({ message: "Invalid JSON input for tool call echo" }),
+      })
+      responseStream = Stream.fromIterable([
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.toolInputStart({ id: "call-malformed", name: "echo" }),
+        LLMEvent.toolInputDelta({ id: "call-malformed", name: "echo", text: '{"text":"partial' }),
+      ]).pipe(Stream.concat(Stream.fail(failure)))
+
+      expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
+      const assistant = requireAssistant(yield* session.context(sessionID))
+
+      response = reply.stop()
+      yield* admit(session, "Continue")
+      yield* session.resume(sessionID)
+
+      expect(yield* recordedStepSettlementEvents(sessionID, assistant.id)).toMatchObject([
+        { type: "session.step.started.1" },
+        {
+          type: "session.tool.failed.1",
+          data: {
+            callID: "call-malformed",
+            error: { type: "provider.invalid-output", message: "Invalid JSON input for tool call echo" },
+          },
+        },
+        {
+          type: "session.step.failed.1",
+          data: { error: { type: "provider.invalid-output", message: "Invalid JSON input for tool call echo" } },
+        },
+      ])
     }),
   )
 


### PR DESCRIPTION
## What

Malformed streamed tool JSON now produces one truthful failure at the point where it occurs. Previously, the malformed call remained unresolved until the next prompt, so the transcript made one provider failure look like two separate failures.

### Before

**1. The provider returns malformed tool input**
The step reports the provider error, but the started tool remains unresolved.

```text
Assistant

Invalid JSON input for tool call echo
```

**2. The user continues the session**
The next prompt discovers the stale tool and adds a second, misleading interruption.

```text
You
Continue

Echo failed
Tool execution interrupted: echo
```

### After

**1. The malformed call fails with the step**
The tool is settled immediately with the original provider error.

```text
Echo failed
Invalid JSON input for tool call echo

Assistant
Invalid JSON input for tool call echo
```

**2. The user continues normally**
There is no stale tool left to repair and no delayed interruption appears.

```text
You
Continue

Assistant
...
```

Fixes #36421

## How

- `packages/core/src/session/runner/publish-llm-event.ts` flushes partial input, fails only started tools that never reached `tool-call`, then publishes the terminal step failure.
- Existing hosted/all unsettled-tool settlement continues through the same event publisher helper.
- `packages/core/test/session-runner.test.ts` covers partial malformed input, an `InvalidProviderOutput` stream failure, durable event ordering, and a later resume with no second repair failure.

## Scope

This is limited to started-but-uncalled tool input at the provider failure boundary. It does not redesign general step settlement, running tool execution, or event architecture.

## Testing

### Red on `origin/v2` (`02e22770573078e346ccc573c4f784d5dc0054a9`)

```sh
cd packages/core
bun run test test/session-runner.test.ts -t "settles malformed streamed tool input before the provider failure"
```

Failed at `expect(terminal).toMatchObject(...)`: received `session.step.failed.1` with `Invalid JSON input for tool call echo`, followed only after resume by `session.tool.failed.1` with `Tool execution interrupted`; expected the tool failure first with the original invalid-output message.

### Green

```sh
bun run test test/session-runner.test.ts -t "settles malformed streamed tool input before the provider failure"
# 1 pass, 0 fail

bun run test test/session-runner.test.ts
# 121 pass, 0 fail

bun run test test/session-runner-tool-events.test.ts
# 10 pass, 0 fail

bun typecheck
# passed
```

The push hook also completed the repository Turbo typecheck: 31 successful tasks.

## Flow

```mermaid
sequenceDiagram
  participant Provider
  participant Publisher
  participant Store
  Provider->>Publisher: tool-input-start + partial input
  Provider--xPublisher: InvalidProviderOutput
  Publisher->>Store: tool input ended
  Publisher->>Store: tool failed (original provider message)
  Publisher->>Store: step failed
  Note over Store: Later resume finds no unsettled tool
```
