### PR TITLE
fix(cli): preserve server startup failure cause

### DIFF
--- a/packages/cli/src/framework/startup-error.ts
+++ b/packages/cli/src/framework/startup-error.ts
@@ -1,0 +1,30 @@
+import { Service } from "@opencode-ai/client/effect"
+import { Cause, Effect } from "effect"
+
+const RED_BOLD = "\x1b[91m\x1b[1m"
+const BOLD = "\x1b[1m"
+const RESET = "\x1b[0m"
+
+export function handle(cause: Cause.Cause<unknown>, command: string) {
+  const error = Cause.squash(cause)
+  if (!(error instanceof Service.StartError)) return Effect.failCause(cause)
+  return Effect.gen(function* () {
+    yield* Effect.logError("background service startup failed", { cause: Cause.pretty(cause) })
+    yield* Effect.sync(() => {
+      process.stderr.write(render(error, command))
+      process.exitCode = 1
+    })
+  })
+}
+
+export function render(error: Service.StartError, command: string) {
+  const detail =
+    error.stage === "spawn"
+      ? "The service process could not be started."
+      : error.stage === "registration"
+        ? "The service exited or never became ready.\nThe expected registration file was not created."
+        : "The service started but did not become ready."
+  return `\n${RED_BOLD}OpenCode could not start its background service${RESET}\n\n${detail}\n\n${BOLD}Try:${RESET}\n  ${command} service restart\n  OPENCODE_LOG_LEVEL=DEBUG ${command}\n`
+}
+
+export * as StartupError from "./startup-error"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Global } from "@opencode-ai/core/global"
 import { AppProcess } from "@opencode-ai/core/process"
+import { StartupError } from "./framework/startup-error"
 
 const Handlers = Runtime.handlers(Commands, {
   $: () => import("./commands/handlers/default"),
@@ -51,6 +52,7 @@ Effect.logInfo("cli starting", {
 }).pipe(
   Effect.flatMap(() => Runtime.run(Commands, Handlers, { version: InstallationVersion })),
   Effect.annotateLogs({ role: "cli" }),
+  Effect.catchCause((cause) => StartupError.handle(cause, Commands.name)),
   Effect.provide(Updater.layer),
   Effect.provide(AppNodeBuilder.build(LayerNode.group([Global.node, AppProcess.node]))),
   Effect.provide(Observability.layer),

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -11,11 +11,72 @@ import { SessionV2 } from "@opencode-ai/core/session"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { expect, test } from "bun:test"
-import { Effect, Schedule, Schema } from "effect"
+import { Cause, Effect, Exit, Schedule, Schema } from "effect"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { ServiceConfig } from "../src/services/service-config"
+import { StartupError } from "../src/framework/startup-error"
+
+const RED_BOLD = "\x1b[91m\x1b[1m"
+const BOLD = "\x1b[1m"
+const RESET = "\x1b[0m"
+
+test("renders a missing registration as an actionable startup failure", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-start-"))
+  const registration = path.join(root, "server.json")
+  const script = path.join(root, "exit.ts")
+  await Bun.write(script, "process.exit(1)\n")
+
+  try {
+    const exit = await Service.start({ file: registration, command: [process.execPath, script] }).pipe(
+      Effect.provide(NodeFileSystem.layer),
+      Effect.exit,
+      Effect.runPromise,
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const error = Cause.squash(exit.cause)
+      expect(error).toBeInstanceOf(Service.StartError)
+      if (error instanceof Service.StartError) {
+        expect(StartupError.render(error, "opencode2")).toBe(
+          `\n${RED_BOLD}OpenCode could not start its background service${RESET}\n\nThe service exited or never became ready.\nThe expected registration file was not created.\n\n${BOLD}Try:${RESET}\n  opencode2 service restart\n  OPENCODE_LOG_LEVEL=DEBUG opencode2\n`,
+        )
+      }
+      expect(Cause.pretty(exit.cause)).toContain(
+        `[cause]: PlatformError: NotFound: FileSystem.readFile (${registration})`,
+      )
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("reports a service spawn failure without losing its cause", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-spawn-"))
+  const command = path.join(os.tmpdir(), "opencode-command-that-does-not-exist")
+  try {
+    const exit = await Service.start({ file: path.join(root, "server.json"), command: [command] }).pipe(
+      Effect.provide(NodeFileSystem.layer),
+      Effect.exit,
+      Effect.runPromise,
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const error = Cause.squash(exit.cause)
+      expect(error).toBeInstanceOf(Service.StartError)
+      if (error instanceof Service.StartError) {
+        expect(error.stage).toBe("spawn")
+        expect(StartupError.render(error, "opencode2")).toContain("The service process could not be started.")
+      }
+      expect(Cause.pretty(exit.cause)).toContain(command)
+    }
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
 
 test("local channel stores service config with the local service filename", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-"))

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -1,5 +1,6 @@
 import { Effect, FileSystem, Option, Schedule, Schema } from "effect"
 import { spawn } from "node:child_process"
+import { once } from "node:events"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
@@ -34,6 +35,11 @@ export type Options = {
 
 export type StartReason = "missing" | "version-mismatch"
 
+export class StartError extends Schema.TaggedErrorClass<StartError>()("ServiceStartError", {
+  stage: Schema.Literals(["spawn", "registration", "readiness"]),
+  cause: Schema.Defect(),
+}) {}
+
 export type StartOptions = Options & {
   // Called once when start() decides it must spawn: either no service was
   // found, or a healthy service with a different version is being replaced.
@@ -66,19 +72,23 @@ export const start = Effect.fn("service.start")(function* (options: StartOptions
   if (mismatched !== undefined) yield* kill(mismatched.info, options).pipe(Effect.ignore)
 
   const [command, ...args] = options.command ?? ["opencode", "serve", "--service"]
-  if (command === undefined) return yield* Effect.fail(new Error("Missing service command"))
-  const child = yield* Effect.try({
-    try: () => {
+  if (command === undefined)
+    return yield* Effect.fail(new StartError({ stage: "spawn", cause: new Error("Missing service command") }))
+  const child = yield* Effect.tryPromise({
+    try: async () => {
       const child = spawn(command, args, { detached: true, stdio: "ignore" })
+      await once(child, "spawn")
       child.unref()
       return child
     },
-    catch: (cause) => new Error("Failed to start server", { cause }),
+    catch: (cause) => new StartError({ stage: "spawn", cause }),
   })
 
-  return yield* discoverLocal(options).pipe(
+  return yield* awaitReady(options).pipe(
     Effect.flatMap((found) =>
-      found === undefined ? Effect.fail(new Error("Server is not ready")) : Effect.succeed(found),
+      found === undefined
+        ? Effect.fail(new StartError({ stage: "readiness", cause: new Error("Server is not ready") }))
+        : Effect.succeed(found),
     ),
     Effect.retry(poll),
     Effect.tap((found) =>
@@ -90,7 +100,6 @@ export const start = Effect.fn("service.start")(function* (options: StartOptions
     ),
     Effect.map((found) => found.endpoint),
     Effect.tapError(() => Effect.try({ try: () => child.kill("SIGTERM"), catch: () => undefined }).pipe(Effect.ignore)),
-    Effect.mapError(() => new Error("Failed to start server")),
   )
 })
 
@@ -133,6 +142,18 @@ const read = Effect.fnUntraced(function* (file?: string) {
   const text = yield* fs.readFileString(file ?? fallback()).pipe(Effect.option)
   if (Option.isNone(text)) return undefined
   return yield* decode(text.value).pipe(Effect.option, Effect.map(Option.getOrUndefined))
+})
+
+const awaitReady = Effect.fnUntraced(function* (options: Options) {
+  const fs = yield* FileSystem.FileSystem
+  const info = yield* fs.readFileString(options.file ?? fallback()).pipe(
+    Effect.mapError(
+      (cause) => new StartError({ stage: cause.reason._tag === "NotFound" ? "registration" : "readiness", cause }),
+    ),
+    Effect.flatMap(decode),
+    Effect.mapError((cause) => (cause instanceof StartError ? cause : new StartError({ stage: "readiness", cause }))),
+  )
+  return yield* probe(info, options.version)
 })
 
 type LocalService = {


### PR DESCRIPTION
## What

When the managed background service exits before registering, the CLI now explains what happened and what to do next instead of dumping a raw Effect error and bundled stack frames.

**1. The background service does not register**

OpenCode starts its normal managed-service flow, but the child exits before creating its registration.

```text
Starting background server...
```

**2. OpenCode presents the failure**

The product output stays concise and uses the shipped CLI name for its recovery commands.

```text
OpenCode could not start its background service

The service exited or never became ready.
The expected registration file was not created.

Try:
  opencode2 service restart
  OPENCODE_LOG_LEVEL=DEBUG opencode2
```

The default terminal no longer exposes `/$bunfs/root` paths or Effect frames. The complete typed cause remains in OpenCode's normal file log for debug diagnosis.

## How

- `packages/client/src/effect/service.ts` returns a typed `Service.StartError` with `spawn`, `registration`, or `readiness` stage information and preserves the original cause. Spawn completion now observes the child process's `spawn`/`error` events, so command launch failures are classified directly.
- `packages/cli/src/framework/startup-error.ts` handles only `Service.StartError` at the CLI's top-level Effect boundary. It writes the user-facing presentation, records the full Effect cause through the existing observability layer, and leaves unrelated failures on the existing renderer.
- The recovery command comes from `Commands.name`, which is injected as `opencode2` in the compiled V2 binary and remains `opencode` for source runs.
- `packages/cli/test/service.test.ts` covers a real child that exits before registration and a nonexistent spawn command. It asserts the exact rendered registration output and the retained nested cause.

## Scope

This PR changes managed background-service startup failure classification and CLI presentation only. It does not change compatibility detection, service election, retry duration, or service-status behavior tracked by #36274.

Fixes #35158

## Testing

- `bun run test` from `packages/cli`: 27 passed, 0 failed across 7 files.
- `bun run test test/effect.test.ts test/contract-identity.test.ts test/import-boundaries.test.ts` from `packages/client`: 9 passed, 0 failed.
- `bun typecheck` from `packages/cli`: passed.
- `bun typecheck` from `packages/client`: passed.
- `bunx prettier --check src/index.ts src/framework/startup-error.ts test/service.test.ts ../client/src/effect/service.ts` from `packages/cli`: passed.
- `bun run build --single --skip-install` from `packages/cli`: built the native `opencode2` V2 binary.
- Real-service terminal capture at `120x40`: the compiled child exited before registration; default output contained no stack frames, while `opencode.log` retained `ServiceStartError -> PlatformError -> ENOENT`.
- Push hook `bun turbo typecheck --concurrency=3`: 31 tasks passed.

## Demo

Both screenshots use compiled V2 binaries, the same real managed-service failure, and identical `120x40` terminal dimensions.

**Before (`9ff7df07d6`)**

The CLI emits the generic raw failure, internal paths, and the complete Effect stack.

![Before: raw startup failure and Effect stack](https://github.com/user-attachments/assets/19fe1f67-c057-4429-8a33-0fac95f1d0ae)

**After (`3b03692aef`)**

The CLI emits the actual user-facing startup failure presentation.

![After: actionable background service startup failure](https://github.com/user-attachments/assets/90d453b5-7721-49c5-8d50-73fef7815efa)

