### PR TITLE
fix(tui): lower durable event log level

### DIFF
--- a/packages/tui/src/context/sdk.tsx
+++ b/packages/tui/src/context/sdk.tsx
@@ -93,7 +93,7 @@ export const { use: useSDK, provider: SDKProvider } = createSimpleContext({
               if (abort.signal.aborted || controller.signal.aborted) return
               if (event.done) return new Error("Event stream disconnected")
               if ("durable" in event.value)
-                log.info("event", {
+                log.debug("event", {
                   type: event.value.type,
                   aggregateID: event.value.durable.aggregateID,
                   seq: event.value.durable.seq,

--- a/packages/tui/test/cli/tui/use-event.test.tsx
+++ b/packages/tui/test/cli/tui/use-event.test.tsx
@@ -9,7 +9,7 @@ import { SDKProvider, useSDK } from "../../../src/context/sdk"
 import { useEvent } from "../../../src/context/event"
 import { createApi, createClient, createEventStream, createFetch } from "../../fixture/tui-sdk"
 import { TestTuiContexts } from "../../fixture/tui-environment"
-import type { LogSink } from "../../../src/context/log"
+import type { LogLevel, LogSink } from "../../../src/context/log"
 
 const projectID = "proj_test"
 
@@ -113,9 +113,9 @@ function Probe(props: {
 
 describe("useEvent", () => {
   test("logs only durable events", async () => {
-    const logs: Array<{ message: string; tags: Readonly<Record<string, unknown>> }> = []
-    const { app, emit, seen } = await mount(undefined, (_level, message, tags) => {
-      if (message === "event") logs.push({ message, tags })
+    const logs: Array<{ level: LogLevel; message: string; tags: Readonly<Record<string, unknown>> }> = []
+    const { app, emit, seen } = await mount(undefined, (level, message, tags) => {
+      if (message === "event") logs.push({ level, message, tags })
     })
     const durable = event(
       {
@@ -135,6 +135,7 @@ describe("useEvent", () => {
 
       expect(logs).toEqual([
         {
+          level: "debug",
           message: "event",
           tags: { component: "sdk", type: "session.renamed", aggregateID: "ses_test", seq: 1 },
         },


### PR DESCRIPTION
## What

**1. Before: one durable event becomes N INFO lines**
With N connected TUIs, every client writes the same durable event to the shared normal log.

```text
1 durable event
      |
      +-- TUI 1 --> INFO  event { type, aggregateID, seq }
      +-- TUI 2 --> INFO  event { type, aggregateID, seq }
      ...
      +-- TUI N --> INFO  event { type, aggregateID, seq }

shared INFO log: N copies, with growth proportional to connected TUIs
```

**2. After: INFO describes connections; DEBUG carries event metadata**
The normal log keeps connection lifecycle messages, while detailed durable-event metadata remains available when DEBUG logging is enabled.

```text
INFO   event stream connecting / connected / disconnected / reconnecting
DEBUG event { type, aggregateID, seq }

shared INFO log: no per-durable-event copies
```

This supersedes the duplicate durable event logging symptom tracked in #36283.

Fixes #36446

## Implementation

- `packages/tui/src/context/sdk.tsx`: emit per-durable-event metadata at DEBUG instead of INFO.
- `packages/tui/test/cli/tui/use-event.test.tsx`: assert that durable event diagnostics use the DEBUG level.

## Scope

This does not change event delivery, SSE subscriptions, durable event contents, or connection lifecycle logging.

## Testing

- `cd packages/tui && bun run test test/cli/tui/use-event.test.tsx` (6 passed, 0 failed)
- `cd packages/tui && bun typecheck` (passed)
- Push hook: `bun turbo typecheck --concurrency=3` (31 successful, 31 total)
- `git diff --check` (passed)
