### PR TITLE
fix(session-ui): escape direction:rtl bidi issue in message-part-directory via LRE/PDF wraps

### DIFF
--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -2159,7 +2159,7 @@ ToolRegistry.register({
                 </div>
                 <Show when={!pending() && props.input.filePath?.includes("/")}>
                   <div data-slot="message-part-path">
-                    <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                    <span data-slot="message-part-directory">{`\u202A${getDirectory(props.input.filePath!)}\u202C`}</span>
                   </div>
                 </Show>
               </div>
@@ -2226,7 +2226,7 @@ ToolRegistry.register({
                 </div>
                 <Show when={!pending() && props.input.filePath?.includes("/")}>
                   <div data-slot="message-part-path">
-                    <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                    <span data-slot="message-part-directory">{`\u202A${getDirectory(props.input.filePath!)}\u202C`}</span>
                   </div>
                 </Show>
               </div>
@@ -2408,7 +2408,7 @@ ToolRegistry.register({
                   </div>
                   <Show when={!pending() && single()!.relativePath.includes("/")}>
                     <div data-slot="message-part-path">
-                      <span data-slot="message-part-directory">{getDirectory(single()!.relativePath)}</span>
+                      <span data-slot="message-part-directory">{`\u202A${getDirectory(single()!.relativePath)}\u202C`}</span>
                     </div>
                   </Show>
                 </div>


### PR DESCRIPTION
## Problem

When `direction: rtl` + `text-overflow: ellipsis` is applied to a path starting with a leading dot (e.g. `.config/opencode/`), the Unicode bidirectional algorithm misplaces the dot, rendering it as `/config/opencode./` in some browsers. This is a known issue with the `direction: rtl` trick for showing the end of a truncated path.

## Fix

Wrap the directory text in LRE (`\u202A`) / PDF (`\u202C`) Unicode control characters, exactly as already done for `apply-patch-directory` in the same file (lines 1458, 2338) and for `session-review-directory` in `session-review.tsx`.

This forces LTR embedding inside the RTL context, preventing the bidi algorithm from misplacing leading dot characters.

## Changes

- `packages/session-ui/src/components/message-part.tsx`: Wrap `getDirectory()` output in LRE/PDF at all 3 `message-part-directory` usage sites (edit-trigger, write-trigger, and patch tool).
