### PR TITLE
fix(session-ui): escape direction:rtl bidi issue in message-part-directory via LRE/PDF wraps

### DIFF
--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -2159,7 +2159,7 @@ ToolRegistry.register({
                 </div>
                 <Show when={!pending() && props.input.filePath?.includes("/")}>
                   <div data-slot="message-part-path">
-                    <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                    <span data-slot="message-part-directory">{`\u202A${getDirectory(props.input.filePath!)}\u202C`}</span>
                   </div>
                 </Show>
               </div>
@@ -2226,7 +2226,7 @@ ToolRegistry.register({
                 </div>
                 <Show when={!pending() && props.input.filePath?.includes("/")}>
                   <div data-slot="message-part-path">
-                    <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                    <span data-slot="message-part-directory">{`\u202A${getDirectory(props.input.filePath!)}\u202C`}</span>
                   </div>
                 </Show>
               </div>
@@ -2408,7 +2408,7 @@ ToolRegistry.register({
                   </div>
                   <Show when={!pending() && single()!.relativePath.includes("/")}>
                     <div data-slot="message-part-path">
-                      <span data-slot="message-part-directory">{getDirectory(single()!.relativePath)}</span>
+                      <span data-slot="message-part-directory">{`\u202A${getDirectory(single()!.relativePath)}\u202C`}</span>
                     </div>
                   </Show>
                 </div>


### PR DESCRIPTION
### Issue for this PR

Closes #36489

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #9591 fixed a text rendering bug where `direction: rtl` + `text-overflow: ellipsis` on paths starting with a leading dot (e.g. `.config/opencode/`) causes the dot to be misplaced by the Unicode bidirectional algorithm. The fix wrapped directory text in LRE (`\u202A`) / PDF (`\u202C`) in `session-review.tsx` and `session-turn.tsx`.

This PR applies the same fix to the 3 `message-part-directory` sites in `message-part.tsx` that were missed in that change:
- edit-trigger (line 2162)
- write-trigger (line 2229)
- patch tool (line 2411)

### How did you verify your code works?

Verified by inspecting the rendered DOM in the opencode UI with `.config/opencode/` paths.

### Screenshots / recordings

| Before | Fixed |
|--------|--------|
| ![config/opencode./](https://github.com/user-attachments/assets/a61693b5-7246-4d88-be16-27ba4eccf6a6) | ![.config/opencode/](https://github.com/user-attachments/assets/fa491a2f-34ef-4fae-ad58-dd19eb213b57) | 

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
