### PR TITLE
fix(web): pagefind.js missing on docs site

### DIFF
--- a/packages/web/astro.config.mjs
+++ b/packages/web/astro.config.mjs
@@ -16,6 +16,11 @@ export default defineConfig({
   output: "server",
   adapter: cloudflare({
     imageService: "passthrough",
+    routes: {
+      extend: {
+        exclude: [{ pattern: "/docs/pagefind/*" }],
+      },
+    },
   }),
   devToolbar: {
     enabled: false,


### PR DESCRIPTION
### Issue for this PR

https://github.com/anomalyco/opencode/issues/36388
https://github.com/anomalyco/opencode/issues/17343
https://github.com/anomalyco/opencode/issues/26157#issuecomment-4402999957

Closes #36388 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Add routes.extend.exclude to the Cloudflare adapter configuration to explicitly exclude pagefind assets from Worker routing:

```patch
  adapter: cloudflare({
    imageService: "passthrough",
+   routes: {
+     extend: {
+       exclude: [{ pattern: "/docs/pagefind/*" }],
+     },
+   },
  }),
```

After fix the generated ` _routes.json` exclude list now includes pagefind:

```json
{
  "include": ["/*"],
  "exclude": ["/docs", "/docs/_astro/*", ..., "/docs/pagefind/*"]
}
```

### How did you verify your code works?

I deployed a fixed version on CF, docs searching works fine, maybe more test needed.
[doc site for testing ](https://opencode-docs-test.pages.dev/docs/fr/)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
