### PR TITLE
fix: wrap message-part-directory with LRE/PDF for RTL path display

### DIFF
--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -2159,7 +2159,7 @@ ToolRegistry.register({
                 </div>
                 <Show when={!pending() && props.input.filePath?.includes("/")}>
                   <div data-slot="message-part-path">
-                    <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                    <span data-slot="message-part-directory">{`\u202A${getDirectory(props.input.filePath!)}\u202C`}</span>
                   </div>
                 </Show>
               </div>
@@ -2226,7 +2226,7 @@ ToolRegistry.register({
                 </div>
                 <Show when={!pending() && props.input.filePath?.includes("/")}>
                   <div data-slot="message-part-path">
-                    <span data-slot="message-part-directory">{getDirectory(props.input.filePath!)}</span>
+                    <span data-slot="message-part-directory">{`\u202A${getDirectory(props.input.filePath!)}\u202C`}</span>
                   </div>
                 </Show>
               </div>
@@ -2408,7 +2408,7 @@ ToolRegistry.register({
                   </div>
                   <Show when={!pending() && single()!.relativePath.includes("/")}>
                     <div data-slot="message-part-path">
-                      <span data-slot="message-part-directory">{getDirectory(single()!.relativePath)}</span>
+                      <span data-slot="message-part-directory">{`\u202A${getDirectory(single()!.relativePath)}\u202C`}</span>
                     </div>
                   </Show>
                 </div>


### PR DESCRIPTION
## What

Fixes the 3 remaining `message-part-directory` spans in `message-part.tsx` that were not covered by PR #9591.

## Problem

CSS `direction: rtl` on `[data-slot="message-part-directory"]` (used for left-side ellipsis) causes the Unicode bidi algorithm to reposition leading dots in path names like `.config/opencode/`, rendering as `config/opencode./`.

PR #9591 fixed this in `session-review.tsx` and `session-turn.tsx` by wrapping the directory text with `‪...‬` (LRE + PDF unicode marks). The same issue exists in 3 places in `message-part.tsx` that were missed.

## Fix

Wrapped the 3 remaining `message-part-directory` spans with the same `‪${getDirectory(...)}‬` pattern:

1. `message-part-directory` with `getDirectory(props.input.filePath!)` (2 instances)
2. `message-part-directory` with `getDirectory(single()!.relativePath)` (1 instance)

The `apply-patch-directory` spans in the same file already had this fix applied.

Closes #36489