### PR TITLE
fix(opencode): define OPENCODE_VERSION in the node server build

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -21,6 +21,7 @@ await Bun.build({
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
     OPENCODE_MODELS_DEV: generated.modelsData,
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },
   files: {


### PR DESCRIPTION
### Issue for this PR

Closes #30197

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The node server bundle that the desktop app ships as its sidecar is built by `script/build-node.ts`, which defines `OPENCODE_CHANNEL` but not `OPENCODE_VERSION` (the CLI build in `script/build.ts` defines both). At runtime that global doesn't exist, so `InstallationVersion` falls back to `"local"` while `InstallationLocal` stays false — and config startup pins the plugin dependency install to `@opencode-ai/plugin@local`, a version that doesn't exist on npm. Every desktop install hits this on every session; #30908 and likely #31708 are the same failure.

It also means anything reading `InstallationVersion` in the sidecar reports `local` — session records, telemetry serviceVersion, User-Agent.

One line: add the same `OPENCODE_VERSION` define the CLI build already uses.

### How did you verify your code works?

Built the bundle before and after with `OPENCODE_VERSION=1.17.18 OPENCODE_CHANNEL=latest`. Before: the bundle still contains the `typeof OPENCODE_VERSION === "string" ? OPENCODE_VERSION : "local"` fallback (channel is inlined, version is not). After: `InstallationVersion = "1.17.18"` is inlined and the fallback is gone, so the dependency install resolves `@opencode-ai/plugin@1.17.18`, which exists on the registry. The `@local` spec in the reported logs matches this exact path — I hit it on my own machine (see #35986 debugging) where the failed install caused the plugin to resolve to workspace TS sources under node.

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
