### PR TITLE
fix(tui): show background subagent completion

### DIFF
--- a/packages/core/src/tool/subagent.ts
+++ b/packages/core/src/tool/subagent.ts
@@ -65,6 +65,7 @@ export const Plugin = {
     const injectCompletion = Effect.fn("SubagentTool.injectCompletion")(function* (
       parentID: SessionSchema.ID,
       childID: SessionSchema.ID,
+      agent: string,
       description: string,
       state: "completed" | "error" | "cancelled",
       text: string,
@@ -72,22 +73,32 @@ export const Plugin = {
       yield* runtime.session.synthetic({
         sessionID: parentID,
         text: `<subagent id="${childID}" state="${state}" description="${description}">\n${text}\n</subagent>`,
+        description: `Background agent ${state}: ${description}`,
+        metadata: { source: "subagent", childID, agent, state, description },
       })
     })
 
     const notifyWhenDone = Effect.fn("SubagentTool.notifyWhenDone")(function* (
       parentID: SessionSchema.ID,
       childID: SessionSchema.ID,
+      agent: string,
       description: string,
     ) {
       yield* runtime.job.wait({ id: childID }).pipe(
         Effect.flatMap((result) => {
           if (result.info?.status === "completed")
-            return injectCompletion(parentID, childID, description, "completed", result.info.output ?? NO_TEXT)
+            return injectCompletion(parentID, childID, agent, description, "completed", result.info.output ?? NO_TEXT)
           if (result.info?.status === "error")
-            return injectCompletion(parentID, childID, description, "error", result.info.error ?? "Subagent failed")
+            return injectCompletion(
+              parentID,
+              childID,
+              agent,
+              description,
+              "error",
+              result.info.error ?? "Subagent failed",
+            )
           if (result.info?.status === "cancelled")
-            return injectCompletion(parentID, childID, description, "cancelled", "Subagent cancelled")
+            return injectCompletion(parentID, childID, agent, description, "cancelled", "Subagent cancelled")
           return Effect.void
         }),
         Effect.forkIn(scope, { startImmediately: true }),
@@ -167,7 +178,7 @@ export const Plugin = {
 
                 if (background) {
                   yield* runtime.job.background(info.id)
-                  yield* notifyWhenDone(context.sessionID, child.id, input.description)
+                  yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                   return {
                     sessionID: child.id,
                     status: "running" as const,
@@ -183,7 +194,7 @@ export const Plugin = {
                   ),
                 )
                 if (result?.type === "backgrounded") {
-                  yield* notifyWhenDone(context.sessionID, child.id, input.description)
+                  yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                   return {
                     sessionID: child.id,
                     status: "running" as const,

--- a/packages/core/src/tool/subagent.ts
+++ b/packages/core/src/tool/subagent.ts
@@ -73,7 +73,7 @@ export const Plugin = {
       yield* runtime.session.synthetic({
         sessionID: parentID,
         text: `<subagent id="${childID}" state="${state}" description="${description}">\n${text}\n</subagent>`,
-        description: `Background agent ${state}: ${description}`,
+        description,
         metadata: { source: "subagent", childID, agent, state, description },
       })
     })

--- a/packages/core/src/tool/subagent.ts
+++ b/packages/core/src/tool/subagent.ts
@@ -74,7 +74,7 @@ export const Plugin = {
         sessionID: parentID,
         text: `<subagent id="${childID}" state="${state}" description="${description}">\n${text}\n</subagent>`,
         description,
-        metadata: { source: "subagent", childID, agent, state, description },
+        metadata: { source: "subagent", childID, agent, state },
       })
     })
 

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -288,6 +288,16 @@ describe("SubagentTool", () => {
 
           const admission = Array.from(yield* Fiber.join(admitted))[0]
           expect(admission?.data.input.data.text).toContain(`<subagent id="${childID}" state="completed"`)
+          expect(admission?.data.input.data).toMatchObject({
+            description: "Background agent completed: background review",
+            metadata: {
+              source: "subagent",
+              childID,
+              agent: "reviewer",
+              state: "completed",
+              description: "background review",
+            },
+          })
           const database = yield* Database.Service
           yield* SessionPending.promoteSteers(database.db, events, parent.id)
           const synthetic = (yield* sessions.context(parent.id)).filter((message) => message.type === "synthetic")

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -289,7 +289,7 @@ describe("SubagentTool", () => {
           const admission = Array.from(yield* Fiber.join(admitted))[0]
           expect(admission?.data.input.data.text).toContain(`<subagent id="${childID}" state="completed"`)
           expect(admission?.data.input.data).toMatchObject({
-            description: "Background agent completed: background review",
+            description: "background review",
             metadata: {
               source: "subagent",
               childID,

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -295,7 +295,6 @@ describe("SubagentTool", () => {
               childID,
               agent: "reviewer",
               state: "completed",
-              description: "background review",
             },
           })
           const database = yield* Database.Service

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1284,6 +1284,7 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
         <text fg={color()}>
           {state() === "completed" ? "↳" : "!"} {agent()} {status()}
         </text>
+        <text fg={theme.textMuted}> · {text()}</text>
       </box>
     </Show>
   )

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1245,15 +1245,47 @@ function SessionSwitchMessageV2(props: { message: SessionMessageInfo }) {
 
 function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const { theme } = useTheme()
+  const completion = () => props.message.type === "synthetic" && props.message.metadata?.source === "subagent"
+  const state = () => {
+    if (props.message.type !== "synthetic") return
+    return typeof props.message.metadata?.state === "string" ? props.message.metadata.state : undefined
+  }
+  const agent = () => {
+    if (props.message.type !== "synthetic") return "Subagent"
+    return typeof props.message.metadata?.agent === "string"
+      ? Locale.titlecase(props.message.metadata.agent)
+      : "Subagent"
+  }
   const text = () => {
     if (props.message.type === "system") return props.message.text
     if (props.message.type === "synthetic") return props.message.description ?? ""
     return ""
   }
+  const status = () => {
+    if (state() === "completed") return "finished"
+    if (state() === "error") return "failed"
+    return state() ?? "finished"
+  }
+  const color = () => {
+    if (state() === "error") return theme.error
+    if (state() === "cancelled") return theme.warning
+    return theme.info
+  }
   return (
-    <InlineToolRow icon="◈" color={theme.textMuted} pending="Notice" complete={true}>
-      {text()}
-    </InlineToolRow>
+    <Show
+      when={completion()}
+      fallback={
+        <InlineToolRow icon="◈" color={theme.textMuted} pending="Notice" complete={true}>
+          {text()}
+        </InlineToolRow>
+      }
+    >
+      <box marginLeft={3} flexDirection="row">
+        <text fg={color()}>
+          {state() === "completed" ? "↳" : "!"} {agent()} {status()}
+        </text>
+      </box>
+    </Show>
   )
 }
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1245,17 +1245,10 @@ function SessionSwitchMessageV2(props: { message: SessionMessageInfo }) {
 
 function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const { theme } = useTheme()
-  const completion = () => props.message.type === "synthetic" && props.message.metadata?.source === "subagent"
-  const state = () => {
-    if (props.message.type !== "synthetic") return
-    return typeof props.message.metadata?.state === "string" ? props.message.metadata.state : undefined
-  }
-  const agent = () => {
-    if (props.message.type !== "synthetic") return "Subagent"
-    return typeof props.message.metadata?.agent === "string"
-      ? Locale.titlecase(props.message.metadata.agent)
-      : "Subagent"
-  }
+  const metadata = () => (props.message.type === "synthetic" ? props.message.metadata : undefined)
+  const completion = () => metadata()?.source === "subagent"
+  const state = () => stringValue(metadata()?.state)
+  const agent = () => Locale.titlecase(stringValue(metadata()?.agent) ?? "Subagent")
   const text = () => {
     if (props.message.type === "system") return props.message.text
     if (props.message.type === "synthetic") return props.message.description ?? ""
@@ -1280,11 +1273,13 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
         </InlineToolRow>
       }
     >
-      <box marginLeft={3} flexDirection="row">
-        <text fg={color()}>
-          {state() === "completed" ? "↳" : "!"} {agent()} {status()}
+      <box marginLeft={3}>
+        <text>
+          <span style={{ fg: color() }}>
+            {state() === "completed" ? "↳" : "!"} {agent()} {status()}
+          </span>
+          <span style={{ fg: theme.textMuted }}> · {text()}</span>
         </text>
-        <text fg={theme.textMuted}> · {text()}</text>
       </box>
     </Show>
   )


### PR DESCRIPTION
## What

Background subagents now leave a concise terminal-state notice in the parent V2 transcript. Success, failure, and cancellation are visible without relying on a later model response, while the full subagent result remains model-only.

## How

- `packages/core/src/tool/subagent.ts` attaches the existing synthetic `description` field and metadata for the child ID, agent, and terminal state.
- `packages/tui/src/routes/session/index.tsx` renders a one-line, theme-aware completion notice from that metadata.
- `packages/core/test/tool-subagent.test.ts` verifies the metadata survives durable synthetic-input admission.

## Scope

This does not change public schemas, Protocol or Server APIs, generated clients, database schemas, or subagent execution semantics. It uses the existing synthetic-message `description` and open metadata fields.

## Testing

- `cd packages/core && bun run test test/tool-subagent.test.ts`
- `cd packages/core && bun typecheck`
- `cd packages/tui && bun run test test/cli/tui/session-rows.test.ts test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- `cd packages/tui && bun typecheck`
- pre-push full monorepo typecheck: 31/31 tasks passed
- deterministic OpenCode Drive reproduction against the V2 TUI

## Demo

The deterministic recording launches the V2 TUI against the simulated OpenCode backend, starts a background Researcher subagent, and shows its completion returning to the parent transcript.

[![V2 TUI background subagent completion](https://github.com/anomalyco/opencode/releases/download/pr-36516-evidence/final.png)](https://github.com/anomalyco/opencode/releases/download/pr-36516-evidence/final.png)

[Watch the recording](https://github.com/anomalyco/opencode/releases/download/pr-36516-evidence/final.webm)

## Flow

```mermaid
sequenceDiagram
  participant Child as Subagent job
  participant Core as Core session
  participant Inbox as Durable parent inbox
  participant TUI as V2 TUI
  Child->>Core: completed / error / cancelled
  Core->>Inbox: admit synthetic completion
  Inbox-->>TUI: session.input.admitted
  TUI->>TUI: render agent, status, and task
  Inbox->>Core: promote at safe boundary
  Core->>Core: include full result in model history
```

Closes #35063