### PR TITLE
fix(tui): show background shell completion

### DIFF
--- a/packages/core/src/tool/shell.ts
+++ b/packages/core/src/tool/shell.ts
@@ -132,6 +132,8 @@ export const Plugin = {
           return runtime.session.synthetic({
             sessionID,
             text: `<shell id="${callID}" state="${state}" command="${command}">\n${text}\n</shell>`,
+            description: command,
+            metadata: { source: "shell", state },
           })
         }),
         Effect.forkIn(scope, { startImmediately: true }),

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises"
 import { realpathSync } from "node:fs"
 import path from "path"
 import { describe, expect, test } from "bun:test"
-import { DateTime, Duration, Effect, Fiber, Layer, Scope } from "effect"
+import { DateTime, Duration, Effect, Fiber, Layer, Scope, Stream } from "effect"
 import { Money } from "@opencode-ai/schema/money"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
@@ -443,6 +443,12 @@ describe("ShellTool", () => {
         reset()
         return withSession(tmp.path, (registry) =>
           Effect.gen(function* () {
+            const events = yield* EventV2.Service
+            const admitted = yield* events.subscribe(SessionEvent.InputAdmitted).pipe(
+              Stream.filter((event) => event.data.sessionID === sessionID && event.data.input.type === "synthetic"),
+              Stream.runHead,
+              Effect.forkScoped({ startImmediately: true }),
+            )
             const settled = yield* settleTool(registry, call({ command: idleCommand, timeout: 50, background: true }))
             const structured = settled.output?.structured as Record<string, unknown> | undefined
             const shellID = typeof structured?.shellID === "string" ? structured.shellID : undefined
@@ -454,6 +460,13 @@ describe("ShellTool", () => {
             const id = ShellSchema.ID.make(shellID)
             expect((yield* shell.list()).map((info) => info.id)).toContain(id)
             expect((yield* shell.wait(id)).status).toBe("timeout")
+            expect((yield* Fiber.join(admitted)).valueOrUndefined?.data.input.data).toMatchObject({
+              description: idleCommand,
+              metadata: {
+                source: "shell",
+                state: "completed",
+              },
+            })
           }),
         )
       },

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1244,6 +1244,7 @@ function SessionSwitchMessageV2(props: { message: SessionMessageInfo }) {
 }
 
 function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
+  const ctx = use()
   const { theme } = useTheme()
   const metadata = () => (props.message.type === "synthetic" ? props.message.metadata : undefined)
   const source = () => stringValue(metadata()?.source)
@@ -1261,6 +1262,9 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
     if (state() === "error") return "failed"
     return state() ?? "finished"
   }
+  const heading = () => `${state() === "completed" ? "↳" : "!"} ${actor()} ${status()}`
+  const suffix = () =>
+    Locale.truncateWidth(` · ${description()}`, Math.max(0, ctx.width - 3 - Bun.stringWidth(heading())))
   const color = () => {
     if (state() === "error") return theme.error
     if (state() === "cancelled") return theme.warning
@@ -1276,11 +1280,9 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
       }
     >
       <box marginLeft={3}>
-        <text wrapMode="none" truncate>
-          <span style={{ fg: color() }}>
-            {state() === "completed" ? "↳" : "!"} {actor()} {status()}
-          </span>
-          <span style={{ fg: theme.textMuted }}> · {description()}</span>
+        <text wrapMode="none">
+          <span style={{ fg: color() }}>{heading()}</span>
+          <span style={{ fg: theme.textMuted }}>{suffix()}</span>
         </text>
       </box>
     </Show>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1246,14 +1246,16 @@ function SessionSwitchMessageV2(props: { message: SessionMessageInfo }) {
 function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const { theme } = useTheme()
   const metadata = () => (props.message.type === "synthetic" ? props.message.metadata : undefined)
-  const completion = () => metadata()?.source === "subagent"
+  const source = () => stringValue(metadata()?.source)
+  const completion = () => source() === "subagent" || source() === "shell"
   const state = () => stringValue(metadata()?.state)
-  const agent = () => Locale.titlecase(stringValue(metadata()?.agent) ?? "Subagent")
+  const actor = () => (source() === "shell" ? "Shell" : Locale.titlecase(stringValue(metadata()?.agent) ?? "Subagent"))
   const text = () => {
     if (props.message.type === "system") return props.message.text
     if (props.message.type === "synthetic") return props.message.description ?? ""
     return ""
   }
+  const description = () => (source() === "shell" ? text().replace(/\s+/g, " ").trim() : text())
   const status = () => {
     if (state() === "completed") return "finished"
     if (state() === "error") return "failed"
@@ -1274,11 +1276,11 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
       }
     >
       <box marginLeft={3}>
-        <text>
+        <text wrapMode="none" truncate>
           <span style={{ fg: color() }}>
-            {state() === "completed" ? "↳" : "!"} {agent()} {status()}
+            {state() === "completed" ? "↳" : "!"} {actor()} {status()}
           </span>
-          <span style={{ fg: theme.textMuted }}> · {text()}</span>
+          <span style={{ fg: theme.textMuted }}> · {description()}</span>
         </text>
       </box>
     </Show>

--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -63,6 +63,24 @@ export function truncate(str: string, len: number): string {
   return str.slice(0, len - 1) + "…"
 }
 
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+
+export function truncateWidth(str: string, width: number): string {
+  if (width <= 0) return ""
+  if (Bun.stringWidth(str) <= width) return str
+  if (width === 1) return "…"
+
+  const result: string[] = []
+  let used = 0
+  for (const item of graphemeSegmenter.segment(str)) {
+    const next = Bun.stringWidth(item.segment)
+    if (used + next > width - 1) break
+    result.push(item.segment)
+    used += next
+  }
+  return result.join("") + "…"
+}
+
 export function truncateLeft(str: string, len: number): string {
   if (str.length <= len) return str
   return "…" + str.slice(-(len - 1))

--- a/packages/tui/test/util/locale.test.ts
+++ b/packages/tui/test/util/locale.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test"
+import { Locale } from "../../src/util/locale"
+
+test("truncates text from the right by terminal width", () => {
+  expect(Locale.truncateWidth("abcdefgh", 5)).toBe("abcd…")
+  expect(Locale.truncateWidth("ab界cd", 5)).toBe("ab界…")
+  expect(Locale.truncateWidth("abcdefgh", 1)).toBe("…")
+  expect(Locale.truncateWidth("abcdefgh", 0)).toBe("")
+})


### PR DESCRIPTION
## What

Background shell completion now appears at the point where it wakes the parent session, using the same concise transcript language as background subagents.

**Before**

```text
│ ◌ $ bun run test
│ Background

The agent resumes with no visible completion boundary.
```

**After**

```text
│ ◌ $ bun run test
│ Background

↳ Shell finished · bun run test
```

Long and multiline commands are normalized to one line and truncated from the right with a muted ellipsis instead of wrapping.

## How

- `packages/core/src/tool/shell.ts` adds the existing synthetic `description` field and shell completion metadata to the durable notification already used to wake the parent.
- `packages/tui/src/routes/session/index.tsx` recognizes shell completion metadata, renders `Shell finished/failed/cancelled`, and constrains the notice to one line.
- `packages/tui/src/util/locale.ts` performs grapheme-safe, terminal-width-aware right truncation so the ellipsis retains the muted command styling.
- Core and TUI tests verify durable synthetic-input admission and terminal-width truncation.

## Scope

This does not change Job semantics, public schemas, Protocol or Server APIs, generated clients, database schemas, or shell execution behavior. `Job.completed` continues to mean the background Effect produced its result, not that the command exited successfully.

## Testing

- `cd packages/core && bun run test test/tool-shell.test.ts`
- `cd packages/core && bun typecheck`
- `cd packages/tui && bun run test test/util/locale.test.ts test/cli/tui/session-rows.test.ts test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- `cd packages/tui && bun typecheck`
- pre-push full monorepo typecheck: 31/31 tasks passed
- Prettier and `git diff --check`
- deterministic OpenCode Drive reproduction at 76 columns

## Demo

The deterministic OpenCode Drive run launches the real V2 TUI against the simulated backend, starts a real background shell command, shows the muted right-truncated completion notice, and then shows the parent response after wakeup.

![Background shell completion notice](https://github.com/user-attachments/assets/464ac3d6-29db-4431-857e-c2e0fb8a2a95)

https://github.com/user-attachments/assets/5c32747f-64a2-4215-84f5-4bab2db00cb8

## Flow

```mermaid
sequenceDiagram
  participant Shell as Background shell
  participant Core as Core session
  participant Inbox as Durable parent inbox
  participant TUI as V2 TUI
  Shell->>Core: job reaches terminal state
  Core->>Inbox: admit synthetic completion
  Inbox-->>TUI: show single-line completion notice
  Core->>Core: wake parent at safe boundary
  Core->>Core: include full output in model history
```