### PR TITLE
docs(ecosystem): add opencode-model-fallback plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-model-fallback](https://github.com/ShutovKS/opencode-model-fallback)                     | Retries failed sessions with the next fallback model on rate limits, quota, or provider errors     |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a community plugin, [opencode-model-fallback](https://github.com/ShutovKS/opencode-model-fallback), to the **Plugins** table on the Ecosystem page.

It keeps a session alive when the current model fails with rate limits, quota exhaustion, overloads, or temporary provider errors by retrying the last user message in the same session with the next configured fallback model.

One new row in `packages/web/src/content/docs/ecosystem.mdx`, formatted to match the existing table.

### How did you verify your code works?

- Confirmed the new row follows the existing markdown table format and the `Name | Description` column widths align with neighboring rows.
- Published on npm as [@shutovks/opencode-model-fallback](https://www.npmjs.com/package/@shutovks/opencode-model-fallback), public repo, MIT-licensed, actively maintained.
- README includes the independent / non-affiliated project note.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
