### PR TITLE
fix(github-copilot): set Copilot-Integration-Id header to vscode-chat

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -163,6 +163,8 @@ export async function CopilotAuthPlugin(input: PluginInput): Promise<Hooks> {
               "User-Agent": `opencode/${InstallationVersion}`,
               Authorization: `Bearer ${info.refresh}`,
               "Openai-Intent": "conversation-edits",
+              "Copilot-Integration-Id":
+                process.env["OPENCODE_COPILOT_INTEGRATION_ID"] ?? "vscode-chat",
             }
 
             if (isVision) {


### PR DESCRIPTION
### Issue for this PR

Closes #36575

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Newer GitHub Copilot models (`gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`) return **403 Forbidden** from the Copilot chat completions endpoint when used through opencode. Existing models (4.1, 5, 5.5, claude-*, etc.) keep working.

**Why**: when opencode omits the `Copilot-Integration-Id` request header, GitHub's Copilot API infers the integration id from the OAuth client id. opencode's OAuth `CLIENT_ID` (`Ov23li8tweQw6odWQebz`) is registered internally as `copilot-language-server`, and that integration is not authorized for the 5.6 model family.

**Fix**: explicitly send `Copilot-Integration-Id: vscode-chat` on every Copilot request, with an env override (`OPENCODE_COPILOT_INTEGRATION_ID`) for advanced users:

```ts
"Copilot-Integration-Id":
  process.env["OPENCODE_COPILOT_INTEGRATION_ID"] ?? "vscode-chat",
```

Two lines changed in `packages/opencode/src/plugin/github-copilot/copilot.ts`. No behavior change for models that already worked (they accept `vscode-chat` too).

### How did you verify your code works?

Reproduced against the live Copilot API with `curl` using the same OAuth-refreshed bearer token, varying only the `Copilot-Integration-Id` header:

| `Copilot-Integration-Id` | 5.6 model (`gpt-5.6-luna`) |
| --- | --- |
| _(header omitted)_ | 403 (server infers `copilot-language-server`) |
| `copilot-language-server` | 403 |
| `vscode-chat` | 200 OK |

Existing models (`gpt-4.1`, `gpt-5`, `gpt-5.5`, `claude-*`) continue to return 200 with `vscode-chat` set, matching the behavior with the header omitted.

### Screenshots / recordings

N/A (no UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR