### PR TITLE
fix(core): merge model.request.headers into SDK options in prepareOptions()

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -78,6 +78,9 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
     ...model.request.body,
   }
   if (model.api.type === "aisdk" && model.api.url) options.baseURL = model.api.url
+  if (model.request.headers && Object.keys(model.request.headers).length > 0) {
+    options.headers = { ...options.headers, ...model.request.headers }
+  }
 
   const customFetch = options.fetch
   const chunkTimeout = options.chunkTimeout


### PR DESCRIPTION
## Problem

When configuring a provider with custom headers (e.g. `User-Agent` for AgentRouter, or `x-api-key` for `@ai-sdk/anthropic`), these headers are silently dropped before reaching the SDK factory.

### Root cause

`prepareOptions()` in `packages/core/src/aisdk.ts` builds the options object for SDK creation by merging `model.api.settings` and `model.request.body`, but **never includes `model.request.headers`**.

The data flow is:
1. Config provider options → `lowerer` (in `provider-options.ts`) correctly extracts headers into `provider.request.headers`
2. `projectModel()` (in `catalog.ts`) correctly merges `provider.request.headers` and `model.request.headers` 
3. **`prepareOptions()`** ignores `model.request.headers` — headers are lost

### Fix

Add a 3-line merge of `model.request.headers` into the options object before passing to the SDK factory (`createAnthropic()` etc.), matching the existing pattern for `settings` and `body`.

## Impact

This affects all providers that set headers through `request.headers` — including `@ai-sdk/anthropic`, `@ai-sdk/openai-compatible`, and any plugin that injects custom headers (e.g. `HTTP-Referer`, `X-Title`).
