### PR TITLE
fix(client): preserve compatible background service

### DIFF
--- a/.changeset/calm-services-start.md
+++ b/.changeset/calm-services-start.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/client": patch
+---
+
+Reuse a same-version background service when a repeated health probe succeeds instead of replacing an endpoint another client may already be using.

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -60,7 +60,7 @@ export const start = Effect.fn("service.start")(function* (options: StartOptions
   const compatible = yield* discover(options)
   if (compatible !== undefined) return compatible
   const existing = yield* find(options)
-  if (existing !== undefined && (options.version === undefined || existing.version === options.version))
+  if (existing?.version !== undefined && (options.version === undefined || existing.version === options.version))
     return existing.endpoint
   yield* Effect.sync(() => options.onStart?.(existing === undefined ? "missing" : "version-mismatch", existing?.info))
   if (existing !== undefined) yield* kill(existing.info, options).pipe(Effect.ignore)

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -59,11 +59,11 @@ const discoverLocal = Effect.fnUntraced(function* (options: Options) {
 export const start = Effect.fn("service.start")(function* (options: StartOptions = {}) {
   const compatible = yield* discover(options)
   if (compatible !== undefined) return compatible
-  const mismatched = yield* find(options)
-  yield* Effect.sync(() =>
-    options.onStart?.(mismatched === undefined ? "missing" : "version-mismatch", mismatched?.info),
-  )
-  if (mismatched !== undefined) yield* kill(mismatched.info, options).pipe(Effect.ignore)
+  const existing = yield* find(options)
+  if (existing !== undefined && (options.version === undefined || existing.version === options.version))
+    return existing.endpoint
+  yield* Effect.sync(() => options.onStart?.(existing === undefined ? "missing" : "version-mismatch", existing?.info))
+  if (existing !== undefined) yield* kill(existing.info, options).pipe(Effect.ignore)
 
   const [command, ...args] = options.command ?? ["opencode", "serve", "--service"]
   if (command === undefined) return yield* Effect.fail(new Error("Missing service command"))
@@ -138,6 +138,7 @@ const read = Effect.fnUntraced(function* (file?: string) {
 type LocalService = {
   readonly info: Info
   readonly endpoint: Endpoint
+  readonly version?: string
 }
 
 const probe = Effect.fnUntraced(function* (info: Info, version?: string, allowLegacy = false) {
@@ -161,7 +162,7 @@ const probe = Effect.fnUntraced(function* (info: Info, version?: string, allowLe
     if (health.value.pid !== info.pid) return undefined
     if (info.version !== undefined && health.value.version !== info.version) return undefined
     if (version !== undefined && health.value.version !== version) return undefined
-    return { info, endpoint } satisfies LocalService
+    return { info, endpoint, version: health.value.version } satisfies LocalService
   }
   if (
     !allowLegacy ||

--- a/packages/client/test/fixture/service.ts
+++ b/packages/client/test/fixture/service.ts
@@ -1,6 +1,6 @@
-import { writeFile } from "node:fs/promises"
+import { rename, writeFile } from "node:fs/promises"
 
-const [registration, mode, firstRequest, release] = process.argv.slice(2)
+const [registration, mode] = process.argv.slice(2)
 if (registration === undefined || mode === undefined) throw new Error("Missing service fixture arguments")
 
 let requests = 0
@@ -9,9 +9,9 @@ const server = Bun.serve({
   async fetch(request) {
     if (new URL(request.url).pathname !== "/api/health") return new Response(null, { status: 404 })
     requests += 1
-    if (firstRequest !== undefined && release !== undefined && requests === 1) {
-      await writeFile(firstRequest, "")
-      while (!(await Bun.file(release).exists())) await Bun.sleep(5)
+    if (mode === "modern" && requests === 1) {
+      await writeFile(registration + ".first-request", "")
+      while (!(await Bun.file(registration + ".release").exists())) await Bun.sleep(5)
       return new Response(null, { status: 503 })
     }
     if (mode === "legacy") return Response.json({ healthy: true })
@@ -20,7 +20,7 @@ const server = Bun.serve({
 })
 
 await writeFile(
-  registration,
+  registration + ".tmp",
   JSON.stringify({
     id: crypto.randomUUID(),
     version: mode === "legacy" ? undefined : "test",
@@ -29,6 +29,7 @@ await writeFile(
   }),
   { mode: 0o600 },
 )
+await rename(registration + ".tmp", registration)
 
 const shutdown = () => {
   server.stop(true)

--- a/packages/client/test/fixture/service.ts
+++ b/packages/client/test/fixture/service.ts
@@ -1,8 +1,7 @@
 import { writeFile } from "node:fs/promises"
 
-const [registration, version, mode, firstRequest, release] = process.argv.slice(2)
-if (registration === undefined || version === undefined || mode === undefined)
-  throw new Error("Missing service fixture arguments")
+const [registration, mode, firstRequest, release] = process.argv.slice(2)
+if (registration === undefined || mode === undefined) throw new Error("Missing service fixture arguments")
 
 let requests = 0
 const server = Bun.serve({
@@ -10,20 +9,26 @@ const server = Bun.serve({
   async fetch(request) {
     if (new URL(request.url).pathname !== "/api/health") return new Response(null, { status: 404 })
     requests += 1
-    if (mode === "block-first" && requests === 1) {
-      if (firstRequest === undefined || release === undefined) throw new Error("Missing probe barrier paths")
+    if (firstRequest !== undefined && release !== undefined && requests === 1) {
       await writeFile(firstRequest, "")
       while (!(await Bun.file(release).exists())) await Bun.sleep(5)
       return new Response(null, { status: 503 })
     }
-    return Response.json({ healthy: true, version, pid: process.pid })
+    if (mode === "legacy") return Response.json({ healthy: true })
+    return Response.json({ healthy: true, version: "test", pid: process.pid })
   },
 })
 
-const id = crypto.randomUUID()
-await writeFile(registration, JSON.stringify({ id, version, url: server.url.toString(), pid: process.pid }), {
-  mode: 0o600,
-})
+await writeFile(
+  registration,
+  JSON.stringify({
+    id: crypto.randomUUID(),
+    version: mode === "legacy" ? undefined : "test",
+    url: server.url.toString(),
+    pid: process.pid,
+  }),
+  { mode: 0o600 },
+)
 
 const shutdown = () => {
   server.stop(true)

--- a/packages/client/test/fixture/service.ts
+++ b/packages/client/test/fixture/service.ts
@@ -1,0 +1,33 @@
+import { writeFile } from "node:fs/promises"
+
+const [registration, version, mode, firstRequest, release] = process.argv.slice(2)
+if (registration === undefined || version === undefined || mode === undefined)
+  throw new Error("Missing service fixture arguments")
+
+let requests = 0
+const server = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    if (new URL(request.url).pathname !== "/api/health") return new Response(null, { status: 404 })
+    requests += 1
+    if (mode === "block-first" && requests === 1) {
+      if (firstRequest === undefined || release === undefined) throw new Error("Missing probe barrier paths")
+      await writeFile(firstRequest, "")
+      while (!(await Bun.file(release).exists())) await Bun.sleep(5)
+      return new Response(null, { status: 503 })
+    }
+    return Response.json({ healthy: true, version, pid: process.pid })
+  },
+})
+
+const id = crypto.randomUUID()
+await writeFile(registration, JSON.stringify({ id, version, url: server.url.toString(), pid: process.pid }), {
+  mode: 0o600,
+})
+
+const shutdown = () => {
+  server.stop(true)
+  process.exit()
+}
+process.on("SIGTERM", shutdown)
+process.on("SIGINT", shutdown)

--- a/packages/client/test/service.test.ts
+++ b/packages/client/test/service.test.ts
@@ -1,6 +1,6 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { afterEach, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Exit } from "effect"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -11,14 +11,6 @@ const processes: Bun.Subprocess[] = []
 const directories: string[] = []
 
 afterEach(async () => {
-  await Promise.all(
-    directories.map(async (directory) => {
-      const info = await Bun.file(join(directory, "service.json"))
-        .json()
-        .catch(() => undefined)
-      if (typeof info?.pid === "number") process.kill(info.pid, "SIGTERM")
-    }),
-  )
   processes.forEach((process) => process.kill("SIGTERM"))
   await Promise.all(processes.splice(0).map((process) => process.exited))
   await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
@@ -29,61 +21,60 @@ test("a concurrent same-version start cannot invalidate a resolved endpoint", as
   const registration = join(directory, "service.json")
   const firstRequest = join(directory, "first-request")
   const release = join(directory, "release")
-  const existing = spawn(registration, "test", "block-first", firstRequest, release)
+  const existing = spawn(registration, "modern", firstRequest, release)
   await waitForFile(registration)
+  const original = await Bun.file(registration).json()
 
+  const starts: Service.StartReason[] = []
   const first = run(
     Service.start({
       file: registration,
       version: "test",
-      command: [process.execPath, fixture, registration, "test", "healthy"],
-    }),
+      command: [],
+      onStart: (reason) => starts.push(reason),
+    }).pipe(Effect.exit),
   )
   await waitForFile(firstRequest)
 
   const resolved = await run(Service.start({ file: registration, version: "test" }))
-  expect(await health(resolved.url)).toBe(true)
+  expect(resolved.url).toBe(original.url)
 
   await writeFile(release, "")
-  await first
-  await Bun.sleep(50)
+  const result = await first
 
-  expect(existing.exitCode).toBe(null)
-  expect(await health(resolved.url)).toBe(true)
-})
-
-test("a successful ungated probe of the requested version is not a mismatch", async () => {
-  const directory = await temp()
-  const registration = join(directory, "service.json")
-  const firstRequest = join(directory, "first-request")
-  const release = join(directory, "release")
-  const existing = spawn(registration, "test", "block-first", firstRequest, release)
-  await waitForFile(registration)
-
-  const starts: Array<{ reason: Service.StartReason; existing?: Service.Info }> = []
-  const started = run(
-    Service.start({
-      file: registration,
-      version: "test",
-      command: [process.execPath, fixture, registration, "test", "healthy"],
-      onStart: (reason, info) => starts.push({ reason, existing: info }),
-    }),
-  )
-  await waitForFile(firstRequest)
-  await writeFile(release, "")
-  const resolved = await started
-
+  expect(Exit.isSuccess(result)).toBe(true)
   expect(starts).toEqual([])
   expect(existing.exitCode).toBe(null)
-  expect(await health(resolved.url)).toBe(true)
+  expect(await Bun.file(registration).json()).toEqual(original)
+  expect(await health(resolved.url)).toEqual({ healthy: true, version: "test", pid: original.pid })
+})
+
+test("a legacy health response is still replaced", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const existing = spawn(registration, "legacy")
+  await waitForFile(registration)
+
+  const starts: Service.StartReason[] = []
+  const result = await run(
+    Service.start({
+      file: registration,
+      command: [],
+      onStart: (reason) => starts.push(reason),
+    }).pipe(Effect.exit),
+  )
+
+  expect(Exit.isFailure(result)).toBe(true)
+  expect(starts).toEqual(["version-mismatch"])
+  await existing.exited
 })
 
 function run<A, E>(effect: Effect.Effect<A, E, never>) {
   return Effect.runPromise(effect.pipe(Effect.provide(NodeFileSystem.layer)))
 }
 
-function spawn(registration: string, version: string, mode: string, ...args: string[]) {
-  const subprocess = Bun.spawn([process.execPath, fixture, registration, version, mode, ...args], {
+function spawn(registration: string, mode: string, ...args: string[]) {
+  const subprocess = Bun.spawn([process.execPath, fixture, registration, mode, ...args], {
     stdout: "ignore",
     stderr: "inherit",
   })
@@ -98,7 +89,7 @@ async function temp() {
 }
 
 async function waitForFile(file: string) {
-  for (let attempt = 0; attempt < 1_000; attempt++) {
+  for (let attempt = 0; attempt < 600; attempt++) {
     if (await Bun.file(file).exists()) return
     await Bun.sleep(5)
   }
@@ -106,7 +97,5 @@ async function waitForFile(file: string) {
 }
 
 async function health(url: string) {
-  return fetch(new URL("/api/health", url))
-    .then((response) => response.ok)
-    .catch(() => false)
+  return fetch(new URL("/api/health", url), { signal: AbortSignal.timeout(1_000) }).then((response) => response.json())
 }

--- a/packages/client/test/service.test.ts
+++ b/packages/client/test/service.test.ts
@@ -1,0 +1,112 @@
+import { NodeFileSystem } from "@effect/platform-node"
+import { afterEach, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Service } from "../src/effect/index"
+
+const fixture = join(import.meta.dir, "fixture/service.ts")
+const processes: Bun.Subprocess[] = []
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    directories.map(async (directory) => {
+      const info = await Bun.file(join(directory, "service.json"))
+        .json()
+        .catch(() => undefined)
+      if (typeof info?.pid === "number") process.kill(info.pid, "SIGTERM")
+    }),
+  )
+  processes.forEach((process) => process.kill("SIGTERM"))
+  await Promise.all(processes.splice(0).map((process) => process.exited))
+  await Promise.all(directories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
+})
+
+test("a concurrent same-version start cannot invalidate a resolved endpoint", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const firstRequest = join(directory, "first-request")
+  const release = join(directory, "release")
+  const existing = spawn(registration, "test", "block-first", firstRequest, release)
+  await waitForFile(registration)
+
+  const first = run(
+    Service.start({
+      file: registration,
+      version: "test",
+      command: [process.execPath, fixture, registration, "test", "healthy"],
+    }),
+  )
+  await waitForFile(firstRequest)
+
+  const resolved = await run(Service.start({ file: registration, version: "test" }))
+  expect(await health(resolved.url)).toBe(true)
+
+  await writeFile(release, "")
+  await first
+  await Bun.sleep(50)
+
+  expect(existing.exitCode).toBe(null)
+  expect(await health(resolved.url)).toBe(true)
+})
+
+test("a successful ungated probe of the requested version is not a mismatch", async () => {
+  const directory = await temp()
+  const registration = join(directory, "service.json")
+  const firstRequest = join(directory, "first-request")
+  const release = join(directory, "release")
+  const existing = spawn(registration, "test", "block-first", firstRequest, release)
+  await waitForFile(registration)
+
+  const starts: Array<{ reason: Service.StartReason; existing?: Service.Info }> = []
+  const started = run(
+    Service.start({
+      file: registration,
+      version: "test",
+      command: [process.execPath, fixture, registration, "test", "healthy"],
+      onStart: (reason, info) => starts.push({ reason, existing: info }),
+    }),
+  )
+  await waitForFile(firstRequest)
+  await writeFile(release, "")
+  const resolved = await started
+
+  expect(starts).toEqual([])
+  expect(existing.exitCode).toBe(null)
+  expect(await health(resolved.url)).toBe(true)
+})
+
+function run<A, E>(effect: Effect.Effect<A, E, never>) {
+  return Effect.runPromise(effect.pipe(Effect.provide(NodeFileSystem.layer)))
+}
+
+function spawn(registration: string, version: string, mode: string, ...args: string[]) {
+  const subprocess = Bun.spawn([process.execPath, fixture, registration, version, mode, ...args], {
+    stdout: "ignore",
+    stderr: "inherit",
+  })
+  processes.push(subprocess)
+  return subprocess
+}
+
+async function temp() {
+  const directory = await mkdtemp(join(tmpdir(), "opencode-client-service-"))
+  directories.push(directory)
+  return directory
+}
+
+async function waitForFile(file: string) {
+  for (let attempt = 0; attempt < 1_000; attempt++) {
+    if (await Bun.file(file).exists()) return
+    await Bun.sleep(5)
+  }
+  throw new Error(`Timed out waiting for ${file}`)
+}
+
+async function health(url: string) {
+  return fetch(new URL("/api/health", url))
+    .then((response) => response.ok)
+    .catch(() => false)
+}

--- a/packages/client/test/service.test.ts
+++ b/packages/client/test/service.test.ts
@@ -1,6 +1,6 @@
 import { NodeFileSystem } from "@effect/platform-node"
 import { afterEach, expect, test } from "bun:test"
-import { Effect, Exit } from "effect"
+import { Effect } from "effect"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -19,9 +19,7 @@ afterEach(async () => {
 test("a concurrent same-version start cannot invalidate a resolved endpoint", async () => {
   const directory = await temp()
   const registration = join(directory, "service.json")
-  const firstRequest = join(directory, "first-request")
-  const release = join(directory, "release")
-  const existing = spawn(registration, "modern", firstRequest, release)
+  spawn(registration, "modern")
   await waitForFile(registration)
   const original = await Bun.file(registration).json()
 
@@ -32,19 +30,17 @@ test("a concurrent same-version start cannot invalidate a resolved endpoint", as
       version: "test",
       command: [],
       onStart: (reason) => starts.push(reason),
-    }).pipe(Effect.exit),
+    }),
   )
-  await waitForFile(firstRequest)
+  await waitForFile(registration + ".first-request")
 
   const resolved = await run(Service.start({ file: registration, version: "test" }))
   expect(resolved.url).toBe(original.url)
 
-  await writeFile(release, "")
-  const result = await first
+  await writeFile(registration + ".release", "")
+  await first
 
-  expect(Exit.isSuccess(result)).toBe(true)
   expect(starts).toEqual([])
-  expect(existing.exitCode).toBe(null)
   expect(await Bun.file(registration).json()).toEqual(original)
   expect(await health(resolved.url)).toEqual({ healthy: true, version: "test", pid: original.pid })
 })
@@ -56,15 +52,9 @@ test("a legacy health response is still replaced", async () => {
   await waitForFile(registration)
 
   const starts: Service.StartReason[] = []
-  const result = await run(
-    Service.start({
-      file: registration,
-      command: [],
-      onStart: (reason) => starts.push(reason),
-    }).pipe(Effect.exit),
-  )
+  const result = run(Service.start({ file: registration, command: [], onStart: (reason) => starts.push(reason) }))
 
-  expect(Exit.isFailure(result)).toBe(true)
+  await expect(result).rejects.toThrow("Missing service command")
   expect(starts).toEqual(["version-mismatch"])
   await existing.exited
 })


### PR DESCRIPTION
## What

Stop a transient health-check failure from turning a healthy, same-version background service into a destructive restart. Concurrent CLI windows now converge on the existing service instead of one window invalidating an endpoint another window has already started using.

## Before / After

**Trigger:** A background service running version `V` is healthy overall, but CLI A's first version-gated health probe transiently fails or times out. Before CLI A performs its fallback probe, CLI B successfully resolves that same service and begins using its endpoint.

**Before:** CLI A performed a second, ungated health probe. Even when that probe succeeded and reported the requested version `V`, `Service.start()` inferred that every successful fallback result was a version mismatch. It invoked the replacement callback, killed the service, and spawned another one. This produced both observed symptoms:

- The preflight UI displayed an update from `V` to the identical version `V`.
- CLI B retained the endpoint it had just resolved, but CLI A terminated the process behind it, so CLI B's first API request could fail with `ClientError: Transport`.

**After:** The fallback probe retains the version reported by a modern health response. When it matches the requested version, `Service.start()` returns the existing endpoint without invoking `onStart`, killing the service, or changing its registration. Both CLI windows keep using the same live process.

Genuine version mismatches still replace the daemon. Legacy health responses retain their existing replacement behavior. Missing or unhealthy services still follow the existing spawn path. Concurrent daemon spawning remains protected by the existing server-side election lock.

## How

- `packages/client/src/effect/service.ts` carries the health response's version through the private probe result and explicitly checks compatibility before replacement.
- `packages/client/test/service.test.ts` deterministically pauses CLI A's first probe while CLI B resolves the service, then verifies the fallback does not fire `onStart`, replace the atomic registration, change PID/version, or kill CLI B's endpoint.
- The same test file verifies that a legacy unversioned health response is still replaced.
- `packages/client/test/fixture/service.ts` provides atomic modern and legacy registrations plus the health-probe barrier.
- `.changeset/calm-services-start.md` records the Client patch.

```mermaid
sequenceDiagram
    participant A as CLI A
    participant B as CLI B
    participant S as Background service V
    A->>S: version-gated health probe
    S--xA: transient failure
    B->>S: version-gated health probe
    S-->>B: healthy, version V
    B-->>B: keep endpoint S
    A->>S: ungated fallback probe
    S-->>A: healthy, version V
    A-->>A: compare V == V
    A-->>A: keep endpoint S
```

## Scope

This PR fixes the destructive same-version classification that produced the equal-version update and invalidated a concurrently resolved endpoint. Broader pre-existing server registration-finalizer and prolonged multi-probe recovery races are not changed here.

## Testing

- `cd packages/client && bun run test test/service.test.ts`
- Repeated the focused regression 10 consecutive times after each simplify pass.
- `cd packages/client && bun typecheck`
- `cd packages/cli && bun run test test/service.test.ts`
- Push hook: repository-wide Turbo typecheck, 31 packages passed after every push.
- GitHub CI passed on Linux and Windows before the final test-only simplification; the final push reruns those checks.
- `cd packages/client && bun run test`: 25 passed; 2 unrelated existing failures expect `server.mcp` while the generated client exposes `mcp`.
- `bunx prettier --check packages/client/src/effect/service.ts packages/client/test/service.test.ts packages/client/test/fixture/service.ts .changeset/calm-services-start.md`