### PR TITLE
fix(core): bound compaction request size

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -19,6 +19,7 @@ const DEFAULT_KEEP_TOKENS = 8_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
 const COMPACTION_CHUNK_TOKENS = 32_000
 const SUMMARY_OUTPUT_TOKENS = 4_096
+const REQUEST_BODY_COMPACTION_BYTES = 8 * 1024 * 1024
 const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
 <template>
 ## Objective
@@ -70,6 +71,7 @@ export type AutoInput = {
   readonly sessionID: SessionSchema.ID
   readonly messages: readonly SessionMessage.Info[]
   readonly model: Model
+  readonly requestBytes: number
 }
 
 export type ManualInput = {
@@ -327,6 +329,7 @@ const make = (dependencies: Dependencies) => {
   })
   const required = (input: AutoInput) => {
     if (!config.auto) return false
+    if (input.requestBytes >= REQUEST_BODY_COMPACTION_BYTES) return true
     const context = input.model.route.defaults.limits?.context
     if (context === undefined || context <= 0) return false
     const last = input.messages.findLast(

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -17,6 +17,8 @@ import { Token } from "../util/token"
 const DEFAULT_BUFFER = 20_000
 const DEFAULT_KEEP_TOKENS = 8_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
+const COMPACTION_CHUNK_TOKENS = 32_000
+const SUMMARY_OUTPUT_TOKENS = 4_096
 const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
 <template>
 ## Objective
@@ -80,7 +82,8 @@ type Plan = {
   readonly sessionID: SessionSchema.ID
   readonly model: Model
   readonly reason: SessionMessage.Compaction["reason"]
-  readonly prompt: string
+  readonly previousSummary?: string
+  readonly context: readonly string[]
   readonly recent: string
   readonly inputID?: SessionMessage.ID
 }
@@ -199,6 +202,14 @@ export const buildPrompt = (input: { readonly previousSummary?: string; readonly
     ...input.context,
   ].join("\n\n")
 
+const chunkContext = (context: readonly string[]) => {
+  const value = context.filter(Boolean).join("\n\n")
+  const size = COMPACTION_CHUNK_TOKENS * 4
+  return Array.from({ length: Math.ceil(value.length / size) }, (_, index) =>
+    value.slice(index * size, (index + 1) * size),
+  )
+}
+
 const planContent = (messages: readonly SessionMessage.Info[], tokens: number) => {
   const selected = select(messages, tokens)
   if (!selected) return
@@ -208,10 +219,8 @@ const planContent = (messages: readonly SessionMessage.Info[], tokens: number) =
   const previousRecent = previousSummary?.type === "compaction" ? previousSummary.recent : ""
   const summarizeRecent = !previousRecent && !selected.head
   return {
-    prompt: buildPrompt({
-      previousSummary: previousSummary?.type === "compaction" ? previousSummary.summary : undefined,
-      context: summarizeRecent ? [selected.recent] : [previousRecent, selected.head].filter(Boolean),
-    }),
+    previousSummary: previousSummary?.type === "compaction" ? previousSummary.summary : undefined,
+    context: chunkContext(summarizeRecent ? [selected.recent] : [previousRecent, selected.head]),
     recent: summarizeRecent ? "" : selected.recent,
   }
 }
@@ -235,62 +244,67 @@ const make = (dependencies: Dependencies) => {
       inputID: plan.inputID,
     })
 
-    const chunks: string[] = []
-    let failure: SessionError.Error | undefined
-    yield* dependencies.llm
-      .stream(
-        LLM.request({
-          model: plan.model,
-          messages: [Message.user(plan.prompt)],
-          tools: [],
-        }),
-      )
-      .pipe(
-        Stream.runForEach((event) => {
-          if (LLMEvent.is.providerError(event))
-            failure = {
-              type: event.classification === "context-overflow" ? "provider.invalid-request" : "provider.error",
-              message: event.message,
-            }
-          if (LLMEvent.is.textDelta(event)) {
-            chunks.push(event.text)
-            return dependencies.events.publish(SessionEvent.Compaction.Delta, {
-              sessionID: plan.sessionID,
-              text: event.text,
-            })
-          }
-          return Effect.void
-        }),
-        Effect.catchTag("LLM.Error", (error) =>
-          Effect.sync(() => {
-            failure = toSessionError(error)
+    let summary = plan.previousSummary
+    for (const [index, context] of plan.context.entries()) {
+      const chunks: string[] = []
+      let failure: SessionError.Error | undefined
+      const publish = index === plan.context.length - 1
+      yield* dependencies.llm
+        .stream(
+          LLM.request({
+            model: plan.model,
+            messages: [Message.user(buildPrompt({ previousSummary: summary, context: [context] }))],
+            tools: [],
+            generation: { maxTokens: SUMMARY_OUTPUT_TOKENS },
           }),
-        ),
-        Effect.onInterrupt(() =>
-          plan.reason === "auto"
-            ? failed({
-                sessionID: plan.sessionID,
-                reason: plan.reason,
-                error: { type: "compaction.interrupted", message: "Compaction was interrupted" },
-                inputID: plan.inputID,
-              }).pipe(Effect.asVoid)
-            : Effect.void,
-        ),
-      )
-    const summary = chunks.join("")
-    if (failure || !summary.trim()) {
-      const error = failure ?? { type: "compaction.failed" as const, message: "Compaction produced no summary" }
-      return yield* failed({
-        sessionID: plan.sessionID,
-        reason: plan.reason,
-        error,
-        inputID: plan.inputID,
-      })
+        )
+        .pipe(
+          Stream.runForEach((event) => {
+            if (LLMEvent.is.providerError(event))
+              failure = {
+                type: event.classification === "context-overflow" ? "provider.invalid-request" : "provider.error",
+                message: event.message,
+              }
+            if (LLMEvent.is.textDelta(event)) {
+              chunks.push(event.text)
+              if (publish)
+                return dependencies.events.publish(SessionEvent.Compaction.Delta, {
+                  sessionID: plan.sessionID,
+                  text: event.text,
+                })
+            }
+            return Effect.void
+          }),
+          Effect.catchTag("LLM.Error", (error) =>
+            Effect.sync(() => {
+              failure = toSessionError(error)
+            }),
+          ),
+          Effect.onInterrupt(() =>
+            plan.reason === "auto"
+              ? failed({
+                  sessionID: plan.sessionID,
+                  reason: plan.reason,
+                  error: { type: "compaction.interrupted", message: "Compaction was interrupted" },
+                  inputID: plan.inputID,
+                }).pipe(Effect.asVoid)
+              : Effect.void,
+          ),
+        )
+      const next = chunks.join("")
+      if (failure || !next.trim())
+        return yield* failed({
+          sessionID: plan.sessionID,
+          reason: plan.reason,
+          error: failure ?? { type: "compaction.failed", message: "Compaction produced no summary" },
+          inputID: plan.inputID,
+        })
+      summary = next
     }
     yield* dependencies.events.publish(SessionEvent.Compaction.Ended, {
       sessionID: plan.sessionID,
       reason: plan.reason,
-      text: summary,
+      text: summary ?? "",
       recent: plan.recent,
     })
     return { status: "completed" as const }

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -186,12 +186,6 @@ const layer = Layer.effect(
       const providerMetadataKey = model.route.providerMetadataKey ?? model.provider
       const history = yield* SessionHistory.entriesForRunner(db, session.id, instructions)
       const context = history.entries.map((entry) => entry.message)
-      const compactionInput = { sessionID: session.id, messages: context, model }
-      if (compaction.required(compactionInput) && !(yield* SessionPending.compaction(db, session.id))) {
-        const compacted = yield* compaction.compact(compactionInput)
-        if (compacted.status === "completed") return { _tag: "RestartAfterCompaction", step: currentStep } as const
-        return yield* new StepFailedError({ error: compacted.error })
-      }
       const isLastStep = agentInfo.steps !== undefined && currentStep >= agentInfo.steps
       const toolMaterialization = isLastStep ? undefined : yield* tools.materialize(agentInfo.permissions)
       const promptCacheKey = /^ses_[0-9a-f]{64}$/.test(session.id) ? session.id.slice(4) : session.id
@@ -208,6 +202,19 @@ const layer = Layer.effect(
         tools: toolMaterialization?.definitions ?? [],
         toolChoice: isLastStep ? "none" : undefined,
       })
+      const compactionInput = {
+        sessionID: session.id,
+        messages: context,
+        model,
+        requestBytes: new TextEncoder().encode(
+          JSON.stringify({ system: request.system, messages: request.messages, tools: request.tools }),
+        ).length,
+      }
+      if (compaction.required(compactionInput) && !(yield* SessionPending.compaction(db, session.id))) {
+        const compacted = yield* compaction.compact(compactionInput)
+        if (compacted.status === "completed") return { _tag: "RestartAfterCompaction", step: currentStep } as const
+        return yield* new StepFailedError({ error: compacted.error })
+      }
       const toolFibers = yield* FiberSet.make<void, ToolOutputStore.Error>()
       const ownedToolFibers: Array<Fiber.Fiber<void, ToolOutputStore.Error>> = []
       let needsContinuation = false
@@ -323,8 +330,7 @@ const layer = Layer.effect(
             recoverOverflow &&
             !publisher.hasRetryEvidence() &&
             isContextOverflowFailure(overflowFailure ?? streamFailure) &&
-            (yield* restore(recoverOverflow({ sessionID: session.id, messages: context, model }))).status ===
-              "completed"
+            (yield* restore(recoverOverflow(compactionInput))).status === "completed"
           )
             return { _tag: "RestartAfterOverflowCompaction", step: currentStep } as const
 

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -96,6 +96,20 @@ test("compaction prompt requires the checkpoint headings in order", () => {
   expect(prompt).toContain("Keep every section, even when empty.")
 })
 
+it.effect("requires compaction before a request reaches the inference body limit", () =>
+  Effect.gen(function* () {
+    const compaction = yield* SessionCompaction.Service
+    expect(
+      compaction.required({
+        sessionID: SessionV2.ID.make("ses_request_body_compaction"),
+        messages: [],
+        model,
+        requestBytes: 8 * 1024 * 1024,
+      }),
+    ).toBe(true)
+  }),
+)
+
 it.effect("manual compaction summarizes short context instead of no-op", () =>
   Effect.gen(function* () {
     requests = []

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -151,7 +151,7 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     expect(Array.from(yield* Fiber.join(delta)).map((event) => event.data.text)).toEqual(["manual summary"])
 
     expect(requests).toHaveLength(1)
-    expect(requests[0]?.generation).toBeUndefined()
+    expect(requests[0]?.generation?.maxTokens).toBe(4_096)
     expect(JSON.stringify(requests[0]?.messages)).toContain("Manual compaction should include this short conversation.")
     expect(yield* store.context(sessionID)).toMatchObject([
       { type: "compaction", reason: "manual", summary: "manual summary", recent: "" },
@@ -168,5 +168,55 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
       { type: EventV2.versionedType(SessionEvent.Compaction.Started.type, 1) },
       { type: EventV2.versionedType(SessionEvent.Compaction.Ended.type, 1) },
     ])
+  }),
+)
+
+it.effect("manual compaction rolls large histories through bounded requests", () =>
+  Effect.gen(function* () {
+    requests = []
+    const db = (yield* Database.Service).db
+    const compaction = yield* SessionCompaction.Service
+    const store = yield* SessionStore.Service
+    const sessionID = SessionV2.ID.make("ses_bounded_compaction")
+    yield* db
+      .insert(ProjectTable)
+      .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+      .onConflictDoNothing()
+      .run()
+      .pipe(Effect.orDie)
+    yield* db
+      .insert(SessionTable)
+      .values({
+        id: sessionID,
+        project_id: Project.ID.global,
+        slug: "bounded-compaction",
+        directory: "/project",
+        title: "Bounded compaction",
+        version: "test",
+      })
+      .run()
+      .pipe(Effect.orDie)
+    const session = yield* store
+      .get(sessionID)
+      .pipe(Effect.flatMap((value) => (value ? Effect.succeed(value) : Effect.die("test session missing"))))
+
+    expect(
+      yield* compaction.compactManual({
+        session,
+        messages: [
+          {
+            id: SessionMessage.ID.create(),
+            type: "user",
+            text: "a".repeat(300_000),
+            time: { created: DateTime.makeUnsafe(0) },
+          },
+        ],
+        inputID: SessionMessage.ID.make("msg_bounded_compaction"),
+      }),
+    ).toEqual({ status: "completed" })
+
+    expect(requests.length).toBeGreaterThan(1)
+    expect(requests.every((request) => JSON.stringify(request.messages).length < 150_000)).toBe(true)
+    expect(JSON.stringify(requests[1]?.messages)).toContain("manual summary")
   }),
 )


### PR DESCRIPTION
## What

Large sessions no longer become permanently wedged when their model context fits but the serialized inference request exceeds the service's 10 MiB body limit.

Before, auto-compaction only considered model token pressure. A session at roughly 240k of a 1M-token context could therefore skip compaction and receive HTTP 413 forever. Compaction itself could also exceed an upstream body limit because it summarized the entire old history in one request.

After this change, OpenCode compacts before the request reaches 8 MiB and rolls large histories through bounded summary requests while preserving a final recent tail.

## How

- `packages/core/src/session/runner/llm.ts` builds the semantic request before the compaction decision and measures its system, messages, and tools payload.
- `packages/core/src/session/compaction.ts` treats 8 MiB as independent compaction pressure and summarizes old history in 32k-token chunks, carrying each structured summary into the next chunk.
- Intermediate summaries remain internal; only the final summary delta and durable compaction result are published.
- Compaction output is capped at 4,096 tokens.

## Scope

This does not raise the inference service's 10 MiB request-body limit. It keeps OpenCode requests safely below that independent transport boundary.

## Testing

- `bun run test test/session-compaction.test.ts` in `packages/core`: 6 passed
- `bun typecheck` in `packages/core`
- Commit hook: all 31 workspace typechecks passed
- Production recovery: the previously wedged Slack-backed session completed bounded compaction, persisted `session.compaction.ended`, and then completed the requested response in the same thread

## Flow

```mermaid
flowchart TD
  A[Build semantic LLM request] --> B{Token pressure or body >= 8 MiB?}
  B -- no --> C[Send normal model request]
  B -- yes --> D[Keep recent tail]
  D --> E[Split older history into bounded chunks]
  E --> F[Summarize chunk]
  F --> G{More chunks?}
  G -- yes --> H[Carry summary into next chunk]
  H --> F
  G -- no --> I[Persist final summary + recent tail]
  I --> A
```
