### PR TITLE
fix(tui): align skills dialog copy

### DIFF
--- a/packages/tui/src/component/dialog-skill.tsx
+++ b/packages/tui/src/component/dialog-skill.tsx
@@ -46,7 +46,6 @@ export function DialogSkill(props: DialogSkillProps) {
       title: skill.name.padEnd(maxWidth),
       description: skill.description?.replace(/\s+/g, " ").trim(),
       value: skill.id,
-      category: "Skills",
       onSelect: () => {
         props.onSelect(skill.id)
         dialog.clear()
@@ -57,7 +56,6 @@ export function DialogSkill(props: DialogSkillProps) {
   return (
     <DialogSelect
       title="Skills"
-      placeholder="Search skills..."
       options={options()}
       renderFilter={!showError()}
       locked={showError()}


### PR DESCRIPTION
## What

Aligns the skills picker with the other selection dialogs:

- uses the shared `Search` placeholder instead of `Search skills...`
- removes the redundant `Skills` section heading beneath the `Skills` dialog title

## How

`packages/tui/src/component/dialog-skill.tsx` now relies on `DialogSelect`'s default search copy and leaves the single list ungrouped.

## Testing

- `bun typecheck` in `packages/tui`
- full V2 repository typecheck via the pre-push hook (31 tasks passed)
- opened `/skills` from the V2 checkout in a real OpenTUI PTY session and verified the rendered dialog

## Demo

The V2 skills dialog has one title, the shared `Search` placeholder, and no duplicate section heading:

![Updated V2 skills dialog](https://github.com/user-attachments/assets/13ff8402-30c9-4891-99a5-51975588524a)
