### PR TITLE
fix: standardize MCP server copy

### DIFF
--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -65,8 +65,8 @@ export const dict = {
   "command.message.next.description": "Go to the next user message",
   "command.model.choose": "Choose model",
   "command.model.choose.description": "Select a different model",
-  "command.mcp.toggle": "Toggle MCPs",
-  "command.mcp.toggle.description": "Toggle MCPs",
+  "command.mcp.toggle": "Manage MCP servers",
+  "command.mcp.toggle.description": "Enable or disable MCP servers",
   "command.agent.cycle": "Cycle agent",
   "command.agent.cycle.description": "Switch to the next agent",
   "command.agent.cycle.reverse": "Cycle agent backwards",
@@ -307,9 +307,9 @@ export const dict = {
   "prompt.toast.promptSendFailed.title": "Failed to send prompt",
   "prompt.toast.promptSendFailed.description": "Unable to retrieve session",
 
-  "dialog.mcp.title": "MCPs",
+  "dialog.mcp.title": "MCP servers",
   "dialog.mcp.description": "{{enabled}} of {{total}} enabled",
-  "dialog.mcp.empty": "No MCPs configured",
+  "dialog.mcp.empty": "No MCP servers configured",
 
   "dialog.lsp.empty": "LSPs auto-detected from file types",
   "dialog.plugins.empty": "Plugins configured in opencode.json",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -522,7 +522,7 @@ function App(props: {
         toast.show({
           variant: "error",
           title: `MCP server failed: ${server.name}`,
-          message: "Open MCPs to view details.",
+          message: "Open MCP servers to view details.",
         })
     }
   })
@@ -785,7 +785,7 @@ function App(props: {
       },
       {
         name: "mcp.list",
-        title: "MCP Servers",
+        title: "MCP servers",
         category: "Agent",
         slashName: "mcps",
         run: () => {

--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -92,7 +92,7 @@ export function DialogMcp() {
         when={detail()}
         fallback={
           <DialogSelect
-            title="MCPs"
+            title="MCP servers"
             options={options()}
             current={focused()}
             preserveSelection
@@ -152,7 +152,7 @@ function DialogMcpError(props: { server: McpServer; onBack: () => void }) {
     <box paddingLeft={4} paddingRight={4} paddingBottom={1} gap={1}>
       <box flexDirection="row" justifyContent="space-between">
         <text attributes={TextAttributes.BOLD} fg={theme.text}>
-          MCP / {props.server.name}
+          MCP server: {props.server.name}
         </text>
         <text fg={theme.textMuted} onMouseUp={props.onBack}>
           esc back

--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -22,9 +22,11 @@ export function DialogStatus() {
           esc
         </text>
       </box>
-      <Show when={mcp().length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
+      <Show when={mcp().length > 0} fallback={<text fg={theme.text}>No MCP servers</text>}>
         <box>
-          <text fg={theme.text}>{mcp().length} MCP Servers</text>
+          <text fg={theme.text}>
+            {mcp().length} MCP server{mcp().length === 1 ? "" : "s"}
+          </text>
           <For each={mcp()}>
             {(item) => (
               <box flexDirection="row" gap={1}>

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -292,7 +292,7 @@ The `mcp debug` command shows the current auth status, tests HTTP connectivity, 
 
 ## Manage
 
-Your MCPs are available as tools in OpenCode, alongside built-in tools. So you can manage them through the OpenCode config like any other tool.
+Tools from your MCP servers are available in OpenCode alongside built-in tools. You can manage them through the OpenCode config like any other tool.
 
 ---
 
@@ -319,7 +319,7 @@ This means that you can enable or disable them globally.
 }
 ```
 
-We can also use a glob pattern to disable all matching MCPs.
+We can also use a glob pattern to disable all matching MCP tools.
 
 ```json title="opencode.json" {14}
 {
@@ -340,7 +340,7 @@ We can also use a glob pattern to disable all matching MCPs.
 }
 ```
 
-Here we are using the glob pattern `my-mcp*` to disable all MCPs.
+Here we are using the glob pattern `my-mcp*` to disable all matching MCP tools.
 
 ---
 


### PR DESCRIPTION
## What

Standardizes user-facing English terminology around Model Context Protocol integrations:

- configured endpoints are `MCP servers`
- capabilities exposed by those servers are `MCP tools`
- `/mcps` and internal identifiers remain unchanged

This replaces ambiguous `MCPs` copy and aligns the TUI and app with the terminology already used throughout the MCP documentation.

## How

- `packages/tui`: updates the command, dialog, status, error-detail, and toast copy; status counts now handle singular and plural forms
- `packages/app`: updates the English MCP management command and dialog strings
- `packages/web`: describes configuration globs as controlling MCP tools rather than MCPs

## Scope

Non-English translations are unchanged. This PR establishes the canonical English source copy without rewriting language-specific terminology.

## Testing

- `bun typecheck` in `packages/tui`
- `bun typecheck` in `packages/app`
- full V2 repository typecheck via the pre-push hook (31 tasks passed)
- opened `/mcps` from the V2 checkout in a real OpenTUI PTY session
- app unit tests reach an existing unrelated i18n parity failure: Arabic is missing three `session.header.reveal.*` keys
- `packages/web` has no `typecheck` script

## Demo

The V2 command and dialog now use `MCP servers`, while the machine-facing `/mcps` command remains unchanged:

![MCP servers dialog](https://github.com/user-attachments/assets/ff8d098b-8651-4ad6-b715-2a8b358ab7d2)
