### PR TITLE
fix(tui): rehydrate pending permissions & questions on reconnect

### DIFF
--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -167,72 +167,6 @@ export const {
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 
-    // Insert a pending request into a per-session store list, keeping it sorted by
-    // id for the binary `search` above. Idempotent: a request already present (added
-    // by a live `*.asked` event) is left untouched. Mirrors the event-handler insert
-    // logic so hydration and live events can interleave safely.
-    function upsertPermission(request: PermissionRequest) {
-      const requests = store.permission[request.sessionID]
-      if (!requests) {
-        setStore("permission", request.sessionID, [request])
-        return
-      }
-      const match = search(requests, request.id, (r) => r.id)
-      if (match.found) return
-      setStore(
-        "permission",
-        request.sessionID,
-        produce((draft) => {
-          draft.splice(match.index, 0, request)
-        }),
-      )
-    }
-
-    function upsertQuestion(request: QuestionRequest) {
-      const requests = store.question[request.sessionID]
-      if (!requests) {
-        setStore("question", request.sessionID, [request])
-        return
-      }
-      const match = search(requests, request.id, (r) => r.id)
-      if (match.found) return
-      setStore(
-        "question",
-        request.sessionID,
-        produce((draft) => {
-          draft.splice(match.index, 0, request)
-        }),
-      )
-    }
-
-    // Rehydrate pending permission/question prompts on (re)connect. The server holds
-    // these as in-memory `Deferred`s and only emits `*.asked` once, at ask time; a
-    // client that connects afterwards (e.g. after detaching the TUI) would otherwise
-    // never learn about them, leaving the agent blocked with no prompt to answer.
-    function hydratePending(workspace: string | undefined) {
-      const permissions = sdk.client.permission
-        .list({ workspace })
-        .then((x) => {
-          for (const request of x.data ?? []) {
-            if (permission.mode === "auto") {
-              void sdk.client.permission.reply({ requestID: request.id, reply: "once", workspace })
-              continue
-            }
-            upsertPermission(request)
-          }
-        })
-        .catch(() => {})
-      const questions = sdk.client.question
-        .list({ workspace })
-        .then((x) => {
-          for (const request of x.data ?? []) {
-            upsertQuestion(request)
-          }
-        })
-        .catch(() => {})
-      return Promise.all([permissions, questions])
-    }
-
     event.subscribe((event, { directory, workspace }) => {
       switch (event.type) {
         case "server.instance.disposed":
@@ -592,7 +526,6 @@ export const {
             }),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
-            hydratePending(workspace),
             project.workspace.sync(),
           ]).then(() => {
             setStore("status", "complete")

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -167,6 +167,71 @@ export const {
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 
+    // Insert a pending request into its per-session list, kept sorted by id so the
+    // binary `search` stays valid. Idempotent: skip a request a live `*.asked` event
+    // already added, so hydration and live events can interleave safely.
+    function upsertPermission(request: PermissionRequest) {
+      const requests = store.permission[request.sessionID]
+      if (!requests) {
+        setStore("permission", request.sessionID, [request])
+        return
+      }
+      const match = search(requests, request.id, (r) => r.id)
+      if (match.found) return
+      setStore(
+        "permission",
+        request.sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 0, request)
+        }),
+      )
+    }
+
+    function upsertQuestion(request: QuestionRequest) {
+      const requests = store.question[request.sessionID]
+      if (!requests) {
+        setStore("question", request.sessionID, [request])
+        return
+      }
+      const match = search(requests, request.id, (r) => r.id)
+      if (match.found) return
+      setStore(
+        "question",
+        request.sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 0, request)
+        }),
+      )
+    }
+
+    // Fetch pending prompts on (re)connect. The `*.asked` events fire once, at ask
+    // time, and aren't replayed, so a client that connects afterwards (e.g. after
+    // detaching the TUI) never sees them via events alone and would leave the agent
+    // blocked with no prompt to answer.
+    function hydratePending(workspace: string | undefined) {
+      const permissions = sdk.client.permission
+        .list({ workspace })
+        .then((x) => {
+          for (const request of x.data ?? []) {
+            if (permission.mode === "auto") {
+              void sdk.client.permission.reply({ requestID: request.id, reply: "once", workspace })
+              continue
+            }
+            upsertPermission(request)
+          }
+        })
+        .catch(() => {})
+      const questions = sdk.client.question
+        .list({ workspace })
+        .then((x) => {
+          for (const request of x.data ?? []) {
+            upsertQuestion(request)
+          }
+        })
+        .catch(() => {})
+      return Promise.all([permissions, questions])
+    }
+
     event.subscribe((event, { directory, workspace }) => {
       switch (event.type) {
         case "server.instance.disposed":
@@ -526,6 +591,7 @@ export const {
             }),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            hydratePending(workspace),
             project.workspace.sync(),
           ]).then(() => {
             setStore("status", "complete")

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -167,6 +167,72 @@ export const {
         .then((x) => (x.data ?? []).toSorted((a, b) => a.id.localeCompare(b.id)))
     }
 
+    // Insert a pending request into a per-session store list, keeping it sorted by
+    // id for the binary `search` above. Idempotent: a request already present (added
+    // by a live `*.asked` event) is left untouched. Mirrors the event-handler insert
+    // logic so hydration and live events can interleave safely.
+    function upsertPermission(request: PermissionRequest) {
+      const requests = store.permission[request.sessionID]
+      if (!requests) {
+        setStore("permission", request.sessionID, [request])
+        return
+      }
+      const match = search(requests, request.id, (r) => r.id)
+      if (match.found) return
+      setStore(
+        "permission",
+        request.sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 0, request)
+        }),
+      )
+    }
+
+    function upsertQuestion(request: QuestionRequest) {
+      const requests = store.question[request.sessionID]
+      if (!requests) {
+        setStore("question", request.sessionID, [request])
+        return
+      }
+      const match = search(requests, request.id, (r) => r.id)
+      if (match.found) return
+      setStore(
+        "question",
+        request.sessionID,
+        produce((draft) => {
+          draft.splice(match.index, 0, request)
+        }),
+      )
+    }
+
+    // Rehydrate pending permission/question prompts on (re)connect. The server holds
+    // these as in-memory `Deferred`s and only emits `*.asked` once, at ask time; a
+    // client that connects afterwards (e.g. after detaching the TUI) would otherwise
+    // never learn about them, leaving the agent blocked with no prompt to answer.
+    function hydratePending(workspace: string | undefined) {
+      const permissions = sdk.client.permission
+        .list({ workspace })
+        .then((x) => {
+          for (const request of x.data ?? []) {
+            if (permission.mode === "auto") {
+              void sdk.client.permission.reply({ requestID: request.id, reply: "once", workspace })
+              continue
+            }
+            upsertPermission(request)
+          }
+        })
+        .catch(() => {})
+      const questions = sdk.client.question
+        .list({ workspace })
+        .then((x) => {
+          for (const request of x.data ?? []) {
+            upsertQuestion(request)
+          }
+        })
+        .catch(() => {})
+      return Promise.all([permissions, questions])
+    }
+
     event.subscribe((event, { directory, workspace }) => {
       switch (event.type) {
         case "server.instance.disposed":
@@ -526,6 +592,7 @@ export const {
             }),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
             sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            hydratePending(workspace),
             project.workspace.sync(),
           ]).then(() => {
             setStore("status", "complete")

--- a/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
@@ -260,3 +260,38 @@ test("a message removed during hydration does not regain stale parts", async () 
     app.renderer.destroy()
   }
 })
+
+test("pending permissions and questions are hydrated on connect without a live event", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+  const permission = {
+    id: "per_hydrated",
+    sessionID,
+    permission: "bash",
+    patterns: ["rm -rf /"],
+    metadata: {},
+    always: ["rm -rf /"],
+  }
+  const question = {
+    id: "que_hydrated",
+    sessionID,
+    questions: [{ question: "Proceed?", header: "Confirm", options: [{ label: "Yes", description: "do it" }] }],
+  }
+
+  // The TUI has just (re)attached: the *.asked events fired while it was
+  // detached, so the only way it can learn about these pending prompts is by
+  // fetching them on connect. No live event is emitted in this test.
+  const { app, sync } = await mount((url) => {
+    if (url.pathname === "/permission") return json([permission])
+    if (url.pathname === "/question") return json([question])
+    return undefined
+  }, tmp.path)
+
+  try {
+    expect(sync.data.permission[sessionID]).toEqual([permission])
+    expect(sync.data.question[sessionID]).toEqual([question])
+  } finally {
+    app.renderer.destroy()
+  }
+})

--- a/packages/tui/test/fixture/tui-sdk.ts
+++ b/packages/tui/test/fixture/tui-sdk.ts
@@ -102,6 +102,7 @@ export function createFetch(override?: FetchHandler, events?: ReturnType<typeof 
       return json({ location: { directory, project: { id: "proj_test", directory } }, data: [] })
     if (url.pathname === "/provider") return json({ all: [], default: {}, connected: [] })
     if (url.pathname === "/session") return json([])
+    if (url.pathname === "/permission" || url.pathname === "/question") return json([])
     if (url.pathname === "/vcs") return json({ branch: "main" })
     throw new Error(`unexpected request: ${url.pathname}`)
   }) as typeof globalThis.fetch


### PR DESCRIPTION
### Issue for this PR

Closes #36604

### Type of change

- [x] Bug fix

### What does this PR do?

Pending permission/question prompts only live in server memory (a `Deferred` the tool blocks on) and are announced with a single `permission.asked`/`question.asked` event at ask time. The SSE stream only forwards events emitted after a client subscribes and never replays what's already pending, and the TUI's `bootstrap()` hydrated everything except these two stores. So if you detach the TUI while a prompt is pending — or one is raised while you're detached — re-attaching shows no prompt even though the agent is still blocked, and the only way out is to fork the session.

This adds `hydratePending()` to `bootstrap()`, which fetches `GET /permission` and `GET /question` on connect and seeds the stores. Inserts go through small `upsert` helpers that mirror the existing `*.asked` event handlers (binary-search by id, skip if already present), so hydration and any live events that arrive during bootstrap interleave without duplicating or clobbering. Auto-approve mode is honoured the same way the live handler does it. Subagent prompts surface via the existing root-session aggregation, so no extra work there.

### How did you verify your code works?

Added a test in `sync-live-hydration.test.tsx` that seeds a pending permission and question on the mock server, emits no live event, and asserts the store is hydrated on connect. It fails against the current `sync.tsx` (`sync.data.permission[sessionID]` is `undefined`) and passes with `hydratePending()`, so it pins the exact regression. Full `packages/tui` suite passes (192 pass / 0 fail), `bun run typecheck` (tsgo) is clean, and `oxlint` reports 0 errors on the changed files. Both list calls are wrapped in `.catch()` so an older server without these endpoints falls back to current behaviour.

### Screenshots / recordings

N/A — no visual change; this only re-populates prompts that already render today.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
