### PR TITLE
chore(opencode): upgrade remix-run/router to 1.23.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1083,6 +1083,7 @@
     "@opentui/core": "catalog:",
     "@opentui/keymap": "catalog:",
     "@opentui/solid": "catalog:",
+    "@remix-run/router": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
   },
@@ -1104,6 +1105,7 @@
     "@opentui/solid": "0.4.3",
     "@pierre/diffs": "1.2.10",
     "@playwright/test": "1.59.1",
+    "@remix-run/router": "1.23.2",
     "@sentry/solid": "10.36.0",
     "@sentry/vite-plugin": "4.6.0",
     "@shikijs/stream": "4.2.0",
@@ -2426,7 +2428,7 @@
 
     "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.8.1", "", {}, "sha512-J1dev372wtJqmqn9U/qbpbZxbJSQrogNN2+Qv1lKlpATpe/WQ9aCZfl/xSb9d2Rgh1IyLSvNxZAXPZxruO6Xig=="],
 
-    "@remix-run/router": ["@remix-run/router@1.9.0", "", {}, "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA=="],
+    "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
       "@sentry/vite-plugin": "4.6.0",
       "solid-js": "1.9.10",
       "vite-plugin-solid": "2.11.10",
-      "@lydell/node-pty": "1.2.0-beta.12"
+      "@lydell/node-pty": "1.2.0-beta.12",
+      "@remix-run/router": "1.23.2"
     }
   },
   "devDependencies": {
@@ -140,7 +141,8 @@
     "@opentui/keymap": "catalog:",
     "@opentui/solid": "catalog:",
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@remix-run/router": "catalog:"
   },
   "patchedDependencies": {
     "@ff-labs/fff-bun@0.9.3": "patches/@ff-labs%2Ffff-bun@0.9.3.patch",


### PR DESCRIPTION
### What does this PR do?

### Summary

Update the transitive `@remix-run/router` dependency resolution to fix a high-severity security vulnerability reported by OSV Scanner.

#### Changes

`package.json`

* Add `@remix-run/router` version `1.23.2` to the workspace catalog
* Add an override for `@remix-run/router` using `catalog:` to force the patched version across the dependency tree

`bun.lock`

* Regenerate the lockfile so `@remix-run/router` resolves to `1.23.2`
* Remove the vulnerable transitive resolution of `@remix-run/router@1.9.0`

### Why?

OSV Scanner reported `@remix-run/router@1.9.0` as vulnerable to **GHSA-2w69-qvjg-hvjx / CVE-2026-22029**.

The vulnerability is a high-severity React Router issue related to XSS via open redirects. Versions of `@remix-run/router` prior to `1.23.2` are affected, and `1.23.2` is the patched version.

Updating the workspace catalog and applying the override ensures the vulnerable transitive dependency is no longer resolved in `bun.lock`.

### Testing

### How did you verify your code works?

1. Added `@remix-run/router@1.23.2` to the workspace catalog
2. Added an override for `@remix-run/router` using `catalog:`
3. Regenerated `bun.lock` with Bun
4. Verified that `bun.lock` resolves `@remix-run/router` to `1.23.2`
5. Re-ran OSV Scanner to confirm the reported vulnerability is no longer present

Related issue: # https://github.com/anomalyco/opencode/security/advisories/GHSA-6jw4-q85v-2435

Fixes #36611 
