### PR TITLE
fix(provider): normalize null reasoning efforts to none

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -984,7 +984,7 @@ const ProviderInterleaved = Schema.Union([
 const ProviderReasoningOption = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("effort"),
-    values: Schema.Array(Schema.NullOr(Schema.String)),
+    values: Schema.Array(Schema.String),
   }),
   Schema.Struct({
     type: Schema.Literal("toggle"),
@@ -1234,7 +1234,11 @@ function normalizeReasoningOption(option: unknown): ReasoningOption | undefined 
     if (!Array.isArray(option.values)) return
     return {
       type: "effort",
-      values: option.values.filter((value): value is string | null => value === null || typeof value === "string"),
+      // models.dev uses null to mean reasoning can be disabled; expose it as "none".
+      values: option.values.flatMap((value) => {
+        if (value === null) return ["none"]
+        return typeof value === "string" ? [value] : []
+      }),
     }
   }
   if (option.type === "toggle") return { type: "toggle" }

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1439,7 +1439,7 @@ test("models.dev reasoning options normalize to known shapes", () => {
         reasoning: true,
         reasoning_options: [
           { type: "future_control", value: true },
-          { type: "effort", values: ["high", null, 42] },
+          { type: "effort", values: [null, "high", 42] },
           { type: "toggle" },
           { type: "budget_tokens", min: 1024, max: "invalid" },
         ],
@@ -1449,7 +1449,7 @@ test("models.dev reasoning options normalize to known shapes", () => {
   } as unknown as ModelsDev.Provider)
 
   expect(provider.models.reasoner.reasoning_options).toEqual([
-    { type: "effort", values: ["high", null] },
+    { type: "effort", values: ["none", "high"] },
     { type: "toggle" },
     { type: "budget_tokens", min: 1024 },
   ])


### PR DESCRIPTION
Typecheck on dev broke after #36543: the SDK generator flattens `Schema.NullOr(Schema.String)` to plain `string`, so the generated `Provider` type (`values: Array<string>`) no longer matched the runtime schema's `(string | null)[]` at the `toPublicInfo` plugin boundaries.

models.dev uses `null` in effort values to mean reasoning can be disabled. Map it to `"none"` during normalization and keep the public schema as plain strings — the generated SDK output is already byte-identical to this shape, so no generated diffs.

This also settles how the upcoming variants PR treats `null`: it becomes the `none` variant, matching current guesser behavior for gpt-5.x.