### PR TITLE
fix(core): merge model.request.headers into SDK options in prepareOptions()

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -78,6 +78,9 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
     ...model.request.body,
   }
   if (model.api.type === "aisdk" && model.api.url) options.baseURL = model.api.url
+  if (model.request.headers && Object.keys(model.request.headers).length > 0) {
+    options.headers = { ...options.headers, ...model.request.headers }
+  }
 
   const customFetch = options.fetch
   const chunkTimeout = options.chunkTimeout


### PR DESCRIPTION
### Issue for this PR

Closes #36619

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`prepareOptions()` in `aisdk.ts` builds the options object for SDK creation by merging `model.api.settings` and `model.request.body`, but never includes `model.request.headers`.

The data flow is:
1. Config provider options → lowerer correctly extracts headers into `provider.request.headers`
2. `projectModel()` in `catalog.ts` correctly merges provider-level and model-level headers into `model.request.headers`
3. `prepareOptions()` ignores `model.request.headers` — headers are lost

This means any custom headers set via provider config (e.g. `User-Agent`, `X-API-Key`, `Authorization` for non-standard auth) are silently dropped before reaching the SDK factory.

This fix adds a 3-line merge of `model.request.headers` into the options object, matching the existing pattern for `settings` and `body`.

### How did you verify your code works?

- Local build passes smoke test
- Verified that provider config headers (e.g. `User-Agent`) now appear in the actual HTTP request
- Existing V1 provider flows (standard OpenAI-compatible, Anthropic) continue to work

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR