### PR TITLE
fix(opencode): filter unsupported GPT-5.6 OAuth alias

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -285,6 +285,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
             .filter(([, model]) => {
               if (ALLOWED_MODELS.has(model.api.id)) return true
               if (DISALLOWED_MODELS.has(model.api.id)) return false
+              if (model.api.id === "gpt-5.6") return false
               const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
               return match ? parseFloat(match[1]) > 5.4 : false
             })

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -173,6 +173,30 @@ describe("plugin.codex", () => {
     )
   })
 
+  test("filters only the exact unsupported GPT-5.6 OAuth API model ID", async () => {
+    const hooks = await CodexAuthPlugin({} as never)
+    const ids = [
+      "gpt-5.6",
+      "gpt-5.6-luna",
+      "gpt-5.6-luna-pro",
+      "gpt-5.6-sol",
+      "gpt-5.6-sol-pro",
+      "gpt-5.6-terra",
+      "gpt-5.6-terra-pro",
+      "gpt-5.6-preview",
+    ]
+    const provider = {
+      models: Object.fromEntries(ids.map((id) => [id, { id, api: { id }, limit: {}, cost: {} }])),
+    }
+
+    const models = await hooks.provider!.models!(provider as never, { auth: { type: "oauth" } } as never)
+
+    expect(Object.keys(models)).toEqual(ids.filter((id) => id !== "gpt-5.6"))
+    expect(await hooks.provider!.models!(provider as never, { auth: { type: "api" } } as never)).toBe(
+      provider.models as never,
+    )
+  })
+
   test("deduplicates concurrent Codex token refreshes", async () => {
     let auth = {
       type: "oauth" as const,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -173,30 +173,6 @@ describe("plugin.codex", () => {
     )
   })
 
-  test("filters only the exact unsupported GPT-5.6 OAuth API model ID", async () => {
-    const hooks = await CodexAuthPlugin({} as never)
-    const ids = [
-      "gpt-5.6",
-      "gpt-5.6-luna",
-      "gpt-5.6-luna-pro",
-      "gpt-5.6-sol",
-      "gpt-5.6-sol-pro",
-      "gpt-5.6-terra",
-      "gpt-5.6-terra-pro",
-      "gpt-5.6-preview",
-    ]
-    const provider = {
-      models: Object.fromEntries(ids.map((id) => [id, { id, api: { id }, limit: {}, cost: {} }])),
-    }
-
-    const models = await hooks.provider!.models!(provider as never, { auth: { type: "oauth" } } as never)
-
-    expect(Object.keys(models)).toEqual(ids.filter((id) => id !== "gpt-5.6"))
-    expect(await hooks.provider!.models!(provider as never, { auth: { type: "api" } } as never)).toBe(
-      provider.models as never,
-    )
-  })
-
   test("deduplicates concurrent Codex token refreshes", async () => {
     let auth = {
       type: "oauth" as const,


### PR DESCRIPTION
## Summary
- filter the unsupported bare OpenAI/ChatGPT OAuth API model ID `gpt-5.6`
- use exact-string matching so `gpt-5.6-luna`, `gpt-5.6-sol`, `gpt-5.6-terra`, suffix variants, and every other model remain available
- leave API-key model lists unchanged