### PR TITLE
fix(provider): tweak reasoning option driven max budget variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1611,17 +1611,14 @@ function effortVariants(model: Provider.Model, values: readonly unknown[]) {
 }
 
 function budgetVariants(model: Provider.Model, min?: number, max?: number) {
-  const limit = model.limit.output - 1
-  if (limit <= 0) return {}
-  const high = Math.min(
-    max === undefined ? Math.max(min ?? 0, 16_000) : Math.min(Math.max(min ?? 0, 16_000), max),
-    limit,
-  )
-  const maximum = max === undefined ? undefined : Math.min(max, limit)
+  const allocation = Math.min(max ?? 32_000, model.limit.output)
+  if (allocation <= 1) return {}
+  const maximum = allocation - 1
+  const high = Math.min(Math.max(min ?? 0, Math.floor(allocation / 2)), maximum)
   return Object.fromEntries(
     [
       { id: "high", budget: high },
-      ...(maximum === undefined || maximum === high ? [] : [{ id: "max", budget: maximum }]),
+      { id: "max", budget: maximum },
     ].flatMap((item) => {
       const settings = reasoningBudget(model, item.budget)
       return settings ? [[item.id, settings]] : []

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1611,10 +1611,9 @@ function effortVariants(model: Provider.Model, values: readonly unknown[]) {
 }
 
 function budgetVariants(model: Provider.Model, min?: number, max?: number) {
-  const allocation = Math.min(max ?? 32_000, model.limit.output)
-  if (allocation <= 1) return {}
-  const maximum = allocation - 1
-  const high = Math.min(Math.max(min ?? 0, Math.floor(allocation / 2)), maximum)
+  const maximum = Math.min(max ?? OUTPUT_TOKEN_MAX - 1, model.limit.output - 1, OUTPUT_TOKEN_MAX - 1)
+  if (maximum <= 0) return {}
+  const high = Math.min(Math.max(min ?? 0, Math.floor((maximum + 1) / 2)), maximum)
   return Object.fromEntries(
     [
       { id: "high", budget: high },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3111,9 +3111,9 @@ describe("ProviderTransform.reasoningVariants", () => {
     ["@ai-sdk/cohere", { thinking: { type: "enabled", tokenBudget: 16_000 } }],
     ["@ai-sdk/alibaba", { enableThinking: true, thinkingBudget: 16_000 }],
   ])("converts token budgets for %s", (npm, high) => {
-    expect(
-      ProviderTransform.reasoningVariants(model([{ type: "budget_tokens", min: 1_024, max: 16_000 }]), target(npm)),
-    ).toEqual({ high })
+    const variants = ProviderTransform.reasoningVariants(model([{ type: "budget_tokens", min: 1_024 }]), target(npm))
+    expect(variants?.high).toEqual(high)
+    expect(Object.keys(variants ?? {})).toEqual(["high", "max"])
   })
 
   test("maps null effort to none", () => {
@@ -3150,6 +3150,7 @@ describe("ProviderTransform.reasoningVariants", () => {
     ).toEqual({
       none: { thinking: { type: "disabled" } },
       high: { thinking: { type: "enabled", tokenBudget: 16_000 } },
+      max: { thinking: { type: "enabled", tokenBudget: 31_999 } },
     })
   })
 
@@ -3160,7 +3161,7 @@ describe("ProviderTransform.reasoningVariants", () => {
         target("@ai-sdk/anthropic"),
       ),
     ).toEqual({
-      high: { thinking: { type: "enabled", budgetTokens: 16_000 } },
+      high: { thinking: { type: "enabled", budgetTokens: 32_000 } },
       max: { thinking: { type: "enabled", budgetTokens: 63_999 } },
     })
   })
@@ -3171,7 +3172,20 @@ describe("ProviderTransform.reasoningVariants", () => {
     expect(
       ProviderTransform.reasoningVariants(model([{ type: "budget_tokens", min: 1_024, max: 64_000 }]), anthropic),
     ).toEqual({
-      high: { thinking: { type: "enabled", budgetTokens: 4_999 } },
+      high: { thinking: { type: "enabled", budgetTokens: 2_500 } },
+      max: { thinking: { type: "enabled", budgetTokens: 4_999 } },
+    })
+  })
+
+  test("derives high and max budgets when models.dev omits max", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "budget_tokens", min: 1_024 }]),
+        target("@ai-sdk/anthropic", "claude-haiku-4-5"),
+      ),
+    ).toEqual({
+      high: { thinking: { type: "enabled", budgetTokens: 16_000 } },
+      max: { thinking: { type: "enabled", budgetTokens: 31_999 } },
     })
   })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3161,8 +3161,8 @@ describe("ProviderTransform.reasoningVariants", () => {
         target("@ai-sdk/anthropic"),
       ),
     ).toEqual({
-      high: { thinking: { type: "enabled", budgetTokens: 32_000 } },
-      max: { thinking: { type: "enabled", budgetTokens: 63_999 } },
+      high: { thinking: { type: "enabled", budgetTokens: 16_000 } },
+      max: { thinking: { type: "enabled", budgetTokens: 31_999 } },
     })
   })
 
@@ -3186,6 +3186,18 @@ describe("ProviderTransform.reasoningVariants", () => {
     ).toEqual({
       high: { thinking: { type: "enabled", budgetTokens: 16_000 } },
       max: { thinking: { type: "enabled", budgetTokens: 31_999 } },
+    })
+  })
+
+  test("preserves explicit inclusive budget maxima", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "budget_tokens", min: 1_024, max: 24_576 }]),
+        target("@ai-sdk/google", "gemini-2.5-pro"),
+      ),
+    ).toEqual({
+      high: { thinkingConfig: { includeThoughts: true, thinkingBudget: 12_288 } },
+      max: { thinkingConfig: { includeThoughts: true, thinkingBudget: 24_576 } },
     })
   })
 


### PR DESCRIPTION
## Summary
- always derive high and max variants for token-budget reasoning controls
- use half of the effective allocation for high and allocation minus one for max
- default missing models.dev maximums to a 32,000-token allocation while respecting model output limits

## Testing
- `bun test test/provider/transform.test.ts --test-name-pattern reasoningVariants`
- `bun typecheck`