### PR TITLE
fix(xai): default store to false for Responses

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1097,12 +1097,16 @@ export function options(input: {
     result["toolStreaming"] = false
   }
 
-  // openai and providers using openai package should set store to false by default.
+  // OpenAI-family Responses clients default to stateless mode (store: false).
+  // For @ai-sdk/xai, store:false also causes the SDK to inject
+  // include: ["reasoning.encrypted_content"] so follow-up turns can receive
+  // encrypted reasoning for rehydration.
   if (
     input.model.providerID === "openai" ||
     input.model.api.npm === "@ai-sdk/openai" ||
     input.model.api.npm === "@ai-sdk/github-copilot" ||
-    input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle"
+    input.model.api.npm === "@ai-sdk/amazon-bedrock/mantle" ||
+    input.model.api.npm === "@ai-sdk/xai"
   ) {
     result["store"] = false
   }
@@ -1257,7 +1261,8 @@ export function smallOptions(model: Provider.Model) {
   if (
     model.providerID === "openai" ||
     model.api.npm === "@ai-sdk/openai" ||
-    model.api.npm === "@ai-sdk/github-copilot"
+    model.api.npm === "@ai-sdk/github-copilot" ||
+    model.api.npm === "@ai-sdk/xai"
   ) {
     const base = { store: false }
     return mergeDeep(base, small)

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1097,10 +1097,7 @@ export function options(input: {
     result["toolStreaming"] = false
   }
 
-  // OpenAI-family Responses clients default to stateless mode (store: false).
-  // For @ai-sdk/xai, store:false also causes the SDK to inject
-  // include: ["reasoning.encrypted_content"] so follow-up turns can receive
-  // encrypted reasoning for rehydration.
+  // openai and providers using openai package should set store to false by default.
   if (
     input.model.providerID === "openai" ||
     input.model.api.npm === "@ai-sdk/openai" ||

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -155,6 +155,43 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.store).toBe(false)
   })
 
+  test("should set store=false for xAI provider by default", () => {
+    const xaiModel = {
+      ...mockModel,
+      providerID: "xai",
+      api: {
+        id: "grok-4",
+        url: "https://api.x.ai",
+        npm: "@ai-sdk/xai",
+      },
+    }
+    const result = ProviderTransform.options({
+      model: xaiModel,
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.store).toBe(false)
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
+  test("should set store=false for xAI SDK regardless of provider ID", () => {
+    const xaiModel = {
+      ...mockModel,
+      providerID: "custom-xai",
+      api: {
+        id: "grok-4",
+        url: "https://api.x.ai",
+        npm: "@ai-sdk/xai",
+      },
+    }
+    const result = ProviderTransform.options({
+      model: xaiModel,
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.store).toBe(false)
+  })
+
   test("should set store=false for azure provider by default", () => {
     const azureModel = {
       ...mockModel,


### PR DESCRIPTION
Match OpenAI-family stateless Responses defaults so @ai-sdk/xai injects include=["reasoning.encrypted_content"] for multi-turn reasoning rehydration.

### Issue for this PR

Closes #36631 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI-family Responses clients already default to `store: false` so multi-turn reasoning can work without server-side stored responses. xAI uses the Responses API via `@ai-sdk/xai`, but OpenCode never set `store: false` for it.

In `@ai-sdk/xai`, when `store === false`, the Responses language model automatically adds:

include: `["reasoning.encrypted_content"]`

Without that, encrypted reasoning is not requested, so follow-up turns can’t get the encrypted state needed for rehydration.

This PR adds `@ai-sdk/xai` to the same default path as OpenAI / Copilot / Mantle in `ProviderTransform.options()` and `smallOptions()`, so xAI models get `store: false` by default (still with the existing `promptCacheKey` behavior).

Note: this guarantees we request encrypted reasoning on the response. Full next-turn replay also depends on `@ai-sdk/xai` input conversion preserving that content; that path still has gaps and is not fully fixed here.

### How did you verify your code works?

- Unit tests in packages/opencode/test/provider/transform.test.ts for xAI defaults (store: false, including custom provider IDs using @ai-sdk/xai)
- Full transform.test.ts suite: 295 pass
- Broader test/provider/ + test/session/llm.test.ts: 454 pass
- Prettier + oxlint on touched files (0 errors)
- Pre-push typecheck via turbo: 30 packages pass

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
