### PR TITLE
fix: prevent UTF-8 corruption when stdout and stderr interleave

### DIFF
--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -1,7 +1,7 @@
 import { Context, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess } from "effect/unstable/process"
-import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import { ChildProcessSpawner, type ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
 import { CrossSpawnSpawner } from "./cross-spawn-spawner"
 import { makeGlobalNode } from "./effect/app-node"
 
@@ -20,7 +20,8 @@ export class AppProcessError extends Schema.TaggedErrorClass<AppProcessError>()(
 }
 
 export interface RunOptions {
-  readonly combineOutput?: boolean
+  // "utf8" keeps each pipe's decoder state independent before combining output.
+  readonly combineOutput?: boolean | "utf8"
   readonly maxOutputBytes?: number
   readonly maxErrorBytes?: number
   readonly signal?: AbortSignal
@@ -118,6 +119,10 @@ const normalizeStdin = (
       ? Stream.make(input)
       : input
 
+// Byte streams must be decoded independently so one pipe cannot complete a partial character from the other.
+export const mergeTextOutput = (handle: Pick<ChildProcessHandle, "stdout" | "stderr">) =>
+  Stream.merge(Stream.decodeText(handle.stdout), Stream.decodeText(handle.stderr))
+
 export const collectStream = (stream: Stream.Stream<Uint8Array, PlatformError>, maxOutputBytes: number | undefined) =>
   Stream.runFold(
     stream,
@@ -147,8 +152,10 @@ const layer = Layer.effect(
         Effect.gen(function* () {
           const handle = yield* spawner.spawn(command)
           if (options?.combineOutput) {
+            const source =
+              options.combineOutput === "utf8" ? mergeTextOutput(handle).pipe(Stream.encodeText) : handle.all
             const [output, exitCode] = yield* Effect.all(
-              [collectStream(handle.all, options.maxOutputBytes), handle.exitCode],
+              [collectStream(source, options.maxOutputBytes), handle.exitCode],
               { concurrency: "unbounded" },
             )
             return {

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -165,7 +165,7 @@ const layer = Layer.effectDiscard(
               const timeout = input.timeout ?? DEFAULT_TIMEOUT_MS
               const result = yield* appProcess
                 .run(command, {
-                  combineOutput: true,
+                  combineOutput: "utf8",
                   timeout: Duration.millis(timeout),
                   maxOutputBytes: MAX_CAPTURE_BYTES,
                 })

--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises"
 import { realpathSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
-import { Effect, Exit, Fiber, Stream } from "effect"
+import { Effect, Exit, Fiber, Latch, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AppProcess } from "@opencode-ai/core/process"
@@ -27,6 +27,30 @@ const waitForFile = (file: string) =>
   })
 
 describe("AppProcess", () => {
+  describe("mergeTextOutput", () => {
+    it.effect(
+      "keeps decoder state isolated per stream",
+      Effect.gen(function* () {
+        const stdoutStarted = yield* Latch.make()
+        const stderrDecoded = yield* Latch.make()
+        const stdout = Stream.concat(
+          Stream.fromEffect(stdoutStarted.open.pipe(Effect.as(Uint8Array.of(0xf0)))),
+          Stream.fromEffect(stderrDecoded.await.pipe(Effect.as(Uint8Array.of(0x9f, 0x99, 0x82)))),
+        )
+        const stderr = Stream.fromEffect(stdoutStarted.await.pipe(Effect.as(new TextEncoder().encode("stderr\n"))))
+        const output = Array.from(
+          yield* AppProcess.mergeTextOutput({ stdout, stderr }).pipe(
+            Stream.tap((chunk) => (chunk.includes("stderr") ? stderrDecoded.open : Effect.void)),
+            Stream.runCollect,
+          ),
+        ).join("")
+        expect(output).toContain("stderr")
+        expect(output).toContain("🙂")
+        expect(output).not.toContain("\uFFFD")
+      }),
+    )
+  })
+
   describe("run", () => {
     it.effect(
       "captures stdout and exit code zero",
@@ -53,6 +77,24 @@ describe("AppProcess", () => {
         expect(result.output?.toString("utf8")).toBe("out 1\nerr 1\nout 2\n")
         expect(result.stdout.toString("utf8")).toBe("")
         expect(result.stderr.toString("utf8")).toBe("")
+      }),
+    )
+
+    it.live(
+      "decodes combined UTF-8 output independently per stream",
+      Effect.gen(function* () {
+        const svc = yield* AppProcess.Service
+        const script = [
+          'const bytes = Buffer.from("🙂")',
+          "process.stdout.write(bytes.subarray(0, 1))",
+          'setTimeout(() => process.stderr.write("stderr\\n"), 20)',
+          "setTimeout(() => process.stdout.write(bytes.subarray(1)), 40)",
+        ].join(";")
+        const result = yield* svc.run(cmd("-e", script), { combineOutput: "utf8" })
+        const output = result.output?.toString("utf8")
+        expect(output).toContain("stderr")
+        expect(output).toContain("🙂")
+        expect(output).not.toContain("\uFFFD")
       }),
     )
 

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -169,7 +169,7 @@ describe("BashTool", () => {
             })
             expect(runs).toMatchObject([{ command: "pwd", cwd: realpathSync(tmp.path) }])
             expect(runs[0]?.options).toMatchObject({
-              combineOutput: true,
+              combineOutput: "utf8",
               maxOutputBytes: BashTool.MAX_CAPTURE_BYTES,
             })
             expect(assertions).toMatchObject([{ sessionID, action: "bash", resources: ["pwd"], save: ["pwd"] }])

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -38,6 +38,7 @@ import { LLM } from "./llm"
 import { Shell } from "@opencode-ai/core/shell"
 import { ShellID } from "@/tool/shell/id"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { AppProcess } from "@opencode-ai/core/process"
 import { Truncate } from "@/tool/truncate"
 import { Image } from "@/image/image"
 import { decodeDataUrl } from "@/util/data-url"
@@ -564,7 +565,7 @@ const layer = Layer.effect(
                 forceKillAfter: "3 seconds",
               })
               const handle = yield* spawner.spawn(cmd)
-              yield* Stream.runForEach(Stream.decodeText(handle.all), (chunk) =>
+              yield* Stream.runForEach(AppProcess.mergeTextOutput(handle), (chunk) =>
                 Effect.gen(function* () {
                   output += chunk
                   if (part.state.status === "running") {

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -9,6 +9,7 @@ import { lazy } from "@/util/lazy"
 import { Language, type Node } from "web-tree-sitter"
 
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { AppProcess } from "@opencode-ai/core/process"
 import { fileURLToPath } from "url"
 import { Config } from "@/config/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -484,7 +485,7 @@ export const ShellTool = Tool.define(
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
           yield* Effect.forkScoped(
-            Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
+            Stream.runForEach(AppProcess.mergeTextOutput(handle), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
               used += size

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1518,6 +1518,29 @@ unixNoLLMServer(
 )
 
 unixNoLLMServer(
+  "shell decodes stdout and stderr independently",
+  () =>
+    Effect.gen(function* () {
+      const { prompt, run, chat } = yield* boot()
+      const result = yield* prompt.shell({
+        sessionID: chat.id,
+        agent: "build",
+        command: "printf '\\360'; sleep 0.05; printf 'stderr\\n' >&2; sleep 0.05; printf '\\237\\231\\202'; sleep 0.05",
+      })
+
+      const tool = completedTool(result.parts)
+      if (!tool) return
+
+      expect(tool.state.output).toContain("stderr")
+      expect(tool.state.output).toContain("🙂")
+      expect(tool.state.output).not.toContain("\uFFFD")
+      expect(tool.state.metadata.output).not.toContain("\uFFFD")
+      yield* run.assertNotBusy(chat.id)
+    }),
+  { config: cfg },
+)
+
+unixNoLLMServer(
   "shell completes a fast command on the preferred shell",
   () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1131,6 +1131,24 @@ describe("tool.shell abort", () => {
   )
 })
 
+if (process.platform !== "win32") {
+  it.live("tool.shell decodes stdout and stderr independently", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const result = yield* run({
+          command:
+            "printf '\\360'; sleep 0.05; printf 'stderr\\n' >&2; sleep 0.05; printf '\\237\\231\\202'; sleep 0.05",
+        })
+        expect(result.output).toContain("stderr")
+        expect(result.output).toContain("🙂")
+        expect(result.output).not.toContain("\uFFFD")
+        expect(result.metadata.exit).toBe(0)
+      }),
+    ),
+  )
+}
+
 describe("tool.shell truncation", () => {
   it.live("truncates output exceeding line limit", () =>
     runIn(


### PR DESCRIPTION
### Issue for this PR

Closes #36655

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bash output currently merges raw stdout and stderr bytes before UTF-8 decoding. If stdout ends a chunk in the middle of a multibyte character and stderr writes before the remaining bytes arrive, both pipes are fed through the same decoder state and the output contains replacement characters.

This changes text output consumers to decode stdout and stderr with separate streaming decoders, then merge the decoded text. Raw combined output remains available for byte-oriented callers. The same text-safe path is used by the current shell tool, direct session shell execution, and the Core Bash implementation.

Cross-stream ordering remains best-effort, as it was before this change.

### How did you verify your code works?

- Added a deterministic stream test that splits one emoji across stdout chunks with a stderr chunk in between.
- Added subprocess regression coverage for AppProcess, the shell tool, and direct session shell execution.
- Ran the affected Core and OpenCode test files.
- Ran Core and OpenCode typechecks serially with Turbo concurrency limited to 1.
- Ran Prettier and Oxlint on all changed files.

### Screenshots / recordings

Not applicable; this changes captured shell text without changing the UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
