### PR TITLE
fix: normalize carriage-return shell output

### DIFF
--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -4,6 +4,7 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { CrossSpawnSpawner } from "./cross-spawn-spawner"
 import { makeGlobalNode } from "./effect/app-node"
+import { TerminalOutput } from "./terminal-output"
 
 export class AppProcessError extends Schema.TaggedErrorClass<AppProcessError>()("AppProcessError", {
   command: Schema.String,
@@ -21,6 +22,7 @@ export class AppProcessError extends Schema.TaggedErrorClass<AppProcessError>()(
 
 export interface RunOptions {
   readonly combineOutput?: boolean
+  readonly renderTerminalOutput?: boolean
   readonly maxOutputBytes?: number
   readonly maxErrorBytes?: number
   readonly signal?: AbortSignal
@@ -147,8 +149,29 @@ const layer = Layer.effect(
         Effect.gen(function* () {
           const handle = yield* spawner.spawn(command)
           if (options?.combineOutput) {
+            const terminal = options.renderTerminalOutput
+              ? TerminalOutput.make({ maxLineLength: options.maxOutputBytes })
+              : undefined
+            const source = terminal
+              ? handle.all.pipe(
+                  Stream.decodeText,
+                  Stream.mapAccum(
+                    () => terminal,
+                    (state, chunk) => {
+                      const output = state.write(chunk)
+                      return [state, output ? [Buffer.from(output)] : []]
+                    },
+                    {
+                      onHalt: (state) => {
+                        const output = state.finish()
+                        return output ? [Buffer.from(output)] : []
+                      },
+                    },
+                  ),
+                )
+              : handle.all
             const [output, exitCode] = yield* Effect.all(
-              [collectStream(handle.all, options.maxOutputBytes), handle.exitCode],
+              [collectStream(source, options.maxOutputBytes), handle.exitCode],
               { concurrency: "unbounded" },
             )
             return {
@@ -157,7 +180,7 @@ const layer = Layer.effect(
               output: output.buffer,
               stdout: Buffer.alloc(0),
               stderr: Buffer.alloc(0),
-              outputTruncated: output.truncated,
+              outputTruncated: output.truncated || terminal?.truncated() === true,
               stdoutTruncated: false,
               stderrTruncated: false,
             } satisfies RunResult

--- a/packages/core/src/terminal-output.ts
+++ b/packages/core/src/terminal-output.ts
@@ -1,0 +1,189 @@
+const MAX_SEQUENCE_LENGTH = 4 * 1024
+
+type Mode = "text" | "escape" | "csi" | "osc" | "osc-escape" | "control" | "control-escape"
+
+/**
+ * Incrementally reduces line-oriented terminal output to visible text. This
+ * models horizontal cursor changes but intentionally does not emulate a full
+ * screen or vertical cursor movement.
+ */
+export function make(options?: { maxLineLength?: number }) {
+  const cells: string[] = []
+  const maxLineLength = options?.maxLineLength ?? Number.POSITIVE_INFINITY
+  let cursor = 0
+  let savedCursor = 0
+  let mode: Mode = "text"
+  let sequence = ""
+  let lineTruncated = false
+  let outputTruncated = false
+
+  const resetLine = () => {
+    cells.length = 0
+    cursor = 0
+    savedCursor = 0
+    lineTruncated = false
+  }
+
+  const commit = (newline: boolean) => {
+    const output = cells.join("") + (newline ? "\n" : "")
+    outputTruncated = outputTruncated || lineTruncated
+    resetLine()
+    return output
+  }
+
+  const parameter = (index: number, fallback: number) => {
+    const value = Number.parseInt(sequence.split(";")[index] ?? "", 10)
+    return Number.isFinite(value) && value > 0 ? value : fallback
+  }
+
+  const eraseLine = () => {
+    const value = Number.parseInt(sequence.split(";")[0] ?? "0", 10)
+    if (value === 2) {
+      cells.length = 0
+      lineTruncated = false
+      return
+    }
+    if (value === 1) {
+      const end = Math.min(cursor, cells.length - 1)
+      for (let i = 0; i <= end; i++) cells[i] = " "
+      if (cursor >= maxLineLength) lineTruncated = false
+      return
+    }
+    if (cursor < cells.length) cells.length = cursor
+    if (cursor <= maxLineLength) lineTruncated = false
+  }
+
+  const applyCSI = (final: string) => {
+    if (final === "K") return eraseLine()
+    if (final === "C" || final === "a") {
+      cursor += parameter(0, 1)
+      return
+    }
+    if (final === "D") {
+      cursor = Math.max(0, cursor - parameter(0, 1))
+      return
+    }
+    if (final === "G" || final === "`") {
+      cursor = parameter(0, 1) - 1
+      return
+    }
+    if (final === "H" || final === "f") {
+      if (parameter(0, 1) === 1) cursor = parameter(1, 1) - 1
+      return
+    }
+    if (final === "s") savedCursor = cursor
+    if (final === "u") cursor = savedCursor
+  }
+
+  const printable = (char: string) => {
+    if (cursor < maxLineLength) {
+      while (cells.length < cursor) cells.push(" ")
+      cells[cursor] = char
+    } else {
+      lineTruncated = true
+    }
+    cursor += 1
+  }
+
+  const write = (input: string) => {
+    const output: string[] = []
+    for (const char of input) {
+      const code = char.codePointAt(0) ?? 0
+
+      if (mode === "osc") {
+        if (char === "\u0007" || char === "\u009c") mode = "text"
+        if (char === "\u001b") mode = "osc-escape"
+        continue
+      }
+      if (mode === "osc-escape") {
+        mode = char === "\\" ? "text" : "osc"
+        continue
+      }
+      if (mode === "control") {
+        if (char === "\u009c") mode = "text"
+        if (char === "\u001b") mode = "control-escape"
+        continue
+      }
+      if (mode === "control-escape") {
+        mode = char === "\\" ? "text" : "control"
+        continue
+      }
+      if (mode === "escape") {
+        mode = "text"
+        if (char === "[") mode = "csi"
+        if (char === "]") mode = "osc"
+        if (char === "P" || char === "X" || char === "^" || char === "_") mode = "control"
+        continue
+      }
+      if (mode === "csi") {
+        if (char === "\u001b") {
+          sequence = ""
+          mode = "escape"
+          continue
+        }
+        if (code >= 0x40 && code <= 0x7e) {
+          applyCSI(char)
+          sequence = ""
+          mode = "text"
+          continue
+        }
+        sequence += char
+        if (sequence.length > MAX_SEQUENCE_LENGTH) {
+          sequence = ""
+          mode = "text"
+        }
+        continue
+      }
+
+      if (char === "\u001b") {
+        mode = "escape"
+        continue
+      }
+      if (char === "\u009b") {
+        mode = "csi"
+        continue
+      }
+      if (char === "\u009d") {
+        mode = "osc"
+        continue
+      }
+      if (char === "\u0090" || char === "\u0098" || char === "\u009e" || char === "\u009f") {
+        mode = "control"
+        continue
+      }
+      if (char === "\r") {
+        cursor = 0
+        continue
+      }
+      if (char === "\n") {
+        output.push(commit(true))
+        continue
+      }
+      if (char === "\b") {
+        cursor = Math.max(0, cursor - 1)
+        continue
+      }
+      if (char === "\t") {
+        cursor += 8 - (cursor % 8)
+        continue
+      }
+      if (code < 0x20 || code === 0x7f || (code >= 0x80 && code < 0xa0)) continue
+      printable(char)
+    }
+    return output.join("")
+  }
+
+  return {
+    write,
+    current: () => cells.join(""),
+    finish: () => commit(false),
+    truncated: () => outputTruncated || lineTruncated,
+  }
+}
+
+export function render(input: string) {
+  const state = make()
+  return state.write(input) + state.finish()
+}
+
+export * as TerminalOutput from "./terminal-output"

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -166,6 +166,7 @@ const layer = Layer.effectDiscard(
               const result = yield* appProcess
                 .run(command, {
                   combineOutput: true,
+                  renderTerminalOutput: true,
                   timeout: Duration.millis(timeout),
                   maxOutputBytes: MAX_CAPTURE_BYTES,
                 })

--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -57,6 +57,22 @@ describe("AppProcess", () => {
     )
 
     it.effect(
+      "renders terminal updates before applying the capture limit",
+      Effect.gen(function* () {
+        const svc = yield* AppProcess.Service
+        const script =
+          'for(let i=0;i<5000;i++)process.stdout.write("\\rPROGRESS index="+String(i).padStart(5,"0"));process.stdout.write("\\nFINAL_MARKER\\n")'
+        const result = yield* svc.run(cmd("-e", script), {
+          combineOutput: true,
+          renderTerminalOutput: true,
+          maxOutputBytes: 100,
+        })
+        expect(result.output?.toString("utf8")).toBe("PROGRESS index=04999\nFINAL_MARKER\n")
+        expect(result.outputTruncated).toBe(false)
+      }),
+    )
+
+    it.effect(
       "non-zero exit returns RunResult; caller can require success",
       Effect.gen(function* () {
         const svc = yield* AppProcess.Service

--- a/packages/core/test/terminal-output.test.ts
+++ b/packages/core/test/terminal-output.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test"
+import { TerminalOutput } from "@opencode-ai/core/terminal-output"
+
+describe("TerminalOutput", () => {
+  test("preserves ordinary line output", () => {
+    expect(TerminalOutput.render("installing\nbuilding\ndone\n")).toBe("installing\nbuilding\ndone\n")
+  })
+
+  test("applies carriage returns as line overwrites", () => {
+    expect(TerminalOutput.render("\rprogress 1%\rprogress 2%\rprogress 3%\ndone\n")).toBe("progress 3%\ndone\n")
+  })
+
+  test("preserves the stale tail unless it is erased", () => {
+    expect(TerminalOutput.render("downloading\rdone")).toBe("doneloading")
+    expect(TerminalOutput.render("downloading\rdone\x1b[K")).toBe("done")
+  })
+
+  test("handles erase-line and SGR sequences", () => {
+    expect(TerminalOutput.render("\x1b[31mold\x1b[0m\x1b[2K\rnew\n")).toBe("new\n")
+  })
+
+  test("keeps parser state across chunks", () => {
+    const state = TerminalOutput.make()
+    expect(state.write("long line\rshort\x1b[")).toBe("")
+    expect(state.write("K\nfinal")).toBe("short\n")
+    expect(state.finish()).toBe("final")
+  })
+
+  test("handles backspace and horizontal cursor movement", () => {
+    expect(TerminalOutput.render("abc\bX\x1b[2D!\n")).toBe("a!X\n")
+  })
+
+  test("bounds unfinished lines without reporting cleared content as truncated", () => {
+    const truncated = TerminalOutput.make({ maxLineLength: 5 })
+    truncated.write("123456")
+    expect(truncated.finish()).toBe("12345")
+    expect(truncated.truncated()).toBe(true)
+
+    const cleared = TerminalOutput.make({ maxLineLength: 5 })
+    cleared.write("123456\rOK\x1b[K")
+    expect(cleared.finish()).toBe("OK")
+    expect(cleared.truncated()).toBe(false)
+  })
+
+  test("discards OSC and control strings", () => {
+    expect(TerminalOutput.render("before\x1b]52;c;secret\x07after\x1bPignored\x1b\\done")).toBe("beforeafterdone")
+  })
+})

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -170,6 +170,7 @@ describe("BashTool", () => {
             expect(runs).toMatchObject([{ command: "pwd", cwd: realpathSync(tmp.path) }])
             expect(runs[0]?.options).toMatchObject({
               combineOutput: true,
+              renderTerminalOutput: true,
               maxOutputBytes: BashTool.MAX_CAPTURE_BYTES,
             })
             expect(assertions).toMatchObject([{ sessionID, action: "bash", resources: ["pwd"], save: ["pwd"] }])
@@ -251,6 +252,37 @@ describe("BashTool", () => {
                   exit: 0,
                 })
                 expect(settled.output?.structured).not.toHaveProperty("output")
+              }),
+            ),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      ),
+    )
+
+    it.live("returns the terminal-visible state of carriage-return output", () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          const script =
+            'for(let i=0;i<5000;i++)process.stdout.write("\\x1b[2K\\rPROGRESS index="+String(i).padStart(5,"0"));process.stdout.write("\\nFINAL_MARKER\\n")'
+          const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`
+          return withTool(
+            tmp.path,
+            (registry) => settleTool(registry, call({ command })),
+            LayerNode.compile(AppProcess.node),
+          ).pipe(
+            Effect.andThen((settled) =>
+              Effect.sync(() => {
+                expect(settled.output?.content[0]).toEqual({
+                  type: "text",
+                  text: "PROGRESS index=04999\nFINAL_MARKER\n",
+                })
+                expect(settled.output?.structured).toMatchObject({
+                  exit: 0,
+                  truncated: false,
+                })
               }),
             ),
           )

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -602,7 +602,7 @@ export const ShellTool = Tool.define(
           output: committed || preview(output),
           exit: code,
           truncated: cut,
-          ...(file ? { outputPath: file } : {}),
+          ...(file ? (cut ? { outputPath: file } : { rawOutputPath: file }) : {}),
         },
         output,
       }

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -9,6 +9,7 @@ import { lazy } from "@/util/lazy"
 import { Language, type Node } from "web-tree-sitter"
 
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { TerminalOutput } from "@opencode-ai/core/terminal-output"
 import { fileURLToPath } from "url"
 import { Config } from "@/config/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
@@ -438,7 +439,7 @@ export const ShellTool = Tool.define(
       const limits = yield* trunc.limits()
       const keep = limits.maxBytes * 2
       let full = ""
-      let last = ""
+      let committed = ""
       const list: Chunk[] = []
       let used = 0
       let file = ""
@@ -446,6 +447,23 @@ export const ShellTool = Tool.define(
       let cut = false
       let expired = false
       let aborted = false
+      // Keep raw bytes for the saved log, but bound the terminal-visible line
+      // before it contributes to the UI or model-facing output.
+      const terminal = TerminalOutput.make({ maxLineLength: keep })
+
+      const append = (chunk: string) => {
+        if (!chunk) return
+        const size = Buffer.byteLength(chunk, "utf-8")
+        list.push({ text: chunk, size })
+        used += size
+        while (used > keep && list.length > 1) {
+          const item = list.shift()
+          if (!item) break
+          used -= item.size
+          cut = true
+        }
+        committed = preview(committed + chunk)
+      }
 
       const closeSink = Effect.fnUntraced(function* () {
         const stream = sink
@@ -483,19 +501,10 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
-              const size = Buffer.byteLength(chunk, "utf-8")
-              list.push({ text: chunk, size })
-              used += size
-              while (used > keep && list.length > 1) {
-                const item = list.shift()
-                if (!item) break
-                used -= item.size
-                cut = true
-              }
-
-              last = preview(last + chunk)
+              append(terminal.write(chunk))
+              const current = preview(committed + terminal.current())
 
               if (file) {
                 sink?.write(chunk)
@@ -506,7 +515,6 @@ export const ShellTool = Tool.define(
                     Effect.andThen((next) =>
                       Effect.sync(() => {
                         file = next
-                        cut = true
                         sink = createWriteStream(next, { flags: "a" })
                         full = ""
                       }),
@@ -514,7 +522,7 @@ export const ShellTool = Tool.define(
                     Effect.andThen(
                       ctx.metadata({
                         metadata: {
-                          output: last,
+                          output: current,
                         },
                       }),
                     ),
@@ -524,7 +532,7 @@ export const ShellTool = Tool.define(
 
               return ctx.metadata({
                 metadata: {
-                  output: last,
+                  output: current,
                 },
               })
             }),
@@ -554,6 +562,10 @@ export const ShellTool = Tool.define(
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
 
+          // Process close and stream callbacks are scheduled independently.
+          // Drain the output fiber before constructing the final result.
+          yield* Fiber.join(output)
+
           return exit.kind === "exit" ? exit.code : null
         }),
       ).pipe(Effect.orDie)
@@ -565,11 +577,13 @@ export const ShellTool = Tool.define(
         )
       }
       if (aborted) meta.push("User aborted the command")
-      const raw = list.map((item) => item.text).join("")
-      const end = tail(raw, limits.maxLines, limits.maxBytes)
+      append(terminal.finish())
+      if (terminal.truncated()) cut = true
+      const rendered = list.map((item) => item.text).join("")
+      const end = tail(rendered, limits.maxLines, limits.maxBytes)
       if (end.cut) cut = true
       if (!file && end.cut) {
-        file = yield* trunc.write(raw)
+        file = yield* trunc.write(full)
       }
 
       let output = end.text
@@ -585,10 +599,10 @@ export const ShellTool = Tool.define(
       return {
         title: input.command,
         metadata: {
-          output: last || preview(output),
+          output: committed || preview(output),
           exit: code,
           truncated: cut,
-          ...(cut && file ? { outputPath: file } : {}),
+          ...(file ? { outputPath: file } : {}),
         },
         output,
       }

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -122,6 +122,12 @@ const fill = (mode: "lines" | "bytes", n: number) => {
   if (PS.has(sh())) return `& ${text}`
   return text
 }
+const progress = (count: number) => {
+  const code = `for(let i=0;i<${count};i++)process.stdout.write("\\x1b[2K\\rPROGRESS index="+String(i).padStart(5,"0"));process.stdout.write("\\nFINAL_MARKER\\n")`
+  const text = `${bin} -e ${evalarg(code)}`
+  if (PS.has(sh())) return `& ${text}`
+  return text
+}
 const glob = (p: string) =>
   process.platform === "win32" ? Filesystem.normalizePathPattern(p) : p.replaceAll("\\", "/")
 
@@ -1088,6 +1094,45 @@ describe("tool.shell abort", () => {
           expect(result.output).toContain("stdout_msg")
           expect(result.output).toContain("stderr_msg")
           expect(result.metadata.exit).toBe(0)
+        }),
+      ),
+    )
+
+    it.live("renders carriage-return updates while preserving the raw log", () =>
+      runIn(
+        projectRoot,
+        Effect.gen(function* () {
+          const updates: string[] = []
+          const result = yield* run(
+            { command: progress(5000) },
+            {
+              ...ctx,
+              metadata: (input) =>
+                Effect.sync(() => {
+                  const output = input.metadata?.output
+                  if (typeof output === "string") updates.push(output)
+                }),
+            },
+          )
+          expect(result.output).toContain("PROGRESS index=04999")
+          expect(result.output).not.toContain("PROGRESS index=00000")
+          expect(result.output).toContain("FINAL_MARKER")
+          expect(result.output).not.toContain("\x1b[2K")
+          expect(result.output).not.toContain("...output truncated...")
+          expect(result.metadata.output).toContain("PROGRESS index=04999")
+          expect(result.metadata.truncated).toBe(false)
+          expect(updates.some((output) => output.includes("PROGRESS index=04999"))).toBe(true)
+          expect(updates.every((output) => (output.match(/PROGRESS index=/g)?.length ?? 0) <= 1)).toBe(true)
+          expect(updates.every((output) => !output.includes("\x1b[2K"))).toBe(true)
+
+          const outputPath = result.metadata.outputPath
+          expect(outputPath).toBeString()
+          if (typeof outputPath !== "string") return
+          const fs = yield* FSUtil.Service
+          const saved = yield* fs.readFileString(outputPath)
+          expect(saved.match(/PROGRESS index=/g)).toHaveLength(5000)
+          expect(saved).toContain("\x1b[2K\rPROGRESS index=00000")
+          expect(saved).toContain("FINAL_MARKER")
         }),
       ),
     )

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1125,11 +1125,12 @@ describe("tool.shell abort", () => {
           expect(updates.every((output) => (output.match(/PROGRESS index=/g)?.length ?? 0) <= 1)).toBe(true)
           expect(updates.every((output) => !output.includes("\x1b[2K"))).toBe(true)
 
-          const outputPath = result.metadata.outputPath
-          expect(outputPath).toBeString()
-          if (typeof outputPath !== "string") return
+          expect(result.metadata.outputPath).toBeUndefined()
+          const rawOutputPath = result.metadata.rawOutputPath
+          expect(rawOutputPath).toBeString()
+          if (typeof rawOutputPath !== "string") return
           const fs = yield* FSUtil.Service
-          const saved = yield* fs.readFileString(outputPath)
+          const saved = yield* fs.readFileString(rawOutputPath)
           expect(saved.match(/PROGRESS index=/g)).toHaveLength(5000)
           expect(saved).toContain("\x1b[2K\rPROGRESS index=00000")
           expect(saved).toContain("FINAL_MARKER")
@@ -1232,6 +1233,7 @@ describe("tool.shell truncation", () => {
 
         const filepath = (result.metadata as { outputPath?: string }).outputPath
         expect(filepath).toBeTruthy()
+        expect(result.metadata.rawOutputPath).toBeUndefined()
 
         const saved = yield* (yield* FSUtil.Service).readFileString(filepath!)
         const lines = saved.trim().split(/\r?\n/)


### PR DESCRIPTION
### Issue for this PR

Closes #36683

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Completed tool results are expected to be included in subsequent model context. This PR does not change when tool results are included or how long they remain in message history.

The bug is in the shell result content. Commands which redraw one line currently retain `\r` and ANSI erase-line frames, so the model receives obsolete progress history instead of the terminal-visible output. Output limits keep the result bounded, but these frames still waste space inside that limit and present stale versions of one logical line. In the core Bash path, enough raw refresh data can also reach the 1 MiB capture limit before the command's final output is collected.

This adds an incremental line-oriented terminal reducer and applies it before Bash capture limits in both the core Bash tool and the legacy shell tool. Ordinary newline-delimited text is preserved, while carriage returns, erase-line sequences, backspace, and horizontal cursor updates produce the final visible line. Live shell metadata and the completed result use the same line-update semantics.

The legacy path still writes raw output to disk, but reports it as `rawOutputPath` when the rendered tool result was not truncated. It also drains the output stream before building the final result so the last chunk cannot race process completion.

This intentionally keeps normal commands on the existing non-PTY path and does not try to emulate a full-screen terminal.

### How did you verify your code works?

- `cd packages/core && bun test test/terminal-output.test.ts test/process/process.test.ts test/tool-bash.test.ts` (45 passed)
- `cd packages/opencode && bun test test/tool/shell.test.ts` (24 passed)
- `bun typecheck` from `packages/core` and `packages/opencode`, run sequentially with a 3 GiB memory limit
- A real shell test writes 5,000 `ESC[2K` + `\r` frames and verifies that the completed tool result contains only the last visible frame and final marker, while the saved raw log still contains all 5,000 frames

### Screenshots / recordings

Not included. The behavior is covered by terminal reducer, process, and shell integration tests.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
