### PR TITLE
fix(ai): classify provider failures consistently

### DIFF
--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,7 +2,7 @@ export { LLMClient } from "./route/client"
 export { Auth } from "./route/auth"
 export { Provider } from "./provider"
 export { ProviderPackage } from "./provider-package"
-export { isContextOverflow, isContextOverflowFailure } from "./provider-error"
+export { classifyProviderFailure, isContextOverflow, isContextOverflowFailure } from "./provider-error"
 export type {
   RouteModelInput,
   RouteRoutedModelInput,

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -3,6 +3,7 @@ export { Auth } from "./route/auth"
 export { Provider } from "./provider"
 export { ProviderPackage } from "./provider-package"
 export { classifyProviderFailure, isContextOverflow, isContextOverflowFailure } from "./provider-error"
+export type { ProviderFailure } from "./provider-error"
 export type {
   RouteModelInput,
   RouteRoutedModelInput,

--- a/packages/ai/src/protocols/bedrock-event-stream.ts
+++ b/packages/ai/src/protocols/bedrock-event-stream.ts
@@ -1,6 +1,6 @@
 import { EventStreamCodec } from "@smithy/eventstream-codec"
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8"
-import { Effect, Stream } from "effect"
+import { Effect, Option, Schema, Stream } from "effect"
 import { Framing } from "../route/framing"
 import { ProviderShared } from "./shared"
 
@@ -53,8 +53,13 @@ const consumeFrames = (route: string) => (state: FrameBufferState, chunk: Uint8A
       })
       cursor = { buffer: cursor.buffer, offset: cursor.offset + totalLength }
 
-      if (decoded.headers[":message-type"]?.value !== "event") continue
-      const eventType = decoded.headers[":event-type"]?.value
+      const messageType = decoded.headers[":message-type"]?.value
+      const eventType =
+        messageType === "event"
+          ? decoded.headers[":event-type"]?.value
+          : messageType === "exception"
+            ? decoded.headers[":exception-type"]?.value
+            : undefined
       if (typeof eventType !== "string") continue
       const payload = utf8.decode(decoded.body)
       if (!payload) continue
@@ -83,5 +88,53 @@ export const framing = (route: string): Framing.Definition<object> => ({
   id: "aws-event-stream",
   frame: (bytes) => bytes.pipe(Stream.mapAccumEffect(() => initialFrameBuffer, consumeFrames(route))),
 })
+
+class StreamExceptionError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+  ) {
+    super(message)
+  }
+}
+
+// The AI SDK Bedrock decoder ignores AWS exception frames before its language
+// model stream can expose them. Fail the byte stream first so the shared AI SDK
+// adapter can classify the transport error instead of accepting a false finish.
+export function monitorExceptions(response: Response) {
+  if (!response.body || !response.headers.get("content-type")?.includes("application/vnd.amazon.eventstream"))
+    return response
+  let state = initialFrameBuffer
+  const body = response.body.pipeThrough(
+    new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        state = appendChunk(state, chunk)
+        while (state.buffer.length - state.offset >= 4) {
+          const view = state.buffer.subarray(state.offset)
+          const totalLength = new DataView(view.buffer, view.byteOffset, view.byteLength).getUint32(0, false)
+          if (view.length < totalLength) break
+          const decoded = eventCodec.decode(view.subarray(0, totalLength))
+          state = { buffer: state.buffer, offset: state.offset + totalLength }
+          const exceptionType = decoded.headers[":exception-type"]?.value
+          if (decoded.headers[":message-type"]?.value === "exception" && typeof exceptionType === "string") {
+            const payload = Option.getOrUndefined(
+              Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(utf8.decode(decoded.body)),
+            )
+            const message =
+              ProviderShared.isRecord(payload) && typeof payload.message === "string" ? payload.message : undefined
+            controller.error(new StreamExceptionError(message ?? `Bedrock ${exceptionType}`, exceptionType))
+            return
+          }
+        }
+        controller.enqueue(chunk)
+      },
+    }),
+  )
+  return new Response(body, {
+    headers: new Headers(response.headers),
+    status: response.status,
+    statusText: response.statusText,
+  })
+}
 
 export * as BedrockEventStream from "./bedrock-event-stream"

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -69,6 +69,8 @@ const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
 
 export interface ProviderFailure {
   readonly message: string
+  /** Provider text used only for classification and never retained on the resulting reason. */
+  readonly evidence?: string | undefined
   readonly status?: number | undefined
   readonly code?: string | undefined
   readonly retryAfterMs?: number | undefined
@@ -81,10 +83,11 @@ export interface ProviderFailure {
 // session retry policy never needs provider-specific string matching.
 export function classifyProviderFailure(input: ProviderFailure): LLMError["reason"] {
   const body = input.http?.body ?? ""
-  const codes = [input.code, ...providerCodes(body), ...providerCodes(input.message)]
+  const evidence = input.evidence ?? ""
+  const codes = [input.code, ...providerCodes(body), ...providerCodes(input.message), ...providerCodes(evidence)]
     .filter((code): code is string => code !== undefined)
     .map((code) => code.toLowerCase())
-  const text = body || input.message
+  const texts = [body, input.message, evidence]
   const common = { message: input.message, providerMetadata: input.providerMetadata, http: input.http }
   const clientScoped = input.status === undefined || (input.status >= 400 && input.status < 500)
 
@@ -92,12 +95,14 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
     clientScoped &&
     (codes.includes("context_length_exceeded") ||
       codes.includes("model_context_window_exceeded") ||
-      isContextOverflow(body) ||
-      isContextOverflow(input.message))
+      texts.some(isContextOverflow))
   )
     return new InvalidRequestReason({ ...common, classification: "context-overflow" })
-  if (CONTENT_POLICY_TEXT.test(text)) return new ContentPolicyReason(common)
-  if (codes.some((code) => QUOTA_CODES.has(code)) || (input.status === 429 && QUOTA_TEXT.test(text)))
+  if (texts.some((text) => CONTENT_POLICY_TEXT.test(text))) return new ContentPolicyReason(common)
+  if (
+    codes.some((code) => QUOTA_CODES.has(code)) ||
+    (input.status === 429 && texts.some((text) => QUOTA_TEXT.test(text)))
+  )
     return new QuotaExceededReason(common)
   if (input.status === 401) return new AuthenticationReason({ ...common, kind: "invalid" })
   if (input.status === 403) return new AuthenticationReason({ ...common, kind: "insufficient-permissions" })
@@ -112,7 +117,7 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
       retryAfterMs: input.retryAfterMs,
       rateLimit: input.rateLimit,
     })
-  if (RATE_LIMIT_TEXT.test(text))
+  if (texts.some((text) => RATE_LIMIT_TEXT.test(text)))
     return new RateLimitReason({
       ...common,
       retryAfterMs: input.retryAfterMs,
@@ -153,7 +158,10 @@ function providerCodes(value: string) {
   const decoded = Option.getOrUndefined(decodeJson(value))
   if (!isRecord(decoded)) return []
   const error = isRecord(decoded.error) ? decoded.error : undefined
-  return [decoded.code, error?.code, error?.type].filter((value): value is string => typeof value === "string")
+  const response = isRecord(decoded.response) ? decoded.response : undefined
+  const responseError = isRecord(response?.error) ? response.error : undefined
+  return [decoded.code, decoded.status, error?.code, error?.type, error?.status, responseError?.code, responseError?.type]
+    .filter((value): value is string => typeof value === "string")
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -57,7 +57,12 @@ const SERVER_CODES = new Set([
   "server_is_overloaded",
   "serviceunavailableexception",
 ])
-const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error", "validationexception"])
+const INVALID_REQUEST_CODES = new Set([
+  "invalid_prompt",
+  "invalid_request_error",
+  "request_too_large",
+  "validationexception",
+])
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
 const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
@@ -87,7 +92,8 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
     clientScoped &&
     (codes.includes("context_length_exceeded") ||
       codes.includes("model_context_window_exceeded") ||
-      isContextOverflow(text))
+      isContextOverflow(body) ||
+      isContextOverflow(input.message))
   )
     return new InvalidRequestReason({ ...common, classification: "context-overflow" })
   if (CONTENT_POLICY_TEXT.test(text)) return new ContentPolicyReason(common)
@@ -112,6 +118,7 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
       retryAfterMs: input.retryAfterMs,
       rateLimit: input.rateLimit,
     })
+  if (codes.some((code) => INVALID_REQUEST_CODES.has(code))) return new InvalidRequestReason(common)
   if (codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable")))
     return new ProviderInternalReason({
       ...common,
@@ -131,7 +138,6 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
       status: input.status,
       retryAfterMs: input.retryAfterMs,
     })
-  if (codes.some((code) => INVALID_REQUEST_CODES.has(code))) return new InvalidRequestReason(common)
   if (
     input.status === 400 ||
     input.status === 404 ||

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -46,26 +46,40 @@ export const isContextOverflowFailure = (failure: unknown) =>
     : Schema.is(ProviderErrorEvent)(failure) && failure.classification === "context-overflow"
 
 const decodeJson = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
+const CONTENT_POLICY_CODES = new Set(["content_filter", "content_policy_violation", "safety"])
 const QUOTA_CODES = new Set(["insufficient_quota", "usage_not_included", "billing_error"])
+const RATE_LIMIT_CODES = new Set(["resource_exhausted", "throttlingexception", "too_many_requests"])
 const SERVER_CODES = new Set([
   "api_error",
+  "internal",
   "internal_error",
+  "internal_server_error",
   "internalserverexception",
   "modelstreamerrorexception",
+  "modeltimeoutexception",
   "overloaded_error",
+  "response_error",
   "server_error",
   "server_is_overloaded",
   "serviceunavailableexception",
 ])
 const INVALID_REQUEST_CODES = new Set([
+  "invalid_argument",
   "invalid_prompt",
   "invalid_request_error",
+  "model_not_found",
+  "not_found",
+  "not_found_error",
+  "resourcenotfoundexception",
   "request_too_large",
   "validationexception",
 ])
-const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
+const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|throttl|too[_\s]?many[_\s]?requests/i
 const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
-const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
+const CONTENT_POLICY_TEXT =
+  /content[-_\s]?(?:filter|policy)|safety (?:filter|policy|rating)|blocked (?:by|due to) safety/i
+const INVALID_REQUEST_TEXT = /validation (?:error|exception)/i
+const SERVER_TEXT = /internal server error|service unavailable/i
 
 export interface ProviderFailure {
   readonly message: string
@@ -98,7 +112,8 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
       texts.some(isContextOverflow))
   )
     return new InvalidRequestReason({ ...common, classification: "context-overflow" })
-  if (texts.some((text) => CONTENT_POLICY_TEXT.test(text))) return new ContentPolicyReason(common)
+  if (codes.some((code) => CONTENT_POLICY_CODES.has(code)) || texts.some((text) => CONTENT_POLICY_TEXT.test(text)))
+    return new ContentPolicyReason(common)
   if (
     codes.some((code) => QUOTA_CODES.has(code)) ||
     (input.status === 429 && texts.some((text) => QUOTA_TEXT.test(text)))
@@ -106,12 +121,15 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
     return new QuotaExceededReason(common)
   if (input.status === 401) return new AuthenticationReason({ ...common, kind: "invalid" })
   if (input.status === 403) return new AuthenticationReason({ ...common, kind: "insufficient-permissions" })
-  if (codes.includes("authentication_error")) return new AuthenticationReason({ ...common, kind: "invalid" })
-  if (codes.includes("permission_error"))
-    return new AuthenticationReason({ ...common, kind: "insufficient-permissions" })
+  if (codes.some((code) => code === "authentication_error" || code === "unauthenticated"))
+    return new AuthenticationReason({ ...common, kind: "invalid" })
   if (
-    codes.some((code) => code.includes("rate_limit") || code === "too_many_requests" || code === "throttlingexception")
+    codes.some(
+      (code) => code === "accessdeniedexception" || code === "permission_error" || code === "permission_denied",
+    )
   )
+    return new AuthenticationReason({ ...common, kind: "insufficient-permissions" })
+  if (codes.some((code) => code.includes("rate_limit") || RATE_LIMIT_CODES.has(code)))
     return new RateLimitReason({
       ...common,
       retryAfterMs: input.retryAfterMs,
@@ -123,8 +141,12 @@ export function classifyProviderFailure(input: ProviderFailure): LLMError["reaso
       retryAfterMs: input.retryAfterMs,
       rateLimit: input.rateLimit,
     })
-  if (codes.some((code) => INVALID_REQUEST_CODES.has(code))) return new InvalidRequestReason(common)
-  if (codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable")))
+  if (codes.some((code) => INVALID_REQUEST_CODES.has(code)) || texts.some((text) => INVALID_REQUEST_TEXT.test(text)))
+    return new InvalidRequestReason(common)
+  if (
+    codes.some((code) => SERVER_CODES.has(code) || code.includes("unavailable")) ||
+    texts.some((text) => SERVER_TEXT.test(text))
+  )
     return new ProviderInternalReason({
       ...common,
       status: input.status,
@@ -160,8 +182,15 @@ function providerCodes(value: string) {
   const error = isRecord(decoded.error) ? decoded.error : undefined
   const response = isRecord(decoded.response) ? decoded.response : undefined
   const responseError = isRecord(response?.error) ? response.error : undefined
-  return [decoded.code, decoded.status, error?.code, error?.type, error?.status, responseError?.code, responseError?.type]
-    .filter((value): value is string => typeof value === "string")
+  return [
+    decoded.code,
+    decoded.status,
+    error?.code,
+    error?.type,
+    error?.status,
+    responseError?.code,
+    responseError?.type,
+  ].filter((value): value is string => typeof value === "string")
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/ai/src/route/executor.ts
+++ b/packages/ai/src/route/executor.ts
@@ -47,14 +47,15 @@ const isSensitiveHeaderName = (name: string) => SENSITIVE_NAME.test(name)
 
 const isSensitiveQueryName = (name: string) => isSensitiveHeaderName(name) || SHORT_QUERY_NAME.test(name)
 
-export const redactHeaders = (headers: Headers.Input, redactedNames: ReadonlyArray<string | RegExp> = []) =>
+const redactHeaders = (headers: Headers.Headers, redactedNames: ReadonlyArray<string | RegExp>) =>
   Object.fromEntries(
-    Object.entries(Headers.redact(Headers.fromInput(headers), [...redactedNames, SENSITIVE_NAME])).map(
-      ([name, value]) => [name, String(value)],
-    ),
+    Object.entries(Headers.redact(headers, [...redactedNames, SENSITIVE_NAME])).map(([name, value]) => [
+      name,
+      String(value),
+    ]),
   )
 
-export const redactUrl = (value: string) => {
+const redactUrl = (value: string) => {
   if (!URL.canParse(value)) return REDACTED
   const url = new URL(value)
   url.searchParams.forEach((_, key) => {
@@ -150,12 +151,7 @@ const responseDetails = (
     headers: redactHeaders(response.headers, redactedNames),
   })
 
-interface RedactionRequest {
-  readonly url: string
-  readonly headers: Headers.Input
-}
-
-const secretValues = (request: RedactionRequest) => {
+const secretValues = (request: HttpClientRequest.HttpClientRequest) => {
   const values = new Set<string>()
   const add = (value: string) => {
     if (value.length < 4) return
@@ -180,13 +176,13 @@ const secretValues = (request: RedactionRequest) => {
 // Two passes: structural (redact `"name": "value"` and `name=value` patterns
 // for any field name that looks sensitive) plus literal (replace any actual
 // secret values we sent in the request, in case the response echoes one back).
-const redactBody = (body: string, request: RedactionRequest) =>
+const redactBody = (body: string, request: HttpClientRequest.HttpClientRequest) =>
   Array.from(secretValues(request)).reduce(
     (text, secret) => text.split(secret).join(REDACTED),
     body.replace(REDACT_JSON_FIELD, `$1"${REDACTED}"`).replace(REDACT_QUERY_FIELD, `$1${REDACTED}`),
   )
 
-export const redactResponseBody = (body: string | void, request: RedactionRequest) => {
+const responseBody = (body: string | void, request: HttpClientRequest.HttpClientRequest) => {
   if (body === undefined) return {}
   const redacted = redactBody(body, request)
   if (redacted.length <= BODY_LIMIT) return { body: redacted }
@@ -202,7 +198,7 @@ const responseHttp = (input: {
   readonly request: HttpClientRequest.HttpClientRequest
   readonly response: HttpClientResponse.HttpClientResponse
   readonly redactedNames: ReadonlyArray<string | RegExp>
-  readonly body: ReturnType<typeof redactResponseBody>
+  readonly body: ReturnType<typeof responseBody>
   readonly requestId?: string | undefined
   readonly rateLimit?: HttpRateLimitDetails | undefined
 }) =>
@@ -223,7 +219,7 @@ const statusError =
       const headers = normalizedHeaders(response.headers)
       const retryAfter = retryAfterMs(headers)
       const rateLimit = rateLimitDetails(headers, retryAfter)
-      const details = redactResponseBody(body, request)
+      const details = responseBody(body, request)
       return yield* new LLMError({
         module: "RequestExecutor",
         method: "execute",

--- a/packages/ai/src/route/executor.ts
+++ b/packages/ai/src/route/executor.ts
@@ -47,15 +47,14 @@ const isSensitiveHeaderName = (name: string) => SENSITIVE_NAME.test(name)
 
 const isSensitiveQueryName = (name: string) => isSensitiveHeaderName(name) || SHORT_QUERY_NAME.test(name)
 
-const redactHeaders = (headers: Headers.Headers, redactedNames: ReadonlyArray<string | RegExp>) =>
+export const redactHeaders = (headers: Headers.Input, redactedNames: ReadonlyArray<string | RegExp> = []) =>
   Object.fromEntries(
-    Object.entries(Headers.redact(headers, [...redactedNames, SENSITIVE_NAME])).map(([name, value]) => [
-      name,
-      String(value),
-    ]),
+    Object.entries(Headers.redact(Headers.fromInput(headers), [...redactedNames, SENSITIVE_NAME])).map(
+      ([name, value]) => [name, String(value)],
+    ),
   )
 
-const redactUrl = (value: string) => {
+export const redactUrl = (value: string) => {
   if (!URL.canParse(value)) return REDACTED
   const url = new URL(value)
   url.searchParams.forEach((_, key) => {
@@ -151,7 +150,12 @@ const responseDetails = (
     headers: redactHeaders(response.headers, redactedNames),
   })
 
-const secretValues = (request: HttpClientRequest.HttpClientRequest) => {
+interface RedactionRequest {
+  readonly url: string
+  readonly headers: Headers.Input
+}
+
+const secretValues = (request: RedactionRequest) => {
   const values = new Set<string>()
   const add = (value: string) => {
     if (value.length < 4) return
@@ -176,13 +180,13 @@ const secretValues = (request: HttpClientRequest.HttpClientRequest) => {
 // Two passes: structural (redact `"name": "value"` and `name=value` patterns
 // for any field name that looks sensitive) plus literal (replace any actual
 // secret values we sent in the request, in case the response echoes one back).
-const redactBody = (body: string, request: HttpClientRequest.HttpClientRequest) =>
+const redactBody = (body: string, request: RedactionRequest) =>
   Array.from(secretValues(request)).reduce(
     (text, secret) => text.split(secret).join(REDACTED),
     body.replace(REDACT_JSON_FIELD, `$1"${REDACTED}"`).replace(REDACT_QUERY_FIELD, `$1${REDACTED}`),
   )
 
-const responseBody = (body: string | void, request: HttpClientRequest.HttpClientRequest) => {
+export const redactResponseBody = (body: string | void, request: RedactionRequest) => {
   if (body === undefined) return {}
   const redacted = redactBody(body, request)
   if (redacted.length <= BODY_LIMIT) return { body: redacted }
@@ -198,7 +202,7 @@ const responseHttp = (input: {
   readonly request: HttpClientRequest.HttpClientRequest
   readonly response: HttpClientResponse.HttpClientResponse
   readonly redactedNames: ReadonlyArray<string | RegExp>
-  readonly body: ReturnType<typeof responseBody>
+  readonly body: ReturnType<typeof redactResponseBody>
   readonly requestId?: string | undefined
   readonly rateLimit?: HttpRateLimitDetails | undefined
 }) =>
@@ -219,7 +223,7 @@ const statusError =
       const headers = normalizedHeaders(response.headers)
       const retryAfter = retryAfterMs(headers)
       const rateLimit = rateLimitDetails(headers, retryAfter)
-      const details = responseBody(body, request)
+      const details = redactResponseBody(body, request)
       return yield* new LLMError({
         module: "RequestExecutor",
         method: "execute",
@@ -240,7 +244,32 @@ const statusError =
       })
     })
 
-const toHttpError = (redactedNames: ReadonlyArray<string | RegExp>) => (error: unknown) => {
+const TIMEOUT_CODES = new Set([
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+])
+
+const errorCause = (error: unknown) => {
+  if (HttpClientError.isHttpClientError(error) && "cause" in error.reason) return error.reason.cause
+  return error instanceof Error ? error.cause : undefined
+}
+
+const errorCode = (error: unknown) => {
+  if (typeof error !== "object" || error === null) return undefined
+  const code = Reflect.get(error, "code")
+  return typeof code === "string" ? code.toUpperCase() : undefined
+}
+
+const errorMessage = (error: unknown, fallback: string) => {
+  const cause = errorCause(error)
+  if (cause instanceof Error) return cause.message
+  if (error instanceof Error) return error.message
+  return fallback
+}
+
+export const mapHttpClientError = (error: unknown, redactedNames: ReadonlyArray<string | RegExp>) => {
   const transportError = (input: {
     readonly message: string
     readonly kind?: string | undefined
@@ -257,23 +286,30 @@ const toHttpError = (redactedNames: ReadonlyArray<string | RegExp>) => (error: u
       }),
     })
 
-  if (Cause.isTimeoutError(error)) {
-    return transportError({ message: error.message, kind: "Timeout" })
-  }
+  const cause = errorCause(error)
+  const code = errorCode(cause) ?? errorCode(error)
+  const request = HttpClientError.isHttpClientError(error) ? error.request : undefined
+  if (
+    Cause.isTimeoutError(error) ||
+    Cause.isTimeoutError(cause) ||
+    (error instanceof Error && error.name === "TimeoutError") ||
+    (cause instanceof Error && cause.name === "TimeoutError") ||
+    (code !== undefined && TIMEOUT_CODES.has(code))
+  )
+    return transportError({ message: errorMessage(error, "HTTP transport timed out"), kind: code ?? "Timeout", request })
   if (!HttpClientError.isHttpClientError(error)) {
-    return transportError({ message: "HTTP transport failed" })
+    return transportError({ message: errorMessage(error, "HTTP transport failed"), kind: code })
   }
-  const request = "request" in error ? error.request : undefined
   if (error.reason._tag === "TransportError") {
     return transportError({
-      message: error.reason.description ?? "HTTP transport failed",
-      kind: error.reason._tag,
+      message: error.reason.description ?? errorMessage(error, "HTTP transport failed"),
+      kind: code ?? error.reason._tag,
       request,
     })
   }
   return transportError({
-    message: `HTTP transport failed: ${error.reason._tag}`,
-    kind: error.reason._tag,
+    message: errorMessage(error, `HTTP transport failed: ${error.reason._tag}`),
+    kind: code ?? error.reason._tag,
     request,
   })
 }
@@ -287,7 +323,10 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient> = Layer.e
         const redactedNames = yield* Headers.CurrentRedactedNames
         return yield* http
           .execute(request)
-          .pipe(Effect.mapError(toHttpError(redactedNames)), Effect.flatMap(statusError(request, redactedNames)))
+          .pipe(
+            Effect.mapError((error) => mapHttpClientError(error, redactedNames)),
+            Effect.flatMap(statusError(request, redactedNames)),
+          )
       })
     return Service.of({
       execute: executeOnce,

--- a/packages/ai/src/route/index.ts
+++ b/packages/ai/src/route/index.ts
@@ -9,7 +9,8 @@ export type {
   Interface as LLMClientShape,
   Service as LLMClientService,
 } from "./client"
-export * from "./executor"
+export { RequestExecutor, Service, fetchLayer, layer } from "./executor"
+export type { Interface } from "./executor"
 export { Auth } from "./auth"
 export { AuthOptions } from "./auth-options"
 export { Endpoint } from "./endpoint"

--- a/packages/ai/src/route/transport/http.ts
+++ b/packages/ai/src/route/transport/http.ts
@@ -6,6 +6,7 @@ import { Framing } from "../framing"
 import type { Transport, TransportPrepareInput } from "./index"
 import * as ProviderShared from "../../protocols/shared"
 import { mergeJsonRecords, type LLMRequest } from "../../schema"
+import { mapHttpClientError } from "../executor"
 
 export type JsonRequestInput<Body> = TransportPrepareInput<Body>
 
@@ -134,14 +135,10 @@ export const httpJson = <Body, Frame>(input: HttpJsonInput<Body, Frame>): HttpJs
         .execute(prepared.request)
         .pipe(
           Effect.map((response) =>
-            prepared.framing.frame(
-              response.stream.pipe(
-                Stream.mapError((error) =>
-                  ProviderShared.eventError(
-                    `${request.model.provider}/${request.model.route.id}`,
-                    `Failed to read ${request.model.provider}/${request.model.route.id} stream`,
-                    ProviderShared.errorText(error),
-                  ),
+            Stream.unwrap(
+              Effect.map(Headers.CurrentRedactedNames, (redactedNames) =>
+                prepared.framing.frame(
+                  response.stream.pipe(Stream.mapError((error) => mapHttpClientError(error, redactedNames))),
                 ),
               ),
             ),

--- a/packages/ai/test/executor.test.ts
+++ b/packages/ai/test/executor.test.ts
@@ -121,6 +121,7 @@ describe("RequestExecutor", () => {
       yield* classify("Request rate increased too quickly")
       yield* classify('{"type":"error","error":{"type":"too_many_requests"}}')
       yield* classify('{"type":"error","error":{"code":"rate_limit_exceeded"}}')
+      yield* classify('{"code":"resource_exhausted"}')
     }),
   )
 
@@ -135,7 +136,6 @@ describe("RequestExecutor", () => {
           expect(error.reason).toMatchObject({ _tag: "ProviderInternal" })
         }).pipe(Effect.provide(responsesLayer([new Response(body, { status: 400 })])))
 
-      yield* classify('{"code":"resource_exhausted"}')
       yield* classify('{"code":"service_unavailable"}')
     }),
   )

--- a/packages/ai/test/lib/http.ts
+++ b/packages/ai/test/lib/http.ts
@@ -63,14 +63,14 @@ export const dynamicResponse = (handler: Handler) => runtimeLayer(handlerLayer(h
  * Layer that emits the supplied SSE chunks and then aborts mid-stream. Used to
  * exercise transport errors that surface during parsing.
  */
-export const truncatedStream = (chunks: ReadonlyArray<string>) =>
+export const truncatedStream = (chunks: ReadonlyArray<string>, error: unknown = new Error("connection reset")) =>
   dynamicResponse((input) =>
     Effect.sync(() => {
       const encoder = new TextEncoder()
       const stream = new ReadableStream({
         start(controller) {
           for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
-          controller.error(new Error("connection reset"))
+          controller.error(error)
         },
       })
       return input.respond(stream, { headers: SSE_HEADERS })

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -61,8 +61,9 @@ describe("provider error classification", () => {
         '{"code":"bad_request","error":{"code":"usage_not_included"}}',
         '{"code":"bad_request","error":{"code":"server_error"}}',
         '{"code":"bad_request","error":{"type":"invalid_request_error"}}',
+        '{"type":"response.failed","response":{"error":{"code":"server_error"}}}',
       ].map((message) => classifyProviderFailure({ message })._tag),
-    ).toEqual(["QuotaExceeded", "ProviderInternal", "InvalidRequest"])
+    ).toEqual(["QuotaExceeded", "ProviderInternal", "InvalidRequest", "ProviderInternal"])
   })
 
   test("keeps unknown and malformed provider payloads non-retryable", () => {

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -26,6 +26,14 @@ describe("provider error classification", () => {
     )
   })
 
+  test("does not treat incidental safety text as a content-policy failure", () => {
+    expect(classifyProviderFailure({ message: "Internal safety check failed", status: 500 })._tag).toBe(
+      "ProviderInternal",
+    )
+    expect(classifyProviderFailure({ message: "Blocked by safety policy", status: 400 })._tag).toBe("ContentPolicy")
+    expect(classifyProviderFailure({ message: "Blocked", status: 400, code: "SAFETY" })._tag).toBe("ContentPolicy")
+  })
+
   test("classifies V1 plain-text rate limit fallbacks", () => {
     expect(
       [
@@ -47,12 +55,48 @@ describe("provider error classification", () => {
     ).toEqual(["RateLimit", "RateLimit", "RateLimit", "RateLimit"])
   })
 
-  test("classifies V1 overloaded provider codes", () => {
+  test("classifies canonical provider retry codes", () => {
     expect(
       ['{"code":"resource_exhausted"}', '{"code":"service_unavailable"}'].map(
         (message) => classifyProviderFailure({ message })._tag,
       ),
-    ).toEqual(["ProviderInternal", "ProviderInternal"])
+    ).toEqual(["RateLimit", "ProviderInternal"])
+  })
+
+  test("keeps temporary per-minute quota wording retryable", () => {
+    expect(classifyProviderFailure({ message: "You exceeded your per-minute quota", status: 429 })._tag).toBe(
+      "RateLimit",
+    )
+  })
+
+  test("classifies canonical Google error codes", () => {
+    expect(
+      ["UNAUTHENTICATED", "PERMISSION_DENIED", "INVALID_ARGUMENT", "NOT_FOUND", "INTERNAL"].map(
+        (code) => classifyProviderFailure({ message: "Provider failed", code })._tag,
+      ),
+    ).toEqual(["Authentication", "Authentication", "InvalidRequest", "InvalidRequest", "ProviderInternal"])
+  })
+
+  test("classifies stripped Bedrock stream errors from their messages", () => {
+    expect(
+      ["Internal server error", "Throttling exception", "Validation error: invalid input"].map(
+        (message) => classifyProviderFailure({ message })._tag,
+      ),
+    ).toEqual(["ProviderInternal", "RateLimit", "InvalidRequest"])
+  })
+
+  test("classifies documented Bedrock exception codes", () => {
+    expect(
+      ["accessDeniedException", "modelTimeoutException", "resourceNotFoundException"].map(
+        (code) => classifyProviderFailure({ message: "Bedrock failed", code })._tag,
+      ),
+    ).toEqual(["Authentication", "ProviderInternal", "InvalidRequest"])
+  })
+
+  test("classifies Anthropic not-found stream errors as invalid requests", () => {
+    expect(classifyProviderFailure({ message: "Model unavailable", code: "not_found_error" })._tag).toBe(
+      "InvalidRequest",
+    )
   })
 
   test("classifies nested provider codes when a top-level code is also present", () => {

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -1,10 +1,29 @@
 import { describe, expect, test } from "bun:test"
-import { isContextOverflow } from "../src"
+import { HttpContext, HttpRequestDetails, isContextOverflow } from "../src"
 import { classifyProviderFailure } from "../src/provider-error"
 
 describe("provider error classification", () => {
   test("classifies Z.AI GLM token limit messages as context overflow", () => {
     expect(isContextOverflow("tokens in request more than max tokens allowed")).toBe(true)
+  })
+
+  test("checks overflow evidence in the message when the response body is uninformative", () => {
+    expect(
+      classifyProviderFailure({
+        message: "Input is too long for requested model",
+        status: 400,
+        http: new HttpContext({
+          request: new HttpRequestDetails({ method: "POST", url: "https://provider.test", headers: {} }),
+          body: "{}",
+        }),
+      }),
+    ).toMatchObject({ classification: "context-overflow" })
+  })
+
+  test("lets semantic invalid-request codes override server status", () => {
+    expect(classifyProviderFailure({ message: "too large", status: 500, code: "request_too_large" })._tag).toBe(
+      "InvalidRequest",
+    )
   })
 
   test("classifies V1 plain-text rate limit fallbacks", () => {

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -6,6 +6,7 @@ import { CacheHint, LLM, Message, ToolCallPart, ToolChoice } from "../../src"
 import { LLMClient } from "../../src/route"
 import { AmazonBedrock } from "../../src/providers"
 import * as BedrockConverse from "../../src/protocols/bedrock-converse"
+import { BedrockEventStream } from "../../src/protocols/bedrock-event-stream"
 import { it } from "../lib/effect"
 import { fixedResponse } from "../lib/http"
 import {
@@ -34,6 +35,16 @@ const eventFrame = (type: string, payload: object) =>
     body: utf8Encoder.encode(JSON.stringify(payload)),
   })
 
+const exceptionFrame = (type: string, payload: object) =>
+  codec.encode({
+    headers: {
+      ":message-type": { type: "string", value: "exception" },
+      ":exception-type": { type: "string", value: type },
+      ":content-type": { type: "string", value: "application/json" },
+    },
+    body: utf8Encoder.encode(JSON.stringify(payload)),
+  })
+
 const concat = (frames: ReadonlyArray<Uint8Array>) => {
   const total = frames.reduce((sum, frame) => sum + frame.length, 0)
   const out = new Uint8Array(total)
@@ -47,6 +58,8 @@ const concat = (frames: ReadonlyArray<Uint8Array>) => {
 
 const eventStreamBody = (...payloads: ReadonlyArray<readonly [string, object]>) =>
   concat(payloads.map(([type, payload]) => eventFrame(type, payload)))
+
+const exceptionStreamBody = (type: string, payload: object) => exceptionFrame(type, payload)
 
 // Override the default SSE content-type with the binary event-stream type so
 // the cassette layer treats the body as bytes when recording.
@@ -357,10 +370,10 @@ describe("Bedrock Converse route", () => {
 
   it.effect("classifies throttlingException as a rate limit", () =>
     Effect.gen(function* () {
-      const body = eventStreamBody(
-        ["messageStart", { role: "assistant" }],
-        ["throttlingException", { message: "Slow down" }],
-      )
+      const body = concat([
+        eventStreamBody(["messageStart", { role: "assistant" }]),
+        exceptionStreamBody("throttlingException", { message: "Slow down" }),
+      ])
       const error = yield* LLMClient.generate(baseRequest).pipe(Effect.provide(fixedBytes(body)), Effect.flip)
 
       expect(error.reason).toMatchObject({ _tag: "RateLimit", message: "Slow down" })
@@ -371,7 +384,7 @@ describe("Bedrock Converse route", () => {
     Effect.gen(function* () {
       const error = yield* LLMClient.generate(baseRequest).pipe(
         Effect.provide(
-          fixedBytes(eventStreamBody(["validationException", { message: "Input is too long for requested model" }])),
+          fixedBytes(exceptionStreamBody("validationException", { message: "Input is too long for requested model" })),
         ),
         Effect.flip,
       )
@@ -381,6 +394,35 @@ describe("Bedrock Converse route", () => {
         message: "Input is too long for requested model",
         classification: "context-overflow",
       })
+    }),
+  )
+
+  it.effect("fails monitored AI SDK bodies on exception wire frames", () =>
+    Effect.gen(function* () {
+      const response = BedrockEventStream.monitorExceptions(
+        new Response(exceptionStreamBody("throttlingException", { message: "Slow down" }), {
+          headers: { "content-type": "application/vnd.amazon.eventstream" },
+        }),
+      )
+      const error = yield* Effect.tryPromise({
+        try: () => response.arrayBuffer(),
+        catch: (error) => error,
+      }).pipe(Effect.flip)
+
+      expect(error).toMatchObject({ code: "throttlingException", message: "Slow down" })
+    }),
+  )
+
+  it.effect("classifies serviceUnavailableException wire frames as provider failures", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(baseRequest).pipe(
+        Effect.provide(
+          fixedBytes(exceptionStreamBody("serviceUnavailableException", { message: "Service unavailable" })),
+        ),
+        Effect.flip,
+      )
+
+      expect(error.reason).toMatchObject({ _tag: "ProviderInternal", message: "Service unavailable" })
     }),
   )
 

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -651,7 +651,22 @@ describe("OpenAI Chat route", () => {
       ])
       const error = yield* LLMClient.generate(request).pipe(Effect.provide(layer), Effect.flip)
 
-      expect(error.message).toContain("Failed to read openai/openai-chat stream")
+      expect(error).toMatchObject({ reason: { _tag: "Transport", message: "connection reset" } })
+    }),
+  )
+
+  it.effect("classifies response body timeouts as transport timeouts", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          truncatedStream([], Object.assign(new Error("body timed out"), { code: "UND_ERR_BODY_TIMEOUT" })),
+        ),
+        Effect.flip,
+      )
+
+      expect(error).toMatchObject({
+        reason: { _tag: "Transport", kind: "UND_ERR_BODY_TIMEOUT", message: "body timed out" },
+      })
     }),
   )
 

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -15,7 +15,13 @@ import type {
   SharedV3ProviderOptions,
 } from "@ai-sdk/provider"
 import {
+  AuthenticationReason,
+  classifyProviderFailure,
   FinishReason,
+  HttpContext,
+  HttpRequestDetails,
+  HttpResponseDetails,
+  InvalidRequestReason,
   InvalidProviderOutputReason,
   LLMEvent,
   LLMError,
@@ -23,13 +29,28 @@ import {
   ProviderID,
   ProviderMetadata,
   ToolResultValue,
+  TransportReason,
   UnknownProviderReason,
   type ContentPart,
   type LLMRequest,
   type ToolDefinition,
   type UsageInput,
 } from "@opencode-ai/ai"
-import { Auth, Endpoint, type AnyRoute } from "@opencode-ai/ai/route"
+import {
+  APICallError,
+  EmptyResponseBodyError,
+  InvalidArgumentError,
+  InvalidPromptError,
+  InvalidResponseDataError,
+  JSONParseError,
+  LoadAPIKeyError,
+  LoadSettingError,
+  NoContentGeneratedError,
+  NoSuchModelError,
+  TypeValidationError,
+  UnsupportedFunctionalityError,
+} from "@ai-sdk/provider"
+import { Auth, Endpoint, RequestExecutor, type AnyRoute } from "@opencode-ai/ai/route"
 import { Cause, Context, Effect, Layer, Option, Schema, Scope, Stream } from "effect"
 import { ModelV2 } from "./model"
 import { ProviderV2 } from "./provider"
@@ -39,6 +60,8 @@ type SDK = any
 type UserContent = Extract<LanguageModelV3Message, { role: "user" }>["content"]
 type AssistantContent = Extract<LanguageModelV3Message, { role: "assistant" }>["content"]
 type ToolResultContent = Extract<AssistantContent[number], { type: "tool-result" }>
+
+class ChunkTimeoutError extends Error {}
 
 export interface SDKEvent {
   readonly model: ModelV2.Info
@@ -64,7 +87,7 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
     async pull(ctrl) {
       const part = await new Promise<Awaited<ReturnType<typeof reader.read>>>((resolve, reject) => {
         const id = setTimeout(() => {
-          const err = new Error("SSE read timed out")
+          const err = new ChunkTimeoutError("SSE read timed out")
           ctl.abort(err)
           void reader.cancel(err)
           reject(err)
@@ -716,15 +739,145 @@ function messageValue(input: unknown) {
 }
 
 function llmError(method: string, error: unknown) {
-  const reason =
-    error instanceof LLMError
-      ? new InvalidProviderOutputReason({ message: error.message })
-      : new UnknownProviderReason({ message: error instanceof Error ? error.message : String(error) })
+  if (error instanceof LLMError) return error
+  const cause = error instanceof Error ? error.cause : undefined
+  const failures = [error, cause]
+  const code = failures.map(machineCode).find((value) => value !== undefined)
+  const reason = (() => {
+    if (
+      error instanceof ChunkTimeoutError ||
+      failures.some((failure) => failure instanceof Error && failure.name === "TimeoutError") ||
+      (code !== undefined && TRANSPORT_TIMEOUT_CODES.has(code))
+    )
+      return new TransportReason({ message: errorMessage(error), kind: code ?? "Timeout" })
+    if (APICallError.isInstance(error)) return apiCallReason(error)
+    if (code !== undefined && TRANSPORT_CONNECTION_CODES.has(code))
+      return new TransportReason({ message: errorMessage(error), kind: code })
+    const malformed = failures.find(isMalformedError)
+    if (malformed) return new InvalidProviderOutputReason({ message: malformed.message })
+    if (LoadAPIKeyError.isInstance(error))
+      return new AuthenticationReason({ message: error.message, kind: "missing" })
+    if (NoSuchModelError.isInstance(error)) return new InvalidRequestReason({ message: error.message })
+    if (
+      LoadSettingError.isInstance(error) ||
+      InvalidPromptError.isInstance(error) ||
+      InvalidArgumentError.isInstance(error) ||
+      UnsupportedFunctionalityError.isInstance(error)
+    )
+      return new InvalidRequestReason({ message: error.message })
+    const providerCode = apiFailureCode(error)
+    if (providerCode)
+      return classifyProviderFailure({ message: apiFailureMessage(error), code: providerCode })
+    return new UnknownProviderReason({ message: errorMessage(error) })
+  })()
   return new LLMError({
     module: "AISDK",
     method,
     reason,
   })
+}
+
+function apiCallReason(error: APICallError) {
+  const malformed = isMalformedError(error.cause) ? error.cause : undefined
+  if (error.statusCode !== undefined && error.statusCode < 400 && malformed)
+    return new InvalidProviderOutputReason({ message: malformed.message })
+  const code = apiFailureCode(error.data) ?? apiFailureCode(error.responseBody)
+  if (error.statusCode === undefined) {
+    if (code) return classifyProviderFailure({ message: error.message, code })
+    if (error.isRetryable)
+      return new TransportReason({ message: error.message, url: RequestExecutor.redactUrl(error.url) })
+    return new UnknownProviderReason({ message: error.message })
+  }
+  const body = RequestExecutor.redactResponseBody(error.responseBody, {
+    url: error.url,
+    headers: error.responseHeaders ?? {},
+  })
+  return classifyProviderFailure({
+    message: error.message,
+    status: error.statusCode,
+    code,
+    retryAfterMs: retryAfterMs(error.responseHeaders),
+    http: new HttpContext({
+      request: new HttpRequestDetails({ method: "POST", url: RequestExecutor.redactUrl(error.url), headers: {} }),
+      response: new HttpResponseDetails({
+        status: error.statusCode,
+        headers: RequestExecutor.redactHeaders(error.responseHeaders ?? {}),
+      }),
+      ...body,
+    }),
+  })
+}
+
+const TRANSPORT_TIMEOUT_CODES = new Set([
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+])
+const TRANSPORT_CONNECTION_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "UND_ERR_SOCKET",
+])
+
+function retryAfterMs(headers: Record<string, string> | undefined) {
+  if (!headers) return undefined
+  const millis = Number(headers["retry-after-ms"])
+  if (Number.isFinite(millis)) return Math.max(0, millis)
+  const value = headers["retry-after"]
+  if (!value) return undefined
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+  const date = Date.parse(value)
+  return Number.isNaN(date) ? undefined : Math.max(0, date - Date.now())
+}
+
+function field(error: unknown, name: string) {
+  return typeof error === "object" && error !== null ? Reflect.get(error, name) : undefined
+}
+
+function machineCode(error: unknown) {
+  const code = field(error, "code")
+  return typeof code === "string" ? code.toUpperCase() : undefined
+}
+
+function apiFailureCode(error: unknown): string | undefined {
+  if (typeof error === "string") {
+    const decoded = Option.getOrUndefined(Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(error))
+    return apiFailureCode(decoded)
+  }
+  const code = field(error, "code")
+  if (typeof code === "string") return code
+  const type = field(error, "type")
+  if (typeof type === "string" && type !== "error") return type
+  const nested = field(error, "error")
+  return nested === undefined || nested === error ? undefined : apiFailureCode(nested)
+}
+
+function apiFailureMessage(error: unknown) {
+  const message = field(error, "message")
+  if (typeof message === "string") return message
+  const nested = field(field(error, "error"), "message")
+  return typeof nested === "string" ? nested : String(error)
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isMalformedError(error: unknown): error is Error {
+  return (
+    InvalidResponseDataError.isInstance(error) ||
+    JSONParseError.isInstance(error) ||
+    TypeValidationError.isInstance(error) ||
+    EmptyResponseBodyError.isInstance(error) ||
+    NoContentGeneratedError.isInstance(error)
+  )
 }
 
 export const node = makeLocationNode({ service: Service, layer: locationLayer, deps: [] })

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -1,38 +1,6 @@
 export * as AISDK from "./aisdk"
 
 import { makeLocationNode } from "./effect/app-node"
-import type {
-  JSONSchema7,
-  JSONValue,
-  LanguageModelV3,
-  LanguageModelV3CallOptions,
-  LanguageModelV3FinishReason,
-  LanguageModelV3FunctionTool,
-  LanguageModelV3Message,
-  LanguageModelV3Prompt,
-  LanguageModelV3StreamPart,
-  LanguageModelV3ToolChoice,
-  SharedV3ProviderOptions,
-} from "@ai-sdk/provider"
-import {
-  AuthenticationReason,
-  classifyProviderFailure,
-  FinishReason,
-  InvalidRequestReason,
-  InvalidProviderOutputReason,
-  LLMEvent,
-  LLMError,
-  Model,
-  ProviderID,
-  ProviderMetadata,
-  ToolResultValue,
-  TransportReason,
-  UnknownProviderReason,
-  type ContentPart,
-  type LLMRequest,
-  type ToolDefinition,
-  type UsageInput,
-} from "@opencode-ai/ai"
 import {
   APICallError,
   EmptyResponseBodyError,
@@ -46,7 +14,38 @@ import {
   NoSuchModelError,
   TypeValidationError,
   UnsupportedFunctionalityError,
+  type JSONSchema7,
+  type JSONValue,
+  type LanguageModelV3,
+  type LanguageModelV3CallOptions,
+  type LanguageModelV3FinishReason,
+  type LanguageModelV3FunctionTool,
+  type LanguageModelV3Message,
+  type LanguageModelV3Prompt,
+  type LanguageModelV3StreamPart,
+  type LanguageModelV3ToolChoice,
+  type SharedV3ProviderOptions,
 } from "@ai-sdk/provider"
+import {
+  AuthenticationReason,
+  classifyProviderFailure,
+  FinishReason,
+  InvalidRequestReason,
+  InvalidProviderOutputReason,
+  LLMEvent,
+  LLMError,
+  Model,
+  ProviderID,
+  ProviderInternalReason,
+  ProviderMetadata,
+  ToolResultValue,
+  TransportReason,
+  UnknownProviderReason,
+  type ContentPart,
+  type LLMRequest,
+  type ToolDefinition,
+  type UsageInput,
+} from "@opencode-ai/ai"
 import { Auth, Endpoint, type AnyRoute } from "@opencode-ai/ai/route"
 import { Cause, Context, Effect, Layer, Option, Schema, Scope, Stream } from "effect"
 import { ModelV2 } from "./model"
@@ -762,9 +761,12 @@ function llmError(method: string, error: unknown) {
       UnsupportedFunctionalityError.isInstance(error)
     )
       return new InvalidRequestReason({ message: error.message })
-    const providerCode = apiFailureCode(error)
-    if (providerCode)
-      return classifyProviderFailure({ message: apiFailureMessage(error), code: providerCode })
+    const providerReason = classifyProviderFailure({
+      message: apiFailureMessage(error),
+      code: apiFailureCode(error),
+      status: apiFailureStatus(error),
+    })
+    if (providerReason._tag !== "UnknownProvider") return providerReason
     return new UnknownProviderReason({ message: errorMessage(error) })
   })()
   return new LLMError({
@@ -780,15 +782,28 @@ function apiCallReason(error: APICallError) {
     return new InvalidProviderOutputReason({ message: malformed.message })
   const code = apiFailureCode(error.data) ?? apiFailureCode(error.responseBody)
   if (error.statusCode === undefined) {
-    if (code) return classifyProviderFailure({ message: error.message, code })
+    const reason =
+      code === undefined && error.responseBody === undefined
+        ? undefined
+        : classifyProviderFailure({ message: error.message, code, evidence: error.responseBody })
+    if (reason && reason._tag !== "UnknownProvider") return reason
     if (error.isRetryable) return new TransportReason({ message: error.message })
-    return new UnknownProviderReason({ message: error.message })
+    return reason ?? new UnknownProviderReason({ message: error.message })
   }
-  return classifyProviderFailure({
+  const retryAfter = retryAfterMs(error.responseHeaders)
+  const reason = classifyProviderFailure({
     message: error.message,
+    evidence: error.responseBody,
     status: error.statusCode,
     code,
+    retryAfterMs: retryAfter,
   })
+  if (!error.isRetryable || (reason._tag !== "UnknownProvider" && reason._tag !== "InvalidRequest")) return reason
+  if (
+    classifyProviderFailure({ message: error.message, evidence: error.responseBody, code })._tag !== "UnknownProvider"
+  )
+    return reason
+  return new ProviderInternalReason({ message: error.message, status: error.statusCode, retryAfterMs: retryAfter })
 }
 
 const TRANSPORT_TIMEOUT_CODES = new Set([
@@ -798,6 +813,8 @@ const TRANSPORT_TIMEOUT_CODES = new Set([
   "UND_ERR_HEADERS_TIMEOUT",
 ])
 const TRANSPORT_CONNECTION_CODES = new Set([
+  "CONNECTIONCLOSED",
+  "CONNECTIONREFUSED",
   "EAI_AGAIN",
   "ECONNREFUSED",
   "ECONNRESET",
@@ -805,6 +822,7 @@ const TRANSPORT_CONNECTION_CODES = new Set([
   "ENETUNREACH",
   "ENOTFOUND",
   "EPIPE",
+  "FAILEDTOOPENSOCKET",
   "UND_ERR_SOCKET",
 ])
 
@@ -822,19 +840,46 @@ function apiFailureCode(error: unknown): string | undefined {
     const decoded = Option.getOrUndefined(Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(error))
     return apiFailureCode(decoded)
   }
+  const nested = field(error, "error") ?? field(field(error, "response"), "error")
+  const nestedCode = nested === undefined || nested === error ? undefined : apiFailureCode(nested)
+  if (nestedCode) return nestedCode
   const code = field(error, "code")
-  if (typeof code === "string") return code
+  if (typeof code === "string" || typeof code === "number") return String(code)
+  const status = field(error, "status")
+  if (typeof status === "string") return status
   const type = field(error, "type")
   if (typeof type === "string" && type !== "error") return type
-  const nested = field(error, "error")
-  return nested === undefined || nested === error ? undefined : apiFailureCode(nested)
 }
 
-function apiFailureMessage(error: unknown) {
+function apiFailureMessage(error: unknown): string {
   const message = field(error, "message")
   if (typeof message === "string") return message
-  const nested = field(field(error, "error"), "message")
-  return typeof nested === "string" ? nested : String(error)
+  const nested = field(error, "error") ?? field(field(error, "response"), "error")
+  return nested === undefined || nested === error ? String(error) : apiFailureMessage(nested)
+}
+
+function apiFailureStatus(error: unknown): number | undefined {
+  const status = field(error, "status")
+  const code = field(error, "code")
+  const value = [status, code]
+    .map((value) => (typeof value === "number" ? value : typeof value === "string" ? Number(value) : undefined))
+    .find((value) => value !== undefined && Number.isInteger(value) && value >= 400 && value < 600)
+  if (value !== undefined) return value
+  const nested = field(error, "error") ?? field(field(error, "response"), "error")
+  return nested === undefined || nested === error ? undefined : apiFailureStatus(nested)
+}
+
+function retryAfterMs(headers: Record<string, string> | undefined) {
+  if (!headers) return undefined
+  const normalized = Object.fromEntries(Object.entries(headers).map(([name, value]) => [name.toLowerCase(), value]))
+  const millis = Number(normalized["retry-after-ms"])
+  if (Number.isFinite(millis)) return Math.max(0, millis)
+  const value = normalized["retry-after"]
+  if (!value) return undefined
+  const seconds = Number(value)
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
+  const date = Date.parse(value)
+  return Number.isNaN(date) ? undefined : Math.max(0, date - Date.now())
 }
 
 function errorMessage(error: unknown) {

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -47,6 +47,7 @@ import {
   type UsageInput,
 } from "@opencode-ai/ai"
 import { Auth, Endpoint, type AnyRoute } from "@opencode-ai/ai/route"
+import { BedrockEventStream } from "@opencode-ai/ai/protocols/bedrock-event-stream"
 import { Cause, Context, Effect, Layer, Option, Schema, Scope, Stream } from "effect"
 import { ModelV2 } from "./model"
 import { ProviderV2 } from "./provider"
@@ -172,8 +173,9 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
       ...opts,
       timeout: false,
     })
-    if (!chunkAbortCtl || typeof chunkTimeout !== "number") return res
-    return wrapSSE(res, chunkTimeout, chunkAbortCtl)
+    const response = pkg === "@ai-sdk/amazon-bedrock" ? BedrockEventStream.monitorExceptions(res) : res
+    if (!chunkAbortCtl || typeof chunkTimeout !== "number") return response
+    return wrapSSE(response, chunkTimeout, chunkAbortCtl)
   }
 
   return options
@@ -739,10 +741,12 @@ function llmError(method: string, error: unknown) {
   const cause = error instanceof Error ? error.cause : undefined
   const failures = [error, cause]
   const code = failures.map(machineCode).find((value) => value !== undefined)
+  const providerCode = apiFailureCode(error)?.toLowerCase()
   const reason = (() => {
     if (
       error instanceof ChunkTimeoutError ||
       failures.some((failure) => failure instanceof Error && failure.name === "TimeoutError") ||
+      providerCode === "timeout_error" ||
       (code !== undefined && TRANSPORT_TIMEOUT_CODES.has(code))
     )
       return new TransportReason({ message: errorMessage(error), kind: code ?? "Timeout" })
@@ -751,8 +755,7 @@ function llmError(method: string, error: unknown) {
       return new TransportReason({ message: errorMessage(error), kind: code })
     const malformed = failures.find(isMalformedError)
     if (malformed) return new InvalidProviderOutputReason({ message: malformed.message })
-    if (LoadAPIKeyError.isInstance(error))
-      return new AuthenticationReason({ message: error.message, kind: "missing" })
+    if (LoadAPIKeyError.isInstance(error)) return new AuthenticationReason({ message: error.message, kind: "missing" })
     if (NoSuchModelError.isInstance(error)) return new InvalidRequestReason({ message: error.message })
     if (
       LoadSettingError.isInstance(error) ||
@@ -780,12 +783,13 @@ function apiCallReason(error: APICallError) {
   const malformed = isMalformedError(error.cause) ? error.cause : undefined
   if (error.statusCode !== undefined && error.statusCode < 400 && malformed)
     return new InvalidProviderOutputReason({ message: malformed.message })
-  const code = apiFailureCode(error.data) ?? apiFailureCode(error.responseBody)
+  const evidence = apiFailureEvidence(error.responseBody)
+  const code = apiFailureCode(error.data) ?? apiFailureCode(evidence)
   if (error.statusCode === undefined) {
     const reason =
-      code === undefined && error.responseBody === undefined
+      code === undefined && evidence === undefined
         ? undefined
-        : classifyProviderFailure({ message: error.message, code, evidence: error.responseBody })
+        : classifyProviderFailure({ message: error.message, code, evidence })
     if (reason && reason._tag !== "UnknownProvider") return reason
     if (error.isRetryable) return new TransportReason({ message: error.message })
     return reason ?? new UnknownProviderReason({ message: error.message })
@@ -793,16 +797,13 @@ function apiCallReason(error: APICallError) {
   const retryAfter = retryAfterMs(error.responseHeaders)
   const reason = classifyProviderFailure({
     message: error.message,
-    evidence: error.responseBody,
+    evidence,
     status: error.statusCode,
     code,
     retryAfterMs: retryAfter,
   })
   if (!error.isRetryable || (reason._tag !== "UnknownProvider" && reason._tag !== "InvalidRequest")) return reason
-  if (
-    classifyProviderFailure({ message: error.message, evidence: error.responseBody, code })._tag !== "UnknownProvider"
-  )
-    return reason
+  if (classifyProviderFailure({ message: error.message, evidence, code })._tag !== "UnknownProvider") return reason
   return new ProviderInternalReason({ message: error.message, status: error.statusCode, retryAfterMs: retryAfter })
 }
 
@@ -825,6 +826,7 @@ const TRANSPORT_CONNECTION_CODES = new Set([
   "FAILEDTOOPENSOCKET",
   "UND_ERR_SOCKET",
 ])
+const FAILURE_EVIDENCE_LIMIT = 65_536
 
 function field(error: unknown, name: string) {
   return typeof error === "object" && error !== null ? Reflect.get(error, name) : undefined
@@ -843,6 +845,8 @@ function apiFailureCode(error: unknown): string | undefined {
   const nested = field(error, "error") ?? field(field(error, "response"), "error")
   const nestedCode = nested === undefined || nested === error ? undefined : apiFailureCode(nested)
   if (nestedCode) return nestedCode
+  if (typeof field(error, "originalMessage") === "string" && typeof field(error, "originalStatusCode") === "number")
+    return "modelstreamerrorexception"
   const code = field(error, "code")
   if (typeof code === "string" || typeof code === "number") return String(code)
   const status = field(error, "status")
@@ -854,19 +858,27 @@ function apiFailureCode(error: unknown): string | undefined {
 function apiFailureMessage(error: unknown): string {
   const message = field(error, "message")
   if (typeof message === "string") return message
+  const originalMessage = field(error, "originalMessage")
+  if (typeof originalMessage === "string") return originalMessage
   const nested = field(error, "error") ?? field(field(error, "response"), "error")
   return nested === undefined || nested === error ? String(error) : apiFailureMessage(nested)
 }
 
 function apiFailureStatus(error: unknown): number | undefined {
   const status = field(error, "status")
+  const statusCode = field(error, "statusCode")
+  const originalStatusCode = field(error, "originalStatusCode")
   const code = field(error, "code")
-  const value = [status, code]
+  const value = [status, statusCode, originalStatusCode, code]
     .map((value) => (typeof value === "number" ? value : typeof value === "string" ? Number(value) : undefined))
     .find((value) => value !== undefined && Number.isInteger(value) && value >= 400 && value < 600)
   if (value !== undefined) return value
   const nested = field(error, "error") ?? field(field(error, "response"), "error")
   return nested === undefined || nested === error ? undefined : apiFailureStatus(nested)
+}
+
+function apiFailureEvidence(error: string | undefined) {
+  return error === undefined ? undefined : error.slice(0, FAILURE_EVIDENCE_LIMIT)
 }
 
 function retryAfterMs(headers: Record<string, string> | undefined) {

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -18,9 +18,6 @@ import {
   AuthenticationReason,
   classifyProviderFailure,
   FinishReason,
-  HttpContext,
-  HttpRequestDetails,
-  HttpResponseDetails,
   InvalidRequestReason,
   InvalidProviderOutputReason,
   LLMEvent,
@@ -50,7 +47,7 @@ import {
   TypeValidationError,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider"
-import { Auth, Endpoint, RequestExecutor, type AnyRoute } from "@opencode-ai/ai/route"
+import { Auth, Endpoint, type AnyRoute } from "@opencode-ai/ai/route"
 import { Cause, Context, Effect, Layer, Option, Schema, Scope, Stream } from "effect"
 import { ModelV2 } from "./model"
 import { ProviderV2 } from "./provider"
@@ -784,27 +781,13 @@ function apiCallReason(error: APICallError) {
   const code = apiFailureCode(error.data) ?? apiFailureCode(error.responseBody)
   if (error.statusCode === undefined) {
     if (code) return classifyProviderFailure({ message: error.message, code })
-    if (error.isRetryable)
-      return new TransportReason({ message: error.message, url: RequestExecutor.redactUrl(error.url) })
+    if (error.isRetryable) return new TransportReason({ message: error.message })
     return new UnknownProviderReason({ message: error.message })
   }
-  const body = RequestExecutor.redactResponseBody(error.responseBody, {
-    url: error.url,
-    headers: error.responseHeaders ?? {},
-  })
   return classifyProviderFailure({
     message: error.message,
     status: error.statusCode,
     code,
-    retryAfterMs: retryAfterMs(error.responseHeaders),
-    http: new HttpContext({
-      request: new HttpRequestDetails({ method: "POST", url: RequestExecutor.redactUrl(error.url), headers: {} }),
-      response: new HttpResponseDetails({
-        status: error.statusCode,
-        headers: RequestExecutor.redactHeaders(error.responseHeaders ?? {}),
-      }),
-      ...body,
-    }),
   })
 }
 
@@ -824,18 +807,6 @@ const TRANSPORT_CONNECTION_CODES = new Set([
   "EPIPE",
   "UND_ERR_SOCKET",
 ])
-
-function retryAfterMs(headers: Record<string, string> | undefined) {
-  if (!headers) return undefined
-  const millis = Number(headers["retry-after-ms"])
-  if (Number.isFinite(millis)) return Math.max(0, millis)
-  const value = headers["retry-after"]
-  if (!value) return undefined
-  const seconds = Number(value)
-  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000)
-  const date = Date.parse(value)
-  return Number.isNaN(date) ? undefined : Math.max(0, date - Date.now())
-}
 
 function field(error: unknown, name: string) {
   return typeof error === "object" && error !== null ? Reflect.get(error, name) : undefined

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -1,6 +1,8 @@
 import {
   APICallError,
+  InvalidPromptError,
   InvalidResponseDataError,
+  LoadAPIKeyError,
   type LanguageModelV3,
   type LanguageModelV3CallOptions,
   type LanguageModelV3StreamPart,
@@ -8,7 +10,7 @@ import {
 import { AISDK } from "@opencode-ai/core/aisdk"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
-import { LLM, Message } from "@opencode-ai/ai"
+import { InvalidRequestReason, LLM, LLMError, Message } from "@opencode-ai/ai"
 import { LLMClient } from "@opencode-ai/ai/route"
 import { expect } from "bun:test"
 import { Effect, Stream } from "effect"
@@ -293,6 +295,26 @@ it.effect("classifies AI SDK API failures", () =>
     const error = yield* streamFailure(
       failingLanguage(
         new APICallError({
+          message: "Bad Request",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 400,
+          responseBody: '{"error":{"code":"insufficient_quota","detail":"quota-body-secret"}}',
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "QuotaExceeded" } })
+    expect("http" in error.reason ? error.reason.http : undefined).toBeUndefined()
+    expect(JSON.stringify(error)).not.toContain("quota-body-secret")
+  }),
+)
+
+it.effect("keeps retryable quota responses terminal", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
           message: "Quota exceeded",
           url: "https://provider.test/v1",
           requestBodyValues: {},
@@ -303,6 +325,132 @@ it.effect("classifies AI SDK API failures", () =>
     )
 
     expect(error).toMatchObject({ reason: { _tag: "QuotaExceeded" } })
+  }),
+)
+
+it.effect("uses response bodies as transient classification evidence", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "Bad Request",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 400,
+          responseBody: "Input is too long for requested model overflow-body-secret",
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "InvalidRequest", classification: "context-overflow" } })
+    expect("http" in error.reason ? error.reason.http : undefined).toBeUndefined()
+    expect(JSON.stringify(error)).not.toContain("overflow-body-secret")
+  }),
+)
+
+it.effect("honors retryable AI SDK request timeouts", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "HTTP 408",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 408,
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", status: 408 } })
+  }),
+)
+
+it.effect("honors retryable AI SDK conflicts", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "HTTP 409",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 409,
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", status: 409 } })
+  }),
+)
+
+it.effect("keeps semantic invalid requests terminal on retryable statuses", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "Conflict",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 409,
+          responseBody: '{"error":{"code":"request_too_large"}}',
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "InvalidRequest" } })
+  }),
+)
+
+it.effect("retries unknown coded conflicts", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "Conflict",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 409,
+          responseBody: '{"error":{"code":"conflict"}}',
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", status: 409 } })
+  }),
+)
+
+it.effect("preserves AI SDK retry delays without HTTP diagnostics", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "Too Many Requests",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "Retry-After-Ms": "250" },
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "RateLimit", retryAfterMs: 250 } })
+    expect("http" in error.reason ? error.reason.http : undefined).toBeUndefined()
+  }),
+)
+
+it.effect("classifies statusless retryable API failures as transport failures", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "Cannot connect to API",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          isRetryable: true,
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "Transport" } })
   }),
 )
 
@@ -324,6 +472,16 @@ it.effect("classifies AI SDK connection failures", () =>
   }),
 )
 
+it.effect("classifies Bun connection failures", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(Object.assign(new Error("connection refused"), { code: "ConnectionRefused" })),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "Transport", kind: "CONNECTIONREFUSED" } })
+  }),
+)
+
 it.effect("classifies structured AI SDK stream errors", () =>
   Effect.gen(function* () {
     const error = yield* streamFailure(
@@ -331,6 +489,75 @@ it.effect("classifies structured AI SDK stream errors", () =>
     )
 
     expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", message: "Overloaded" } })
+  }),
+)
+
+it.effect("classifies structured stream messages without codes", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      streamingLanguage({ type: "error", error: { message: "Rate limit exceeded" } }),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "RateLimit" } })
+  }),
+)
+
+it.effect("classifies nested OpenAI Responses stream errors", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      streamingLanguage({
+        type: "error",
+        error: {
+          type: "response.failed",
+          response: { error: { code: "server_error", message: "Provider failed" } },
+        },
+      }),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", message: "Provider failed" } })
+  }),
+)
+
+it.effect("classifies numeric string stream statuses", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      streamingLanguage({ type: "error", error: { code: "503", message: "Unavailable" } }),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", status: 503 } })
+  }),
+)
+
+it.effect("classifies missing AI SDK API keys", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(new LoadAPIKeyError({ message: "API key is missing" })),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "Authentication", kind: "missing" } })
+  }),
+)
+
+it.effect("classifies invalid AI SDK prompts", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(new InvalidPromptError({ prompt: [], message: "unsupported prompt" })),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "InvalidRequest" } })
+  }),
+)
+
+it.effect("preserves existing LLM errors", () =>
+  Effect.gen(function* () {
+    const original = new LLMError({
+      module: "test",
+      method: "run",
+      reason: new InvalidRequestReason({ message: "invalid" }),
+    })
+    const error = yield* streamFailure(failingLanguage(original))
+
+    expect(error).toBe(original)
   }),
 )
 

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -492,11 +492,52 @@ it.effect("classifies structured AI SDK stream errors", () =>
   }),
 )
 
-it.effect("classifies structured stream messages without codes", () =>
+it.effect("classifies AI Gateway errors with statusCode", () =>
   Effect.gen(function* () {
     const error = yield* streamFailure(
-      streamingLanguage({ type: "error", error: { message: "Rate limit exceeded" } }),
+      streamingLanguage({
+        type: "error",
+        error: { type: "internal_server_error", message: "Gateway failed", statusCode: 503 },
+      }),
     )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", status: 503 } })
+  }),
+)
+
+it.effect("classifies AI Gateway timeouts as retryable", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      streamingLanguage({
+        type: "error",
+        error: { type: "timeout_error", message: "Gateway timed out", statusCode: 408 },
+      }),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "Transport", kind: "Timeout" } })
+  }),
+)
+
+it.effect("classifies stripped Bedrock model stream errors", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      streamingLanguage({
+        type: "error",
+        error: {
+          message: "The model stream failed",
+          originalMessage: "Upstream provider failed",
+          originalStatusCode: 424,
+        },
+      }),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", status: 424 } })
+  }),
+)
+
+it.effect("classifies structured stream messages without codes", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(streamingLanguage({ type: "error", error: { message: "Rate limit exceeded" } }))
 
     expect(error).toMatchObject({ reason: { _tag: "RateLimit" } })
   }),
@@ -528,11 +569,81 @@ it.effect("classifies numeric string stream statuses", () =>
   }),
 )
 
+it.effect("classifies readable stream failures", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure({
+      ...failingLanguage(new Error("unused")),
+      doStream: async () => ({
+        stream: new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            controller.error(Object.assign(new Error("connection reset"), { code: "ECONNRESET" }))
+          },
+        }),
+        request: { body: {} },
+      }),
+    })
+
+    expect(error).toMatchObject({ method: "readStream", reason: { _tag: "Transport", kind: "ECONNRESET" } })
+  }),
+)
+
+it.live("times out stalled SSE chunks", () =>
+  Effect.acquireUseRelease(
+    Effect.sync(() =>
+      Bun.serve({
+        port: 0,
+        fetch: () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(": connected\n\n"))
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+      }),
+    ),
+    (server) =>
+      Effect.gen(function* () {
+        const aisdk = yield* AISDK.Service
+        let wrappedFetch: typeof fetch | undefined
+        yield* aisdk.hook.sdk((event) => {
+          wrappedFetch = event.options.fetch
+          event.sdk = {}
+        })
+        yield* aisdk.hook.language((event) => {
+          event.language = {
+            ...failingLanguage(new Error("unused")),
+            doStream: async () => {
+              const fetcher = wrappedFetch
+              if (!fetcher) throw new Error("AI SDK fetch was not configured")
+              const response = await fetcher(server.url, { method: "POST" })
+              if (!response.body) throw new Error("AI SDK response body was missing")
+              return {
+                stream: response.body.pipeThrough(
+                  new TransformStream<Uint8Array, LanguageModelV3StreamPart>({ transform() {} }),
+                ),
+                request: { body: {} },
+              }
+            },
+          }
+        })
+        const resolved = yield* aisdk.model(model("@ai-sdk/openai", { chunkTimeout: 10 }))
+        const request = LLM.request({ model: resolved, prompt: "Hello" })
+        const prepared = yield* LLMClient.prepare<LanguageModelV3CallOptions>(request)
+        const error = yield* resolved.route
+          .streamPrepared(prepared.body, request, { http: { execute: () => Effect.die("unused") } })
+          .pipe(Stream.runDrain, Effect.flip)
+
+        expect(error).toMatchObject({ method: "readStream", reason: { _tag: "Transport", kind: "Timeout" } })
+      }),
+    (server) => Effect.promise(() => server.stop(true)),
+  ),
+)
+
 it.effect("classifies missing AI SDK API keys", () =>
   Effect.gen(function* () {
-    const error = yield* streamFailure(
-      failingLanguage(new LoadAPIKeyError({ message: "API key is missing" })),
-    )
+    const error = yield* streamFailure(failingLanguage(new LoadAPIKeyError({ message: "API key is missing" })))
 
     expect(error).toMatchObject({ reason: { _tag: "Authentication", kind: "missing" } })
   }),

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -1,11 +1,17 @@
-import type { LanguageModelV3CallOptions } from "@ai-sdk/provider"
+import {
+  APICallError,
+  InvalidResponseDataError,
+  type LanguageModelV3,
+  type LanguageModelV3CallOptions,
+  type LanguageModelV3StreamPart,
+} from "@ai-sdk/provider"
 import { AISDK } from "@opencode-ai/core/aisdk"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { LLM, Message } from "@opencode-ai/ai"
 import { LLMClient } from "@opencode-ai/ai/route"
 import { expect } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Stream } from "effect"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(AISDK.locationLayer)
@@ -17,6 +23,49 @@ const model = (packageName: string, settings: Record<string, unknown> = {}) =>
     package: ProviderV2.aisdk(packageName),
     settings,
     limit: { context: 100, output: 20 },
+  })
+
+const failingLanguage = (error: unknown): LanguageModelV3 => ({
+  specificationVersion: "v3",
+  provider: "test-provider",
+  modelId: "api-model",
+  supportedUrls: {},
+  doGenerate: async () => {
+    throw error
+  },
+  doStream: async () => {
+    throw error
+  },
+})
+
+const streamingLanguage = (...events: LanguageModelV3StreamPart[]): LanguageModelV3 => ({
+  ...failingLanguage(new Error("unused")),
+  doStream: async () => ({
+    stream: new ReadableStream<LanguageModelV3StreamPart>({
+      start(controller) {
+        events.forEach((event) => controller.enqueue(event))
+        controller.close()
+      },
+    }),
+    request: { body: {} },
+  }),
+})
+
+const streamFailure = (language: LanguageModelV3) =>
+  Effect.gen(function* () {
+    const aisdk = yield* AISDK.Service
+    yield* aisdk.hook.sdk((event) => {
+      event.sdk = {}
+    })
+    yield* aisdk.hook.language((event) => {
+      event.language = language
+    })
+    const resolved = yield* aisdk.model(model("@ai-sdk/openai"))
+    const request = LLM.request({ model: resolved, prompt: "Hello" })
+    const prepared = yield* LLMClient.prepare<LanguageModelV3CallOptions>(request)
+    return yield* resolved.route
+      .streamPrepared(prepared.body, request, { http: { execute: () => Effect.die("unused") } })
+      .pipe(Stream.runDrain, Effect.flip)
   })
 
 it.effect("keys language models by package and flattened overlays", () =>
@@ -236,5 +285,79 @@ it.effect("projects replay metadata onto AI SDK prompt parts", () =>
         ],
       },
     ])
+  }),
+)
+
+it.effect("classifies AI SDK API failures with redacted diagnostics", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "Quota exceeded",
+          url: "https://provider.test/v1?key=url-secret",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "retry-after-ms": "250", "x-api-key": "header-secret" },
+          responseBody: '{"error":{"code":"insufficient_quota","api_key":"body-secret"}}',
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({
+      reason: {
+        _tag: "QuotaExceeded",
+        http: {
+          request: { url: "https://provider.test/v1?key=%3Credacted%3E" },
+          response: { headers: { "x-api-key": "<redacted>" } },
+          body: '{"error":{"code":"insufficient_quota","api_key":"<redacted>"}}',
+        },
+      },
+    })
+  }),
+)
+
+it.effect("classifies AI SDK timeouts", () =>
+  Effect.gen(function* () {
+    const timeout = yield* streamFailure(failingLanguage(new DOMException("timed out", "TimeoutError")))
+
+    expect(timeout).toMatchObject({ reason: { _tag: "Transport", kind: "Timeout" } })
+  }),
+)
+
+it.effect("classifies AI SDK connection failures", () =>
+  Effect.gen(function* () {
+    const reset = yield* streamFailure(
+      failingLanguage(Object.assign(new Error("connection reset"), { code: "ECONNRESET" })),
+    )
+
+    expect(reset).toMatchObject({ reason: { _tag: "Transport", kind: "ECONNRESET" } })
+  }),
+)
+
+it.effect("classifies structured AI SDK stream errors", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      streamingLanguage({ type: "error", error: { type: "overloaded_error", message: "Overloaded" } }),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "ProviderInternal", message: "Overloaded" } })
+  }),
+)
+
+it.effect("classifies malformed AI SDK response causes", () =>
+  Effect.gen(function* () {
+    const error = yield* streamFailure(
+      failingLanguage(
+        new APICallError({
+          message: "Failed to process response",
+          url: "https://provider.test/v1",
+          requestBodyValues: {},
+          statusCode: 200,
+          cause: new InvalidResponseDataError({ data: { invalid: true } }),
+        }),
+      ),
+    )
+
+    expect(error).toMatchObject({ reason: { _tag: "InvalidProviderOutput" } })
   }),
 )

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -288,31 +288,21 @@ it.effect("projects replay metadata onto AI SDK prompt parts", () =>
   }),
 )
 
-it.effect("classifies AI SDK API failures with redacted diagnostics", () =>
+it.effect("classifies AI SDK API failures", () =>
   Effect.gen(function* () {
     const error = yield* streamFailure(
       failingLanguage(
         new APICallError({
           message: "Quota exceeded",
-          url: "https://provider.test/v1?key=url-secret",
+          url: "https://provider.test/v1",
           requestBodyValues: {},
           statusCode: 429,
-          responseHeaders: { "retry-after-ms": "250", "x-api-key": "header-secret" },
-          responseBody: '{"error":{"code":"insufficient_quota","api_key":"body-secret"}}',
+          responseBody: '{"error":{"code":"insufficient_quota"}}',
         }),
       ),
     )
 
-    expect(error).toMatchObject({
-      reason: {
-        _tag: "QuotaExceeded",
-        http: {
-          request: { url: "https://provider.test/v1?key=%3Credacted%3E" },
-          response: { headers: { "x-api-key": "<redacted>" } },
-          body: '{"error":{"code":"insufficient_quota","api_key":"<redacted>"}}',
-        },
-      },
-    })
+    expect(error).toMatchObject({ reason: { _tag: "QuotaExceeded" } })
   }),
 )
 


### PR DESCRIPTION
## Summary
- Keep the existing `LLMError { module, method, reason }` shape and all session error/retry consumers unchanged.
- Map AI SDK API, transport, timeout, malformed-response, authentication, configuration, and invalid-request failures into the existing reason union instead of collapsing them to `UnknownProvider`.
- Handle nested OpenAI Responses failures, structured numeric statuses, Bun/Node/Undici connection errors, and statusless retryable API failures.
- Respect AI SDK retryability for generic `408`/`409` responses while keeping semantic quota, overflow, and invalid-request failures terminal.
- Use response bodies only as transient classification evidence; no AI SDK URL, header, body, or HTTP context is retained.
- Preserve only `Retry-After` timing because it directly controls session scheduling.
- Classify native response-stream read failures as `Transport` errors, including Undici body timeouts.

## Deliberately omitted
- AI SDK HTTP diagnostic retention and supporting redaction changes.
- Flat error tags and new session error variants.
- Provider-specific/community SDK exception mapping beyond the common AI SDK error contract.
- Bedrock exception-frame handling.
- Broader terminal-stream contract changes.

## Testing
- `packages/ai`: 333 pass, 29 skip, 0 fail
- `packages/core`: 1,351 pass, 6 skip, 0 fail
- AI and Core typechecks pass
- AI build passes
- `git diff --check` passes