### PR TITLE
fix(app): terminal tab rename focus

### DIFF
--- a/packages/app/src/pages/session/terminal-panel-v2.tsx
+++ b/packages/app/src/pages/session/terminal-panel-v2.tsx
@@ -285,7 +285,15 @@ export function TerminalPanelV2(props: { stacked?: boolean } = {}) {
                 onChange={(id) => terminal.open(id)}
                 class={newLayout() ? "!h-[52px] !flex-none" : "!h-auto !flex-none"}
               >
-                <Tabs.List ref={tabList} class={newLayout() ? undefined : "h-10 border-b border-border-weaker-base"}>
+                <Tabs.List
+                  ref={tabList}
+                  class={newLayout() ? undefined : "h-10 border-b border-border-weaker-base"}
+                  onPointerDown={(event: PointerEvent & { currentTarget: HTMLDivElement }) => {
+                    const active = document.activeElement
+                    if (event.target === active) return
+                    if (active instanceof HTMLInputElement && event.currentTarget.contains(active)) active.blur()
+                  }}
+                >
                   <For each={all()}>
                     {(pty, index) => (
                       <SortableTerminalTabV2 terminal={pty} index={index} newLayout={newLayout()} onClose={close} />


### PR DESCRIPTION
### Issue for this PR

Closes #184

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Clicking outside a terminal tab but inside the tab strip now correctly exits renaming state. 

### How did you verify your code works?
- Ran the app locally and verified the updated UI manually
- Ran type checks locally (`bun turbo typecheck`)

### Screenshots / recordings
N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
