### PR TITLE
feat(tui): preserve selected thinking effort per agent per model for primary agents

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -363,7 +363,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           selected() {
             const m = currentModel()
             if (!m) return undefined
-            const key = `${m.providerID}/${m.modelID}`
+            const a = agent.current()
+            const key = a ? `${a.name}/${m.providerID}/${m.modelID}` : `${m.providerID}/${m.modelID}`
             return modelStore.variant[key]
           },
           current() {
@@ -383,7 +384,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           set(value: string | undefined) {
             const m = currentModel()
             if (!m) return
-            const key = `${m.providerID}/${m.modelID}`
+            const a = agent.current()
+            const key = a ? `${a.name}/${m.providerID}/${m.modelID}` : `${m.providerID}/${m.modelID}`
             setModelStore("variant", key, value ?? "default")
             save()
           },


### PR DESCRIPTION
### Issue for this PR

Closes #36703 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Variant (**thinking effort**) selection was stored keyed only by `providerID/modelID`, so **Primary Agents** sharing the same model would overwrite each other's setting. Now the key includes the agent name so each primary agent holds its own thinking effort independently. i.e `name/providerID/modelID`

### How did you verify your code works?
1. Ran TUI locally using `bun dev`
2. Tested with same model on different agents with different thinking effort
3. On each cycle the thinking effort is preserved per agent per model

### Screenshots / recordings

https://github.com/user-attachments/assets/925c776e-b006-4bad-aa61-46b4da6ad5f1


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
