### PR TITLE
fix(core): compact after tool settlement

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -543,7 +543,8 @@ const layer = Layer.effect(
           needsContinuation = result.needsContinuation
           step = result.step + 1
           if (needsContinuation) {
-            promotion = (yield* SessionPending.compaction(db, input.sessionID)) ? undefined : "steer"
+            yield* runPendingCompaction(input.sessionID)
+            promotion = "steer"
             continue
           }
           yield* runPendingCompaction(input.sessionID)

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1614,14 +1614,14 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
-  it.effect("runs one durable compaction barrier before later steer and queued prompts", () =>
+  it.effect("runs one durable compaction barrier after tool settlement and before later inputs", () =>
     Effect.gen(function* () {
       const session = yield* setup
       currentModel = recoveryModel
       streamGate = yield* Deferred.make<void>()
       streamStarted = yield* Deferred.make<void>()
       responses = [
-        reply.text("Active complete", "text-active"),
+        reply.tool("call-active", "echo", { text: "active" }),
         [LLMEvent.textDelta({ id: "summary", text: "durable summary" })],
         reply.text("Steer complete", "text-steer"),
         reply.text("Queue complete", "text-queue"),


### PR DESCRIPTION
## What

Run an admitted manual compaction immediately after the active step's tools settle, before the runner starts another model step or promotes later inputs.

Fixes #36714.

## Before / After

**Before:** When an active step returned tool calls, the runner noticed the pending compaction, suppressed steer promotion, and still started the ordinary tool-loop continuation. It could cross multiple settled step boundaries while both compaction and steering remained pending.

**After:** Tool settlement is the compaction boundary. The runner executes any pending compaction, then promotes steering input into the next model step. Queued input retains its existing later-turn behavior.

## How

- `packages/core/src/session/runner/llm.ts` runs the pending compaction in the `needsContinuation` branch before selecting steer promotion.
- `packages/core/test/session-runner.test.ts` exercises the durable compaction barrier with a real local tool call, so an ordinary continuation cannot consume the compaction response.

```mermaid
flowchart LR
  A[Model step calls tools] --> B[Tools settle]
  B --> C[Run pending compaction]
  C --> D[Promote pending steers]
  D --> E[Start next model step]
```

## Scope

This PR does not change TUI placement of the `Compaction queued` row. That independent rendering issue is tracked by #36715.

## Testing

- `bun run test test/session-runner.test.ts` from `packages/core`: 121 passed
- `bun typecheck` from `packages/core`
