### PR TITLE
fix(tui): distinguish dialog empty states

### DIFF
--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -26,6 +26,7 @@ export function DialogSessionList() {
   const sdk = useSDK()
   const local = useLocal()
   const toast = useToast()
+  const [filter, setFilter] = createSignal("")
   const [search, setSearch] = createDebouncedSignal("", 150)
   const [toDelete, setToDelete] = createSignal<string>()
   const quickSwitch1 = useCommandShortcut("session.quick_switch.1")
@@ -55,10 +56,15 @@ export function DialogSessionList() {
 
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
   const sessions = createMemo(() => {
-    const query = search()
+    const query = filter()
     if (!query) return data.session.list()
     const result = searchResults()
     return result?.query === query ? result.sessions : []
+  })
+  const searching = createMemo(() => {
+    const query = filter()
+    if (!query) return false
+    return query !== search() || searchResults.loading || searchResults()?.query !== query
   })
 
   const quickSwitchHint = createMemo(() => {
@@ -118,9 +124,18 @@ export function DialogSessionList() {
     <DialogSelect
       title="Sessions"
       options={options()}
+      loading={searching()}
+      emptyView={
+        <box paddingLeft={4} paddingRight={4} paddingTop={1}>
+          <text fg={theme.textMuted}>No sessions yet</text>
+        </box>
+      }
       skipFilter={true}
       current={currentSessionID()}
-      onFilter={setSearch}
+      onFilter={(query) => {
+        setFilter(query)
+        setSearch(query)
+      }}
       onMove={() => setToDelete(undefined)}
       onSelect={(option) => {
         route.navigate({ type: "session", sessionID: option.value })

--- a/packages/tui/src/component/dialog-skill.tsx
+++ b/packages/tui/src/component/dialog-skill.tsx
@@ -57,6 +57,7 @@ export function DialogSkill(props: DialogSkillProps) {
     <DialogSelect
       title="Skills"
       options={options()}
+      loading={skills.loading}
       renderFilter={!showError()}
       locked={showError()}
       emptyView={
@@ -67,7 +68,11 @@ export function DialogSkill(props: DialogSkillProps) {
             </text>
             <text fg={theme.textMuted}>{errorMessage(loadError())}</text>
           </box>
-        ) : undefined
+        ) : (
+          <box paddingLeft={4} paddingRight={4} paddingTop={1}>
+            <text fg={theme.textMuted}>No skills available</text>
+          </box>
+        )
       }
     />
   )

--- a/packages/tui/src/component/dialog-tag.tsx
+++ b/packages/tui/src/component/dialog-tag.tsx
@@ -40,6 +40,7 @@ export function DialogTag(props: { onSelect?: (value: string) => void }) {
     <DialogSelect
       title="Autocomplete"
       options={options()}
+      loading={files.loading}
       onSelect={(option) => {
         props.onSelect?.(option.value)
         dialog.clear()

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -26,6 +26,7 @@ export interface DialogSelectProps<T> {
   placeholder?: string
   footer?: JSX.Element
   emptyView?: JSX.Element
+  loading?: boolean
   options: DialogSelectOption<T>[]
   flat?: boolean
   ref?: (ref: DialogSelectRef<T>) => void
@@ -603,11 +604,29 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
         <Show
           when={grouped().length > 0}
           fallback={
-            props.emptyView ?? (
-              <box paddingLeft={4} paddingRight={4} paddingTop={1}>
-                <text fg={theme.textMuted}>No results found</text>
-              </box>
-            )
+            <Show
+              when={!props.loading}
+              fallback={
+                <box paddingLeft={4} paddingRight={4} paddingTop={1}>
+                  <text fg={theme.textMuted}>Loading...</text>
+                </box>
+              }
+            >
+              <Show
+                when={store.filter.length === 0}
+                fallback={
+                  <box paddingLeft={4} paddingRight={4} paddingTop={1}>
+                    <text fg={theme.textMuted}>No matching results</text>
+                  </box>
+                }
+              >
+                {props.emptyView ?? (
+                  <box paddingLeft={4} paddingRight={4} paddingTop={1}>
+                    <text fg={theme.textMuted}>No items</text>
+                  </box>
+                )}
+              </Show>
+            </Show>
           }
         >
           <scrollbox

--- a/packages/tui/test/ui/dialog-select.test.tsx
+++ b/packages/tui/test/ui/dialog-select.test.tsx
@@ -1,0 +1,70 @@
+/** @jsxImportSource @opentui/solid */
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { createSignal, onCleanup, type JSX } from "solid-js"
+import { ConfigProvider } from "../../src/config"
+import { ThemeProvider } from "../../src/context/theme"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "../../src/keymap"
+import { DialogProvider } from "../../src/ui/dialog"
+import { DialogSelect } from "../../src/ui/dialog-select"
+import { ToastProvider } from "../../src/ui/toast"
+import { TestTuiContexts } from "../fixture/tui-environment"
+import { createTuiResolvedConfig } from "../fixture/tui-runtime"
+
+async function mountDialogSelect(content: () => JSX.Element) {
+  const config = createTuiResolvedConfig()
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const off = registerOpencodeKeymap(keymap, renderer, config)
+    onCleanup(off)
+
+    return (
+      <TestTuiContexts>
+        <OpencodeKeymapProvider keymap={keymap}>
+          <ConfigProvider config={config}>
+            <ThemeProvider mode="dark" source={{ discover: () => Promise.resolve({}) }}>
+              <ToastProvider>
+                <DialogProvider>{content()}</DialogProvider>
+              </ToastProvider>
+            </ThemeProvider>
+          </ConfigProvider>
+        </OpencodeKeymapProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />, { width: 80, height: 20 })
+  app.renderer.start()
+  return app
+}
+
+test("distinguishes loading, unfiltered empty, and filtered no-match states", async () => {
+  const [loading, setLoading] = createSignal(true)
+  const app = await mountDialogSelect(() => (
+    <DialogSelect title="Skills" options={[]} loading={loading()} emptyView={<text>Could not load skills</text>} />
+  ))
+  try {
+    await app.waitForFrame((frame) => frame.includes("Loading..."))
+
+    setLoading(false)
+    await app.waitForFrame((frame) => frame.includes("Could not load skills"))
+
+    await app.mockInput.typeText("missing")
+    await app.waitForFrame((frame) => frame.includes("No matching results"))
+    expect(app.captureCharFrame()).not.toContain("Could not load skills")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("uses a generic fallback for an unfiltered empty list", async () => {
+  const app = await mountDialogSelect(() => <DialogSelect title="Items" options={[]} />)
+  try {
+    await app.waitForFrame((frame) => frame.includes("No items"))
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
## What

Give `DialogSelect` explicit empty-state semantics so loading, an empty collection, and a filtered miss no longer all read as `No results found`.

Sessions now says `No sessions yet` when the collection is empty. Skills says `No skills available` when no skills load, while preserving its existing inline load error. Both resource-backed dialogs show `Loading...` while appropriate, and filtered misses use the existing app convention `No matching results`.

## Before / After

**Before:** Opening an empty Sessions dialog immediately showed `No results found`. Searching Sessions or Skills for a missing item showed the same copy, including while a debounced remote session query had not completed, so users could not tell whether the collection was empty, the filter missed, or data was still loading.

**After:** An unfiltered empty collection uses the consumer's domain copy, a pending empty result uses `Loading...`, and a non-empty filter with no visible options uses `No matching results`. Session search ties loading to the visible query as well as the debounced resource key, so stale results cannot briefly claim there are no matches.

## How

- Add an optional `loading` prop to `DialogSelect` and resolve empty content in this order: loading, filtered miss, consumer `emptyView`, generic `No items` fallback.
- Track the Sessions dialog's visible filter separately from its debounced request query and accept resource data only when its query identity matches the visible filter.
- Pass resource loading and domain empty views from Sessions and Skills; pass the clear initial resource loading state from file autocomplete.
- Add focused `@opentui/solid` `testRender` coverage for loading, custom unfiltered empty/error content, filtered no-match content, and the generic fallback.

```mermaid
flowchart TD
  A[No visible options] --> B{loading?}
  B -->|yes| C[Loading...]
  B -->|no| D{filter non-empty?}
  D -->|yes| E[No matching results]
  D -->|no| F[Consumer emptyView or No items]
```

## Scope

- V2 `packages/tui` only. `packages/opencode` V1 is unchanged.
- Existing dialogs that already model loading/error rows explicitly are unchanged.
- No server, protocol, or resource API changes.

## Testing

- `bun run test test/ui/dialog-select.test.tsx` from `packages/tui` (2 passed)
- `bun typecheck` from `packages/tui`
- Push hook: `bun turbo typecheck --concurrency=3` (32 tasks passed)
- `opencode-drive check ./dialog-empty-states.drive.ts` before each recording
- Same isolated Sessions/Skills walkthrough recorded against unmodified `origin/v2` and this branch

## Demo

Left: unmodified `origin/v2`. Right: this branch. The drive fixture has no user sessions. V2 always contributes the built-in OpenCode and Report skills, so the Skills segment honestly demonstrates a filtered miss; the Sessions `Loading...` frame is the real 150 ms debounce/resource transition, not an artificial delay.

https://github.com/user-attachments/assets/129959a4-4107-435b-9e5c-ebba6058e62b
