### PR TITLE
fix(core): recover from sqlite corruption and avoid WAL on network filesystems

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -24,7 +24,9 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const db = yield* makeDatabase
 
-    yield* db.run("PRAGMA journal_mode = WAL")
+    // The driver layer owns the journal-mode decision (WAL, or DELETE as a
+    // fallback on network filesystems) and the corruption recovery that runs
+    // before the file is opened for real. See ./sqlite.bun.ts / ./sqlite.node.ts.
     yield* db.run("PRAGMA synchronous = NORMAL")
     yield* db.run("PRAGMA busy_timeout = 5000")
     yield* db.run("PRAGMA cache_size = -64000")

--- a/packages/core/src/database/recovery.ts
+++ b/packages/core/src/database/recovery.ts
@@ -1,0 +1,19 @@
+export * as DatabaseRecovery from "./recovery"
+
+import { existsSync, renameSync } from "node:fs"
+
+// A malformed SQLite database bricks every future launch until the file is
+// removed by hand. Instead of deleting it, move the database and its WAL/SHM
+// sidecars aside so a fresh database can be created while the corrupt bytes are
+// preserved for later salvage. Renaming (rather than unlinking) is atomic, can
+// never lose data, and tolerates stale .nfs* handles from crashed processes.
+export function renameAside(filename: string) {
+  const stamp = Date.now()
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const source = filename + suffix
+    if (!existsSync(source)) continue
+    try {
+      renameSync(source, `${filename}.corrupt-${stamp}${suffix}`)
+    } catch {}
+  }
+}

--- a/packages/core/src/database/sqlite.bun.ts
+++ b/packages/core/src/database/sqlite.bun.ts
@@ -14,6 +14,22 @@ import type { Connection } from "effect/unstable/sql/SqlConnection"
 import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
 import * as Statement from "effect/unstable/sql/Statement"
 import { Sqlite } from "./sqlite"
+import { DatabaseRecovery } from "./recovery"
+
+// Uses prepare() + finalize() rather than the cached query() so no read cursor
+// stays open on the connection; a lingering read lock makes a later
+// wal_checkpoint fail with SQLITE_LOCKED.
+function pragmaValue(native: Database, pragma: string) {
+  const statement = native.prepare(pragma)
+  try {
+    const row = statement.get() as Record<string, string> | null
+    return row ? Object.values(row)[0] : undefined
+  } catch {
+    return undefined
+  } finally {
+    statement.finalize()
+  }
+}
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
@@ -155,13 +171,49 @@ const nativeLayer = (config: Config) =>
   Layer.effect(
     Sqlite.Native,
     Effect.gen(function* () {
-      const native = new Database(config.filename, {
-        readonly: config.readonly,
-        readwrite: config.readwrite ?? true,
-        create: config.create ?? true,
-      })
+      const open = () =>
+        new Database(config.filename, {
+          readonly: config.readonly,
+          readwrite: config.readwrite ?? true,
+          create: config.create ?? true,
+        })
+      let native = open()
       yield* Effect.addFinalizer(() => Effect.sync(() => native.close()))
-      if (config.disableWAL !== true) native.run("PRAGMA journal_mode = WAL;")
+
+      // Returns whether the connection is healthy. Journal mode is set before the
+      // integrity check on purpose: the check reads pages, and in a rollback
+      // journal that read holds a lock that later makes a concurrent
+      // wal_checkpoint fail with SQLITE_LOCKED. In WAL mode the read is harmless.
+      const prepare = () => {
+        try {
+          // busy_timeout first: switching journal mode needs an exclusive lock
+          // and NFS can hold stale locks from killed processes.
+          native.run("PRAGMA busy_timeout = 5000;")
+          // WAL coordinates writers through an mmap'd -shm file, which is broken
+          // on NFS and other network filesystems and corrupts the database.
+          // SQLite refuses WAL there, so verify it stuck and fall back to DELETE
+          // (file-level locks only) when it did not.
+          if (config.disableWAL !== true) {
+            native.run("PRAGMA journal_mode = WAL;")
+            if (pragmaValue(native, "PRAGMA journal_mode") !== "wal") native.run("PRAGMA journal_mode = DELETE;")
+          }
+          return pragmaValue(native, "PRAGMA quick_check") === "ok"
+        } catch {
+          return false
+        }
+      }
+
+      // quick_check is fast; integrity_check reads every page and can hang on
+      // large corrupt databases. On corruption, move the malformed files aside
+      // (preserving them for later salvage) and reopen a fresh database instead
+      // of crash-looping every launch.
+      const durable = config.filename !== ":memory:" && config.readonly !== true
+      if (!prepare() && durable) {
+        native.close()
+        DatabaseRecovery.renameAside(config.filename)
+        native = open()
+        prepare()
+      }
       return native
     }),
   )

--- a/packages/core/src/database/sqlite.node.ts
+++ b/packages/core/src/database/sqlite.node.ts
@@ -14,6 +14,16 @@ import type { Connection } from "effect/unstable/sql/SqlConnection"
 import { classifySqliteError, SqlError } from "effect/unstable/sql/SqlError"
 import * as Statement from "effect/unstable/sql/Statement"
 import { Sqlite } from "./sqlite"
+import { DatabaseRecovery } from "./recovery"
+
+function pragmaValue(native: DatabaseSync, pragma: string) {
+  try {
+    const row = native.prepare(pragma).get() as Record<string, string> | undefined
+    return row ? Object.values(row)[0] : undefined
+  } catch {
+    return undefined
+  }
+}
 
 const ATTR_DB_SYSTEM_NAME = "db.system.name"
 
@@ -148,15 +158,51 @@ const nativeLayer = (config: Config) =>
   Layer.effect(
     Sqlite.Native,
     Effect.gen(function* () {
-      const native = new DatabaseSync(config.filename, {
-        readOnly: config.readonly,
-        timeout: config.timeout,
-        allowExtension: config.allowExtension,
-        enableForeignKeyConstraints: true,
-        open: true,
-      })
+      const open = () =>
+        new DatabaseSync(config.filename, {
+          readOnly: config.readonly,
+          timeout: config.timeout,
+          allowExtension: config.allowExtension,
+          enableForeignKeyConstraints: true,
+          open: true,
+        })
+      let native = open()
       yield* Effect.addFinalizer(() => Effect.sync(() => native.close()))
-      if (config.disableWAL !== true && config.readonly !== true) native.exec("PRAGMA journal_mode = WAL;")
+
+      // Returns whether the connection is healthy. Journal mode is set before the
+      // integrity check on purpose: the check reads pages, and in a rollback
+      // journal that read holds a lock that later makes a concurrent
+      // wal_checkpoint fail with SQLITE_LOCKED. In WAL mode the read is harmless.
+      const prepare = () => {
+        try {
+          // busy_timeout first: switching journal mode needs an exclusive lock
+          // and NFS can hold stale locks from killed processes.
+          native.exec("PRAGMA busy_timeout = 5000;")
+          // WAL coordinates writers through an mmap'd -shm file, which is broken
+          // on NFS and other network filesystems and corrupts the database.
+          // SQLite refuses WAL there, so verify it stuck and fall back to DELETE
+          // (file-level locks only) when it did not.
+          if (config.disableWAL !== true && config.readonly !== true) {
+            native.exec("PRAGMA journal_mode = WAL;")
+            if (pragmaValue(native, "PRAGMA journal_mode") !== "wal") native.exec("PRAGMA journal_mode = DELETE;")
+          }
+          return pragmaValue(native, "PRAGMA quick_check") === "ok"
+        } catch {
+          return false
+        }
+      }
+
+      // quick_check is fast; integrity_check reads every page and can hang on
+      // large corrupt databases. On corruption, move the malformed files aside
+      // (preserving them for later salvage) and reopen a fresh database instead
+      // of crash-looping every launch.
+      const durable = config.filename !== ":memory:" && config.readonly !== true
+      if (!prepare() && durable) {
+        native.close()
+        DatabaseRecovery.renameAside(config.filename)
+        native = open()
+        prepare()
+      }
       return native
     }),
   )

--- a/packages/core/test/database-recovery.test.ts
+++ b/packages/core/test/database-recovery.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test"
+import { Database as BunDatabase } from "bun:sqlite"
+import { Effect, Layer } from "effect"
+import { existsSync, writeFileSync } from "fs"
+import path from "path"
+import { Database } from "@opencode-ai/core/database/database"
+import { tmpdir } from "./fixture/tmpdir"
+
+const build = (filename: string) =>
+  Effect.runPromise(Effect.scoped(Layer.build(Database.layerFromPath(filename))))
+
+describe("Database recovery", () => {
+  test("moves a malformed database aside and reopens a fresh one", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "opencode.db")
+
+    // Write bytes that are not a valid SQLite database.
+    writeFileSync(filename, "this is not a sqlite database".repeat(64))
+
+    await build(filename)
+
+    // The corrupt file is preserved (not deleted) under a *.corrupt-* name, and a
+    // usable database now exists at the original path with the migration table.
+    const preserved = (await Array.fromAsync(new Bun.Glob("opencode.db.corrupt-*").scan({ cwd: tmp.path }))).length
+    expect(preserved).toBeGreaterThan(0)
+
+    const check = new BunDatabase(filename).query("PRAGMA quick_check").get() as { quick_check: string }
+    expect(check.quick_check).toBe("ok")
+  })
+
+  test("uses WAL journal mode on an ordinary filesystem", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "opencode.db")
+
+    await Effect.runPromise(
+      Layer.build(Database.layerFromPath(filename)).pipe(
+        Effect.scoped,
+        Effect.flatMap(() =>
+          Effect.sync(() => {
+            const mode = new BunDatabase(filename).query("PRAGMA journal_mode").get() as { journal_mode: string }
+            expect(mode.journal_mode).toBe("wal")
+          }),
+        ),
+      ),
+    )
+  })
+
+  test("leaves an existing healthy database untouched", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "opencode.db")
+
+    await build(filename)
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.flatMap(Layer.build(Database.layerFromPath(filename)), () =>
+          Effect.sync(() =>
+            expect(existsSync(path.join(tmp.path, "opencode.db"))).toBe(true),
+          ),
+        ),
+      ),
+    )
+
+    // No corrupt copy should have been created for a healthy database.
+    const preserved = (await Array.fromAsync(new Bun.Glob("opencode.db.corrupt-*").scan({ cwd: tmp.path }))).length
+    expect(preserved).toBe(0)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #14970

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

All opencode processes on a machine share one SQLite database opened in WAL mode. WAL coordinates writers through an mmap'd `-shm` file plus POSIX locks, both of which are unreliable on NFS and VM shared folders. So when two sessions write concurrently on such a filesystem, the DB corrupts (`database disk image is malformed`), and after that every launch crash-loops until the file is deleted by hand.

Two changes in the driver layer (`sqlite.bun.ts` / `sqlite.node.ts`):

1. Set WAL, then read `PRAGMA journal_mode` back; if it isn't `wal`, fall back to `DELETE`. SQLite silently refuses WAL on filesystems that can't support the shared-memory file, so the read-back tells us whether WAL actually engaged. I used this instead of an NFS magic-number check so it also covers virtio-fs/9p/SMB, not just NFS. DELETE uses file-level locks only and doesn't corrupt there.
2. Run `PRAGMA quick_check` on open. If it fails (or setup throws), move the `db`/`-wal`/`-shm` files aside to `*.corrupt-<timestamp>` and reopen a fresh database, so a corrupt file self-heals instead of bricking every launch. I rename rather than delete so the old bytes are still there for salvage. I used `quick_check` rather than `integrity_check` because the latter reads every page and can hang on large corrupt files.

One ordering detail I hit while testing: journal mode must be set before `quick_check`. Reading pages in a rollback journal leaves a lock that then makes the existing startup `wal_checkpoint` fail with `SQLITE_LOCKED`; doing the read in WAL mode avoids it. Pragma reads also use `prepare()` + `finalize()` so no read cursor stays open.

Scope is deliberately just corruption + recovery. Two related items from the issue thread (per-version DB paths for schema drift, and a visible fatal DB error instead of a blank TUI) are left as separate follow-ups.

### How did you verify your code works?

Ran from `packages/core`:
- `bun typecheck` — clean
- `bun test test/database-migration.test.ts test/database-recovery.test.ts` — 18 pass
- `bun test test/session-create.test.ts test/event.test.ts` — 63 pass (real DB path, no regressions)

The concurrent-init migration test caught a real regression in my first attempt (the `SQLITE_LOCKED` issue above), which is what led to the ordering fix. Added `test/database-recovery.test.ts` covering: a corrupt file being moved aside and reopened fresh, the corrupt copy being preserved, WAL being selected on an ordinary filesystem, and a healthy DB being left untouched — all through the real `Database.layerFromPath`.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR