### PR TITLE
fix(www): generate collections before typecheck

### DIFF
--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -8,6 +8,7 @@
     "dev": "vite dev --host 0.0.0.0 --port 3000",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0",
+    "pretypecheck": "fumadocs-mdx",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## What

Generate the ignored Fumadocs collection modules before typechecking `packages/www`.

## Before / After

**Before:** Fresh checkouts failed the monorepo typecheck because `collections/server` and `collections/browser` resolve to generated files under `packages/www/.source`, but CI never generated that directory.

**After:** The package's `pretypecheck` lifecycle generates the collections before `tsgo --noEmit`, so package, root, pre-push, and CI typechecks use the same setup.

## How

- Add `fumadocs-mdx` as the `pretypecheck` script in `packages/www/package.json`.

## Testing

- `bun typecheck` from `packages/www` on a fresh worktree
- `bun typecheck` from the repository root: 32 packages passed
- Pre-push monorepo typecheck: 32 packages passed
