### PR TITLE
refactor(tui): remove unused subagent formatters

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2398,21 +2398,12 @@ function Subagent(props: ToolProps) {
   )
 }
 
-export function formatSubagentToolcalls(count: number) {
-  return `${count} toolcall${count === 1 ? "" : "s"}`
-}
-
 export function formatSubagentTitle(agent: string, description: string, background: boolean) {
   return `${agent} Subagent — ${description}${background ? " [background]" : ""}`
 }
 
 export function formatSubagentRetry(attempt: number, message: string) {
   return `Retrying (attempt ${attempt}) · ${message}`
-}
-
-export function formatCompletedSubagentDetail(toolcalls: number, duration: string) {
-  if (toolcalls === 0) return duration
-  return `${formatSubagentToolcalls(toolcalls)} · ${duration}`
 }
 
 type ExecuteCall = { tool: string; status: "running" | "completed" | "error"; input?: Record<string, unknown> }

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -2,10 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { For } from "solid-js"
 import { testRender, type JSX } from "@opentui/solid"
 import {
-  formatCompletedSubagentDetail,
   formatSubagentRetry,
   formatSubagentTitle,
-  formatSubagentToolcalls,
   InlineToolRow,
   parseApplyPatchFiles,
   parseDiagnostics,
@@ -182,13 +180,6 @@ describe("TUI inline tool wrapping", () => {
     ).toEqual([{ message: "valid", range: { start: { line: 2, character: 3 } } }])
   })
 
-  test("formats completed subagent toolcall details", () => {
-    expect(formatCompletedSubagentDetail(0, "501ms")).toBe("501ms")
-    expect(formatCompletedSubagentDetail(1, "501ms")).toBe("1 toolcall · 501ms")
-    expect(formatCompletedSubagentDetail(2, "501ms")).toBe("2 toolcalls · 501ms")
-    expect(formatSubagentToolcalls(0)).toBe("0 toolcalls")
-  })
-
   test("keeps background state attached to the subagent identity", () => {
     expect(formatSubagentTitle("Explore", "Inspect renderer", false)).toBe("Explore Subagent — Inspect renderer")
     expect(formatSubagentTitle("Explore", "Inspect renderer", true)).toBe(
@@ -207,5 +198,4 @@ describe("TUI inline tool wrapping", () => {
   test("snapshots expanded tool errors under the tool text", async () => {
     expect(await renderFrame(() => <Fixture errorExpanded />, { width: 72, height: 12 })).toMatchSnapshot()
   })
-
 })


### PR DESCRIPTION
## What

Remove two unused subagent-detail formatting helpers and the test that was their only consumer.

The dead helpers surfaced during the V2 TUI copy audit in #36707 because they contained the otherwise unused `toolcall` spelling.

## How

- Remove `formatSubagentToolcalls` and `formatCompletedSubagentDetail` from the session route.
- Remove their test-only imports and assertions from the inline-tool test file.

## Scope

This does not change rendered TUI copy or active subagent behavior. Existing visible copy already uses `tool call` correctly.

## Testing

- `bun run test test/cli/tui/inline-tool-wrap-snapshot.test.tsx` (10 passed, 2 snapshots)
- `bun typecheck` from `packages/tui`
- Pre-push hook: `bun turbo typecheck --concurrency=3` (32/32 tasks passed)
- Prettier check for both changed files
