### PR TITLE
fix(tui): pin queued compaction below output

### DIFF
--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -177,7 +177,9 @@ export function createSessionRows(sessionID: Accessor<string>) {
   }
 
   const queuedStart = (rows: SessionRow[]) => {
-    const index = rows.findIndex((row) => row.type === "message" && isPending(row.messageID))
+    const index = rows.findIndex(
+      (row) => row.type === "compaction-queued" || (row.type === "message" && isPending(row.messageID)),
+    )
     return index === -1 ? rows.length : index
   }
 

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -1203,6 +1203,21 @@ test("restores queued compaction from durable pending input", async () => {
     ])
 
     emitEvent(events, {
+      id: "evt_text_ended",
+      created: 2,
+      type: "session.text.ended",
+      durable: durable(sessionID, 5),
+      data: {
+        sessionID,
+        assistantMessageID: "message-assistant",
+        ordinal: 0,
+        text: "Active output",
+      },
+    })
+    await wait(() => rows.some((row) => row.type === "part"))
+    expect(rows.map((row) => row.type)).toEqual(["part", "compaction-queued", "compaction-queued"])
+
+    emitEvent(events, {
       id: "evt_compaction_started",
       created: 2,
       type: "session.compaction.started",


### PR DESCRIPTION
## What

Keep the queued-compaction banner below all active assistant output and above queued user messages while a response is still streaming.

Fixes #36715.

## Before / After

**Before:** A restored `compaction-queued` pseudo-row was not recognized as the start of the pending region. New assistant rows were inserted after the banner, so an active `Exploring - 1 read` row appeared between `Compaction queued` and the queued user message.

**After:** The first queued-compaction row is a pending-region boundary. New reasoning, text, tool, and footer rows remain above it while queued user messages remain below it.

## How

- `packages/tui/src/routes/session/rows.ts` includes `compaction-queued` rows in `queuedStart()`.
- `packages/tui/test/cli/tui/data.test.tsx` restores durable queued compactions, emits live assistant output, and asserts the incremental row order.

## Scope

This PR only changes TUI row placement. The separate runner fix that executes compaction after tool settlement landed in #36718.

## Testing

- `bun run test test/cli/tui/data.test.tsx test/cli/tui/session-rows.test.ts` from `packages/tui`: 41 passed
- `bun typecheck` from the repository root: 32 packages passed
- OpenCode Drive: identical scripted compaction-plus-active-tool flow against `origin/v2` and this branch

## Demo

**Before:** the active `Exploring - 1 read` row moves below `Compaction queued`.

https://github.com/user-attachments/assets/7a727f18-4bda-4a8c-9989-31e39f62139c

**After:** active output remains above `Compaction queued`, and the queued user message remains below it.

https://github.com/user-attachments/assets/910ee852-638d-4497-82f5-4b7de4bcb067
