### PR TITLE
fix(app): share worktree/notification event handling across layouts

### DIFF
--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -6,11 +6,13 @@ import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
 import { usePlatform } from "@/context/platform"
 import { setNavigate } from "@/utils/notification-click"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
+import { useNotificationToasts } from "./layout/notification-toasts"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
   const navigate = useNavigate()
   setNavigate(navigate)
+  useNotificationToasts()
 
   createEffect(() => setV2Toast(true))
 

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -39,10 +39,8 @@ import { useServerSDK } from "@/context/server-sdk"
 import { clearWorkspaceTerminals } from "@/context/terminal"
 import { pickSessionCacheEvictions } from "@/context/global-sync/session-cache"
 import { useNotification } from "@/context/notification"
-import { usePermission } from "@/context/permission"
 import { Binary } from "@opencode-ai/core/util/binary"
 import { retry } from "@opencode-ai/core/util/retry"
-import { playSoundById } from "@/utils/sound"
 import { createAim } from "@/utils/aim"
 import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
@@ -74,6 +72,7 @@ import {
   drainPendingDeepLinks,
 } from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
+import { useNotificationToasts } from "./layout/notification-toasts"
 import {
   LocalWorkspace,
   SortableWorkspace,
@@ -114,7 +113,6 @@ export default function LegacyLayout(props: ParentProps) {
   const settings = useSettings()
   const server = useServer()
   const notification = useNotification()
-  const permission = usePermission()
   const navigate = useNavigate()
   setNavigate(navigate)
   const providers = useProviders()
@@ -372,130 +370,7 @@ export default function LegacyLayout(props: ParentProps) {
     setLocale(next)
   }
 
-  const useSDKNotificationToasts = () =>
-    onMount(() => {
-      const toastBySession = new Map<string, number>()
-      const alertedAtBySession = new Map<string, number>()
-      const cooldownMs = 5000
-
-      const dismissSessionAlert = (sessionKey: string) => {
-        const toastId = toastBySession.get(sessionKey)
-        if (toastId === undefined) return
-        toaster.dismiss(toastId)
-        toastBySession.delete(sessionKey)
-        alertedAtBySession.delete(sessionKey)
-      }
-
-      const unsub = serverSDK().event.listen((e) => {
-        if (e.details?.type === "worktree.ready") {
-          setBusy(e.name, false)
-          WorktreeState.ready(serverSDK().scope, e.name)
-          return
-        }
-
-        if (e.details?.type === "worktree.failed") {
-          setBusy(e.name, false)
-          WorktreeState.failed(
-            serverSDK().scope,
-            e.name,
-            e.details.properties?.message ?? language.t("common.requestFailed"),
-          )
-          return
-        }
-
-        if (
-          e.details?.type === "question.replied" ||
-          e.details?.type === "question.rejected" ||
-          e.details?.type === "permission.replied"
-        ) {
-          const props = e.details.properties as { sessionID: string }
-          const sessionKey = `${e.name}:${props.sessionID}`
-          dismissSessionAlert(sessionKey)
-          return
-        }
-
-        if (e.details?.type !== "permission.asked" && e.details?.type !== "question.asked") return
-        const title =
-          e.details.type === "permission.asked"
-            ? language.t("notification.permission.title")
-            : language.t("notification.question.title")
-        const icon = e.details.type === "permission.asked" ? ("checklist" as const) : ("bubble-5" as const)
-        const directory = e.name
-        const props = e.details.properties
-        if (e.details.type === "permission.asked" && permission.autoResponds(e.details.properties, directory)) return
-
-        const [store] = serverSync().child(directory, { bootstrap: false })
-        const session = store.session.find((s) => s.id === props.sessionID)
-        const sessionKey = `${directory}:${props.sessionID}`
-
-        const sessionTitle = session?.title ?? language.t("command.session.new")
-        const projectName = getFilename(directory)
-        const description =
-          e.details.type === "permission.asked"
-            ? language.t("notification.permission.description", { sessionTitle, projectName })
-            : language.t("notification.question.description", { sessionTitle, projectName })
-        const href = `/${base64Encode(directory)}/session/${props.sessionID}`
-
-        const now = Date.now()
-        const lastAlerted = alertedAtBySession.get(sessionKey) ?? 0
-        if (now - lastAlerted < cooldownMs) return
-        alertedAtBySession.set(sessionKey, now)
-
-        if (e.details.type === "permission.asked") {
-          if (settings.sounds.permissionsEnabled()) {
-            void playSoundById(settings.sounds.permissions())
-          }
-          if (settings.notifications.permissions()) {
-            void platform.notify(title, description, href)
-          }
-        }
-
-        if (e.details.type === "question.asked") {
-          if (settings.notifications.agent()) {
-            void platform.notify(title, description, href)
-          }
-        }
-
-        const currentSession = params.id
-        if (pathKey(directory) === pathKey(currentDir()) && props.sessionID === currentSession) return
-        if (pathKey(directory) === pathKey(currentDir()) && session?.parentID === currentSession) return
-
-        dismissSessionAlert(sessionKey)
-
-        const toastId = showToast({
-          persistent: true,
-          icon,
-          title,
-          description,
-          actions: [
-            {
-              label: language.t("notification.action.goToSession"),
-              onClick: () => navigate(href),
-            },
-            {
-              label: language.t("common.dismiss"),
-              onClick: "dismiss",
-            },
-          ],
-        })
-        toastBySession.set(sessionKey, toastId)
-      })
-      onCleanup(unsub)
-
-      createEffect(() => {
-        const currentSession = params.id
-        if (!currentDir() || !currentSession) return
-        const sessionKey = `${currentDir()}:${currentSession}`
-        dismissSessionAlert(sessionKey)
-        const [store] = serverSync().child(currentDir(), { bootstrap: false })
-        const childSessions = store.session.filter((s) => s.parentID === currentSession)
-        for (const child of childSessions) {
-          dismissSessionAlert(`${currentDir()}:${child.id}`)
-        }
-      })
-    })
-
-  useSDKNotificationToasts()
+  useNotificationToasts({ setBusy })
 
   function scrollToSession(sessionId: string, sessionKey: string) {
     if (!scrollContainerRef) return

--- a/packages/app/src/pages/layout/notification-toasts.ts
+++ b/packages/app/src/pages/layout/notification-toasts.ts
@@ -1,0 +1,162 @@
+import { createEffect, onCleanup, onMount } from "solid-js"
+import { useNavigate, useParams } from "@solidjs/router"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { getFilename } from "@opencode-ai/core/util/path"
+import { toaster } from "@opencode-ai/ui/toast"
+import { showToast } from "@/utils/toast"
+import { decode64 } from "@/utils/base64"
+import { useServerSync } from "@/context/server-sync"
+import { useServerSDK } from "@/context/server-sdk"
+import { usePlatform } from "@/context/platform"
+import { useSettings } from "@/context/settings"
+import { usePermission } from "@/context/permission"
+import { useLanguage } from "@/context/language"
+import { playSoundById } from "@/utils/sound"
+import { pathKey } from "@/utils/path-key"
+import { Worktree as WorktreeState } from "@/utils/worktree"
+
+// Server-scoped notification + worktree lifecycle handling. Lives here rather than
+// inside a specific layout because it is a server concern: it releases the new-worktree
+// prompt gate (WorktreeState.ready/failed) and surfaces permission/question toasts.
+// Both the legacy and new layouts mount it so neither silently drops these events.
+// `setBusy` is optional so the legacy sidebar can reflect per-workspace busy state; the
+// new layout omits it.
+export function useNotificationToasts(options?: { setBusy?: (directory: string, value: boolean) => void }) {
+  const params = useParams()
+  const navigate = useNavigate()
+  const serverSDK = useServerSDK()
+  const serverSync = useServerSync()
+  const platform = usePlatform()
+  const settings = useSettings()
+  const permission = usePermission()
+  const language = useLanguage()
+
+  const setBusy = (directory: string, value: boolean) => options?.setBusy?.(directory, value)
+  const currentDir = () => {
+    const dir = decode64(params.dir)
+    if (!dir) return ""
+    return serverSync().peek(dir, { bootstrap: false })[0].path.directory || dir
+  }
+
+  onMount(() => {
+    const toastBySession = new Map<string, number>()
+    const alertedAtBySession = new Map<string, number>()
+    const cooldownMs = 5000
+
+    const dismissSessionAlert = (sessionKey: string) => {
+      const toastId = toastBySession.get(sessionKey)
+      if (toastId === undefined) return
+      toaster.dismiss(toastId)
+      toastBySession.delete(sessionKey)
+      alertedAtBySession.delete(sessionKey)
+    }
+
+    const unsub = serverSDK().event.listen((e) => {
+      if (e.details?.type === "worktree.ready") {
+        setBusy(e.name, false)
+        WorktreeState.ready(serverSDK().scope, e.name)
+        return
+      }
+
+      if (e.details?.type === "worktree.failed") {
+        setBusy(e.name, false)
+        WorktreeState.failed(
+          serverSDK().scope,
+          e.name,
+          e.details.properties?.message ?? language.t("common.requestFailed"),
+        )
+        return
+      }
+
+      if (
+        e.details?.type === "question.replied" ||
+        e.details?.type === "question.rejected" ||
+        e.details?.type === "permission.replied"
+      ) {
+        const props = e.details.properties as { sessionID: string }
+        const sessionKey = `${e.name}:${props.sessionID}`
+        dismissSessionAlert(sessionKey)
+        return
+      }
+
+      if (e.details?.type !== "permission.asked" && e.details?.type !== "question.asked") return
+      const title =
+        e.details.type === "permission.asked"
+          ? language.t("notification.permission.title")
+          : language.t("notification.question.title")
+      const icon = e.details.type === "permission.asked" ? ("checklist" as const) : ("bubble-5" as const)
+      const directory = e.name
+      const props = e.details.properties
+      if (e.details.type === "permission.asked" && permission.autoResponds(e.details.properties, directory)) return
+
+      const [store] = serverSync().child(directory, { bootstrap: false })
+      const session = store.session.find((s) => s.id === props.sessionID)
+      const sessionKey = `${directory}:${props.sessionID}`
+
+      const sessionTitle = session?.title ?? language.t("command.session.new")
+      const projectName = getFilename(directory)
+      const description =
+        e.details.type === "permission.asked"
+          ? language.t("notification.permission.description", { sessionTitle, projectName })
+          : language.t("notification.question.description", { sessionTitle, projectName })
+      const href = `/${base64Encode(directory)}/session/${props.sessionID}`
+
+      const now = Date.now()
+      const lastAlerted = alertedAtBySession.get(sessionKey) ?? 0
+      if (now - lastAlerted < cooldownMs) return
+      alertedAtBySession.set(sessionKey, now)
+
+      if (e.details.type === "permission.asked") {
+        if (settings.sounds.permissionsEnabled()) {
+          void playSoundById(settings.sounds.permissions())
+        }
+        if (settings.notifications.permissions()) {
+          void platform.notify(title, description, href)
+        }
+      }
+
+      if (e.details.type === "question.asked") {
+        if (settings.notifications.agent()) {
+          void platform.notify(title, description, href)
+        }
+      }
+
+      const currentSession = params.id
+      if (pathKey(directory) === pathKey(currentDir()) && props.sessionID === currentSession) return
+      if (pathKey(directory) === pathKey(currentDir()) && session?.parentID === currentSession) return
+
+      dismissSessionAlert(sessionKey)
+
+      const toastId = showToast({
+        persistent: true,
+        icon,
+        title,
+        description,
+        actions: [
+          {
+            label: language.t("notification.action.goToSession"),
+            onClick: () => navigate(href),
+          },
+          {
+            label: language.t("common.dismiss"),
+            onClick: "dismiss",
+          },
+        ],
+      })
+      toastBySession.set(sessionKey, toastId)
+    })
+    onCleanup(unsub)
+
+    createEffect(() => {
+      const currentSession = params.id
+      if (!currentDir() || !currentSession) return
+      const sessionKey = `${currentDir()}:${currentSession}`
+      dismissSessionAlert(sessionKey)
+      const [store] = serverSync().child(currentDir(), { bootstrap: false })
+      const childSessions = store.session.filter((s) => s.parentID === currentSession)
+      for (const child of childSessions) {
+        dismissSessionAlert(`${currentDir()}:${child.id}`)
+      }
+    })
+  })
+}


### PR DESCRIPTION
### Issue for this PR

Closes #36731

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Starting a session with "New Workspace" stalls forever under the new layout: the first prompt never sends, no title is generated, and after 5 minutes you get the "still preparing" toast.

The client holds the first prompt in `waitForWorktree` until `WorktreeState` flips from `pending` to `ready`. That flip only happens when something calls `WorktreeState.ready(...)` in response to the `worktree.ready` server event. The only place that listener was registered is `useSDKNotificationToasts` inside the legacy layout (`layout.tsx`). The new layout (`layout-new.tsx`) — which is where the New Workspace selector is shown — never registered it and didn't even import `WorktreeState`. So the worktree boots, the `worktree.ready` event reaches the browser, but nothing consumes it, the gate stays `pending`, and the prompt is never delivered.

The fix extracts that handler into a shared `useNotificationToasts` hook (in `pages/layout/notification-toasts.ts`) that resolves its own contexts and is mounted by both layouts. Now the gate is released (and the permission/question notification toasts fire) regardless of which layout is active. This works because the handler was never layout-specific — it is a server-scoped concern that was simply living in the wrong place; the new layout was silently dropping every event the legacy layout handled.

### How did you verify your code works?

Built a local desktop (beta channel) build with the change and confirmed a New Workspace session now sends the first prompt, gets a response, and generates a title. Before the change I traced the stall end to end: server logs showed the worktree booting cleanly and `worktree.ready` being emitted, the browser DevTools showed the event arriving on the `/global/event` SSE stream with the correct directory, yet the prompt gate timed out — matching the missing listener in the new layout. `bun typecheck` passes; existing `worktree.test.ts` and `layout/helpers.test.ts` pass; lint is unchanged (the new file has no warnings).

### Screenshots / recordings

_N/A — the change wires an existing event handler into the new layout; the visible effect is that a New Workspace session now behaves like a Local repository session._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
