### PR TITLE
feat(tui): style background subagent indicator

### DIFF
--- a/packages/tui/src/component/spinner.tsx
+++ b/packages/tui/src/component/spinner.tsx
@@ -9,18 +9,25 @@ registerOpencodeSpinner()
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
-export function Spinner(props: { children?: JSX.Element; color?: RGBA }) {
+export function Spinner(props: { children?: JSX.Element; color?: RGBA; trailing?: JSX.Element }) {
   const { theme } = useTheme()
   const config = useConfig().data
   const color = () => props.color ?? theme.textMuted
   return (
-    <Show when={config.animations ?? true} fallback={<text fg={color()}>⋯ {props.children}</text>}>
-      <box flexDirection="row" gap={1}>
+    <box flexDirection="row" gap={1}>
+      <Show when={config.animations ?? true} fallback={<text fg={color()}>⋯</text>}>
         <spinner frames={SPINNER_FRAMES} interval={80} color={color()} />
-        <Show when={props.children}>
-          <text fg={color()}>{props.children}</text>
+      </Show>
+      <Show when={props.children}>
+        <Show when={props.trailing} fallback={<text fg={color()}>{props.children}</text>}>
+          {(trailing) => (
+            <box flexDirection="row" flexWrap="wrap" columnGap={1} flexGrow={1}>
+              <text fg={color()}>{props.children}</text>
+              {trailing()}
+            </box>
+          )}
         </Show>
-      </box>
-    </Show>
+      </Show>
+    </box>
   )
 }

--- a/packages/tui/src/component/spinner.tsx
+++ b/packages/tui/src/component/spinner.tsx
@@ -9,25 +9,21 @@ registerOpencodeSpinner()
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
-export function Spinner(props: { children?: JSX.Element; color?: RGBA; trailing?: JSX.Element }) {
+export function Spinner(props: { children?: JSX.Element; color?: RGBA }) {
   const { theme } = useTheme()
   const config = useConfig().data
   const color = () => props.color ?? theme.textMuted
   return (
-    <box flexDirection="row" gap={1}>
-      <Show when={config.animations ?? true} fallback={<text fg={color()}>⋯</text>}>
+    <Show
+      when={config.animations ?? true}
+      fallback={<text fg={color()}>{props.children ? <>⋯ {props.children}</> : "⋯"}</text>}
+    >
+      <box flexDirection="row" gap={1}>
         <spinner frames={SPINNER_FRAMES} interval={80} color={color()} />
-      </Show>
-      <Show when={props.children}>
-        <Show when={props.trailing} fallback={<text fg={color()}>{props.children}</text>}>
-          {(trailing) => (
-            <box flexDirection="row" flexWrap="wrap" columnGap={1} flexGrow={1}>
-              <text fg={color()}>{props.children}</text>
-              {trailing()}
-            </box>
-          )}
+        <Show when={props.children}>
+          <text fg={color()}>{props.children}</text>
         </Show>
-      </Show>
-    </box>
+      </box>
+    </Show>
   )
 }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1978,6 +1978,7 @@ function InlineTool(props: {
   pending: string
   failure?: string
   spinner?: boolean
+  trailing?: JSX.Element
   children: JSX.Element
   part: SessionMessageAssistantTool
   onClick?: () => void
@@ -2028,6 +2029,7 @@ function InlineTool(props: {
       pending={props.pending}
       failure={props.failure}
       spinner={props.spinner}
+      trailing={props.trailing}
       onMouseOver={() => clickable() && setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {
@@ -2057,6 +2059,7 @@ export function InlineToolRow(props: {
   pending: string
   failure?: string
   spinner?: boolean
+  trailing?: JSX.Element
   children: JSX.Element
   onMouseOver?: () => void
   onMouseOut?: () => void
@@ -2066,7 +2069,7 @@ export function InlineToolRow(props: {
     <box paddingLeft={3} onMouseOver={props.onMouseOver} onMouseOut={props.onMouseOut} onMouseUp={props.onMouseUp}>
       <Switch>
         <Match when={props.spinner}>
-          <Spinner color={props.color} children={props.children} />
+          <Spinner color={props.color} children={props.children} trailing={props.trailing} />
         </Match>
         <Match when={true}>
           <Show fallback={<Spinner color={props.color}>{props.pending}</Spinner>} when={props.complete || props.failed}>
@@ -2078,13 +2081,32 @@ export function InlineToolRow(props: {
               >
                 {props.icon}
               </text>
-              <text
-                flexGrow={1}
-                fg={props.failed ? props.errorColor : props.color}
-                attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
+              <Show
+                when={props.trailing}
+                fallback={
+                  <text
+                    flexGrow={1}
+                    fg={props.failed ? props.errorColor : props.color}
+                    attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
+                  >
+                    {props.failed && !props.complete ? (props.failure ?? props.children) : props.children}
+                  </text>
+                }
               >
-                {props.failed && !props.complete ? (props.failure ?? props.children) : props.children}
-              </text>
+                {(trailing) => (
+                  <box flexDirection="row" flexWrap="wrap" columnGap={1} flexGrow={1}>
+                    <text
+                      maxWidth="100%"
+                      flexShrink={0}
+                      fg={props.failed ? props.errorColor : props.color}
+                      attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
+                    >
+                      {props.failed && !props.complete ? (props.failure ?? props.children) : props.children}
+                    </text>
+                    {trailing()}
+                  </box>
+                )}
+              </Show>
             </box>
           </Show>
         </Match>
@@ -2388,15 +2410,18 @@ function Subagent(props: ToolProps) {
         const id = sessionID()
         if (id) navigate({ type: "session", sessionID: id })
       }}
+      trailing={
+        background() ? (
+          <text paddingLeft={1} paddingRight={1} flexShrink={0} bg={theme.backgroundElement} fg={theme.textMuted}>
+            Background
+          </text>
+        ) : undefined
+      }
     >
       {formatSubagentTitle(
         Locale.titlecase(stringValue(props.input.agent) ?? stringValue(props.input.subagent_type) ?? "General"),
         description() ?? "Subagent",
       )}
-      <Show when={background()}>
-        {" "}
-        <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}>Background</span>
-      </Show>
     </InlineTool>
   )
 }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2412,8 +2412,9 @@ function Subagent(props: ToolProps) {
       }}
       trailing={
         background() ? (
-          <text paddingLeft={1} paddingRight={1} flexShrink={0} bg={theme.backgroundElement} fg={theme.textMuted}>
-            Background
+          <text flexShrink={0} bg={theme.backgroundElement} fg={theme.textMuted}>
+            {" "}
+            Background{" "}
           </text>
         ) : undefined
       }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1978,7 +1978,7 @@ function InlineTool(props: {
   pending: string
   failure?: string
   spinner?: boolean
-  trailing?: JSX.Element
+  status?: JSX.Element
   children: JSX.Element
   part: SessionMessageAssistantTool
   onClick?: () => void
@@ -2029,7 +2029,7 @@ function InlineTool(props: {
       pending={props.pending}
       failure={props.failure}
       spinner={props.spinner}
-      trailing={props.trailing}
+      status={props.status}
       onMouseOver={() => clickable() && setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {
@@ -2059,7 +2059,7 @@ export function InlineToolRow(props: {
   pending: string
   failure?: string
   spinner?: boolean
-  trailing?: JSX.Element
+  status?: JSX.Element
   children: JSX.Element
   onMouseOver?: () => void
   onMouseOut?: () => void
@@ -2069,7 +2069,16 @@ export function InlineToolRow(props: {
     <box paddingLeft={3} onMouseOver={props.onMouseOver} onMouseOut={props.onMouseOut} onMouseUp={props.onMouseUp}>
       <Switch>
         <Match when={props.spinner}>
-          <Spinner color={props.color} children={props.children} trailing={props.trailing} />
+          <Show when={props.status} fallback={<Spinner color={props.color} children={props.children} />}>
+            {(status) => (
+              <box flexDirection="row" gap={1}>
+                <Spinner color={props.color} />
+                <InlineToolLabel color={props.color} status={status()}>
+                  {props.children}
+                </InlineToolLabel>
+              </box>
+            )}
+          </Show>
         </Match>
         <Match when={true}>
           <Show fallback={<Spinner color={props.color}>{props.pending}</Spinner>} when={props.complete || props.failed}>
@@ -2082,7 +2091,7 @@ export function InlineToolRow(props: {
                 {props.icon}
               </text>
               <Show
-                when={props.trailing}
+                when={props.status}
                 fallback={
                   <text
                     flexGrow={1}
@@ -2093,18 +2102,14 @@ export function InlineToolRow(props: {
                   </text>
                 }
               >
-                {(trailing) => (
-                  <box flexDirection="row" flexWrap="wrap" columnGap={1} flexGrow={1}>
-                    <text
-                      maxWidth="100%"
-                      flexShrink={0}
-                      fg={props.failed ? props.errorColor : props.color}
-                      attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
-                    >
-                      {props.failed && !props.complete ? (props.failure ?? props.children) : props.children}
-                    </text>
-                    {trailing()}
-                  </box>
+                {(status) => (
+                  <InlineToolLabel
+                    color={props.failed ? props.errorColor : props.color}
+                    denied={props.denied}
+                    status={status()}
+                  >
+                    {props.failed && !props.complete ? (props.failure ?? props.children) : props.children}
+                  </InlineToolLabel>
                 )}
               </Show>
             </box>
@@ -2117,6 +2122,32 @@ export function InlineToolRow(props: {
         </box>
       </Show>
     </box>
+  )
+}
+
+function InlineToolLabel(props: { color?: RGBA; denied?: boolean; status: JSX.Element; children: JSX.Element }) {
+  return (
+    <box flexDirection="row" flexWrap="wrap" columnGap={1} flexGrow={1}>
+      <text
+        maxWidth="100%"
+        flexShrink={0}
+        fg={props.color}
+        attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
+      >
+        {props.children}
+      </text>
+      {props.status}
+    </box>
+  )
+}
+
+function StatusBadge(props: { children: string }) {
+  const { theme } = useTheme()
+  return (
+    <text flexShrink={0} bg={theme.backgroundElement} fg={theme.textMuted}>
+      {" "}
+      {props.children}{" "}
+    </text>
   )
 }
 
@@ -2263,9 +2294,7 @@ function Shell(props: ToolProps) {
           </Show>
         </Show>
         <Show when={shellID()}>
-          <text>
-            <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> Background </span>
-          </text>
+          <StatusBadge>Background</StatusBadge>
         </Show>
         <Show when={collapsed().overflow}>
           <text fg={theme.textMuted}>{expanded() ? "Click to collapse" : "Click to expand"}</text>
@@ -2389,11 +2418,9 @@ function WebSearch(props: ToolProps) {
 
 function Subagent(props: ToolProps) {
   const { navigate } = useRoute()
-  const { theme } = useTheme()
   const data = useData()
   const sessionID = createMemo(() => stringValue(props.metadata.sessionID) ?? stringValue(props.metadata.sessionId))
   const description = createMemo(() => stringValue(props.input.description))
-  const background = createMemo(() => props.input.background === true || props.metadata.status === "running")
   const isRunning = createMemo(() => {
     const id = sessionID()
     return props.part.state.status === "running" || Boolean(id && data.session.status(id) === "running")
@@ -2410,25 +2437,15 @@ function Subagent(props: ToolProps) {
         const id = sessionID()
         if (id) navigate({ type: "session", sessionID: id })
       }}
-      trailing={
-        background() ? (
-          <text flexShrink={0} bg={theme.backgroundElement} fg={theme.textMuted}>
-            {" "}
-            Background{" "}
-          </text>
+      status={
+        props.input.background === true || props.metadata.status === "running" ? (
+          <StatusBadge>Background</StatusBadge>
         ) : undefined
       }
     >
-      {formatSubagentTitle(
-        Locale.titlecase(stringValue(props.input.agent) ?? stringValue(props.input.subagent_type) ?? "General"),
-        description() ?? "Subagent",
-      )}
+      {`${Locale.titlecase(stringValue(props.input.agent) ?? stringValue(props.input.subagent_type) ?? "General")} Subagent — ${description() ?? "Subagent"}`}
     </InlineTool>
   )
-}
-
-export function formatSubagentTitle(agent: string, description: string) {
-  return `${agent} Subagent — ${description}`
 }
 
 export function formatSubagentRetry(attempt: number, message: string) {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2394,7 +2394,8 @@ function Subagent(props: ToolProps) {
         description() ?? "Subagent",
       )}
       <Show when={background()}>
-        <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> Background </span>
+        {" "}
+        <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}>Background</span>
       </Show>
     </InlineTool>
   )

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2367,9 +2367,11 @@ function WebSearch(props: ToolProps) {
 
 function Subagent(props: ToolProps) {
   const { navigate } = useRoute()
+  const { theme } = useTheme()
   const data = useData()
   const sessionID = createMemo(() => stringValue(props.metadata.sessionID) ?? stringValue(props.metadata.sessionId))
   const description = createMemo(() => stringValue(props.input.description))
+  const background = createMemo(() => props.input.background === true || props.metadata.status === "running")
   const isRunning = createMemo(() => {
     const id = sessionID()
     return props.part.state.status === "running" || Boolean(id && data.session.status(id) === "running")
@@ -2390,14 +2392,16 @@ function Subagent(props: ToolProps) {
       {formatSubagentTitle(
         Locale.titlecase(stringValue(props.input.agent) ?? stringValue(props.input.subagent_type) ?? "General"),
         description() ?? "Subagent",
-        props.input.background === true || props.metadata.status === "running",
       )}
+      <Show when={background()}>
+        <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}> Background </span>
+      </Show>
     </InlineTool>
   )
 }
 
-export function formatSubagentTitle(agent: string, description: string, background: boolean) {
-  return `${agent} Subagent — ${description}${background ? " [background]" : ""}`
+export function formatSubagentTitle(agent: string, description: string) {
+  return `${agent} Subagent — ${description}`
 }
 
 export function formatSubagentRetry(attempt: number, message: string) {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -99,6 +99,23 @@ function ReminderAlignmentFixture() {
   )
 }
 
+function TrailingStatusFixture() {
+  return (
+    <InlineToolRow
+      icon=":"
+      complete={true}
+      pending=""
+      trailing={
+        <text paddingLeft={1} paddingRight={1} flexShrink={0}>
+          Background
+        </text>
+      }
+    >
+      Explore Subagent — Inspect renderer status styling
+    </InlineToolRow>
+  )
+}
+
 async function renderFrame(component: () => JSX.Element, options: { width: number; height: number }) {
   testSetup = await testRender(component, options)
   await testSetup.renderOnce()
@@ -139,6 +156,15 @@ describe("TUI inline tool wrapping", () => {
   test("aligns switch reminders with instruction reminders", async () => {
     expect(await renderFrame(() => <ReminderAlignmentFixture />, { width: 35, height: 2 })).toBe(
       "   Switched variant to medium\n   ◈ Instructions updated",
+    )
+  })
+
+  test("wraps a trailing status as one padded item", async () => {
+    expect(await renderFrame(() => <TrailingStatusFixture />, { width: 70, height: 2 })).toBe(
+      "   : Explore Subagent — Inspect renderer status styling Background",
+    )
+    expect(await renderFrame(() => <TrailingStatusFixture />, { width: 62, height: 2 })).toBe(
+      "   : Explore Subagent — Inspect renderer status styling\n     Background",
     )
   })
 

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -101,16 +101,7 @@ function ReminderAlignmentFixture() {
 
 function TrailingStatusFixture() {
   return (
-    <InlineToolRow
-      icon=":"
-      complete={true}
-      pending=""
-      trailing={
-        <text paddingLeft={1} paddingRight={1} flexShrink={0}>
-          Background
-        </text>
-      }
-    >
+    <InlineToolRow icon=":" complete={true} pending="" trailing={<text flexShrink={0}> Background </text>}>
       Explore Subagent — Inspect renderer status styling
     </InlineToolRow>
   )
@@ -161,10 +152,10 @@ describe("TUI inline tool wrapping", () => {
 
   test("wraps a trailing status as one padded item", async () => {
     expect(await renderFrame(() => <TrailingStatusFixture />, { width: 70, height: 2 })).toBe(
-      "   : Explore Subagent — Inspect renderer status styling Background",
+      "   : Explore Subagent — Inspect renderer status styling  Background",
     )
     expect(await renderFrame(() => <TrailingStatusFixture />, { width: 62, height: 2 })).toBe(
-      "   : Explore Subagent — Inspect renderer status styling\n     Background",
+      "   : Explore Subagent — Inspect renderer status styling\n      Background",
     )
   })
 

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -180,11 +180,8 @@ describe("TUI inline tool wrapping", () => {
     ).toEqual([{ message: "valid", range: { start: { line: 2, character: 3 } } }])
   })
 
-  test("keeps background state attached to the subagent identity", () => {
-    expect(formatSubagentTitle("Explore", "Inspect renderer", false)).toBe("Explore Subagent — Inspect renderer")
-    expect(formatSubagentTitle("Explore", "Inspect renderer", true)).toBe(
-      "Explore Subagent — Inspect renderer [background]",
-    )
+  test("keeps status styling separate from the subagent title", () => {
+    expect(formatSubagentTitle("Explore", "Inspect renderer")).toBe("Explore Subagent — Inspect renderer")
   })
 
   test("keeps retry status ahead of wrapping messages", () => {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -3,7 +3,6 @@ import { For } from "solid-js"
 import { testRender, type JSX } from "@opentui/solid"
 import {
   formatSubagentRetry,
-  formatSubagentTitle,
   InlineToolRow,
   parseApplyPatchFiles,
   parseDiagnostics,
@@ -101,13 +100,14 @@ function ReminderAlignmentFixture() {
 
 function TrailingStatusFixture() {
   return (
-    <InlineToolRow icon=":" complete={true} pending="" trailing={<text flexShrink={0}> Background </text>}>
+    <InlineToolRow icon=":" complete={true} pending="" status={<text flexShrink={0}> Background </text>}>
       Explore Subagent — Inspect renderer status styling
     </InlineToolRow>
   )
 }
 
 async function renderFrame(component: () => JSX.Element, options: { width: number; height: number }) {
+  testSetup?.renderer.destroy()
   testSetup = await testRender(component, options)
   await testSetup.renderOnce()
   await testSetup.renderOnce()
@@ -195,10 +195,6 @@ describe("TUI inline tool wrapping", () => {
         "a.ts",
       ),
     ).toEqual([{ message: "valid", range: { start: { line: 2, character: 3 } } }])
-  })
-
-  test("keeps status styling separate from the subagent title", () => {
-    expect(formatSubagentTitle("Explore", "Inspect renderer")).toBe("Explore Subagent — Inspect renderer")
   })
 
   test("keeps retry status ahead of wrapping messages", () => {


### PR DESCRIPTION
## What

Background subagent rows now show a subtle, padded `Background` status pill instead of a literal `[background]` suffix.

**Before:** the background state was embedded in the title as bracketed text, so it had the same visual weight as the subagent identity and description.

**After:** the title remains plain text and the state uses the existing muted `backgroundElement` treatment with one painted padding cell on each side. Foreground subagent rows remain unchanged.

## How

- derive background state reactively in `packages/tui/src/routes/session/index.tsx`
- add an optional trailing renderable to inline-tool rows and spinners
- render the literal padded text as a non-shrinking flex item, so it stays at the far right when it fits and wraps as a complete unit when it does not
- keep `formatSubagentTitle` responsible only for the unstyled identity and description

## Scope

This only changes TUI presentation. Subagent execution, background lifecycle, and session state are unchanged.

## Testing

- `bun run test` from `packages/tui`: 221 passed, 1 skipped
- `bun typecheck` from `packages/tui`
- `bunx prettier --check packages/tui/src/component/spinner.tsx packages/tui/src/routes/session/index.tsx packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx`
- pre-push `bun turbo typecheck --concurrency=3`: 32 package tasks passed
- renderer regression test verifies inline and whole-item wrapping boundaries, including both padding cells
- scripted OpenCode Drive walkthrough verified active and completed background states at 100 and 62 columns

## Demo

The newest local OpenCode Drive `main` runs the real TUI and subagent tool flow against a simulated LLM backend. The recording shows the active spinner and painted padded status pill, atomic narrow-terminal wrapping, and the completed checkmark state.

https://github.com/user-attachments/assets/90266f00-8e15-4195-84a9-143b089e5bb9
