### PR TITLE
fix(nix): relax Bun version check for desktop build

### DIFF
--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -42,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
   };
 
-  # NOTE: Relax Bun version check to be a warning instead of an error
   postPatch =
+    # NOTE: Relax Bun version check to be a warning instead of an error
     ''
       substituteInPlace packages/script/src/index.ts \
         --replace-fail 'throw new Error(`This script requires bun@''${expectedBunVersionRange}' \

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -42,16 +42,23 @@ stdenv.mkDerivation (finalAttrs: {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
   };
 
-  # https://github.com/electron/electron/issues/31121
-  # mac builds use a .app bundle which doesnt have this issue
-  postPatch = lib.optionalString stdenv.isLinux ''
-    BASE_PATH=packages/desktop
-    FILES=(src/main/windows.ts)
-    for file in "''${FILES[@]}"; do
-      substituteInPlace $BASE_PATH/$file \
-        --replace-fail "process.resourcesPath" "'$out/opt/opencode-desktop/resources'"
-    done
-  '';
+  postPatch =
+    ''
+      # NOTE: Relax Bun version check to be a warning instead of an error
+      substituteInPlace packages/script/src/index.ts \
+        --replace-fail 'throw new Error(`This script requires bun@''${expectedBunVersionRange}' \
+                       'console.warn(`Warning: This script requires bun@''${expectedBunVersionRange}'
+    ''
+    # https://github.com/electron/electron/issues/31121
+    # mac builds use a .app bundle which doesnt have this issue
+    + lib.optionalString stdenv.isLinux ''
+      BASE_PATH=packages/desktop
+      FILES=(src/main/windows.ts)
+      for file in "''${FILES[@]}"; do
+        substituteInPlace $BASE_PATH/$file \
+          --replace-fail "process.resourcesPath" "'$out/opt/opencode-desktop/resources'"
+      done
+    '';
 
   preBuild = ''
     cp -r "${electron.dist}" $HOME/.electron-dist

--- a/nix/desktop.nix
+++ b/nix/desktop.nix
@@ -42,9 +42,9 @@ stdenv.mkDerivation (finalAttrs: {
     ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
   };
 
+  # NOTE: Relax Bun version check to be a warning instead of an error
   postPatch =
     ''
-      # NOTE: Relax Bun version check to be a warning instead of an error
       substituteInPlace packages/script/src/index.ts \
         --replace-fail 'throw new Error(`This script requires bun@''${expectedBunVersionRange}' \
                        'console.warn(`Warning: This script requires bun@''${expectedBunVersionRange}'


### PR DESCRIPTION
### Issue for this PR

Closes #36331

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Applies the existing Nix-specific Bun version-check relaxation to the desktop derivation, which has its own `postPatch` and therefore did not inherit the substitution from `nix/opencode.nix`. The existing Linux-only Electron resource-path substitution remains unchanged.

### How did you verify your code works?

- `nix build .#opencode-desktop --no-link`
- `nix build .#opencode --no-link`
- `git diff --check`

### Screenshots / recordings

N/A - build-only fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR