### PR TITLE
chore(codemode): run tests in CI

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,10 @@
       "dependsOn": [],
       "outputs": ["dist/**"]
     },
+    "@opencode-ai/codemode#test": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
     "@opencode-ai/core#test": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
## What

`packages/codemode` has a `test` script and 787+ tests, but they never ran in CI: the `test` workflow runs `bun turbo test`, and `turbo.json` only defines `test` tasks for six explicit packages (`core`, `cli`, `tui`, `app`, `ui`, `session-ui`). A `turbo test --dry` confirmed `@opencode-ai/codemode#test` was absent from the task graph.

This adds the missing task following the existing per-package pattern.

## Only runs when codemode changes

Turbo caching handles this naturally: codemode has no workspace dependencies, so the task hash changes only when `packages/codemode` files (or global inputs) change. Verified locally: first run executes 787 tests, second run is a cache hit (`FULL TURBO`, 113ms).