### PR TITLE
fix(codemode): validate JSON response bodies

### DIFF
--- a/packages/codemode/src/openapi/runtime.ts
+++ b/packages/codemode/src/openapi/runtime.ts
@@ -31,8 +31,9 @@ export const invoke = (plan: Plan, input: unknown): Effect.Effect<unknown, unkno
     const text = yield* readResponseBody(response, plan)
     const mediaType = response.headers["content-type"]?.split(";")[0]?.trim().toLowerCase()
     const json = mediaType === "application/json" || mediaType?.endsWith("+json") === true
-    const decoded = text === "" ? Option.some(null) : json ? decodeJson(text) : Option.none()
-    const parsed = json ? Option.getOrElse(decoded, () => text) : text === "" ? null : text
+    const empty = text === ""
+    const decoded = json && !empty ? decodeJson(text) : Option.none()
+    const parsed = json ? (empty ? null : Option.getOrElse(decoded, () => text)) : empty ? null : text
     if (response.status < 200 || response.status >= 300) {
       const rendered = typeof parsed === "string" ? parsed : (JSON.stringify(parsed) ?? "")
       const summary =
@@ -45,7 +46,13 @@ export const invoke = (plan: Plan, input: unknown): Effect.Effect<unknown, unkno
         toolError(`${plan.operation.method} ${plan.operation.path} failed with HTTP ${response.status}: ${summary}`),
       )
     }
-    if (json && Option.isNone(decoded)) {
+    const bodyless = plan.operation.method === "HEAD" || response.status === 204 || response.status === 205
+    if (json && empty && !bodyless) {
+      return yield* Effect.fail(
+        toolError(`${plan.operation.method} ${plan.operation.path} returned an empty JSON response.`),
+      )
+    }
+    if (json && !empty && Option.isNone(decoded)) {
       return yield* Effect.fail(toolError(`${plan.operation.method} ${plan.operation.path} returned malformed JSON.`))
     }
     return parsed
@@ -322,5 +329,9 @@ const readResponseBody = (
         )
       }),
     )
-    return new TextDecoder().decode(body.subarray(0, size))
+    return yield* Effect.try({
+      try: () => new TextDecoder("utf-8", { fatal: true }).decode(body.subarray(0, size)),
+      catch: (cause) =>
+        toolError(`${plan.operation.method} ${plan.operation.path} returned invalid UTF-8.`, cause),
+    })
   })

--- a/packages/codemode/test/openapi.test.ts
+++ b/packages/codemode/test/openapi.test.ts
@@ -768,13 +768,19 @@ describe("OpenAPI.fromSpec", () => {
     )
   })
 
-  test("rejects oversized and malformed JSON responses", async () => {
+  test("rejects oversized, malformed, empty, and invalid UTF-8 JSON responses", async () => {
     const tool = toolAt(OpenAPI.fromSpec({ baseUrl, spec: singleOperation({}) }).tools, "test")
     if (!Tool.isDefinition(tool)) throw new Error("test was not generated")
     const oversized = recordingClient(
       () => new Response(null, { headers: { "content-length": String(50 * 1024 * 1024 + 1) } }),
     )
     const malformed = recordingClient(() => new Response("{", { headers: { "content-type": "application/json" } }))
+    const empty = recordingClient(() => new Response(null, { headers: { "content-type": "application/json" } }))
+    const invalid = recordingClient(
+      () => new Response(new Uint8Array([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d]), {
+        headers: { "content-type": "application/json" },
+      }),
+    )
     const chunked = recordingClient(() => new Response(new Uint8Array(50 * 1024 * 1024 + 1)))
 
     await expect(Effect.runPromise(tool.run({}).pipe(Effect.provide(oversized.layer)))).rejects.toThrow(
@@ -783,9 +789,33 @@ describe("OpenAPI.fromSpec", () => {
     await expect(Effect.runPromise(tool.run({}).pipe(Effect.provide(malformed.layer)))).rejects.toThrow(
       "returned malformed JSON",
     )
+    await expect(Effect.runPromise(tool.run({}).pipe(Effect.provide(empty.layer)))).rejects.toThrow(
+      "returned an empty JSON response",
+    )
+    await expect(Effect.runPromise(tool.run({}).pipe(Effect.provide(invalid.layer)))).rejects.toThrow(
+      "returned invalid UTF-8",
+    )
     await expect(Effect.runPromise(tool.run({}).pipe(Effect.provide(chunked.layer)))).rejects.toThrow(
       "response exceeds 50 MiB",
     )
+  })
+
+  test.each([204, 205])("accepts empty JSON responses for HTTP %i", async (status) => {
+    const tool = toolAt(OpenAPI.fromSpec({ baseUrl, spec: singleOperation({}) }).tools, "test")
+    if (!Tool.isDefinition(tool)) throw new Error("test was not generated")
+    const client = recordingClient(() =>
+      new Response(null, { status, headers: { "content-type": "application/json" } }),
+    )
+
+    await expect(Effect.runPromise(tool.run({}).pipe(Effect.provide(client.layer)))).resolves.toBeNull()
+  })
+
+  test("accepts an empty JSON response to HEAD", async () => {
+    const tool = toolAt(OpenAPI.fromSpec({ baseUrl, spec: singleOperation({}, "head") }).tools, "test")
+    if (!Tool.isDefinition(tool)) throw new Error("test was not generated")
+    const client = recordingClient(() => new Response(null, { headers: { "content-type": "application/json" } }))
+
+    await expect(Effect.runPromise(tool.run({}).pipe(Effect.provide(client.layer)))).resolves.toBeNull()
   })
 
   test("keeps non-JSON responses raw and unions every success output", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #36800

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Rejects empty or invalid UTF-8 JSON response bodies instead of treating them as successful data. Bodyless `HEAD`, `204`, and `205` responses remain valid and return `null`.

### How did you verify your code works?

- Current `dev` plus the regression test fails because HTTP 200 empty JSON resolves successfully
- `bun test test/openapi.test.ts --timeout 30000` in `packages/codemode` (`29 pass`)
- `bun test --timeout 30000` in `packages/codemode` (`266 pass`)
- `bun typecheck` in `packages/codemode`
- `bun lint packages/codemode/src/openapi/runtime.ts packages/codemode/test/openapi.test.ts` (`0 errors`)
- Pre-push `bun turbo typecheck` (`36 packages`)
- `git diff --check origin/dev...HEAD`

### Screenshots / recordings

N/A; non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
