### PR TITLE
feat(codemode): support URL-encoded bodies

### DIFF
--- a/packages/codemode/src/openapi/runtime.ts
+++ b/packages/codemode/src/openapi/runtime.ts
@@ -8,6 +8,9 @@ const decodeJson = Schema.decodeUnknownOption(Schema.UnknownFromJsonString)
 const maxErrorBodyChars = 1_024
 const maxResponseBodyBytes = 50 * 1024 * 1024
 
+const isFormScalarValue = (value: unknown): value is string | number | boolean =>
+  typeof value === "string" || typeof value === "boolean" || (typeof value === "number" && Number.isFinite(value))
+
 export const invoke = (plan: Plan, input: unknown): Effect.Effect<unknown, unknown, HttpClient.HttpClient> =>
   Effect.gen(function* () {
     const value = isRecord(input) ? input : {}
@@ -88,7 +91,7 @@ const buildRequest = (
       request = HttpClientRequest.setHeader(request, field.name, serialized)
     }
 
-    const setBody = (value: unknown, mediaType: string) =>
+    const setJsonBody = (value: unknown, mediaType: string) =>
       HttpClientRequest.bodyJson(request, value).pipe(
         Effect.map((next) => HttpClientRequest.setHeader(next, "content-type", mediaType)),
         Effect.mapError((cause) =>
@@ -98,7 +101,7 @@ const buildRequest = (
     if (plan.body?.mode === "value") {
       const field = plan.fields.find((field) => field.location === "body")
       const body = field === undefined ? undefined : own(input, field.inputName)
-      if (body !== undefined) request = yield* setBody(body, plan.body.mediaType)
+      if (body !== undefined) request = yield* setJsonBody(body, plan.body.mediaType)
     }
     if (plan.body?.mode === "object") {
       const entries = plan.fields.flatMap((field) => {
@@ -107,7 +110,21 @@ const buildRequest = (
         return item === undefined ? [] : [[field.name, item] as const]
       })
       if (plan.body.required || entries.length > 0) {
-        request = yield* setBody(Object.fromEntries(entries), plan.body.mediaType)
+        if (plan.body.serialization === "form") {
+          const unsupported = entries.find(([, item]) => !isFormScalarValue(item))
+          if (unsupported !== undefined) {
+            return yield* Effect.fail(toolError(`URL-encoded body field '${unsupported[0]}' must be a scalar value.`))
+          }
+          request = HttpClientRequest.bodyUrlParams(
+            request,
+            entries.filter((entry): entry is readonly [string, string | number | boolean] =>
+              isFormScalarValue(entry[1]),
+            ),
+          )
+          request = HttpClientRequest.setHeader(request, "content-type", plan.body.mediaType)
+        } else {
+          request = yield* setJsonBody(Object.fromEntries(entries), plan.body.mediaType)
+        }
       }
     }
     return request

--- a/packages/codemode/src/openapi/spec.ts
+++ b/packages/codemode/src/openapi/spec.ts
@@ -85,6 +85,24 @@ const jsonContent = (
   return entry !== undefined && isRecord(entry[1]) ? { mediaType: entry[0], schema: entry[1].schema } : undefined
 }
 
+const formContent = (
+  content: Record<string, unknown>,
+): { readonly mediaType: string; readonly schema: unknown; readonly encoding: unknown } | undefined => {
+  const entry = Object.entries(content).find(
+    ([mediaType]) => mediaType.split(";")[0]?.trim().toLowerCase() === "application/x-www-form-urlencoded",
+  )
+  return entry !== undefined && isRecord(entry[1])
+    ? { mediaType: entry[0], schema: entry[1].schema, encoding: entry[1].encoding }
+    : undefined
+}
+
+const isFormScalarSchema = (document: Document, value: unknown): boolean => {
+  const schema = resolve(document, value)
+  if (!isRecord(schema) || schema.nullable === true || schema.format === "binary") return false
+  if (schema.anyOf !== undefined || schema.oneOf !== undefined || schema.allOf !== undefined) return false
+  return schema.type === "string" || schema.type === "number" || schema.type === "integer" || schema.type === "boolean"
+}
+
 const isFlattenableObjectBody = (
   schema: unknown,
   requestRequired: boolean,
@@ -185,7 +203,9 @@ const operationBody = (
   const resolved = resolve(document, operation.requestBody)
   if (!isRecord(resolved)) return { ok: true, value: { fields: [], body: undefined } }
   const content = isRecord(resolved.content) ? resolved.content : {}
-  const selected = jsonContent(content)
+  const json = jsonContent(content)
+  const form = json === undefined ? formContent(content) : undefined
+  const selected = json ?? form
   if (selected === undefined) {
     return {
       ok: false,
@@ -194,6 +214,40 @@ const operationBody = (
   }
   const schema = resolve(document, selected.schema)
   const required = resolved.required === true
+  if (form !== undefined) {
+    if (form.encoding !== undefined && (!isRecord(form.encoding) || Object.keys(form.encoding).length > 0)) {
+      return { ok: false, reason: "URL-encoded request body uses unsupported property encoding" }
+    }
+    if (
+      !isRecord(schema) ||
+      schema.type !== "object" ||
+      !isRecord(schema.properties) ||
+      schema.additionalProperties !== false
+    ) {
+      return { ok: false, reason: "URL-encoded request body must declare a closed object schema with properties" }
+    }
+    const unsupported = Object.entries(schema.properties).find(([, value]) => !isFormScalarSchema(document, value))
+    if (unsupported !== undefined) {
+      return { ok: false, reason: `URL-encoded body field '${unsupported[0]}' must use a scalar schema` }
+    }
+    const requiredProperties = new Set(
+      Array.isArray(schema.required) ? schema.required.filter((item): item is string => typeof item === "string") : [],
+    )
+    return {
+      ok: true,
+      value: {
+        fields: Object.entries(schema.properties).map(([name, value]) => ({
+          name,
+          location: "body" as const,
+          required: required && requiredProperties.has(name),
+          schema: projectSchema(document, value),
+          style: undefined,
+          explode: undefined,
+        })),
+        body: { required, mode: "object", mediaType: form.mediaType, serialization: "form" },
+      },
+    }
+  }
   if (!isFlattenableObjectBody(schema, required)) {
     return {
       ok: true,

--- a/packages/codemode/src/openapi/types.ts
+++ b/packages/codemode/src/openapi/types.ts
@@ -85,7 +85,12 @@ export type InputField = {
   readonly explode: boolean | undefined
 }
 
-export type Body = { readonly required: boolean; readonly mode: "object" | "value"; readonly mediaType: string }
+export type Body = {
+  readonly required: boolean
+  readonly mode: "object" | "value"
+  readonly mediaType: string
+  readonly serialization?: "form"
+}
 
 export type OperationInput = {
   readonly fields: ReadonlyArray<InputField>

--- a/packages/codemode/test/openapi.test.ts
+++ b/packages/codemode/test/openapi.test.ts
@@ -33,8 +33,13 @@ const recordingClient = (respond: (request: HttpClientRequest.HttpClientRequest)
   const layer = Layer.succeed(HttpClient.HttpClient)(
     HttpClient.make((request) =>
       Effect.gen(function* () {
+        const bodyText = request.body._tag === "Uint8Array" ? new TextDecoder().decode(request.body.body) : undefined
         const body =
-          request.body._tag === "Uint8Array" ? JSON.parse(new TextDecoder().decode(request.body.body)) : undefined
+          bodyText === undefined
+            ? undefined
+            : request.headers["content-type"]?.includes("json")
+              ? JSON.parse(bodyText)
+              : bodyText
         const url = Option.map(HttpClientRequest.toUrl(request), (resolved) => resolved.toString())
         requests.push({
           method: request.method,
@@ -766,6 +771,109 @@ describe("OpenAPI.fromSpec", () => {
     await expect(Effect.runPromise(tool.run({ body: cyclic }).pipe(Effect.provide(client.layer)))).rejects.toThrow(
       "Invalid JSON body",
     )
+  })
+
+  test("serializes flat URL-encoded request bodies", async () => {
+    const resolutions: Array<string> = []
+    const client = recordingClient(() => json({ ok: true }))
+    const api = OpenAPI.fromSpec({
+      baseUrl,
+      spec: {
+        ...singleOperation(
+          {
+            requestBody: {
+              required: true,
+              content: {
+                "application/x-www-form-urlencoded; charset=utf-8": {
+                  schema: {
+                    type: "object",
+                    additionalProperties: false,
+                    required: ["grant_type"],
+                    properties: {
+                      grant_type: { type: "string" },
+                      count: { type: "integer" },
+                      enabled: { type: "boolean" },
+                    },
+                  },
+                },
+              },
+            },
+            security: [{ bearer: [] }],
+          },
+          "post",
+        ),
+        components: { securitySchemes: { bearer: { type: "http", scheme: "bearer" } } },
+      },
+      auth: {
+        resolve: ({ name }) => {
+          resolutions.push(name)
+          return Effect.succeed({ type: "bearer", token: "secret" })
+        },
+      },
+    })
+    const tool = toolAt(api.tools, "test")
+
+    expect(api.skipped).toEqual([])
+    if (!Tool.isDefinition(tool)) throw new Error("form operation was not generated")
+    expect(inputTypeScript(tool)).toBe("{ grant_type: string; count?: number; enabled?: boolean }")
+
+    await expect(
+      Effect.runPromise(tool.run({ grant_type: { nested: true } }).pipe(Effect.provide(client.layer))),
+    ).rejects.toThrow("must be a scalar value")
+    expect(resolutions).toEqual([])
+    expect(client.requests).toEqual([])
+
+    await Effect.runPromise(
+      tool
+        .run({ grant_type: "client + secret", count: 2, enabled: false })
+        .pipe(Effect.provide(client.layer)),
+    )
+
+    expect(client.requests).toHaveLength(1)
+    expect(resolutions).toEqual(["bearer"])
+    expect(client.requests[0]!.headers.authorization).toBe("Bearer secret")
+    expect(client.requests[0]!.headers["content-type"]).toBe(
+      "application/x-www-form-urlencoded; charset=utf-8",
+    )
+    expect(client.requests[0]!.body).toBe("grant_type=client+%2B+secret&count=2&enabled=false")
+  })
+
+  test.each([
+    {
+      name: "nested fields",
+      media: {
+        schema: {
+          type: "object",
+          additionalProperties: false,
+          properties: { metadata: { type: "object", properties: { source: { type: "string" } } } },
+        },
+      },
+      reason: "URL-encoded body field 'metadata' must use a scalar schema",
+    },
+    {
+      name: "property encoding",
+      media: {
+        schema: { type: "object", additionalProperties: false, properties: { tags: { type: "string" } } },
+        encoding: { tags: { allowReserved: true } },
+      },
+      reason: "URL-encoded request body uses unsupported property encoding",
+    },
+    {
+      name: "open object schemas",
+      media: { schema: { type: "object", properties: { value: { type: "string" } } } },
+      reason: "URL-encoded request body must declare a closed object schema with properties",
+    },
+  ])("skips URL-encoded bodies with $name", ({ media, reason }) => {
+    const result = OpenAPI.fromSpec({
+      baseUrl,
+      spec: singleOperation(
+        { requestBody: { content: { "application/x-www-form-urlencoded": media } } },
+        "post",
+      ),
+    })
+
+    expect(result.skipped).toEqual([{ method: "POST", path: "/test", reason }])
+    expect(toolAt(result.tools, "test")).toBeUndefined()
   })
 
   test("rejects oversized and malformed JSON responses", async () => {


### PR DESCRIPTION
### Issue for this PR

Part of #36209

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds bounded `application/x-www-form-urlencoded` request-body support to the CodeMode OpenAPI adapter. Closed object schemas with scalar fields are serialized as URL parameters; nested values, open schemas, and custom property encoding remain skipped with precise reasons, and runtime validation happens before auth resolution.

### How did you verify your code works?

- `bun test test/openapi.test.ts --timeout 30000` from `packages/codemode` (30 passed)
- `bun test --timeout 30000` from `packages/codemode` (267 passed)
- `bun typecheck` from `packages/codemode`
- `bun lint packages/codemode/src/openapi/runtime.ts packages/codemode/src/openapi/spec.ts packages/codemode/src/openapi/types.ts packages/codemode/test/openapi.test.ts` (0 errors; 38 pre-existing warnings)
- `git diff --check origin/dev...HEAD`
- Repeated the focused test, package typecheck, lint, and diff check on a synthetic merge with current `origin/dev`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
