### PR TITLE
chore(deps): update @remix-run/router resolution #36611

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1083,6 +1083,7 @@
     "@opentui/core": "catalog:",
     "@opentui/keymap": "catalog:",
     "@opentui/solid": "catalog:",
+    "@remix-run/router": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
   },
@@ -1104,6 +1105,7 @@
     "@opentui/solid": "0.4.3",
     "@pierre/diffs": "1.2.10",
     "@playwright/test": "1.59.1",
+    "@remix-run/router": "1.23.2",
     "@sentry/solid": "10.36.0",
     "@sentry/vite-plugin": "4.6.0",
     "@shikijs/stream": "4.2.0",
@@ -2426,7 +2428,7 @@
 
     "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.8.1", "", {}, "sha512-J1dev372wtJqmqn9U/qbpbZxbJSQrogNN2+Qv1lKlpATpe/WQ9aCZfl/xSb9d2Rgh1IyLSvNxZAXPZxruO6Xig=="],
 
-    "@remix-run/router": ["@remix-run/router@1.9.0", "", {}, "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA=="],
+    "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
       "@sentry/vite-plugin": "4.6.0",
       "solid-js": "1.9.10",
       "vite-plugin-solid": "2.11.10",
-      "@lydell/node-pty": "1.2.0-beta.12"
+      "@lydell/node-pty": "1.2.0-beta.12",
+      "@remix-run/router": "1.23.2"
     }
   },
   "devDependencies": {
@@ -140,7 +141,8 @@
     "@opentui/keymap": "catalog:",
     "@opentui/solid": "catalog:",
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "@remix-run/router": "catalog:"
   },
   "patchedDependencies": {
     "@ff-labs/fff-bun@0.9.3": "patches/@ff-labs%2Ffff-bun@0.9.3.patch",


### PR DESCRIPTION
### Issue for this PR

Closes #36611 

### Type of change

- [ ] Bug fix
- [ ] New feature
- [X] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The current bun.lock resolves @remix-run/router to 1.9.0, which is outdated and reported by dependency scanning tools.

This updates the transitive @remix-run/router resolution to 1.23.2 using the existing workspace catalog + overrides pattern.


### How did you verify your code works?

OSV Scanner 

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

### Changes:

* Adds @remix-run/router 1.23.2 to the workspace catalog
* Adds @remix-run/router to overrides using catalog:
* Regenerates bun.lock so the dependency tree resolves to 1.23.2

This keeps the lockfile aligned with the latest patched 1.x release and reduces dependency maintenance noise from scanners.

### Verified locally

Ran bun install to regenerate bun.lock and confirmed @remix-run/router now resolves to 1.23.2.

Also re-ran OSV Scanner to confirm the outdated transitive resolution is no longer reported.
