### PR TITLE
fix(cli): ensure service on first reconnect

### DIFF
--- a/packages/cli/src/services/server.ts
+++ b/packages/cli/src/services/server.ts
@@ -27,9 +27,7 @@ export const resolve = Effect.fn("cli.server.resolve")(function* (args: Args) {
     const password = yield* Env.password
     const endpoint = {
       url: args.server,
-      auth: password
-        ? { type: "basic" as const, username: "opencode", password: Redacted.value(password) }
-        : undefined,
+      auth: password ? { type: "basic" as const, username: "opencode", password: Redacted.value(password) } : undefined,
     } satisfies Service.Endpoint
     const client = OpenCode.make({ baseUrl: endpoint.url, headers: Service.headers(endpoint) })
     const health = yield* Effect.tryPromise({
@@ -48,18 +46,9 @@ export const resolve = Effect.fn("cli.server.resolve")(function* (args: Args) {
 
   const options = yield* ServiceConfig.options()
   const endpoint = yield* resolveManaged({ ...options, onStart: args.onStart }, args.mismatch ?? "replace")
-  const reconnectOptions = { ...options, version: undefined }
   return {
     endpoint,
-    reconnect: (attempt) =>
-      Effect.runPromise(
-        Effect.gen(function* () {
-          if (attempt > 3) return yield* Service.start(reconnectOptions)
-          const endpoint = yield* Service.discover(reconnectOptions)
-          if (endpoint !== undefined) return endpoint
-          return yield* Effect.fail(new Error("Background server is unavailable"))
-        }).pipe(Effect.provide(NodeFileSystem.layer)),
-      ),
+    reconnect: () => Effect.runPromise(managedReconnect(options).pipe(Effect.provide(NodeFileSystem.layer))),
     reload: () =>
       Effect.runPromise(
         Effect.gen(function* () {
@@ -68,6 +57,10 @@ export const resolve = Effect.fn("cli.server.resolve")(function* (args: Args) {
         }).pipe(Effect.provide(NodeFileSystem.layer)),
       ),
   } satisfies Resolved
+})
+
+export const managedReconnect = Effect.fnUntraced(function* (options: Service.StartOptions) {
+  return yield* Service.start({ ...options, version: undefined })
 })
 
 const resolveManaged = Effect.fnUntraced(function* (
@@ -80,7 +73,8 @@ const resolveManaged = Effect.fnUntraced(function* (
   const compatible = yield* Service.discover(options)
   if (compatible !== undefined) return compatible
   const existing = yield* Service.discover({ ...options, version: undefined })
-  if (existing !== undefined) return yield* Effect.fail(new Error("Background server version does not match this client"))
+  if (existing !== undefined)
+    return yield* Effect.fail(new Error("Background server version does not match this client"))
   return yield* Service.start(options)
 })
 

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -12,10 +12,63 @@ import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionTable } from "@opencode-ai/core/session/sql"
 import { expect, test } from "bun:test"
 import { Effect, Schedule, Schema } from "effect"
+import { createServer } from "node:http"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { ServiceConfig } from "../src/services/service-config"
+import { Server } from "../src/services/server"
+
+test("managed reconnect ensures the service on the first failure", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-reconnect-"))
+  const starts: Service.StartReason[] = []
+  try {
+    const exit = await Effect.runPromise(
+      Server.managedReconnect({
+        file: path.join(root, "service.json"),
+        onStart: (reason) => {
+          starts.push(reason)
+          throw new Error("service ensure invoked")
+        },
+      }).pipe(Effect.provide(NodeFileSystem.layer), Effect.exit),
+    )
+    expect(exit._tag).toBe("Failure")
+    expect(starts).toEqual(["missing"])
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("managed reconnect reuses a healthy service from another version", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-reconnect-version-"))
+  const server = createServer((request, response) => {
+    if (request.url !== "/api/health") {
+      response.writeHead(404).end()
+      return
+    }
+    response.writeHead(200, { "content-type": "application/json" })
+    response.end(JSON.stringify({ healthy: true, version: "older", pid: process.pid }))
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (address === null || typeof address === "string") throw new Error("Expected TCP server address")
+  const file = path.join(root, "service.json")
+  const url = `http://127.0.0.1:${address.port}`
+  await Bun.write(file, JSON.stringify({ url, pid: process.pid, version: "older" }))
+  try {
+    const endpoint = await Effect.runPromise(
+      Server.managedReconnect({ file, version: "newer", command: [path.join(root, "must-not-start")] }).pipe(
+        Effect.provide(NodeFileSystem.layer),
+      ),
+    )
+    expect(endpoint.url).toBe(url)
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error === undefined ? resolve() : reject(error))),
+    )
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
 
 test("local channel stores service config with the local service filename", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-"))


### PR DESCRIPTION
### Issue for this PR

Closes #36581

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Managed TUI reconnect now invokes the idempotent, version-agnostic service ensure operation on the first failed stream attempt instead of waiting through three passive discovery failures. Healthy services from another version are still reused rather than replaced.

### How did you verify your code works?

- `bun test test/service.test.ts --timeout 30000 --test-name-pattern 'managed reconnect'` (2 passed)
- `bun typecheck` from `packages/cli`
- `bun lint packages/cli/src/services/server.ts packages/cli/test/service.test.ts`
- `git diff --check`
- Synthetic merge with current `origin/v2`
- The existing `concurrent service processes elect one server` test times out locally on both `origin/v2` and this branch; focused tests and typecheck are green.

### Screenshots / recordings

N/A; no UI rendering change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
