### PR TITLE
fix(opencode): cap retry delay without retry hint

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -33,32 +33,28 @@ function cap(ms: number) {
 }
 
 export function delay(attempt: number, error?: SessionV1.APIError) {
-  if (error) {
-    const headers = error.data.responseHeaders
-    if (headers) {
-      const retryAfterMs = headers["retry-after-ms"]
-      if (retryAfterMs) {
-        const parsedMs = Number.parseFloat(retryAfterMs)
-        if (!Number.isNaN(parsedMs)) {
-          return cap(parsedMs)
-        }
+  const headers = error?.data.responseHeaders
+  if (headers) {
+    const retryAfterMs = headers["retry-after-ms"]
+    if (retryAfterMs) {
+      const parsedMs = Number.parseFloat(retryAfterMs)
+      if (!Number.isNaN(parsedMs)) {
+        return cap(parsedMs)
       }
+    }
 
-      const retryAfter = headers["retry-after"]
-      if (retryAfter) {
-        const parsedSeconds = Number.parseFloat(retryAfter)
-        if (!Number.isNaN(parsedSeconds)) {
-          // convert seconds to milliseconds
-          return cap(Math.ceil(parsedSeconds * 1000))
-        }
-        // Try parsing as HTTP date format
-        const parsed = Date.parse(retryAfter) - Date.now()
-        if (!Number.isNaN(parsed) && parsed > 0) {
-          return cap(Math.ceil(parsed))
-        }
+    const retryAfter = headers["retry-after"]
+    if (retryAfter) {
+      const parsedSeconds = Number.parseFloat(retryAfter)
+      if (!Number.isNaN(parsedSeconds)) {
+        // convert seconds to milliseconds
+        return cap(Math.ceil(parsedSeconds * 1000))
       }
-
-      return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1))
+      // Try parsing as HTTP date format
+      const parsed = Date.parse(retryAfter) - Date.now()
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        return cap(Math.ceil(parsed))
+      }
     }
   }
 

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -39,6 +39,12 @@ describe("session.retry.delay", () => {
     expect(delays).toStrictEqual([2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000])
   })
 
+  test("caps delay at 30 seconds when headers have no retry hint", () => {
+    const error = apiError({ "x-ratelimit-limit-requests": "100" })
+    const delays = Array.from({ length: 10 }, (_, index) => SessionRetry.delay(index + 1, error))
+    expect(delays).toStrictEqual([2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000, 30000])
+  })
+
   test("prefers retry-after-ms when shorter than exponential", () => {
     const error = apiError({ "retry-after-ms": "1500" })
     expect(SessionRetry.delay(4, error)).toBe(1500)


### PR DESCRIPTION
## Summary\n- cap session retry backoff at the no-header maximum when responses include headers but no Retry-After hint\n- keep explicit retry-after / retry-after-ms behavior unchanged\n- add coverage for rate-limit headers without retry hints\n\n## Tests\n- bun test test/session/retry.test.ts\n- bun typecheck\n- bun turbo typecheck