### PR TITLE
fix(app): avoid Suspense splash on session switch

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -551,7 +551,6 @@ export default function Page() {
   const lastUserMessage = timeline.lastUserMessage
   const messages = timeline.messages
   const messagesReady = timeline.ready
-  const sessionSync = timeline.resource
   const userMessages = timeline.userMessages
   const visibleUserMessages = timeline.visibleUserMessages
 
@@ -2092,7 +2091,6 @@ export default function Page() {
 
   const sessionPanelContent = () => (
     <>
-      {sessionSync() ?? ""}
       <Show when={!isDesktop() && !!params.id && settings.general.newLayoutDesigns() && !mobileTabsBottom()}>
         {mobileTabs(true)}
       </Show>


### PR DESCRIPTION
### Issue for this PR

Fixes #36876

### Type of change

- [x] Bug fix

### What does this PR do?

Removes a spurious `<Suspense>` trigger on every session switch.

The session timeline resource was read directly in JSX as `{sessionSync() ?? ""}` (`session.tsx`). Reading a `createResource` in JSX subscribes the render to it and trips the nearest `<Suspense>` boundary — the app-level splash — on every switch, even though the resource resolves to `void` and renders nothing.

This PR removes the JSX read and the now-unused local alias. `createResource` fetches eagerly from its source signal (`sessionID`), so the refresh still runs; only the spurious Suspense subscription is gone.

> **Scope note:** an earlier version of this PR also removed `deferRender`. Upstream has since deliberately kept `deferRender` (paired with the `reviewPanelV2Rendered` latch) for first-paint deferral, so this PR has been reduced to only the still-valid `sessionSync` Suspense-read removal to stay aligned with upstream.

### How did you verify your code works?

`bun typecheck` passes. Switching between sessions no longer shows the app splash flicker; timeline still refreshes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
