### PR TITLE
fix(opencode): open themes dialog

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/tui.ts
@@ -49,7 +49,7 @@ export const tuiHandlers = HttpApiBuilder.group(InstanceHttpApi, "tui", (handler
     })
 
     const openThemes = Effect.fn("TuiHttpApi.openThemes")(function* () {
-      yield* publishCommand("session.list")
+      yield* publishCommand("theme.switch")
       return true
     })
 

--- a/packages/opencode/test/server/httpapi-event.test.ts
+++ b/packages/opencode/test/server/httpapi-event.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect } from "bun:test"
 import { Effect, Layer, Queue, Schema, Stream } from "effect"
 import { EventPaths } from "../../src/server/routes/instance/httpapi/groups/event"
+import { TuiPaths } from "../../src/server/routes/instance/httpapi/groups/tui"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -88,6 +89,24 @@ describe("event HttpApi", () => {
         const created = yield* requestInDirectory("/session", directory, { method: "POST" })
         expect(created.status).toBe(200)
         expect(yield* readEvent(reader)).toMatchObject({ type: "session.created" })
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
+    "opens the theme dialog",
+    () =>
+      Effect.gen(function* () {
+        const { directory } = yield* TestInstance
+        const { reader } = yield* openEventStream(directory)
+        expect(yield* readEvent(reader)).toMatchObject({ type: "server.connected", properties: {} })
+
+        const response = yield* requestInDirectory(TuiPaths.openThemes, directory, { method: "POST" })
+        expect(response.status).toBe(200)
+        expect(yield* readEvent(reader)).toMatchObject({
+          type: "tui.command.execute",
+          properties: { command: "theme.switch" },
+        })
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #36849

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`POST /tui/open-themes` returned success but published `session.list`, which opens the session picker. It now publishes the existing `theme.switch` command. The SSE test asserts the command sent to a connected TUI.

### How did you verify your code works?

- `bun test test/server/httpapi-event.test.ts` — 4 passed
- `bun typecheck` from `packages/opencode`

### Screenshots / recordings

Not applicable; the change corrects an HTTP event route.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
