### PR TITLE
fix(opencode): strip MiniMax trailing tool_call leak suffix from assistant text

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -27,6 +27,18 @@ import { Database } from "@opencode-ai/core/database/database"
 import { Usage, type LLMEvent } from "@opencode-ai/llm"
 
 const DOOM_LOOP_THRESHOLD = 3
+
+const MINIMAX_TRAILING_TOOL_CALL_LEAK_RE = /\]<\]minimax\[>\[<\/tool_call>\s*$/i
+const TRAILING_TOOL_CALL_RE = /<\/tool_call>\s*$/i
+
+function sanitizeTrailingToolCallLeak(text: string, modelID: string) {
+  if (!modelID.toLowerCase().includes("minimax")) return text
+  const withoutMinimaxMarker = text.replace(MINIMAX_TRAILING_TOOL_CALL_LEAK_RE, "")
+  const withoutToolCall = withoutMinimaxMarker.replace(TRAILING_TOOL_CALL_RE, "")
+  if (withoutToolCall === text) return text
+  return withoutToolCall.trimEnd()
+}
+
 export type Result = "compact" | "stop" | "continue"
 
 export interface Handle {
@@ -522,6 +534,7 @@ const layer = Layer.effect(
               },
               { text: ctx.currentText.text },
             )).text
+            ctx.currentText.text = sanitizeTrailingToolCallLeak(ctx.currentText.text, ctx.model.id)
             {
               const end = Date.now()
               ctx.currentText.time = { start: ctx.currentText.time?.start ?? end, end }

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -226,6 +226,28 @@ const fragmentFailureLLM = Layer.succeed(
 const fragmentFailureEnv = LayerNode.compile(root, [...replacements, [LLM.node, fragmentFailureLLM]])
 const itFragmentFailure = testEffect(fragmentFailureEnv)
 
+const minimaxLeakLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () =>
+      Stream.make(
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.textStart({ id: "text-1" }),
+        LLMEvent.textDelta({ id: "text-1", text: "Answer ]<" }),
+        LLMEvent.textDelta({ id: "text-1", text: "]minimax[>[" }),
+        LLMEvent.textDelta({ id: "text-1", text: "</tool_call>" }),
+        LLMEvent.textEnd({ id: "text-1" }),
+        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+        LLMEvent.finish({ reason: "stop" }),
+      ),
+  }),
+)
+const minimaxLeakEnv = LayerNode.compile(root, [
+  ...replacements,
+  [LLM.node, minimaxLeakLLM],
+])
+const itMinimaxLeak = testEffect(minimaxLeakEnv)
+
 const boot = Effect.fn("test.boot")(function* () {
   const processors = yield* SessionProcessor.Service
   const session = yield* Session.Service
@@ -1061,6 +1083,98 @@ itFragmentFailure.live("session.processor effect tests retain partial legacy par
         expect(seen).toContain(MessageV2.Event.PartUpdated.type)
         expect(seen).toContain(Session.Event.Error.type)
         expect(seen.filter((type) => type.startsWith("session.next."))).toEqual([])
+      }),
+    { config: cfg },
+  ),
+)
+
+itMinimaxLeak.live("session.processor strips MiniMax trailing tool_call leak suffix from assistant text", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "test minimax leak")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const baseModel = yield* provider.getModel(ref.providerID, ref.modelID)
+        const minimaxModel = {
+          ...baseModel,
+          id: ModelV2.ID.make("minimax-m3-free"),
+          api: {
+            ...baseModel.api,
+            id: "minimax-m3-free",
+          },
+        } as typeof baseModel
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: minimaxModel,
+        })
+
+        yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: minimaxModel,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "hi" }],
+          tools: {},
+        } satisfies LLM.StreamInput)
+
+        const parts = yield* MessageV2.parts(msg.id)
+        const textParts = parts.filter((p): p is SessionV1.TextPart => p.type === "text")
+        expect(textParts).toHaveLength(1)
+        expect(textParts[0].text).toBe("Answer")
+      }),
+    { config: cfg },
+  ),
+)
+
+itMinimaxLeak.live("session.processor does not strip MiniMax suffix from non-MiniMax models", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "test no leak")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const nonMinimaxModel = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: nonMinimaxModel,
+        })
+
+        yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: nonMinimaxModel,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "hi" }],
+          tools: {},
+        } satisfies LLM.StreamInput)
+
+        const parts = yield* MessageV2.parts(msg.id)
+        const textParts = parts.filter((p): p is SessionV1.TextPart => p.type === "text")
+        expect(textParts).toHaveLength(1)
+        expect(textParts[0].text).toBe("Answer ]<]minimax[>[</tool_call>")
       }),
     { config: cfg },
   ),


### PR DESCRIPTION
### Issue for this PR

Closes #30684

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

MiniMax models can append a trailing serialized tool-call marker artifact
(e.g. `]<\`]minimax[>[/<\`/tool_call>`) to plain assistant text. This text leak
surfaces in the UI and can confuse downstream parsing.

The fix adds a regex-based sanitizer that removes the trailing artifact
from assistant text-end events, gated to MiniMax model ids only.

### How did you verify your code works?

- `bun test test/session/processor-effect.test.ts` — 17 tests pass including 2 new tests for the MiniMax leak path and non-MiniMax regression
- `bun typecheck` — clean

### Screenshots / recordings

N/A (no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
