### PR TITLE
fix(desktop): validate openExternal URLs by protocol

### DIFF
--- a/packages/desktop/src/main/external-link.test.ts
+++ b/packages/desktop/src/main/external-link.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { isSafeExternalLink } from "./external-link"
+
+describe("external link", () => {
+  test("allows http and https links", () => {
+    expect(isSafeExternalLink("https://opencode.ai")).toBe(true)
+    expect(isSafeExternalLink("http://localhost:3000")).toBe(true)
+  })
+
+  test("blocks non-http protocols", () => {
+    expect(isSafeExternalLink("file:///tmp/demo.txt")).toBe(false)
+    expect(isSafeExternalLink("javascript:alert(1)")).toBe(false)
+    expect(isSafeExternalLink("smb://attacker/share")).toBe(false)
+    expect(isSafeExternalLink("ms-msdt:/id PCWDiagnostic")).toBe(false)
+  })
+
+  test("blocks malformed links", () => {
+    expect(isSafeExternalLink("not a url")).toBe(false)
+    expect(isSafeExternalLink("/relative/path")).toBe(false)
+    expect(isSafeExternalLink("")).toBe(false)
+  })
+})

--- a/packages/desktop/src/main/external-link.ts
+++ b/packages/desktop/src/main/external-link.ts
@@ -1,0 +1,10 @@
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"])
+
+export function isSafeExternalLink(url: string) {
+  try {
+    const parsed = new URL(url)
+    return ALLOWED_PROTOCOLS.has(parsed.protocol)
+  } catch {
+    return false
+  }
+}

--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -8,6 +8,7 @@ import type { DesktopMenuAction } from "@opencode-ai/app/desktop-menu"
 import type { FatalRendererError, ServerReadyData, TitlebarTheme } from "../preload/types"
 import { runDesktopMenuAction } from "./desktop-menu-actions"
 import { assertAttachmentBudget, createPickedFileAuthorizations } from "./attachment-picker"
+import { isSafeExternalLink } from "./external-link"
 import { getStore, removeStoreFileIfEmpty } from "./store"
 import { getPinchZoomEnabled, getWindowID, setPinchZoomEnabled, setTitlebar, updateTitlebar } from "./windows"
 import type { UpdaterController } from "./updater-controller"
@@ -172,6 +173,7 @@ export function registerIpcHandlers(deps: Deps) {
   )
 
   ipcMain.on("open-link", (_event: IpcMainEvent, url: string) => {
+    if (!isSafeExternalLink(url)) return
     void shell.openExternal(url)
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #30613

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`shell.openExternal` accepts any URL without validation, allowing potentially dangerous protocols like `file://`, `javascript:`, and `smb:`. This adds an `isSafeExternalLink()` guard that restricts `open-link` IPC calls to `http:` and `https:` URLs only, with dedicated helper module for testability.

### How did you verify your code works?

- `bun test src/main/external-link.test.ts` — 3 tests pass covering allowed protocols, blocked protocols, and malformed URLs
- `bun typecheck` (desktop package) — clean

### Screenshots / recordings

N/A (no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR