### PR TITLE
feat(opencode): make webfetch response size limit configurable via env

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect"
+import { Config, Effect, Schema } from "effect"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Parser } from "htmlparser2"
 import * as Tool from "./tool"
@@ -6,7 +6,7 @@ import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
 import { isImageAttachment } from "@/util/media"
 
-const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
+const DEFAULT_MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
 const MAX_TIMEOUT = 120 * 1000 // 2 minutes
 
@@ -48,6 +48,9 @@ export const WebFetchTool = Tool.define(
           })
 
           const timeout = Math.min((params.timeout ?? DEFAULT_TIMEOUT / 1000) * 1000, MAX_TIMEOUT)
+          const maxResponseSize = yield* Config.number("OPENCODE_WEBFETCH_MAX_SIZE").pipe(
+            Config.withDefault(DEFAULT_MAX_RESPONSE_SIZE),
+          )
 
           // Build Accept header based on requested format with q parameters for fallbacks
           let acceptHeader = "*/*"
@@ -94,13 +97,13 @@ export const WebFetchTool = Tool.define(
 
           // Check content length
           const contentLength = response.headers["content-length"]
-          if (contentLength && parseInt(contentLength) > MAX_RESPONSE_SIZE) {
-            throw new Error("Response too large (exceeds 5MB limit)")
+          if (contentLength && parseInt(contentLength) > maxResponseSize) {
+            throw new Error(`Response too large (exceeds ${maxResponseSize} bytes limit)`)
           }
 
           const arrayBuffer = yield* response.arrayBuffer
-          if (arrayBuffer.byteLength > MAX_RESPONSE_SIZE) {
-            throw new Error("Response too large (exceeds 5MB limit)")
+          if (arrayBuffer.byteLength > maxResponseSize) {
+            throw new Error(`Response too large (exceeds ${maxResponseSize} bytes limit)`)
           }
 
           const contentType = response.headers["content-type"] || ""

--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -8,6 +8,7 @@ Usage notes:
   - IMPORTANT: if another tool is present that offers better web fetching capabilities, is more targeted to the task, or has fewer restrictions, prefer using that tool instead of this one.
   - The URL must be a fully-formed valid URL
   - HTTP URLs will be automatically upgraded to HTTPS
+  - Maximum response size defaults to 5MB and can be configured via `OPENCODE_WEBFETCH_MAX_SIZE` (bytes)
   - Format options: "markdown" (default), "text", or "html"
   - This tool is read-only and does not modify any files
   - Results may be summarized if the content is very large


### PR DESCRIPTION
### Issue for this PR

Closes #15459

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support for configuring the webfetch response size limit through the `OPENCODE_WEBFETCH_MAX_SIZE` environment variable (in bytes). The default limit remains 5MB when the variable is not set. The tool description is also updated to mention the configurable limit.

### How did you verify your code works?

- `bun test test/tool/webfetch.test.ts` — 4 tests pass (existing test suite covers the core fetch/size-check behavior)
- `bun typecheck` — clean
- Manual verification: setting `OPENCODE_WEBFETCH_MAX_SIZE=5` causes webfetch to reject any response over 5 bytes

### Screenshots / recordings

N/A (no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
