### PR TITLE
feat(opencode): per-tool execution timeout with abort + session recovery

### DIFF
--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -35,6 +35,10 @@ const AgentSchema = Schema.StructWithRest(
       description: "Maximum number of agentic iterations before forcing text-only response",
     }),
     maxSteps: Schema.optional(PositiveInt).annotate({ description: "@deprecated Use 'steps' field instead." }),
+    tool_timeout: Schema.optional(PositiveInt).annotate({
+      description:
+        "Per-agent override for tool execution timeout in ms. 0 disables. Beats experimental.tool_timeout. See #20096.",
+    }),
     permission: Schema.optional(ConfigPermissionV1.Info),
   }),
   [Schema.Record(Schema.String, Schema.Any)],
@@ -53,6 +57,7 @@ const KNOWN_KEYS = new Set([
   "color",
   "steps",
   "maxSteps",
+  "tool_timeout",
   "options",
   "permission",
   "disable",

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -179,6 +179,14 @@ export const Info = Schema.Struct({
       mcp_timeout: Schema.optional(PositiveInt).annotate({
         description: "Timeout in milliseconds for model context protocol (MCP) requests",
       }),
+      tool_timeout: Schema.optional(PositiveInt).annotate({
+        description:
+          "Default execution timeout in ms for any tool call. When a tool runs longer than this, opencode aborts it and synthesizes a tool-result so the agent loop can continue instead of wedging. 0 disables. Default: 600000 (10 min). See #20096.",
+      }),
+      task_timeout: Schema.optional(PositiveInt).annotate({
+        description:
+          "Execution timeout in ms for the `task` (subagent) tool. Falls back to experimental.tool_timeout when unset. 0 disables. See #20096.",
+      }),
       policies: Schema.optional(Schema.mutable(Schema.Array(ConfigExperimental.Policy))).annotate({
         description: "Policy statements applied to supported resources, such as provider access",
       }),

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -52,6 +52,7 @@ export const Info = Schema.Struct({
   prompt: Schema.optional(Schema.String),
   options: Schema.Record(Schema.String, Schema.Unknown),
   steps: Schema.optional(Schema.Finite),
+  tool_timeout: Schema.optional(Schema.Finite),
 }).annotate({ identifier: "Agent" })
 export type Info = DeepMutable<Schema.Schema.Type<typeof Info>>
 
@@ -289,6 +290,7 @@ const layer = Layer.effect(
           item.hidden = value.hidden ?? item.hidden
           item.name = value.name ?? item.name
           item.steps = value.steps ?? item.steps
+          item.tool_timeout = value.tool_timeout ?? item.tool_timeout
           item.options = mergeDeep(item.options, value.options ?? {})
           item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
         }

--- a/packages/opencode/src/session/tool-timeout.ts
+++ b/packages/opencode/src/session/tool-timeout.ts
@@ -1,0 +1,61 @@
+export * as ToolTimeout from "./tool-timeout"
+
+import { Schema } from "effect"
+import { Effect } from "effect"
+import { Agent } from "@/agent/agent"
+import { Config } from "@/config/config"
+
+/**
+ * Raised when a tool call exceeds its configured execution deadline. The runner
+ * catches this to synthesize a tool-result so the agent loop can continue
+ * instead of wedging on a `status="running"` part that never resolves.
+ *
+ * See https://github.com/anomalyco/opencode/issues/20096 — the documented LLM
+ * `timeout` covers provider requests but opencode had no equivalent for the
+ * tool-side execution path, so a hung tool (e.g. an MCP server, a bash command
+ * that spawns a daemon, a detached browser session) blocked the session
+ * indefinitely.
+ */
+export class ToolTimeoutError extends Schema.TaggedErrorClass<ToolTimeoutError>()(
+  "ToolTimeoutError",
+  {
+    tool: Schema.String,
+    timeoutMs: Schema.Number,
+  },
+) {
+  override get message() {
+    return `Tool "${this.tool}" timed out after ${this.timeoutMs}ms`
+  }
+}
+
+/**
+ * Per-tool execution deadline in milliseconds. `0` disables the timeout for
+ * this tool entirely (the agent's underlying `abort` signal still fires on
+ * user-initiated interrupt via Esc).
+ */
+export const DEFAULT_TOOL_TIMEOUT_MS = 600_000
+
+/**
+ * Resolve the per-call execution timeout for the given (tool, agent) pair.
+ *
+ * Precedence (highest wins):
+ *   1. Per-agent `agent.tool_timeout`
+ *   2. `experimental.task_timeout` (only for the `task` tool)
+ *   3. Global `experimental.tool_timeout`
+ *   4. Hardcoded `DEFAULT_TOOL_TIMEOUT_MS` (10 min)
+ *
+ * Returns `0` when the effective config value is `0`, which the runner
+ * interprets as "disable the timeout entirely".
+ */
+export const resolve = Effect.fnUntraced(function* (input: {
+  tool: string
+  agent: Agent.Info
+}) {
+  const service = yield* Config.Service
+  const cfg = yield* service.get()
+  const experimental = cfg.experimental
+  const globalDefault = experimental?.tool_timeout ?? DEFAULT_TOOL_TIMEOUT_MS
+  if (input.agent.tool_timeout !== undefined) return input.agent.tool_timeout
+  if (input.tool === "task" && experimental?.task_timeout !== undefined) return experimental.task_timeout
+  return globalDefault
+})

--- a/packages/opencode/src/session/tool-timeout.ts
+++ b/packages/opencode/src/session/tool-timeout.ts
@@ -1,6 +1,6 @@
 export * as ToolTimeout from "./tool-timeout"
 
-import { Schema } from "effect"
+import { Schema, Duration } from "effect"
 import { Effect } from "effect"
 import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
@@ -16,15 +16,56 @@ import { Config } from "@/config/config"
  * that spawns a daemon, a detached browser session) blocked the session
  * indefinitely.
  */
-export class ToolTimeoutError extends Schema.TaggedErrorClass<ToolTimeoutError>()(
-  "ToolTimeoutError",
-  {
-    tool: Schema.String,
-    timeoutMs: Schema.Number,
-  },
-) {
+export class ToolTimeoutError extends Schema.TaggedErrorClass<ToolTimeoutError>()("ToolTimeoutError", {
+  tool: Schema.String,
+  timeoutMs: Schema.Number,
+}) {
   override get message() {
     return `Tool "${this.tool}" timed out after ${this.timeoutMs}ms`
+  }
+}
+
+// Combine the upstream caller's AbortSignal (user-initiated Esc interrupt) with
+// our session-level timeout controller so a single `ctx.abort` surfaces both.
+// `AbortSignal.any` is Node 20+/Bun-native; when both inputs are missing we
+// return undefined so we don't replace nothing with nothing.
+function composeSignals(user?: AbortSignal, ours?: AbortSignal): AbortSignal | undefined {
+  const signals = [user, ours].filter((s): s is AbortSignal => Boolean(s))
+  if (signals.length === 0) return undefined
+  if (signals.length === 1) return signals[0]
+  return AbortSignal.any(signals)
+}
+
+/**
+ * Wrap a tool execution with a timeout controller. Creates an AbortController
+ * that fires `ToolTimeoutError` after `timeoutMs`, composes it with the
+ * caller's abort signal, and guarantees cleanup (clearTimeout) via finally.
+ *
+ * Returns `{ signal, ctx }` with the merged abort signal so the tool can
+ * pass it into its context construction. The caller is responsible for
+ * catching `ToolTimeoutError` and synthesizing the tool-result.
+ */
+/**
+ * Create a timeout controller for a single tool execution. Returns:
+ * - `signal`: merged AbortSignal (caller's signal + our timeout timer)
+ * - `dispose`: cleanup function — must be called in a finally block
+ *
+ * The caller passes `signal` into their tool context construction and calls
+ * `dispose()` to clear the timer after execution completes or fails.
+ */
+export function createTimeoutController(opts: { tool: string; timeoutMs: number; userSignal?: AbortSignal }): {
+  signal: AbortSignal | undefined
+  dispose: () => void
+} {
+  const controller = new AbortController()
+  const timer = setTimeout(
+    () => controller.abort(new ToolTimeoutError({ tool: opts.tool, timeoutMs: opts.timeoutMs })),
+    opts.timeoutMs,
+  )
+  const signal = composeSignals(opts.userSignal, controller.signal)
+  return {
+    signal,
+    dispose: () => clearTimeout(timer),
   }
 }
 
@@ -47,10 +88,7 @@ export const DEFAULT_TOOL_TIMEOUT_MS = 600_000
  * Returns `0` when the effective config value is `0`, which the runner
  * interprets as "disable the timeout entirely".
  */
-export const resolve = Effect.fnUntraced(function* (input: {
-  tool: string
-  agent: Agent.Info
-}) {
+export const resolve = Effect.fnUntraced(function* (input: { tool: string; agent: Agent.Info }) {
   const service = yield* Config.Service
   const cfg = yield* service.get()
   const experimental = cfg.experimental

--- a/packages/opencode/src/session/tool-timeout.ts
+++ b/packages/opencode/src/session/tool-timeout.ts
@@ -1,6 +1,6 @@
 export * as ToolTimeout from "./tool-timeout"
 
-import { Schema, Duration } from "effect"
+import { Schema } from "effect"
 import { Effect } from "effect"
 import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
@@ -36,15 +36,6 @@ function composeSignals(user?: AbortSignal, ours?: AbortSignal): AbortSignal | u
   return AbortSignal.any(signals)
 }
 
-/**
- * Wrap a tool execution with a timeout controller. Creates an AbortController
- * that fires `ToolTimeoutError` after `timeoutMs`, composes it with the
- * caller's abort signal, and guarantees cleanup (clearTimeout) via finally.
- *
- * Returns `{ signal, ctx }` with the merged abort signal so the tool can
- * pass it into its context construction. The caller is responsible for
- * catching `ToolTimeoutError` and synthesizing the tool-result.
- */
 /**
  * Create a timeout controller for a single tool execution. Returns:
  * - `signal`: merged AbortSignal (caller's signal + our timeout timer)

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -23,6 +23,7 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { isRecord } from "@/util/record"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { ToolTimeout } from "./tool-timeout"
 
 const MCP_RESOURCE_TOOLS = {
   list: "list_mcp_resources",
@@ -102,31 +103,62 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
       execute(args, options) {
         return run.promise(
           Effect.gen(function* () {
-            const ctx = context(args, options)
+            const timeoutMs = yield* ToolTimeout.resolve({ tool: item.id, agent: input.agent })
+            // Compose the user's abort signal with our own timer-driven controller
+            // so an Esc interrupt OR a timeout expires both fire the same signal
+            // that the tool's `execute(ctx.abort)` already listens to.
+            const controller = timeoutMs > 0 ? new AbortController() : undefined
+            const timer =
+              controller && setTimeout(
+                () => controller.abort(new ToolTimeout.ToolTimeoutError({ tool: item.id, timeoutMs })),
+                timeoutMs,
+              )
+            const mergedSignal = composeSignals(options.abortSignal, controller?.signal)
+            const ctx = context(args, { ...options, abortSignal: mergedSignal })
             yield* plugin.trigger(
               "tool.execute.before",
               { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
               { args },
             )
-            const result = yield* item.execute(args, ctx)
-            const output = {
-              ...result,
-              attachments: result.attachments?.map((attachment) => ({
-                ...attachment,
-                id: PartID.ascending(),
-                sessionID: ctx.sessionID,
-                messageID: input.processor.message.id,
-              })),
+            try {
+              const result = yield* item.execute(args, ctx)
+              const output = {
+                ...result,
+                attachments: result.attachments?.map((attachment) => ({
+                  ...attachment,
+                  id: PartID.ascending(),
+                  sessionID: ctx.sessionID,
+                  messageID: input.processor.message.id,
+                })),
+              }
+              yield* plugin.trigger(
+                "tool.execute.after",
+                { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
+                output,
+              )
+              if (options.abortSignal?.aborted) {
+                yield* input.processor.completeToolCall(options.toolCallId, output)
+              }
+              return output
+            } catch (error) {
+              if (error instanceof ToolTimeout.ToolTimeoutError) {
+                // Synthesize a tool-result so the agent loop continues instead of
+                // wedging on a part that stays `status="running"` forever. The
+                // underlying process may still be alive — the abort signal we
+                // fired into `ctx.abort` is the cleanup nudge, but completion is
+                // best-effort. See #20096.
+                const output = {
+                  title: `Tool timed out after ${timeoutMs}ms`,
+                  metadata: { timeout: true, tool: item.id, timeoutMs },
+                  output: `Tool "${item.id}" was aborted after ${timeoutMs}ms. The underlying process may still be running. Consider retrying with a different approach, a shorter scope, or splitting the work into smaller steps.`,
+                }
+                yield* input.processor.completeToolCall(options.toolCallId, output)
+                return output
+              }
+              throw error
+            } finally {
+              if (timer) clearTimeout(timer)
             }
-            yield* plugin.trigger(
-              "tool.execute.after",
-              { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
-              output,
-            )
-            if (options.abortSignal?.aborted) {
-              yield* input.processor.completeToolCall(options.toolCallId, output)
-            }
-            return output
           }),
         )
       },
@@ -398,92 +430,116 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     item.execute = (args, opts) =>
       run.promise(
         Effect.gen(function* () {
-          const ctx = context(args, opts)
+          const timeoutMs = yield* ToolTimeout.resolve({ tool: key, agent: input.agent })
+          const controller = timeoutMs > 0 ? new AbortController() : undefined
+          const timer =
+            controller && setTimeout(
+              () => controller.abort(new ToolTimeout.ToolTimeoutError({ tool: key, timeoutMs })),
+              timeoutMs,
+            )
+          const mergedSignal = composeSignals(opts.abortSignal, controller?.signal)
+          const ctx = context(args, { ...opts, abortSignal: mergedSignal })
           yield* plugin.trigger(
             "tool.execute.before",
             { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
             { args },
           )
-          const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
-            yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
-            return yield* Effect.promise(() => execute(args, opts))
-          }).pipe(
-            Effect.withSpan("Tool.execute", {
-              attributes: {
-                "tool.name": key,
-                "tool.call_id": opts.toolCallId,
-                "session.id": ctx.sessionID,
-                "message.id": input.processor.message.id,
-              },
-            }),
-          )
-          yield* plugin.trigger(
-            "tool.execute.after",
-            { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
-            result,
-          )
+          try {
+            const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
+              yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
+              return yield* Effect.promise(() => execute(args, { ...opts, abortSignal: mergedSignal }))
+            }).pipe(
+              Effect.withSpan("Tool.execute", {
+                attributes: {
+                  "tool.name": key,
+                  "tool.call_id": opts.toolCallId,
+                  "session.id": ctx.sessionID,
+                  "message.id": input.processor.message.id,
+                },
+              }),
+            )
+            yield* plugin.trigger(
+              "tool.execute.after",
+              { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
+              result,
+            )
 
-          const textParts: string[] = []
-          const attachments: Omit<SessionV1.FilePart, "id" | "sessionID" | "messageID">[] = []
-          for (const contentItem of result.content) {
-            if (contentItem.type === "text") textParts.push(contentItem.text)
-            else if (contentItem.type === "image") {
-              attachments.push({
-                type: "file",
-                mime: contentItem.mimeType,
-                url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
-              })
-            } else if (contentItem.type === "resource") {
-              const { resource } = contentItem
-              if (resource.text) textParts.push(resource.text)
-              if (resource.blob) {
-                const mime = resource.mimeType ?? "application/octet-stream"
-                const size = base64Size(resource.blob)
-                if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
-                  textParts.push(
-                    `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
-                  )
-                  continue
-                }
-                if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
-                  textParts.push(
-                    `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) exceeds ${formatBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
-                  )
-                  continue
-                }
+            const textParts: string[] = []
+            const attachments: Omit<SessionV1.FilePart, "id" | "sessionID" | "messageID">[] = []
+            for (const contentItem of result.content) {
+              if (contentItem.type === "text") textParts.push(contentItem.text)
+              else if (contentItem.type === "image") {
                 attachments.push({
                   type: "file",
-                  mime,
-                  url: `data:${mime};base64,${resource.blob}`,
-                  filename: resource.uri,
+                  mime: contentItem.mimeType,
+                  url: `data:${contentItem.mimeType};base64,${contentItem.data}`,
                 })
+              } else if (contentItem.type === "resource") {
+                const { resource } = contentItem
+                if (resource.text) textParts.push(resource.text)
+                if (resource.blob) {
+                  const mime = resource.mimeType ?? "application/octet-stream"
+                  const size = base64Size(resource.blob)
+                  if (!SUPPORTED_MCP_RESOURCE_ATTACHMENT_MIMES.has(mime)) {
+                    textParts.push(
+                      `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) is not a supported attachment type]`,
+                    )
+                    continue
+                  }
+                  if (size > MAX_MCP_RESOURCE_BLOB_BYTES) {
+                    textParts.push(
+                      `[Binary MCP resource omitted: ${resource.uri} (${mime}, ${formatBytes(size)}) exceeds ${formatBytes(MAX_MCP_RESOURCE_BLOB_BYTES)}]`,
+                    )
+                    continue
+                  }
+                  attachments.push({
+                    type: "file",
+                    mime,
+                    url: `data:${mime};base64,${resource.blob}`,
+                    filename: resource.uri,
+                  })
+                }
               }
             }
-          }
 
-          const truncated = yield* truncate.output(textParts.join("\n\n"), {}, input.agent)
-          const metadata = {
-            ...result.metadata,
-            truncated: truncated.truncated,
-            ...(truncated.truncated && { outputPath: truncated.outputPath }),
-          }
+            const truncated = yield* truncate.output(textParts.join("\n\n"), {}, input.agent)
+            const metadata = {
+              ...result.metadata,
+              truncated: truncated.truncated,
+              ...(truncated.truncated && { outputPath: truncated.outputPath }),
+            }
 
-          const output = {
-            title: "",
-            metadata,
-            output: truncated.content,
-            attachments: attachments.map((attachment) => ({
-              ...attachment,
-              id: PartID.ascending(),
-              sessionID: ctx.sessionID,
-              messageID: input.processor.message.id,
-            })),
-            content: result.content,
+            const output = {
+              title: "",
+              metadata,
+              output: truncated.content,
+              attachments: attachments.map((attachment) => ({
+                ...attachment,
+                id: PartID.ascending(),
+                sessionID: ctx.sessionID,
+                messageID: input.processor.message.id,
+              })),
+              content: result.content,
+            }
+            if (opts.abortSignal?.aborted) {
+              yield* input.processor.completeToolCall(opts.toolCallId, output)
+            }
+            return output
+          } catch (error) {
+            if (error instanceof ToolTimeout.ToolTimeoutError) {
+              const output = {
+                title: `Tool timed out after ${timeoutMs}ms`,
+                metadata: { timeout: true, tool: key, timeoutMs },
+                output: `Tool "${key}" was aborted after ${timeoutMs}ms. The underlying MCP server may still be processing. Consider retrying with a different approach, a shorter scope, or splitting the work.`,
+                content: [],
+              }
+              yield* input.processor.completeToolCall(opts.toolCallId, output)
+              return output
+            }
+            throw error
+          } finally {
+            if (timer) clearTimeout(timer)
           }
-          if (opts.abortSignal?.aborted) {
-            yield* input.processor.completeToolCall(opts.toolCallId, output)
-          }
-          return output
         }),
       )
     tools[key] = item
@@ -495,6 +551,17 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
 function toRecord(value: unknown) {
   if (isRecord(value)) return value
   return {}
+}
+
+// Combine the upstream caller's AbortSignal (user-initiated Esc interrupt) with
+// our session-level timeout controller so a single `ctx.abort` surfaces both.
+// `AbortSignal.any` is Node 20+/Bun-native; when both inputs are missing we
+// return undefined so we don't replace nothing with nothing.
+function composeSignals(user?: AbortSignal, ours?: AbortSignal): AbortSignal | undefined {
+  const signals = [user, ours].filter((s): s is AbortSignal => Boolean(s))
+  if (signals.length === 0) return undefined
+  if (signals.length === 1) return signals[0]
+  return AbortSignal.any(signals)
 }
 
 function parseListMcpResourcesArgs(value: unknown) {

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -104,17 +104,15 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
         return run.promise(
           Effect.gen(function* () {
             const timeoutMs = yield* ToolTimeout.resolve({ tool: item.id, agent: input.agent })
-            // Compose the user's abort signal with our own timer-driven controller
-            // so an Esc interrupt OR a timeout expires both fire the same signal
-            // that the tool's `execute(ctx.abort)` already listens to.
-            const controller = timeoutMs > 0 ? new AbortController() : undefined
-            const timer =
-              controller && setTimeout(
-                () => controller.abort(new ToolTimeout.ToolTimeoutError({ tool: item.id, timeoutMs })),
-                timeoutMs,
-              )
-            const mergedSignal = composeSignals(options.abortSignal, controller?.signal)
-            const ctx = context(args, { ...options, abortSignal: mergedSignal })
+            const tc =
+              timeoutMs > 0
+                ? ToolTimeout.createTimeoutController({
+                    tool: item.id,
+                    timeoutMs,
+                    userSignal: options.abortSignal,
+                  })
+                : { signal: options.abortSignal, dispose: () => {} }
+            const ctx = context(args, { ...options, abortSignal: tc.signal })
             yield* plugin.trigger(
               "tool.execute.before",
               { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
@@ -142,11 +140,6 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               return output
             } catch (error) {
               if (error instanceof ToolTimeout.ToolTimeoutError) {
-                // Synthesize a tool-result so the agent loop continues instead of
-                // wedging on a part that stays `status="running"` forever. The
-                // underlying process may still be alive — the abort signal we
-                // fired into `ctx.abort` is the cleanup nudge, but completion is
-                // best-effort. See #20096.
                 const output = {
                   title: `Tool timed out after ${timeoutMs}ms`,
                   metadata: { timeout: true, tool: item.id, timeoutMs },
@@ -157,7 +150,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
               }
               throw error
             } finally {
-              if (timer) clearTimeout(timer)
+              tc.dispose()
             }
           }),
         )
@@ -431,14 +424,15 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
       run.promise(
         Effect.gen(function* () {
           const timeoutMs = yield* ToolTimeout.resolve({ tool: key, agent: input.agent })
-          const controller = timeoutMs > 0 ? new AbortController() : undefined
-          const timer =
-            controller && setTimeout(
-              () => controller.abort(new ToolTimeout.ToolTimeoutError({ tool: key, timeoutMs })),
-              timeoutMs,
-            )
-          const mergedSignal = composeSignals(opts.abortSignal, controller?.signal)
-          const ctx = context(args, { ...opts, abortSignal: mergedSignal })
+          const tc =
+            timeoutMs > 0
+              ? ToolTimeout.createTimeoutController({
+                  tool: key,
+                  timeoutMs,
+                  userSignal: opts.abortSignal,
+                })
+              : { signal: opts.abortSignal, dispose: () => {} }
+          const ctx = context(args, { ...opts, abortSignal: tc.signal })
           yield* plugin.trigger(
             "tool.execute.before",
             { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
@@ -447,7 +441,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           try {
             const result: Awaited<ReturnType<NonNullable<typeof execute>>> = yield* Effect.gen(function* () {
               yield* ctx.ask({ permission: key, metadata: {}, patterns: ["*"], always: ["*"] })
-              return yield* Effect.promise(() => execute(args, { ...opts, abortSignal: mergedSignal }))
+              return yield* Effect.promise(() => execute(args, { ...opts, abortSignal: tc.signal }))
             }).pipe(
               Effect.withSpan("Tool.execute", {
                 attributes: {
@@ -538,7 +532,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
             }
             throw error
           } finally {
-            if (timer) clearTimeout(timer)
+            tc.dispose()
           }
         }),
       )

--- a/packages/opencode/test/session/tool-timeout.test.ts
+++ b/packages/opencode/test/session/tool-timeout.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+
+import { ToolTimeout } from "../../src/session/tool-timeout"
+import type { Agent } from "../../src/agent/agent"
+import { Config } from "@/config/config"
+import { TestConfig } from "../fixture/config"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.empty)
+
+function makeAgent(overrides: Partial<Agent.Info> = {}): Agent.Info {
+  return {
+    name: "test",
+    mode: "primary",
+    permission: [],
+    options: {},
+    ...overrides,
+  } as Agent.Info
+}
+
+function configLayerWith(experimental: Record<string, unknown> | undefined) {
+  return Layer.succeed(
+    Config.Service,
+    TestConfig.make({
+      get: () => Effect.succeed({ experimental } as ReturnType<Config.Interface["get"] extends () => Effect.Effect<infer A> ? () => A : never>),
+    }),
+  )
+}
+
+describe("session.tool-timeout.resolve", () => {
+  it.effect("uses DEFAULT_TOOL_TIMEOUT_MS when no config is set", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "read",
+        agent: makeAgent(),
+      }).pipe(Effect.provide(configLayerWith(undefined)))
+      expect(result).toBe(ToolTimeout.DEFAULT_TOOL_TIMEOUT_MS)
+    }),
+  )
+
+  it.effect("uses experimental.tool_timeout when set", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "read",
+        agent: makeAgent(),
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 30_000 })))
+      expect(result).toBe(30_000)
+    }),
+  )
+
+  it.effect("agent.tool_timeout beats experimental.tool_timeout", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "read",
+        agent: makeAgent({ tool_timeout: 15_000 }),
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 30_000 })))
+      expect(result).toBe(15_000)
+    }),
+  )
+
+  it.effect("returns 0 when agent.tool_timeout is 0 (disabled)", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "read",
+        agent: makeAgent({ tool_timeout: 0 }),
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 30_000 })))
+      expect(result).toBe(0)
+    }),
+  )
+
+  it.effect("returns 0 when experimental.tool_timeout is 0 (disabled)", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "read",
+        agent: makeAgent(),
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 0 })))
+      expect(result).toBe(0)
+    }),
+  )
+
+  it.effect("task tool uses experimental.task_timeout when set", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "task",
+        agent: makeAgent(),
+      }).pipe(
+        Effect.provide(
+          configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 }),
+        ),
+      )
+      expect(result).toBe(120_000)
+    }),
+  )
+
+  it.effect("task tool falls back to tool_timeout when task_timeout is unset", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "task",
+        agent: makeAgent(),
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 45_000 })))
+      expect(result).toBe(45_000)
+    }),
+  )
+
+  it.effect("non-task tools ignore experimental.task_timeout", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "bash",
+        agent: makeAgent(),
+      }).pipe(
+        Effect.provide(
+          configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 }),
+        ),
+      )
+      expect(result).toBe(30_000)
+    }),
+  )
+
+  it.effect("agent.tool_timeout beats task_timeout for the task tool", () =>
+    Effect.gen(function* () {
+      const result = yield* ToolTimeout.resolve({
+        tool: "task",
+        agent: makeAgent({ tool_timeout: 90_000 }),
+      }).pipe(
+        Effect.provide(
+          configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 }),
+        ),
+      )
+      expect(result).toBe(90_000)
+    }),
+  )
+})
+
+describe("session.tool-timeout.ToolTimeoutError", () => {
+  test("message includes tool name and timeout", () => {
+    const error = new ToolTimeout.ToolTimeoutError({
+      tool: "bash",
+      timeoutMs: 42_000,
+    })
+    expect(error.message).toBe('Tool "bash" timed out after 42000ms')
+    expect(error.tool).toBe("bash")
+    expect(error.timeoutMs).toBe(42_000)
+  })
+})

--- a/packages/opencode/test/session/tool-timeout.test.ts
+++ b/packages/opencode/test/session/tool-timeout.test.ts
@@ -23,7 +23,10 @@ function configLayerWith(experimental: Record<string, unknown> | undefined) {
   return Layer.succeed(
     Config.Service,
     TestConfig.make({
-      get: () => Effect.succeed({ experimental } as ReturnType<Config.Interface["get"] extends () => Effect.Effect<infer A> ? () => A : never>),
+      get: () =>
+        Effect.succeed({ experimental } as ReturnType<
+          Config.Interface["get"] extends () => Effect.Effect<infer A> ? () => A : never
+        >),
     }),
   )
 }
@@ -84,11 +87,7 @@ describe("session.tool-timeout.resolve", () => {
       const result = yield* ToolTimeout.resolve({
         tool: "task",
         agent: makeAgent(),
-      }).pipe(
-        Effect.provide(
-          configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 }),
-        ),
-      )
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 })))
       expect(result).toBe(120_000)
     }),
   )
@@ -108,11 +107,7 @@ describe("session.tool-timeout.resolve", () => {
       const result = yield* ToolTimeout.resolve({
         tool: "bash",
         agent: makeAgent(),
-      }).pipe(
-        Effect.provide(
-          configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 }),
-        ),
-      )
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 })))
       expect(result).toBe(30_000)
     }),
   )
@@ -122,11 +117,7 @@ describe("session.tool-timeout.resolve", () => {
       const result = yield* ToolTimeout.resolve({
         tool: "task",
         agent: makeAgent({ tool_timeout: 90_000 }),
-      }).pipe(
-        Effect.provide(
-          configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 }),
-        ),
-      )
+      }).pipe(Effect.provide(configLayerWith({ tool_timeout: 30_000, task_timeout: 120_000 })))
       expect(result).toBe(90_000)
     }),
   )
@@ -141,5 +132,60 @@ describe("session.tool-timeout.ToolTimeoutError", () => {
     expect(error.message).toBe('Tool "bash" timed out after 42000ms')
     expect(error.tool).toBe("bash")
     expect(error.timeoutMs).toBe(42_000)
+  })
+})
+
+describe("session.tool-timeout.createTimeoutController", () => {
+  test("fires ToolTimeoutError after timeout", async () => {
+    const tc = ToolTimeout.createTimeoutController({ tool: "test-tool", timeoutMs: 50 })
+    const fired = new Promise<unknown>((resolve) => {
+      tc.signal!.addEventListener("abort", () => resolve((tc.signal as AbortSignal).reason))
+    })
+    const result = await fired
+    expect(result).toBeInstanceOf(ToolTimeout.ToolTimeoutError)
+    tc.dispose()
+  })
+
+  test("aborted signal has correct tool and timeoutMs", async () => {
+    const tc = ToolTimeout.createTimeoutController({ tool: "my-tool", timeoutMs: 100 })
+    const fired = new Promise<unknown>((resolve) => {
+      tc.signal!.addEventListener("abort", () => resolve((tc.signal as AbortSignal).reason))
+    })
+    const error = (await fired) as ToolTimeout.ToolTimeoutError
+    expect(error.tool).toBe("my-tool")
+    expect(error.timeoutMs).toBe(100)
+    tc.dispose()
+  })
+
+  test("composes user signal with timeout signal", () => {
+    const userController = new AbortController()
+    const tc = ToolTimeout.createTimeoutController({
+      tool: "compound",
+      timeoutMs: 5000,
+      userSignal: userController.signal,
+    })
+    // The composed signal should abort when the user aborts
+    const aborted = new Promise<void>((resolve) => {
+      tc.signal!.addEventListener("abort", () => resolve())
+    })
+    userController.abort()
+    return aborted.then(() => {
+      tc.dispose()
+    })
+  })
+
+  test("dispose clears the timer so no abort fires", async () => {
+    const tc = ToolTimeout.createTimeoutController({ tool: "no-timeout", timeoutMs: 30 })
+    tc.dispose()
+    // Wait longer than the timeout to confirm no abort fires
+    await new Promise((resolve) => setTimeout(resolve, 80))
+    expect(tc.signal?.aborted).toBe(false)
+  })
+
+  test("createTimeoutController with non-aborted signal", () => {
+    const tc = ToolTimeout.createTimeoutController({ tool: "idle", timeoutMs: 999_999 })
+    expect(tc.signal).toBeDefined()
+    expect(tc.signal?.aborted).toBe(false)
+    tc.dispose()
   })
 })


### PR DESCRIPTION
### Issue for this PR

Related: #20096, #34888, #20216, #34022, #34960

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Tools (built-in and MCP) can hang the agent loop indefinitely when they wedge on a long-running or unresponsive process. This adds a configurable per-tool execution timeout that aborts the call and synthesizes a tool-result so the agent can continue instead of staying stuck on a `status=running` part forever.

**Config surface** (all optional, in milliseconds, `0` disables):

| field | scope | default |
|---|---|---|
| `experimental.tool_timeout` | global default | `600000` (10 min) |
| `experimental.task_timeout` | `task` tool only | falls back to `tool_timeout` |
| `agent.tool_timeout` | per-agent override | highest precedence |

**Precedence:** `agent.tool_timeout` > `experimental.task_timeout` (task only) > `experimental.tool_timeout` > `DEFAULT_TOOL_TIMEOUT_MS`

On timeout the runner fires an `AbortController` composed with the user's existing abort signal via `AbortSignal.any`, so both Esc interrupts and timeouts surface through the same `ctx.abort` path. The catch block synthesizes a tool-result with `metadata.timeout=true` and a message guiding the agent to retry differently. The underlying process may still be alive — the abort is a best-effort cleanup nudge, not a hard kill.

**Related PRs:** #20103 covers the same feature area with the same config keys. That PR is from a different contributor and has been open for a while; this one is an independent implementation with a different approach (centralized `ToolTimeout.resolve` module, `composeSignals` helper, per-agent override surfaced on `Agent.Info`). Happy to collaborate or defer if maintainers prefer consolidating.

### How did you verify your code works?

- `test/session/tool-timeout.test.ts` — 10 tests covering: default fallback, global override, per-agent override, `0` disable, task tool precedence, task_timeout fallback, non-task tools ignoring task_timeout, agent override beating task_timeout, and ToolTimeoutError message shape.
- `bun typecheck` in `packages/opencode` — clean.
- `bun test test/session/retry.test.ts test/tool/task.test.ts` — 49 pass, 0 fail.
- `bun test test/session/llm.test.ts` failures are pre-existing (mock LLM server route mismatches causing 5s timeouts), confirmed by running the same suite on clean `dev`.

### Screenshots / recordings

_N/A._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
