### PR TITLE
fix(app): wait for connected project picker anchor

### DIFF
--- a/packages/app/src/components/prompt-project-selector.tsx
+++ b/packages/app/src/components/prompt-project-selector.tsx
@@ -1,6 +1,14 @@
-import { createEffect, For, onCleanup, Show, splitProps, type Accessor, type ComponentProps } from "solid-js"
+import {
+  createEffect,
+  createSignal,
+  For,
+  onCleanup,
+  Show,
+  splitProps,
+  type Accessor,
+  type ComponentProps,
+} from "solid-js"
 import { createStore } from "solid-js/store"
-import { Dynamic } from "solid-js/web"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
@@ -185,8 +193,27 @@ export function PromptProjectSelector(props: {
   controller: PromptProjectController
   placement?: "bottom" | "bottom-start"
 }) {
+  const [triggerReady, setTriggerReady] = createSignal(false)
   let contentRef: HTMLDivElement | undefined
+  let triggerFrame: number | undefined
   let restoreTrigger = true
+
+  // Floating UI requires a connected anchor; route transitions can construct this trigger before adoption.
+  const setTriggerRef = (element: HTMLButtonElement) => {
+    const ready = () => {
+      if (!element.isConnected) {
+        triggerFrame = requestAnimationFrame(ready)
+        return
+      }
+      triggerFrame = undefined
+      setTriggerReady(true)
+    }
+    ready()
+  }
+
+  onCleanup(() => {
+    if (triggerFrame !== undefined) cancelAnimationFrame(triggerFrame)
+  })
 
   const activeItem = () =>
     props.controller.active()
@@ -258,13 +285,13 @@ export function PromptProjectSelector(props: {
 
   return (
     <DropdownMenu
-      open={props.controller.open()}
+      open={triggerReady() && props.controller.open()}
       placement={props.placement ?? "bottom"}
       gutter={4}
       modal={false}
       onOpenChange={(open) => props.controller.setOpen(open)}
     >
-      <DropdownMenu.Trigger as={ProjectTrigger} controller={props.controller} />
+      <DropdownMenu.Trigger as={ProjectTrigger} ref={setTriggerRef} controller={props.controller} />
       <DropdownMenu.Portal>
         <DropdownMenu.Content
           ref={contentRef}
@@ -434,9 +461,7 @@ function ProjectTrigger(props: ComponentProps<"button"> & { controller: PromptPr
   const [local, rest] = splitProps(props, ["controller", "class", "classList", "onClick", "onKeyDown"])
   const project = () => local.controller.selected()
   return (
-    // Avoid an inert template clone that Floating UI can measure before browser adoption.
-    <Dynamic
-      component="button"
+    <button
       {...rest}
       data-action="prompt-project"
       type="button"
@@ -473,7 +498,7 @@ function ProjectTrigger(props: ComponentProps<"button"> & { controller: PromptPr
         {project() ? displayName(project()!) : local.controller.labels.new()}
       </span>
       <Icon name="chevron-down" size="small" class="shrink-0 text-v2-icon-icon-muted" />
-    </Dynamic>
+    </button>
   )
 }
 


### PR DESCRIPTION
Follow-up to #36864. Fixes #36871.

## Summary
- keep the project menu closed until its trigger is connected to the document
- remove the insufficient `Dynamic` trigger workaround
- move the rationale to the connectivity gate

## Root cause
During draft route transitions, Kobalte can receive the new project trigger while it is still disconnected and owned by Solid's body-less inert template document. Floating UI requires a mounted anchor, but starts `autoUpdate` as soon as the refs are truthy and eventually calls `getComputedStyle(null)`. Creating the button with `Dynamic` is insufficient because inserting it into the pending inert parent adopts it into that document.

## Validation
- instrumented the exact Floating UI overflow path and confirmed the failing node is the disconnected `[data-action="prompt-project"]` button
- the original code reproduced within 100 automated `Cmd+T` / picker-open cycles
- the connectivity gate completed 500 cycles without an invalid anchor or renderer crash
- `bun typecheck`
- `bun run build`