### PR TITLE
fix(llm): reject unterminated provider streams

### DIFF
--- a/packages/llm/src/route/client.ts
+++ b/packages/llm/src/route/client.ts
@@ -10,7 +10,7 @@ import { WebSocketExecutor } from "./transport"
 import type { Protocol } from "./protocol"
 import { applyCachePolicy } from "../cache-policy"
 import * as ProviderShared from "../protocols/shared"
-import type { LLMError, LLMEvent, PreparedRequestOf, ProtocolID, ProviderOptions } from "../schema"
+import type { LLMError, PreparedRequestOf, ProtocolID, ProviderOptions } from "../schema"
 import {
   GenerationOptions,
   HttpOptions,
@@ -19,6 +19,7 @@ import {
   Model,
   ModelLimits,
   LLMError as LLMErrorClass,
+  LLMEvent,
   PreparedRequest,
   ProviderID,
   mergeGenerationOptions,
@@ -229,6 +230,28 @@ const streamError = (route: string, message: string, cause: Cause.Cause<unknown>
   return ProviderShared.eventError(route, message, Cause.pretty(cause))
 }
 
+const requireTerminalEvent = (route: string) => (events: Stream.Stream<LLMEvent, LLMError>) =>
+  Stream.suspend(() => {
+    let terminal = false
+    return events.pipe(
+      Stream.mapEffect((event) => {
+        if (terminal)
+          return Effect.fail(
+            ProviderShared.eventError(route, `Provider emitted ${event.type} after the terminal event`),
+          )
+        if (LLMEvent.is.finish(event) || LLMEvent.is.providerError(event)) terminal = true
+        return Effect.succeed(event)
+      }),
+      Stream.onEnd(
+        Effect.suspend(() =>
+          terminal
+            ? Effect.void
+            : Effect.fail(ProviderShared.eventError(route, "Provider stream ended without a terminal finish event")),
+        ),
+      ),
+    )
+  })
+
 function makeFromTransport<Body, Prepared, Frame, Event, State>(
   input: MakeTransportInput<Body, Prepared, Frame, Event, State>,
 ): Route<Body, Prepared> {
@@ -298,6 +321,7 @@ function makeFromTransport<Body, Prepared, Frame, Event, State>(
             protocol.stream.onHalt ? { onHalt: protocol.stream.onHalt } : undefined,
           ),
           Stream.catchCause((cause) => Stream.fail(streamError(route, `Failed to read ${route} stream`, cause))),
+          requireTerminalEvent(route),
         )
       },
     } satisfies Route<Body, Prepared>

--- a/packages/llm/test/adapter.test.ts
+++ b/packages/llm/test/adapter.test.ts
@@ -105,6 +105,9 @@ const echoLayer = dynamicResponse(({ text, respond }) =>
 )
 
 const it = testEffect(echoLayer)
+const unterminated = testEffect(
+  dynamicResponse(({ respond }) => Effect.succeed(respond(encodeJson([{ type: "text", text: "partial" }])))),
+)
 
 describe("llm route", () => {
   it.effect("stream and generate use the route pipeline", () =>
@@ -122,6 +125,15 @@ describe("llm route", () => {
       expect(response.usage).toEqual(reduced.usage)
       expect(response.finishReason).toEqual(reduced.finishReason)
       expect(response.message.content).toEqual([{ type: "text", text: 'echo:{"body":"hello"}' }])
+    }),
+  )
+
+  unterminated.effect("fails when the normalized stream ends without a terminal event", () =>
+    Effect.gen(function* () {
+      const error = yield* (yield* LLMClient.Service).stream(request).pipe(Stream.runDrain, Effect.flip)
+
+      expect(error.reason).toMatchObject({ _tag: "InvalidProviderOutput" })
+      expect(error.message).toContain("Provider stream ended without a terminal finish event")
     }),
   )
 

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -602,7 +602,7 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
-  it.effect("does not finalize streamed tool calls without a finish reason", () =>
+  it.effect("fails a streamed tool call when the provider ends without a finish reason", () =>
     Effect.gen(function* () {
       const body = sseEvents(
         deltaChunk({
@@ -614,8 +614,11 @@ describe("OpenAI Chat route", () => {
       const input = LLM.updateRequest(request, {
         tools: [{ name: "lookup", description: "Lookup data", inputSchema: { type: "object" } }],
       })
-      const events = Array.from(
-        yield* LLMClient.stream(input).pipe(Stream.runCollect, Effect.provide(fixedResponse(body))),
+      const events: LLMEvent[] = []
+      const streamError = yield* LLMClient.stream(input).pipe(
+        Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+        Effect.flip,
+        Effect.provide(fixedResponse(body)),
       )
       const error = yield* LLMClient.generate(input).pipe(Effect.provide(fixedResponse(body)), Effect.flip)
 
@@ -626,6 +629,8 @@ describe("OpenAI Chat route", () => {
         { type: "tool-input-delta", id: "call_1", name: "lookup", text: ':"weather"}' },
       ])
       expect(events.filter(LLMEvent.is.toolCall)).toEqual([])
+      expect(streamError.reason).toMatchObject({ _tag: "InvalidProviderOutput" })
+      expect(streamError.message).toContain("Provider stream ended without a terminal finish event")
       expect(error.message).toContain("Provider stream ended without a terminal finish event")
     }),
   )


### PR DESCRIPTION
## What

Reject provider streams that reach clean EOF without an explicit terminal event.

A truncated tool-input stream could previously look like a successful provider response. The session runner would preserve the partial input, observe neither a parsed tool call nor an error, and publish `session.execution.succeeded`.

## Before / After

**Before**

```text
tool-input-start
tool-input-delta...
EOF
-> partial input flushed
-> no tool-call
-> no stream error
-> execution.succeeded
```

The tool never ran, but the caller received a successful execution with no completed response.

**After**

```text
tool-input-start
tool-input-delta...
EOF without finish/provider-error
-> InvalidProviderOutput
-> partial input preserved
-> unfinished tool failed (executed: false)
-> step.failed
-> execution.failed
```

Explicit `provider-error` events remain valid terminal outcomes. Intentional prefix consumption such as `Stream.take(1)` also remains valid because terminal validation runs only when the source stream ends successfully.

## How

- `packages/llm/src/route/client.ts` applies a per-subscription terminal-event guard inside `Route.streamPrepared` after protocol normalization.
- The guard accepts `finish` and `provider-error`, rejects output after either terminal event, and turns successful EOF without either event into `InvalidProviderOutput`.
- `packages/llm/test/adapter.test.ts` covers the provider-neutral route invariant.
- `packages/llm/test/provider/openai-chat.test.ts` covers the production-shaped case: partial tool input remains observable, no `tool-call` is synthesized, and complete stream consumption fails.
- Core's existing malformed-tool regression verifies that `InvalidProviderOutput` settles the unfinished tool before the step fails.

## Scope

- No automatic reconnect or replay after partial output. Retrying a whole provider request after response evidence can duplicate content or tool effects.
- No durable event vocabulary changes. Distinguishing cleanup-generated fragment endings from normal completion is tracked in #36874.
- No bounded model recovery for malformed tool arguments; this PR only prevents clean EOF from being upgraded to success.

## Testing

- `cd packages/llm && bun run test` (311 passed, 29 skipped)
- `cd packages/llm && bun run typecheck`
- `cd packages/core && bun run test test/session-runner.test.ts` (123 passed)
- `cd packages/core && bun run typecheck`
- Pre-push `bun turbo typecheck --concurrency=3` (32 tasks passed)
- `git diff --check`

## Flow

```mermaid
sequenceDiagram
    participant Provider
    participant Route as LLM route
    participant Runner as Session runner
    participant Log as Durable session log

    Provider->>Route: tool-input-start + deltas
    Provider--xRoute: EOF without terminal event
    Route-->>Runner: InvalidProviderOutput
    Runner->>Log: preserve partial input
    Runner->>Log: tool.failed (executed: false)
    Runner->>Log: step.failed
    Runner->>Log: execution.failed
```
