### PR TITLE
fix(core): support OpenAI pro mode

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -103,7 +103,7 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
 }
 
 function prepareOptions(model: ModelV2.Info, pkg: string) {
-  const projected = projectOptions(model)
+  const projected = mapBodyToProviderOptions(model)
   const options: Record<string, any> = {
     name: model.providerID,
     ...(model.settings ?? {}),
@@ -302,7 +302,7 @@ export const defaultLayer = locationLayer
 
 function modelFromLanguage(info: ModelV2.Info, language: LanguageModelV3) {
   const packageName = ProviderV2.packageName(info.package)
-  const projected = projectOptions(info)
+  const projected = mapBodyToProviderOptions(info)
   const optionKey = providerOptionKey(packageName, info.providerID)
   const route: AnyRoute = {
     id: `ai-sdk:${ProviderV2.packageName(info.package) ?? "unknown"}`,
@@ -365,22 +365,13 @@ function requestSettings(settings: Readonly<Record<string, unknown>> | undefined
   return Object.keys(result).length === 0 ? undefined : result
 }
 
-function projectOptions(model: ModelV2.Info) {
+function mapBodyToProviderOptions(model: ModelV2.Info) {
   const settings = requestSettings(model.settings)
   if (ProviderV2.packageName(model.package) !== "@ai-sdk/openai") return { settings, body: model.body }
-  const reasoning = model.body?.reasoning
-  if (
-    typeof reasoning !== "object" ||
-    reasoning === null ||
-    Array.isArray(reasoning) ||
-    !("mode" in reasoning) ||
-    reasoning.mode !== "pro"
-  )
+  if (!Schema.is(Schema.Struct({ mode: Schema.Literal("pro") }))(model.body?.reasoning))
     return { settings, body: model.body }
   const body = { ...model.body }
-  const remaining = Object.fromEntries(Object.entries(reasoning).filter(([key]) => key !== "mode"))
-  if (Object.keys(remaining).length === 0) delete body.reasoning
-  if (Object.keys(remaining).length > 0) body.reasoning = remaining
+  delete body.reasoning
   return {
     settings: ProviderV2.mergeOverlay(settings, { reasoningMode: "pro" }),
     body: Object.keys(body).length === 0 ? undefined : body,

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -103,11 +103,12 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
 }
 
 function prepareOptions(model: ModelV2.Info, pkg: string) {
+  const projected = projectOptions(model)
   const options: Record<string, any> = {
     name: model.providerID,
     ...(model.settings ?? {}),
     headers: model.headers,
-    body: model.body,
+    body: projected.body,
   }
 
   const customFetch = options.fetch
@@ -300,8 +301,9 @@ export const locationLayer = Layer.effect(
 export const defaultLayer = locationLayer
 
 function modelFromLanguage(info: ModelV2.Info, language: LanguageModelV3) {
-  const settings = requestSettings(info.settings)
-  const optionKey = providerOptionKey(ProviderV2.packageName(info.package), info.providerID)
+  const packageName = ProviderV2.packageName(info.package)
+  const projected = projectOptions(info)
+  const optionKey = providerOptionKey(packageName, info.providerID)
   const route: AnyRoute = {
     id: `ai-sdk:${ProviderV2.packageName(info.package) ?? "unknown"}`,
     provider: ProviderID.make(info.providerID),
@@ -317,11 +319,14 @@ function modelFromLanguage(info: ModelV2.Info, language: LanguageModelV3) {
     defaults: {
       headers: info.headers,
       http:
-        info.body === undefined && info.headers === undefined
+        projected.body === undefined && info.headers === undefined
           ? undefined
-          : { body: info.body === undefined ? undefined : { ...info.body }, headers: info.headers },
+          : {
+              body: projected.body === undefined ? undefined : { ...projected.body },
+              headers: info.headers,
+            },
       limits: { context: info.limit.context, output: info.limit.output },
-      providerOptions: settings === undefined ? undefined : { [optionKey]: settings },
+      providerOptions: projected.settings === undefined ? undefined : { [optionKey]: projected.settings },
     },
     body: {
       schema: Schema.Unknown,
@@ -339,9 +344,13 @@ function providerOptionKey(packageName: string | undefined, providerID: Provider
   if (packageName === "@ai-sdk/google") return "google"
   if (packageName === "@ai-sdk/google-vertex") return "vertex"
   if (packageName === "@ai-sdk/google-vertex/anthropic") return "anthropic"
-  if (packageName === "@ai-sdk/amazon-bedrock" || packageName === "@ai-sdk/amazon-bedrock/mantle") return "bedrock"
+  if (packageName === "@ai-sdk/amazon-bedrock") return "bedrock"
+  if (packageName === "@ai-sdk/amazon-bedrock/mantle") return "openai"
   if (packageName === "@ai-sdk/azure") return "azure"
+  if (packageName === "@ai-sdk/github-copilot") return "copilot"
+  if (packageName === "@ai-sdk/openai-compatible") return providerID.split(".")[0]
   if (packageName === "@openrouter/ai-sdk-provider") return "openrouter"
+  if (packageName === "ai-gateway-provider") return "openaiCompatible"
   if (packageName?.startsWith("@ai-sdk/")) return packageName.slice("@ai-sdk/".length)
   return providerID
 }
@@ -354,6 +363,28 @@ function requestSettings(settings: Readonly<Record<string, unknown>> | undefined
     ),
   )
   return Object.keys(result).length === 0 ? undefined : result
+}
+
+function projectOptions(model: ModelV2.Info) {
+  const settings = requestSettings(model.settings)
+  if (ProviderV2.packageName(model.package) !== "@ai-sdk/openai") return { settings, body: model.body }
+  const reasoning = model.body?.reasoning
+  if (
+    typeof reasoning !== "object" ||
+    reasoning === null ||
+    Array.isArray(reasoning) ||
+    !("mode" in reasoning) ||
+    reasoning.mode !== "pro"
+  )
+    return { settings, body: model.body }
+  const body = { ...model.body }
+  const remaining = Object.fromEntries(Object.entries(reasoning).filter(([key]) => key !== "mode"))
+  if (Object.keys(remaining).length === 0) delete body.reasoning
+  if (Object.keys(remaining).length > 0) body.reasoning = remaining
+  return {
+    settings: ProviderV2.mergeOverlay(settings, { reasoningMode: "pro" }),
+    body: Object.keys(body).length === 0 ? undefined : body,
+  }
 }
 
 function callOptions(request: LLMRequest): LanguageModelV3CallOptions {

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -344,13 +344,9 @@ function providerOptionKey(packageName: string | undefined, providerID: Provider
   if (packageName === "@ai-sdk/google") return "google"
   if (packageName === "@ai-sdk/google-vertex") return "vertex"
   if (packageName === "@ai-sdk/google-vertex/anthropic") return "anthropic"
-  if (packageName === "@ai-sdk/amazon-bedrock") return "bedrock"
-  if (packageName === "@ai-sdk/amazon-bedrock/mantle") return "openai"
+  if (packageName === "@ai-sdk/amazon-bedrock" || packageName === "@ai-sdk/amazon-bedrock/mantle") return "bedrock"
   if (packageName === "@ai-sdk/azure") return "azure"
-  if (packageName === "@ai-sdk/github-copilot") return "copilot"
-  if (packageName === "@ai-sdk/openai-compatible") return providerID.split(".")[0]
   if (packageName === "@openrouter/ai-sdk-provider") return "openrouter"
-  if (packageName === "ai-gateway-provider") return "openaiCompatible"
   if (packageName?.startsWith("@ai-sdk/")) return packageName.slice("@ai-sdk/".length)
   return providerID
 }

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -363,7 +363,6 @@ function requestSettings(settings: Readonly<Record<string, unknown>> | undefined
 
 function mapBodyToProviderOptions(model: ModelV2.Info) {
   const settings = requestSettings(model.settings)
-  if (ProviderV2.packageName(model.package) !== "@ai-sdk/openai") return { settings, body: model.body }
   if (!Schema.is(Schema.Struct({ mode: Schema.Literal("pro") }))(model.body?.reasoning))
     return { settings, body: model.body }
   const body = { ...model.body }

--- a/packages/core/src/plugin/provider/openai-codex.ts
+++ b/packages/core/src/plugin/provider/openai-codex.ts
@@ -31,7 +31,7 @@ export const accountID = (credential: CredentialLike | undefined) => {
 }
 
 const allowed = new Set(["gpt-5.5", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"])
-const disallowed = new Set(["gpt-5.5-pro"])
+const disallowed = new Set(["gpt-5.5-pro", "gpt-5.6"])
 
 /** Which API model ids a ChatGPT subscription may call through the codex backend. */
 export const eligible = (apiID: string) => {

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -194,6 +194,10 @@ export const OpenAIPlugin = define({
         // ChatGPT-plan tokens only authorize codex-eligible models, and the
         // subscription covers usage, so hide the rest and zero the cost.
         evt.model.update(item.provider.id, model.id, (draft) => {
+          if (Schema.is(Schema.Struct({ mode: Schema.Literal("pro") }))(draft.body?.reasoning)) {
+            draft.enabled = false
+            return
+          }
           if (!OpenAICodex.eligible(draft.modelID ?? draft.id)) {
             draft.enabled = false
             return

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -87,30 +87,6 @@ it.effect("converts pro reasoning mode only at the OpenAI AI SDK boundary", () =
 
     expect(body).toBeUndefined()
     expect(prepared.body.providerOptions).toEqual({ openai: { reasoningMode: "pro" } })
-    expect(prepared.body).not.toHaveProperty("reasoning")
-  }),
-)
-
-it.effect("maps package-specific AI SDK provider option keys", () =>
-  Effect.gen(function* () {
-    const aisdk = yield* AISDK.Service
-    yield* aisdk.hook.sdk((event) => {
-      event.sdk = { languageModel: () => ({ provider: event.model.providerID }) }
-    })
-
-    const cases = [
-      ["@ai-sdk/github-copilot", "copilot"],
-      ["@ai-sdk/amazon-bedrock/mantle", "openai"],
-      ["@ai-sdk/openai-compatible", "test-provider"],
-      ["ai-gateway-provider", "openaiCompatible"],
-    ] as const
-    for (const [packageName, key] of cases) {
-      const resolved = yield* aisdk.model(model(packageName, { reasoningEffort: "high" }))
-      const prepared = yield* LLMClient.prepare<LanguageModelV3CallOptions>(
-        LLM.request({ model: resolved, prompt: "Hello" }),
-      )
-      expect(prepared.body.providerOptions).toEqual({ [key]: { reasoningEffort: "high" } })
-    }
   }),
 )
 

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -68,7 +68,7 @@ it.effect("projects request settings, headers, and body overlays", () =>
   }),
 )
 
-it.effect("converts pro reasoning mode only at the OpenAI AI SDK boundary", () =>
+it.effect("maps pro reasoning bodies to AI SDK provider options", () =>
   Effect.gen(function* () {
     const aisdk = yield* AISDK.Service
     let body: unknown

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -68,6 +68,52 @@ it.effect("projects request settings, headers, and body overlays", () =>
   }),
 )
 
+it.effect("converts pro reasoning mode only at the OpenAI AI SDK boundary", () =>
+  Effect.gen(function* () {
+    const aisdk = yield* AISDK.Service
+    let body: unknown
+    yield* aisdk.hook.sdk((event) => {
+      body = event.options.body
+      event.sdk = { languageModel: () => ({ provider: event.model.providerID }) }
+    })
+
+    const resolved = yield* aisdk.model({
+      ...model("@ai-sdk/openai"),
+      body: { reasoning: { mode: "pro" } },
+    })
+    const prepared = yield* LLMClient.prepare<LanguageModelV3CallOptions>(
+      LLM.request({ model: resolved, prompt: "Hello" }),
+    )
+
+    expect(body).toBeUndefined()
+    expect(prepared.body.providerOptions).toEqual({ openai: { reasoningMode: "pro" } })
+    expect(prepared.body).not.toHaveProperty("reasoning")
+  }),
+)
+
+it.effect("maps package-specific AI SDK provider option keys", () =>
+  Effect.gen(function* () {
+    const aisdk = yield* AISDK.Service
+    yield* aisdk.hook.sdk((event) => {
+      event.sdk = { languageModel: () => ({ provider: event.model.providerID }) }
+    })
+
+    const cases = [
+      ["@ai-sdk/github-copilot", "copilot"],
+      ["@ai-sdk/amazon-bedrock/mantle", "openai"],
+      ["@ai-sdk/openai-compatible", "test-provider"],
+      ["ai-gateway-provider", "openaiCompatible"],
+    ] as const
+    for (const [packageName, key] of cases) {
+      const resolved = yield* aisdk.model(model(packageName, { reasoningEffort: "high" }))
+      const prepared = yield* LLMClient.prepare<LanguageModelV3CallOptions>(
+        LLM.request({ model: resolved, prompt: "Hello" }),
+      )
+      expect(prepared.body.providerOptions).toEqual({ [key]: { reasoningEffort: "high" } })
+    }
+  }),
+)
+
 it.effect("projects replay metadata onto AI SDK prompt parts", () =>
   Effect.gen(function* () {
     const aisdk = yield* AISDK.Service

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -204,7 +204,6 @@ describe("OpenAIPlugin", () => {
         })
         catalog.model.update(item.id, ModelV2.ID.make("gpt-5.6"), () => {})
         catalog.model.update(item.id, ModelV2.ID.make("gpt-5.6-sol"), () => {})
-        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.7-pro"), () => {})
         catalog.model.update(item.id, ModelV2.ID.make("gpt-4.1"), () => {})
       })
       yield* credentials.create({
@@ -235,9 +234,6 @@ describe("OpenAIPlugin", () => {
       )
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.6"))).enabled).toBe(false)
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.6-sol"))).enabled).toBe(
-        true,
-      )
-      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.7-pro"))).enabled).toBe(
         true,
       )
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-4.1"))).enabled).toBe(false)

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -198,6 +198,13 @@ describe("OpenAIPlugin", () => {
           ]
         })
         catalog.model.update(item.id, ModelV2.ID.make("gpt-5.5-pro"), () => {})
+        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.4-pro"), (model) => {
+          model.modelID = ModelV2.ID.make("gpt-5.4")
+          model.body = { reasoning: { mode: "pro" } }
+        })
+        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.6"), () => {})
+        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.6-sol"), () => {})
+        catalog.model.update(item.id, ModelV2.ID.make("gpt-5.7-pro"), () => {})
         catalog.model.update(item.id, ModelV2.ID.make("gpt-4.1"), () => {})
       })
       yield* credentials.create({
@@ -222,6 +229,16 @@ describe("OpenAIPlugin", () => {
       expect(eligible.enabled).toBe(true)
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.5-pro"))).enabled).toBe(
         false,
+      )
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.4-pro"))).enabled).toBe(
+        false,
+      )
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.6"))).enabled).toBe(false)
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.6-sol"))).enabled).toBe(
+        true,
+      )
+      expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.7-pro"))).enabled).toBe(
+        true,
       )
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-4.1"))).enabled).toBe(false)
     }),

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -154,19 +154,6 @@ describe("SessionRunnerModel", () => {
     }),
   )
 
-  it.effect("passes pro reasoning mode through the native request body", () =>
-    Effect.gen(function* () {
-      const resolved = yield* SessionRunnerModel.fromCatalogModel(
-        model(ProviderV2.aisdk("@ai-sdk/openai"), {
-          headers: {},
-          body: { reasoning: { mode: "pro" } },
-        }),
-      )
-
-      expect(resolved.route.defaults.http?.body).toEqual({ reasoning: { mode: "pro" } })
-    }),
-  )
-
   it.effect("overlays selected OpenAI-compatible Session variant bodies", () =>
     Effect.gen(function* () {
       const catalog = model(ProviderV2.aisdk("@ai-sdk/openai-compatible"), {

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -154,6 +154,19 @@ describe("SessionRunnerModel", () => {
     }),
   )
 
+  it.effect("passes pro reasoning mode through the native request body", () =>
+    Effect.gen(function* () {
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(
+        model(ProviderV2.aisdk("@ai-sdk/openai"), {
+          headers: {},
+          body: { reasoning: { mode: "pro" } },
+        }),
+      )
+
+      expect(resolved.route.defaults.http?.body).toEqual({ reasoning: { mode: "pro" } })
+    }),
+  )
+
   it.effect("overlays selected OpenAI-compatible Session variant bodies", () =>
     Effect.gen(function* () {
       const catalog = model(ProviderV2.aisdk("@ai-sdk/openai-compatible"), {


### PR DESCRIPTION
## Summary
- preserve provider-native pro reasoning bodies on native LLM routes
- map `reasoning: { mode: "pro" }` to `reasoningMode: "pro"` at the AI SDK boundary
- filter unsupported pro aliases and exact `gpt-5.6` from ChatGPT Codex while retaining eligible suffixed models

## Testing
- `bun typecheck` in `packages/core`
- `bun test test/aisdk.test.ts test/plugin/provider-openai.test.ts` in `packages/core`
- full `packages/tui` test suite
- repository typecheck push hook