### PR TITLE
fix(cli): handle descendant permission asks

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -37,6 +37,33 @@ function pick(value: string | undefined): ModelInput | undefined {
   } as ModelInput
 }
 
+function clientErrorStatus(error: unknown): number | undefined {
+  if (!(error instanceof Error) || typeof error.cause !== "object" || error.cause === null) return undefined
+  if (!("status" in error.cause) || typeof error.cause.status !== "number") return undefined
+  return error.cause.status
+}
+
+export async function isSessionInTree(
+  parent: (sessionID: string) => Promise<string | undefined>,
+  targetID: string,
+  sessions: Set<string>,
+): Promise<boolean> {
+  if (sessions.has(targetID)) return true
+  const lineage: string[] = []
+  const seen = new Set<string>()
+  let current = targetID
+  while (!sessions.has(current)) {
+    if (seen.has(current)) return false
+    seen.add(current)
+    lineage.push(current)
+    const parentID = await parent(current)
+    if (!parentID) return false
+    current = parentID
+  }
+  lineage.forEach((id) => sessions.add(id))
+  return true
+}
+
 function resolveRunInput(value?: string, piped?: string): string | undefined {
   if (!value) {
     return piped
@@ -690,15 +717,35 @@ export const RunCommand = effectCmd({
           return false
         }
 
+        const requestAbort = new AbortController()
+
         // Consume one subscribed event stream for the active session and mirror it
         // to stdout/UI. `client` is passed explicitly because attach mode may
         // rebind the SDK to the session's directory after the subscription is
         // created, and replies issued from inside the loop must use that client.
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
+          const sessions = new Set([sessionID])
+          const parent = async (id: string): Promise<string | undefined> => {
+            try {
+              const result = await client.session.get(
+                { sessionID: id },
+                { throwOnError: true, signal: AbortSignal.timeout(10_000) },
+              )
+              return result.data.parentID
+            } catch (error) {
+              if (clientErrorStatus(error) === 404) return undefined
+              throw error
+            }
+          }
           let error: string | undefined
 
           for await (const event of events.stream) {
+            if (event.type === "session.created" || event.type === "session.updated") {
+              const info = event.properties.info
+              if (info.parentID && sessions.has(info.parentID)) sessions.add(info.id)
+            }
+
             if (
               event.type === "message.updated" &&
               event.properties.sessionID === sessionID &&
@@ -795,7 +842,14 @@ export const RunCommand = effectCmd({
 
             if (event.type === "permission.asked") {
               const permission = event.properties
-              if (permission.sessionID !== sessionID) continue
+              const related = await isSessionInTree(parent, permission.sessionID, sessions).catch(async (error) => {
+                requestAbort.abort(error)
+                await client.session
+                  .abort({ sessionID }, { throwOnError: true, signal: AbortSignal.timeout(5_000) })
+                  .catch(() => undefined)
+                throw error
+              })
+              if (!related) continue
 
               if (auto) {
                 await client.permission.reply({
@@ -838,14 +892,17 @@ export const RunCommand = effectCmd({
           }
 
           if (args.command) {
-            const result = await client.session.command({
-              sessionID,
-              agent,
-              model: args.model,
-              command: args.command,
-              arguments: message,
-              variant: args.variant,
-            })
+            const result = await client.session.command(
+              {
+                sessionID,
+                agent,
+                model: args.model,
+                command: args.command,
+                arguments: message,
+                variant: args.variant,
+              },
+              { signal: requestAbort.signal },
+            )
             if (result.error) {
               if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
               process.exitCode = 1
@@ -856,13 +913,16 @@ export const RunCommand = effectCmd({
           }
 
           const model = pick(args.model)
-          const result = await client.session.prompt({
-            sessionID,
-            agent,
-            model,
-            variant: args.variant,
-            parts: [...files, { type: "text", text: message }],
-          })
+          const result = await client.session.prompt(
+            {
+              sessionID,
+              agent,
+              model,
+              variant: args.variant,
+              parts: [...files, { type: "text", text: message }],
+            },
+            { signal: requestAbort.signal },
+          )
           if (result.error) {
             if (!emit("error", { error: result.error })) UI.error(formatRunError(result.error))
             process.exitCode = 1

--- a/packages/opencode/test/cli/run/permission-session-tree.test.ts
+++ b/packages/opencode/test/cli/run/permission-session-tree.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { isSessionInTree } from "@/cli/cmd/run"
+
+type Node = { id: string; parentID?: string }
+
+function parent(nodes: Node[], calls: string[] = []) {
+  const sessions = new Map(nodes.map((node) => [node.id, node]))
+  return async (sessionID: string) => {
+    calls.push(sessionID)
+    return sessions.get(sessionID)?.parentID
+  }
+}
+
+describe("run permission session tree", () => {
+  const nodes = [
+    { id: "root" },
+    { id: "child", parentID: "root" },
+    { id: "grandchild", parentID: "child" },
+    { id: "other" },
+    { id: "other-child", parentID: "other" },
+  ]
+
+  test("matches the root without loading a session", async () => {
+    const calls: string[] = []
+    expect(await isSessionInTree(parent(nodes, calls), "root", new Set(["root"]))).toBe(true)
+    expect(calls).toEqual([])
+  })
+
+  test("matches descendants and caches their lineage", async () => {
+    const calls: string[] = []
+    const sessions = new Set(["root"])
+    const lookup = parent(nodes, calls)
+
+    expect(await isSessionInTree(lookup, "grandchild", sessions)).toBe(true)
+    expect(calls).toEqual(["grandchild", "child"])
+    expect(sessions).toEqual(new Set(["root", "grandchild", "child"]))
+
+    calls.length = 0
+    expect(await isSessionInTree(lookup, "grandchild", sessions)).toBe(true)
+    expect(calls).toEqual([])
+  })
+
+  test("rejects unrelated and cyclic session trees", async () => {
+    expect(await isSessionInTree(parent(nodes), "other-child", new Set(["root"]))).toBe(false)
+    expect(
+      await isSessionInTree(
+        parent([
+          { id: "a", parentID: "b" },
+          { id: "b", parentID: "a" },
+        ]),
+        "a",
+        new Set(["root"]),
+      ),
+    ).toBe(false)
+  })
+
+  test("propagates session lookup failures", async () => {
+    const lookup = async () => {
+      throw new Error("lookup failed")
+    }
+    let caught: unknown
+    try {
+      await isSessionInTree(lookup, "child", new Set(["root"]))
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(Error)
+    if (!(caught instanceof Error)) throw new Error("expected lookup to fail")
+    expect(caught.message).toBe("lookup failed")
+  })
+})

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -277,6 +277,39 @@ describe("opencode run (non-interactive subprocess)", () => {
     60_000,
   )
 
+  // Regression for #36868: the headless responder used to ignore permission
+  // asks from Task child sessions, leaving both child and parent blocked.
+  cliIt.concurrent(
+    "answers permission requests from Task child sessions",
+    ({ home, llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.push(
+          reply().tool("task", {
+            description: "exercise child permission",
+            prompt: "Create the requested marker file, then report completion.",
+            subagent_type: "general",
+          }),
+          reply().tool("bash", {
+            command: "touch child-approved",
+            description: "Create the child marker",
+          }),
+          reply().text("child completed"),
+          reply().text("root completed"),
+        )
+
+        const result = yield* opencode.run("delegate this task", {
+          permission: { task: "allow", bash: "ask" },
+          extraArgs: ["--auto"],
+          timeoutMs: 30_000,
+        })
+
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("root completed")
+        expect(yield* Effect.promise(() => Bun.file(`${home}/child-approved`).exists())).toBe(true)
+      }),
+    60_000,
+  )
+
   cliIt.live(
     "attach mode sends client-local file contents without a shared path",
     ({ home, llm, opencode }) =>


### PR DESCRIPTION
### Issue for this PR

Closes #36868

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Headless `opencode run` only answered permission requests from the root session, so a Task child requesting permission blocked both sessions indefinitely.

This tracks descendants from session events and verifies missed sessions by following `parentID`. Descendant requests now use the existing `--auto` approve / non-auto reject policy. A failed ancestry lookup cancels the pending local request and makes a bounded best-effort server abort instead of leaving the CLI blocked.

Related: #35823. This version avoids `session.list()` pagination limits and adds a real Task-child subprocess regression.

### How did you verify your code works?

- `bun run typecheck` in `packages/opencode`
- `bun test test/cli/run/permission-session-tree.test.ts` (4 pass, 0 fail)
- Prettier and oxlint on the changed files (no new warnings)
- `bun run script/build.ts --single`, CLI smoke test, and compiled CLI + fake LLM reproduction (parent completed and child marker was created)

The complete subprocess test file cannot run in this Windows checkout because Bun panics while importing its runtime fixture; the equivalent compiled-binary flow passed and the regression test is included for CI. The monorepo pre-push check is also blocked because the tracked app symlink is checked out as path text on Windows; the changed `opencode` package passes typecheck.

### Screenshots / recordings

Not applicable; this changes headless CLI behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
