### PR TITLE
feat(app): add fork button to assistant response texts

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1944,7 +1944,25 @@ export default function Page() {
     download()
   }
 
-  const actions = { revert, openAttachment }
+  const fork = (input: { sessionID: string; messageID: string }) => {
+    if (reverting()) return
+    sdk()
+      .client.session.fork({ sessionID: input.sessionID, messageID: input.messageID })
+      .then((forked) => {
+        if (!forked.data) {
+          showToast({ title: language.t("common.requestFailed") })
+          return
+        }
+        const dir = base64Encode(sdk().directory)
+        navigate(`/${dir}/session/${forked.data.id}`)
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        showToast({ title: language.t("common.requestFailed"), description: message })
+      })
+  }
+
+  const actions = { revert, fork, openAttachment }
 
   createEffect(() => {
     const sessionID = params.id

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1038,6 +1038,7 @@ export function MessageTimeline(props: {
               <MessagePart
                 part={part()}
                 message={message()}
+                actions={props.actions}
                 showAssistantCopyPartID={assistantCopyPartID(row().userMessageID)}
                 turnDurationMs={turnDurationMs(row().userMessageID)}
                 useV2Actions={settings.general.newLayoutDesigns()}

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -203,6 +203,7 @@ export interface MessagePartProps {
   showAssistantCopyPartID?: string | null
   turnDurationMs?: number
   useV2Actions?: boolean
+  actions?: UserActions
 }
 
 function MessageActionButton(
@@ -1747,6 +1748,21 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
         </div>
         <Show when={showCopy()}>
           <div data-slot="text-part-copy-wrapper" data-interrupted={interrupted() ? "" : undefined}>
+            <Show when={props.actions?.fork && props.message.role === "assistant"}>
+              <IconButton
+                icon="fork"
+                size="normal"
+                variant="ghost"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  void props.actions!.fork!({
+                    sessionID: props.message.sessionID,
+                    messageID: props.message.id,
+                  })
+                }}
+                aria-label="Fork conversation from this point"
+              />
+            </Show>
             <MessageActionButton
               icon={copied() ? "check" : "copy"}
               label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}


### PR DESCRIPTION
Closes #36923

Adds a fork icon button on assistant text responses that appears on hover next to the copy button. Clicking it forks the session at that message point and navigates to the new session.

Uses the existing `POST /api/session/:sessionID/fork` endpoint and the existing `UserActions.fork` type.