### PR TITLE
fix(core): refresh session recency on activity

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -186,6 +186,12 @@ function run(db: DatabaseService, event: SessionEvent.Event) {
       updateShell: updateMessage,
       appendMessage,
     }
+    yield* db
+      .update(SessionTable)
+      .set({ time_updated: DateTime.toEpochMillis(event.data.timestamp) })
+      .where(eq(SessionTable.id, event.data.sessionID))
+      .run()
+      .pipe(Effect.orDie)
     yield* SessionMessageUpdater.update(adapter, event)
   })
 }

--- a/packages/core/test/session-projector.test.ts
+++ b/packages/core/test/session-projector.test.ts
@@ -331,7 +331,7 @@ describe("SessionProjector", () => {
       ).toMatchObject({
         agent: "build",
         model,
-        time_updated: DateTime.toEpochMillis(created),
+        time_updated: DateTime.toEpochMillis(DateTime.makeUnsafe(1)),
       })
     }),
   )


### PR DESCRIPTION
## Summary
- refresh `session.time_updated` when durable activity events are projected
- keep session recency in sync while a turn is actively producing output
- update the projector test expectation to cover the newer timestamp behavior

## Root cause
`SessionTable.time_updated` was only set at session creation time in this path, so active sessions could sort as stale even while new execution events were being projected.

## Validation
- `cd packages/core && bun typecheck`
- `cd packages/core && bun test test/session-projector.test.ts`

Closes #36893
