### PR TITLE
feat(app): add delete session with confirmation dialog

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -894,6 +894,63 @@ export default function LegacyLayout(props: ParentProps) {
     }
   }
 
+  function deleteSession(session: Session) {
+    dialog.show(() => <DialogDeleteSession session={session} />)
+  }
+
+  function DialogDeleteSession(dprops: { session: Session }) {
+    const dialogCtx = useDialog()
+    const sdk = useServerSDK()
+    const sync = useServerSync()
+    const nav = useNavigate()
+    const prms = useParams()
+    const lang = useLanguage()
+    const name = () => sessionTitle(dprops.session.title)
+
+    const handleDelete = async () => {
+      const result = await sdk()
+        .client.session.delete({ sessionID: dprops.session.id })
+        .then((x) => x.data)
+        .catch((err) => {
+          showToast({
+            title: lang.t("session.delete.failed.title"),
+            description: errorMessage(err, lang.t("common.requestFailed")),
+          })
+          return false
+        })
+
+      if (!result) {
+        dialogCtx.close()
+        return
+      }
+
+      if (dprops.session.id === prms.id) {
+        const sessions = (sync().child(dprops.session.directory)[0].session ?? []).filter(
+          (s) => !s.parentID && !s.time?.archived,
+        )
+        const idx = sessions.findIndex((s) => s.id === dprops.session.id)
+        const next = sessions[idx + 1] ?? sessions[idx - 1]
+        if (next) nav(`/${prms.dir}/session/${next.id}`)
+        else nav(`/${prms.dir}/session`)
+      }
+
+      dialogCtx.close()
+    }
+
+    return (
+      <Dialog title={lang.t("session.delete.title")} description={lang.t("session.delete.confirm", { name: name() })}>
+        <div class="flex justify-end gap-2 mt-4">
+          <Button variant="secondary" onClick={() => dialogCtx.close()}>
+            {lang.t("common.cancel")}
+          </Button>
+          <Button variant="danger" onClick={handleDelete}>
+            {lang.t("session.delete.button")}
+          </Button>
+        </div>
+      </Dialog>
+    )
+  }
+
   command.register("layout", () => {
     const commands: CommandOption[] = [
       {
@@ -1913,6 +1970,7 @@ export default function LegacyLayout(props: ParentProps) {
       clearHoverProjectSoon,
       prefetchSession,
       archiveSession,
+      deleteSession,
     },
   }
 

--- a/packages/app/src/pages/layout/sidebar-items.tsx
+++ b/packages/app/src/pages/layout/sidebar-items.tsx
@@ -87,6 +87,7 @@ export type SessionItemProps = {
   clearHoverProjectSoon: () => void
   prefetchSession: (session: Session, priority?: "high" | "low") => void
   archiveSession: (session: Session) => Promise<void>
+  deleteSession?: (session: Session) => void
 }
 
 const SessionRow = (props: {


### PR DESCRIPTION
### Issue for this PR

Closes #36962

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a right-click/context menu option "Delete Session" to session items in the sidebar. Clicking it opens a confirmation dialog, and confirming it calls the `DELETE` API on the session, cleanly removing it from both local state and backend.

### How did you verify your code works?

Tested right-clicking a session, triggering the delete option, confirming the modal, and checking that the session was correctly deleted and removed from the list.

### Screenshots / recordings

_Delete option in the sidebar session menu and the confirmation modal._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR