### PR TITLE
fix: send max-steps instruction as user message, not assistant

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1278,7 +1278,7 @@ const layer = Layer.effect(
               system,
               messages: [
                 ...modelMsgs,
-                ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS_PROMPT }] : []),
+                ...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS_PROMPT }] : []),
               ],
               tools,
               model,

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -514,6 +514,38 @@ it.instance("loop calls LLM and returns assistant message", () =>
   }),
 )
 
+it.instance("loop sends max steps instruction as a user message", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      agent: { build: { steps: 1 } },
+    }))
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    yield* llm.text("world")
+
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const hits = yield* llm.hits
+    expect(hits).toHaveLength(1)
+    const messages = hits[0]?.body.messages
+    expect(messages).toBeArray()
+    if (!Array.isArray(messages)) return
+    const maxSteps = messages.find(
+      (message) => JSON.stringify(message).includes("CRITICAL - MAXIMUM STEPS REACHED"),
+    )
+    expect(maxSteps).toMatchObject({ role: "user" })
+  }),
+  30_000,
+)
+
 withMcpInstructions.instance(
   "loop includes MCP instructions in model system context",
   () =>


### PR DESCRIPTION
Fixes #32548

## Problem

When an agent hits its configured `steps` cap mid-turn, the loop forces
a text-only response by appending the "wrap up now" instruction
(`MAX_STEPS_PROMPT`) to the outgoing message array as a `role: "assistant"`
message:

```ts
messages: [
  ...modelMsgs,
  ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS_PROMPT }] : []),
],
```

This leaves the request ending on an assistant turn. Anthropic (and other
providers) treat a trailing assistant message as a response prefill, and
Claude models with thinking enabled reject it outright:

```
400 This model does not support assistant message prefill. The conversation
must end with a user message.
```

Independently confirmed in production logs across every agent/model
combination in proportion to usage, all with zero cost/output tokens on
the failing turn, all traced back to this exact `isLastStep` branch —
matches #32548's 100%-reproducible repro steps exactly.

## Fix

The max-steps instruction is directed at the model, not written by it —
it belongs on a `user` turn:

```ts
...(isLastStep ? [{ role: "user" as const, content: MAX_STEPS_PROMPT }] : []),
```

Tool results already present in `modelMsgs` are untouched; only the role
of the appended instruction changes.

## Testing

- Added a regression test in `prompt.test.ts` that configures
  `agent: { build: { steps: 1 } }`, drives the loop to the cap, and
  asserts the appended max-steps message has `role: "user"` (fails if
  reverted to `role: "assistant"`).
- `bun run lint` clean on both changed files (no new warnings).
- `bun turbo typecheck` passes (ran via the pre-push hook, 30/30 packages).
- `bun test test/session/prompt.test.ts` — new test passes; the file has
  2 pre-existing flaky/timeout failures unrelated to this change,
  confirmed to occur identically on a clean checkout before this patch.
