### PR TITLE
fix(app): tolerate null session archive times

### DIFF
--- a/packages/app/src/context/global-sync/home-session-index.test.ts
+++ b/packages/app/src/context/global-sync/home-session-index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import type { SessionV2Info } from "@opencode-ai/sdk/v2/client"
 import {
   applyHomeSessionEvent,
   appendHomeSessionEvent,
@@ -72,8 +73,13 @@ describe("Home V2 session index", () => {
   })
 
   test("maps visible roots to Home session summaries", () => {
+    const activeNull = {
+      ...session({ id: "active-null", updated: 20 }),
+      time: { created: 1, updated: 20, archived: null },
+    } as unknown as SessionV2Info
     const result = parseHomeSessionIndex([
       session({ id: "root", updated: 30 }),
+      activeNull,
       session({ id: "child", parentID: "root", updated: 40 }),
       session({ id: "archived", archived: 50, updated: 50 }),
     ])
@@ -87,6 +93,10 @@ describe("Home V2 session index", () => {
         projectID: "project",
         title: "root",
         time: { created: 1, updated: 30 },
+      }),
+      expect.objectContaining({
+        id: "active-null",
+        time: { created: 1, updated: 20, archived: null },
       }),
     ])
   })

--- a/packages/app/src/context/global-sync/home-session-index.ts
+++ b/packages/app/src/context/global-sync/home-session-index.ts
@@ -132,7 +132,7 @@ export function createHomeSessionIndexCache(queryClient: QueryClient, server: st
 // parentID: null, order: "desc" }), then remove this adapter and its V1 fields.
 export function parseHomeSessionIndex(sessions: SessionV2Info[]): Session[] {
   return sessions.flatMap((item) => {
-    if (item.parentID || item.time.archived !== undefined) return []
+    if (item.parentID || typeof item.time.archived === "number") return []
     return [toLegacySummary(item)]
   })
 }
@@ -145,7 +145,7 @@ export function retainHomeSessions(sessions: Session[], limit: number, now: numb
 export function applyHomeSessionEvent(sessions: Session[], event: HomeSessionEvent) {
   const info = event.properties.info
   const index = sessions.findIndex((session) => session.id === info.id)
-  if (event.type === "session.deleted" || info.parentID || info.time.archived !== undefined) {
+  if (event.type === "session.deleted" || info.parentID || typeof info.time.archived === "number") {
     if (index === -1) return sessions
     return sessions.toSpliced(index, 1)
   }


### PR DESCRIPTION
## Summary
- keep active sessions visible when older servers encode an absent archive time as `null`
- handle the same compatibility case in home session events
- add regression coverage for the observed wire payload

## Testing
- `bun test src/context/global-sync/home-session-index.test.ts`
- `bun typecheck` in `packages/app`
- repository-wide pre-push typecheck