### PR TITLE
fix(provider): fix Vertex AI multi-region location producing invalid hostname

### DIFF
--- a/packages/core/src/plugin/provider/google-vertex.ts
+++ b/packages/core/src/plugin/provider/google-vertex.ts
@@ -98,13 +98,22 @@ export const GoogleVertexPlugin = define({
         if (evt.package !== "@ai-sdk/google-vertex") return
         const mod = yield* Effect.promise(() => import("@ai-sdk/google-vertex"))
         const project = resolveProject(evt.options)
-        const location = resolveLocation(evt.options)
+        const location = String(resolveLocation(evt.options))
         const options = { ...evt.options }
         delete options.fetch
         evt.sdk = mod.createVertex({
           ...options,
           project,
           location,
+          // @ai-sdk/google-vertex's own baseURL default only special-cases
+          // "global", producing an invalid "us-aiplatform.googleapis.com" /
+          // "eu-aiplatform.googleapis.com" host for continental multi-regions;
+          // compute the correct host ourselves instead of relying on it.
+          ...(project && !options.apiKey && !options.baseURL
+            ? {
+                baseURL: `https://${vertexEndpoint(location)}/v1beta1/projects/${project}/locations/${location}/publishers/google`,
+              }
+            : {}),
         })
       }),
     )

--- a/packages/core/src/plugin/provider/google-vertex.ts
+++ b/packages/core/src/plugin/provider/google-vertex.ts
@@ -24,8 +24,13 @@ function resolveLocation(options: Record<string, any>) {
   )
 }
 
+// "global", "us", and "eu" are multi-region locations that resolve via the
+// bare aiplatform.googleapis.com host; only single-region locations (e.g.
+// "us-central1") use a location-prefixed host.
+const VERTEX_MULTI_REGIONS = new Set(["global", "us", "eu"])
+
 function vertexEndpoint(location: string) {
-  if (location === "global") return "aiplatform.googleapis.com"
+  if (VERTEX_MULTI_REGIONS.has(location)) return "aiplatform.googleapis.com"
   return `${location}-aiplatform.googleapis.com`
 }
 

--- a/packages/core/test/plugin/provider-google-vertex.test.ts
+++ b/packages/core/test/plugin/provider-google-vertex.test.ts
@@ -338,6 +338,68 @@ describe("GoogleVertexPlugin", () => {
     ),
   )
 
+  it.effect("overrides the native Vertex SDK baseURL for multi-region locations", () =>
+    withEnv(
+      {
+        GOOGLE_CLOUD_PROJECT: "env-project",
+        GOOGLE_VERTEX_LOCATION: "us",
+      },
+      () =>
+        Effect.gen(function* () {
+          vertexOptions.length = 0
+          const aisdk = yield* AISDK.Service
+          yield* addPlugin()
+          yield* aisdk.runSDK({
+            model: ModelV2.Info.make({
+              ...ModelV2.Info.empty(ProviderV2.ID.make("google-vertex"), ModelV2.ID.make("gemini")),
+              api: {
+                id: ModelV2.ID.make("gemini"),
+                type: "aisdk",
+                package: "@ai-sdk/google-vertex",
+              },
+            }),
+            package: "@ai-sdk/google-vertex",
+            options: { name: "google-vertex" },
+          })
+          expect(vertexOptions).toHaveLength(1)
+          expect(vertexOptions[0].baseURL).toBe(
+            "https://aiplatform.googleapis.com/v1beta1/projects/env-project/locations/us/publishers/google",
+          )
+        }),
+    ),
+  )
+
+  it.effect("keeps the native Vertex SDK baseURL region-prefixed for single regions", () =>
+    withEnv(
+      {
+        GOOGLE_CLOUD_PROJECT: "env-project",
+        GOOGLE_VERTEX_LOCATION: "us-central1",
+      },
+      () =>
+        Effect.gen(function* () {
+          vertexOptions.length = 0
+          const aisdk = yield* AISDK.Service
+          yield* addPlugin()
+          yield* aisdk.runSDK({
+            model: ModelV2.Info.make({
+              ...ModelV2.Info.empty(ProviderV2.ID.make("google-vertex"), ModelV2.ID.make("gemini")),
+              api: {
+                id: ModelV2.ID.make("gemini"),
+                type: "aisdk",
+                package: "@ai-sdk/google-vertex",
+              },
+            }),
+            package: "@ai-sdk/google-vertex",
+            options: { name: "google-vertex" },
+          })
+          expect(vertexOptions).toHaveLength(1)
+          expect(vertexOptions[0].baseURL).toBe(
+            "https://us-central1-aiplatform.googleapis.com/v1beta1/projects/env-project/locations/us-central1/publishers/google",
+          )
+        }),
+    ),
+  )
+
   it.effect("keeps Google auth fetch for OpenAI-compatible Vertex endpoints", () =>
     Effect.gen(function* () {
       googleAuthOptions.length = 0

--- a/packages/core/test/plugin/provider-google-vertex.test.ts
+++ b/packages/core/test/plugin/provider-google-vertex.test.ts
@@ -231,7 +231,7 @@ describe("GoogleVertexPlugin", () => {
     ),
   )
 
-  it.effect("keeps OpenAI-compatible Vertex endpoint templates regional for eu", () =>
+  it.effect("keeps OpenAI-compatible Vertex endpoint templates multi-region for eu", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service
       yield* catalog.transform((catalog) =>
@@ -250,7 +250,31 @@ describe("GoogleVertexPlugin", () => {
       expect(provider.api).toEqual({
         type: "aisdk",
         package: "@ai-sdk/openai-compatible",
-        url: "https://eu-aiplatform.googleapis.com/v1/projects/config-project/locations/eu",
+        url: "https://aiplatform.googleapis.com/v1/projects/config-project/locations/eu",
+      })
+    }),
+  )
+
+  it.effect("keeps OpenAI-compatible Vertex endpoint templates multi-region for us", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      yield* catalog.transform((catalog) =>
+        catalog.provider.update(ProviderV2.ID.make("google-vertex"), (provider) => {
+          provider.api = {
+            type: "aisdk",
+            package: "@ai-sdk/openai-compatible",
+            url: "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}",
+          }
+          provider.request.body.project = "config-project"
+          provider.request.body.location = "us"
+        }),
+      )
+      yield* addPlugin()
+      const provider = required(yield* catalog.provider.get(ProviderV2.ID.make("google-vertex")))
+      expect(provider.api).toEqual({
+        type: "aisdk",
+        package: "@ai-sdk/openai-compatible",
+        url: "https://aiplatform.googleapis.com/v1/projects/config-project/locations/us",
       })
     }),
   )

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -98,6 +98,16 @@ function googleVertexAnthropicBaseURL(project: string | undefined, location: str
   return `https://aiplatform.${location}.rep.googleapis.com/v1/projects/${project}/locations/${location}/publishers/anthropic/models`
 }
 
+// "global", "us", and "eu" are multi-region locations that resolve via the
+// bare aiplatform.googleapis.com host; only single-region locations (e.g.
+// "us-central1") use a location-prefixed host.
+const VERTEX_MULTI_REGIONS = new Set(["global", "us", "eu"])
+
+function googleVertexEndpoint(location: string) {
+  if (VERTEX_MULTI_REGIONS.has(location)) return "aiplatform.googleapis.com"
+  return `${location}-aiplatform.googleapis.com`
+}
+
 type BundledSDK = {
   languageModel(modelId: string): LanguageModelV3
   chat?: (modelId: string) => LanguageModelV3
@@ -517,7 +527,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       return {
         autoload: true,
         vars(_options: Record<string, any>) {
-          const endpoint = location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`
+          const endpoint = googleVertexEndpoint(location)
           return {
             ...(project && { GOOGLE_VERTEX_PROJECT: project }),
             GOOGLE_VERTEX_LOCATION: location,

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1690,6 +1690,21 @@ const layer = Layer.effect(
           if (baseURL) options.baseURL = baseURL
         }
 
+        if (
+          model.providerID === "google-vertex" &&
+          model.api.npm === "@ai-sdk/google-vertex" &&
+          !options.baseURL &&
+          !options.apiKey &&
+          typeof options.project === "string"
+        ) {
+          // @ai-sdk/google-vertex's own baseURL default only special-cases
+          // "global", producing an invalid "us-aiplatform.googleapis.com" /
+          // "eu-aiplatform.googleapis.com" host for continental multi-regions;
+          // compute the correct host ourselves instead of relying on it.
+          const location = typeof options.location === "string" ? options.location : "us-central1"
+          options.baseURL = `https://${googleVertexEndpoint(location)}/v1beta1/projects/${options.project}/locations/${location}/publishers/google`
+        }
+
         if (model.providerID === "google-vertex" && !model.api.npm.includes("@ai-sdk/openai-compatible")) {
           delete options.fetch
         }

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1867,6 +1867,32 @@ it.instance("Google Vertex: keeps regional Claude endpoints unchanged", () =>
   }),
 )
 
+it.instance("Google Vertex: uses aiplatform.googleapis.com for Gemini in continental multi-regions", () =>
+  Effect.gen(function* () {
+    yield* set("GOOGLE_CLOUD_PROJECT", "test-project")
+    yield* set("VERTEX_LOCATION", "us")
+    const provider = yield* Provider.Service
+    const model = yield* provider.getModel(ProviderV2.ID.make("google-vertex"), ModelV2.ID.make("gemini-2.5-flash"))
+    const language = yield* provider.getLanguage(model)
+    expect(languageBaseURL(language)).toBe(
+      "https://aiplatform.googleapis.com/v1beta1/projects/test-project/locations/us/publishers/google",
+    )
+  }),
+)
+
+it.instance("Google Vertex: keeps regional Gemini endpoints unchanged", () =>
+  Effect.gen(function* () {
+    yield* set("GOOGLE_CLOUD_PROJECT", "test-project")
+    yield* set("VERTEX_LOCATION", "europe-west1")
+    const provider = yield* Provider.Service
+    const model = yield* provider.getModel(ProviderV2.ID.make("google-vertex"), ModelV2.ID.make("gemini-2.5-flash"))
+    const language = yield* provider.getLanguage(model)
+    expect(languageBaseURL(language)).toBe(
+      "https://europe-west1-aiplatform.googleapis.com/v1beta1/projects/test-project/locations/europe-west1/publishers/google",
+    )
+  }),
+)
+
 it.instance("cloudflare-ai-gateway loads with env variables", () =>
   Effect.gen(function* () {
     yield* set("CLOUDFLARE_ACCOUNT_ID", "test-account")


### PR DESCRIPTION
### Issue for this PR

Closes #37006

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the Vertex AI provider building an invalid hostname (`us-aiplatform.googleapis.com`) when `location` is set to a continental multi-region value like `us` or `eu`. Only `global` was treated as not needing a region prefix; `us`/`eu` need the same treatment.

Two separate places had this bug and both needed fixing:
1. The endpoint-template helper used for the OpenAI-compatible Vertex path (in both the legacy provider loader and the newer plugin system) only special-cased `global`.
2. opencode also calls `@ai-sdk/google-vertex`'s `createVertex()` directly for the native SDK path, and that package has the identical bug in its own default `baseURL` computation. Since we can't fix the dependency here, we pass `baseURL` explicitly to override its broken default.

The legacy `provider.ts` fix had to be scoped carefully in `resolveSDK` (only for `npm === "@ai-sdk/google-vertex"`, not the `/anthropic` variant) because the existing Claude-on-Vertex code path already relies on `options.baseURL` being unset to trigger its own REP-endpoint override — setting a `baseURL` unconditionally there would have broken that.

I did generate this code using AI, but I did review. I am not normally writing typescript so it certainly is not my forte, but nothing stuck out to me as incorrect in the code generation. The above summary text was AI generated, but it does seem to accurately reflect the changes and the issue based on my review.

### How did you verify your code works?

- Added/updated unit tests in both `packages/core` and `packages/opencode` asserting the exact constructed `baseURL`/endpoint string for `us`, `eu`, and regular single-region locations (e.g. `us-central1`), for both the OpenAI-compatible and native SDK paths.
- Ran the full test suites: `packages/core` (1077 passing) and `packages/opencode` (3168 passing), no regressions.
- I manually reproduced the original error against a real Vertex-backed project with `location: "us"` and confirmed the request now succeeds with the updated code using bun dev with the same configuration that failed on the released 1.18.1 OpenCode

I'm a little unsure about the version in the uri, the sdk shows v1beta1. Additionally the path now includes ../publishers/google. I'm unable to test other models at the moment other than Gemini and Anthropic models, but those models did work after these changes.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
