### PR TITLE
fix(llm): ignore named SSE extension events

### DIFF
--- a/packages/llm/src/protocols/openai-compatible-chat.ts
+++ b/packages/llm/src/protocols/openai-compatible-chat.ts
@@ -19,7 +19,7 @@ export const route = Route.make({
   providerMetadataKey: "openai",
   protocol: OpenAIChat.protocol,
   endpoint: Endpoint.path("/chat/completions"),
-  framing: Framing.sse,
+  framing: Framing.sseMessages,
 })
 
 export * as OpenAICompatibleChat from "./openai-compatible-chat"

--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -239,14 +239,21 @@ export const errorText = (error: unknown) => {
  * implement client-driven retries) so the public error channel stays
  * `LLMError`.
  */
-export const sseFraming = (bytes: Stream.Stream<Uint8Array, LLMError>): Stream.Stream<string, LLMError> =>
-  bytes.pipe(
-    Stream.decodeText(),
-    Stream.pipeThroughChannel(Sse.decode()),
-    Stream.catchTag("Retry", () => Stream.empty),
-    Stream.filter((event) => event.data.length > 0 && event.data !== "[DONE]"),
-    Stream.map((event) => event.data),
-  )
+const frameSse =
+  (accept: (event: Sse.Event) => boolean) =>
+  (bytes: Stream.Stream<Uint8Array, LLMError>): Stream.Stream<string, LLMError> =>
+    bytes.pipe(
+      Stream.decodeText(),
+      Stream.pipeThroughChannel(Sse.decode()),
+      Stream.catchTag("Retry", () => Stream.empty),
+      Stream.filter((event) => accept(event) && event.data.length > 0 && event.data !== "[DONE]"),
+      Stream.map((event) => event.data),
+    )
+
+export const sseFraming = frameSse(() => true)
+
+// EventSource dispatches events without an explicit name as `message`.
+export const sseMessageFraming = frameSse((event) => event.event.length === 0 || event.event === "message")
 
 /**
  * Canonical invalid-request constructor. Lift one-line `const invalid =

--- a/packages/llm/src/route/framing.ts
+++ b/packages/llm/src/route/framing.ts
@@ -8,7 +8,8 @@ import type { LLMError } from "../schema"
  * `Framing` is the byte-stream-shaped seam between transport and protocol:
  *
  * - SSE (`Framing.sse`) — UTF-8 decode the body, run the SSE channel decoder,
- *   drop empty / `[DONE]` keep-alives. Each emitted frame is the JSON `data:`
+ *   drop empty / `[DONE]` keep-alives. `Framing.sseMessages` additionally
+ *   ignores named extension events. Each emitted frame is the JSON `data:`
  *   payload of one event.
  * - AWS event stream — length-prefixed binary frames with CRC checksums.
  *   Each emitted frame is one parsed binary event record.
@@ -21,7 +22,10 @@ export interface Framing<Frame> {
   readonly frame: (bytes: Stream.Stream<Uint8Array, LLMError>) => Stream.Stream<Frame, LLMError>
 }
 
-/** Server-Sent Events framing. Used by every JSON-streaming HTTP provider. */
+/** Generic Server-Sent Events framing that forwards every event name. */
 export const sse: Framing<string> = { id: "sse", frame: ProviderShared.sseFraming }
+
+/** EventSource-style framing that ignores named extensions and emits default messages. */
+export const sseMessages: Framing<string> = { id: "sse-messages", frame: ProviderShared.sseMessageFraming }
 
 export * as Framing from "./framing"

--- a/packages/llm/test/provider/openai-compatible-chat.test.ts
+++ b/packages/llm/test/provider/openai-compatible-chat.test.ts
@@ -6,8 +6,8 @@ import { Auth, LLMClient } from "../../src/route"
 import * as OpenAICompatible from "../../src/providers/openai-compatible"
 import * as OpenAICompatibleChat from "../../src/protocols/openai-compatible-chat"
 import { it } from "../lib/effect"
-import { dynamicResponse } from "../lib/http"
-import { sseEvents } from "../lib/sse"
+import { dynamicResponse, fixedResponse } from "../lib/http"
+import { sseEvents, sseRaw } from "../lib/sse"
 
 const Json = Schema.fromJsonString(Schema.Unknown)
 const decodeJson = Schema.decodeUnknownSync(Json)
@@ -232,6 +232,31 @@ describe("OpenAI-compatible Chat route", () => {
 
       expect(response.text).toBe("Hello!")
       expect(response.usage).toMatchObject({ inputTokens: 5, outputTokens: 2, totalTokens: 7 })
+      expect(response.events.at(-1)).toMatchObject({ type: "finish", reason: "stop" })
+    }),
+  )
+
+  it.effect("ignores named SSE events", () =>
+    Effect.gen(function* () {
+      const body = sseRaw(
+        `event: hermes.tool.progress\ndata: ${JSON.stringify({
+          tool: "terminal",
+          toolCallId: "call_1",
+          status: "running",
+        })}`,
+        `event: message\ndata: ${JSON.stringify(deltaChunk({ role: "assistant", content: "Hello" }))}`,
+        `event: hermes.tool.progress\ndata: ${JSON.stringify({
+          tool: "terminal",
+          toolCallId: "call_1",
+          status: "completed",
+        })}`,
+        `data: ${JSON.stringify(deltaChunk({}, "stop"))}`,
+        "data: [DONE]",
+      )
+
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.text).toBe("Hello")
       expect(response.events.at(-1)).toMatchObject({ type: "finish", reason: "stop" })
     }),
   )


### PR DESCRIPTION
Closes #28833

Refs #36428

## Summary
- add EventSource-style framing for default `message` events
- use it for OpenAI-compatible Chat so named progress events bypass chunk validation
- retain generic SSE framing for protocols that consume named events

## Testing
- `bun run test` in `packages/llm` (319 passed, 29 skipped)
- `bun run typecheck` in `packages/llm`
- pre-push `bun turbo typecheck --concurrency=3` (32 packages)