### PR TITLE
fix(opencode): include skill files when invoking via slash command

### DIFF
--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -1,3 +1,4 @@
+import { Glob } from "@opencode-ai/core/util/glob"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import path from "path"
 import { InstanceState } from "@/effect/instance-state"
@@ -140,12 +141,25 @@ const layer = Layer.effect(
           source: "skill",
           get template() {
             if (!dir) return item.content
-            return [
+            const files = Glob.scanSync("**/*", { cwd: dir, include: "file", dot: true })
+              .filter((f) => f !== "SKILL.md")
+              .slice(0, 10)
+            const sections = [
               item.content,
               "",
               `Base directory for this skill: ${dir}`,
               "Relative paths in this skill (e.g., scripts/, references/) are relative to this base directory.",
-            ].join("\n")
+            ]
+            if (files.length > 0) {
+              sections.push(
+                "Note: file list is sampled.",
+                "",
+                "<skill_files>",
+                ...files.map((f) => `<file>${path.resolve(dir, f)}</file>`),
+                "</skill_files>",
+              )
+            }
+            return sections.join("\n")
           },
           hints: [],
         }


### PR DESCRIPTION
Closes #24831

### Type of change

- [x] Bug fix

### What does this PR do?

`/skill-name` slash commands only injected the skill markdown body as prompt text, without the `<skill_files>` section that the `skill` tool provides. This meant referenced files (scripts, reference docs) in the skill directory were not discoverable by the model when using the slash command shortcut.

This fix scans the skill directory for files (excluding SKILL.md, up to 10) and appends a `<skill_files>` section to the command template, matching the format used by the `skill` tool (`tool/skill.ts`). Built-in skills with `<built-in>` location are unchanged.

Note: PR #35522 addresses the same issue. This implementation uses `Glob.scanSync` for a synchronous approach that doesn't require the template getter to return a Promise, and uses `**/*` to include files in subdirectories.

### How did you verify your code works?

- Typecheck in `packages/opencode` passes with no new errors
- Output format matches the `<skill_files>` layout from `tool/skill.ts`
- Uses `Glob.scanSync` so works inside the template getter

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
