### PR TITLE
Add shipsmooth-opencode to plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,7 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
-
+| [@bitkentech/shipsmooth-opencode](https://www.shipsmooth.net)                                      | A coding workflow plugin that enables iterative development, vertical slices, and a 'risky bits first' approach |
 ---
 
 ## Projects


### PR DESCRIPTION
Adding a coding workflow plugin that I've developed.

I've linked to its homepage (and not github) as it's better explained there: https://www.shipsmooth.net/. The source repository is https://github.com/bitkentech/shipsmooth.

### Issue for this PR

Closes # https://github.com/anomalyco/opencode/issues/37048

### Type of change
- [x] Documentation

### What does this PR do?
Adds the opencode plugin of shipsmooth (https://www.shipsmooth.net/) to opencode plugins list documentation.

### How did you verify your code works?
I've tested and used the plugin on my local opencode installation (on Linux).
<img width="1768" height="862" alt="Screenshot_20260715_120941" src="https://github.com/user-attachments/assets/3e51764f-a232-4874-975a-99d51c05eca7" />

### Screenshots / recordings
Not an Opencode UI change.

### Checklist
- [x ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
