### PR TITLE
fix(xai): cross-process single-flight for OAuth refresh

### DIFF
--- a/packages/opencode/src/plugin/xai.ts
+++ b/packages/opencode/src/plugin/xai.ts
@@ -3,6 +3,16 @@ import { OAUTH_DUMMY_KEY } from "../auth"
 import { createServer } from "http"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { OauthCallbackPage } from "@opencode-ai/core/oauth/page"
+import { Global } from "@opencode-ai/core/global"
+import { Flock } from "@opencode-ai/core/util/flock"
+
+// Ensure Flock's process-shared lock root is initialized (side effect of Global).
+void Global.Path.state
+
+// Cross-process single-flight key. xAI rotates refresh tokens; concurrent
+// opencode (or Grok CLI) processes sharing ~/.local/share/opencode/auth.json
+// must not each call refresh_token with the same value.
+const XAI_OAUTH_REFRESH_LOCK = "xai-oauth-refresh"
 
 // Public Grok-CLI OAuth client. xAI's auth server rejects loopback OAuth from
 // non-allowlisted clients, so we reuse the Grok-CLI client_id that xAI ships
@@ -455,6 +465,71 @@ interface RefreshResult {
   expires: number
 }
 
+type OauthAuth = {
+  type: "oauth"
+  access: string
+  refresh: string
+  expires: number
+}
+
+export function oauthAccessExpiresSoon(
+  auth: { access?: string; expires?: number },
+  now: number = Date.now(),
+  skewMs: number = ACCESS_TOKEN_REFRESH_SKEW_MS,
+): boolean {
+  // Refresh either when the stored expires timestamp is within the skew
+  // window, or — for JWT access tokens — when the JWT exp claim itself is.
+  // The stored expires field is best-effort (xAI doesn't always return
+  // expires_in) so the JWT check is the load-bearing one for tokens that
+  // lack a fresh stored deadline.
+  return !auth.expires || auth.expires - now <= skewMs || accessTokenIsExpiring(auth.access, skewMs)
+}
+
+async function refreshOauthUnderLock(
+  getAuth: () => Promise<{ type: string; access?: string; refresh?: string; expires?: number }>,
+  input: PluginInput,
+  options: XaiAuthPluginOptions,
+): Promise<RefreshResult> {
+  // Cross-process single-flight via Flock (same mechanism as plugin-meta / tui kv).
+  // After acquiring the lock, re-read auth: another process may have already
+  // rotated the refresh token and written the new pair to disk.
+  return Flock.withLock(XAI_OAUTH_REFRESH_LOCK, async () => {
+    const latest = await getAuth()
+    if (latest.type !== "oauth" || !latest.refresh || !latest.access) {
+      throw new Error("xAI OAuth credentials missing during refresh")
+    }
+    if (!oauthAccessExpiresSoon(latest)) {
+      return {
+        access: latest.access,
+        refresh: latest.refresh,
+        expires: latest.expires ?? Date.now() + 3600_000,
+      }
+    }
+
+    const refreshToken = latest.refresh
+    const tokens = await refreshAccessToken(refreshToken, options)
+    const refreshedExpires = Date.now() + (tokens.expires_in ?? 3600) * 1000
+    const refreshedRefresh = tokens.refresh_token || refreshToken
+    // Persist the rotated pair as best-effort. xAI has already consumed the
+    // old refresh_token by the time we get here; an auth.set failure leaves
+    // the on-disk state stale but the in-memory result is still valid for
+    // this turn. Subsequent processes that re-read under the lock will still
+    // see a usable access token until it expires, then force re-login.
+    await input.client.auth
+      .set({
+        path: { id: "xai" },
+        body: {
+          type: "oauth",
+          access: tokens.access_token,
+          refresh: refreshedRefresh,
+          expires: refreshedExpires,
+        },
+      })
+      .catch(() => {})
+    return { access: tokens.access_token, refresh: refreshedRefresh, expires: refreshedExpires }
+  })
+}
+
 export async function XaiAuthPlugin(input: PluginInput, options: XaiAuthPluginOptions = {}): Promise<Hooks> {
   return {
     auth: {
@@ -463,8 +538,9 @@ export async function XaiAuthPlugin(input: PluginInput, options: XaiAuthPluginOp
         const auth = await getAuth()
         if (auth.type !== "oauth") return {}
 
-        // Single-flight refresh: collapse concurrent fetches from this loaded
-        // provider onto one HTTP call so we don't replay a rotating refresh_token.
+        // In-process single-flight: collapse concurrent fetches from this
+        // loaded provider onto one refresh path. Cross-process single-flight
+        // is handled inside refreshOauthUnderLock via Flock.
         let refreshPromise: Promise<RefreshResult> | undefined
 
         return {
@@ -482,46 +558,14 @@ export async function XaiAuthPlugin(input: PluginInput, options: XaiAuthPluginOp
             // Authorization header reaches xAI unmodified.
             if (currentAuth.type !== "oauth") return fetch(requestInput, init)
 
-            // Refresh either when the stored expires timestamp is within the
-            // skew window, or — for JWT access tokens — when the JWT exp
-            // claim itself is. The stored expires field is best-effort
-            // (xAI doesn't always return expires_in) so the JWT check is the
-            // load-bearing one for tokens that lack a fresh stored deadline.
-            const expiresSoon =
-              !currentAuth.expires ||
-              currentAuth.expires - Date.now() <= ACCESS_TOKEN_REFRESH_SKEW_MS ||
-              accessTokenIsExpiring(currentAuth.access)
-            if (expiresSoon) {
+            if (oauthAccessExpiresSoon(currentAuth)) {
               if (!refreshPromise) {
-                const refreshToken = currentAuth.refresh
-                refreshPromise = refreshAccessToken(refreshToken, options)
-                  .then(async (tokens) => {
-                    const refreshedExpires = Date.now() + (tokens.expires_in ?? 3600) * 1000
-                    const refreshedRefresh = tokens.refresh_token || refreshToken
-                    // Persist the rotated pair as best-effort. xAI has already consumed the
-                    // old refresh_token by the time we get here; an auth.set failure leaves
-                    // the on-disk state stale but the in-memory result is still valid for
-                    // this turn. The next live refresh against the stale disk state will
-                    // 4xx and force re-login — a known cross-process limitation.
-                    await input.client.auth
-                      .set({
-                        path: { id: "xai" },
-                        body: {
-                          type: "oauth",
-                          access: tokens.access_token,
-                          refresh: refreshedRefresh,
-                          expires: refreshedExpires,
-                        },
-                      })
-                      .catch(() => {})
-                    return { access: tokens.access_token, refresh: refreshedRefresh, expires: refreshedExpires }
-                  })
-                  .finally(() => {
-                    refreshPromise = undefined
-                  })
+                refreshPromise = refreshOauthUnderLock(getAuth, input, options).finally(() => {
+                  refreshPromise = undefined
+                })
               }
               const refreshed = await refreshPromise
-              currentAuth = { ...currentAuth, ...refreshed }
+              currentAuth = { ...currentAuth, ...refreshed } as OauthAuth
             }
 
             // Copy the caller's headers into a fresh Headers (case-insensitive)

--- a/packages/opencode/test/plugin/xai.test.ts
+++ b/packages/opencode/test/plugin/xai.test.ts
@@ -269,7 +269,9 @@ describe("plugin.xai", () => {
       expect((setCalls[0].body as any).refresh).toBe("rt-new")
     })
 
-    test("does not share refresh single-flight across loader instances", async () => {
+    test("does not share refresh single-flight across loader instances with distinct tokens", async () => {
+      // Distinct refresh tokens still refresh independently (serialized by the
+      // cross-process Flock, but each still needs its own grant rotation).
       const { input } = makeInput()
       const tokenRequests: string[] = []
       const apiRequests: string[] = []
@@ -304,6 +306,63 @@ describe("plugin.xai", () => {
 
       expect(tokenRequests.sort()).toEqual(["rt-a", "rt-b"])
       expect(apiRequests.sort()).toEqual(["Bearer access-rt-a", "Bearer access-rt-b"])
+    })
+
+    test("cross-loader shared store: only one refresh when both see the same rotating token", async () => {
+      // Simulates two processes / loader instances sharing auth.json: after the
+      // first refresh wins the Flock and auth.set updates the shared store, the
+      // second re-reads under the lock and skips refresh_token reuse.
+      const store = {
+        type: "oauth" as const,
+        access: "old",
+        refresh: "rt-shared",
+        expires: 0,
+      }
+      const setCalls: Array<Record<string, unknown>> = []
+      const input = {
+        client: {
+          auth: {
+            set: async (req: Record<string, unknown>) => {
+              setCalls.push(req)
+              const body = req.body as { access: string; refresh: string; expires: number }
+              store.access = body.access
+              store.refresh = body.refresh
+              store.expires = body.expires
+            },
+          },
+        },
+      } as any
+      let tokenRequests = 0
+      const apiAuth: string[] = []
+      using server = makeServer(async (request, url) => {
+        if (url.pathname === "/oauth2/token") {
+          tokenRequests++
+          const body = await request.text()
+          expect(body).toContain("refresh_token=rt-shared")
+          await new Promise((resolve) => setTimeout(resolve, 40))
+          return Response.json({
+            access_token: "new-access",
+            refresh_token: "rt-rotated",
+            expires_in: 3600,
+          })
+        }
+        apiAuth.push(request.headers.get("authorization")!)
+        return new Response("{}", { status: 200 })
+      })
+      const hooks = await XaiAuthPlugin(input, serverOptions(server))
+      const getAuth = async () => ({ ...store })
+      const a = await hooks.auth!.loader!(getAuth, {} as any)
+      const b = await hooks.auth!.loader!(getAuth, {} as any)
+
+      await Promise.all([
+        a.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
+        b.fetch!(new URL("/chat/completions", server.url), { headers: {} }),
+      ])
+
+      expect(tokenRequests).toBe(1)
+      expect(setCalls).toHaveLength(1)
+      expect(apiAuth).toEqual(["Bearer new-access", "Bearer new-access"])
+      expect(store.refresh).toBe("rt-rotated")
     })
 
     test("starts a new refresh after success and clears the refresh promise after failure", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #37059

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

xAI rotates refresh tokens. Multiple opencode processes sharing `auth.json` each try to refresh the same token; losers get `invalid_grant` / token revoked.

Keep the existing in-process `refreshPromise`, and wrap the real refresh in `Flock.withLock("xai-oauth-refresh")`. After taking the lock, re-read auth so if another process already rotated and wrote the new pair, we reuse it instead of replaying the old refresh token.

### How did you verify your code works?

- `bun test test/plugin/xai.test.ts` — 27 pass, including a new shared-store concurrent-loader test (two loaders, one refresh hit).
- Pre-commit `turbo typecheck` clean.
- Local `build.ts --single --skip-embed-web-ui`; binary contains the lock key.

### Screenshots / recordings

N/A (auth path only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR