### PR TITLE
docs: add opencode-zellij-indicator to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-zellij-indicator](https://github.com/aidan-gallagher/opencode-zellij-indicator)          | Show each OpenCode session's status and title on its Zellij tab (working / needs-you / done)       |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-zellij-indicator` to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

The plugin shows each OpenCode session's status (working / needs-you / done) and title on its Zellij tab, so with multiple sessions open across tabs you can tell which agent is busy, which is blocked on a prompt, and which has finished without switching tabs.

Distinct from the existing `opencode-zellij-namer` entry, which does AI-powered session naming.

- GitHub: https://github.com/aidan-gallagher/opencode-zellij-indicator
- npm: https://www.npmjs.com/package/opencode-zellij-indicator

### How did you verify your code works?

Confirmed the new row is added to the Plugins table with correct link target and column alignment, and that no other files are changed.

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR