### PR TITLE
docs: Add shipsmooth-opencode plugin to list of plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,7 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
-
+| [@bitkentech/shipsmooth-opencode](https://www.shipsmooth.net)                                      | A coding workflow plugin that enables iterative development, vertical slices, and a 'risky bits first' approach |
 ---
 
 ## Projects


### PR DESCRIPTION
Adding a coding workflow plugin that I've developed.

I've linked to its homepage (and not github) as it's better explained there: https://www.shipsmooth.net/. The source repository is https://github.com/bitkentech/shipsmooth.

### Issue for this PR

Closes #37048

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds the opencode plugin of shipsmooth (https://www.shipsmooth.net/) to opencode plugins list documentation.

### How did you verify your code works?
I've tested and used the plugin on my local opencode installation (on Linux)
<img width="1768" height="862" alt="image" src="https://github.com/user-attachments/assets/ab070136-72cc-46b8-87f0-5f228965988a" />

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
