### PR TITLE
fix(opencode): hint that privatemode-ai needs its local proxy

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -477,6 +477,16 @@ export const ProvidersLoginCommand = effectCmd({
       )
     }
 
+    if (provider === "privatemode-ai") {
+      yield* Prompt.log.info(
+        "Privatemode requires the privatemode-proxy running locally first (default http://localhost:8080/v1) - " +
+          "this key alone will not work.\n" +
+          "Start it, e.g.: docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest --apiKey <your-key>\n" +
+          "If you start the proxy with --apiKey, the key below is not used by the proxy - any value works.\n" +
+          "Details: https://docs.privatemode.ai/api/proxy-configuration/",
+      )
+    }
+
     const key = yield* Prompt.password({
       message: "Enter your API key",
       validate: (x) => (x && x.length > 0 ? undefined : "Required"),


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Privatemode has no hosted API endpoint - it's only reachable through the self-hosted privatemode-proxy (default `http://localhost:8080/v1`), which handles end-to-end encryption and remote attestation. Without that proxy running, `opencode auth login` for `privatemode-ai` silently accepts an API key that connects to nothing, so requests fail later with no clear reason why.

This adds an info message before the password prompt in `providers.ts`, following the existing pattern already used for `amazon-bedrock`, `opencode`, `vercel`, and `cloudflare` in the same file: explain the proxy requirement, give the docker command to start it, and note that if the proxy is started with `--apiKey` the value entered here doesn't matter.

### How did you verify your code works?

- `tsgo --noEmit` and `oxlint` on the changed file pass with no new warnings/errors.
- Ran `opencode auth login --provider privatemode-ai` locally against a real `privatemode-proxy` container and confirmed the hint renders correctly before the key prompt.
- Confirmed the underlying model list issue this hint accompanies is fixed via a companion models.dev PR: https://github.com/anomalyco/models.dev/pull/3270

### Screenshots / recordings

Not applicable - this is a CLI text prompt, not a UI change. Example output:

```
●  Privatemode requires the privatemode-proxy running locally first (default http://localhost:8080/v1) - this key alone will not work.
   Start it, e.g.: docker run -p 8080:8080 ghcr.io/edgelesssys/privatemode/privatemode-proxy:latest --apiKey <your-key>
   If you start the proxy with --apiKey, the key below is not used by the proxy - any value works.
   Details: https://docs.privatemode.ai/api/proxy-configuration/
◆  Enter your API key
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR