### PR TITLE
fix(tui): hide background hint for async work

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1344,17 +1344,8 @@ function BackgroundToolHint(props: { messages: SessionMessageInfo[] }) {
   const theme = useTheme()
   const shortcut = Keymap.useShortcut("session.background")
   const running = createMemo(() => {
-    if (!shortcut()) return
-    const current = props.messages.findLast(
-      (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
-    )
-    const part = current?.content.find((part): part is SessionMessageAssistantTool => {
-      if (part.type !== "tool" || part.state.status !== "running") return false
-      const name = canonicalToolName(part.name)
-      return name === "shell" || name === "subagent"
-    })
-    if (!current || !part) return
-    return `${current.id}:${part.id}`
+    if (!shortcut()) return undefined
+    return backgroundableToolID(props.messages)
   })
   const visible = createDelayedPresence(running, BACKGROUND_TOOL_HINT_DELAY)
   return (
@@ -1368,6 +1359,19 @@ function BackgroundToolHint(props: { messages: SessionMessageInfo[] }) {
       )}
     </Show>
   )
+}
+
+export function backgroundableToolID(messages: SessionMessageInfo[]) {
+  const current = messages.findLast(
+    (message): message is SessionMessageAssistant => message.type === "assistant" && !message.time.completed,
+  )
+  const part = current?.content.find((part): part is SessionMessageAssistantTool => {
+    if (part.type !== "tool" || part.state.status !== "running" || part.state.input.background === true) return false
+    const name = canonicalToolName(part.name)
+    return name === "shell" || name === "subagent"
+  })
+  if (!current || !part) return undefined
+  return `${current.id}:${part.id}`
 }
 
 function SessionMessageView(props: { message: SessionMessageInfo }) {

--- a/packages/tui/test/cli/tui/background-tool-hint.test.ts
+++ b/packages/tui/test/cli/tui/background-tool-hint.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test"
+import type { SessionMessageAssistant, SessionMessageAssistantTool } from "@opencode-ai/client"
+import { backgroundableToolID } from "../../../src/routes/session"
+
+test("shows the hint for running foreground work", () => {
+  expect(backgroundableToolID([assistant(tool("subagent"))])).toBe("assistant:subagent")
+  expect(backgroundableToolID([assistant(tool("shell"))])).toBe("assistant:shell")
+})
+
+test("hides the hint when all running work started in the background", () => {
+  expect(backgroundableToolID([assistant(tool("subagent", true), tool("shell", true))])).toBeUndefined()
+})
+
+test("shows the hint when foreground work remains alongside background work", () => {
+  expect(backgroundableToolID([assistant(tool("subagent", true), tool("shell"))])).toBe("assistant:shell")
+})
+
+test("ignores running tools that cannot be backgrounded", () => {
+  expect(backgroundableToolID([assistant(tool("read"))])).toBeUndefined()
+})
+
+function assistant(...content: SessionMessageAssistantTool[]): SessionMessageAssistant {
+  return {
+    type: "assistant",
+    id: "assistant",
+    agent: "build",
+    model: { id: "model", providerID: "provider" },
+    content,
+    time: { created: 1 },
+  }
+}
+
+function tool(name: string, background = false): SessionMessageAssistantTool {
+  return {
+    type: "tool",
+    id: name,
+    name,
+    state: {
+      status: "running",
+      input: background ? { background: true } : {},
+      metadata: {},
+    },
+    time: { created: 1 },
+  }
+}


### PR DESCRIPTION
### Issue for this PR

Closes #36940

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Hides the Ctrl+B backgrounding hint when every running shell or subagent was launched with `background: true`. The hint remains visible when at least one foreground shell or subagent can still be moved to the background.

The refreshed implementation keeps the current `v2` delayed-presence behavior and canonical tool-name matching. Focused coverage includes foreground-only, background-only, mixed, and unrelated running tools.

### How did you verify your code works?

- `cd packages/tui && bun test --timeout 30000 --only-failures` — 631 pass, 5 skip
- `cd packages/tui && bun run typecheck`
- `bun run typecheck` — 33/33 package tasks passed
- `bun run lint packages/tui/src/routes/session/index.tsx packages/tui/test/cli/tui/background-tool-hint.test.ts` — 0 errors

### Screenshots / recordings

Not included: this only suppresses an inapplicable hint; it does not change the hint styling or layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
