### PR TITLE
fix(provider): pass Gitlab token to authorize and use token for model discovery

### DIFF
--- a/packages/opencode/src/cli/cmd/providers.ts
+++ b/packages/opencode/src/cli/cmd/providers.ts
@@ -188,7 +188,7 @@ const handlePluginAuth = Effect.fn("Cli.providers.pluginAuth")(function* (
       return true
     }
 
-    const result = yield* cliTry("Failed to authorize: ", () => authorizeApi(inputs))
+    const result = yield* cliTry("Failed to authorize: ", () => authorizeApi({ ...inputs, token: apiKey }))
     if (result.type === "failed") {
       yield* Prompt.log.error("Failed to authorize")
     }

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -659,12 +659,11 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           })
         },
         async discoverModels(): Promise<Record<string, Model>> {
-          if (!apiKey) {
+          if (!token) {
             return {}
           }
 
           try {
-            const token = apiKey
             const getHeaders = (): Record<string, string> =>
               auth?.type === "api" ? { "PRIVATE-TOKEN": token } : { Authorization: `Bearer ${token}` }
 


### PR DESCRIPTION
Forward the entered apiKey as `token` in authorizeApi inputs, and gate model discovery on the resolved `token` rather than `apiKey` so OAuth (GitLab Duo) flows discover models correctly.


### Issue for this PR

Closes #37107 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

1. Gitlab Duo agent platform (`duo-workflow-`) models are dependent on the specific namespace that's loaded and discovery of models thus requires you to be logged in correctly. This wires through the key correctly if it's provided as an environment variable
2. Signing in to Gitlab Duo by passing a PAT in the user interface was just broken

### How did you verify your code works?

I have run this code against a Gitlab Enterprise self-hosted server and used it to run OpenCode.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
