### PR TITLE
fix(session): guard repeated no-progress tool outcomes

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -46,10 +46,68 @@ interface FetchDecompressionError extends Error {
 export const SYNTHETIC_ATTACHMENT_PROMPT = "Attached media from tool result:"
 export { isMedia }
 
+type ToolReplayAttachment = {
+  mime: string
+  url: string
+  filename?: string
+}
+
+export type ToolReplay =
+  | {
+      type: "completed"
+      output: string | { text: string; attachments: Array<Pick<ToolReplayAttachment, "mime" | "url">> }
+      media: ToolReplayAttachment[]
+    }
+  | { type: "error"; state: "output-available"; output: string }
+  | { type: "error"; state: "output-error"; errorText: string }
+
 function truncateToolOutput(text: string, maxChars?: number) {
   if (!maxChars || text.length <= maxChars) return text
   const omitted = text.length - maxChars
   return `${text.slice(0, maxChars)}\n[Tool output truncated for compaction: omitted ${omitted} chars]`
+}
+
+function supportsMediaInToolResult(model: Provider.Model, attachment: { mime: string }) {
+  if (model.api.npm === "@ai-sdk/anthropic") return true
+  if (model.api.npm === "@ai-sdk/openai") return true
+  if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return true
+  if (model.api.npm === "@ai-sdk/amazon-bedrock") return attachment.mime.startsWith("image/")
+  if (model.api.npm === "@ai-sdk/xai") return attachment.mime.startsWith("image/")
+  if (model.api.npm === "@ai-sdk/google-vertex/anthropic") return true
+  if (model.api.npm === "@ai-sdk/google") {
+    const id = model.api.id.toLowerCase()
+    return id.includes("gemini-3") && !id.includes("gemini-2")
+  }
+  return false
+}
+
+export function toolReplay(
+  part: SessionV1.ToolPart,
+  model: Provider.Model,
+  options?: { stripMedia?: boolean; toolOutputMaxChars?: number },
+): ToolReplay | undefined {
+  if (part.state.status === "completed") {
+    const outputText = part.state.time.compacted
+      ? "[Old tool result content cleared]"
+      : truncateToolOutput(part.state.output, options?.toolOutputMaxChars)
+    const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
+    const media = attachments
+      .filter((attachment) => isMedia(attachment.mime) && !supportsMediaInToolResult(model, attachment))
+      .map((attachment) => ({ mime: attachment.mime, url: attachment.url, filename: attachment.filename }))
+    const supported = attachments
+      .filter((attachment) => !isMedia(attachment.mime) || supportsMediaInToolResult(model, attachment))
+      .map((attachment) => ({ mime: attachment.mime, url: attachment.url }))
+    return {
+      type: "completed",
+      output: supported.length > 0 ? { text: outputText, attachments: supported } : outputText,
+      media,
+    }
+  }
+
+  if (part.state.status !== "error") return
+  const output = part.state.metadata?.interrupted === true ? part.state.metadata.output : undefined
+  if (typeof output === "string") return { type: "error", state: "output-available", output }
+  return { type: "error", state: "output-error", errorText: part.state.error }
 }
 
 export const Event = {
@@ -135,29 +193,6 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
 ) {
   const result: UIMessage[] = []
   const toolNames = new Set<string>()
-  // Track media from tool results that need to be injected as user messages
-  // for providers that don't support that media type in tool results.
-  //
-  // OpenAI-compatible APIs only support string content in tool results, so we need
-  // to extract media and inject as user messages. Some SDKs only support a subset
-  // of media in tool results; e.g. Bedrock supports images but not PDFs there.
-  //
-  // Only apply this workaround if the model actually supports that media input -
-  // otherwise unsupportedParts() will turn it into a user-visible error.
-  const supportsMediaInToolResult = (attachment: { mime: string }) => {
-    if (model.api.npm === "@ai-sdk/anthropic") return true
-    if (model.api.npm === "@ai-sdk/openai") return true
-    if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return true
-    if (model.api.npm === "@ai-sdk/amazon-bedrock") return attachment.mime.startsWith("image/")
-    if (model.api.npm === "@ai-sdk/xai") return attachment.mime.startsWith("image/")
-    if (model.api.npm === "@ai-sdk/google-vertex/anthropic") return true
-    if (model.api.npm === "@ai-sdk/google") {
-      const id = model.api.id.toLowerCase()
-      return id.includes("gemini-3") && !id.includes("gemini-2")
-    }
-    return false
-  }
-
   const toModelOutput = (options: { toolCallId: string; input: unknown; output: unknown }) => {
     const output = options.output
     if (typeof output === "string") {
@@ -290,47 +325,30 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
         if (part.type === "tool") {
           toolNames.add(part.tool)
           if (part.state.status === "completed") {
-            const outputText = part.state.time.compacted
-              ? "[Old tool result content cleared]"
-              : truncateToolOutput(part.state.output, options?.toolOutputMaxChars)
-            const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
-
-            // For providers that don't support media in tool results, extract media files
-            // (images, PDFs) to be sent as a separate user message
-            const mediaAttachments = attachments.filter((a) => isMedia(a.mime))
-            const extractedMedia = mediaAttachments.filter((a) => !supportsMediaInToolResult(a))
-            if (extractedMedia.length > 0) {
-              media.push(...extractedMedia)
-            }
-            const finalAttachments = attachments.filter((a) => !isMedia(a.mime) || supportsMediaInToolResult(a))
-
-            const output =
-              finalAttachments.length > 0
-                ? {
-                    text: outputText,
-                    attachments: finalAttachments,
-                  }
-                : outputText
+            const replay = toolReplay(part, model, options)
+            if (!replay || replay.type !== "completed") continue
+            media.push(...replay.media)
 
             assistantMessage.parts.push({
               type: ("tool-" + part.tool) as `tool-${string}`,
               state: "output-available",
               toolCallId: part.callID,
               input: part.state.input,
-              output,
+              output: replay.output,
               ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
               ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
             })
           }
           if (part.state.status === "error") {
-            const output = part.state.metadata?.interrupted === true ? part.state.metadata.output : undefined
-            if (typeof output === "string") {
+            const replay = toolReplay(part, model, options)
+            if (!replay || replay.type !== "error") continue
+            if (replay.state === "output-available") {
               assistantMessage.parts.push({
                 type: ("tool-" + part.tool) as `tool-${string}`,
                 state: "output-available",
                 toolCallId: part.callID,
                 input: part.state.input,
-                output,
+                output: replay.output,
                 ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
                 ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
               })
@@ -340,7 +358,7 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
                 state: "output-error",
                 toolCallId: part.callID,
                 input: part.state.input,
-                errorText: part.state.error,
+                errorText: replay.errorText,
                 ...(part.metadata?.providerExecuted ? { providerExecuted: true } : {}),
                 ...(differentModel ? {} : { callProviderMetadata: providerMeta(part.metadata) }),
               })

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -24,10 +24,27 @@ import { errorMessage } from "@/util/error"
 import { isRecord } from "@/util/record"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
+import { Hash } from "@opencode-ai/core/util/hash"
 import { Usage, type LLMEvent } from "@opencode-ai/llm"
 
 const DOOM_LOOP_THRESHOLD = 3
+const DOOM_LOOP_PAGE_SIZE = 50
 export type Result = "compact" | "stop" | "continue"
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .flatMap((key) => {
+        const item = value[key]
+        if (item === undefined || typeof item === "function" || typeof item === "symbol") return []
+        return [`${JSON.stringify(key)}:${stableStringify(item)}`]
+      })
+      .join(",")}}`
+  }
+  return JSON.stringify(value) ?? "null"
+}
 
 export interface Handle {
   readonly message: SessionV1.Assistant
@@ -44,6 +61,9 @@ export interface Handle {
       attachments?: SessionV1.FilePart[]
     },
   ) => Effect.Effect<void>
+  readonly guardToolCall: (
+    input: { id: string; name: string; input: Record<string, unknown> },
+  ) => Effect.Effect<void, unknown>
   readonly process: (streamInput: LLM.StreamInput) => Effect.Effect<Result>
 }
 
@@ -72,6 +92,7 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: SessionV1.TextPart | undefined
   reasoningMap: Record<string, SessionV1.ReasoningPart>
+  preflightedToolCalls: Set<string>
 }
 
 type StreamEvent = LLMEvent
@@ -111,6 +132,7 @@ const layer = Layer.effect(
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        preflightedToolCalls: new Set(),
       }
       let aborted = false
 
@@ -252,7 +274,129 @@ const layer = Layer.effect(
         return { call: ctx.toolcalls[input.id], part }
       })
 
+      const startToolCall = Effect.fn("SessionProcessor.startToolCall")(function* (input: {
+        id: string
+        name: string
+        value: Record<string, unknown>
+        providerExecuted?: boolean
+        providerMetadata?: Record<string, unknown>
+      }) {
+        yield* ensureToolCall({ id: input.id, name: input.name, providerExecuted: input.providerExecuted })
+        yield* updateToolCall(input.id, (match) => ({
+          ...match,
+          tool: input.name,
+          state:
+            match.state.status === "running"
+              ? { ...match.state, input: input.value }
+              : {
+                  status: "running",
+                  input: input.value,
+                  time: { start: Date.now() },
+                },
+          metadata: match.metadata?.providerExecuted
+            ? { ...input.providerMetadata, providerExecuted: true }
+            : input.providerMetadata,
+        }))
+      })
+
       const isFilePart = (value: unknown): value is SessionV1.FilePart => Schema.is(SessionV1.FilePart)(value)
+
+      const recentToolOutcomes = Effect.fn("SessionProcessor.recentToolOutcomes")(function* (tool: string) {
+        const result: SessionV1.ToolPart[] = []
+        let before: string | undefined
+
+        while (result.length < DOOM_LOOP_THRESHOLD) {
+          const page = yield* MessageV2.page({
+            sessionID: ctx.sessionID,
+            limit: DOOM_LOOP_PAGE_SIZE,
+            before,
+          }).pipe(Effect.provideService(Database.Service, database))
+
+          for (let messageIndex = page.items.length - 1; messageIndex >= 0; messageIndex--) {
+            const message = page.items[messageIndex]
+            if (!message) continue
+            if (message.info.role === "user" && message.info.id === ctx.assistantMessage.parentID) return result
+            if (message.info.role !== "assistant" || message.info.parentID !== ctx.assistantMessage.parentID) continue
+
+            for (let partIndex = message.parts.length - 1; partIndex >= 0; partIndex--) {
+              const part = message.parts[partIndex]
+              if (
+                part?.type === "tool" &&
+                part.tool === tool &&
+                (part.state.status === "completed" || part.state.status === "error")
+              ) {
+                result.push(part)
+                if (result.length === DOOM_LOOP_THRESHOLD) return result
+              }
+            }
+          }
+
+          if (!page.more || !page.cursor) return result
+          before = page.cursor
+        }
+
+        return result
+      })
+
+      const doomLoopPatterns = Effect.fn("SessionProcessor.doomLoopPatterns")(function* (input: {
+        name: string
+        value: Record<string, unknown>
+      }) {
+        const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
+          Effect.provideService(Database.Service, database),
+        )
+        const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
+        const sameInput =
+          recentParts.length === DOOM_LOOP_THRESHOLD &&
+          recentParts.every(
+            (part) =>
+              part.type === "tool" &&
+              part.tool === input.name &&
+              part.state.status !== "pending" &&
+              JSON.stringify(part.state.input) === JSON.stringify(input.value),
+          )
+
+        const outcomes = yield* recentToolOutcomes(input.name)
+        const fingerprints = outcomes.map((part) => {
+          const replay = MessageV2.toolReplay(part, ctx.model)
+          return replay ? Hash.sha256(stableStringify(replay)) : undefined
+        })
+        const outcomePattern =
+          fingerprints.length === DOOM_LOOP_THRESHOLD &&
+          fingerprints.every((fingerprint) => fingerprint !== undefined && fingerprint === fingerprints[0])
+            ? `doom-loop/${ctx.sessionID}/${ctx.assistantMessage.parentID}/${input.name}/${fingerprints[0]}`
+            : undefined
+
+        return [...new Set([...(sameInput ? [input.name] : []), ...(outcomePattern ? [outcomePattern] : [])])]
+      })
+
+      const askDoomLoop = Effect.fn("SessionProcessor.askDoomLoop")(function* (input: {
+        name: string
+        value: Record<string, unknown>
+      }) {
+        const patterns = yield* doomLoopPatterns(input)
+        if (patterns.length === 0) return
+        const agent = yield* agents.get(ctx.assistantMessage.agent)
+        yield* permission.ask({
+          permission: "doom_loop",
+          patterns,
+          sessionID: ctx.assistantMessage.sessionID,
+          metadata: { tool: input.name, input: input.value },
+          always: patterns,
+          ruleset: agent.permission,
+        })
+      })
+
+      const guardToolCall = Effect.fn("SessionProcessor.guardToolCall")(function* (input: {
+        id: string
+        name: string
+        input: Record<string, unknown>
+      }) {
+        if (ctx.preflightedToolCalls.has(input.id)) return
+        yield* startToolCall({ id: input.id, name: input.name, value: input.input })
+        ctx.preflightedToolCalls.add(input.id)
+        yield* askDoomLoop({ name: input.name, value: input.input })
+      })
 
       const toolResultOutput = (
         value: Extract<StreamEvent, { type: "tool-result" }>,
@@ -271,7 +415,11 @@ const layer = Layer.effect(
           title: value.name,
           metadata: value.result.type === "json" && isRecord(value.result.value) ? value.result.value : {},
           output:
-            typeof value.result.value === "string" ? value.result.value : (JSON.stringify(value.result.value) ?? ""),
+            value.result.type === "json"
+              ? stableStringify(value.result.value)
+              : typeof value.result.value === "string"
+                ? value.result.value
+                : (JSON.stringify(value.result.value) ?? ""),
         }
       }
 
@@ -332,51 +480,16 @@ const layer = Layer.effect(
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.name}`)
             }
-            yield* ensureToolCall(value)
             const input = isRecord(value.input) ? value.input : { value: value.input }
-            yield* updateToolCall(value.id, (match) => ({
-              ...match,
-              tool: value.name,
-              state:
-                match.state.status === "running"
-                  ? { ...match.state, input }
-                  : {
-                      status: "running",
-                      input,
-                      time: { start: Date.now() },
-                    },
-              metadata: match.metadata?.providerExecuted
-                ? { ...value.providerMetadata, providerExecuted: true }
-                : value.providerMetadata,
-            }))
-
-            const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
-              Effect.provideService(Database.Service, database),
-            )
-            const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
-
-            if (
-              recentParts.length !== DOOM_LOOP_THRESHOLD ||
-              !recentParts.every(
-                (part) =>
-                  part.type === "tool" &&
-                  part.tool === value.name &&
-                  part.state.status !== "pending" &&
-                  JSON.stringify(part.state.input) === JSON.stringify(input),
-              )
-            ) {
-              return
-            }
-
-            const agent = yield* agents.get(ctx.assistantMessage.agent)
-            yield* permission.ask({
-              permission: "doom_loop",
-              patterns: [value.name],
-              sessionID: ctx.assistantMessage.sessionID,
-              metadata: { tool: value.name, input },
-              always: [value.name],
-              ruleset: agent.permission,
+            yield* startToolCall({
+              id: value.id,
+              name: value.name,
+              value: input,
+              providerExecuted: value.providerExecuted,
+              providerMetadata: value.providerMetadata,
             })
+            if (ctx.preflightedToolCalls.has(value.id)) return
+            yield* askDoomLoop({ name: value.name, value: input })
             return
           }
 
@@ -688,6 +801,7 @@ const layer = Layer.effect(
         },
         updateToolCall,
         completeToolCall,
+        guardToolCall,
         process,
       } satisfies Handle
     })

--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -42,7 +42,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   agent: Agent.Info
   model: Provider.Model
   session: Session.Info
-  processor: Pick<SessionProcessor.Handle, "message" | "updateToolCall" | "completeToolCall">
+  processor: Pick<SessionProcessor.Handle, "message" | "updateToolCall" | "completeToolCall" | "guardToolCall">
   bypassAgentCheck: boolean
   messages: SessionV1.WithParts[]
   promptOps: TaskPromptOps
@@ -55,6 +55,32 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   const mcp = yield* MCP.Service
   const truncate = yield* Truncate.Service
   const flags = yield* RuntimeFlags.Service
+
+  const guardToolCalls = (items: Record<string, AITool>) =>
+    Object.fromEntries(
+      Object.entries(items).map(([name, item]) => {
+        if (!item.execute) return [name, item]
+        const execute = item.execute
+        return [
+          name,
+          {
+            ...item,
+            execute: async (args, options) => {
+              await run.promise(
+                input.processor
+                  .guardToolCall({
+                    id: options.toolCallId,
+                    name,
+                    input: toRecord(args),
+                  })
+                  .pipe(Effect.orDie),
+              )
+              return execute(args, options)
+            },
+          },
+        ]
+      }),
+    ) as Record<string, AITool>
 
   const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => ({
     sessionID: input.session.id,
@@ -385,7 +411,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     })
   }
 
-  if (flags.experimentalCodeMode) return tools
+  if (flags.experimentalCodeMode) return guardToolCalls(tools)
 
   for (const [key, entry] of Object.entries(yield* mcp.tools())) {
     const item = McpCatalog.convertTool(entry.def, entry.client, entry.timeout)
@@ -489,7 +515,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
     tools[key] = item
   }
 
-  return tools
+  return guardToolCalls(tools)
 })
 
 function toRecord(value: unknown) {

--- a/packages/opencode/test/fixture/mcp-no-progress-stdio.ts
+++ b/packages/opencode/test/fixture/mcp-no-progress-stdio.ts
@@ -1,0 +1,35 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+
+const server = new Server({ name: "mcp-no-progress", version: "1.0.0" }, { capabilities: { tools: {} } })
+
+server.setRequestHandler(ListToolsRequestSchema, () =>
+  Promise.resolve({
+    tools: [
+      {
+        name: "opaque_lookup",
+        description: "Look up a value.",
+        inputSchema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      },
+    ],
+  }),
+)
+
+server.setRequestHandler(CallToolRequestSchema, (request) => {
+  const query = request.params.arguments?.query
+  return Promise.resolve({
+    content: [
+      {
+        type: "text" as const,
+        text: query === "break" ? "PROGRESS" : "NO_PROGRESS",
+      },
+    ],
+  })
+})
+
+await server.connect(new StdioServerTransport())

--- a/packages/opencode/test/fixture/no-progress-openai.ts
+++ b/packages/opencode/test/fixture/no-progress-openai.ts
@@ -1,0 +1,70 @@
+const port = Number(process.env.NO_PROGRESS_LLM_PORT ?? "8787")
+const flow = process.env.NO_PROGRESS_FLOW === "B" ? "B" : "A"
+
+const calls =
+  flow === "B"
+    ? [
+        // The TUI can issue one tool-call turn while local MCP discovery finishes.
+        // That warm-up is intentionally not part of either proof's counted streak.
+        { type: "tool" as const, query: "warmup" },
+        { type: "tool" as const, query: "one" },
+        { type: "tool" as const, query: "two" },
+        { type: "tool" as const, query: "three" },
+        { type: "tool" as const, query: "break" },
+        { type: "tool" as const, query: "after" },
+        { type: "text" as const, text: "done" },
+      ]
+    : [
+        // The TUI can issue one tool-call turn while local MCP discovery finishes.
+        // That warm-up is intentionally not part of Flow A's counted streak.
+        { type: "tool" as const, query: "warmup" },
+        { type: "tool" as const, query: "one" },
+        { type: "tool" as const, query: "two" },
+        { type: "tool" as const, query: "three" },
+        { type: "tool" as const, query: "four" },
+      ]
+
+let next = 0
+
+function line(value: unknown) {
+  return `data: ${JSON.stringify(value)}\n\n`
+}
+
+function chunk(delta: Record<string, unknown>, finishReason?: string) {
+  return {
+    id: "chatcmpl-no-progress",
+    object: "chat.completion.chunk",
+    choices: [{ delta, ...(finishReason ? { finish_reason: finishReason } : {}) }],
+  }
+}
+
+function stream(lines: unknown[]) {
+  return new Response([...lines.map(line), "data: [DONE]\n\n"].join(""), {
+    headers: { "content-type": "text/event-stream" },
+  })
+}
+
+const server = Bun.serve({
+  port,
+  fetch(req) {
+    const url = new URL(req.url)
+    if (req.method !== "POST" || url.pathname !== "/v1/chat/completions") {
+      return new Response("not found", { status: 404 })
+    }
+
+    const item = calls[next++]
+    if (!item) return new Response("unexpected model request", { status: 500 })
+    if (item.type === "text") return stream([chunk({ role: "assistant" }), chunk({ content: item.text }), chunk({}, "stop")])
+
+    const id = `call_${next}`
+    return stream([
+      chunk({ role: "assistant" }),
+      chunk({ tool_calls: [{ index: 0, id, type: "function", function: { name: "opaque_opaque_lookup", arguments: "" } }] }),
+      chunk({ tool_calls: [{ index: 0, function: { arguments: JSON.stringify({ query: item.query }) } }] }),
+      chunk({}, "tool_calls"),
+    ])
+  },
+})
+
+console.log(`no-progress-openai flow ${flow} listening on ${server.url}`)
+await new Promise<never>(() => {})

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -23,6 +23,7 @@ import { pollWithTimeout, testEffect } from "../lib/effect"
 
 const it = testEffect(LayerNode.compile(MCP.node))
 const stdioFixture = path.join(import.meta.dir, "../fixture/mcp-lifecycle-stdio.ts")
+const noProgressFixture = path.join(import.meta.dir, "../fixture/mcp-no-progress-stdio.ts")
 
 type Page<T> = { items: T[]; nextCursor?: string }
 
@@ -214,6 +215,24 @@ it.instance(
       )
     }),
   { init: (directory) => Effect.promise(() => Bun.$`mkdir -p ${path.join(directory, "plugins/sub")}`.quiet()) },
+)
+
+it.instance("local opaque MCP tools execute without annotations", () =>
+  Effect.gen(function* () {
+    const mcp = yield* MCP.Service
+    yield* mcp.add("opaque", {
+      type: "local",
+      command: [process.execPath, noProgressFixture],
+    })
+
+    const tool = (yield* mcp.tools()).opaque_opaque_lookup
+    expect(tool?.def.description).toBe("Look up a value.")
+    const result = yield* Effect.promise(() =>
+      tool?.client.callTool({ name: "opaque_lookup", arguments: { query: "changed-input" } }) ??
+        Promise.reject(new Error("opaque tool missing")),
+    )
+    expect(result?.content).toEqual([{ type: "text", text: "NO_PROGRESS" }])
+  }),
 )
 
 it.instance("tools() reuses cached definitions until a protocol notification", () =>

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -204,6 +204,7 @@ function fake(
     },
     updateToolCall: Effect.fn("TestSessionProcessor.updateToolCall")(() => Effect.succeed(undefined)),
     completeToolCall: Effect.fn("TestSessionProcessor.completeToolCall")(() => Effect.void),
+    guardToolCall: Effect.fn("TestSessionProcessor.guardToolCall")(() => Effect.void),
     process: Effect.fn("TestSessionProcessor.process")(() => Effect.succeed(result)),
   } satisfies SessionProcessorModule.SessionProcessor.Handle
 }

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -112,6 +112,75 @@ function basePart(messageID: string, id: string) {
 }
 
 describe("session.message-v2.toModelMessage", () => {
+  test("projects completed, compacted, attachment, and error tool replay consistently", () => {
+    const messageID = "m-assistant"
+    const attachment = {
+      ...basePart(messageID, "file-1"),
+      type: "file" as const,
+      mime: "image/png",
+      filename: "attachment.png",
+      url: "data:image/png;base64,Zm9v",
+    }
+    const completed = {
+      ...basePart(messageID, "tool-completed"),
+      type: "tool" as const,
+      callID: "call-completed",
+      tool: "lookup",
+      state: {
+        status: "completed" as const,
+        input: {},
+        output: "same result",
+        title: "lookup",
+        metadata: {},
+        time: { start: 0, end: 1 },
+        attachments: [attachment],
+      },
+    } satisfies SessionV1.ToolPart
+    const compacted = {
+      ...completed,
+      id: PartID.make("prt_tool_compacted"),
+      state: { ...completed.state, time: { start: 0, end: 1, compacted: 1 } },
+    } satisfies SessionV1.ToolPart
+    const interrupted = {
+      ...basePart(messageID, "tool-error"),
+      type: "tool" as const,
+      callID: "call-error",
+      tool: "lookup",
+      state: {
+        status: "error" as const,
+        input: {},
+        error: "Tool execution aborted",
+        metadata: { interrupted: true, output: "partial result" },
+        time: { start: 0, end: 1 },
+      },
+    } satisfies SessionV1.ToolPart
+    const compatible = {
+      ...model,
+      api: { ...model.api, npm: "@ai-sdk/openai-compatible" },
+    } as Provider.Model
+
+    expect(MessageV2.toolReplay(completed, model)).toEqual({
+      type: "completed",
+      output: { text: "same result", attachments: [{ mime: "image/png", url: attachment.url }] },
+      media: [],
+    })
+    expect(MessageV2.toolReplay(completed, compatible)).toEqual({
+      type: "completed",
+      output: "same result",
+      media: [{ mime: "image/png", url: attachment.url, filename: "attachment.png" }],
+    })
+    expect(MessageV2.toolReplay(compacted, model)).toEqual({
+      type: "completed",
+      output: "[Old tool result content cleared]",
+      media: [],
+    })
+    expect(MessageV2.toolReplay(interrupted, model)).toEqual({
+      type: "error",
+      state: "output-available",
+      output: "partial result",
+    })
+  })
+
   test("filters out messages with no parts", async () => {
     const input: SessionV1.WithParts[] = [
       {

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -7,7 +7,7 @@ import { tool } from "ai"
 import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
 import path from "path"
 import z from "zod"
-import type { Agent } from "../../src/agent/agent"
+import { Agent } from "../../src/agent/agent"
 import { Provider } from "@/provider/provider"
 
 import { Session } from "@/session/session"
@@ -17,6 +17,7 @@ import { SessionProcessor } from "../../src/session/processor"
 import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
+import { Permission } from "../../src/permission"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -105,7 +106,7 @@ function defer<T>() {
 
 const waitFor = <A>(check: Effect.Effect<A | undefined>, message: string) =>
   Effect.gen(function* () {
-    const stop = Date.now() + 500
+    const stop = Date.now() + 2_000
     while (Date.now() < stop) {
       const value = yield* check
       if (value !== undefined) return value
@@ -167,6 +168,8 @@ const assistant = Effect.fn("TestSession.assistant")(function* (
 
 const root = LayerNode.group([
   SessionProcessor.node,
+  Agent.node,
+  Permission.node,
   Session.node,
   SessionProjector.node,
   Provider.node,
@@ -226,6 +229,56 @@ const fragmentFailureLLM = Layer.succeed(
 const fragmentFailureEnv = LayerNode.compile(root, [...replacements, [LLM.node, fragmentFailureLLM]])
 const itFragmentFailure = testEffect(fragmentFailureEnv)
 
+const outcomeGateLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () =>
+      Stream.make(
+        LLMEvent.toolInputStart({ id: "call-next", name: "lookup" }),
+        LLMEvent.toolInputEnd({ id: "call-next", name: "lookup" }),
+        LLMEvent.toolCall({ id: "call-next", name: "lookup", input: { query: "next" }, providerExecuted: true }),
+        LLMEvent.toolResult({
+          id: "call-next",
+          name: "lookup",
+          result: { type: "text", value: "NO_PROGRESS" },
+          providerExecuted: true,
+        }),
+        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+        LLMEvent.finish({ reason: "stop" }),
+      ),
+  }),
+)
+const outcomeGateEnv = LayerNode.compile(root, [...replacements, [LLM.node, outcomeGateLLM]])
+const itOutcomeGate = testEffect(outcomeGateEnv)
+
+function toolResultLLM(result: { type: "json"; value: unknown } | { type: "text"; value: string }) {
+  return Layer.succeed(
+    LLM.Service,
+    LLM.Service.of({
+      stream: () =>
+        Stream.make(
+          LLMEvent.toolInputStart({ id: "call-result", name: "lookup" }),
+          LLMEvent.toolInputEnd({ id: "call-result", name: "lookup" }),
+          LLMEvent.toolCall({ id: "call-result", name: "lookup", input: {}, providerExecuted: true }),
+          LLMEvent.toolResult({ id: "call-result", name: "lookup", result, providerExecuted: true }),
+          LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+          LLMEvent.finish({ reason: "stop" }),
+        ),
+    }),
+  )
+}
+
+const typedJsonResultEnv = LayerNode.compile(root, [
+  ...replacements,
+  [LLM.node, toolResultLLM({ type: "json", value: { b: 2, a: 1 } })],
+])
+const plainJsonTextResultEnv = LayerNode.compile(root, [
+  ...replacements,
+  [LLM.node, toolResultLLM({ type: "text", value: '{"b":2,"a":1}' })],
+])
+const itTypedJsonResult = testEffect(typedJsonResultEnv)
+const itPlainJsonTextResult = testEffect(plainJsonTextResultEnv)
+
 const boot = Effect.fn("test.boot")(function* () {
   const processors = yield* SessionProcessor.Service
   const session = yield* Session.Service
@@ -233,9 +286,298 @@ const boot = Effect.fn("test.boot")(function* () {
   return { processors, session, provider }
 })
 
+const completeTool = Effect.fn("TestSession.completeTool")(function* (input: {
+  sessionID: SessionID
+  parentID: MessageID
+  tool?: string
+  output: string
+  input?: Record<string, unknown>
+  attachments?: SessionV1.FilePart[]
+  error?: string
+  interruptedOutput?: string
+  compacted?: number
+}) {
+  const session = yield* Session.Service
+  const msg = yield* assistant(input.sessionID, input.parentID, "/tmp")
+  const end = Date.now()
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID: input.sessionID,
+    type: "tool",
+    callID: `call-${msg.id}`,
+    tool: input.tool ?? "lookup",
+    state: input.error
+      ? {
+          status: "error",
+          input: input.input ?? {},
+          error: input.error,
+          metadata: input.interruptedOutput ? { interrupted: true, output: input.interruptedOutput } : {},
+          time: { start: end - 1, end },
+        }
+      : {
+          status: "completed",
+          input: input.input ?? {},
+          output: input.output,
+          metadata: {},
+          title: input.tool ?? "lookup",
+          time: { start: end - 1, end, ...(input.compacted ? { compacted: input.compacted } : {}) },
+          attachments: input.attachments,
+        },
+  } satisfies SessionV1.ToolPart)
+  return msg
+})
+
+const processorInput = (parent: SessionV1.User, sessionID: SessionID, model: Provider.Model): LLM.StreamInput => ({
+  user: {
+    id: parent.id,
+    sessionID,
+    role: "user",
+    time: parent.time,
+    agent: parent.agent,
+    model: { providerID: ref.providerID, modelID: ref.modelID },
+  } satisfies SessionV1.User,
+  sessionID,
+  model,
+  agent: agent(),
+  system: [],
+  messages: [{ role: "user", content: "lookup" }],
+  tools: {},
+})
+
+const pendingDoomLoop = Effect.fn("TestSession.pendingDoomLoop")(function* () {
+  const permission = yield* Permission.Service
+  return yield* waitFor(
+    Effect.gen(function* () {
+      const request = (yield* permission.list()).find((item) => item.permission === "doom_loop")
+      return request
+    }),
+    "timed out waiting for doom loop permission",
+  )
+})
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+itOutcomeGate.live("session.processor guards the fourth replay-equivalent outcome across persisted turns", () =>
+  provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const permission = yield* Permission.Service
+        const status = yield* SessionStatus.Service
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "look this up")
+        const model = yield* provider.getModel(ref.providerID, ref.modelID)
+
+        // Inputs differ, but the model-visible terminal result is unchanged.
+        yield* completeTool({ sessionID: chat.id, parentID: parent.id, input: { query: "one" }, output: "NO_PROGRESS" })
+        yield* completeTool({ sessionID: chat.id, parentID: parent.id, tool: "other", output: "unrelated" })
+        yield* completeTool({ sessionID: chat.id, parentID: parent.id, input: { query: "two" }, output: "NO_PROGRESS" })
+        yield* completeTool({ sessionID: chat.id, parentID: parent.id, input: { query: "three" }, output: "NO_PROGRESS" })
+
+        // A fresh processor reads the durable tool parts through MessageV2.page().
+        const next = yield* assistant(chat.id, parent.id, "/tmp")
+        const handle = yield* processors.create({ assistantMessage: next, sessionID: chat.id, model })
+        const run = yield* handle.process(processorInput(parent, chat.id, model)).pipe(Effect.forkChild)
+        const request = yield* pendingDoomLoop()
+
+        expect(request.patterns).toHaveLength(1)
+        expect(request.patterns[0]).toStartWith(`doom-loop/${chat.id}/${parent.id}/lookup/`)
+        expect(request.always).toEqual(request.patterns)
+
+        yield* permission.reply({ requestID: request.id, reply: "reject" })
+        const exit = yield* Fiber.await(run)
+        expect(Exit.isSuccess(exit)).toBe(true)
+        expect((yield* status.get(chat.id)).type).toBe("idle")
+      }),
+    { config: cfg },
+  ),
+)
+
+itOutcomeGate.live("session.processor resets the replay outcome streak and retains same-input protection", () =>
+  provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const permission = yield* Permission.Service
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "look this up")
+        const model = yield* provider.getModel(ref.providerID, ref.modelID)
+
+        yield* completeTool({ sessionID: chat.id, parentID: parent.id, input: { query: "one" }, output: "NO_PROGRESS" })
+        yield* completeTool({ sessionID: chat.id, parentID: parent.id, input: { query: "two" }, output: "NO_PROGRESS" })
+        yield* completeTool({ sessionID: chat.id, parentID: parent.id, input: { query: "three" }, output: "PROGRESS" })
+
+        const reset = yield* assistant(chat.id, parent.id, "/tmp")
+        const resetHandle = yield* processors.create({ assistantMessage: reset, sessionID: chat.id, model })
+        expect(yield* resetHandle.process(processorInput(parent, chat.id, model))).toBe("continue")
+        expect(yield* permission.list()).toEqual([])
+
+        // The pre-existing same-input guard is still evaluated independently.
+        const sameInput = yield* assistant(chat.id, parent.id, "/tmp")
+        for (const output of ["first", "second"]) {
+          yield* session.updatePart({
+            id: PartID.ascending(),
+            messageID: sameInput.id,
+            sessionID: chat.id,
+            type: "tool",
+            callID: `same-${output}`,
+            tool: "lookup",
+            state: {
+              status: "completed",
+              input: { query: "next" },
+              output,
+              metadata: {},
+              title: "lookup",
+              time: { start: Date.now() - 1, end: Date.now() },
+            },
+          } satisfies SessionV1.ToolPart)
+        }
+        const sameInputHandle = yield* processors.create({ assistantMessage: sameInput, sessionID: chat.id, model })
+        const run = yield* sameInputHandle.process(processorInput(parent, chat.id, model)).pipe(Effect.forkChild)
+        const request = yield* pendingDoomLoop()
+
+        expect(request.patterns).toEqual(["lookup"])
+        expect(request.always).toEqual(["lookup"])
+        yield* permission.reply({ requestID: request.id, reply: "reject" })
+        expect(Exit.isSuccess(yield* Fiber.await(run))).toBe(true)
+      }),
+    { config: cfg },
+  ),
+)
+
+itOutcomeGate.live("session.processor bounds Always approvals to one outcome, root user, tool, and session", () =>
+  provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const permission = yield* Permission.Service
+        const model = yield* provider.getModel(ref.providerID, ref.modelID)
+        const chat = yield* session.create({})
+        const root = yield* user(chat.id, "first root")
+
+        const proposal = Effect.fn("TestSession.outcomeProposal")(function* (
+          parent: SessionV1.User,
+          tool: string,
+          output: string,
+        ) {
+          const msg = yield* assistant(chat.id, parent.id, "/tmp")
+          const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+          const run = yield* handle
+            .guardToolCall({ id: `proposal-${msg.id}`, name: tool, input: { output } })
+            .pipe(Effect.forkChild)
+          return { handle, run, request: yield* pendingDoomLoop() }
+        })
+
+        for (const query of ["one", "two", "three"]) {
+          yield* completeTool({ sessionID: chat.id, parentID: root.id, input: { query }, output: "A" })
+        }
+        const a = yield* proposal(root, "lookup", "A")
+        const patternA = a.request.patterns[0]
+        expect(a.request.always).toEqual([patternA])
+        yield* permission.reply({ requestID: a.request.id, reply: "always" })
+        expect(Exit.isSuccess(yield* Fiber.await(a.run))).toBe(true)
+        yield* a.handle.completeToolCall(`proposal-${a.handle.message.id}`, {
+          title: "lookup",
+          metadata: {},
+          output: "B",
+        })
+
+        for (const query of ["four", "five"]) {
+          yield* completeTool({ sessionID: chat.id, parentID: root.id, input: { query }, output: "B" })
+        }
+        const b = yield* proposal(root, "lookup", "B")
+        const patternB = b.request.patterns[0]
+        expect(patternB).not.toBe(patternA)
+        expect(patternB).toStartWith(`doom-loop/${chat.id}/${root.id}/lookup/`)
+        expect(b.request.always).toEqual([patternB])
+        yield* permission.reply({ requestID: b.request.id, reply: "reject" })
+        yield* Fiber.await(b.run)
+
+        const nextRoot = yield* user(chat.id, "second root")
+        for (const query of ["one", "two", "three"]) {
+          yield* completeTool({ sessionID: chat.id, parentID: nextRoot.id, input: { query }, output: "A" })
+        }
+        const nextRootProposal = yield* proposal(nextRoot, "lookup", "A")
+        expect(nextRootProposal.request.patterns[0]).not.toBe(patternA)
+        expect(nextRootProposal.request.always).toEqual(nextRootProposal.request.patterns)
+        yield* permission.reply({ requestID: nextRootProposal.request.id, reply: "reject" })
+        yield* Fiber.await(nextRootProposal.run)
+
+        for (const query of ["one", "two", "three"]) {
+          yield* completeTool({ sessionID: chat.id, parentID: root.id, tool: "other", input: { query }, output: "A" })
+        }
+        const other = yield* proposal(root, "other", "A")
+        expect(other.request.patterns[0]).not.toBe(patternA)
+        expect(other.request.patterns[0]).toStartWith(`doom-loop/${chat.id}/${root.id}/other/`)
+        yield* permission.reply({ requestID: other.request.id, reply: "reject" })
+        yield* Fiber.await(other.run)
+
+        const secondSession = yield* session.create({})
+        const secondSessionRoot = yield* user(secondSession.id, "other session")
+        for (const query of ["one", "two", "three"]) {
+          yield* completeTool({ sessionID: secondSession.id, parentID: secondSessionRoot.id, input: { query }, output: "A" })
+        }
+        const msg = yield* assistant(secondSession.id, secondSessionRoot.id, "/tmp")
+        const secondSessionHandle = yield* processors.create({ assistantMessage: msg, sessionID: secondSession.id, model })
+        const run = yield* secondSessionHandle
+          .guardToolCall({ id: `proposal-${msg.id}`, name: "lookup", input: {} })
+          .pipe(Effect.forkChild)
+        const otherSession = yield* pendingDoomLoop()
+        expect(otherSession.patterns[0]).not.toBe(patternA)
+        expect(otherSession.patterns[0]).toStartWith(`doom-loop/${secondSession.id}/${secondSessionRoot.id}/lookup/`)
+        yield* permission.reply({ requestID: otherSession.id, reply: "reject" })
+        yield* Fiber.await(run)
+      }),
+    { config: cfg },
+  ),
+)
+
+itTypedJsonResult.live("session.processor stably persists explicit JSON tool results", () =>
+  provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "result")
+        const model = yield* provider.getModel(ref.providerID, ref.modelID)
+        const msg = yield* assistant(chat.id, parent.id, "/tmp")
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+
+        expect(yield* handle.process(processorInput(parent, chat.id, model))).toBe("continue")
+        const call = (yield* MessageV2.parts(msg.id)).find(
+          (part): part is SessionV1.ToolPart => part.type === "tool",
+        )
+        expect(call?.state.status).toBe("completed")
+        if (call?.state.status === "completed") expect(call.state.output).toBe('{"a":1,"b":2}')
+      }),
+    { config: cfg },
+  ),
+)
+
+itPlainJsonTextResult.live("session.processor preserves JSON-looking text results byte-for-byte", () =>
+  provideTmpdirInstance(
+    () =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "result")
+        const model = yield* provider.getModel(ref.providerID, ref.modelID)
+        const msg = yield* assistant(chat.id, parent.id, "/tmp")
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model })
+
+        expect(yield* handle.process(processorInput(parent, chat.id, model))).toBe("continue")
+        const call = (yield* MessageV2.parts(msg.id)).find(
+          (part): part is SessionV1.ToolPart => part.type === "tool",
+        )
+        expect(call?.state.status).toBe("completed")
+        if (call?.state.status === "completed") expect(call.state.output).toBe('{"b":2,"a":1}')
+      }),
+    { config: cfg },
+  ),
+)
 
 it.live("session.processor effect tests capture llm input cleanly", () =>
   provideTmpdirServer(

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -109,14 +109,14 @@ function errorTool(parts: SessionV1.Part[]) {
   return part?.state.status === "error" ? (part as ErrorToolPart) : undefined
 }
 
-function makeMcp(instructions: MCP.ServerInstructions[] = []) {
+function makeMcp(input?: { instructions?: MCP.ServerInstructions[]; tools?: Record<string, MCP.McpTool> }) {
   return Layer.succeed(
     MCP.Service,
     MCP.Service.of({
       status: () => Effect.succeed({}),
       clients: () => Effect.succeed({}),
-      instructions: () => Effect.succeed(instructions),
-      tools: () => Effect.succeed({}),
+      instructions: () => Effect.succeed(input?.instructions ?? []),
+      tools: () => Effect.succeed(input?.tools ?? {}),
       prompts: () => Effect.succeed({}),
       resources: () => Effect.succeed({}),
       resourceTemplates: () => Effect.succeed({}),
@@ -208,11 +208,15 @@ const promptRoot = LayerNode.group([
   RuntimeFlags.node,
 ])
 
-function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makePrompt(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  mcpTools?: Record<string, MCP.McpTool>
+  processor?: "blocking"
+}) {
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
-    [MCP.node, makeMcp(input?.mcpInstructions)],
+    [MCP.node, makeMcp({ instructions: input?.mcpInstructions, tools: input?.mcpTools })],
     [RuntimeFlags.node, runtimeFlags],
   ] as const
   if (input?.processor === "blocking") {
@@ -221,12 +225,16 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
   return LayerNode.compile(promptRoot, replacements)
 }
 
-function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttp(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  mcpTools?: Record<string, MCP.McpTool>
+  processor?: "blocking"
+}) {
   const root = LayerNode.group([promptRoot, testLLMServerNode])
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
-    [MCP.node, makeMcp(input?.mcpInstructions)],
+    [MCP.node, makeMcp({ instructions: input?.mcpInstructions, tools: input?.mcpTools })],
     [RuntimeFlags.node, runtimeFlags],
   ] as const
   if (input?.processor === "blocking") {
@@ -235,13 +243,42 @@ function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processo
   return LayerNode.compile(root, replacements)
 }
 
-function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttpNoLLMServer(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  mcpTools?: Record<string, MCP.McpTool>
+  processor?: "blocking"
+}) {
   return makePrompt(input)
 }
 
 const it = testEffect(makeHttp())
 const noLLMServer = testEffect(makeHttpNoLLMServer())
 const raceNoLLMServer = testEffect(makeHttpNoLLMServer({ processor: "blocking" }))
+const opaqueMcpCalls: string[] = []
+const opaqueMcpTools: Record<string, MCP.McpTool> = {
+  opaque_opaque_lookup: {
+    // This fixture deliberately exposes no annotations or guard-specific configuration.
+    def: {
+      name: "opaque_lookup",
+      description: "Look up a value.",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    },
+    client: {
+      callTool: async (request: { arguments?: Record<string, unknown> }) => {
+        const query = typeof request.arguments?.query === "string" ? request.arguments.query : ""
+        opaqueMcpCalls.push(query)
+        return {
+          content: [{ type: "text" as const, text: query === "break" ? "PROGRESS" : "NO_PROGRESS" }],
+        }
+      },
+    } as unknown as MCP.McpTool["client"],
+  },
+}
+const opaqueMcp = testEffect(makeHttp({ mcpTools: opaqueMcpTools }))
 const withMcpInstructions = testEffect(
   makeHttp({
     mcpInstructions: [
@@ -320,6 +357,16 @@ const useServerConfig = Effect.fn("test.useServerConfig")(function* (config: (ur
   const llm = yield* TestLLMServer
   yield* writeConfig(dir, config(llm.url))
   return { dir, llm }
+})
+
+const waitForDoomLoop = Effect.fn("test.waitForDoomLoop")(function* () {
+  const permission = yield* Permission.Service
+  return yield* pollWithTimeout(
+    Effect.gen(function* () {
+      return (yield* permission.list()).find((item) => item.permission === "doom_loop")
+    }),
+    "timed out waiting for doom loop permission",
+  )
 })
 
 // Wait for a session's runner to enter a busy state. SessionStatus is flipped
@@ -808,6 +855,88 @@ it.instance("loop continues when finish is tool-calls", () =>
       expect(result.info.finish).toBe("stop")
     }
   }),
+)
+
+opaqueMcp.instance(
+  "opaque MCP repeated outcomes hold the fourth changed-input call and deny returns idle",
+  () =>
+    Effect.gen(function* () {
+      opaqueMcpCalls.length = 0
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const permission = yield* Permission.Service
+      const status = yield* SessionStatus.Service
+      const chat = yield* sessions.create({
+        permission: [{ permission: "opaque_opaque_lookup", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "try opaque lookups" }],
+      })
+
+      yield* llm.tool("opaque_opaque_lookup", { query: "one" })
+      yield* llm.tool("opaque_opaque_lookup", { query: "two" })
+      yield* llm.tool("opaque_opaque_lookup", { query: "three" })
+      yield* llm.tool("opaque_opaque_lookup", { query: "four" })
+
+      const run = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+      yield* awaitWithTimeout(llm.wait(4), "timed out waiting for held fourth opaque MCP proposal", "10 seconds")
+      const request = yield* waitForDoomLoop()
+
+      expect(opaqueMcpCalls).toEqual(["one", "two", "three"])
+      expect(request.patterns).toHaveLength(1)
+      expect(request.patterns[0]).toStartWith("doom-loop/")
+      expect(request.always).toEqual(request.patterns)
+
+      yield* permission.reply({ requestID: request.id, reply: "reject" })
+      expect(Exit.isSuccess(yield* Fiber.await(run))).toBe(true)
+      expect(opaqueMcpCalls).toEqual(["one", "two", "three"])
+      expect((yield* status.get(chat.id)).type).toBe("idle")
+    }),
+  { config: cfg },
+  20_000,
+)
+
+opaqueMcp.instance(
+  "opaque MCP once allows a changed result and the next call does not prompt",
+  () =>
+    Effect.gen(function* () {
+      opaqueMcpCalls.length = 0
+      const { llm } = yield* useServerConfig(providerCfg)
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const permission = yield* Permission.Service
+      const chat = yield* sessions.create({
+        permission: [{ permission: "opaque_opaque_lookup", pattern: "*", action: "allow" }],
+      })
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "try opaque lookups" }],
+      })
+
+      yield* llm.tool("opaque_opaque_lookup", { query: "one" })
+      yield* llm.tool("opaque_opaque_lookup", { query: "two" })
+      yield* llm.tool("opaque_opaque_lookup", { query: "three" })
+      yield* llm.tool("opaque_opaque_lookup", { query: "break" })
+      yield* llm.tool("opaque_opaque_lookup", { query: "after" })
+      yield* llm.text("done")
+
+      const run = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+      yield* awaitWithTimeout(llm.wait(4), "timed out waiting for held fourth opaque MCP proposal", "10 seconds")
+      const request = yield* waitForDoomLoop()
+      yield* permission.reply({ requestID: request.id, reply: "once" })
+
+      expect(Exit.isSuccess(yield* Fiber.await(run))).toBe(true)
+      expect(opaqueMcpCalls).toEqual(["one", "two", "three", "break", "after"])
+      expect(yield* permission.list()).toEqual([])
+    }),
+  { config: cfg },
+  20_000,
 )
 
 it.instance("glob tool keeps instance context during prompt runs", () =>


### PR DESCRIPTION
Fixes #31942

## Behavior
- Fingerprints the exact model-visible replay projection for terminal tool outcomes and holds the next same-tool proposal after three matching persisted outcomes in one session/root-user lineage.
- Uses a lineage/tool/fingerprint-scoped `doom_loop` permission pattern; Once releases one call, Always remains bounded to that exact outcome scope, and Reject uses the existing permission-denied flow.
- Preserves the existing same-input doom-loop check and runs the new gate before local tool execution, preventing the held MCP invocation from reaching the server.

## Non-goals
- No MCP discovery annotations, contracts, tool identity plumbing, schemas, or permission-service changes.
- No fuzzy matching, input normalization, or durable fingerprint field.

## Verification
- `mise exec bun@1.3.14 -- bun test test/mcp/lifecycle.test.ts`
- `mise exec bun@1.3.14 -- bun test test/session/processor-effect.test.ts`
- `mise exec bun@1.3.14 -- bun test test/session/prompt.test.ts`
- `mise exec bun@1.3.14 -- bun typecheck`
- `mise exec bun@1.3.14 -- bun run lint`

## Runtime proof
Ran `mise exec bun@1.3.14 -- bun dev` with an ephemeral OpenAI-compatible fixture and an opaque local stdio MCP tool.

- Flow A: three changed-input `NO_PROGRESS` results held the fourth proposal; Reject left the fourth tool part permission-denied and the session idle.
- Flow B: three matching outcomes held the fourth proposal; Once allowed a changed `PROGRESS` result, and the following same-tool call ran without an outcome prompt.