### PR TITLE
fix(opencode): stop repeated empty tool loops

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -29,8 +29,10 @@ import { SessionCompaction } from "../compaction"
 import { SessionEvent } from "../event"
 import { SessionHistory } from "../history"
 import { SessionInput } from "../input"
+import { SessionMessage } from "../message"
 import { SessionSchema } from "../schema"
 import { SessionStore } from "../store"
+import { ToolLoop } from "../tool-loop"
 import { type RunError, Service } from "./index"
 import { SessionRunnerModel } from "./model"
 import { createLLMEventPublisher } from "./publish-llm-event"
@@ -89,6 +91,46 @@ import { llmClient } from "../../effect/app-node-platform"
  * provider turn. Registry definitions are advertised, local tool calls are settled durably, and an
  * explicit loop starts the next provider turn after local settlement. Configured agent step limits bound the loop.
  */
+
+const toolLoopObservations = (messages: ReadonlyArray<SessionMessage.Message>) => {
+  const result: ToolLoop.Observation[] = []
+  for (const message of messages) {
+    if (message.type === "user") {
+      result.push({ type: "reset" })
+      continue
+    }
+    if (message.type !== "assistant") continue
+    for (const part of message.content) {
+      if (part.type !== "tool") continue
+      if (part.state.status === "completed") {
+        result.push({
+          type: "tool",
+          tool: part.name,
+          outcome: {
+            type: "success",
+            values: [
+              part.state.structured,
+              ...part.state.content.flatMap((content) => (content.type === "text" ? [content.text] : [])),
+            ],
+            files:
+              (part.state.attachments?.length ?? 0) +
+              (part.state.outputPaths?.length ?? 0) +
+              part.state.content.filter((content) => content.type === "file").length,
+          },
+        })
+        continue
+      }
+      if (part.state.status === "error") {
+        result.push({
+          type: "tool",
+          tool: part.name,
+          outcome: { type: "error", message: part.state.error.message },
+        })
+      }
+    }
+  }
+  return result
+}
 
 const layer = Layer.effect(
   Service,
@@ -196,9 +238,28 @@ const layer = Layer.effect(
       }
       const system =
         initialized ?? (yield* SessionContextEpoch.prepare(db, events, loadSystemContext(agent), session.id))
-      const model = yield* models.resolve(session)
       const entries = yield* SessionHistory.entriesForRunner(db, session.id, system.baselineSeq)
       const context = entries.map((entry) => entry.message)
+      const latest = context.at(-1)
+      if (latest?.type === "assistant" && ToolLoop.stopped(latest.error?.message)) {
+        return { needsContinuation: false, step: currentStep }
+      }
+      const model = yield* models.resolve(session)
+      const publication = {
+        sessionID: session.id,
+        agent: agent.id,
+        model: {
+          id: ModelV2.ID.make(model.id),
+          providerID: ProviderV2.ID.make(model.provider),
+          ...(session.model?.variant === undefined ? {} : { variant: session.model.variant }),
+        },
+      }
+      const detection = ToolLoop.detect(toolLoopObservations(context))
+      if (detection) {
+        const publisher = createLLMEventPublisher(events, publication)
+        yield* publisher.failAssistant(ToolLoop.message(detection))
+        return { needsContinuation: false, step: currentStep }
+      }
       const isLastStep = agent.info?.steps !== undefined && currentStep >= agent.info.steps
       const toolMaterialization = isLastStep ? undefined : yield* tools.materialize(agent.info?.permissions)
       const promptCacheKey = /^ses_[0-9a-f]{64}$/.test(session.id) ? session.id.slice(4) : session.id
@@ -216,13 +277,7 @@ const layer = Layer.effect(
         return yield* Effect.die(continueAfterCompaction(currentStep))
       const startSnapshot = yield* snapshots.capture()
       const publisher = createLLMEventPublisher(events, {
-        sessionID: session.id,
-        agent: agent.id,
-        model: {
-          id: ModelV2.ID.make(model.id),
-          providerID: ProviderV2.ID.make(model.provider),
-          ...(session.model?.variant === undefined ? {} : { variant: session.model.variant }),
-        },
+        ...publication,
         snapshot: startSnapshot,
       })
       const withPublication = Semaphore.makeUnsafe(1).withPermit

--- a/packages/core/src/session/tool-loop.ts
+++ b/packages/core/src/session/tool-loop.ts
@@ -1,0 +1,139 @@
+export * as ToolLoop from "./tool-loop"
+
+export const THRESHOLD = 3
+
+export type Outcome =
+  | {
+      readonly type: "success"
+      readonly values: ReadonlyArray<unknown>
+      readonly files?: number
+    }
+  | {
+      readonly type: "error"
+      readonly message: string
+    }
+
+export type Observation =
+  | { readonly type: "reset" }
+  | {
+      readonly type: "tool"
+      readonly tool: string
+      readonly outcome: Outcome
+    }
+
+export type Detection = {
+  readonly tool: string
+  readonly count: number
+  readonly outcome: "empty" | "error"
+}
+
+export const REF = "tool_loop_no_progress"
+
+const discoveryTool = (tool: string) => {
+  const words = tool
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+  return words.some((word) =>
+    ["discover", "find", "glob", "grep", "list", "lookup", "query", "scan", "search", "websearch"].includes(word),
+  )
+}
+
+const noMatch = (value: string) => {
+  const text = value.trim().toLowerCase()
+  if (text === "") return true
+  if (/^not found[.!]?$/.test(text)) return true
+  if (/^0\s+(?:results?|resources?|items?|matches?|tools?)\b/.test(text)) return true
+  if (/^no\s+(?:matching\s+)?(?:results?|resources?|items?|matches?|tools?)[.!]?$/.test(text)) return true
+  if (/\bno\b.*\b(?:results?|resources?|items?|matches?|tools?)\b.*\b(?:found|available|returned|matched)\b/.test(text))
+    return true
+  if (/\b(?:results?|resources?|items?|matches?|tools?)\b.*\bnot found\b/.test(text)) return true
+  return false
+}
+
+const isEmpty = (value: unknown, key?: string): boolean => {
+  if (value === undefined || value === null) return true
+  if (typeof value === "string") {
+    if (noMatch(value)) return true
+    const text = value.trim()
+    if ((text.startsWith("[") && text.endsWith("]")) || (text.startsWith("{") && text.endsWith("}"))) {
+      try {
+        return isEmpty(JSON.parse(text), key)
+      } catch {
+        return false
+      }
+    }
+    return false
+  }
+  if (Array.isArray(value)) return value.length === 0
+  if (typeof value === "number") return value === 0 && /^(?:count|total|size)$/i.test(key ?? "")
+  if (typeof value === "boolean") {
+    if (/^(?:ok|success)$/i.test(key ?? "")) return value
+    if (/^(?:hasMore|truncated)$/i.test(key ?? "")) return !value
+    return false
+  }
+  if (typeof value !== "object") return false
+
+  const entries = Object.entries(value)
+  if (entries.length === 0) return true
+  return entries.every(([name, item]) => {
+    if (/^(?:filter|input|limit|offset|page|prefix|query|search|server)$/i.test(name)) return true
+    if (name === "status" && typeof item === "string") return /^(?:empty|ok|success|no[_ -]?results?)$/i.test(item)
+    return isEmpty(item, name)
+  })
+}
+
+const fingerprint = (tool: string, outcome: Outcome): string | undefined => {
+  if (outcome.type === "error") {
+    const message = outcome.message.trim()
+    return message === "" ? undefined : `error:${message}`
+  }
+  // An empty payload does not prove that a mutation made no progress. Restrict
+  // successful empty-result detection to discovery-shaped tools; repeated
+  // failures remain eligible for every tool because the operation did not succeed.
+  if (!discoveryTool(tool)) return undefined
+  if ((outcome.files ?? 0) > 0) return undefined
+  return outcome.values.every((value) => isEmpty(value)) ? "empty" : undefined
+}
+
+export function detect(observations: ReadonlyArray<Observation>, threshold = THRESHOLD): Detection | undefined {
+  if (!Number.isInteger(threshold) || threshold < 1) throw new Error("Tool loop threshold must be a positive integer")
+
+  let streak: Array<{ readonly tool: string; readonly fingerprint: string }> = []
+  for (const observation of observations) {
+    if (observation.type === "reset") {
+      streak = []
+      continue
+    }
+
+    const outcome = fingerprint(observation.tool, observation.outcome)
+    if (!outcome) {
+      streak = []
+      continue
+    }
+
+    const previous = streak.at(-1)
+    if (!previous || previous.tool !== observation.tool || previous.fingerprint !== outcome) streak = []
+    streak.push({ tool: observation.tool, fingerprint: outcome })
+  }
+
+  const latest = streak.at(-1)
+  if (!latest || streak.length < threshold) return undefined
+  return {
+    tool: latest.tool,
+    count: streak.length,
+    outcome: latest.fingerprint === "empty" ? "empty" : "error",
+  }
+}
+
+export function message(detection: Detection) {
+  const subject = /(?:^|[_-])resources?(?:[_-]|$)/i.test(detection.tool) ? "resource" : "result"
+  if (detection.outcome === "empty") {
+    return `Tool "${detection.tool}" returned no matching ${subject}s ${detection.count} times in a row. No matching ${subject} was found, so OpenCode stopped the run to prevent a no-progress loop.`
+  }
+  return `Tool "${detection.tool}" failed with the same error ${detection.count} times in a row. OpenCode stopped the run to prevent a no-progress loop.`
+}
+
+export function stopped(value: string | undefined) {
+  return value?.endsWith("OpenCode stopped the run to prevent a no-progress loop.") === true
+}

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1463,6 +1463,84 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("stops before a fourth provider turn after repeated empty tool results", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const applicationTools = yield* ApplicationTools.Service
+      yield* applicationTools.register({
+        empty_search: Tool.make({
+          description: "Search for resources",
+          input: Schema.Struct({ prefix: Schema.String }),
+          output: Schema.Array(Schema.String),
+          execute: () => Effect.succeed([]),
+        }),
+      })
+      const session = yield* SessionV2.Service
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Find the missing resource" }), resume: false })
+
+      requests.length = 0
+      responses = [
+        [
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolCall({ id: "call-empty-1", name: "empty_search", input: { prefix: "m" } }),
+          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+          LLMEvent.finish({ reason: "tool-calls" }),
+        ],
+        [
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolCall({ id: "call-empty-2", name: "empty_search", input: { prefix: "m3" } }),
+          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+          LLMEvent.finish({ reason: "tool-calls" }),
+        ],
+        [
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.toolCall({ id: "call-empty-3", name: "empty_search", input: { prefix: "m365" } }),
+          LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+          LLMEvent.finish({ reason: "tool-calls" }),
+        ],
+        fragmentFixture("text", "text-unreachable", ["Still searching"]).completeEvents,
+      ]
+
+      yield* session.resume(sessionID)
+
+      expect(requests).toHaveLength(3)
+      const context = yield* session.context(sessionID)
+      expect(
+        context.flatMap((message) =>
+          message.type === "assistant"
+            ? message.content.flatMap((part) =>
+                part.type === "tool" && part.name === "empty_search" ? [part.state.input] : [],
+              )
+            : [],
+        ),
+      ).toEqual([{ prefix: "m" }, { prefix: "m3" }, { prefix: "m365" }])
+      expect(context.at(-1)).toMatchObject({
+        type: "assistant",
+        finish: "error",
+        error: {
+          type: "unknown",
+          message: expect.stringContaining("No matching result was found"),
+        },
+      })
+
+      yield* replaySessionProjection(sessionID)
+      expect((yield* session.context(sessionID)).at(-1)).toMatchObject({
+        type: "assistant",
+        finish: "error",
+        error: {
+          type: "unknown",
+          message: expect.stringContaining("No matching result was found"),
+        },
+      })
+
+      yield* session.resume(sessionID)
+      expect(requests).toHaveLength(3)
+      expect(
+        (yield* session.context(sessionID)).filter((message) => message.type === "assistant" && message.error),
+      ).toHaveLength(1)
+    }),
+  )
+
   it.effect("reloads a model switch before a tool-driven continuation turn", () =>
     Effect.gen(function* () {
       yield* setup

--- a/packages/core/test/session-tool-loop.test.ts
+++ b/packages/core/test/session-tool-loop.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test"
+import { ToolLoop } from "@opencode-ai/core/session/tool-loop"
+
+const empty = (tool: string, ...values: ReadonlyArray<unknown>): ToolLoop.Observation => ({
+  type: "tool",
+  tool,
+  outcome: { type: "success", values },
+})
+
+describe("ToolLoop", () => {
+  test("detects consecutive empty results from the same tool", () => {
+    expect(
+      ToolLoop.detect([
+        empty("gumps_mcp_resource_list", ""),
+        empty("gumps_mcp_resource_list", {
+          resources: [],
+          total: 0,
+          prefix: "m3",
+          success: true,
+          hasMore: false,
+        }),
+        empty("gumps_mcp_resource_list", "No matching resources found."),
+      ]),
+    ).toEqual({ tool: "gumps_mcp_resource_list", count: 3, outcome: "empty" })
+    expect(ToolLoop.detect([empty("search", []), empty("search", [])], 2)).toEqual({
+      tool: "search",
+      count: 2,
+      outcome: "empty",
+    })
+  })
+
+  test("resets when another tool or meaningful output makes progress", () => {
+    expect(
+      ToolLoop.detect([
+        empty("search", []),
+        empty("search", []),
+        empty("read", []),
+        empty("search", []),
+        empty("search", []),
+      ]),
+    ).toBeUndefined()
+
+    expect(
+      ToolLoop.detect([
+        empty("search", []),
+        empty("search", []),
+        empty("search", [{ id: "found" }]),
+        empty("search", []),
+        empty("search", []),
+      ]),
+    ).toBeUndefined()
+
+    expect(ToolLoop.detect([empty("write", ""), empty("write", ""), empty("write", "")])).toBeUndefined()
+  })
+
+  test("treats files, cursors, and new user input as progress", () => {
+    expect(
+      ToolLoop.detect([
+        empty("search", []),
+        empty("search", []),
+        { type: "tool", tool: "search", outcome: { type: "success", values: [[]], files: 1 } },
+      ]),
+    ).toBeUndefined()
+    expect(
+      ToolLoop.detect([empty("search", []), empty("search", []), empty("search", { nextCursor: "page-2" })]),
+    ).toBeUndefined()
+    expect(
+      ToolLoop.detect([empty("search", []), empty("search", []), { type: "reset" }, empty("search", [])]),
+    ).toBeUndefined()
+  })
+
+  test("detects only the same repeated error", () => {
+    const failed = (message: string): ToolLoop.Observation => ({
+      type: "tool",
+      tool: "lookup",
+      outcome: { type: "error", message },
+    })
+    expect(ToolLoop.detect([failed("offline"), failed("offline"), failed("offline")])).toEqual({
+      tool: "lookup",
+      count: 3,
+      outcome: "error",
+    })
+    expect(ToolLoop.detect([failed("offline"), failed("timeout"), failed("offline")])).toBeUndefined()
+  })
+})

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -25,8 +25,8 @@ import { isRecord } from "@/util/record"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
 import { Usage, type LLMEvent } from "@opencode-ai/llm"
+import { ToolLoop } from "@opencode-ai/core/session/tool-loop"
 
-const DOOM_LOOP_THRESHOLD = 3
 export type Result = "compact" | "stop" | "continue"
 
 export interface Handle {
@@ -353,10 +353,10 @@ const layer = Layer.effect(
             const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
               Effect.provideService(Database.Service, database),
             )
-            const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
+            const recentParts = parts.slice(-ToolLoop.THRESHOLD)
 
             if (
-              recentParts.length !== DOOM_LOOP_THRESHOLD ||
+              recentParts.length !== ToolLoop.THRESHOLD ||
               !recentParts.every(
                 (part) =>
                   part.type === "tool" &&

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -56,6 +56,7 @@ import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { ToolLoop } from "@opencode-ai/core/session/tool-loop"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -97,6 +98,43 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   // cleanup() marks abandoned tool_use blocks this way after retries/aborts.
   // They are not pending work and must not trigger an assistant-prefill request.
   return part.state.status === "error" && part.state.metadata?.interrupted === true
+}
+
+function toolLoopObservations(messages: SessionV1.WithParts[]) {
+  const result: ToolLoop.Observation[] = []
+  const chronological = messages.toSorted((a, b) => a.info.id.localeCompare(b.info.id))
+  for (const message of chronological) {
+    if (message.info.role === "user") {
+      const synthetic = message.parts.every((part) => "synthetic" in part && part.synthetic)
+      const compaction = message.parts.some((part) => part.type === "compaction")
+      if (!synthetic && !compaction) result.push({ type: "reset" })
+      continue
+    }
+    if (message.info.role !== "assistant") continue
+    for (const part of message.parts.toSorted((a, b) => a.id.localeCompare(b.id))) {
+      if (part.type !== "tool") continue
+      if (part.state.status === "completed") {
+        result.push({
+          type: "tool",
+          tool: part.tool,
+          outcome: {
+            type: "success",
+            values: [part.state.output],
+            files: part.state.attachments?.length,
+          },
+        })
+        continue
+      }
+      if (part.state.status === "error" && !isOrphanedInterruptedTool(part)) {
+        result.push({
+          type: "tool",
+          tool: part.tool,
+          outcome: { type: "error", message: part.state.error },
+        })
+      }
+    }
+  }
+  return result
 }
 
 export interface Interface {
@@ -1126,6 +1164,28 @@ const layer = Layer.effect(
               })
             }
             yield* Effect.logInfo("exiting loop", { "session.id": sessionID })
+            break
+          }
+
+          if (
+            lastAssistantMsg?.info.role === "assistant" &&
+            lastAssistantMsg.info.error?.name === "UnknownError" &&
+            lastAssistantMsg.info.error.data.ref === ToolLoop.REF &&
+            lastUser.id < lastAssistantMsg.info.id
+          ) {
+            break
+          }
+
+          const detection = ToolLoop.detect(toolLoopObservations(msgs))
+          if (detection && lastAssistantMsg?.info.role === "assistant") {
+            const error = new NamedError.Unknown({
+              message: ToolLoop.message(detection),
+              ref: ToolLoop.REF,
+            }).toObject()
+            lastAssistantMsg.info.error = error
+            lastAssistantMsg.info.time.completed ??= Date.now()
+            yield* sessions.updateMessage(lastAssistantMsg.info)
+            yield* events.publish(Session.Event.Error, { sessionID, error })
             break
           }
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -109,14 +109,20 @@ function errorTool(parts: SessionV1.Part[]) {
   return part?.state.status === "error" ? (part as ErrorToolPart) : undefined
 }
 
-function makeMcp(instructions: MCP.ServerInstructions[] = []) {
+type PromptLayerInput = {
+  mcpInstructions?: MCP.ServerInstructions[]
+  mcpTools?: Record<string, MCP.McpTool>
+  processor?: "blocking"
+}
+
+function makeMcp(instructions: MCP.ServerInstructions[] = [], tools: Record<string, MCP.McpTool> = {}) {
   return Layer.succeed(
     MCP.Service,
     MCP.Service.of({
       status: () => Effect.succeed({}),
       clients: () => Effect.succeed({}),
       instructions: () => Effect.succeed(instructions),
-      tools: () => Effect.succeed({}),
+      tools: () => Effect.succeed(tools),
       prompts: () => Effect.succeed({}),
       resources: () => Effect.succeed({}),
       resourceTemplates: () => Effect.succeed({}),
@@ -208,11 +214,11 @@ const promptRoot = LayerNode.group([
   RuntimeFlags.node,
 ])
 
-function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makePrompt(input?: PromptLayerInput) {
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
-    [MCP.node, makeMcp(input?.mcpInstructions)],
+    [MCP.node, makeMcp(input?.mcpInstructions, input?.mcpTools)],
     [RuntimeFlags.node, runtimeFlags],
   ] as const
   if (input?.processor === "blocking") {
@@ -221,12 +227,12 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
   return LayerNode.compile(promptRoot, replacements)
 }
 
-function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttp(input?: PromptLayerInput) {
   const root = LayerNode.group([promptRoot, testLLMServerNode])
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
-    [MCP.node, makeMcp(input?.mcpInstructions)],
+    [MCP.node, makeMcp(input?.mcpInstructions, input?.mcpTools)],
     [RuntimeFlags.node, runtimeFlags],
   ] as const
   if (input?.processor === "blocking") {
@@ -235,7 +241,7 @@ function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processo
   return LayerNode.compile(root, replacements)
 }
 
-function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttpNoLLMServer(input?: PromptLayerInput) {
   return makePrompt(input)
 }
 
@@ -251,6 +257,26 @@ const withMcpInstructions = testEffect(
         tools: ["guide-server_lookup"],
       },
     ],
+  }),
+)
+const withEmptyMcpSearch = testEffect(
+  makeHttp({
+    mcpTools: {
+      gumps_mcp_resource_list: {
+        def: {
+          name: "resource_list",
+          description: "List matching MCP resources",
+          inputSchema: {
+            type: "object",
+            properties: { prefix: { type: "string" } },
+            required: ["prefix"],
+          },
+        } as MCP.McpTool["def"],
+        client: {
+          callTool: async () => ({ content: [] }),
+        } as unknown as MCP.McpTool["client"],
+      },
+    },
   }),
 )
 const unix = process.platform !== "win32" ? it.instance : it.instance.skip
@@ -807,6 +833,66 @@ it.instance("loop continues when finish is tool-calls", () =>
       expect(result.parts.some((part) => part.type === "text" && part.text === "second")).toBe(true)
       expect(result.info.finish).toBe("stop")
     }
+  }),
+)
+
+withEmptyMcpSearch.instance("loop stops after repeated empty MCP results with varied inputs", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "Missing MCP resource",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "find m365-inbox" }],
+    })
+    yield* llm.tool("gumps_mcp_resource_list", { prefix: "m" })
+    yield* llm.tool("gumps_mcp_resource_list", { prefix: "m3" })
+    yield* llm.tool("gumps_mcp_resource_list", { prefix: "m365" })
+    yield* llm.text("unreachable")
+
+    const result = yield* prompt.loop({ sessionID: session.id })
+
+    expect(yield* llm.calls).toBe(3)
+    expect(yield* llm.pending).toBe(1)
+    expect(result.info).toMatchObject({
+      role: "assistant",
+      error: {
+        name: "UnknownError",
+        data: {
+          ref: "tool_loop_no_progress",
+          message: expect.stringContaining("No matching resource was found"),
+        },
+      },
+    })
+    const history = yield* sessions.messages({ sessionID: session.id })
+    const calls = history
+      .toSorted((a, b) => a.info.id.localeCompare(b.info.id))
+      .flatMap((message) => message.parts)
+      .filter((part): part is SessionV1.ToolPart => part.type === "tool" && part.tool === "gumps_mcp_resource_list")
+    expect(calls.map((part) => part.state.input)).toEqual([{ prefix: "m" }, { prefix: "m3" }, { prefix: "m365" }])
+    expect(calls.map((part) => part.state.status)).toEqual(["completed", "completed", "completed"])
+
+    const resumed = yield* prompt.loop({ sessionID: session.id })
+    expect(resumed.info.id).toBe(result.info.id)
+    expect(yield* llm.calls).toBe(3)
+    expect(yield* llm.pending).toBe(1)
+
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "stop searching and summarize" }],
+    })
+    const recovered = yield* prompt.loop({ sessionID: session.id })
+    expect(yield* llm.calls).toBe(4)
+    expect(yield* llm.pending).toBe(0)
+    expect(recovered.parts).toContainEqual(expect.objectContaining({ type: "text", text: "unreachable" }))
   }),
 )
 


### PR DESCRIPTION
### Issue for this PR

Closes #31942

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops sequential discovery-tool loops after three consecutive empty/no-match outcomes, even when the model changes the query each time. The guard checks settled session history before the next provider turn, so it works across assistant messages instead of only within one processor stream.

The stop is durable and user-visible, resets after meaningful output, another tool, or new user input, and does not classify empty mutation-tool payloads as no progress. Exact repeated tool errors are also bounded. This keeps the existing exact-input `doom_loop` permission as an earlier complementary warning.

This builds on the conservative empty-result handling explored in #31998, but moves detection to the continuation boundary so it covers the production cross-turn loop shape. The detector accepts a threshold and defaults to 3; user-facing threshold policy remains tracked separately in #23531.

### How did you verify your code works?

- `cd packages/core && bun test test/session-tool-loop.test.ts test/session-runner.test.ts` (88 passed)
- `cd packages/opencode && bun test test/session/prompt.test.ts test/session/processor-effect.test.ts` (72 passed, 1 pre-existing skip)
- `bun typecheck` (30 package tasks passed)
- Pre-push hook passed with the repository's required Bun 1.3.14

The regressions use three separate provider turns with varied MCP prefixes, assert that a queued fourth response is not consumed, verify replay durability and inert resume behavior, and confirm that fresh user input can continue the session.

### Screenshots / recordings

N/A (runtime-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
