### PR TITLE
fix(build): add OPENCODE_VERSION define for Node.js Desktop build

### DIFF
--- a/packages/opencode/script/build-node.ts
+++ b/packages/opencode/script/build-node.ts
@@ -20,6 +20,7 @@ await Bun.build({
   sourcemap: "linked",
   external: ["jsonc-parser", "@lydell/node-pty"],
   define: {
+    OPENCODE_VERSION: `'${Script.version}'`,
     OPENCODE_MODELS_DEV: generated.modelsData,
     OPENCODE_CHANNEL: `'${Script.channel}'`,
   },


### PR DESCRIPTION
The CLI build (build.ts) defines OPENCODE_VERSION but the Node.js Desktop build (build-node.ts) was missing it. This caused InstallationVersion to fall back to 'local', making the Desktop app attempt to install @opencode-ai/plugin@local (which does not exist on npm) instead of the published version.

Fixes #30908