### PR TITLE
feat(simulation): expose normalized terminal frames

### DIFF
--- a/packages/simulation/src/frontend/actions.ts
+++ b/packages/simulation/src/frontend/actions.ts
@@ -110,6 +110,25 @@ export function matches(harness: Pick<Harness, "screen">, text: string) {
   return harness.screen().includes(text)
 }
 
+export const capture = Effect.fn("SimulationActions.capture")(function* (harness: Harness) {
+  yield* Effect.tryPromise(() => harness.renderOnce())
+  const buffer = harness.renderer.currentRenderBuffer
+  return {
+    cols: buffer.width,
+    rows: buffer.height,
+    cursor: [0, 0] as const,
+    lines: buffer.getSpanLines().map((line) => ({
+      spans: line.spans.map((span) => ({
+        text: span.text,
+        fg: span.fg.toInts(),
+        bg: span.bg.toInts(),
+        attributes: span.attributes,
+        width: span.width,
+      })),
+    })),
+  } satisfies SimulationProtocol.Frontend.CapturedFrame
+})
+
 export const screenshot = Effect.fn("SimulationActions.screenshot")(function* (harness: Harness, name?: string) {
   const filename = name ?? `screenshot-${crypto.randomUUID()}`
   if (!filename || filename.includes("/") || filename.includes("\\") || extname(filename))

--- a/packages/simulation/src/frontend/server.ts
+++ b/packages/simulation/src/frontend/server.ts
@@ -6,6 +6,8 @@ import { SimulationRenderer } from "./renderer"
 
 function handle(harness: Harness, request: SimulationProtocol.Frontend.Request) {
   switch (request.method) {
+    case "ui.capture":
+      return SimulationActions.capture(harness)
     case "ui.screenshot":
       return SimulationActions.screenshot(harness, request.params?.name)
     case "ui.state":

--- a/packages/simulation/src/protocol/index.ts
+++ b/packages/simulation/src/protocol/index.ts
@@ -95,6 +95,29 @@ export namespace Frontend {
   export const Screenshot = Schema.String
   export type Screenshot = Schema.Schema.Type<typeof Screenshot>
 
+  export const Color = Schema.Tuple([Schema.Number, Schema.Number, Schema.Number, Schema.Number])
+  export type Color = Schema.Schema.Type<typeof Color>
+
+  export const CapturedFrame = Schema.Struct({
+    cols: Schema.Number,
+    rows: Schema.Number,
+    cursor: Schema.Tuple([Schema.Number, Schema.Number]),
+    lines: Schema.Array(
+      Schema.Struct({
+        spans: Schema.Array(
+          Schema.Struct({
+            text: Schema.String,
+            fg: Color,
+            bg: Color,
+            attributes: Schema.Number,
+            width: Schema.Number,
+          }),
+        ),
+      }),
+    ),
+  })
+  export interface CapturedFrame extends Schema.Schema.Type<typeof CapturedFrame> {}
+
   export const RecordingFinish = Schema.String
   export type RecordingFinish = Schema.Schema.Type<typeof RecordingFinish>
 
@@ -142,6 +165,7 @@ export namespace Frontend {
       ...JsonRpc.RequestFields,
       method: Schema.Literals(["ui.enter", "ui.state", "ui.recording.finish"]),
     }),
+    Schema.Struct({ ...JsonRpc.RequestFields, method: Schema.Literal("ui.capture") }),
   ])
   export type Request = Schema.Schema.Type<typeof Request>
   export const decodeRequest = Schema.decodeUnknownSync(Request)

--- a/packages/simulation/test/frontend-server.test.ts
+++ b/packages/simulation/test/frontend-server.test.ts
@@ -25,6 +25,17 @@ test("scopes the frontend control server and reports malformed JSON", async () =
           result: { focused: { editor: false }, elements: [] },
         })
 
+        socket.send(JSON.stringify({ jsonrpc: "2.0", id: 2, method: "ui.capture" }))
+        expect(yield* Queue.take(messages)).toMatchObject({
+          id: 2,
+          result: {
+            cols: 100,
+            rows: 40,
+            cursor: [0, 0],
+            lines: expect.any(Array),
+          },
+        })
+
         socket.send("{")
         expect(yield* Queue.take(messages)).toMatchObject({
           id: null,


### PR DESCRIPTION
## What

Add `ui.capture` to the frontend simulation protocol so automation can persist the terminal's rendered state without coupling capture to PNG output.

The result preserves viewport dimensions, cursor position, span text and cell widths, resolved RGBA foreground/background colors, and text attributes in a JSON-safe value.

## How

- `packages/simulation/src/protocol/index.ts` defines the normalized frame response and `ui.capture` request.
- `packages/simulation/src/frontend/actions.ts` renders once, reads the live OpenTUI span buffer, and converts `RGBA` objects to integer tuples.
- `packages/simulation/src/frontend/server.ts` routes the new protocol command.
- `packages/simulation/test/frontend-server.test.ts` verifies the command over the real simulation WebSocket.

## Scope

This does not remove or change `ui.screenshot`. PNG generation remains available for consumers that need an image artifact; `ui.capture` is the renderer-neutral snapshot path.

## Testing

- `bun run typecheck` in `packages/simulation`
- `bun test` in `packages/simulation` (19 tests)
- Repository pre-push typecheck across 32 packages
- End-to-end OpenCode Drive capture of 23 TUI states through `ui.capture`

## Flow

```mermaid
sequenceDiagram
  participant Driver
  participant Simulation
  participant OpenTUI
  Driver->>Simulation: ui.capture
  Simulation->>OpenTUI: renderOnce + getSpanLines
  OpenTUI-->>Simulation: CapturedFrame with RGBA objects
  Simulation-->>Driver: JSON frame with RGBA tuples
```
