### PR TITLE
fix(core): bound default search results

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -31,6 +31,8 @@ export type ListInput = typeof ListInput.Type
 
 export { FindInput }
 
+export const DEFAULT_SEARCH_LIMIT = 100
+
 export class GlobInput extends Schema.Class<GlobInput>("FileSystem.GlobInput")({
   pattern: Schema.String,
   path: RelativePath.pipe(Schema.optional),

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -56,7 +56,7 @@ export const ripgrepLayer = Layer.effect(
             .glob({
               cwd,
               pattern: input.pattern,
-              limit: input.limit ?? Number.MAX_SAFE_INTEGER,
+              limit: input.limit ?? FileSystem.DEFAULT_SEARCH_LIMIT,
             })
             .pipe(
               Effect.map((result) =>
@@ -81,7 +81,7 @@ export const ripgrepLayer = Layer.effect(
               pattern: input.pattern,
               file: info.type === "File" ? path.basename(target) : undefined,
               include: input.include,
-              limit: input.limit ?? Number.MAX_SAFE_INTEGER,
+              limit: input.limit ?? FileSystem.DEFAULT_SEARCH_LIMIT,
             })
             .pipe(
               Effect.map((result) =>
@@ -150,7 +150,7 @@ export const fffLayer = Layer.effect(
           const prefix = input.path?.replaceAll("\\", "/").replace(/\/$/, "")
           const found = result.value.glob(prefix ? `${prefix}/${input.pattern}` : input.pattern, {
             pageIndex: 0,
-            pageSize: input.limit,
+            pageSize: input.limit ?? FileSystem.DEFAULT_SEARCH_LIMIT,
           })
           if (!found.ok) throw found.error
           return found.value.items.map((item) =>
@@ -167,7 +167,7 @@ export const fffLayer = Layer.effect(
             [prefix ? `${prefix}/**` : undefined, input.include, input.pattern]
               .filter((value) => value !== undefined)
               .join(" "),
-            { mode: "regex", pageSize: input.limit, timeBudgetMs: 1_500 },
+            { mode: "regex", pageSize: input.limit ?? FileSystem.DEFAULT_SEARCH_LIMIT, timeBudgetMs: 1_500 },
           )
           if (!found.ok) throw found.error
           return found.value.items.map((match) => {

--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -20,7 +20,7 @@ export const Input = Schema.Struct({
     description: "Relative directory to search. Defaults to the active Location.",
   }),
   limit: FileSystem.GlobInput.fields.limit.annotate({
-    description: "Maximum results to return",
+    description: `Maximum results to return (default: ${FileSystem.DEFAULT_SEARCH_LIMIT})`,
   }),
 })
 
@@ -86,7 +86,7 @@ export const Plugin = {
                   .glob({
                     cwd,
                     pattern: input.pattern,
-                    limit: input.limit ?? Number.MAX_SAFE_INTEGER,
+                    limit: input.limit ?? FileSystem.DEFAULT_SEARCH_LIMIT,
                   })
                   .pipe(
                     Effect.map((result) =>

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -25,7 +25,7 @@ export const Input = Schema.Struct({
     description: 'File glob to include in the search (for example, "*.js" or "*.{ts,tsx}")',
   }),
   limit: FileSystem.GrepInput.fields.limit.annotate({
-    description: "Maximum matches to return",
+    description: `Maximum matches to return (default: ${FileSystem.DEFAULT_SEARCH_LIMIT})`,
   }),
 })
 
@@ -106,7 +106,7 @@ export const Plugin = {
                     pattern: input.pattern,
                     file: info?.type === "File" ? path.basename(target) : undefined,
                     include: input.include,
-                    limit: input.limit ?? Number.MAX_SAFE_INTEGER,
+                    limit: input.limit ?? FileSystem.DEFAULT_SEARCH_LIMIT,
                   })
                   .pipe(
                     Effect.map((result) =>

--- a/packages/core/test/tool-search.test.ts
+++ b/packages/core/test/tool-search.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { Effect, Layer } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { makeLocationNode } from "@opencode-ai/core/effect/app-node"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { FileSystem } from "@opencode-ai/core/filesystem"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Location } from "@opencode-ai/core/location"
 import { PermissionV2 } from "@opencode-ai/core/permission"
@@ -16,7 +19,7 @@ import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
 import { location } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
-import { executeTool, registerToolPlugin, toolIdentity } from "./lib/tool"
+import { executeTool, registerToolPlugin, settleTool, toolIdentity } from "./lib/tool"
 
 const globToolNode = makeLocationNode({
   name: "test/glob-tool-plugin",
@@ -66,6 +69,32 @@ const call = (name: "glob" | "grep", input: unknown) => ({
 const it = testEffect(Layer.empty)
 
 describe("search tools", () => {
+  it.live("bounds omitted glob and grep limits", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() =>
+            Promise.all(
+              Array.from({ length: FileSystem.DEFAULT_SEARCH_LIMIT + 1 }, (_, index) =>
+                fs.writeFile(path.join(tmp.path, `${index}.txt`), "needle\n"),
+              ),
+            ),
+          )
+          yield* withTools(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              const glob = yield* settleTool(registry, call("glob", { pattern: "*" }))
+              const grep = yield* settleTool(registry, call("grep", { pattern: "needle" }))
+
+              expect(glob.output?.structured).toHaveLength(FileSystem.DEFAULT_SEARCH_LIMIT)
+              expect(grep.output?.structured).toHaveLength(FileSystem.DEFAULT_SEARCH_LIMIT)
+            }),
+          )
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   for (const name of ["glob", "grep"] as const) {
     it.live(`${name} reports a missing search path`, () =>
       Effect.acquireUseRelease(


### PR DESCRIPTION
## What

Give V2 filesystem `glob` and `grep` searches the same 100-result default bound as V1 when callers omit `limit`.

The audit found both model-facing search tools had the same unbounded fallback. Other built-in tools already have concrete capture limits: `read` bounds lines and bytes, `shell` bounds captured output, and `webfetch` / `websearch` bound response sizes.

## Before / After

**Before:** A model could call `glob` or `grep` without `limit`. The tool translated that omission to `Number.MAX_SAFE_INTEGER`, and the ripgrep adapter collected matching rows in memory. A broad search over a large worktree could therefore retain millions of paths or matches, exhaust process memory, and leave the tool call running indefinitely.

**After:** Omitted limits resolve to 100 before either ripgrep or fff executes. Ripgrep's existing `take(limit + 1)` boundary stops collection and terminates the scoped subprocess once the bounded result is known.

## How

- `packages/core/src/filesystem.ts` defines the shared `DEFAULT_SEARCH_LIMIT`.
- `packages/core/src/tool/glob.ts` and `packages/core/src/tool/grep.ts` apply and advertise that default for model calls.
- `packages/core/src/filesystem/search.ts` applies the same default in both ripgrep and fff service implementations so non-tool consumers cannot recover the unbounded omission behavior.
- `packages/core/test/tool-search.test.ts` executes both real registered tools against 101 matches and verifies omitted limits settle with 100 structured results.

## Scope

This does not change explicit caller-supplied limits or the Location file indexer, whose catch-all scan deliberately uses separate indexing behavior. It does not modify V1, which already hard-codes a 100-result bound for both tools.

## Testing

- `cd packages/core && bun run test test/tool-search.test.ts` (3 passed)
- `cd packages/core && bun run test` (1,292 passed, 6 skipped)
- `cd packages/core && bun run typecheck`
- Pre-push hook: `bun turbo typecheck --concurrency=3` (32 packages passed)
- `bun run prettier --check packages/core/src/filesystem.ts packages/core/src/filesystem/search.ts packages/core/src/tool/glob.ts packages/core/src/tool/grep.ts packages/core/test/tool-search.test.ts`
- `bun run lint` (passes with existing repository warnings)
- `bun run lint:effect-patterns` remains blocked by seven pre-existing findings outside this diff
