### PR TITLE
fix(server): SSE event loss under bwrap PID namespace

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -2,7 +2,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { InstanceState } from "@/effect/instance-state"
 import { GlobalBus } from "@/bus/global"
 import { EventV2 } from "@opencode-ai/core/event"
-import { Effect, Queue } from "effect"
+import { Effect, PubSub } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
@@ -28,10 +28,12 @@ function eventResponse(events: EventV2.Interface) {
     const workspaceID = yield* InstanceState.workspaceID
     // Listener registration is eager, so events published after this point cannot
     // be lost while the HTTP body fiber is starting or emitting server.connected.
-    const queue = yield* Queue.unbounded<EventV2.Payload>()
-    const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
+    // PubSub.publish goes through the Effect fiber scheduler; Queue.offerUnsafe
+    // bypasses it and stalls under bwrap --unshare-pid (see #37128).
+    const pubsub = yield* PubSub.unbounded<EventV2.Payload>()
+    const unsubscribe = yield* events.listen((event) => PubSub.publish(pubsub, event))
     yield* Effect.addFinalizer(() => unsubscribe)
-    const stream = Stream.fromQueue(queue).pipe(
+    const stream = Stream.fromPubSub(pubsub).pipe(
       Stream.filter(
         (event) =>
           event.location?.directory === instance.directory &&
@@ -39,23 +41,28 @@ function eventResponse(events: EventV2.Interface) {
       ),
       Stream.map((event) => ({ id: event.id, type: event.type, properties: event.data })),
     )
-    const disposed = Stream.callback<{ id: string; type: string; properties: unknown }>((queue) => {
-      const listener = (event: {
-        directory?: string
-        payload: { id?: string; type?: string; properties?: unknown }
-      }) => {
-        if (event.directory !== instance.directory || event.payload.type !== "server.instance.disposed") return
-        Queue.offerUnsafe(queue, {
+    // PubSub for consistency with the main stream; single-consumer so equivalent to Queue.
+    const disposedPubsub = yield* PubSub.unbounded<{ id: string; type: string; properties: unknown }>()
+    const runtime = yield* Effect.runtime<never>()
+    const disposedListener = (event: {
+      directory?: string
+      payload: { id?: string; type?: string; properties?: unknown }
+    }) => {
+      if (event.directory !== instance.directory || event.payload.type !== "server.instance.disposed") return
+      // unbounded PubSub.publish completes synchronously — runSync avoids orphan fibers
+      runtime.runSync(
+        PubSub.publish(disposedPubsub, {
           id: event.payload.id ?? eventID(),
           type: "server.instance.disposed",
           properties: event.payload.properties ?? {},
-        })
-      }
-      return Effect.acquireRelease(
-        Effect.sync(() => GlobalBus.on("event", listener)),
-        () => Effect.sync(() => GlobalBus.off("event", listener)),
+        }),
       )
-    })
+    }
+    yield* Effect.acquireRelease(
+      Effect.sync(() => GlobalBus.on("event", disposedListener)),
+      () => Effect.sync(() => GlobalBus.off("event", disposedListener)),
+    )
+    const disposed = Stream.fromPubSub(disposedPubsub)
     const output = stream.pipe(
       Stream.merge(disposed, { haltStrategy: "left" }),
       Stream.takeUntil((event) => event.type === "server.instance.disposed"),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/global.ts
@@ -5,7 +5,7 @@ import { EventV2 } from "@opencode-ai/core/event"
 import { Installation } from "@/installation"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
-import { Effect, Queue, Schema } from "effect"
+import { Effect, PubSub, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
@@ -33,13 +33,19 @@ function parseBody(body: string) {
 function eventResponse() {
   return Effect.gen(function* () {
     yield* Effect.logInfo("global event connected")
-    const events = Stream.callback<GlobalBusEvent>((queue) => {
-      const handler = (event: GlobalBusEvent) => Queue.offerUnsafe(queue, event)
-      return Effect.acquireRelease(
-        Effect.sync(() => GlobalBus.on("event", handler)),
-        () => Effect.sync(() => GlobalBus.off("event", handler)),
-      )
-    })
+    // PubSub.publish goes through the Effect fiber scheduler; Queue.offerUnsafe
+    // via Stream.callback stalls under bwrap --unshare-pid (see #37128).
+    const pubsub = yield* PubSub.unbounded<GlobalBusEvent>()
+    const runtime = yield* Effect.runtime<never>()
+    // unbounded PubSub.publish completes synchronously — runSync avoids orphan fibers
+    const handler = (event: GlobalBusEvent) => {
+      runtime.runSync(PubSub.publish(pubsub, event))
+    }
+    yield* Effect.acquireRelease(
+      Effect.sync(() => GlobalBus.on("event", handler)),
+      () => Effect.sync(() => GlobalBus.off("event", handler)),
+    )
+    const events = Stream.fromPubSub(pubsub)
     const heartbeat = Stream.tick("10 seconds").pipe(
       Stream.drop(1),
       Stream.map(() => ({ payload: { id: EventV2.ID.create(), type: "server.heartbeat", properties: {} } })),

--- a/packages/opencode/src/server/server.ts
+++ b/packages/opencode/src/server/server.ts
@@ -198,6 +198,7 @@ function forceClose(state: ListenerState) {
 
 function serverLayer(opts: { port: number; hostname: string }) {
   const server = createServer()
+  server.keepAliveTimeout = 0
   const serverRef = { closeStarted: false, forceStop: false }
   const close = server.close.bind(server)
   // Keep shutdown owned by NodeHttpServer, but honor listener.stop(true) by


### PR DESCRIPTION
### Issue for this PR

Closes #37128

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes SSE event streams stalling after the first chunk when `opencode serve` runs inside a bwrap `--unshare-pid` sandbox.

SSE endpoints (`/event`, `/global/event`) used `Queue.offerUnsafe` (and `Stream.callback` which also uses it) to push events into the HTTP response stream. `offerUnsafe` bypasses Effect's fiber scheduler and wakes the taker via Deferred/microtask; under a bwrap PID namespace that wakeup path fails, so later events sit in the queue and never reach the client. The first chunk still arrives because it comes from a synchronous `Stream.make` (e.g. `server.connected`).

This PR:

1. **`event.ts`** — replace `Queue` + `offerUnsafe` + `Stream.fromQueue` with `PubSub` + `publish` + `Stream.fromPubSub` for the main event stream and the disposed stream.
2. **`global.ts`** — same conversion for the global event stream (replacing `Stream.callback` + `offerUnsafe`).
3. **`server.ts`** — set `server.keepAliveTimeout = 0` so Node's default 5s idle timeout does not kill long-lived SSE connections before the 10s heartbeat.

`PubSub.publish` is a normal Effect that goes through the fiber runtime; `runSync` is used for GlobalBus callbacks because unbounded publish completes synchronously.

### How did you verify your code works?

Root cause was isolated via a behavior matrix under bwrap:

- First SSE chunk arrives (sync `Stream.make`) then stalls (queue + unsafe wakeup)
- Sync `POST /session/:id/message` works (no queue path)
- `opencode run` without serve works (no SSE)
- Host serve + attach works; bwrap serve + attach breaks

The change only replaces the unsafe queue path on SSE endpoints with PubSub on the Effect scheduler. Rebased onto current `dev` (which already uses `Effect.logInfo` for connect/disconnect logging).

### Screenshots / recordings

N/A — server-side SSE path, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR