### PR TITLE
fix(webfetch): scope always-allow to domain instead of all URLs

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -36,10 +36,11 @@ export const WebFetchTool = Tool.define(
             throw new Error("URL must start with http:// or https://")
           }
 
+          const origin = URL.canParse(params.url) ? new URL(params.url).origin + "/*" : undefined
           yield* ctx.ask({
             permission: "webfetch",
             patterns: [params.url],
-            always: ["*"],
+            always: origin ? [origin] : ["*"],
             metadata: {
               url: params.url,
               format: params.format,

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -7,6 +7,10 @@ import DESCRIPTION from "./webfetch.txt"
 import { isImageAttachment } from "@/util/media"
 
 const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
+
+export function originPattern(url: string): string | undefined {
+  return URL.canParse(url) ? new URL(url).origin + "/*" : undefined
+}
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
 const MAX_TIMEOUT = 120 * 1000 // 2 minutes
 
@@ -36,7 +40,7 @@ export const WebFetchTool = Tool.define(
             throw new Error("URL must start with http:// or https://")
           }
 
-          const origin = URL.canParse(params.url) ? new URL(params.url).origin + "/*" : undefined
+          const origin = originPattern(params.url)
           yield* ctx.ask({
             permission: "webfetch",
             patterns: [params.url],

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, it as baseIt } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
 import { Effect, Layer } from "effect"
 import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { Agent } from "../../src/agent/agent"
 import { Truncate } from "@/tool/truncate"
-import { WebFetchTool } from "../../src/tool/webfetch"
+import { WebFetchTool, originPattern } from "../../src/tool/webfetch"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { Tool } from "@/tool/tool"
 import { testEffect } from "../lib/effect"
@@ -41,6 +41,32 @@ const exec = Effect.fn("WebFetchToolTest.exec")(function* (args: Tool.InferParam
   const info = yield* WebFetchTool
   const tool = yield* info.init()
   return yield* tool.execute(args, ctx)
+})
+
+describe("originPattern", () => {
+  baseIt("returns origin with /* wildcard for valid https URL", () => {
+    expect(originPattern("https://github.com/anomalyco/opencode/issues/123")).toBe("https://github.com/*")
+  })
+
+  baseIt("returns origin with /* wildcard for valid http URL", () => {
+    expect(originPattern("http://example.com/page.html")).toBe("http://example.com/*")
+  })
+
+  baseIt("handles subdomains", () => {
+    expect(originPattern("https://docs.example.com/path/file")).toBe("https://docs.example.com/*")
+  })
+
+  baseIt("handles URLs with port", () => {
+    expect(originPattern("https://localhost:8080/test")).toBe("https://localhost:8080/*")
+  })
+
+  baseIt("returns undefined for invalid URL", () => {
+    expect(originPattern("not-a-url")).toBeUndefined()
+  })
+
+  baseIt("returns undefined for empty string", () => {
+    expect(originPattern("")).toBeUndefined()
+  })
 })
 
 describe("tool.webfetch", () => {


### PR DESCRIPTION
The always-allow pattern for WebFetch was ['*'], meaning a user clicking "always allow" saved a wildcard that approved ALL future URLs without asking. Now parses the URL origin and scopes "always allow" to the current domain.

- Adds originPattern() helper with unit tests
- 6 new tests covering valid URLs, subdomains, ports, and invalid inputs