### PR TITLE
fix(session): reject empty assistant responses

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1083,6 +1083,7 @@ const layer = Layer.effect(
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
+        let retriedEmptyResponse = false
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1107,12 +1108,17 @@ const layer = Layer.effect(
             lastAssistantMsg?.parts.some(
               (part) => part.type === "tool" && !part.metadata?.providerExecuted && !isOrphanedInterruptedTool(part),
             ) ?? false
+          const hasVisibleOutput =
+            lastAssistantMsg?.parts.some(
+              (part) => part.type === "tool" || (part.type === "text" && part.text.trim().length > 0),
+            ) ?? false
 
           if (
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastUser.id < lastAssistant.id &&
+            !(retriedEmptyResponse && !hasVisibleOutput)
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),
@@ -1313,6 +1319,28 @@ const layer = Layer.effect(
                 }).toObject()
                 yield* sessions.updateMessage(handle.message)
                 return "break" as const
+              }
+
+              const parts = yield* MessageV2.parts(handle.message.id).pipe(
+                Effect.provideService(Database.Service, database),
+              )
+              const hasVisibleOutput = parts.some(
+                (part) => part.type === "tool" || (part.type === "text" && part.text.trim().length > 0),
+              )
+              if (!hasVisibleOutput) {
+                if (!retriedEmptyResponse) {
+                  retriedEmptyResponse = true
+                  yield* Effect.logWarning("retrying empty assistant response", {
+                    "session.id": sessionID,
+                    messageID: handle.message.id,
+                  })
+                  return "continue" as const
+                }
+                const error = new NamedError.Unknown({ message: "Model returned an empty response after retry" })
+                handle.message.error = error.toObject()
+                yield* sessions.updateMessage(handle.message)
+                yield* events.publish(Session.Event.Error, { sessionID, error: handle.message.error })
+                throw error
               }
             }
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2201,6 +2201,48 @@ it.instance("does not loop empty assistant turns for a simple reply", () =>
   }),
 )
 
+it.instance("retries a reasoning-only assistant response once", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({ title: "Empty response retry" })
+
+    yield* llm.push(reply().reason("thinking").stop(), reply().text("done").stop())
+
+    const result = yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      parts: [{ type: "text", text: "Answer me" }],
+    })
+
+    expect(yield* llm.calls).toBe(2)
+    expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+  }),
+)
+
+it.instance("fails after two reasoning-only assistant responses", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({ title: "Empty response failure" })
+
+    yield* llm.push(reply().reason("thinking").stop(), reply().reason("still thinking").stop())
+
+    const exit = yield* prompt
+      .prompt({
+        sessionID: session.id,
+        agent: "build",
+        parts: [{ type: "text", text: "Answer me" }],
+      })
+      .pipe(Effect.exit)
+
+    expect(yield* llm.calls).toBe(2)
+    expect(Exit.isFailure(exit)).toBe(true)
+  }),
+)
+
 it.instance("records aborted errors when prompt is cancelled mid-stream", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
## What

Prevent reasoning-only assistant responses from silently completing a Session without any user-visible output. OpenCode now retries one empty terminal response and fails explicitly if the retry is also empty.

Fixes #30411

## Before / After

**Before**

A provider could return `finish: stop` with reasoning but no text or tool call. `SessionPrompt` accepted the response, emitted a successful execution, and left clients with no assistant message or error. In the production OpenCode Agent incident that prompted this fix, Slack showed only a completed progress card while repeated requests received no reply.

**After**

The first terminal response without text or a tool call is retried once. If the retry produces visible output, the Session completes normally. If it is also empty, the assistant message records an error and the execution fails instead of reporting false success.

```mermaid
flowchart TD
  A[Provider returns terminal response] --> B{Text or tool call?}
  B -- Yes --> C[Complete normally]
  B -- No --> D{Already retried?}
  D -- No --> E[Retry once]
  E --> A
  D -- Yes --> F[Fail with explicit empty-response error]
```

## How

- `packages/opencode/src/session/prompt.ts` checks terminal assistant parts for non-whitespace text or a tool call.
- The prompt loop bypasses its normal terminal exit for one bounded empty-response retry.
- A second empty response records and publishes an error, then fails the execution.
- `packages/opencode/test/session/prompt.test.ts` covers recovery on retry and bounded failure after two empty responses.

## Scope

This does not attempt to diagnose why a provider emitted a reasoning-only response. It hardens the OpenCode Session boundary so that provider behavior cannot become a silent successful turn.

## Testing

- `bun run typecheck` in `packages/opencode`
- Push hook: `bun turbo typecheck --concurrency=3` (32 packages passed)
- Focused prompt tests were attempted, but current `v2` fails during provider catalog setup before the target test because a live `models.dev` entry decodes an `undefined` required string. The new regression cases are included for CI once that external catalog data is valid.