### PR TITLE
fix(tui): align streaming shell output

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -66,7 +66,7 @@ import { useConfig } from "../../config"
 import { useClipboard } from "../../context/clipboard"
 import { nextThinkingMode, reasoningSummary, type ThinkingMode } from "../../context/thinking"
 import { getScrollAcceleration } from "../../util/scroll"
-import { collapseToolOutput } from "../../util/collapse-tool-output"
+import { collapseToolOutput, collapseToolOutputParts } from "../../util/collapse-tool-output"
 import { usePluginRuntime } from "../../plugin/runtime"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut } from "../../keymap"
 import { usePathFormatter } from "../../context/path-format"
@@ -2384,16 +2384,10 @@ function Shell(props: ToolProps) {
   const maxLines = 10
   const maxChars = createMemo(() => maxLines * Math.max(20, ctx.width - 6))
   const input = createMemo(() => (command() ? `${isRunning() ? "" : "$ "}${command()}` : ""))
-  const content = createMemo(() => [input(), output()].filter(Boolean).join("\n\n"))
-  const collapsed = createMemo(() => collapseToolOutput(content(), maxLines, maxChars()))
+  const collapsed = createMemo(() => collapseToolOutputParts(input(), output(), maxLines, maxChars()))
   const visible = createMemo(() => {
-    const command = input()
-    if (expanded()) return { input: command, output: output() }
-    const preview = collapsed().overflow ? collapsed().output : content()
-    return {
-      input: preview.slice(0, command.length),
-      output: preview.slice(command.length).replace(/^\n+/, ""),
-    }
+    if (expanded()) return { input: input(), output: output() }
+    return collapsed()
   })
   const expandable = createMemo(() => Boolean(shellID()) || collapsed().overflow)
   const toggle = () => {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2386,9 +2386,14 @@ function Shell(props: ToolProps) {
   const input = createMemo(() => (command() ? `${isRunning() ? "" : "$ "}${command()}` : ""))
   const content = createMemo(() => [input(), output()].filter(Boolean).join("\n\n"))
   const collapsed = createMemo(() => collapseToolOutput(content(), maxLines, maxChars()))
-  const limited = createMemo(() => {
-    if (expanded() || !collapsed().overflow) return content()
-    return collapsed().output
+  const visible = createMemo(() => {
+    const command = input()
+    if (expanded()) return { input: command, output: output() }
+    const preview = collapsed().overflow ? collapsed().output : content()
+    return {
+      input: preview.slice(0, command.length),
+      output: preview.slice(command.length).replace(/^\n+/, ""),
+    }
   })
   const expandable = createMemo(() => Boolean(shellID()) || collapsed().overflow)
   const toggle = () => {
@@ -2413,17 +2418,16 @@ function Shell(props: ToolProps) {
           <Show
             when={isRunning()}
             fallback={
-              <text>
-                <span style={{ fg: themeV2.text() }}>{limited().slice(0, input().length)}</span>
-                <span style={{ fg: themeV2.text.subdued() }}>{limited().slice(input().length)}</span>
-              </text>
+              <text fg={themeV2.text()}>{visible().input}</text>
             }
           >
             <Spinner color={color()}>
-              <span style={{ fg: themeV2.text() }}>{limited().slice(0, input().length)}</span>
-              <span style={{ fg: themeV2.text.subdued() }}>{limited().slice(input().length)}</span>
+              <span style={{ fg: themeV2.text() }}>{visible().input}</span>
             </Spinner>
           </Show>
+        </Show>
+        <Show when={visible().output}>
+          {(value) => <text fg={themeV2.text.subdued()}>{value()}</text>}
         </Show>
         <Show when={shellID()}>
           <StatusBadge>Background</StatusBadge>

--- a/packages/tui/src/util/collapse-tool-output.ts
+++ b/packages/tui/src/util/collapse-tool-output.ts
@@ -19,3 +19,26 @@ export function collapseToolOutput(output: string, maxLines: number, maxChars: n
 
   return { output: preview, overflow: true }
 }
+
+export function collapseToolOutputParts(input: string, output: string, maxLines: number, maxChars: number) {
+  const separator = input && output ? "\n\n" : ""
+  const collapsed = collapseToolOutput(`${input}${separator}${output}`, maxLines, maxChars)
+  if (!collapsed.overflow) return { input, output, overflow: false }
+
+  const ellipsis = collapsed.output.endsWith("…") ? "…" : ""
+  const preview = ellipsis ? collapsed.output.slice(0, -1) : collapsed.output
+  const outputStart = input.length + separator.length
+  if (preview.length <= outputStart) {
+    return {
+      input: preview.slice(0, input.length) + ellipsis,
+      output: "",
+      overflow: true,
+    }
+  }
+
+  return {
+    input,
+    output: preview.slice(outputStart) + ellipsis,
+    overflow: true,
+  }
+}

--- a/packages/tui/test/cli/tui/collapse-tool-output.test.ts
+++ b/packages/tui/test/cli/tui/collapse-tool-output.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { collapseToolOutput } from "../../../src/util/collapse-tool-output"
+import { collapseToolOutput, collapseToolOutputParts } from "../../../src/util/collapse-tool-output"
 
 test("limits command input and output to the same line budget", () => {
   const command = Array.from({ length: 8 }, (_, index) => `command ${index + 1}`).join("\n")
@@ -11,4 +11,34 @@ test("limits command input and output to the same line budget", () => {
   expect(collapsed.output).toContain("$ command 1")
   expect(collapsed.output).toContain("command 8\n\noutput 1…")
   expect(collapsed.output).not.toContain("output 2")
+})
+
+test.each([
+  {
+    name: "inside the command",
+    maxChars: 5,
+    expected: { input: "$ co…", output: "", overflow: true },
+  },
+  {
+    name: "after the command",
+    maxChars: 10,
+    expected: { input: "$ command…", output: "", overflow: true },
+  },
+  {
+    name: "on the first separator newline",
+    maxChars: 11,
+    expected: { input: "$ command…", output: "", overflow: true },
+  },
+  {
+    name: "on the second separator newline",
+    maxChars: 12,
+    expected: { input: "$ command…", output: "", overflow: true },
+  },
+  {
+    name: "inside the output",
+    maxChars: 15,
+    expected: { input: "$ command", output: "out…", overflow: true },
+  },
+])("keeps the ellipsis with the visible $name", ({ maxChars, expected }) => {
+  expect(collapseToolOutputParts("$ command", "output", 10, maxChars)).toEqual(expected)
 })


### PR DESCRIPTION
## What

Keep shell output aligned while a command is running and after it settles.

The running shell card previously passed the command and multiline output through one `Spinner`, so every output line inherited the spinner's two-column prefix. When the call completed, the spinner disappeared and the same output jumped left.

## Before / After

**Before:** streamed output was indented beneath the running command, then shifted left when the shell call succeeded or failed.

```text
⠋ deploy production
  Connecting to deployment target...
  Running preflight checks...
```

**After:** only the command line owns the spinner. Streamed output is a separate muted block, so its left edge remains fixed through running, failure, retry, and success states.

```text
⠋ deploy production
Connecting to deployment target...
Running preflight checks...
```

## How

- `packages/tui/src/routes/session/index.tsx` renders the visible command and output as separate nodes.
- `packages/tui/src/util/collapse-tool-output.ts` preserves that boundary while applying the existing shared line and character budget.
- Truncation keeps the ellipsis with the visible command when the cut lands inside the command or its separator, avoiding a spurious output row.
- Expanded background output remains separate from the collapsed preview path.

## Scope

This does not change the footer's path/action width allocation. That layout issue is handled separately in #37180.

## Testing

- `bun run typecheck` in `packages/tui`
- `bun run test test/cli/tui/inline-tool-wrap-snapshot.test.tsx test/cli/tui/collapse-tool-output.test.ts` (17 tests, 2 snapshots)
- `bun run lint packages/tui/src/routes/session/index.tsx packages/tui/src/util/collapse-tool-output.ts packages/tui/test/cli/tui/collapse-tool-output.test.ts` (0 errors; existing route warnings remain)
- Full repository pre-push typecheck (32 packages)
- End-to-end OpenCode Drive recording against rebased commit `7d911b824d`, with two Effect-native simulated `shell` calls: a streamed failure followed by a streamed success

## Demo

The screenshot captures the first call while it is still running. The spinner prefixes only the command; both streamed output lines begin at the card's stable left edge.

![Streaming shell output aligned independently from the command spinner](https://github.com/user-attachments/assets/02bd8823-a1cd-47b6-9d24-2ed547cd924c)

The recording exercises the production simulation protocol, tool registry, session events, shell component, failure UI, retry turn, and recording pipeline. Tool execution is deterministic and simulated by Drive; no deployment command runs.

https://github.com/user-attachments/assets/d36c688f-0b05-4061-a5f5-95fb4561af51
