### PR TITLE
fix(tui): preserve prompt footer actions

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1556,101 +1556,113 @@ export function Prompt(props: PromptProps) {
           />
         </box>
         <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
-          <Switch>
-            <Match when={status() === "running"}>
-              <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
-                <box marginLeft={1}>
-                  <Show when={config.animations ?? true} fallback={<text fg={themeV2.text.subdued()}>[⋯]</text>}>
-                    <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
-                  </Show>
-                </box>
-                <text fg={store.interrupt > 0 ? themeV2.background.action() : themeV2.text()}>
-                  esc{" "}
-                  <span
-                    style={{
-                      fg: store.interrupt > 0 ? themeV2.background.action() : themeV2.text.subdued(),
-                    }}
-                  >
-                    {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
-                  </span>
-                </text>
-              </box>
-            </Match>
-            <Match when={move.progress()}>
-              {(progress) => (
-                <box paddingLeft={3}>
-                  <Spinner color={themeV2.hue.accent(500)}>
-                    {progress()}
-                    <span style={{ fg: themeV2.text.subdued() }}>{".".repeat(move.creatingDots())}</span>
-                  </Spinner>
-                </box>
-              )}
-            </Match>
-            <Match when={move.pendingNew()}>
-              <box paddingLeft={3}>
-                <text fg={themeV2.hue.accent(500)}>(new working copy)</text>
-              </box>
-            </Match>
-            <Match when={true}>
-              <Show when={!props.hint && locationLabel()} fallback={props.hint ?? <text />}>
-                {(location) => (
-                  <text fg={themeV2.text.subdued()} wrapMode="none" truncate flexGrow={1} flexShrink={1}>
-                    {location()}
-                  </text>
-                )}
-              </Show>
-            </Match>
-          </Switch>
-          <box gap={2} flexDirection="row" flexShrink={0}>
-            <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
-              {(file) => (
-                <text fg={editorContextLabelState() === "pending" ? themeV2.hue.accent(500) : themeV2.text.subdued()}>
-                  {file()}
-                </text>
-              )}
-            </Show>
+          <box flexGrow={1} flexShrink={1} minWidth={0}>
             <Switch>
-              <Match when={store.mode === "normal"}>
-                <Switch>
-                  <Match when={liveWorkStatusVisible() || statusItems().length > 0}>
-                    <text fg={themeV2.text.subdued()} wrapMode="none">
-                      <Show when={liveWorkStatusVisible() && liveWorkShortcut()}>
-                        {(shortcut) => <span style={{ fg: themeV2.text() }}>{shortcut()} </span>}
-                      </Show>
-                      <Show when={subagentStatusLabel()}>
-                        {(label) => <span style={{ fg: themeV2.text.subdued() }}>{label()}</span>}
-                      </Show>
-                      <Show when={subagentStatusLabel() && shellStatusLabel()}>
-                        <span style={{ fg: themeV2.text.subdued() }}> · </span>
-                      </Show>
-                      <Show when={shellStatusLabel()}>
-                        {(label) => <span style={{ fg: themeV2.text.subdued() }}>{label()}</span>}
-                      </Show>
-                      <Show when={liveWorkStatusVisible() && statusItems().length > 0}>
-                        <span style={{ fg: themeV2.text.subdued() }}> · </span>
-                      </Show>
-                      <Show when={statusItems().length > 0}>
-                        <span style={{ fg: themeV2.text.subdued() }}>{statusItems().join(" · ")}</span>
-                      </Show>
-                    </text>
-                  </Match>
-                  <Match when={true}>
-                    <text fg={themeV2.text()}>
-                      {agentShortcut()} <span style={{ fg: themeV2.text.subdued() }}>agents</span>
-                    </text>
-                  </Match>
-                </Switch>
-                <text fg={themeV2.text()}>
-                  {paletteShortcut()} <span style={{ fg: themeV2.text.subdued() }}>commands</span>
-                </text>
+              <Match when={status() === "running"}>
+                <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">
+                  <box marginLeft={1}>
+                    <Show when={config.animations ?? true} fallback={<text fg={themeV2.text.subdued()}>[⋯]</text>}>
+                      <spinner color={spinnerDef().color} frames={spinnerDef().frames} interval={40} />
+                    </Show>
+                  </box>
+                  <text
+                    fg={store.interrupt > 0 ? themeV2.background.action() : themeV2.text()}
+                    wrapMode="none"
+                    truncate
+                    flexShrink={1}
+                  >
+                    esc{" "}
+                    <span
+                      style={{
+                        fg: store.interrupt > 0 ? themeV2.background.action() : themeV2.text.subdued(),
+                      }}
+                    >
+                      {store.interrupt > 0 ? "again to interrupt" : "interrupt"}
+                    </span>
+                  </text>
+                </box>
               </Match>
-              <Match when={store.mode === "shell"}>
-                <text fg={themeV2.text()}>
-                  esc <span style={{ fg: themeV2.text.subdued() }}>exit shell mode</span>
-                </text>
+              <Match when={move.progress()}>
+                {(progress) => (
+                  <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
+                    <Spinner color={themeV2.hue.accent(500)}>
+                      {progress()}
+                      <span style={{ fg: themeV2.text.subdued() }}>{".".repeat(move.creatingDots())}</span>
+                    </Spinner>
+                  </box>
+                )}
+              </Match>
+              <Match when={move.pendingNew()}>
+                <box paddingLeft={3} height={1} minHeight={0} flexShrink={1}>
+                  <text fg={themeV2.hue.accent(500)} wrapMode="none" truncate>
+                    (new working copy)
+                  </text>
+                </box>
+              </Match>
+              <Match when={true}>
+                <Show when={!props.hint && locationLabel()} fallback={props.hint ?? <text />}>
+                  {(location) => (
+                    <text fg={themeV2.text.subdued()} wrapMode="none" truncate flexGrow={1} flexShrink={1}>
+                      {location()}
+                    </text>
+                  )}
+                </Show>
               </Match>
             </Switch>
           </box>
+          <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
+            {(file) => (
+              <text
+                wrapMode="none"
+                truncate
+                flexShrink={1}
+                fg={editorContextLabelState() === "pending" ? themeV2.hue.accent(500) : themeV2.text.subdued()}
+              >
+                {file()}
+              </text>
+            )}
+          </Show>
+          <Switch>
+            <Match when={store.mode === "normal"}>
+              <Switch>
+                <Match when={liveWorkStatusVisible() || statusItems().length > 0}>
+                  <text fg={themeV2.text.subdued()} wrapMode="none" truncate flexShrink={1}>
+                    <Show when={liveWorkStatusVisible() && liveWorkShortcut()}>
+                      {(shortcut) => <span style={{ fg: themeV2.text() }}>{shortcut()} </span>}
+                    </Show>
+                    <Show when={subagentStatusLabel()}>
+                      {(label) => <span style={{ fg: themeV2.text.subdued() }}>{label()}</span>}
+                    </Show>
+                    <Show when={subagentStatusLabel() && shellStatusLabel()}>
+                      <span style={{ fg: themeV2.text.subdued() }}> · </span>
+                    </Show>
+                    <Show when={shellStatusLabel()}>
+                      {(label) => <span style={{ fg: themeV2.text.subdued() }}>{label()}</span>}
+                    </Show>
+                    <Show when={liveWorkStatusVisible() && statusItems().length > 0}>
+                      <span style={{ fg: themeV2.text.subdued() }}> · </span>
+                    </Show>
+                    <Show when={statusItems().length > 0}>
+                      <span style={{ fg: themeV2.text.subdued() }}>{statusItems().join(" · ")}</span>
+                    </Show>
+                  </text>
+                </Match>
+                <Match when={true}>
+                  <text fg={themeV2.text()} flexShrink={0}>
+                    {agentShortcut()} <span style={{ fg: themeV2.text.subdued() }}>agents</span>
+                  </text>
+                </Match>
+              </Switch>
+              <text fg={themeV2.text()} flexShrink={0}>
+                {paletteShortcut()} <span style={{ fg: themeV2.text.subdued() }}>commands</span>
+              </text>
+            </Match>
+            <Match when={store.mode === "shell"}>
+              <text fg={themeV2.text()} flexShrink={0}>
+                esc <span style={{ fg: themeV2.text.subdued() }}>exit shell mode</span>
+              </text>
+            </Match>
+          </Switch>
         </box>
       </box>
       <Autocomplete

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1601,7 +1601,7 @@ export function Prompt(props: PromptProps) {
               </Show>
             </Match>
           </Switch>
-          <box gap={2} flexDirection="row">
+          <box gap={2} flexDirection="row" flexShrink={0}>
             <Show when={editorContextLabelState() !== "none" ? editorFileLabelDisplay() : undefined}>
               {(file) => (
                 <text fg={editorContextLabelState() === "pending" ? themeV2.hue.accent(500) : themeV2.text.subdued()}>

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1555,7 +1555,7 @@ export function Prompt(props: PromptProps) {
             }
           />
         </box>
-        <box width="100%" flexDirection="row" justifyContent="space-between">
+        <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
           <Switch>
             <Match when={status() === "running"}>
               <box flexDirection="row" gap={1} flexGrow={1} justifyContent="flex-start">


### PR DESCRIPTION
## What

Keep prompt footer actions readable when the current directory or transient metadata is long.

## Before / After

**Before:** the directory label and right-side action group both participated in shrinking. At narrow widths, `tab agents` and `ctrl+p commands` were compressed into stacked or clipped text while the path retained more space.

**After:** the persistent actions keep their intrinsic width. The directory, editor context, dynamic work status, and transient left-side labels remain single-line shrink targets, and the path yields two columns before the first action.

## How

- `packages/tui/src/component/prompt/index.tsx` gives the footer an explicit `gap={2}`.
- An always-growing, shrinkable left region consumes surplus width and truncates running, move, and location labels on one line.
- Optional editor and dynamic work metadata remain independently shrinkable.
- Only persistent action labels (`agents`, `commands`, and shell exit) use `flexShrink={0}`.

## Scope

This is intentionally separate from #37178, which fixes streamed shell output alignment. The footer issue was discovered while reviewing that PR's OpenCode Drive recording.

## Testing

- `bun run typecheck` in `packages/tui`
- `bun run test test/cli/tui/form.test.tsx test/prompt/display.test.ts` (3 tests)
- `bun run lint packages/tui/src/component/prompt/index.tsx` (0 errors; existing file warnings remain)
- Full repository pre-push typecheck (32 packages)
- Repeated `simplify` review across idle, running, move, editor-context, dynamic-status, and shell-mode states
- OpenCode Drive screenshot at the original 100-column reproduction width

## Demo

The long isolated project path truncates with a visible two-column gap before `tab agents`, while both persistent action labels remain complete on one line.

![footer actions remain readable while the path truncates](https://github.com/user-attachments/assets/2617073d-627e-413b-8eba-866316bdf915)
