### PR TITLE
feat(plugin): support dynamic Effect tools

### DIFF
--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -317,6 +317,13 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: PluginV2.Int
               add: (name, tool, options) => {
                 registrations.push({ name, tool, ...(options ? { options } : {}) })
               },
+              addDynamic: (name, config, options) => {
+                registrations.push({
+                  name,
+                  tool: Tool.make(config),
+                  ...(options ? { options } : {}),
+                })
+              },
             }),
           )
           yield* Effect.forEach(

--- a/packages/core/test/lib/tool.ts
+++ b/packages/core/test/lib/tool.ts
@@ -59,6 +59,9 @@ export const registerToolPlugin = <R>(plugin: {
               add: (name, tool, options) => {
                 registrations.push({ name, tool, ...(options ? { options } : {}) })
               },
+              addDynamic: (name, config, options) => {
+                registrations.push({ name, tool: Tool.make(config), ...(options ? { options } : {}) })
+              },
             })
             yield* Effect.forEach(
               registrations,

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -274,6 +274,42 @@ describe("PluginV2", () => {
     }),
   )
 
+  it.effect("registers dynamic Effect tools through the host context", () =>
+    Effect.gen(function* () {
+      const plugins = yield* PluginV2.Service
+      const registry = yield* ToolRegistry.Service
+      const plugin = EffectPlugin.define({
+        id: "dynamic-tool-plugin",
+        effect: (ctx) =>
+          ctx.tool
+            .transform((draft) =>
+              draft.addDynamic(
+                "dynamic_tool",
+                {
+                  description: "Dynamic plugin tool",
+                  jsonSchema: {
+                    type: "object",
+                    properties: { value: { type: "string" } },
+                    required: ["value"],
+                    additionalProperties: false,
+                  },
+                  execute: (input) =>
+                    Effect.succeed({
+                      structured: input,
+                      content: [{ type: "text", text: "dynamic output" }],
+                    }),
+                },
+                { codemode: false },
+              ),
+            )
+            .pipe(Effect.orDie),
+      })
+
+      yield* plugins.activate([versioned(plugin)])
+      expect((yield* registry.materialize()).definitions.map((tool) => tool.name)).toContain("dynamic_tool")
+    }),
+  )
+
   it.effect("groups tool names and routes codemode registrations through execute", () =>
     Effect.gen(function* () {
       const plugins = yield* PluginV2.Service

--- a/packages/plugin/src/v2/effect/tool.ts
+++ b/packages/plugin/src/v2/effect/tool.ts
@@ -103,7 +103,7 @@ export type DynamicOutput = {
  * time (MCP servers, plugin manifests). Input is passed through as `unknown`;
  * `execute` returns the already-projected structured value and model content.
  */
-type DynamicConfig = {
+export type DynamicConfig = {
   readonly description: string
   readonly jsonSchema: JsonSchema.JsonSchema
   readonly outputSchema?: JsonSchema.JsonSchema
@@ -284,6 +284,8 @@ export interface RegisterOptions {
 
 export interface ToolDraft {
   add(name: string, tool: AnyTool, options?: RegisterOptions): void
+  /** Registers a dynamic Effect tool without importing the host's Tool module. */
+  addDynamic(name: string, config: DynamicConfig, options?: RegisterOptions): void
 }
 
 export interface ToolHooks {


### PR DESCRIPTION
## What

Allow external V2 Effect plugins to register dynamic tools without importing the host's opaque `Tool.make` instance.

## Before / After

**Before:** `ctx.tool.transform` accepted only `Tool.AnyTool`. External Effect plugins had to import the exact in-process `@opencode-ai/plugin` module because tool runtimes are backed by a module-local `WeakMap`. A separately resolved package copy produced an incompatible opaque tool.

**After:** the host context exposes `draft.addDynamic(name, config, options)`. Plugins provide a structural JSON Schema and Effect executor; OpenCode calls its canonical `Tool.make` inside the host.

```ts
ctx.tool.transform((draft) =>
  draft.addDynamic("lookup", {
    description: "Lookup a value",
    jsonSchema: { type: "object", properties: {}, additionalProperties: false },
    execute: () => Effect.succeed({
      structured: {},
      content: [{ type: "text", text: "result" }],
    }),
  }),
)
```

## How

- Exports the existing dynamic Effect tool configuration type.
- Adds `ToolDraft.addDynamic` to the public Effect plugin domain.
- Converts the structural definition with host-owned `Tool.make` before registry registration.
- Leaves existing opaque typed-tool registration unchanged.

## Testing

- `bun run test test/plugin.test.ts` in `packages/core` (12 tests)
- `bun run typecheck` in `packages/core`
- `bun run typecheck` in `packages/plugin`
- Full pre-push monorepo typecheck (32 packages)
