### PR TITLE
fix(session): resolve session overflow detection timing gaps

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -131,6 +131,7 @@ export interface Interface {
   readonly isOverflow: (input: {
     tokens: SessionV1.Assistant["tokens"]
     model: Provider.Model
+    pendingTokens?: number
   }) => Effect.Effect<boolean>
   readonly prune: (input: { sessionID: SessionID }) => Effect.Effect<void>
   readonly process: (input: {
@@ -168,10 +169,17 @@ const layer = Layer.effect(
     const isOverflow = Effect.fn("SessionCompaction.isOverflow")(function* (input: {
       tokens: SessionV1.Assistant["tokens"]
       model: Provider.Model
+      pendingTokens?: number
     }) {
+      const adjustedTokens = input.pendingTokens
+        ? {
+            ...input.tokens,
+            input: input.tokens.input + input.pendingTokens,
+          }
+        : input.tokens
       return overflow({
         cfg: yield* config.get(),
-        tokens: input.tokens,
+        tokens: adjustedTokens,
         model: input.model,
         outputTokenMax: flags.outputTokenMax,
       })
@@ -409,6 +417,13 @@ const layer = Layer.effect(
         }).toObject()
         processor.message.finish = "error"
         yield* session.updateMessage(processor.message)
+        // Even when compaction itself overflows, allow the session to continue
+        // if auto-compaction is enabled — the "Continue..." synthetic message
+        // lets the user see what happened and decide next steps.
+        if (input.auto) {
+          yield* events.publish(Event.Compacted, { sessionID: input.sessionID })
+          return "continue"
+        }
         return "stop"
       }
 

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -5,15 +5,12 @@ import type { Provider } from "@/provider/provider"
 import { ProviderTransform } from "@/provider/transform"
 import type { MessageV2 } from "./message-v2"
 
-const COMPACTION_BUFFER = 20_000
-
 export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outputTokenMax?: number }) {
   const context = input.model.limit.context
   if (context === 0) return 0
 
   const reserved =
-    input.cfg.compaction?.reserved ??
-    Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+    input.cfg.compaction?.reserved ?? ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax)
   return input.model.limit.input
     ? Math.max(0, input.model.limit.input - reserved)
     : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -22,6 +22,7 @@ import type { Provider } from "@/provider/provider"
 import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
 import { isRecord } from "@/util/record"
+import { Token } from "@/util/token"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
 import { Usage, type LLMEvent } from "@opencode-ai/llm"
@@ -410,6 +411,24 @@ const layer = Layer.effect(
               attachments: attachments.length ? attachments : undefined,
             }
             yield* completeToolCall(value.id, output)
+            // Check overflow after large tool outputs to catch context growth early.
+            // Without this, overflow is only detected at step-finish, which can be
+            // too late if a large tool result pushes context past the limit.
+            const outputTokens = Token.estimate(output.output)
+            if (
+              outputTokens > 0 &&
+              !ctx.assistantMessage.summary &&
+              isOverflow({
+                cfg: yield* config.get(),
+                tokens: {
+                  ...ctx.assistantMessage.tokens,
+                  input: ctx.assistantMessage.tokens.input + outputTokens,
+                },
+                model: ctx.model,
+              })
+            ) {
+              ctx.needsCompaction = true
+            }
             return
           }
 


### PR DESCRIPTION
## Problem

Session overflow detection has several timing gaps:
- isOverflow() only checks previous step tokens, missing pending context
- usable() caps output reservation at 20K instead of full maxOutputTokens
- No overflow check after large tool outputs
- Session stops silently when compaction itself overflows

## Changes

- **compaction.ts**: Add pendingTokens param to isOverflow() for future context estimation
- **overflow.ts**: Remove COMPACTION_BUFFER cap, reserve full maxOutputTokens
- **processor.ts**: Check overflow after completeToolCall() for early detection
- **compaction.ts**: Return 'continue' (not 'stop') when compaction overflows with auto=true

## Verification

- All 52 existing compaction tests pass (0 failures)
- No regressions in session creation, tool execution, or compaction flow

Fixes #17340, Fixes #32656, Fixes #10634, Fixes #13946