### PR TITLE
fix(plugin): make tool values structural

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -724,6 +724,7 @@
         "@opencode-ai/client": "workspace:*",
         "@opencode-ai/schema": "workspace:*",
         "@opencode-ai/sdk": "workspace:*",
+        "@standard-schema/spec": "^1.1.0",
         "effect": "catalog:",
         "zod": "catalog:",
       },
@@ -3008,7 +3009,7 @@
 
     "@standard-community/standard-openapi": ["@standard-community/standard-openapi@0.2.9", "", { "peerDependencies": { "@standard-community/standard-json": "^0.3.5", "@standard-schema/spec": "^1.0.0", "arktype": "^2.1.20", "effect": "^3.17.14", "openapi-types": "^12.1.3", "sury": "^10.0.0", "typebox": "^1.0.0", "valibot": "^1.1.0", "zod": "^3.25.0 || ^4.0.0", "zod-openapi": "^4" }, "optionalPeers": ["arktype", "effect", "sury", "typebox", "valibot", "zod", "zod-openapi"] }, "sha512-htj+yldvN1XncyZi4rehbf9kLbu8os2Ke/rfqoZHCMHuw34kiF3LP/yQPdA0tQ940y8nDq3Iou8R3wG+AGGyvg=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@stoplight/better-ajv-errors": ["@stoplight/better-ajv-errors@1.0.3", "", { "dependencies": { "jsonpointer": "^5.0.0", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-0p9uXkuB22qGdNfy3VeEhxkU5uwvp/KrBTAbrLBURv6ilxIVwanKwjMc41lQfIVgPGcOkmLbTolfFrSsueu7zA=="],
 
@@ -6392,8 +6393,6 @@
 
     "@ai-sdk/perplexity/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
-    "@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@ai-sdk/togetherai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
 
     "@ai-sdk/vercel/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.21", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw=="],
@@ -6609,6 +6608,8 @@
     "@hey-api/openapi-ts/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
     "@hey-api/openapi-ts/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "@hono/standard-validator/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
@@ -7332,8 +7333,6 @@
 
     "editorconfig/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
-    "effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "electron-builder/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "electron-builder/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -7393,8 +7392,6 @@
     "fumadocs-core/js-yaml": ["js-yaml@5.2.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.mjs" } }, "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw=="],
 
     "fumadocs-core/shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
-
-    "fumadocs-mdx/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "fumadocs-mdx/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -7533,6 +7530,8 @@
     "opencode/@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@2.0.41", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-kNAGINk71AlOXx10Dq/PXw4t/9XjdK8uxfpVElRwtSFMdeSiLVt58p9TPx4/FJD+hxZuVhvxYj9r42osxWq79g=="],
 
     "opencode/@solid-primitives/scheduled": ["@solid-primitives/scheduled@1.5.2", "", { "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-/j2igE0xyNaHhj6kMfcUQn5rAVSTLbAX+CDEBm25hSNBmNiHLu2lM7Usj2kJJ5j36D67bE8wR1hBNA8hjtvsQA=="],
+
+    "opencode/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "opencode/minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
 
@@ -7739,46 +7738,6 @@
     "@actions/github/@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
 
     "@actions/github/@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
-
-    "@ai-sdk/amazon-bedrock/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/anthropic/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/azure/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/cerebras/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/cohere/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/deepgram/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/deepinfra/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/deepseek/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/elevenlabs/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/fireworks/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/google-vertex/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/google/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/groq/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/mistral/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/openai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/perplexity/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/togetherai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/vercel/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@ai-sdk/xai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@astrojs/check/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -8382,10 +8341,6 @@
 
     "@solidjs/start/shiki/@shikijs/types": ["@shikijs/types@1.29.2", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw=="],
 
-    "@standard-community/standard-json/effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "@standard-community/standard-openapi/effect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@stoplight/spectral-core/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
     "@storybook/addon-docs/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
@@ -8850,10 +8805,6 @@
 
     "venice-ai-sdk-provider/@ai-sdk/provider-utils/@ai-sdk/provider": ["@ai-sdk/provider@3.0.12", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-sj9DWTJ2Ze0WR9qsiOPqoqzNx3OxL6iMxHImbhvoe9qOspekbzxNDMiJ4TIGfYHYh9w4OmBjz3prvqhzTi96+Q=="],
 
-    "venice-ai-sdk-provider/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "vitest/@vitest/expect/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
@@ -9118,8 +9069,6 @@
 
     "@octokit/rest/@octokit/core/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 
-    "@opencode-ai/core/@ai-sdk/openai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@opencode-ai/desktop/@actions/artifact/@actions/http-client/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "@opencode-ai/www/@cloudflare/vite-plugin/@cloudflare/unenv-preset/workerd": ["workerd@1.20260708.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260708.1", "@cloudflare/workerd-darwin-arm64": "1.20260708.1", "@cloudflare/workerd-linux-64": "1.20260708.1", "@cloudflare/workerd-linux-arm64": "1.20260708.1", "@cloudflare/workerd-windows-64": "1.20260708.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w=="],
@@ -9301,14 +9250,6 @@
     "@vitejs/plugin-react/vite/lightningcss/lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "@vitejs/plugin-react/vite/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
-
-    "ai-gateway-provider/@ai-sdk/amazon-bedrock/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "ai-gateway-provider/@ai-sdk/anthropic/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "ai-gateway-provider/@ai-sdk/azure/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
-    "ai-gateway-provider/@ai-sdk/deepseek/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/core/src/tool/AGENTS.md
+++ b/packages/core/src/tool/AGENTS.md
@@ -4,7 +4,7 @@ This folder owns Core's one local tool representation, process and Location regi
 
 ## Representations
 
-- `tool.ts` defines the opaque canonical `Tool.make({ description, input, output, execute, toModelOutput })` value. Shipped built-ins and plugin tools use the same type.
+- `tool.ts` defines the structural canonical `Tool.make({ description, input, output, execute, toModelOutput })` declaration. Shipped built-ins and plugin tools use the same type.
 - `tools.ts` exposes the registration-only `Tools.Service` view used by Location producers.
 - `registry.ts` stores only canonical Location registrations, derives definitions, invokes tools, and applies generic output bounding.
 
@@ -12,7 +12,7 @@ Do not add a second executable entry type, registry-owned executor, authorizatio
 
 ## Construction
 
-Tool schemas and projection use `input` and `output` terminology. A tool value is opaque: its codecs, executor, definition derivation, and catalog permission declaration are private runtime details.
+Tool schemas and projection use `input` and `output` terminology. A tool value carries its schemas, executor, projection, and optional catalog permission directly so separately loaded plugin package instances can exchange it structurally.
 
 Location-scoped built-in layers acquire `PermissionV2.Service` and every other required Location service while the layer is constructed. The executor captures those services. Permission sources are always constructed from the canonical invocation context:
 

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -107,17 +107,6 @@ describe("ToolRegistry", () => {
     }),
   )
 
-  it.effect("reuses model definitions across requests", () =>
-    Effect.gen(function* () {
-      const service = yield* ToolRegistry.Service
-      yield* service.register({ echo: make() }, { codemode: false })
-      const first = yield* toolDefinitions(service)
-      const second = yield* toolDefinitions(service)
-
-      expect(second[0]).toBe(first[0])
-    }),
-  )
-
   it.effect("removes a scoped registration", () =>
     Effect.gen(function* () {
       const service = yield* ToolRegistry.Service

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -29,6 +29,7 @@
     "@opencode-ai/client": "workspace:*",
     "@opencode-ai/schema": "workspace:*",
     "@opencode-ai/sdk": "workspace:*",
+    "@standard-schema/spec": "^1.1.0",
     "effect": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/plugin/src/v2/effect/tool.ts
+++ b/packages/plugin/src/v2/effect/tool.ts
@@ -90,8 +90,8 @@ export type Content =
 
 export type Definition<
   Input extends SchemaType<any>,
-  Output extends SchemaType<any>,
-  Structured extends SchemaType<any> = Output,
+  Structured extends SchemaType<any>,
+  Output extends SchemaType<any> = any,
 > = {
   readonly description: string
   readonly input: Input
@@ -127,13 +127,13 @@ export type DynamicDefinition = {
   readonly execute: (input: unknown, context: Context) => Effect.Effect<DynamicOutput, Failure>
 }
 
-export type AnyTool = Definition<any, any, any> | DynamicDefinition
+export type AnyTool = Definition<any, any> | DynamicDefinition
 
 export function make<
   Input extends SchemaType<any>,
   Output extends SchemaType<any>,
   Structured extends SchemaType<any> = Output,
->(config: Definition<Input, Output, Structured>): Definition<Input, Output, Structured>
+>(config: Definition<Input, Structured, Output>): Definition<Input, Structured, Output>
 export function make(config: DynamicDefinition): DynamicDefinition
 export function make(config: AnyTool): AnyTool
 export function make(config: AnyTool): AnyTool {

--- a/packages/plugin/src/v2/effect/tool.ts
+++ b/packages/plugin/src/v2/effect/tool.ts
@@ -186,34 +186,27 @@ export const definition = (name: string, tool: AnyTool): ToolDefinition =>
         outputSchema: outputJsonSchema(tool.structured ?? tool.output),
       }
 
-export const settle = (tool: AnyTool, call: ToolCall, context: Context): Effect.Effect<ToolOutput, Failure> => {
-  if ("jsonSchema" in tool)
-    return tool
-      .execute(call.input, context)
-      .pipe(Effect.map((output) => ({ structured: output.structured, content: output.content.map(toModelContent) })))
-  return decodeInput(tool.input, call.input).pipe(
-    Effect.flatMap((input) =>
-      tool.execute(input, context).pipe(
-        Effect.flatMap((value) =>
-          encodeOutput(tool.output, value).pipe(
-            Effect.flatMap((output) => {
-              if (!tool.structured || !tool.toStructuredOutput) return Effect.succeed({ output, structured: output })
-              return encodeOutput(tool.structured, tool.toStructuredOutput({ input, output })).pipe(
-                Effect.map((structured) => ({ output, structured })),
-              )
-            }),
-          ),
-        ),
-        Effect.map(({ output, structured }) => ({
-          structured,
-          content:
-            tool.toModelOutput?.({ input, output }).map(toModelContent) ??
-            (typeof output === "string" ? [{ type: "text" as const, text: output }] : []),
-        })),
-      ),
-    ),
-  )
-}
+export const settle = (tool: AnyTool, call: ToolCall, context: Context): Effect.Effect<ToolOutput, Failure> =>
+  Effect.gen(function* () {
+    if ("jsonSchema" in tool) {
+      const output = yield* tool.execute(call.input, context)
+      return { structured: output.structured, content: output.content.map(toModelContent) }
+    }
+
+    const input = yield* decodeInput(tool.input, call.input)
+    const value = yield* tool.execute(input, context)
+    const output = yield* encodeOutput(tool.output, value)
+    const structured =
+      tool.structured && tool.toStructuredOutput
+        ? yield* encodeOutput(tool.structured, tool.toStructuredOutput({ input, output }))
+        : output
+    return {
+      structured,
+      content:
+        tool.toModelOutput?.({ input, output }).map(toModelContent) ??
+        (typeof output === "string" ? [{ type: "text" as const, text: output }] : []),
+    }
+  })
 
 function decodeInput(schema: SchemaType<any>, value: unknown): Effect.Effect<any, Failure> {
   if (Schema.isSchema(schema))
@@ -234,26 +227,25 @@ function encodeOutput(schema: SchemaType<any>, value: unknown): Effect.Effect<an
 }
 
 function validateStandard(schema: StandardSchemaType, value: unknown, prefix: string): Effect.Effect<unknown, Failure> {
-  const result = Effect.try({
-    try: () => schema["~standard"].validate(value),
-    catch: (error) => new Failure({ message: `${prefix}: ${error instanceof Error ? error.message : String(error)}` }),
+  return Effect.gen(function* () {
+    const pending = yield* Effect.try({
+      try: () => schema["~standard"].validate(value),
+      catch: (error) => standardFailure(prefix, error),
+    })
+    const result =
+      pending instanceof Promise
+        ? yield* Effect.tryPromise({ try: () => pending, catch: (error) => standardFailure(prefix, error) })
+        : pending
+    if (result.issues)
+      return yield* Effect.fail(
+        new Failure({ message: `${prefix}: ${result.issues.map((issue) => issue.message).join(", ")}` }),
+      )
+    return result.value
   })
-  return result.pipe(
-    Effect.flatMap((result) =>
-      result instanceof Promise
-        ? Effect.tryPromise({
-            try: () => result,
-            catch: (error) =>
-              new Failure({ message: `${prefix}: ${error instanceof Error ? error.message : String(error)}` }),
-          })
-        : Effect.succeed(result),
-    ),
-    Effect.flatMap((result) =>
-      result.issues
-        ? Effect.fail(new Failure({ message: `${prefix}: ${result.issues.map((issue) => issue.message).join(", ")}` }))
-        : Effect.succeed(result.value),
-    ),
-  )
+}
+
+function standardFailure(prefix: string, error: unknown) {
+  return new Failure({ message: `${prefix}: ${error instanceof Error ? error.message : String(error)}` })
 }
 
 function inputJsonSchema(schema: SchemaType<any>): JsonSchema.JsonSchema {

--- a/packages/plugin/src/v2/effect/tool.ts
+++ b/packages/plugin/src/v2/effect/tool.ts
@@ -4,7 +4,8 @@ import { Agent } from "@opencode-ai/schema/agent"
 import type { LLM } from "@opencode-ai/schema/llm"
 import { Session } from "@opencode-ai/schema/session"
 import { SessionMessage } from "@opencode-ai/schema/session-message"
-import { Effect, JsonSchema, Schema, type Scope } from "effect"
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
+import { Effect, JsonSchema, Schema } from "effect"
 import type { Hooks, Transform } from "./registration.js"
 
 export interface Context {
@@ -20,7 +21,34 @@ export interface Progress {
   readonly content?: ReadonlyArray<Content>
 }
 
-export type SchemaType<A> = Schema.Codec<A, any>
+export type StandardSchemaType<Input = unknown, Output = Input> = StandardSchemaV1<Input, Output> &
+  StandardJSONSchemaV1<Input, Output>
+export type SchemaType<A> = Schema.Codec<A, any> | StandardSchemaType<any, A>
+type IsAny<A> = 0 extends 1 & A ? true : false
+export type InputValue<S> =
+  IsAny<S> extends true
+    ? any
+    : S extends Schema.Codec<infer A, any>
+      ? A
+      : S extends StandardSchemaV1<any, infer A>
+        ? A
+        : never
+export type OutputValue<S> =
+  IsAny<S> extends true
+    ? any
+    : S extends Schema.Codec<infer A, any>
+      ? A
+      : S extends StandardSchemaV1<infer A, any>
+        ? A
+        : never
+export type EncodedValue<S> =
+  IsAny<S> extends true
+    ? any
+    : S extends Schema.Codec<any, infer A>
+      ? A
+      : S extends StandardSchemaV1<any, infer A>
+        ? A
+        : never
 
 type ToolDefinition = {
   readonly name: string
@@ -45,16 +73,6 @@ type ToolOutput = {
   readonly content: ReadonlyArray<LLM.ToolContent>
 }
 
-declare const TypeId: unique symbol
-
-export interface Definition<Input extends SchemaType<any>, Output extends SchemaType<any>> {
-  readonly [TypeId]: {
-    readonly _Input: Input
-    readonly _Output: Output
-  }
-}
-
-export type AnyTool = Definition<any, any>
 export class Failure extends Schema.TaggedErrorClass<Failure>()("LLM.ToolFailure", {
   message: Schema.String,
   error: Schema.optional(Schema.Defect()),
@@ -70,7 +88,7 @@ export type Content =
   | { readonly type: "text"; readonly text: string }
   | { readonly type: "file"; readonly data: string; readonly mime: string; readonly name?: string }
 
-type Config<
+export type Definition<
   Input extends SchemaType<any>,
   Output extends SchemaType<any>,
   Structured extends SchemaType<any> = Output,
@@ -79,17 +97,15 @@ type Config<
   readonly input: Input
   readonly output: Output
   readonly structured?: Structured
+  readonly permission?: string
   readonly toStructuredOutput?: (input: {
-    readonly input: Schema.Schema.Type<Input>
-    readonly output: Output["Encoded"]
-  }) => Schema.Schema.Type<Structured>
-  readonly execute: (
-    input: Schema.Schema.Type<Input>,
-    context: Context,
-  ) => Effect.Effect<Schema.Schema.Type<Output>, Failure>
+    readonly input: InputValue<Input>
+    readonly output: EncodedValue<Output>
+  }) => OutputValue<Structured>
+  readonly execute: (input: InputValue<Input>, context: Context) => Effect.Effect<OutputValue<Output>, Failure>
   readonly toModelOutput?: (input: {
-    readonly input: Schema.Schema.Type<Input>
-    readonly output: Output["Encoded"]
+    readonly input: InputValue<Input>
+    readonly output: EncodedValue<Output>
   }) => ReadonlyArray<Content>
 }
 
@@ -103,109 +119,25 @@ export type DynamicOutput = {
  * time (MCP servers, plugin manifests). Input is passed through as `unknown`;
  * `execute` returns the already-projected structured value and model content.
  */
-type DynamicConfig = {
+export type DynamicDefinition = {
   readonly description: string
   readonly jsonSchema: JsonSchema.JsonSchema
   readonly outputSchema?: JsonSchema.JsonSchema
+  readonly permission?: string
   readonly execute: (input: unknown, context: Context) => Effect.Effect<DynamicOutput, Failure>
 }
 
-type Runtime = {
-  readonly permission?: string
-  readonly definition: (name: string) => ToolDefinition
-  readonly settle: (call: ToolCall, context: Context) => Effect.Effect<ToolOutput, Failure>
-}
-
-const runtimes = new WeakMap<AnyTool, Runtime>()
+export type AnyTool = Definition<any, any, any> | DynamicDefinition
 
 export function make<
   Input extends SchemaType<any>,
   Output extends SchemaType<any>,
   Structured extends SchemaType<any> = Output,
->(config: Config<Input, Output, Structured>): Definition<Input, Structured>
-export function make(config: DynamicConfig): AnyTool
-export function make(config: Config<any, any, any> | DynamicConfig): AnyTool {
-  if ("jsonSchema" in config) return makeDynamic(config)
-  return makeTyped(config)
-}
-
-function makeTyped<
-  Input extends SchemaType<any>,
-  Output extends SchemaType<any>,
-  Structured extends SchemaType<any> = Output,
->(config: Config<Input, Output, Structured>): Definition<Input, Structured> {
-  const tool = Object.freeze({}) as Definition<Input, Structured>
-  const definitions = new Map<string, ToolDefinition>()
-  runtimes.set(tool, {
-    definition: (name) => {
-      const cached = definitions.get(name)
-      if (cached) return cached
-      const definition: ToolDefinition = {
-        name,
-        description: config.description,
-        inputSchema: toJsonSchema(config.input),
-        outputSchema: toJsonSchema(config.structured ?? config.output),
-      }
-      definitions.set(name, definition)
-      return definition
-    },
-    settle: (call, context) =>
-      Schema.decodeUnknownEffect(config.input)(call.input).pipe(
-        Effect.mapError((error) => new Failure({ message: `Invalid tool input: ${error.message}` })),
-        Effect.flatMap((input) =>
-          config.execute(input, context).pipe(
-            Effect.flatMap((output) =>
-              Schema.encodeEffect(config.output)(output).pipe(
-                Effect.flatMap((output) => {
-                  if (!config.structured || !config.toStructuredOutput)
-                    return Effect.succeed({ output, structured: output })
-                  return Schema.encodeEffect(config.structured)(config.toStructuredOutput({ input, output })).pipe(
-                    Effect.map((structured) => ({ output, structured })),
-                  )
-                }),
-                Effect.mapError(
-                  (error) =>
-                    new Failure({
-                      message: `Tool returned an invalid value for its output schema: ${error.message}`,
-                    }),
-                ),
-              ),
-            ),
-            Effect.map(({ output, structured }) => ({
-              structured,
-              content:
-                config.toModelOutput?.({ input, output }).map(toModelContent) ??
-                (typeof output === "string" ? [{ type: "text" as const, text: output }] : []),
-            })),
-          ),
-        ),
-      ),
-  })
-  return tool
-}
-
-function makeDynamic(config: DynamicConfig): AnyTool {
-  const tool = Object.freeze({}) as AnyTool
-  const definitions = new Map<string, ToolDefinition>()
-  runtimes.set(tool, {
-    definition: (name) => {
-      const cached = definitions.get(name)
-      if (cached) return cached
-      const definition: ToolDefinition = {
-        name,
-        description: config.description,
-        inputSchema: config.jsonSchema,
-        outputSchema: config.outputSchema,
-      }
-      definitions.set(name, definition)
-      return definition
-    },
-    settle: (call, context) =>
-      config
-        .execute(call.input, context)
-        .pipe(Effect.map((output) => ({ structured: output.structured, content: output.content.map(toModelContent) }))),
-  })
-  return tool
+>(config: Definition<Input, Output, Structured>): Definition<Input, Output, Structured>
+export function make(config: DynamicDefinition): DynamicDefinition
+export function make(config: AnyTool): AnyTool
+export function make(config: AnyTool): AnyTool {
+  return config
 }
 
 function toModelContent(part: Content) {
@@ -230,23 +162,110 @@ export const registrationEntries = (tools: Readonly<Record<string, AnyTool>>, gr
     }
   })
 
-export const withPermission = <Input extends SchemaType<any>, Output extends SchemaType<any>>(
-  tool: Definition<Input, Output>,
+export const withPermission = <T extends AnyTool>(
+  tool: T,
   permission: string,
-) => {
-  const decorated = Object.freeze({}) as Definition<Input, Output>
-  runtimes.set(decorated, { ...runtimeOf(tool), permission })
-  return decorated
+): Omit<T, "permission"> & {
+  readonly permission: string
+} => ({ ...tool, permission })
+
+export const permission = (tool: AnyTool, name: string) => tool.permission ?? name
+
+export const definition = (name: string, tool: AnyTool): ToolDefinition =>
+  "jsonSchema" in tool
+    ? {
+        name,
+        description: tool.description,
+        inputSchema: tool.jsonSchema,
+        outputSchema: tool.outputSchema,
+      }
+    : {
+        name,
+        description: tool.description,
+        inputSchema: inputJsonSchema(tool.input),
+        outputSchema: outputJsonSchema(tool.structured ?? tool.output),
+      }
+
+export const settle = (tool: AnyTool, call: ToolCall, context: Context): Effect.Effect<ToolOutput, Failure> => {
+  if ("jsonSchema" in tool)
+    return tool
+      .execute(call.input, context)
+      .pipe(Effect.map((output) => ({ structured: output.structured, content: output.content.map(toModelContent) })))
+  return decodeInput(tool.input, call.input).pipe(
+    Effect.flatMap((input) =>
+      tool.execute(input, context).pipe(
+        Effect.flatMap((value) =>
+          encodeOutput(tool.output, value).pipe(
+            Effect.flatMap((output) => {
+              if (!tool.structured || !tool.toStructuredOutput) return Effect.succeed({ output, structured: output })
+              return encodeOutput(tool.structured, tool.toStructuredOutput({ input, output })).pipe(
+                Effect.map((structured) => ({ output, structured })),
+              )
+            }),
+          ),
+        ),
+        Effect.map(({ output, structured }) => ({
+          structured,
+          content:
+            tool.toModelOutput?.({ input, output }).map(toModelContent) ??
+            (typeof output === "string" ? [{ type: "text" as const, text: output }] : []),
+        })),
+      ),
+    ),
+  )
 }
 
-export const permission = (tool: AnyTool, name: string) => runtimeOf(tool).permission ?? name
-export const definition = (name: string, tool: AnyTool) => runtimeOf(tool).definition(name)
-export const settle = (tool: AnyTool, call: ToolCall, context: Context) => runtimeOf(tool).settle(call, context)
+function decodeInput(schema: SchemaType<any>, value: unknown): Effect.Effect<any, Failure> {
+  if (Schema.isSchema(schema))
+    return Schema.decodeUnknownEffect(schema)(value).pipe(
+      Effect.mapError((error) => new Failure({ message: `Invalid tool input: ${error.message}` })),
+    )
+  return validateStandard(schema, value, "Invalid tool input")
+}
 
-function runtimeOf(tool: AnyTool) {
-  const runtime = runtimes.get(tool)
-  if (!runtime) throw new TypeError("Invalid Tool value")
-  return runtime
+function encodeOutput(schema: SchemaType<any>, value: unknown): Effect.Effect<any, Failure> {
+  if (Schema.isSchema(schema))
+    return Schema.encodeEffect(schema)(value).pipe(
+      Effect.mapError(
+        (error) => new Failure({ message: `Tool returned an invalid value for its output schema: ${error.message}` }),
+      ),
+    )
+  return validateStandard(schema, value, "Tool returned an invalid value for its output schema")
+}
+
+function validateStandard(schema: StandardSchemaType, value: unknown, prefix: string): Effect.Effect<unknown, Failure> {
+  const result = Effect.try({
+    try: () => schema["~standard"].validate(value),
+    catch: (error) => new Failure({ message: `${prefix}: ${error instanceof Error ? error.message : String(error)}` }),
+  })
+  return result.pipe(
+    Effect.flatMap((result) =>
+      result instanceof Promise
+        ? Effect.tryPromise({
+            try: () => result,
+            catch: (error) =>
+              new Failure({ message: `${prefix}: ${error instanceof Error ? error.message : String(error)}` }),
+          })
+        : Effect.succeed(result),
+    ),
+    Effect.flatMap((result) =>
+      result.issues
+        ? Effect.fail(new Failure({ message: `${prefix}: ${result.issues.map((issue) => issue.message).join(", ")}` }))
+        : Effect.succeed(result.value),
+    ),
+  )
+}
+
+function inputJsonSchema(schema: SchemaType<any>): JsonSchema.JsonSchema {
+  if (!Schema.isSchema(schema))
+    return schema["~standard"].jsonSchema.input({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
+  return toJsonSchema(schema)
+}
+
+function outputJsonSchema(schema: SchemaType<any>): JsonSchema.JsonSchema {
+  if (!Schema.isSchema(schema))
+    return schema["~standard"].jsonSchema.output({ target: "draft-2020-12" }) as JsonSchema.JsonSchema
+  return toJsonSchema(schema)
 }
 
 function toJsonSchema(schema: Schema.Top): JsonSchema.JsonSchema {

--- a/packages/plugin/src/v2/promise/tool.ts
+++ b/packages/plugin/src/v2/promise/tool.ts
@@ -1,8 +1,4 @@
 import type { Tool } from "../effect/tool.js"
-import type { Agent } from "@opencode-ai/schema/agent"
-import type { Session } from "@opencode-ai/schema/session"
-import type { SessionMessage } from "@opencode-ai/schema/session-message"
-import type { JsonSchema, Schema } from "effect"
 import type { Hooks, Transform } from "./registration.js"
 
 export type Context = Omit<Tool.Context, "progress"> & {
@@ -16,71 +12,28 @@ export type Definition<
   Input extends SchemaType<any>,
   Output extends SchemaType<any>,
   Structured extends SchemaType<any> = Output,
-> = {
+> = Omit<Tool.Definition<Input, Output, Structured>, "execute" | "permission"> & {
   readonly name: string
   readonly options?: RegisterOptions
-  readonly description: string
-  readonly input: Input
-  readonly output: Output
-  readonly structured?: Structured
-  readonly toStructuredOutput?: (input: {
-    readonly input: Schema.Schema.Type<Input>
-    readonly output: Output["Encoded"]
-  }) => Schema.Schema.Type<Structured>
-  readonly execute: (
-    input: Schema.Schema.Type<Input>,
-    context: Context,
-  ) => Promise<Schema.Schema.Type<Output>>
-  readonly toModelOutput?: (input: {
-    readonly input: Schema.Schema.Type<Input>
-    readonly output: Output["Encoded"]
-  }) => ReadonlyArray<Content>
+  readonly execute: (input: Tool.InputValue<Input>, context: Context) => Promise<Tool.OutputValue<Output>>
 }
 
-export type DynamicDefinition = {
+export type DynamicDefinition = Omit<Tool.DynamicDefinition, "execute" | "permission"> & {
   readonly name: string
   readonly options?: RegisterOptions
-  readonly description: string
-  readonly jsonSchema: JsonSchema.JsonSchema
-  readonly outputSchema?: JsonSchema.JsonSchema
   readonly execute: (input: unknown, context: Context) => Promise<DynamicOutput>
 }
 
 export type AnyTool = Definition<any, any, any> | DynamicDefinition
 
-export interface ToolExecuteBeforeEvent {
-  readonly tool: string
-  readonly sessionID: Session.ID
-  readonly agent: Agent.ID
-  readonly messageID: SessionMessage.ID
-  readonly callID: string
-  input: unknown
-}
-
-export interface ToolExecuteAfterEvent {
-  readonly tool: string
-  readonly sessionID: Session.ID
-  readonly agent: Agent.ID
-  readonly messageID: SessionMessage.ID
-  readonly callID: string
-  readonly input: unknown
-  result: Tool.ToolExecuteAfterEvent["result"]
-  output?: Tool.ToolExecuteAfterEvent["output"]
-  outputPaths?: ReadonlyArray<string>
-}
-
-export interface RegisterOptions {
-  readonly group?: string
-  /** Defaults to true. False exposes the tool directly to the provider. */
-  readonly codemode?: boolean
-}
+export type ToolExecuteBeforeEvent = Tool.ToolExecuteBeforeEvent
+export type ToolExecuteAfterEvent = Tool.ToolExecuteAfterEvent
+export type RegisterOptions = Tool.RegisterOptions
 
 export interface ToolDraft {
-  add<
-    Input extends SchemaType<any>,
-    Output extends SchemaType<any>,
-    Structured extends SchemaType<any> = Output,
-  >(tool: Definition<Input, Output, Structured>): void
+  add<Input extends SchemaType<any>, Output extends SchemaType<any>, Structured extends SchemaType<any> = Output>(
+    tool: Definition<Input, Output, Structured>,
+  ): void
   add(tool: DynamicDefinition): void
 }
 

--- a/packages/plugin/src/v2/promise/tool.ts
+++ b/packages/plugin/src/v2/promise/tool.ts
@@ -12,7 +12,7 @@ export type Definition<
   Input extends SchemaType<any>,
   Output extends SchemaType<any>,
   Structured extends SchemaType<any> = Output,
-> = Omit<Tool.Definition<Input, Output, Structured>, "execute" | "permission"> & {
+> = Omit<Tool.Definition<Input, Structured, Output>, "execute" | "permission"> & {
   readonly name: string
   readonly options?: RegisterOptions
   readonly execute: (input: Tool.InputValue<Input>, context: Context) => Promise<Tool.OutputValue<Output>>

--- a/packages/plugin/test/tool.test.ts
+++ b/packages/plugin/test/tool.test.ts
@@ -114,3 +114,19 @@ test("portable schema failures become tool failures", async () => {
   const error = await Effect.runPromiseExit(Tool.settle(tool, { input: 1 }, context))
   expect(error.toString()).toContain("Invalid tool input: expected a string")
 })
+
+test("two-parameter Definition annotations retain their original meaning", () => {
+  const input = Schema.Struct({ value: Schema.String })
+  const output = Schema.Struct({ value: Schema.String, internal: Schema.Boolean })
+  const structured = Schema.Struct({ value: Schema.String })
+  const tool: Tool.Definition<typeof input, typeof structured> = Tool.make({
+    description: "Annotated tool",
+    input,
+    output,
+    structured,
+    toStructuredOutput: ({ output }) => ({ value: output.value }),
+    execute: ({ value }) => Effect.succeed({ value, internal: true }),
+  })
+
+  expect(tool.structured).toBe(structured)
+})

--- a/packages/plugin/test/tool.test.ts
+++ b/packages/plugin/test/tool.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import { Agent } from "@opencode-ai/schema/agent"
+import { Session } from "@opencode-ai/schema/session"
+import { SessionMessage } from "@opencode-ai/schema/session-message"
+import { Effect, Schema } from "effect"
+import * as Tool from "../src/v2/effect/tool"
+
+const context = {
+  sessionID: Session.ID.make("ses_test"),
+  agent: Agent.ID.make("build"),
+  messageID: SessionMessage.ID.make("msg_test"),
+  callID: "call_test",
+  progress: () => Effect.void,
+} satisfies Tool.Context
+
+test("tools remain valid across separate module instances", async () => {
+  const ForeignTool = await import(`${new URL("../src/v2/effect/tool.ts", import.meta.url).href}?foreign`)
+  const config = {
+    description: "Foreign tool",
+    input: Schema.Struct({ value: Schema.String }),
+    output: Schema.Struct({ ok: Schema.Boolean }),
+    execute: () => Effect.succeed({ ok: true }),
+  }
+  const tool = ForeignTool.make(config)
+
+  expect(Tool.definition("foreign", tool)).toEqual({
+    name: "foreign",
+    description: "Foreign tool",
+    inputSchema: {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+      required: ["ok"],
+      additionalProperties: false,
+    },
+  })
+  expect(await Effect.runPromise(Tool.settle(tool, { input: { value: "input" } }, context))).toEqual({
+    structured: { ok: true },
+    content: [],
+  })
+})
+
+test("portable schemas validate and describe typed tools", async () => {
+  const input: Tool.StandardSchemaType<{ count: string }, { count: number }> = {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (value) => {
+        if (typeof value !== "object" || value === null || !("count" in value) || typeof value.count !== "string")
+          return { issues: [{ message: "count must be numeric" }] }
+        const count = Number(value.count)
+        return Number.isFinite(count) ? { value: { count } } : { issues: [{ message: "count must be numeric" }] }
+      },
+      jsonSchema: {
+        input: () => ({ type: "object", properties: { count: { type: "string" } } }),
+        output: () => ({ type: "object", properties: { count: { type: "number" } } }),
+      },
+    },
+  }
+  const output: Tool.StandardSchemaType<number, string> = {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (value) => ({ value: String(value) }),
+      jsonSchema: {
+        input: () => ({ type: "number" }),
+        output: () => ({ type: "string" }),
+      },
+    },
+  }
+  const tool = Tool.make({
+    description: "Portable tool",
+    input,
+    output,
+    execute: ({ count }) => Effect.succeed(count + 1),
+  })
+
+  expect(Tool.definition("portable", tool)).toEqual({
+    name: "portable",
+    description: "Portable tool",
+    inputSchema: { type: "object", properties: { count: { type: "string" } } },
+    outputSchema: { type: "string" },
+  })
+  expect(await Effect.runPromise(Tool.settle(tool, { input: { count: "41" } }, context))).toEqual({
+    structured: "42",
+    content: [{ type: "text", text: "42" }],
+  })
+})
+
+test("portable schema failures become tool failures", async () => {
+  const input: Tool.StandardSchemaType<string> = {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: () => ({ issues: [{ message: "expected a string" }] }),
+      jsonSchema: {
+        input: () => ({ type: "string" }),
+        output: () => ({ type: "string" }),
+      },
+    },
+  }
+  const tool = Tool.make({
+    description: "Failing tool",
+    input,
+    output: input,
+    execute: Effect.succeed,
+  })
+
+  const error = await Effect.runPromiseExit(Tool.settle(tool, { input: 1 }, context))
+  expect(error.toString()).toContain("Invalid tool input: expected a string")
+})

--- a/specs/v2/tools.md
+++ b/specs/v2/tools.md
@@ -2,9 +2,9 @@
 
 Status: **Current semantic overview.** The Plugin package owns the public tool type; Core owns registration, settlement, and generic output bounding.
 
-## Tool Definitions Are Opaque
+## Tool Declarations
 
-V2 has one opaque type for locally executable tools. Typed tools declare codecs, execution, and optional model-facing projection together:
+V2 has one structural declaration for locally executable tools. Typed tools declare schemas, execution, and optional model-facing projection together:
 
 ```ts
 const read = Tool.make({
@@ -16,11 +16,13 @@ const read = Tool.make({
 })
 ```
 
-`structured` and `toStructuredOutput` may expose a smaller validated result than the complete execution output. Dynamic MCP and manifest tools use the same opaque representation with runtime JSON Schema.
+`structured` and `toStructuredOutput` may expose a smaller validated result than the complete execution output. Dynamic MCP and manifest tools use the same declaration with runtime JSON Schema.
 
 Built-ins and statically authored plugin tools use this same constructor and execution contract.
 
-`Tool.Definition` is opaque and has exactly one executor. Its schemas and executor are not public fields. The Tool module privately derives model definitions and interprets invocations for the registry; callers normally rely on `Tool.make` inference rather than naming the carrier type.
+`Tool.Definition` is a transparent structural value with exactly one executor. Effect schemas and schemas implementing both Standard Schema V1 and Standard JSON Schema V1 are accepted. The Tool module derives model definitions and interprets invocations for the registry; callers normally rely on `Tool.make` inference rather than naming the declaration type.
+
+Standard input schemas validate model input into the handler value. Standard output schemas validate the handler result into the model-facing value. Effect codecs retain their native decode-input and encode-output directions.
 
 Input and output codecs are self-contained. Schema conversion cannot require services. Tool dependencies are acquired during construction and captured by `execute`.
 


### PR DESCRIPTION
## What

Make V2 Effect tool values transparent structural declarations so tools created by an external plugin remain valid when the plugin and OpenCode resolve separate physical copies of `@opencode-ai/plugin`.

Typed tools now accept either Effect codecs or schemas implementing both Standard Schema V1 and Standard JSON Schema V1. The existing raw `jsonSchema` overload remains available for MCP, manifests, and process bridges.

## Before / After

**Before:** `Tool.make` returned a frozen empty object and stored its schemas and executor in a module-local `WeakMap`. When an external Effect plugin registered a tool from its package copy, OpenCode looked up that object in the host package copy's different `WeakMap` and threw `Invalid Tool value`.

**After:** the tool value directly carries its declaration. The host derives definitions and settles calls from those fields, so package-copy identity is irrelevant.

```ts
const tool = Tool.make({
  description: "Lookup",
  input: Schema.Struct({ query: Schema.String }),
  output: Schema.String,
  execute: ({ query }) => Effect.succeed(query),
})
```

## How

- Replaces the opaque `WeakMap` carrier with structural typed and raw-JSON declaration variants.
- Keeps Effect codecs on their native decode-input and encode-output paths.
- Supports portable schemas through Standard Schema validation and Standard JSON Schema definition generation.
- Derives Promise tool declarations and events from the Effect declaration model; Promise execution is still lifted at the host boundary.
- Removes the unconsumed model-definition referential-identity test and does not add a replacement cache.
- Updates the V2 tool architecture documentation to describe the structural contract.

```mermaid
flowchart LR
  P[External plugin package] -->|structural Tool value| H[OpenCode plugin host]
  H --> R[Tool registry]
  R --> D[Model definition]
  R --> E[Effect executor]
```

## Scope

- Keeps the existing `Tool.make` overload for raw JSON Schema tools; no separate `Tool.dynamic` API is added.
- Does not cache generated model definitions. Referential identity has no consumer or external semantics; caching can be added at a measured materialization boundary if profiling justifies it.
- Replaces #37192, whose `addDynamic` method worked around the package-identity issue without fixing the tool representation.

## Testing

- `bun run test` in `packages/core`: 1,301 passed, 6 skipped
- `bun run test` in `packages/plugin`: 6 passed
- `bun run build` in `packages/plugin`
- Changed-file lint: 0 warnings, 0 errors
- Full monorepo `bun run typecheck`: 32 tasks passed
- Regression test loads a second module instance, creates a typed tool there, and defines and settles it through the host module instance
- Portable-schema tests cover input transformation, output transformation, JSON Schema direction, and failure mapping
