### PR TITLE
refactor(core): extract session context loading

### DIFF
--- a/packages/core/src/session/context.ts
+++ b/packages/core/src/session/context.ts
@@ -1,0 +1,118 @@
+export * as SessionContext from "./context"
+
+import { Context, Effect, Layer } from "effect"
+import { AgentV2 } from "../agent"
+import { Database } from "../database/database"
+import { makeLocationNode } from "../effect/app-node"
+import { InstructionDiscovery } from "../instruction-discovery"
+import { Instructions } from "../instructions/index"
+import { InstructionBuiltIns } from "../instructions/builtins"
+import { Location } from "../location"
+import { McpGuidance } from "../mcp/guidance"
+import { PluginSupervisor } from "../plugin/supervisor"
+import { ReferenceGuidance } from "../reference/guidance"
+import { SkillGuidance } from "../skill/guidance"
+import { AgentNotFoundError } from "./error"
+import { SessionHistory } from "./history"
+import { InstructionEntry } from "./instruction-entry"
+import { SessionMessage } from "./message"
+import { SessionRunnerModel } from "./runner/model"
+import { SessionSchema } from "./schema"
+import { SessionStore } from "./store"
+
+export interface Selection {
+  readonly session: SessionSchema.Info
+  readonly agent: AgentV2.Selection & { readonly info: AgentV2.Info }
+  readonly instructions: Instructions.Instructions
+}
+
+export interface Loaded {
+  readonly session: SessionSchema.Info
+  readonly agent: AgentV2.Selection & { readonly info: AgentV2.Info }
+  readonly model: SessionRunnerModel.Resolved
+  readonly initial: string
+  readonly messages: ReadonlyArray<SessionMessage.Info>
+}
+
+export interface Interface {
+  /** Resolves the Session, selected agent, and current instruction sources before durable Step preparation. */
+  readonly select: (sessionID: SessionSchema.ID) => Effect.Effect<Selection, AgentNotFoundError>
+  /** Loads the selected model and active history after instruction sync and pending-input promotion. */
+  readonly load: (selection: Selection) => Effect.Effect<Loaded, SessionRunnerModel.Error>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/v2/SessionContext") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const agents = yield* AgentV2.Service
+    const builtins = yield* InstructionBuiltIns.Service
+    const db = (yield* Database.Service).db
+    const discovery = yield* InstructionDiscovery.Service
+    const entries = yield* InstructionEntry.Service
+    const location = yield* Location.Service
+    const mcpGuidance = yield* McpGuidance.Service
+    const models = yield* SessionRunnerModel.Service
+    const plugins = yield* PluginSupervisor.Service
+    const referenceGuidance = yield* ReferenceGuidance.Service
+    const skillGuidance = yield* SkillGuidance.Service
+    const store = yield* SessionStore.Service
+
+    const select = Effect.fn("SessionContext.select")(function* (sessionID: SessionSchema.ID) {
+      const session = yield* store.get(sessionID)
+      if (!session) return yield* Effect.die(new Error(`Session not found: ${sessionID}`))
+      if (session.location.directory !== location.directory || session.location.workspaceID !== location.workspaceID)
+        return yield* Effect.interrupt
+
+      yield* plugins.flush
+      const agent = yield* agents.select(session.agent)
+      if (!agent.info) return yield* new AgentNotFoundError({ sessionID: session.id, agent: session.agent ?? agent.id })
+      const instructions = yield* Effect.all(
+        [
+          builtins.load(sessionID),
+          discovery.load(),
+          skillGuidance.load(agent),
+          referenceGuidance.load(),
+          mcpGuidance.load(agent),
+          entries.load(sessionID),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(Effect.map(Instructions.combine))
+      return { session, agent: { ...agent, info: agent.info }, instructions }
+    })
+
+    const load = Effect.fn("SessionContext.load")(function* (selection: Selection) {
+      const model = yield* models.resolve(selection.session)
+      const history = yield* SessionHistory.entriesForRunner(db, selection.session.id, selection.instructions)
+      return {
+        session: selection.session,
+        agent: selection.agent,
+        model,
+        initial: history.initial,
+        messages: history.entries.map((entry) => entry.message),
+      }
+    })
+
+    return Service.of({ select, load })
+  }),
+)
+
+export const node = makeLocationNode({
+  service: Service,
+  layer,
+  deps: [
+    AgentV2.node,
+    Database.node,
+    InstructionBuiltIns.node,
+    InstructionDiscovery.node,
+    InstructionEntry.node,
+    Location.node,
+    McpGuidance.node,
+    PluginSupervisor.node,
+    ReferenceGuidance.node,
+    SessionRunnerModel.node,
+    SessionStore.node,
+    SkillGuidance.node,
+  ],
+})

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -14,33 +14,23 @@ import type { SessionHooks } from "@opencode-ai/plugin/v2/effect/session"
 import { SessionError } from "@opencode-ai/schema/session-error"
 import { Money } from "@opencode-ai/schema/money"
 import { Cause, Effect, Exit, Fiber, FiberSet, Layer, Option, Semaphore, Stream } from "effect"
-import { AgentV2 } from "../../agent"
 import { Database } from "../../database/database"
 import { EventV2 } from "../../event"
-import { Location } from "../../location"
 import { ModelV2 } from "../../model"
 import { PermissionV2 } from "../../permission"
-import { Instructions } from "../../instructions/index"
-import { InstructionBuiltIns } from "../../instructions/builtins"
-import { InstructionDiscovery } from "../../instruction-discovery"
-import { SkillGuidance } from "../../skill/guidance"
-import { ReferenceGuidance } from "../../reference/guidance"
-import { McpGuidance } from "../../mcp/guidance"
-import { InstructionEntry } from "../instruction-entry"
 import { QuestionTool } from "../../tool/question"
 import { ToolRegistry } from "../../tool/registry"
 import { ToolOutputStore } from "../../tool-output-store"
 import { InstructionState } from "../instruction-state"
 import { SessionCompaction } from "../compaction"
+import { SessionContext } from "../context"
 import { SessionEvent } from "../event"
-import { SessionHistory } from "../history"
 import { SessionPending } from "../pending"
 import { SessionMessage } from "../message"
 import { SessionSchema } from "../schema"
 import { SessionStore } from "../store"
 import { SessionTitle } from "../title"
 import { Service } from "./index"
-import { SessionRunnerModel } from "./model"
 import { createLLMEventPublisher } from "./publish-llm-event"
 import { toLLMMessages } from "./to-llm-message"
 import { MAX_STEPS_PROMPT } from "./max-steps"
@@ -48,10 +38,9 @@ import PROMPT_DEFAULT from "./prompt/base.txt"
 import { Snapshot } from "../../snapshot"
 import { makeLocationNode } from "../../effect/app-node"
 import { llmClient } from "../../effect/app-node-platform"
-import { AgentNotFoundError, StepFailedError } from "../error"
+import { StepFailedError } from "../error"
 import { toSessionError } from "../to-session-error"
 import { SessionRunnerRetry } from "./retry"
-import { PluginSupervisor } from "../../plugin/supervisor"
 import { PluginHooks } from "../../plugin/hooks"
 import { SessionModelHeaders } from "../model-headers"
 
@@ -89,23 +78,14 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const events = yield* EventV2.Service
     const llm = yield* LLMClient.Service
-    const agents = yield* AgentV2.Service
     const tools = yield* ToolRegistry.Service
     const hooks = yield* PluginHooks.Service
-    const models = yield* SessionRunnerModel.Service
     const store = yield* SessionStore.Service
-    const location = yield* Location.Service
-    const builtins = yield* InstructionBuiltIns.Service
-    const discovery = yield* InstructionDiscovery.Service
-    const skillGuidance = yield* SkillGuidance.Service
-    const referenceGuidance = yield* ReferenceGuidance.Service
-    const mcpGuidance = yield* McpGuidance.Service
-    const entries = yield* InstructionEntry.Service
+    const context = yield* SessionContext.Service
     const snapshots = yield* Snapshot.Service
     const db = (yield* Database.Service).db
     const compaction = yield* SessionCompaction.Service
     const title = yield* SessionTitle.Service
-    const plugins = yield* PluginSupervisor.Service
     // Title generation is a side effect of the first step; it must not delay step continuation.
     // Tracked per process so repeated wakes before the second user message arrives don't
     // re-fire a redundant LLM call; `SessionTitle` itself is idempotent based on durable history.
@@ -116,9 +96,6 @@ const layer = Layer.effect(
       if (!session) return yield* Effect.die(new Error(`Session not found: ${sessionID}`))
       return session
     })
-    const isCurrentLocation = (session: SessionSchema.Info) =>
-      session.location.directory === location.directory && session.location.workspaceID === location.workspaceID
-
     const failInterruptedTools = Effect.fn("SessionRunner.failInterruptedTools")(function* (
       sessionID: SessionSchema.ID,
     ) {
@@ -145,19 +122,6 @@ const layer = Layer.effect(
           (reason.defect instanceof PermissionV2.DeclinedError || reason.defect instanceof QuestionTool.CancelledError),
       )
 
-    const loadInstructions = (agent: AgentV2.Selection, sessionID: SessionSchema.ID) =>
-      Effect.all(
-        [
-          builtins.load(sessionID),
-          discovery.load(),
-          skillGuidance.load(agent),
-          referenceGuidance.load(),
-          mcpGuidance.load(agent),
-          entries.load(sessionID),
-        ],
-        { concurrency: "unbounded" },
-      ).pipe(Effect.map(Instructions.combine))
-
     const attemptStep = Effect.fn("SessionRunner.attemptStep")(function* (
       sessionID: SessionSchema.ID,
       promotion: SessionPending.Delivery | undefined,
@@ -165,32 +129,28 @@ const layer = Layer.effect(
       recoverOverflow?: typeof compaction.compact,
       assistantMessageID?: SessionMessage.ID,
     ) {
-      const session = yield* getSession(sessionID)
-      if (!isCurrentLocation(session)) return yield* Effect.interrupt
-      yield* plugins.flush
-      const agent = yield* agents.select(session.agent)
-      const agentInfo = agent.info
-      if (!agentInfo) return yield* new AgentNotFoundError({ sessionID: session.id, agent: session.agent ?? agent.id })
+      const selected = yield* context.select(sessionID)
       // Establish what the model knows before admitting what the user said, so
       // a blocked first step leaves pending inputs untouched.
-      const instructions = yield* loadInstructions(agent, session.id)
-      yield* InstructionState.prepare(db, events, instructions, session.id)
+      yield* InstructionState.prepare(db, events, selected.instructions, selected.session.id)
       let currentStep = step
       if (promotion) {
         let promoted = 0
-        if (promotion === "steer") promoted = yield* SessionPending.promoteSteers(db, events, session.id)
+        if (promotion === "steer") promoted = yield* SessionPending.promoteSteers(db, events, selected.session.id)
         if (promotion === "queue") {
-          promoted += Number(yield* SessionPending.promoteNextQueued(db, events, session.id))
-          promoted += yield* SessionPending.promoteSteers(db, events, session.id)
+          promoted += Number(yield* SessionPending.promoteNextQueued(db, events, selected.session.id))
+          promoted += yield* SessionPending.promoteSteers(db, events, selected.session.id)
         }
         if (promoted > 0) currentStep = 1
       }
-      const resolved = yield* models.resolve(session)
+      const loaded = yield* context.load(selected)
+      const session = loaded.session
+      const agent = loaded.agent
+      const agentInfo = agent.info
+      const resolved = loaded.model
       const model = resolved.model
       const providerMetadataKey = model.route.providerMetadataKey ?? model.provider
-      const history = yield* SessionHistory.entriesForRunner(db, session.id, instructions)
-      const context = history.entries.map((entry) => entry.message)
-      const compactionInput = { session, messages: context, model }
+      const compactionInput = { session, messages: loaded.messages, model }
       if (compaction.required(compactionInput) && !(yield* SessionPending.compaction(db, session.id))) {
         const compacted = yield* compaction.compact(compactionInput)
         if (compacted.status === "completed") return { _tag: "RestartAfterCompaction", step: currentStep } as const
@@ -205,11 +165,11 @@ const layer = Layer.effect(
           headers: SessionModelHeaders.make(session),
         },
         providerOptions: { openai: { promptCacheKey } },
-        system: [agentInfo.system ? agentInfo.system : PROMPT_DEFAULT, history.initial]
+        system: [agentInfo.system ? agentInfo.system : PROMPT_DEFAULT, loaded.initial]
           .filter((part): part is string => part !== undefined && part.length > 0)
           .map(SystemPart.make),
         messages: [
-          ...toLLMMessages(context, resolved.ref, providerMetadataKey),
+          ...toLLMMessages(loaded.messages, resolved.ref, providerMetadataKey),
           ...(isLastStep ? [Message.assistant(MAX_STEPS_PROMPT)] : []),
         ],
         tools: toolMaterialization?.definitions ?? [],
@@ -366,8 +326,7 @@ const layer = Layer.effect(
             recoverOverflow &&
             !publisher.hasRetryEvidence() &&
             isContextOverflowFailure(overflowFailure ?? streamFailure) &&
-            (yield* restore(recoverOverflow({ session, messages: context, model }))).status ===
-              "completed"
+            (yield* restore(recoverOverflow({ session, messages: loaded.messages, model }))).status === "completed"
           )
             return { _tag: "RestartAfterOverflowCompaction", step: currentStep } as const
 
@@ -612,22 +571,13 @@ export const node = makeLocationNode({
   deps: [
     EventV2.node,
     llmClient,
-    AgentV2.node,
     ToolRegistry.node,
     PluginHooks.node,
-    SessionRunnerModel.node,
+    SessionContext.node,
     SessionStore.node,
-    Location.node,
-    InstructionBuiltIns.node,
-    InstructionDiscovery.node,
-    SkillGuidance.node,
-    ReferenceGuidance.node,
-    McpGuidance.node,
-    InstructionEntry.node,
     SessionCompaction.node,
     SessionTitle.node,
     Snapshot.node,
     Database.node,
-    PluginSupervisor.node,
   ],
 })

--- a/plans/session-generate.md
+++ b/plans/session-generate.md
@@ -1,0 +1,281 @@
+# Session-Aware One-Shot Generation Plan
+
+Status: **Proposed**
+
+## Decision
+
+Add a Session operation that prepares one request from the Session's active model context, appends a transient prompt, executes exactly one Physical Attempt, returns the assistant text, and leaves the Session unchanged:
+
+```ts
+const { text } = await client.session.generate({
+  sessionID,
+  text: "Summarize where we left off.",
+})
+```
+
+The operation belongs to Session because its meaning depends on Session History, selected agent and model, instructions, tools, provider transforms, hooks, and prompt-cache identity. The existing stateless `Generate.text` module remains unaware of Session.
+
+This feature should deepen the Session request-preparation module rather than add a second approximation of the runner. The durable runner and `session.generate` must share preparation, then diverge before provider output acquires durable consequences.
+
+## Why The Current Shape Resists This Operation
+
+`SessionRunner.attemptStep` currently interleaves six distinct concerns:
+
+1. It synchronizes instructions and promotes pending inputs.
+2. It resolves the Session's agent and model.
+3. It selects active Session History and initiates compaction when required.
+4. It constructs the provider request, materializes tools, and applies Session hooks.
+5. It performs one Physical Attempt.
+6. It projects assistant output, executes tools, records usage, and decides whether to continue.
+
+`session.generate` needs the middle of that sequence without the durable work on either side. Calling `session.prompt` would admit durable input and enter the full loop. Calling `Generate.text` would lose Session context and cache identity. Forking would preserve context but create temporary durable state and cleanup obligations.
+
+The desired architecture makes request preparation independently callable while preserving one canonical implementation.
+
+## Target Architecture
+
+```text
+session.prompt
+    -> SessionAdmission
+    -> SessionExecution
+    -> SessionContext.snapshot
+    -> SessionRequest.prepare
+    -> LLMClient.stream
+    -> SessionSettlement
+
+session.generate
+    -> SessionContext.snapshot
+    -> SessionRequest.prepare
+    -> LLMClient.generate
+    -> return text
+```
+
+The modules have distinct jobs:
+
+- `SessionAdmission` records and promotes durable input.
+- `SessionContext` resolves a read-only, internally consistent view of what the selected agent would see.
+- `SessionRequest` converts that view into the provider request used by a Physical Attempt.
+- `LLMClient` executes one provider request without deciding what becomes durable.
+- `SessionSettlement` gives streamed provider events their durable Session meaning, executes local tools, records usage, and decides continuation.
+- `SessionCompaction` replaces oversized active history and remains a durable Session operation.
+
+Durability becomes a property of admission and settlement, not request preparation or provider execution.
+
+## The Core Seam
+
+The first extraction should be one internal Location-scoped module with a small interface. Names are provisional; behavior is not.
+
+```ts
+interface SessionRequest {
+  readonly prepare: (input: {
+    snapshot: SessionContext.Snapshot
+    operation: { type: "step"; current: number; maximum?: number } | { type: "generate"; prompt: Message.User }
+  }) => Effect<PreparedSessionRequest, SessionRequestError>
+}
+```
+
+```ts
+type PreparedSessionRequest = {
+  request: LLM.Request
+  snapshot: SessionContext.Snapshot
+  executableTools?: MaterializedTools
+}
+```
+
+`prepare` hides:
+
+- Session and Location validation;
+- plugin flush and selected-agent resolution;
+- selected-model and credential resolution;
+- instruction source loading and assembly;
+- active-history selection after the latest completed compaction;
+- conversion to provider messages;
+- provider system prompts and model headers;
+- tool permission filtering and definition materialization;
+- provider transforms and Session context hooks;
+- Session-based prompt-cache identity.
+
+The operation determines tool capability and request shape:
+
+- `step` advertises tools and returns the execution capability used by durable settlement, except when the agent's Step limit disables tools.
+- `generate` advertises the same definitions but returns no execution capability.
+
+`session.generate` keeps normal tool choice so providers retain the normal request and cache shape. Several protocols omit tool definitions entirely when `toolChoice` is `none`, so that setting cannot satisfy cache-shape parity. A generated tool call is collected but never executed or continued.
+
+Avoid a broad bag of booleans or independently selectable tool modes. The operation discriminant derives valid tool materialization and request behavior. Admission, compaction, attempts, and settlement remain separate modules rather than modes hidden inside preparation.
+
+## Read-Only Session Context
+
+Request preparation must not call `InstructionState.prepare`, promote pending input, or initiate compaction. Those operations mutate the Session.
+
+Split instruction behavior into two phases:
+
+```text
+resolve and assemble current instruction context   read-only
+commit the canonical model's instruction state    durable
+```
+
+Both a durable Step and `session.generate` resolve and assemble instructions. Only durable execution commits instruction-state changes. A transient request must not make the false durable claim that the canonical Session model saw an instruction update.
+
+The context snapshot should be loaded from one consistent database view and carry a revision, likely the latest aggregate or projected sequence used to assemble it. A concurrent durable Step may advance the Session after that point; the transient request continues against its immutable snapshot.
+
+Pending inputs remain excluded. They are not Session History until promotion, and `session.generate` must not alter admission order or expose queued work early.
+
+## One Physical Attempt Without Settlement
+
+Use the existing `LLMClient` interface directly. The durable runner consumes `llm.stream(prepared.request)`, while `session.generate` calls `llm.generate(prepared.request)` to collect the same event stream into its existing `LLMResponse` model. No additional provider-attempt module is needed.
+
+`LLMClient.generate` collects exactly one provider stream. It does not retry as a new logical Step, execute tools, continue after tool calls, publish Session events, capture filesystem snapshots, or update Session usage.
+
+The initial public result exposes only `{ text }`. Keeping richer evidence internal avoids prematurely committing the public contract while allowing tests to verify tool-call and finish behavior.
+
+If a provider returns tool calls, collection records and ignores them. No tool hook or execution path runs. Assistant text, including an empty string, remains a successful result. Empty text is required for cache-warming calls.
+
+## Compaction Does Not Belong In The First Operation
+
+Normal Step preparation may discover that active context requires compaction. Compaction is durable and usually requires another provider call. Automatically compacting from `session.generate` would violate both transcript immutability and the exactly-one-attempt contract.
+
+The first operation should use history after the latest completed compaction and fail with a typed context-overflow error when that snapshot cannot fit. It must not initiate compaction.
+
+Transient in-memory compaction can be considered later as a separate operation or explicit policy. It should not silently weaken the first contract.
+
+## Concurrency Uses Snapshot Semantics
+
+The first contract should state:
+
+> `session.generate` uses the latest committed model context captured when request preparation begins. Later Session changes do not alter the in-flight request.
+
+The operation does not acquire ownership of the durable Session Drain and does not fail merely because the Session is running. This keeps transient generation independent from durable scheduling.
+
+The prepared result carries the captured revision internally. A later recap integration can suppress stale output when the Session advances while generation runs. Returning the revision publicly can follow if more consumers need compare-and-display behavior.
+
+## Hooks Follow The Stage They Affect
+
+The existing Session context hook should run because it participates in normal request preparation. Its event should eventually identify the operation:
+
+```ts
+type SessionRequestOperation = { type: "step"; step: number } | { type: "generate" } | { type: "compaction" }
+```
+
+Request preparation and observation hooks run for `session.generate`. Admission, projection, Session settlement, and tool-execution hooks do not run because those stages do not occur.
+
+The no-mutation guarantee covers OpenCode's durable Session state. Arbitrary plugin hooks may still perform external side effects.
+
+## Public Contract
+
+Start with the smallest useful interface:
+
+```ts
+type SessionGenerateInput = {
+  sessionID: SessionID
+  text: string
+}
+
+type SessionGenerateOutput = {
+  text: string
+}
+```
+
+The operation:
+
+1. Resolves the Session or returns the normal Session-not-found error.
+2. Captures its latest committed active model context.
+3. Uses the selected agent, model, instructions, provider configuration, tools, transforms, hooks, and Session cache key.
+4. Appends `text` only to the in-memory provider request.
+5. Executes exactly one Physical Attempt with normal tool definitions and no executable tool capability.
+6. Returns collected assistant text, including an empty string.
+7. Does not admit input, publish Session events, execute tools, initiate compaction, update usage, or mutate Session projections.
+
+Files, agent attachments, usage, model identity, finish metadata, and revision are follow-up extensions. They should be added only when a concrete caller needs them.
+
+## Implementation Sequence
+
+Each stage should preserve existing durable runner behavior before the next stage starts.
+
+### 1. Characterize Current Request Preparation
+
+Add focused tests around a normal Step's prepared request. Pin:
+
+- selected agent and model;
+- system and instruction assembly;
+- active history after compaction;
+- tool definitions and last-step behavior;
+- provider headers and prompt-cache key;
+- Session context-hook transformations.
+
+Use a recording LLM adapter rather than reproducing request-construction logic in tests.
+
+### 2. Extract Instruction Resolution From Durable Synchronization
+
+Move instruction source loading and read-only assembly behind one internal interface. Keep `InstructionState.prepare` in the durable runner path. Verify that normal Steps produce byte-equivalent instruction context and unchanged durable instruction events.
+
+This commit should not add `session.generate`.
+
+### 3. Extract Session Request Preparation
+
+Move model resolution, history selection, request construction, tool definitions, cache identity, and context hooks into the Location-scoped `SessionRequest` module. Make the durable runner its only caller first.
+
+Verify the recorded normal request before and after extraction. Keep compaction detection and pending promotion outside the new module if putting them inside would make preparation mutate state.
+
+### 4. Separate Provider Attempt From Durable Settlement
+
+Make the runner explicitly pass `llm.stream(prepared.request)` into durable settlement. Keep event publication, tool execution, snapshots, retries, usage, and continuation behavior unchanged.
+
+This stage should make the durable path read as orchestration:
+
+```ts
+promote -> snapshot -> compact if required -> prepare -> attempt -> settle
+```
+
+### 5. Add The Core `Session.generate` Operation
+
+Use read-only snapshot and request preparation, append one transient user message, select advertise-only tools, collect one attempt, and return text. Add tests proving that messages, pending inputs, instruction state, Session events, snapshots, and usage remain unchanged.
+
+Test concurrent Session advancement with deterministic synchronization around request dispatch. The generated request should retain its captured context while the source Session advances independently.
+
+### 6. Add Protocol, Server, Client, And Plugin Surfaces
+
+Add `POST /api/session/:sessionID/generate` to Protocol, a thin Server handler, generated Promise and Effect clients, and `ctx.session.generate` in the V2 plugin context. Regenerate clients from the assembled `HttpApi`; do not edit generated files manually.
+
+### 7. Build Recap As The First External Consumer
+
+Implement recap outside Core using `session.generate`. The recap integration owns idle/focus policy, the recap prompt, stale-result suppression, output cleaning, and display. Core owns only session-authentic transient generation.
+
+## Verification Laws
+
+The implementation is complete when tests establish these laws:
+
+1. **Request equivalence:** the durable runner's prepared request remains equivalent before and after extraction.
+2. **Transcript immutability:** `session.generate` leaves Session messages and pending inputs unchanged.
+3. **Instruction immutability:** transient generation does not advance instruction state or publish instruction events.
+4. **Single attempt:** one call produces exactly one `llm.stream` invocation and no continuation.
+5. **No tool execution:** advertised tool calls never reach tool settlement or tool hooks.
+6. **Cache identity:** normal Steps and transient generation use the same Session-derived prompt-cache key.
+7. **Hook parity:** Session request hooks see and may transform transient requests through the same preparation seam.
+8. **Empty success:** a provider response with no assistant text returns `{ text: "" }`.
+9. **Snapshot isolation:** concurrent Session advancement does not change an already prepared transient request.
+10. **No accounting mutation:** transient usage does not alter durable Session cost or token totals.
+
+## Rejected First Implementations
+
+### Prompt, Wait, And Read
+
+This path mutates Session History, enters the agent loop, may execute tools, and changes usage. Deleting projected messages afterward cannot undo durable events or external effects.
+
+### Durable Fork With Cleanup
+
+A fork is useful for a prototype but creates durable state, emits events, requires reliable deletion, and can execute tools unless the normal runner is changed anyway. It does not establish the reusable preparation seam.
+
+### Session Calling Stateless Generate
+
+`Generate.text` intentionally knows nothing about Session. Teaching it Session semantics reverses the intended dependency and duplicates request preparation outside the runner.
+
+### A General `persist: false` Runner Mode
+
+Persistence, tool execution, admission, compaction, and continuation are separate behaviors. One flag would leave callers responsible for understanding unsafe combinations and would keep the current concerns interleaved.
+
+## Expected Scope
+
+The narrow implementation is expected to touch Core Session and runner modules, Protocol, Server, generated clients, and the V2 plugin context. It should require no database migration and no new durable event.
+
+The architectural work is larger than the endpoint. Most risk lies in extracting instruction and request preparation without changing normal Step behavior. The staged sequence keeps that risk observable and gives every new seam two real callers before broadening its interface.


### PR DESCRIPTION
## What

Extract the Session context-loading work currently embedded in `SessionRunner.attemptStep` and record the proposed architecture for a future non-persistent `session.generate` operation.

The new internal `SessionContext` module owns Session/Location validation, plugin readiness, selected-agent resolution, instruction-source loading, selected-model resolution, and active-history assembly. The runner keeps the durable instruction-sync and pending-promotion barriers explicit between `select` and `load`.

This is an exploratory first slice. It reduces the runner's direct responsibilities without changing request or execution behavior.

## How

- `packages/core/src/session/context.ts` adds a Location-scoped context loader with a two-phase interface.
- `packages/core/src/session/runner/llm.ts` delegates context selection and loading while preserving instruction sync, pending promotion, compaction, request construction, provider streaming, persistence, and tool execution in their existing order.
- `plans/session-generate.md` records the target architecture, public semantics, staged implementation sequence, verification laws, and rejected shortcuts.
- The simplify pass removed a proposed duplicate `ModelAttempt` module in favor of `LLMClient.stream` / `LLMClient.generate`, made request preparation consume a captured context, derived tool policy from an operation discriminant, and stopped retaining instruction sources after history assembly.

## Scope

This PR does not add `session.generate`, Protocol or client operations, or plugin behavior.

The extracted loader is intentionally still runner-oriented. A read-only context snapshot for `session.generate` requires a follow-up instruction-state extraction so a fresh or instruction-changed Session can assemble current instructions without committing `session.instructions.updated`. Snapshot revision and concurrent freshness semantics also remain follow-up work.

## Testing

- `bun typecheck` in `packages/core`
- `bun run test` in `packages/core`: 1,302 passed, 6 skipped
- `bun run test session-runner.test.ts session-runner-recorded.test.ts session-instructions.test.ts session-compaction.test.ts`: 138 passed
- `bunx prettier --check packages/core/src/session/context.ts packages/core/src/session/runner/llm.ts plans/session-generate.md`
- `bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/session/context.ts packages/core/src/session/runner/llm.ts`
- Repository pre-push typecheck: 32 packages passed

Changed-file Oxlint completed with no errors. It reports three pre-existing warnings in unchanged portions of `session/runner/llm.ts`.

## Flow

```mermaid
sequenceDiagram
    participant Runner as SessionRunner
    participant Context as SessionContext
    participant Instructions as InstructionState
    participant Pending as SessionPending
    participant Model as Model/History

    Runner->>Context: select(sessionID)
    Context-->>Runner: session + agent + instruction sources
    Runner->>Instructions: prepare(...)
    Runner->>Pending: promote eligible input
    Runner->>Context: load(selection)
    Context->>Model: resolve model + active history
    Context-->>Runner: loaded context
    Runner->>Runner: existing request, attempt, and settlement
```
