### PR TITLE
fix(acp): advertise compact command

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -937,10 +937,15 @@ function sendAvailableCommands(
         sessionId,
         update: {
           sessionUpdate: "available_commands_update",
-          availableCommands: snapshot.availableCommands.map((command) => ({
-            name: command.name,
-            description: command.description ?? "",
-          })),
+          availableCommands: [
+            ...(snapshot.availableCommands.some((command) => command.name === "compact")
+              ? []
+              : [{ name: "compact", description: "Compact the current session context" }]),
+            ...snapshot.availableCommands.map((command) => ({
+              name: command.name,
+              description: command.description ?? "",
+            })),
+          ],
         },
       })
     }, 0)

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -297,6 +297,7 @@ describe("ACP service sessions", () => {
     expect(updates).toHaveLength(1)
     expect(JSON.stringify(updates[0])).toContain("available_commands_update")
     expect(JSON.stringify(updates[0])).toContain("review-skill")
+    expect(JSON.stringify(updates[0])).toContain('"name":"compact"')
     expect(mcpAdds).toEqual(["tools"])
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #37229

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Advertises the built-in `/compact` command through ACP `available_commands_update`. ACP already routes this command to `session.summarize()`, but clients such as Zed rejected it because it was missing from the advertised command list.

The command is added only to the ACP notification, preserving the existing summarize path and avoiding duplicate entries when a user-defined command has the same name.

### How did you verify your code works?

- Ran `mise exec -- bun test test/acp/service-session.test.ts` (32 tests passed).
- Ran `mise exec -- bun typecheck` in `packages/opencode`.
- Passed the pre-push full-repository typecheck (30 tasks).
- Checked both changed files with Prettier.

### Screenshots / recordings

Not applicable; this changes ACP command discovery without changing OpenCode UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
