### PR TITLE
fix(session): ignore hidden user turns

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -588,7 +588,13 @@ export function latest(msgs: WithParts[]) {
   let finished: Assistant | undefined
   for (const msg of msgs) {
     const info = msg.info
-    if (info.role === "user" && (!user || info.id > user.id)) user = info
+    if (
+      info.role === "user" &&
+      !(msg.parts.length > 0 && msg.parts.every((part) => "ignored" in part && part.ignored)) &&
+      (!user || info.id > user.id)
+    ) {
+      user = info
+    }
     if (info.role === "assistant" && (!assistant || info.id > assistant.id)) assistant = info
     if (info.role === "assistant" && info.finish && (!finished || info.id > finished.id)) finished = info
   }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -460,6 +460,28 @@ noLLMServer.instance(
   { config: cfg },
 )
 
+noLLMServer.instance(
+  "loop ignores user messages with only ignored parts",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      const seeded = yield* seed(chat.id, { finish: "stop" })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "internal status", ignored: true }],
+      })
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.id).toBe(seeded.assistant.id)
+    }),
+  { config: cfg },
+)
+
 it.instance("loop exits without an LLM request for interrupted orphan tool calls", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
## Summary

- ignore user messages whose parts are all marked `ignored` when choosing the latest actionable user turn
- add a regression test showing that such a message after a completed response does not start another loop iteration

Fixes #37200

## Root cause

`MessageV2.latest()` selected the newest user message by ID without considering whether that message can be sent to a model. A user message made entirely of ignored parts is removed from model context, but was still treated as new work by the session loop. After a completed assistant turn, that mismatch could produce a phantom LLM request.

## Validation

- `bun test test/session/prompt.test.ts --test-name-pattern "loop ignores user messages"`
- `bun typecheck`
- `git diff --check`
