### PR TITLE
docs: add AICtrl to the OpenCode ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [@aictrl/opencode](https://github.com/aictrl-dev/skills)                                          | Install eleven portable SDLC skills and optional OAuth-connected AICtrl workflows                |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #37247

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the English Ecosystem Plugins table for `@aictrl/opencode`, linking to the canonical AICtrl skills repository.

The package is publicly available as `@aictrl/opencode@1.1.0-beta.2` and provides eleven portable SDLC skills plus optional OAuth-connected AICtrl workflows.

### How did you verify your code works?

- `git diff --check`
- `npm view @aictrl/opencode@1.1.0-beta.2`
- Clean published-package install, repeat install, OAuth-boundary discovery, and uninstall
- Claude and Codex tagged-release lifecycle smoke tests

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR