### PR TITLE
fix(core): honor oauth attempt expiration

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -63,6 +63,7 @@ export type Inputs = Integration.Inputs
 export type OAuthAuthorization = {
   readonly url: string
   readonly instructions: string
+  readonly expiresAt?: number
 } & (
   | {
       readonly mode: "auto"
@@ -427,7 +428,7 @@ export const locationLayer = Layer.effect(
           )
           const id = AttemptID.create()
           const created = yield* Clock.currentTimeMillis
-          const time = { created, expires: created + attemptLifetime }
+          const time = { created, expires: authorization.expiresAt ?? created + attemptLifetime }
           yield* SynchronizedRef.update(attempts, (current) =>
             new Map(current).set(id, {
               status: "pending",

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Schema, Semaphore, Stream } from "effect"
+import { Clock, Duration, Effect, Schema, Semaphore, Stream } from "effect"
 import type { Scope } from "effect"
 import type { IntegrationOAuthMethodRegistration } from "@opencode-ai/plugin/v2/effect/integration"
 import { define } from "@opencode-ai/plugin/v2/effect/plugin"
@@ -49,6 +49,7 @@ function oauth(http: HttpClient.HttpClient) {
           mode: "auto" as const,
           url: `${defaultServer}${device.verification_uri_complete}`,
           instructions: `Enter code: ${device.user_code}`,
+          expiresAt: (yield* Clock.currentTimeMillis) + device.expires_in * 1000,
           callback: poll(http, defaultServer, device.device_code, Duration.seconds(device.interval)),
         }
       }),

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Duration, Effect, Exit, Fiber, Scope, Stream } from "effect"
+import { Clock, Duration, Effect, Exit, Fiber, Scope, Stream } from "effect"
 import * as TestClock from "effect/testing/TestClock"
 import { Credential } from "@opencode-ai/core/credential"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -194,6 +194,7 @@ describe("Integration", () => {
       const credentials = yield* Credential.Service
       const integrationID = Integration.ID.make("openai")
       const methodID = Integration.MethodID.make("chatgpt")
+      const expiresAt = (yield* Clock.currentTimeMillis) + Duration.toMillis(Duration.hours(1))
       let closed = false
       yield* integrations.transform((editor) =>
         editor.method.update({
@@ -205,6 +206,7 @@ describe("Integration", () => {
                 mode: "code" as const,
                 url: "https://example.com/authorize",
                 instructions: "Paste the code",
+                expiresAt,
                 callback: () => Effect.die("unexpected callback"),
               }),
             ),
@@ -212,6 +214,7 @@ describe("Integration", () => {
       )
 
       const attempt = yield* integrations.connection.oauth({ integrationID, methodID, inputs: {} })
+      expect(attempt.time.expires).toBe(expiresAt)
       expect(yield* integrations.attempt.complete({ attemptID: attempt.attemptID }).pipe(Effect.flip)).toBeInstanceOf(
         Integration.CodeRequiredError,
       )
@@ -219,6 +222,68 @@ describe("Integration", () => {
       yield* integrations.attempt.cancel(attempt.attemptID)
       expect(closed).toBe(true)
       expect(yield* credentials.list(integrationID)).toEqual([])
+    }),
+  )
+
+  it.effect("honors shorter and longer OAuth expirations", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const integrationID = Integration.ID.make("openai")
+      const shortMethodID = Integration.MethodID.make("short")
+      const longMethodID = Integration.MethodID.make("long")
+      const created = yield* Clock.currentTimeMillis
+      const shortExpiresAt = created + Duration.toMillis(Duration.minutes(1))
+      const longExpiresAt = created + Duration.toMillis(Duration.minutes(20))
+      let shortClosed = false
+      let longClosed = false
+
+      yield* integrations.transform((editor) => {
+        editor.method.update({
+          integrationID,
+          method: { id: shortMethodID, type: "oauth", label: "Short" },
+          authorize: () =>
+            Effect.addFinalizer(() => Effect.sync(() => (shortClosed = true))).pipe(
+              Effect.as({
+                mode: "auto" as const,
+                url: "https://example.com/short",
+                instructions: "Sign in",
+                expiresAt: shortExpiresAt,
+                callback: Effect.never,
+              }),
+            ),
+        })
+        editor.method.update({
+          integrationID,
+          method: { id: longMethodID, type: "oauth", label: "Long" },
+          authorize: () =>
+            Effect.addFinalizer(() => Effect.sync(() => (longClosed = true))).pipe(
+              Effect.as({
+                mode: "auto" as const,
+                url: "https://example.com/long",
+                instructions: "Sign in",
+                expiresAt: longExpiresAt,
+                callback: Effect.never,
+              }),
+            ),
+        })
+      })
+
+      const short = yield* integrations.connection.oauth({ integrationID, methodID: shortMethodID, inputs: {} })
+      const long = yield* integrations.connection.oauth({ integrationID, methodID: longMethodID, inputs: {} })
+      expect(short.time.expires).toBe(shortExpiresAt)
+      expect(long.time.expires).toBe(longExpiresAt)
+
+      yield* TestClock.adjust(Duration.minutes(1))
+      yield* Effect.yieldNow
+      expect((yield* integrations.attempt.status(short.attemptID)).status).toBe("expired")
+      expect((yield* integrations.attempt.status(long.attemptID)).status).toBe("pending")
+      expect(shortClosed).toBe(true)
+      expect(longClosed).toBe(false)
+
+      yield* TestClock.adjust(Duration.minutes(19))
+      yield* Effect.yieldNow
+      expect((yield* integrations.attempt.status(long.attemptID)).status).toBe("expired")
+      expect(longClosed).toBe(true)
     }),
   )
 

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
+import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { EventV2 } from "@opencode-ai/core/event"
@@ -79,6 +80,36 @@ describe("OpencodePlugin", () => {
         },
         { type: "key", label: "API key (service account)" },
       ])
+    }),
+  )
+
+  it.effect("uses the device code expiration for the OAuth attempt", () =>
+    Effect.gen(function* () {
+      const expiresIn = 20 * 60
+      const http = HttpClient.make((request) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            Response.json({
+              device_code: "device-code",
+              user_code: "user-code",
+              verification_uri_complete: "/auth/device",
+              expires_in: expiresIn,
+              interval: 5,
+            }),
+          ),
+        ),
+      )
+      yield* addPlugin().pipe(Effect.provideService(HttpClient.HttpClient, http))
+
+      const integration = yield* Integration.Service
+      const attempt = yield* integration.connection.oauth({
+        integrationID: Integration.ID.make("opencode"),
+        methodID: Integration.MethodID.make("device"),
+        inputs: {},
+      })
+      expect(attempt.time.expires - attempt.time.created).toBe(expiresIn * 1000)
+      yield* integration.attempt.cancel(attempt.attemptID)
     }),
   )
 

--- a/packages/plugin/src/v2/effect/integration.ts
+++ b/packages/plugin/src/v2/effect/integration.ts
@@ -15,6 +15,7 @@ import type { Hooks } from "./registration.js"
 export type IntegrationOAuthAuthorization = {
   readonly url: string
   readonly instructions: string
+  readonly expiresAt?: number
 } & (
   | {
       readonly mode: "auto"


### PR DESCRIPTION
### Issue for this PR

Closes #36954

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Uses a provider-supplied absolute OAuth expiration when available and keeps the existing ten-minute fallback. The OpenCode device flow now carries its advertised expires_in value into the integration attempt.

### How did you verify your code works?

- Core integration and OpenCode provider tests: 21 passed
- Core and plugin package typechecks
- Pre-push workspace typecheck: 30 tasks passed
- Prettier and git diff checks

### Screenshots / recordings

Not applicable; this is a non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
