### PR TITLE
fix(skill): validate skill frontmatter

### DIFF
--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -32,10 +32,11 @@ export const available = (skills: ReadonlyArray<Info>, agent: AgentV2.Info) =>
 
 const Frontmatter = Schema.Struct({
   name: Schema.String.pipe(Schema.optional),
-  description: Schema.String.pipe(Schema.optional),
+  description: Skill.Description,
   slash: Schema.Boolean.pipe(Schema.optional),
 })
 const decodeFrontmatter = Schema.decodeUnknownOption(Frontmatter)
+const decodeName = Schema.decodeUnknownOption(Skill.Name)
 
 export type Data = {
   sources: Types.DeepMutable<Source>[]
@@ -84,14 +85,22 @@ const layer = Layer.effect(
           const markdown = ConfigMarkdown.parseOption(content)
           if (!markdown) continue
           const frontmatter = decodeFrontmatter(markdown.data).valueOrUndefined
-          if (!frontmatter) continue
-          const name =
+          if (!frontmatter) {
+            yield* Effect.logWarning("invalid skill frontmatter", { skill: filepath })
+            continue
+          }
+          const candidate =
             frontmatter.name !== undefined
               ? frontmatter.name
               : path.dirname(filepath) === directory
                 ? path.basename(filepath, ".md")
                 : undefined
-          if (!name) continue
+          if (candidate === undefined) continue
+          const name = decodeName(candidate).valueOrUndefined
+          if (!name) {
+            yield* Effect.logWarning("invalid skill name", { skill: filepath, name: candidate })
+            continue
+          }
           skills.push({
             name,
             description: frontmatter.description,

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -27,12 +27,12 @@ const it = testEffect(
   AppNodeBuilder.build(LayerNode.group([SkillV2.node, AgentV2.node]), [[SkillDiscovery.node, discovery]]),
 )
 
-function write(directory: string, name: string, description: string) {
+function write(directory: string, name: string, description?: string) {
   return fs.writeFile(
     path.join(directory, name, "SKILL.md"),
     `---
 name: ${name}
-description: ${description}
+${description === undefined ? "" : `description: ${description}`}
 ---
 # ${name}`,
   )
@@ -53,7 +53,7 @@ describe("SkillV2", () => {
             await fs.mkdir(path.join(second, "review"), { recursive: true })
             await write(first, "review", "First")
             await write(second, "review", "Second")
-            await fs.writeFile(path.join(first, "foo.md"), "---\nslash: true\n---\n# foo")
+            await fs.writeFile(path.join(first, "foo.md"), "---\ndescription: Flat skill\nslash: true\n---\n# foo")
           })
 
           const skill = yield* SkillV2.Service
@@ -74,6 +74,7 @@ describe("SkillV2", () => {
           expect(yield* skill.list()).toEqual([
             SkillV2.Info.make({
               name: "foo",
+              description: "Flat skill",
               slash: true,
               location: AbsolutePath.make(path.join(first, "foo.md")),
               content: "# foo",
@@ -118,6 +119,44 @@ describe("SkillV2", () => {
           expect((yield* skill.list()).map((item) => item.name)).toEqual(["deploy"])
           expect(pulls).toBe(1)
           expect(SkillV2.available(yield* skill.list(), (yield* agents.get(AgentV2.ID.make("reviewer")))!)).toEqual([])
+        }),
+      ),
+    ),
+  )
+
+  it.live("skips skills with invalid names or descriptions", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const names = {
+            minimum: "a",
+            maximum: `a${"b".repeat(63)}`,
+            tooLong: `a${"b".repeat(64)}`,
+            invalid: "invalid_name",
+            missingDescription: "missing-description",
+            emptyDescription: "empty-description",
+            longDescription: "long-description",
+          }
+          yield* Effect.promise(async () => {
+            await Promise.all(
+              Object.values(names).map((name) => fs.mkdir(path.join(tmp.path, name), { recursive: true })),
+            )
+            await write(tmp.path, names.minimum, "x")
+            await write(tmp.path, names.maximum, "x".repeat(1024))
+            await write(tmp.path, names.tooLong, "Too long name")
+            await write(tmp.path, names.invalid, "Invalid name")
+            await write(tmp.path, names.missingDescription)
+            await write(tmp.path, names.emptyDescription, "")
+            await write(tmp.path, names.longDescription, "x".repeat(1025))
+          })
+
+          const skill = yield* SkillV2.Service
+          yield* skill.transform((editor) => editor.source({ type: "directory", path: AbsolutePath.make(tmp.path) }))
+
+          expect((yield* skill.list()).map((item) => item.name)).toEqual([names.minimum, names.maximum])
         }),
       ),
     ),

--- a/packages/core/test/skill/guidance.test.ts
+++ b/packages/core/test/skill/guidance.test.ts
@@ -16,11 +16,6 @@ const effect = SkillV2.Info.make({
   location: AbsolutePath.make(path.resolve("/skills/effect/SKILL.md")),
   content: "Effect guidance",
 })
-const hidden = SkillV2.Info.make({
-  name: "hidden",
-  location: AbsolutePath.make(path.resolve("/skills/hidden/SKILL.md")),
-  content: "Undescribed guidance",
-})
 const denied = SkillV2.Info.make({
   name: "denied",
   description: "Must not be advertised",
@@ -39,7 +34,7 @@ describe("SkillGuidance", () => {
       ...AgentV2.Info.empty(build),
       permissions: [{ action: "skill", resource: "denied", effect: "deny" }],
     })
-    let skills = [hidden, denied, effect]
+    let skills = [denied, effect]
     return Effect.gen(function* () {
       const guidance = yield* SkillGuidance.Service
       const initialized = yield* guidance

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -15,8 +15,8 @@ import { ConfigMarkdown } from "@/config/markdown"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Glob } from "@opencode-ai/core/util/glob"
 import { Discovery } from "./discovery"
-import { isRecord } from "@/util/record"
 import { escapeHtml } from "@/util/html"
+import { Name, Description } from "@opencode-ai/schema/skill"
 
 const CLAUDE_EXTERNAL_DIR = ".claude"
 const AGENTS_EXTERNAL_DIR = ".agents"
@@ -35,8 +35,8 @@ const CUSTOMIZE_OPENCODE_SKILL_DESCRIPTION =
 const CUSTOMIZE_OPENCODE_SKILL_BODY = SkillPlugin.CustomizeOpencodeContent
 
 export const Info = Schema.Struct({
-  name: Schema.String,
-  description: Schema.optional(Schema.String),
+  name: Name,
+  description: Description,
   location: Schema.String,
   content: Schema.String,
 })
@@ -50,13 +50,8 @@ const Issue = Schema.StructWithRest(
   [Schema.Record(Schema.String, Schema.Unknown)],
 )
 
-function isSkillFrontmatter(data: unknown): data is { name: string; description?: string } {
-  return (
-    isRecord(data) &&
-    typeof data.name === "string" &&
-    (data.description === undefined || typeof data.description === "string")
-  )
-}
+const Frontmatter = Schema.Struct({ name: Name, description: Description })
+const decodeFrontmatter = Schema.decodeUnknownOption(Frontmatter)
 
 export class InvalidError extends Schema.TaggedErrorClass<InvalidError>()("SkillInvalidError", {
   path: Schema.String,
@@ -120,20 +115,24 @@ const add = Effect.fnUntraced(function* (state: State, match: string, events: Ev
 
   if (!md) return
 
-  if (!isSkillFrontmatter(md.data)) return
+  const frontmatter = decodeFrontmatter(md.data).valueOrUndefined
+  if (!frontmatter) {
+    yield* Effect.logWarning("invalid skill frontmatter", { skill: match })
+    return
+  }
 
-  if (state.skills[md.data.name]) {
+  if (state.skills[frontmatter.name]) {
     yield* Effect.logWarning("duplicate skill name", {
-      name: md.data.name,
-      existing: state.skills[md.data.name].location,
+      name: frontmatter.name,
+      existing: state.skills[frontmatter.name].location,
       duplicate: match,
     })
   }
 
   state.dirs.add(path.dirname(match))
-  state.skills[md.data.name] = {
-    name: md.data.name,
-    description: md.data.description,
+  state.skills[frontmatter.name] = {
+    name: frontmatter.name,
+    description: frontmatter.description,
     location: match,
     content: md.content,
   }

--- a/packages/opencode/test/session/system.test.ts
+++ b/packages/opencode/test/session/system.test.ts
@@ -29,11 +29,6 @@ const skills: Skill.Info[] = [
     location: "/tmp/middle-skill/SKILL.md",
     content: "# middle-skill",
   },
-  {
-    name: "manual-skill",
-    location: "/tmp/manual-skill/SKILL.md",
-    content: "# manual-skill",
-  },
 ]
 
 const build: Agent.Info = {
@@ -106,7 +101,6 @@ describe("session.system", () => {
       expect(alpha).toBeGreaterThan(-1)
       expect(middle).toBeGreaterThan(alpha)
       expect(zeta).toBeGreaterThan(middle)
-      expect(output).not.toContain("manual-skill")
     }),
   )
 

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -211,7 +211,7 @@ Just some content without YAML frontmatter.
     ),
   )
 
-  it.live("discovers skills without descriptions", () =>
+  it.live("skips skills without descriptions", () =>
     provideTmpdirInstance(
       (dir) =>
         Effect.gen(function* () {
@@ -231,12 +231,50 @@ Instructions here.
 
           const skill = yield* Skill.Service
           const list = (yield* skill.all()).filter((s) => s.location !== "<built-in>")
-          expect(list.length).toBe(1)
-          const item = list.find((x) => x.name === "manual-skill")
-          expect(item).toBeDefined()
-          expect(item!.description).toBeUndefined()
-          expect(Skill.fmt(list, { verbose: false })).toBe("No skills are currently available.")
-          expect(Skill.fmt(list, { verbose: true })).toBe("No skills are currently available.")
+          expect(list).toEqual([])
+        }),
+      { git: true },
+    ),
+  )
+
+  it.live("skips skills with invalid names or descriptions", () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const names = {
+            minimum: "a",
+            maximum: `a${"b".repeat(63)}`,
+            tooLong: `a${"b".repeat(64)}`,
+            invalid: "invalid_name",
+            emptyDescription: "empty-description",
+            longDescription: "long-description",
+          }
+          const skillRoot = path.join(dir, ".opencode", "skill")
+          yield* Effect.promise(() =>
+            Promise.all(
+              [
+                [names.minimum, "x"],
+                [names.maximum, "x".repeat(1024)],
+                [names.tooLong, "Too long name"],
+                [names.invalid, "Invalid name"],
+                [names.emptyDescription, ""],
+                [names.longDescription, "x".repeat(1025)],
+              ].map(([name, description]) =>
+                Bun.write(
+                  path.join(skillRoot, name, "SKILL.md"),
+                  `---\nname: ${name}\ndescription: ${description}\n---\n# ${name}`,
+                ),
+              ),
+            ),
+          )
+
+          const skill = yield* Skill.Service
+          expect(
+            (yield* skill.all())
+              .filter((item) => item.location !== "<built-in>")
+              .map((item) => item.name)
+              .toSorted(),
+          ).toEqual([names.minimum, names.maximum].toSorted())
         }),
       { git: true },
     ),

--- a/packages/schema/src/skill.ts
+++ b/packages/schema/src/skill.ts
@@ -4,6 +4,19 @@ import { Schema } from "effect"
 import { optional } from "./schema"
 import { AbsolutePath } from "./schema"
 
+export const Name = Schema.String.annotate({ identifier: "Skill.Name" }).check(
+  Schema.isMinLength(1),
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^[a-z0-9]+(-[a-z0-9]+)*$/),
+)
+export type Name = typeof Name.Type
+
+export const Description = Schema.String.annotate({ identifier: "Skill.Description" }).check(
+  Schema.isMinLength(1),
+  Schema.isMaxLength(1024),
+)
+export type Description = typeof Description.Type
+
 export interface DirectorySource extends Schema.Schema.Type<typeof DirectorySource> {}
 export const DirectorySource = Schema.Struct({
   type: Schema.Literal("directory"),
@@ -18,8 +31,8 @@ export const UrlSource = Schema.Struct({
 
 export interface Info extends Schema.Schema.Type<typeof Info> {}
 export const Info = Schema.Struct({
-  name: Schema.String,
-  description: Schema.String.pipe(optional),
+  name: Name,
+  description: Description,
   slash: Schema.Boolean.pipe(optional),
   location: AbsolutePath,
   content: Schema.String,

--- a/packages/schema/test/contract-hygiene.test.ts
+++ b/packages/schema/test/contract-hygiene.test.ts
@@ -9,6 +9,7 @@ import { Question } from "../src/question"
 import { Session } from "../src/session"
 import { SessionEvent } from "../src/session-event"
 import { SessionTodo } from "../src/session-todo"
+import { Skill } from "../src/skill"
 import { optional } from "../src/schema"
 
 describe("contract hygiene", () => {
@@ -33,6 +34,29 @@ describe("contract hygiene", () => {
     expect(Pty.ID.create()).toStartWith("pty_")
   })
 
+  test("skill names and descriptions enforce documented bounds", () => {
+    const decode = Schema.decodeUnknownOption(Skill.Info)
+    const input = (name: string, description: string) => ({
+      name,
+      description,
+      location: "/tmp/SKILL.md",
+      content: "# Skill",
+    })
+
+    expect(decode(input("a", "x")).valueOrUndefined).toBeDefined()
+    expect(decode(input(`a${"b".repeat(63)}`, "x".repeat(1024))).valueOrUndefined).toBeDefined()
+    expect(decode(input("", "x")).valueOrUndefined).toBeUndefined()
+    expect(decode(input(`a${"b".repeat(64)}`, "x")).valueOrUndefined).toBeUndefined()
+    for (const name of ["Invalid-name", "invalid_name", "-invalid", "invalid-", "invalid--name"]) {
+      expect(decode(input(name, "x")).valueOrUndefined).toBeUndefined()
+    }
+    expect(
+      decode({ name: "valid-name", location: "/tmp/SKILL.md", content: "# Skill" }).valueOrUndefined,
+    ).toBeUndefined()
+    expect(decode(input("valid-name", "")).valueOrUndefined).toBeUndefined()
+    expect(decode(input("valid-name", "x".repeat(1025))).valueOrUndefined).toBeUndefined()
+  })
+
   test("reusable public identifiers are stable and unique", () => {
     const identifiers = [
       Agent.Color,
@@ -47,6 +71,8 @@ describe("contract hygiene", () => {
       Project.Info,
       Pty.Info,
       Session.ListAnchor,
+      Skill.Name,
+      Skill.Description,
     ].map((schema) => schema.ast.annotations?.identifier)
 
     expect(identifiers.every((identifier) => typeof identifier === "string")).toBe(true)


### PR DESCRIPTION
### Issue for this PR

Closes #31616

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds shared documented validation for skill names and descriptions. Both V1 and V2 loaders skip invalid skills with a warning; metadata, command autocomplete, and directory-name matching remain out of scope.

### How did you verify your code works?

- Schema contract tests: 6 passed
- Core skill tests: 8 passed
- OpenCode skill and system tests: 22 passed
- Schema, core, and OpenCode package typechecks
- Pre-push workspace typecheck: 30 tasks passed
- Prettier and git diff checks

### Screenshots / recordings

Not applicable; this is a non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
