### PR TITLE
fix(tui): preserve contrast for transparent themes

### DIFF
--- a/packages/tui/src/feature-plugins/system/diff-viewer-file-tree.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer-file-tree.tsx
@@ -85,14 +85,14 @@ export function DiffViewerFileTree(props: DiffViewerFileTreeProps) {
                     backgroundColor={highlighted() ? props.theme.primary : undefined}
                     onMouseUp={() => props.onRowClick?.(row)}
                   >
-                    <text fg={highlighted() ? props.theme.background : fadedColor()} wrapMode="none" flexShrink={0}>
+                    <text fg={highlighted() ? props.theme.selectedListItemText : fadedColor()} wrapMode="none" flexShrink={0}>
                       {prefix()}
                     </text>
                     <box flexGrow={1} minWidth={0}>
                       <text
                         fg={
                           highlighted()
-                            ? props.theme.background
+                            ? props.theme.selectedListItemText
                             : selected()
                               ? props.theme.primary
                               : reviewed() || row.kind === "directory"
@@ -105,7 +105,7 @@ export function DiffViewerFileTree(props: DiffViewerFileTreeProps) {
                       </text>
                     </box>
                     <text
-                      fg={highlighted() ? props.theme.background : props.theme.textMuted}
+                      fg={highlighted() ? props.theme.selectedListItemText : props.theme.textMuted}
                       wrapMode="none"
                       flexShrink={0}
                     >

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -73,6 +73,7 @@ import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
 import { createSessionRows, resolvePart, type PartRef, type SessionRow } from "./rows"
 import { switchLabel } from "../../util/model"
+import { selectedForeground } from "../../theme"
 
 addDefaultParsers(parsers.parsers)
 
@@ -1594,7 +1595,9 @@ function UserMessage(props: { message: SessionMessageUser }) {
                   const label = file.mime === "application/x-directory" ? "dir" : "file"
                   return (
                     <text fg={theme.text}>
-                      <span style={{ bg: theme.secondary, fg: theme.background, bold: true }}>{` ${label} `}</span>
+                      <span style={{ bg: theme.secondary, fg: selectedForeground(theme, theme.secondary), bold: true }}>
+                        {` ${label} `}
+                      </span>
                       <span style={{ bg: theme.backgroundElement, fg: theme.textMuted }}>
                         {" "}
                         {file.name ?? (file.source.type === "uri" ? file.source.uri : "attachment")}{" "}

--- a/packages/tui/src/theme/index.ts
+++ b/packages/tui/src/theme/index.ts
@@ -116,6 +116,10 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
   const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined
   if (hasSelectedListItemText) {
     resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!)
+  } else if (resolved.background?.a === 0) {
+    const bg = resolved.primary ?? RGBA.fromInts(0, 0, 0)
+    const luminance = 0.299 * bg.r + 0.587 * bg.g + 0.114 * bg.b
+    resolved.selectedListItemText = luminance > 0.5 ? RGBA.fromInts(0, 0, 0) : RGBA.fromInts(255, 255, 255)
   } else {
     // Backward compatibility: if selectedListItemText is not defined, use background color
     // This preserves the current behavior for all existing themes

--- a/packages/tui/src/theme/v1.ts
+++ b/packages/tui/src/theme/v1.ts
@@ -148,13 +148,15 @@ export function selectedForeground(theme: Theme, bg?: RGBA): RGBA {
   if (theme._hasSelectedListItemText) return theme.selectedListItemText
 
   if (theme.background.a === 0) {
-    const targetColor = bg ?? theme.primary
-    const { r, g, b } = targetColor
-    const luminance = 0.299 * r + 0.587 * g + 0.114 * b
-    return luminance > 0.5 ? RGBA.fromInts(0, 0, 0) : RGBA.fromInts(255, 255, 255)
+    return contrastForeground(bg ?? theme.primary)
   }
 
   return theme.background
+}
+
+function contrastForeground(bg: RGBA): RGBA {
+  const luminance = 0.299 * bg.r + 0.587 * bg.g + 0.114 * bg.b
+  return luminance > 0.5 ? RGBA.fromInts(0, 0, 0) : RGBA.fromInts(255, 255, 255)
 }
 
 export function generateSyntax(theme: Theme) {

--- a/packages/tui/src/theme/v2/v1-migrate.ts
+++ b/packages/tui/src/theme/v2/v1-migrate.ts
@@ -139,7 +139,9 @@ function resolveV1(theme: ThemeJson, mode: "dark" | "light"): Theme {
   const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined
   resolved.selectedListItemText = hasSelectedListItemText
     ? resolveColor(theme.theme.selectedListItemText)
-    : resolved.background
+    : resolved.background?.a === 0
+      ? contrastForeground(resolved.primary ?? RGBA.fromInts(0, 0, 0))
+      : resolved.background
   resolved.backgroundMenu = theme.theme.backgroundMenu
     ? resolveColor(theme.theme.backgroundMenu)
     : resolved.backgroundElement
@@ -154,6 +156,10 @@ function resolveV1(theme: ThemeJson, mode: "dark" | "light"): Theme {
 function selectedForeground(theme: Theme, background: RGBA) {
   if (theme._hasSelectedListItemText) return theme.selectedListItemText
   if (theme.background.a !== 0) return theme.background
+  return contrastForeground(background)
+}
+
+function contrastForeground(background: RGBA) {
   return 0.299 * background.r + 0.587 * background.g + 0.114 * background.b > 0.5
     ? RGBA.fromInts(0, 0, 0)
     : RGBA.fromInts(255, 255, 255)

--- a/packages/tui/test/theme.test.ts
+++ b/packages/tui/test/theme.test.ts
@@ -45,6 +45,14 @@ test("resolveTheme rejects circular color refs", () => {
   expect(() => resolveTheme(item, "dark")).toThrow("Circular color reference")
 })
 
+test("resolveTheme uses a contrasting selected foreground for transparent themes", () => {
+  const item = structuredClone(DEFAULT_THEMES.opencode)
+  item.theme.background = "transparent"
+  item.theme.primary = "#eeeeee"
+
+  expect(resolveTheme(item, "dark").selectedListItemText.toInts()).toEqual([0, 0, 0, 255])
+})
+
 function terminalColors(defaultBackground: string | null, palette: Array<string | null> = []): TerminalColors {
   return {
     palette,

--- a/packages/tui/test/theme.test.ts
+++ b/packages/tui/test/theme.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
 import type { TerminalColors } from "@opentui/core"
-import { DEFAULT_THEMES, addTheme, allThemes, hasTheme, resolveTheme } from "../src/theme"
+import { DEFAULT_THEMES, addTheme, allThemes, hasTheme, resolveTheme, selectedForeground } from "../src/theme"
 import { discoverThemes } from "../src/context/theme"
 import { terminalMode } from "../src/theme/system"
 import { tmpdir } from "./fixture/fixture"
@@ -49,8 +49,29 @@ test("resolveTheme uses a contrasting selected foreground for transparent themes
   const item = structuredClone(DEFAULT_THEMES.opencode)
   item.theme.background = "transparent"
   item.theme.primary = "#eeeeee"
+  item.theme.secondary = "#111111"
 
-  expect(resolveTheme(item, "dark").selectedListItemText.toInts()).toEqual([0, 0, 0, 255])
+  const theme = resolveTheme(item, "dark")
+  expect(theme.selectedListItemText.toInts()).toEqual([0, 0, 0, 255])
+  expect(selectedForeground(theme, theme.secondary).toInts()).toEqual([255, 255, 255, 255])
+})
+
+test("resolveTheme uses white selected text for dark transparent-theme actions", () => {
+  const item = structuredClone(DEFAULT_THEMES.opencode)
+  item.theme.background = "transparent"
+  item.theme.primary = "#111111"
+
+  expect(resolveTheme(item, "dark").selectedListItemText.toInts()).toEqual([255, 255, 255, 255])
+})
+
+test("resolveTheme preserves an explicit selected foreground for transparent themes", () => {
+  const item = structuredClone(DEFAULT_THEMES.opencode)
+  item.theme.background = "transparent"
+  item.theme.selectedListItemText = "#123456"
+
+  const theme = resolveTheme(item, "dark")
+  expect(theme.selectedListItemText.toInts()).toEqual([18, 52, 86, 255])
+  expect(selectedForeground(theme, theme.secondary).toInts()).toEqual([18, 52, 86, 255])
 })
 
 function terminalColors(defaultBackground: string | null, palette: Array<string | null> = []): TerminalColors {

--- a/packages/tui/test/theme/v2/v1-migrate.test.ts
+++ b/packages/tui/test/theme/v2/v1-migrate.test.ts
@@ -32,11 +32,24 @@ test("preserves V1 selected foreground behavior on transparent backgrounds", () 
   const source = structuredClone(DEFAULT_THEMES.opencode)
   source.theme.background = "transparent"
   source.theme.primary = { light: "#ffffff", dark: "#000000" }
+  source.theme.error = { light: "#ffffff", dark: "#000000" }
   delete source.theme.selectedListItemText
   const migrated = migrateV1(source)
 
   expect(migrated.light.color?.text?.action?.primary?.default).toBe("#000000")
   expect(migrated.dark.color?.text?.action?.primary?.default).toBe("#ffffff")
+  expect(migrated.light.color?.text?.action?.destructive?.default).toBe("#000000")
+  expect(migrated.dark.color?.text?.action?.destructive?.default).toBe("#ffffff")
+})
+
+test("preserves explicit V1 selected text during migration", () => {
+  const source = structuredClone(DEFAULT_THEMES.opencode)
+  source.theme.background = "transparent"
+  source.theme.selectedListItemText = "#123456"
+
+  const migrated = migrateV1(source)
+  expect(migrated.light.color?.text?.action?.primary?.default).toBe("#123456")
+  expect(migrated.dark.color?.text?.action?.destructive?.default).toBe("#123456")
 })
 
 test("retains V1 circular reference errors", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #30056.

Ported over from https://github.com/anomalyco/opencode/pull/36239 which was targeting dev branch.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Badge text becomes invisible if your background is transparent. This fixes that by checking the background color and setting the text color accordingly in two places: file badge when a file is tagged, and another in the diff viewer. 

### How did you verify your code works?

Ran this with same theme and terminal, and you can see the screenshots below for before and after.

In my case, I ran it with system theme in Ghostty. You will see this with any theme in Ghostty.

### Screenshots / recordings

#### Badge

Before:
<img width="396" height="143" alt="Screenshot 2026-07-10 at 17 35 23@2x" src="https://github.com/user-attachments/assets/e710d3c0-a0fc-4850-8065-61347bd47fd7" />

After: 

<img width="565" height="203" alt="Screenshot 2026-07-10 at 17 34 10@2x" src="https://github.com/user-attachments/assets/03d48cb1-20d5-42f0-ba0a-24a6a5a6ddbe" />


#### Diff Viewer

Before:
<img width="787" height="421" alt="Screenshot 2026-07-10 at 17 32 48@2x" src="https://github.com/user-attachments/assets/4cdbfaca-497f-41bd-8869-2a2f9e6558ca" />

After:
<img width="922" height="447" alt="Screenshot 2026-07-10 at 17 33 55@2x" src="https://github.com/user-attachments/assets/a62b295c-f944-48aa-bd95-5bf7e7d45b56" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
