### PR TITLE
fix(acp): emit diff content block directly from edit metadata (avoid applyPatch)

### DIFF
--- a/packages/opencode/src/acp/permission.ts
+++ b/packages/opencode/src/acp/permission.ts
@@ -187,33 +187,18 @@ async function permissionContent(toolName: string, input: ToolInput): Promise<To
   if (files.length) return diffContentForFiles(files)
 
   const filepath = stringValue(input.filepath) ?? stringValue(input.filePath)
-  const diff = stringValue(input.diff)
-  if (!filepath || !diff) return []
-  const content = await diffContentForPatch(filepath, diff)
-  return content ? [content] : []
+  const oldText = stringValue(input.oldString)
+  const newText = stringValue(input.newString)
+  if (!filepath || oldText === undefined || newText === undefined) return []
+  return [{ type: "diff" as const, path: filepath, oldText, newText }]
 }
 
-async function diffContentForFiles(files: PermissionFileMetadata[]) {
-  const content = await Promise.all(
-    files.map(async (file) => {
-      if (!file.patch) return []
-      const content = await diffContentForPatch(file.filePath, file.patch, file.movePath)
-      return content ? [content] : []
-    }),
-  )
-  return content.flat()
-}
-
-async function diffContentForPatch(filepath: string, diff: string, displayPath = filepath) {
-  const content = (await exists(filepath)) ? await readText(filepath) : ""
-  const next = applyPatch(content, diff)
-  if (next === false) return undefined
-  return {
-    type: "diff" as const,
-    path: displayPath,
-    oldText: content,
-    newText: next,
-  }
+function diffContentForFiles(files: PermissionFileMetadata[]): ToolCallContent[] {
+  return files.flatMap((file) => {
+    if (file.oldString === undefined || file.newString === undefined) return []
+    const displayPath = file.movePath ?? file.filePath
+    return [{ type: "diff" as const, path: displayPath, oldText: file.oldString, newText: file.newString }]
+  })
 }
 
 function selectedReply(result: RequestPermissionResponse): Reply {
@@ -231,6 +216,8 @@ type PermissionFileMetadata = {
   readonly relativePath?: string
   readonly movePath?: string
   readonly patch?: string
+  readonly oldString?: string
+  readonly newString?: string
 }
 
 function fileMetadata(input: ToolInput): PermissionFileMetadata[] {
@@ -246,6 +233,8 @@ function fileMetadata(input: ToolInput): PermissionFileMetadata[] {
         relativePath: stringValue(info.relativePath),
         movePath: stringValue(info.movePath),
         patch: stringValue(info.patch),
+        oldString: stringValue(info.oldString),
+        newString: stringValue(info.newString),
       },
     ]
   })

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -196,6 +196,8 @@ export const ApplyPatchTool = Tool.define(
         relativePath: path.relative(instance.worktree, change.movePath ?? change.filePath).replaceAll("\\", "/"),
         type: change.type,
         patch: change.diff,
+        oldString: change.oldContent,
+        newString: change.newContent,
         additions: change.additions,
         deletions: change.deletions,
         movePath: change.movePath,

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -106,6 +106,8 @@ export const EditTool = Tool.define(
                   metadata: {
                     filepath: filePath,
                     diff,
+                    oldString: contentOld,
+                    newString: contentNew,
                   },
                 })
                 yield* afs.writeWithDirs(filePath, Bom.join(contentNew, desiredBom))
@@ -149,6 +151,8 @@ export const EditTool = Tool.define(
                 metadata: {
                   filepath: filePath,
                   diff,
+                  oldString: contentOld,
+                  newString: contentNew,
                 },
               })
 

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -58,6 +58,8 @@ export const WriteTool = Tool.define(
             metadata: {
               filepath,
               diff,
+              oldString: contentOld,
+              newString: contentNew,
             },
           })
 


### PR DESCRIPTION
### Issue for this PR

Closes #37266

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `toolCall.content` block (`type: "diff"`) is silently dropped from edit permission requests whenever the edited hunk sits entirely inside an indented block. ACP clients then have no diff to show next to the approval prompt. The actual edit still applies correctly via the fuzzy replacers in `edit.ts` — this is a preview-only regression.

**Why it happens:** `edit.ts` trims common indentation from the unified diff (`trimDiff`) for readability. Then `permission.ts::diffContentForPatch` tries to reconstruct the result by re-applying that indentation-stripped patch via `applyPatch(fileContent, trimmedDiff)`. `applyPatch` returns `false` because the context lines no longer match the file (their indentation was removed). With `fuzzFactor: 0` there is no tolerance, so the hunk can't be located, and no content block is emitted.

This was introduced by #34079, which added the `applyPatch` reconstruction. The earlier PR #31783 by @ReeSilva proposed a simpler approach — passing `oldString`/`newString` directly from the edit tool metadata — but was closed in favor of #34079's broader scope. This PR revives that approach and extends it to the multi-file path (`apply_patch.ts`).

**The fix:** `edit.ts`, `write.ts`, and `apply_patch.ts` already compute `contentOld`/`contentNew` before asking for permission. Pass them through `metadata` (`oldString`/`newString`), and in `permission.ts` read them directly instead of re-deriving via `applyPatch`. This avoids the trim/apply round-trip entirely and has no failure mode.

### How did you verify your code works?

Standalone repro from the issue — previously `applyPatch(trimmed)` → `FAILED`; after this change the content block is always emitted:

```js
import { applyPatch, createTwoFilesPatch } from "diff"

// trimDiff, copied verbatim from packages/opencode/src/tool/edit.ts
function trimDiff(diff) {
  const lines = diff.split("\n")
  const contentLines = lines.filter(
    (l) => (l.startsWith("+") || l.startsWith("-") || l.startsWith(" ")) &&
           !l.startsWith("---") && !l.startsWith("+++"),
  )
  if (contentLines.length === 0) return diff
  let min = Infinity
  for (const line of contentLines) {
    const c = line.slice(1)
    if (c.trim().length > 0) {
      const m = c.match(/^(\s*)/); if (m) min = Math.min(min, m[1].length)
    }
  }
  if (min === Infinity || min === 0) return diff
  return lines.map((l) =>
    (l.startsWith("+") || l.startsWith("-") || l.startsWith(" ")) &&
    !l.startsWith("---") && !l.startsWith("+++")
      ? l[0] + l.slice(1).slice(min) : l,
  ).join("\n")
}

const old =
`function compute() {
    const v0 = 0
    const v1 = 1
    const v2 = 2
    const v3 = 3
    const v4 = 4
    const v5 = 5
    const v6 = 6
    const v7 = 7
    const v8 = 8
    const v9 = 9
    const v10 = 10
    return sum
}
`
const next = old.replace("    const v5 = 5", "    const v5 = 50")

const raw = createTwoFilesPatch("f", "f", old, next)
const trimmed = trimDiff(raw)

console.log("applyPatch(raw):     ", applyPatch(old, raw) === false ? "FAILED" : "OK")
console.log("applyPatch(trimmed): ", applyPatch(old, trimmed) === false ? "FAILED  <- no preview" : "OK")
```

Also tested end-to-end against an ACP client over `opencode acp`: edits inside indented blocks now render a diff next to the approval prompt, matching edits near the top level.

### Screenshots / recordings

_N/A — not a UI change in the TUI. The effect is visible only in external ACP clients._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
