### PR TITLE
feat(ai): default Vertex xAI to Responses

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -131,10 +131,14 @@ OpenAI Chat and OpenAI Responses are separate semantic entrypoints:
 - `@opencode-ai/ai/providers/google-vertex/chat`
 - `@opencode-ai/ai/providers/google-vertex/responses`
 - `@opencode-ai/ai/providers/google-vertex/messages`
+- `@opencode-ai/ai/providers/google-vertex/xai`
+- `@opencode-ai/ai/providers/google-vertex/xai/chat`
 
 Responses HTTP versus WebSocket is a scoped `transport` setting on the OpenAI Responses entrypoint, not another entrypoint. Azure follows the same Chat/Responses split at `providers/azure/chat` and `providers/azure/responses`. Generic OpenAI-compatible Chat remains at `providers/openai-compatible`; compatible Responses is separate at `providers/openai-compatible/responses`. Generic Anthropic Messages-compatible providers use `providers/anthropic-compatible`, which the named Anthropic provider composes. Google Gemini and Amazon Bedrock expose their single native API through their existing provider paths.
 
 Vertex Gemini, Vertex Chat, Vertex Responses, and Vertex Messages are separate API entrypoints. All accept `project`, `location`, and an optional `accessToken`; when no explicit token or auth override is supplied they lazily use Google Application Default Credentials. Vertex Gemini instead selects express mode when `apiKey` or `GOOGLE_VERTEX_API_KEY` is present. Vertex Chat targets MaaS models through the OpenAI-compatible Chat Completions endpoint, while Vertex Responses targets Grok models and defaults `store` to `false` as required by Vertex. `providers/google-vertex` remains the default alias for `providers/google-vertex/gemini`.
+
+The Vertex xAI package alias defaults to Responses at `providers/google-vertex/xai`; select Chat explicitly with `providers/google-vertex/xai/chat`.
 
 Tuned Vertex Gemini deployments use model ids shaped like `endpoints/1234567890` and require OAuth or ADC; Vertex express-mode API keys support publisher models only.
 

--- a/packages/ai/STATUS.md
+++ b/packages/ai/STATUS.md
@@ -57,7 +57,7 @@ Other `aisdk:` packages, including Google Vertex, Azure, and Bedrock, currently 
 | `@ai-sdk/google-vertex`           | Vertex Gemini namespace/facade                                 | Partial / usable | Add runner/catalog mapping, recorded coverage, and broader provider-option parity.                                                                                                                                  |
 | `@ai-sdk/google-vertex/anthropic` | Anthropic Messages over Vertex namespace/facade                | Partial / usable | Add runner/catalog mapping, recorded coverage, and Vertex-specific hosted-tool parity.                                                                                                                              |
 | `@ai-sdk/google-vertex/maas`      | Vertex Chat                                                    | Partial / usable | Add runner/catalog mapping, recorded coverage, and MaaS family-specific request parity.                                                                                                                             |
-| `@ai-sdk/google-vertex/xai`       | Vertex Chat / Responses                                        | Partial / usable | Decide Chat/Responses selection for catalog models, add runner mapping and recorded coverage, and review xAI-specific request options.                                                                              |
+| `@ai-sdk/google-vertex/xai`       | Vertex Responses by default; Chat explicit                     | Partial / usable | Add runner mapping and recorded coverage, and review xAI-specific request options.                                                                                                                                  |
 | `@ai-sdk/azure`                   | Azure OpenAI Chat/Responses facade                             | Partial          | Map runner/catalog metadata to native Azure, handle resourceName/baseURL/apiVersion variants, add AAD/token auth story, and verify Chat vs Responses deployment selection.                                          |
 | `@ai-sdk/amazon-bedrock`          | Bedrock Converse                                               | Partial          | Add default AWS credential chain/profile support, region/inference-profile model ID handling, provider option parity via `additionalModelRequestFields`, guardrails/performance config, and runner/catalog mapping. |
 | `@ai-sdk/amazon-bedrock/mantle`   | Bedrock Mantle OpenAI-compatible Chat/Responses namespace      | Missing          | Decide native Mantle shape, likely separate from Converse because it uses OpenAI-compatible Chat/Responses semantics over Bedrock. Add package mapping and tests.                                                   |
@@ -71,7 +71,7 @@ Other `aisdk:` packages, including Google Vertex, Azure, and Bedrock, currently 
 5. Azure is only a provider facade, not a full runtime replacement. Native Azure exists, but the catalog runner does not select it, and token auth/resource variants need review.
 6. Provider option typing is uneven. OpenAI, Anthropic, Gemini, Bedrock, and OpenRouter each expose a small typed subset plus raw HTTP overlays; this is useful but not equivalent to AI SDK provider option coverage.
 7. Structured output is not provider-native yet. `LLM.generateObject` still uses a synthetic tool strategy, while the future design expects native structured output where reliable and tool fallback where needed.
-8. Package/namespace boundaries for the current native loading set are explicit in docs and exports. Other exported provider facades are not catalog package entrypoints until they implement the contract. Vertex xAI still needs catalog API selection; the missing native boundary is Bedrock Mantle.
+8. Package/namespace boundaries for the current native loading set are explicit in docs and exports. Other exported provider facades are not catalog package entrypoints until they implement the contract. Vertex xAI defaults to Responses with explicit Chat selection; the missing native boundary is Bedrock Mantle.
 9. Recorded coverage is uneven. OpenAI, Anthropic, Gemini, Bedrock Converse, Cloudflare, OpenRouter, and several OpenAI-compatible Chat providers have cassettes. Azure, Vertex, and Mantle need first-class recorded scenarios before switching defaults.
 
 ## Native Namespace Shape
@@ -91,6 +91,8 @@ These are implementation/API slices, not separate npm packages.
 | Vertex Chat                   | `@opencode-ai/ai/providers/google-vertex/chat`          | Vertex OpenAI-compatible Chat Completions for MaaS models.                   |
 | Vertex Responses              | `@opencode-ai/ai/providers/google-vertex/responses`     | Vertex OpenAI-compatible Responses for Grok models.                          |
 | Vertex Messages               | `@opencode-ai/ai/providers/google-vertex/messages`      | Vertex-hosted Anthropic Messages API.                                        |
+| Vertex xAI                    | `@opencode-ai/ai/providers/google-vertex/xai`           | Responses by default.                                                        |
+| Vertex xAI Chat               | `@opencode-ai/ai/providers/google-vertex/xai/chat`      | Explicit Chat selection.                                                     |
 | Bedrock Converse              | `@opencode-ai/ai/providers/amazon-bedrock`              | AWS Bedrock Converse API.                                                    |
 | Bedrock Mantle                | Missing                                                 | AWS Bedrock Mantle OpenAI-compatible APIs.                                   |
 | Azure OpenAI Chat             | `@opencode-ai/ai/providers/azure/chat`                  | Azure specialization of OpenAI Chat.                                         |
@@ -102,7 +104,7 @@ These are implementation/API slices, not separate npm packages.
 2. Add API-aware runner/catalog selection between OpenAI-compatible Chat and Responses.
 3. Bring Bedrock native auth/config to AI SDK parity: region, profile, default AWS credential chain, bearer token env, endpoint override, and cross-region inference profile handling.
 4. Add runner/catalog mappings and recorded scenarios for the native Vertex Gemini, Chat, Responses, and Messages entrypoints.
-5. Decide Chat/Responses selection for `@ai-sdk/google-vertex/xai` catalog models.
+5. Map `@ai-sdk/google-vertex/xai` catalog models to Responses by default while preserving explicit Chat selection.
 6. Add Bedrock Mantle as a separate OpenAI-compatible Bedrock namespace after deciding whether it uses Chat, Responses, or both by model.
 7. Expand typed provider options from the existing V1 lowerer knowledge in `packages/core/src/v1/config/provider-options.ts` before adding more raw overlay examples.
 8. Add recorded provider tests for Azure, Vertex Gemini, Vertex Chat, Vertex Responses, Vertex Messages, Bedrock credential-chain behavior, and Mantle before making native runtime the default for those packages.

--- a/packages/ai/example/call-sites.md
+++ b/packages/ai/example/call-sites.md
@@ -381,6 +381,9 @@ import { model } from "@opencode-ai/ai/providers/google-vertex/responses"
 model("xai/grok-4.20-reasoning", { project, location: "global" })
 ```
 
+Vertex xAI defaults to that Responses entrypoint. Callers that require Chat select
+`@opencode-ai/ai/providers/google-vertex/xai/chat` explicitly.
+
 ```ts
 import { model } from "@opencode-ai/ai/providers/google-vertex/messages"
 

--- a/packages/ai/src/providers/google-vertex/xai.ts
+++ b/packages/ai/src/providers/google-vertex/xai.ts
@@ -1,0 +1,2 @@
+export { model } from "../google-vertex-responses"
+export type { Settings } from "../google-vertex-responses"

--- a/packages/ai/src/providers/google-vertex/xai/chat.ts
+++ b/packages/ai/src/providers/google-vertex/xai/chat.ts
@@ -1,0 +1,2 @@
+export { model } from "../../google-vertex-chat"
+export type { Settings } from "../../google-vertex-chat"

--- a/packages/ai/test/provider-package.test.ts
+++ b/packages/ai/test/provider-package.test.ts
@@ -21,6 +21,8 @@ describe("provider package entrypoints", () => {
       import("@opencode-ai/ai/providers/google-vertex/chat"),
       import("@opencode-ai/ai/providers/google-vertex/responses"),
       import("@opencode-ai/ai/providers/google-vertex/messages"),
+      import("@opencode-ai/ai/providers/google-vertex/xai"),
+      import("@opencode-ai/ai/providers/google-vertex/xai/chat"),
     ])
 
     for (const module of modules) expect(module.model).toBeFunction()
@@ -292,5 +294,28 @@ describe("provider package entrypoints", () => {
         { apiKey: "fixture", project: "vertex-project" },
       ]),
     ).toThrow("Google Vertex Responses does not support API keys")
+  })
+
+  test("defaults Vertex xAI to Responses with explicit Chat selection", async () => {
+    const GoogleVertexXAI = await import("@opencode-ai/ai/providers/google-vertex/xai")
+    const GoogleVertexXAIChat = await import("@opencode-ai/ai/providers/google-vertex/xai/chat")
+    const GoogleVertexChat = await import("@opencode-ai/ai/providers/google-vertex/chat")
+    const GoogleVertexResponses = await import("@opencode-ai/ai/providers/google-vertex/responses")
+    const settings = {
+      accessToken: "fixture",
+      location: "global",
+      project: "vertex-project",
+    }
+
+    expect(GoogleVertexXAI.model).toBe(GoogleVertexResponses.model)
+    expect(GoogleVertexXAIChat.model).toBe(GoogleVertexChat.model)
+    expect(GoogleVertexXAI.model("xai/grok-4.20-reasoning", settings).route).toMatchObject({
+      id: "google-vertex-responses",
+      protocol: "openai-responses",
+    })
+    expect(GoogleVertexXAIChat.model("xai/grok-4.20-reasoning", settings).route).toMatchObject({
+      id: "google-vertex-chat",
+      protocol: "openai-chat",
+    })
   })
 })

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -560,6 +560,8 @@ describe("SessionRunnerModel", () => {
         ["@opencode-ai/ai/providers/google-vertex/chat", "accessToken"],
         ["@opencode-ai/ai/providers/google-vertex/responses", "accessToken"],
         ["@opencode-ai/ai/providers/google-vertex/messages", "accessToken"],
+        ["@opencode-ai/ai/providers/google-vertex/xai", "accessToken"],
+        ["@opencode-ai/ai/providers/google-vertex/xai/chat", "accessToken"],
         ["@opencode-ai/ai/providers/anthropic", "authToken"],
         ["@opencode-ai/ai/providers/anthropic-compatible", "authToken"],
       ] as const


### PR DESCRIPTION
## summary
- add `@opencode-ai/ai/providers/google-vertex/xai` as a package alias for Vertex Responses
- add `@opencode-ai/ai/providers/google-vertex/xai/chat` for explicit Chat selection
- reuse the existing Vertex Responses and Chat model functions directly and document the selection policy

## testing
- `bun test` in `packages/ai` (331 passed, 29 skipped)
- `bun typecheck` and `bun run build` in `packages/ai`
- `bun typecheck` and `bun test test/session-runner-model.test.ts` in `packages/core`
- repository typecheck via push hook