### PR TITLE
fix(tui): label only detached subagents as background

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1340,7 +1340,7 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
     if (state() === "error") return "failed"
     return state() ?? "finished"
   }
-  const heading = () => `${state() === "completed" ? "↳" : "!"} ${actor()} ${status()}`
+  const heading = () => `${state() === "completed" ? "✓" : "!"} ${actor()} ${status()}`
   const suffix = () =>
     Locale.truncateWidth(` · ${description()}`, Math.max(0, ctx.width - 3 - Bun.stringWidth(heading())))
   const color = () => {
@@ -2548,10 +2548,8 @@ function WebSearch(props: ToolProps) {
 function Subagent(props: ToolProps) {
   const { navigate } = useRoute()
   const data = useData()
-  const input = createMemo(() => (typeof props.part.state.input === "string" ? {} : props.part.state.input))
-  const metadata = createMemo(() => (props.part.state.status === "streaming" ? {} : props.part.state.structured))
-  const sessionID = createMemo(() => stringValue(metadata().sessionID) ?? stringValue(metadata().sessionId))
-  const description = createMemo(() => stringValue(input().description))
+  const sessionID = createMemo(() => stringValue(props.metadata.sessionID) ?? stringValue(props.metadata.sessionId))
+  const description = createMemo(() => stringValue(props.input.description))
   const isRunning = createMemo(() => {
     const id = sessionID()
     return props.part.state.status === "running" || Boolean(id && data.session.status(id) === "running")
@@ -2569,14 +2567,21 @@ function Subagent(props: ToolProps) {
         if (id) navigate({ type: "session", sessionID: id })
       }}
       status={
-        input().background === true || metadata().status === "running" ? (
+        isBackgroundSubagent(props.metadata, props.part.state.status) ? (
           <StatusBadge>Background</StatusBadge>
         ) : undefined
       }
     >
-      {`${Locale.titlecase(stringValue(input().agent) ?? stringValue(input().subagent_type) ?? "General")} Subagent — ${description() ?? "Subagent"}`}
+      {`${Locale.titlecase(stringValue(props.input.agent) ?? stringValue(props.input.subagent_type) ?? "General")} Subagent — ${description() ?? "Subagent"}`}
     </InlineTool>
   )
+}
+
+export function isBackgroundSubagent(
+  metadata: Record<string, unknown>,
+  status: SessionMessageAssistantTool["state"]["status"],
+) {
+  return status === "completed" && metadata.status === "running"
 }
 
 export function formatSubagentRetry(attempt: number, message: string) {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1340,7 +1340,7 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
     if (state() === "error") return "failed"
     return state() ?? "finished"
   }
-  const heading = () => `${state() === "completed" ? "✓" : "!"} ${actor()} ${status()}`
+  const heading = () => `${state() === "completed" ? "↳" : "!"} ${actor()} ${status()}`
   const suffix = () =>
     Locale.truncateWidth(` · ${description()}`, Math.max(0, ctx.width - 3 - Bun.stringWidth(heading())))
   const color = () => {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -4,6 +4,7 @@ import { testRender, type JSX } from "@opentui/solid"
 import {
   formatSubagentRetry,
   InlineToolRow,
+  isBackgroundSubagent,
   parseApplyPatchFiles,
   parseDiagnostics,
   parseQuestionAnswers,
@@ -199,6 +200,13 @@ describe("TUI inline tool wrapping", () => {
 
   test("keeps retry status ahead of wrapping messages", () => {
     expect(formatSubagentRetry(2, "Rate limited by provider")).toBe("Retrying (attempt 2) · Rate limited by provider")
+  })
+
+  test("labels only detached or async subagents as background", () => {
+    expect(isBackgroundSubagent({ status: "running" }, "running")).toBeFalse()
+    expect(isBackgroundSubagent({ status: "running" }, "completed")).toBeTrue()
+    expect(isBackgroundSubagent({ status: "running" }, "error")).toBeFalse()
+    expect(isBackgroundSubagent({ status: "completed" }, "completed")).toBeFalse()
   })
 
   test("snapshots consecutive grep, glob, and read rows at a narrow width", async () => {


### PR DESCRIPTION
### What

Stop foreground running subagents from receiving a misleading `Background` badge.

### Before / After

**Before:** Any child with structured `status: "running"` was labeled `Background`, even while its outer tool call was still running in the foreground. The card therefore claimed the child was backgrounded while the valid `ctrl+b` hint said it was still blocking.

**After:** `Background` appears only when the outer tool call has completed while the child remains running. This is the shared state produced by either `ctrl+b` detachment or an immediate `background: true` launch. Foreground and failed calls are not mislabeled.

### How

- `packages/tui/src/routes/session/index.tsx` derives the badge from the outer tool lifecycle plus structured child status and reuses normalized tool input/metadata.
- `packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx` covers foreground, detached/async, failed, and completed-child states.

### Scope

This does not change subagent execution, backgrounding lifecycle, notification icons, or keyboard behavior. Async-only hint suppression remains covered by #37088, subagent-picker presentation by #36480, and narrow footer action layout by #37180.

### Testing

- `bun test test/cli/tui/inline-tool-wrap-snapshot.test.tsx` (11 pass)
- `bun run typecheck` from `packages/tui`
- `bun run lint packages/tui/src/routes/session/index.tsx packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx` (0 errors; existing warnings in `session/index.tsx`)
- Pre-push `bun turbo typecheck --concurrency=3` (32/32 tasks)
- Durable reproduction from `ses_099291c64ffep0rHSS1Yl4mq42` confirms the reported card was foreground/running despite its false badge
- Matched Effect-native OpenCode Drive runs against the PR base and PR head

### Demo

Both recordings use the same Effect program, simulated model responses, 110×34 viewport, and held child-completion gates. Each run shows all three valid lifecycle paths:

1. A foreground child blocks for 2.5 seconds with `ctrl+b` available.
2. `ctrl+b` detaches that child, the card becomes `Background`, and the parent continues before the child is released.
3. A second child launches with `background: true`, immediately shows `Background`, and the parent continues before that child is released.

**Before**

The first foreground child is incorrectly labeled `Background` before `ctrl+b` is pressed.

https://github.com/user-attachments/assets/54cf7011-019c-4df6-ab59-19da4c56b866

**After**

The first foreground child has no badge. The badge appears only after `ctrl+b`, and still appears immediately for the explicit background launch.

https://github.com/user-attachments/assets/c696b7f9-f4c9-492d-bee3-d24d9b0fc430

The MP4s were exported with OpenCode Drive #12, which renders the intended `↳` completion icon without the prior missing-glyph artifact.
