### PR TITLE
fix(tool): gracefully skip broken custom workspace tools

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -189,10 +189,32 @@ const layer = Layer.effect(
           const namespace = path.basename(match, path.extname(match))
           // `match` is an absolute filesystem path from `Glob.scanSync(..., { absolute: true })`.
           // Import it as `file://` so Node on Windows accepts the dynamic import.
-          const mod = yield* Effect.promise(() => import(pathToFileURL(match).href))
+          const mod = yield* Effect.tryPromise({
+            try: () => import(pathToFileURL(match).href),
+            catch: (error) => error,
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning(`failed to load custom tool file from: ${match}`, {
+                error: error instanceof Error ? error.stack ?? error.message : String(error),
+              }).pipe(Effect.as(null)),
+            ),
+          )
+          if (!mod) continue
           for (const [id, def] of Object.entries(mod)) {
             if (!isPluginTool(def)) continue
-            custom.push(fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def))
+            const tool = yield* Effect.try({
+              try: () => fromPlugin(id === "default" ? namespace : `${namespace}_${id}`, def),
+              catch: (error) => error,
+            }).pipe(
+              Effect.catch((error) =>
+                Effect.logWarning(`failed to register custom tool definition '${id}' in '${match}'`, {
+                  error: error instanceof Error ? error.stack ?? error.message : String(error),
+                }).pipe(Effect.as(null)),
+              ),
+            )
+            if (tool) {
+              custom.push(tool)
+            }
           }
         }
 

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -569,4 +569,36 @@ describe("tool.registry", () => {
       expect(ids).toContain("cowsay")
     }),
   )
+
+  it.instance("tolerates an invalid custom tool file throwing compilation or import errors", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const opencode = path.join(test.directory, ".opencode")
+      const tools = path.join(opencode, "tools")
+      yield* Effect.promise(() => fs.mkdir(tools, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tools, "invalid-tool.ts"),
+          "import { invalid } from 'non-existent-module-abc-123'\nexport default {}",
+        ),
+      )
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(tools, "valid-tool.ts"),
+          [
+            "export default {",
+            "  description: 'valid custom tool',",
+            "  args: {},",
+            "  execute: async () => 'ok',",
+            "}",
+          ].join("\n"),
+        ),
+      )
+      const registry = yield* ToolRegistry.Service
+      const ids = yield* registry.ids()
+      expect(ids).not.toContain("invalid-tool")
+      expect(ids).toContain("valid-tool")
+      expect(ids).toContain("read")
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #37317

Related: #8006 #10467

### Type of change

- [x] Bug fix

### What does this PR do?

Custom workspace tools from `.opencode/tool/` and `.opencode/tools/` are dynamically imported during startup. If a tool file has unresolved dependencies or an initialization error, the unhandled rejection can prevent the session from starting normally.

This wraps the `import()` and `fromPlugin()` calls in `Effect.tryPromise`/`Effect.catch` boundaries. Broken tools are logged and skipped; the session starts normally.

### How did you verify your code works?

- `bun test test/tool/registry.test.ts` — 16/16 tests passed
- `bun turbo typecheck` — 30/30 tasks passed

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
