### PR TITLE
fix(core): reject unknown session interrupts

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -276,7 +276,7 @@ export interface Interface {
   readonly active: Effect.Effect<ReadonlySet<SessionSchema.ID>>
   readonly background: (sessionID: SessionSchema.ID) => Effect.Effect<void, NotFoundError>
   readonly resume: (sessionID: SessionSchema.ID) => Effect.Effect<void, NotFoundError | SessionRunner.RunError>
-  readonly interrupt: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  readonly interrupt: (sessionID: SessionSchema.ID) => Effect.Effect<void, NotFoundError>
   readonly synthetic: (input: {
     id?: SessionMessage.ID
     sessionID: SessionSchema.ID
@@ -804,7 +804,12 @@ const layer = Layer.effect(
         ),
       ),
       interrupt: Effect.fn("V2Session.interrupt")((sessionID) =>
-        Effect.uninterruptible(execution.interrupt(sessionID)),
+        Effect.uninterruptible(
+          Effect.gen(function* () {
+            yield* result.get(sessionID)
+            yield* execution.interrupt(sessionID)
+          }),
+        ),
       ),
       revert: {
         stage: Effect.fn("V2Session.revert.stage")(function* (input) {

--- a/packages/core/src/tool/subagent.ts
+++ b/packages/core/src/tool/subagent.ts
@@ -188,7 +188,13 @@ export const Plugin = {
                   yield* runtime.session.prompt({ sessionID: child.id, text: input.prompt, resume: false })
                   yield* runtime.session.resume(child.id)
                   return yield* latestAssistantText(child.id)
-                }).pipe(Effect.onInterrupt(() => runtime.session.interrupt(child.id)))
+                }).pipe(
+                  Effect.onInterrupt(() =>
+                    runtime.session
+                      .interrupt(child.id)
+                      .pipe(Effect.catchTag("Session.NotFoundError", () => Effect.void)),
+                  ),
+                )
 
                 const info = yield* runtime.job.start({
                   id: child.id,
@@ -208,13 +214,21 @@ export const Plugin = {
                   }
                 }
 
-                const result = yield* runtime.job.block({ id: child.id, sessionID: context.sessionID }).pipe(
-                  Effect.onInterrupt(() =>
-                    Effect.all([runtime.session.interrupt(child.id), runtime.job.cancel(child.id)], {
-                      discard: true,
-                    }),
-                  ),
-                )
+                const result = yield* runtime.job
+                  .block({ id: child.id, sessionID: context.sessionID })
+                  .pipe(
+                    Effect.onInterrupt(() =>
+                      Effect.all(
+                        [
+                          runtime.session
+                            .interrupt(child.id)
+                            .pipe(Effect.catchTag("Session.NotFoundError", () => Effect.void)),
+                          runtime.job.cancel(child.id),
+                        ],
+                        { discard: true },
+                      ),
+                    ),
+                  )
                 if (result?.type === "backgrounded") {
                   yield* notifyWhenDone(context.sessionID, child.id, agent.name, input.description)
                   return {

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -156,13 +156,16 @@ describe("SessionV2.prompt", () => {
     }),
   )
 
-  it.effect("delegates interruption without requiring a recorded Session", () =>
+  it.effect("rejects interruption for an unknown Session", () =>
     Effect.gen(function* () {
       const session = yield* SessionV2.Service
       interruptCalls.length = 0
+      const missing = SessionV2.ID.make("ses_missing")
 
-      yield* session.interrupt(SessionV2.ID.make("ses_missing"))
-      expect(interruptCalls).toEqual([SessionV2.ID.make("ses_missing")])
+      expect(yield* session.interrupt(missing).pipe(Effect.flip)).toEqual(
+        new SessionV2.NotFoundError({ sessionID: missing }),
+      )
+      expect(interruptCalls).toEqual([])
     }),
   )
 


### PR DESCRIPTION
## What

Make public V2 Session interruption reject unknown Session IDs with the existing `Session.NotFoundError` contract while preserving interruption as a no-op for known Sessions with no process-local owner.

## Before / After

**Before:** `SessionV2.interrupt` delegated every ID directly to `SessionExecution`. Because execution interruption is intentionally process-local and idle-safe, an unknown durable Session ID incorrectly returned success.

**After:** `SessionV2.interrupt` first validates the Session in durable storage. Unknown IDs fail with `Session.NotFoundError`; known idle or locally unowned Sessions still delegate to `SessionExecution` and succeed as a no-op.

## How

- `packages/core/src/session.ts` widens the public interrupt error type and validates existence before process-local delegation.
- `packages/core/test/session-prompt.test.ts` replaces the old unknown-ID delegation expectation with a focused NotFound regression and verifies execution is not called.
- `packages/core/src/tool/subagent.ts` handles the newly explicit NotFound contract in interruption-only child cleanup without masking the original interruption.

## Scope

This only changes public V2 Session interrupt validation. It does not change `SessionExecution` process-local ownership or idle interruption behavior.

## Testing

- `bun run test test/session-prompt.test.ts` from `packages/core`: 36 passed, 0 failed.
- `bun typecheck` from `packages/core`: passed.
- Push hook `bun turbo typecheck --concurrency=3`: 32 tasks passed.