### PR TITLE
fix(provider): restore Azure Cognitive Services endpoints

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -277,7 +277,7 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
         },
       }
     }),
-    "azure-cognitive-services": Effect.fnUntraced(function* () {
+    "azure-cognitive-services": Effect.fnUntraced(function* (provider: Info) {
       const resourceName = yield* dep.get("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME")
       return {
         autoload: false,
@@ -285,7 +285,9 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           return selectAzureLanguageModel(sdk, modelID, Boolean(options?.["useCompletionUrls"]))
         },
         options: {
-          baseURL: resourceName ? `https://${resourceName}.cognitiveservices.azure.com/openai` : undefined,
+          baseURL: resourceName
+            ? `https://${resourceName}.cognitiveservices.azure.com/openai${provider.options?.useDeploymentBasedUrls ? "" : "/v1"}`
+            : undefined,
         },
       }
     }),

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -805,38 +805,6 @@ it.instance("getSmallModel skips inferred models for Azure Cognitive Services", 
   }),
 )
 
-it.instance("Azure Cognitive Services uses the v1 OpenAI endpoint", () =>
-  Effect.gen(function* () {
-    yield* set("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME", "test-resource")
-    yield* set("AZURE_COGNITIVE_SERVICES_API_KEY", "test-key")
-    const providers = yield* list
-    expect(providers[ProviderV2.ID.make("azure-cognitive-services")].options.baseURL).toBe(
-      "https://test-resource.cognitiveservices.azure.com/openai/v1",
-    )
-  }),
-)
-
-it.instance(
-  "Azure Cognitive Services preserves deployment-based endpoints",
-  Effect.gen(function* () {
-    yield* set("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME", "test-resource")
-    yield* set("AZURE_COGNITIVE_SERVICES_API_KEY", "test-key")
-    const providers = yield* list
-    expect(providers[ProviderV2.ID.make("azure-cognitive-services")].options.baseURL).toBe(
-      "https://test-resource.cognitiveservices.azure.com/openai",
-    )
-  }),
-  {
-    config: {
-      provider: {
-        "azure-cognitive-services": {
-          options: { useDeploymentBasedUrls: true },
-        },
-      },
-    },
-  },
-)
-
 it.instance(
   "getSmallModel respects config small_model override",
   Effect.gen(function* () {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -805,6 +805,38 @@ it.instance("getSmallModel skips inferred models for Azure Cognitive Services", 
   }),
 )
 
+it.instance("Azure Cognitive Services uses the v1 OpenAI endpoint", () =>
+  Effect.gen(function* () {
+    yield* set("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME", "test-resource")
+    yield* set("AZURE_COGNITIVE_SERVICES_API_KEY", "test-key")
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.make("azure-cognitive-services")].options.baseURL).toBe(
+      "https://test-resource.cognitiveservices.azure.com/openai/v1",
+    )
+  }),
+)
+
+it.instance(
+  "Azure Cognitive Services preserves deployment-based endpoints",
+  Effect.gen(function* () {
+    yield* set("AZURE_COGNITIVE_SERVICES_RESOURCE_NAME", "test-resource")
+    yield* set("AZURE_COGNITIVE_SERVICES_API_KEY", "test-key")
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.make("azure-cognitive-services")].options.baseURL).toBe(
+      "https://test-resource.cognitiveservices.azure.com/openai",
+    )
+  }),
+  {
+    config: {
+      provider: {
+        "azure-cognitive-services": {
+          options: { useDeploymentBasedUrls: true },
+        },
+      },
+    },
+  },
+)
+
 it.instance(
   "getSmallModel respects config small_model override",
   Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- include `/v1` in generated Azure Cognitive Services OpenAI endpoints
- preserve legacy deployment-based endpoint construction when `useDeploymentBasedUrls` is enabled

`@ai-sdk/azure` 3.0.84+ treats non-`.openai.azure.com` base URLs as custom gateways and no longer appends `/v1`. OpenCode previously supplied the ACS base URL without `/v1`, causing SDK 3.0.88 to request `/openai/responses` and return `Resource not found`.

Fixes #37333.

## Testing

- `bun test test/provider/provider.test.ts`
- `bun typecheck`
- `git diff --check`