### PR TITLE
fix(session): show project references without a description in the system prompt

### DIFF
--- a/packages/opencode/src/session/system.ts
+++ b/packages/opencode/src/session/system.ts
@@ -58,7 +58,7 @@ const layer = Layer.effect(
       environment: Effect.fn("SystemPrompt.environment")(function* (model: Provider.Model) {
         const ctx = yield* InstanceState.context
         const references = yield* Effect.gen(function* () {
-          return (yield* (yield* Reference.Service).list()).filter((reference) => reference.description !== undefined)
+          return yield* (yield* Reference.Service).list()
         }).pipe(Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(ctx.directory) }))))
         return [
           [


### PR DESCRIPTION
## Problem

Project references configured without a `description` are silently omitted from the `<available_references>` block in the system prompt.

`SystemPrompt.environment` filtered the reference list on `description !== undefined`:

```ts
return (yield* (yield* Reference.Service).list()).filter((reference) => reference.description !== undefined)
```

So a reference declared with just a repository/path (no description) is registered and usable on disk, but the agent never sees it in its prompt. When every reference lacks a description, the entire `<available_references>` block is dropped, and the agent behaves as if no references exist — e.g. a code-review agent re-clones the repo into `/tmp` instead of branching a worktree from the already-checked-out reference.

## Fix

Remove the filter so references are listed regardless of whether they have a description. The renderer already handles a missing description gracefully (it just omits the `<description>` line, `system.ts:86-88`) and still returns `undefined` for an empty list (`:75`), so no other changes are needed.

```ts
return yield* (yield* Reference.Service).list()
```

## Note

There is an identical filter in the v2 `ReferenceGuidance` path (`packages/core/src/reference/guidance.ts:42`). Left untouched here to keep this a one-line change to the active prompt path; happy to fold it in if preferred.