### PR TITLE
fix(tui): remove debug theme toggle

### DIFF
--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -50,9 +50,8 @@ function Mcp(props: { context: Plugin.Context }) {
 }
 
 function View(props: { context: Plugin.Context }) {
-  const { themeV2, mode, setMode } = useTheme()
+  const { themeV2 } = useTheme()
   const dimensions = useTerminalDimensions()
-  const modeLabel = createMemo(() => (mode() === "dark" ? "Light mode" : "Dark mode"))
   const mcpWidth = createMemo(() => {
     const list = props.context.data.location.mcp.server.list(props.context.location) ?? []
     if (list.length === 0) return 0
@@ -73,16 +72,10 @@ function View(props: { context: Plugin.Context }) {
     >
       <Directory
         context={props.context}
-        maxWidth={Math.max(
-          2,
-          dimensions().width - 10 - Bun.stringWidth(InstallationVersion) - Bun.stringWidth(modeLabel()) - mcpWidth(),
-        )}
+        maxWidth={Math.max(2, dimensions().width - 8 - Bun.stringWidth(InstallationVersion) - mcpWidth())}
       />
       <Mcp context={props.context} />
       <box flexGrow={1} />
-      <box flexShrink={0} onMouseUp={() => setMode(mode() === "dark" ? "light" : "dark")}>
-        <text fg={themeV2.text.action.secondary()}>{modeLabel()}</text>
-      </box>
       <box flexShrink={0}>
         <text fg={themeV2.text.subdued()}>{InstallationVersion}</text>
       </box>


### PR DESCRIPTION
## Summary
- remove the temporary light/dark mode control from the home footer
- restore footer width allocation to directory, MCP status, and version content only

## Testing
- `bun typecheck` in `packages/tui`