### PR TITLE
fix(tui): correct truncateLeft output when len is 1

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -65,7 +65,7 @@ export function truncate(str: string, len: number): string {
 
 export function truncateLeft(str: string, len: number): string {
   if (str.length <= len) return str
-  return "…" + str.slice(-(len - 1))
+  return "…" + str.slice(str.length - (len - 1))
 }
 
 export function truncateMiddle(str: string, maxLength: number = 35): string {


### PR DESCRIPTION
### Issue for this PR

Closes #37368

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`truncateLeft(str, len)` ended with `"…" + str.slice(-(len - 1))`. When `len === 1` that is `str.slice(-0)`, and `slice(-0)` equals `slice(0)` — the whole string — so the function returned something *longer* than the input (`truncateLeft("abcdef", 1)` → `"…abcdef"`).

This replaces the negative index with an equivalent positive one: `str.slice(str.length - (len - 1))`. At `len === 1` that becomes `str.slice(str.length)` → `""`, giving `"…"`. For every `len >= 2` the two expressions are identical, so existing behavior is unchanged. This also brings it in line with the sibling `truncate()`, which already handles `len === 1` correctly.

### How did you verify your code works?

Ran the old and new implementations side by side over a range of lengths:

- `len === 1`: old `"…abcdef"` (7 chars) → new `"…"` (1 char) ✅
- `len === 2, 3, 5`: identical output to before (`"…f"`, `"…ef"`, `"…cdef"`) ✅
- `len >= str.length`: returns the string unchanged ✅

One-character diff, no caller changes needed.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
