### PR TITLE
feat(tui): resolve action state priority

### DIFF
--- a/packages/tui/src/routes/session/composer/shell-tab.tsx
+++ b/packages/tui/src/routes/session/composer/shell-tab.tsx
@@ -100,17 +100,16 @@ export function ShellTab(props: { sessionID: string }) {
           <For each={entries()}>
             {(shell, index) => {
               const active = createMemo(() => index() === store.selected)
-              const states = createMemo(() => ({ focused: active() }))
               return (
                 <box
                   flexDirection="row"
                   paddingLeft={1}
                   paddingRight={1}
-                  backgroundColor={themeV2.background.action.primary(states())}
+                  backgroundColor={themeV2.background.action.primary({ focused: active() })}
                   onMouseOver={() => setStore("selected", index())}
                 >
                   <text
-                    fg={themeV2.text.action.primary(states())}
+                    fg={themeV2.text.action.primary({ focused: active() })}
                     attributes={active() ? TextAttributes.BOLD : undefined}
                     wrapMode="none"
                   >

--- a/packages/tui/src/routes/session/composer/shell-tab.tsx
+++ b/packages/tui/src/routes/session/composer/shell-tab.tsx
@@ -1,6 +1,6 @@
 import { createMemo, For, Show, createEffect, onMount, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
-import { TextAttributes, RGBA, ScrollBoxRenderable } from "@opentui/core"
+import { TextAttributes, ScrollBoxRenderable } from "@opentui/core"
 import { useData } from "../../../context/data"
 import { useLocation } from "../../../context/location"
 import { useClient } from "../../../context/client"
@@ -100,16 +100,17 @@ export function ShellTab(props: { sessionID: string }) {
           <For each={entries()}>
             {(shell, index) => {
               const active = createMemo(() => index() === store.selected)
+              const states = createMemo(() => ({ focused: active() }))
               return (
                 <box
                   flexDirection="row"
                   paddingLeft={1}
                   paddingRight={1}
-                  backgroundColor={active() ? themeV2.background.action.primary("selected") : RGBA.fromInts(0, 0, 0, 0)}
+                  backgroundColor={themeV2.background.action.primary(states())}
                   onMouseOver={() => setStore("selected", index())}
                 >
                   <text
-                    fg={themeV2.text.action.primary(active() ? "focused" : "default")}
+                    fg={themeV2.text.action.primary(states())}
                     attributes={active() ? TextAttributes.BOLD : undefined}
                     wrapMode="none"
                   >

--- a/packages/tui/src/routes/session/composer/subagents-tab.tsx
+++ b/packages/tui/src/routes/session/composer/subagents-tab.tsx
@@ -1,6 +1,6 @@
 import { createMemo, For, Show, createEffect, onMount, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
-import { TextAttributes, RGBA, ScrollBoxRenderable } from "@opentui/core"
+import { TextAttributes, ScrollBoxRenderable } from "@opentui/core"
 import { useRoute, useRouteData } from "../../../context/route"
 import { useData } from "../../../context/data"
 import { useClient } from "../../../context/client"
@@ -207,6 +207,7 @@ export function SubagentsTab(props: { sessionID: string }) {
           <For each={entries()}>
             {(entry, index) => {
               const active = createMemo(() => index() === selected())
+              const states = createMemo(() => ({ focused: active(), selected: entry.current }))
               const status = createMemo(() => {
                 if (entry.status === "running") return "Running"
                 return ""
@@ -216,7 +217,7 @@ export function SubagentsTab(props: { sessionID: string }) {
                   flexDirection="row"
                   paddingLeft={1}
                   paddingRight={1}
-                  backgroundColor={themeV2.background.action.primary(active() ? "focused" : "default")}
+                  backgroundColor={themeV2.background.action.primary(states())}
                   onMouseOver={() => setStore("selected", index())}
                   onMouseUp={() => {
                     setStore("selected", index())
@@ -225,9 +226,7 @@ export function SubagentsTab(props: { sessionID: string }) {
                 >
                   <box flexGrow={1} minWidth={0} flexDirection="row">
                     <text
-                      fg={themeV2.text.action.primary(
-                        active() ? "focused" : entry.current ? "selected" : "default",
-                      )}
+                      fg={themeV2.text.action.primary(states())}
                       attributes={active() ? TextAttributes.BOLD : undefined}
                       wrapMode="none"
                     >
@@ -235,7 +234,7 @@ export function SubagentsTab(props: { sessionID: string }) {
                     </text>
                   </box>
                   <Show when={status()}>
-                    <text fg={active() ? themeV2.text.action.primary() : themeV2.text.subdued()} wrapMode="none">
+                    <text fg={active() ? themeV2.text.action.primary(states()) : themeV2.text.subdued()} wrapMode="none">
                       {status()}
                     </text>
                   </Show>

--- a/packages/tui/src/routes/session/composer/subagents-tab.tsx
+++ b/packages/tui/src/routes/session/composer/subagents-tab.tsx
@@ -207,7 +207,6 @@ export function SubagentsTab(props: { sessionID: string }) {
           <For each={entries()}>
             {(entry, index) => {
               const active = createMemo(() => index() === selected())
-              const states = createMemo(() => ({ focused: active(), selected: entry.current }))
               const status = createMemo(() => {
                 if (entry.status === "running") return "Running"
                 return ""
@@ -217,7 +216,7 @@ export function SubagentsTab(props: { sessionID: string }) {
                   flexDirection="row"
                   paddingLeft={1}
                   paddingRight={1}
-                  backgroundColor={themeV2.background.action.primary(states())}
+                  backgroundColor={themeV2.background.action.primary({ focused: active(), selected: entry.current })}
                   onMouseOver={() => setStore("selected", index())}
                   onMouseUp={() => {
                     setStore("selected", index())
@@ -226,7 +225,7 @@ export function SubagentsTab(props: { sessionID: string }) {
                 >
                   <box flexGrow={1} minWidth={0} flexDirection="row">
                     <text
-                      fg={themeV2.text.action.primary(states())}
+                      fg={themeV2.text.action.primary({ focused: active(), selected: entry.current })}
                       attributes={active() ? TextAttributes.BOLD : undefined}
                       wrapMode="none"
                     >
@@ -234,7 +233,14 @@ export function SubagentsTab(props: { sessionID: string }) {
                     </text>
                   </box>
                   <Show when={status()}>
-                    <text fg={active() ? themeV2.text.action.primary(states()) : themeV2.text.subdued()} wrapMode="none">
+                    <text
+                      fg={
+                        active()
+                          ? themeV2.text.action.primary({ focused: active(), selected: entry.current })
+                          : themeV2.text.subdued()
+                      }
+                      wrapMode="none"
+                    >
                       {status()}
                     </text>
                   </Show>

--- a/packages/tui/src/theme/v2/component.ts
+++ b/packages/tui/src/theme/v2/component.ts
@@ -1,7 +1,6 @@
 import type { RGBA } from "@opentui/core"
 import type { Accessor } from "solid-js"
 import type {
-  ActionState,
   ActionVariant,
   FormfieldState,
   ResolvedActionState,
@@ -9,6 +8,9 @@ import type {
   ResolvedThemeView,
   HueStep,
 } from "./index"
+import { ActionState } from "./schema"
+
+export type ActionStates = Partial<Record<ActionState, boolean>>
 
 export function createComponentTheme(current: Accessor<ResolvedThemeView>) {
   const textAction = actions((variant, state) => current().text.action[variant][state])
@@ -121,7 +123,10 @@ export function createComponentTheme(current: Accessor<ResolvedThemeView>) {
 }
 
 function actions(get: (variant: ActionVariant, state: ResolvedActionState) => RGBA) {
-  const action = (variant: ActionVariant) => (state: ActionState | "default" = "default") => get(variant, state)
+  const action = (variant: ActionVariant) => (states: ActionState | "default" | ActionStates = "default") => {
+    if (typeof states === "string") return get(variant, states)
+    return get(variant, ActionState.literals.find((state) => states[state]) ?? "default")
+  }
   const primary = action("primary")
   return Object.assign(primary, {
     primary,

--- a/packages/tui/src/theme/v2/schema.ts
+++ b/packages/tui/src/theme/v2/schema.ts
@@ -12,7 +12,7 @@ export type HueAlias = Schema.Schema.Type<typeof HueAlias>
 export const ActionVariant = Schema.Literals(["primary", "secondary", "destructive"])
 export type ActionVariant = Schema.Schema.Type<typeof ActionVariant>
 
-export const ActionState = Schema.Literals(["focused", "pressed", "selected", "disabled"])
+export const ActionState = Schema.Literals(["disabled", "pressed", "focused", "selected"])
 export type ActionState = Schema.Schema.Type<typeof ActionState>
 export type ActionStateKey = `$${ActionState}`
 

--- a/packages/tui/test/theme/v2/component.test.ts
+++ b/packages/tui/test/theme/v2/component.test.ts
@@ -23,6 +23,19 @@ test("provides reactive property, variant, state, and context accessors", () => 
   expect(theme.text.action.primary("pressed")).toBe(resolved().text.action.primary.pressed)
   expect(theme.text.action.primary("selected")).toBe(resolved().text.action.primary.selected)
   expect(theme.background.action.primary("selected")).toBe(resolved().background.action.primary.selected)
+  expect(theme.background.action.primary({ selected: true })).toBe(resolved().background.action.primary.selected)
+  expect(theme.background.action.primary({ focused: true, selected: true })).toBe(
+    resolved().background.action.primary.focused,
+  )
+  expect(theme.background.action.primary({ pressed: true, focused: true, selected: true })).toBe(
+    resolved().background.action.primary.pressed,
+  )
+  expect(theme.background.action.primary({ disabled: true, pressed: true, focused: true, selected: true })).toBe(
+    resolved().background.action.primary.disabled,
+  )
+  expect(theme.background.action.primary({ disabled: false, selected: false })).toBe(
+    resolved().background.action.primary.default,
+  )
   expect(theme.background.action.secondary("disabled")).toBe(
     resolved().background.action.secondary.disabled,
   )


### PR DESCRIPTION
## Summary
- allow V2 action accessors to accept partial Boolean state maps
- resolve active states deterministically as disabled, pressed, focused, selected
- preserve direct string state selection and default fallback
- migrate subagent and shell picker styling to the object state form

## Context
- follows merged PR #37371

## Verification
- OpenCode Drive populated subagent picker capture
- `bun typecheck` in `packages/tui`
- `bun test` in `packages/tui` (254 passed, 1 skipped)