### PR TITLE
test(core): harden process and project copy timing

### DIFF
--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -18,11 +18,12 @@ const waitForFile = (file: string) =>
   Effect.promise(async () => {
     while (true) {
       try {
-        return await fs.readFile(file, "utf8")
+        const contents = await fs.readFile(file, "utf8")
+        if (contents.length > 0) return contents
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
-        await new Promise<void>((resolve) => setTimeout(resolve, 10))
       }
+      await new Promise<void>((resolve) => setTimeout(resolve, 10))
     }
   })
 

--- a/packages/core/test/project-copy.test.ts
+++ b/packages/core/test/project-copy.test.ts
@@ -333,7 +333,8 @@ describe("ProjectCopy", () => {
     }),
   )
 
-  it.live("refresh ignores stale git worktree registrations", () =>
+  it.live(
+    "refresh ignores stale git worktree registrations",
     Effect.gen(function* () {
       const input = yield* setup()
       const copy = yield* ProjectCopy.Service
@@ -356,6 +357,7 @@ describe("ProjectCopy", () => {
         ].toSorted((a, b) => a.directory.localeCompare(b.directory)),
       )
     }),
+    15_000,
   )
 
   it.live("refresh ignores existing directories that are no longer git checkouts", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #37321

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Retries the process-test PID file read when the file exists but is still empty. It also gives the stale-worktree project-copy test a scoped 15 second timeout for slower CI runners.

### How did you verify your code works?

- Ran `bun test test/process/process.test.ts test/project-copy.test.ts --only-failures` 10 times: 370/370 tests passed.
- Ran `bun typecheck` in `packages/core`.
- Passed the pre-push workspace typecheck: 30/30 tasks.
- Ran Prettier, Oxlint, and `git diff --check` on the changed test files.

### Screenshots / recordings

Not applicable; this only changes test synchronization and timeout behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
