### PR TITLE
fix: preserve file API text content

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/file.ts
@@ -113,7 +113,7 @@ export const fileHandlers = HttpApiBuilder.group(InstanceHttpApi, "file", (handl
         ),
         Effect.map(({ item, text }) =>
           Option.isSome(text)
-            ? { type: "text" as const, content: text.value.trim() }
+            ? { type: "text" as const, content: text.value }
             : {
                 type: "binary" as const,
                 content: Buffer.from(item.content).toString("base64"),

--- a/packages/opencode/test/server/httpapi-file.test.ts
+++ b/packages/opencode/test/server/httpapi-file.test.ts
@@ -32,7 +32,8 @@ afterEach(async () => {
 describe("file HttpApi", () => {
   test("serves read endpoints", async () => {
     await using tmp = await tmpdir({ git: true })
-    await Bun.write(path.join(tmp.path, "hello.txt"), "hello")
+    const fileContent = "\n  hello  \n\n"
+    await Bun.write(path.join(tmp.path, "hello.txt"), fileContent)
 
     const [list, content, status] = await Promise.all([
       request(FilePaths.list, tmp.path, { path: "." }),
@@ -46,7 +47,7 @@ describe("file HttpApi", () => {
     )
 
     expect(content.status).toBe(200)
-    expect(await content.json()).toMatchObject({ type: "text", content: "hello" })
+    expect(await content.json()).toMatchObject({ type: "text", content: fileContent })
 
     expect(status.status).toBe(200)
     expect(await status.json()).toEqual([])


### PR DESCRIPTION
### Issue for this PR

Closes #37384

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The instance file API currently calls `trim()` on decoded text and changes leading, trailing, and blank-line whitespace. This returns the decoded text unchanged while preserving the existing binary and invalid UTF-8 behavior, with HTTP-level regression coverage.

### How did you verify your code works?

- `PATH=/home/hermes/.bun/bin:$PATH bun test --timeout 180000 -t 'serves read endpoints' test/server/httpapi-file.test.ts` - 1 passed, 1 filtered, 6 assertions
- `bun run typecheck` - shared current-base package check reached only unrelated existing errors in `src/provider/transform.ts`, `src/tool/task.ts`, and their tests; current hosted CI remains required
- `bunx prettier --check src/server/routes/instance/httpapi/handlers/file.ts test/server/httpapi-file.test.ts` - passed
- `git diff --check 1d2a7b4c860f6a29eb90bdda07757b2adf34ab61..HEAD` - passed

### Screenshots / recordings

Not applicable; this is an HTTP API response-content fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
