### PR TITLE
fix: check apply_patch move destinations

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -202,7 +202,15 @@ export const ApplyPatchTool = Tool.define(
       }))
 
       // Check permissions if needed
-      const relativePaths = fileChanges.map((c) => path.relative(instance.worktree, c.filePath).replaceAll("\\", "/"))
+      const relativePaths = Array.from(
+        new Set(
+          fileChanges.flatMap((change) =>
+            [change.filePath, change.movePath]
+              .filter((filePath): filePath is string => filePath !== undefined)
+              .map((filePath) => path.relative(instance.worktree, filePath).replaceAll("\\", "/")),
+          ),
+        ),
+      )
       yield* ctx.ask({
         permission: "edit",
         patterns: relativePaths,

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -178,6 +178,7 @@ describe("tool.apply_patch freeform", () => {
         expect(moveFile.type).toBe("move")
         expect(moveFile.relativePath).toBe("renamed/dir/name.txt")
         expect(moveFile.movePath).toBe(path.join(test.directory, "renamed/dir/name.txt"))
+        expect(permissionCall.patterns).toEqual(["old/name.txt", "renamed/dir/name.txt"])
         expect(moveFile.patch).toContain("-old content")
         expect(moveFile.patch).toContain("+new content")
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #37382

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`apply_patch` currently asks for edit permission using only a move's source path, even though it writes the destination. This includes both normalized source and destination paths in the permission patterns, deduplicates them, and adds a regression assertion.

### How did you verify your code works?

- `bun test --timeout 60000 test/tool/apply_patch.test.ts` - 27 passed
- `bun run typecheck` - candidate reached only unrelated existing errors in `src/provider/transform.ts`, `src/tool/task.ts`, and their tests; current hosted CI remains required
- `bunx prettier --check src/tool/apply_patch.ts test/tool/apply_patch.test.ts` - passed
- `git diff --check 1d2a7b4c860f6a29eb90bdda07757b2adf34ab61..HEAD` - passed

### Screenshots / recordings

Not applicable; this is tool permission-path behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
