### PR TITLE
fix: return failure for unsuccessful share imports

### DIFF
--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -109,9 +109,9 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
     const slug = parseShareUrl(file)
     if (!slug) {
       const baseUrl = yield* Effect.orDie(share.url())
-      process.stdout.write(`Invalid URL format. Expected: ${baseUrl}/share/<slug>`)
-      process.stdout.write(EOL)
-      return
+      return yield* Effect.fail(
+        new CliError({ message: `Invalid share URL: ${file}. Expected: ${baseUrl}/share/<slug>` }),
+      )
     }
 
     const baseUrl = new URL(file).origin
@@ -135,9 +135,7 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
     }
 
     if (!response.ok) {
-      process.stdout.write(`Failed to fetch share data: ${response.statusText}`)
-      process.stdout.write(EOL)
-      return
+      return yield* Effect.fail(new CliError({ message: `Failed to fetch share data: ${response.statusText}` }))
     }
 
     const shareData = yield* Effect.tryPromise({
@@ -147,9 +145,7 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
     const transformed = transformShareData(shareData)
 
     if (!transformed) {
-      process.stdout.write(`Share not found or empty: ${slug}`)
-      process.stdout.write(EOL)
-      return
+      return yield* Effect.fail(new CliError({ message: `Share not found or empty: ${slug}` }))
     }
 
     exportData = transformed

--- a/packages/opencode/test/cli/import.test.ts
+++ b/packages/opencode/test/cli/import.test.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../lib/cli-process"
 import {
   parseShareUrl,
   shouldAttachShareAuthHeaders,
@@ -52,3 +54,16 @@ test("returns null for invalid share data", () => {
   expect(transformShareData([{ type: "message", data: {} as any }])).toBeNull()
   expect(transformShareData([{ type: "session", data: { id: "s" } as any }])).toBeNull() // no messages
 })
+
+cliIt.live(
+  "share import failures exit non-zero and emit one diagnostic",
+  ({ opencode }) =>
+    Effect.gen(function* () {
+      const result = yield* opencode.spawn(["import", "https://example.com/not-a-share"], { timeoutMs: 60_000 })
+      expect(result.exitCode).not.toBe(0)
+      const output = `${result.stdout}\n${result.stderr}`
+      expect(output).toContain("Invalid share URL: https://example.com/not-a-share")
+      expect(output.match(/Invalid share URL: https:\/\/example\.com\/not-a-share/g)).toHaveLength(1)
+    }),
+  60_000,
+)


### PR DESCRIPTION
### Issue for this PR

Closes #37383

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Share imports currently print a diagnostic and return success when the URL is invalid, the share request is unsuccessful, or the share is empty. This routes those failures through the existing `CliError` path so callers receive a non-zero exit status and one diagnostic.

### How did you verify your code works?

- `PATH=/home/hermes/.bun/bin:$PATH bun test --timeout 180000 test/cli/import.test.ts` - 6 passed, 0 failed, including the process-level non-zero exit and one-diagnostic assertion
- `bun run typecheck` - not completed; `tsgo --noEmit` stalled for roughly four minutes and was stopped
- `bunx prettier --check src/cli/cmd/import.ts test/cli/import.test.ts` - passed
- `git diff --check` and the two-file changed-path allowlist - passed

Current hosted CI remains required because the local package typecheck did not
complete successfully; see the dated validation receipt.

### Screenshots / recordings

Not applicable; this is CLI exit-status behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
