### PR TITLE
fix(core): surface refusal category and explanation on content filter

### DIFF
--- a/packages/core/src/v1/session.ts
+++ b/packages/core/src/v1/session.ts
@@ -65,4 +65,8 @@ export const ContextOverflowError = NamedError.create("ContextOverflowError", {
   message: Schema.String,
   responseBody: Schema.optional(Schema.String),
 })
-export const ContentFilterError = NamedError.create("ContentFilterError", { message: Schema.String })
+export const ContentFilterError = NamedError.create("ContentFilterError", {
+  message: Schema.String,
+  category: Schema.optional(Schema.String),
+  explanation: Schema.optional(Schema.String),
+})

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -24,13 +24,14 @@ import { errorMessage } from "@/util/error"
 import { isRecord } from "@/util/record"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Database } from "@opencode-ai/core/database/database"
-import { Usage, type LLMEvent } from "@opencode-ai/llm"
+import { Usage, type LLMEvent, type ProviderMetadata } from "@opencode-ai/llm"
 
 const DOOM_LOOP_THRESHOLD = 3
 export type Result = "compact" | "stop" | "continue"
 
 export interface Handle {
   readonly message: SessionV1.Assistant
+  readonly contentFilter: { category?: string; explanation?: string } | undefined
   readonly updateToolCall: (
     toolCallID: string,
     update: (part: SessionV1.ToolPart) => SessionV1.ToolPart,
@@ -72,9 +73,19 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: SessionV1.TextPart | undefined
   reasoningMap: Record<string, SessionV1.ReasoningPart>
+  contentFilter: { category?: string; explanation?: string } | undefined
 }
 
 type StreamEvent = LLMEvent
+
+export function readContentFilter(metadata: ProviderMetadata | undefined) {
+  const details = metadata?.["anthropic"]?.["stopDetails"]
+  if (!isRecord(details)) return undefined
+  const category = typeof details["category"] === "string" ? details["category"] : undefined
+  const explanation = typeof details["explanation"] === "string" ? details["explanation"] : undefined
+  if (!category && !explanation) return undefined
+  return { ...(category ? { category } : {}), ...(explanation ? { explanation } : {}) }
+}
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionProcessor") {}
 
@@ -111,6 +122,7 @@ const layer = Layer.effect(
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        contentFilter: undefined,
       }
       let aborted = false
 
@@ -441,6 +453,7 @@ const layer = Layer.effect(
               metadata: value.providerMetadata,
             })
             ctx.assistantMessage.finish = value.reason
+            if (value.reason === "content-filter") ctx.contentFilter = readContentFilter(value.providerMetadata)
             ctx.assistantMessage.cost += usage.cost
             ctx.assistantMessage.tokens = usage.tokens
             yield* session.updatePart({
@@ -532,6 +545,8 @@ const layer = Layer.effect(
             return
 
           case "finish":
+            if (!ctx.contentFilter && value.reason === "content-filter")
+              ctx.contentFilter = readContentFilter(value.providerMetadata)
             return
         }
       })
@@ -685,6 +700,9 @@ const layer = Layer.effect(
       return {
         get message() {
           return ctx.assistantMessage
+        },
+        get contentFilter() {
+          return ctx.contentFilter
         },
         updateToolCall,
         completeToolCall,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1299,8 +1299,13 @@ const layer = Layer.effect(
               // output at all — previously the session went idle silently — or
               // partial text that was cut off by the provider's filter.
               if (handle.message.finish === "content-filter") {
+                const filter = handle.contentFilter
                 handle.message.error = new SessionV1.ContentFilterError({
-                  message: "The response was blocked by the provider's content filter",
+                  message: filter?.category
+                    ? `Response refused by provider (${filter.category})${filter.explanation ? `: ${filter.explanation}` : ""}`
+                    : "The response was blocked by the provider's content filter",
+                  category: filter?.category,
+                  explanation: filter?.explanation,
                 }).toObject()
                 yield* sessions.updateMessage(handle.message)
                 yield* events.publish(Session.Event.Error, { sessionID, error: handle.message.error })

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -202,6 +202,7 @@ function fake(
     get message() {
       return msg
     },
+    contentFilter: undefined,
     updateToolCall: Effect.fn("TestSessionProcessor.updateToolCall")(() => Effect.succeed(undefined)),
     completeToolCall: Effect.fn("TestSessionProcessor.completeToolCall")(() => Effect.void),
     process: Effect.fn("TestSessionProcessor.process")(() => Effect.succeed(result)),

--- a/packages/opencode/test/session/content-filter.test.ts
+++ b/packages/opencode/test/session/content-filter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import { SessionProcessor } from "../../src/session/processor"
+
+describe("readContentFilter", () => {
+  test("extracts category and explanation from anthropic stopDetails", () => {
+    const metadata = {
+      anthropic: {
+        stopDetails: { type: "refusal", category: "reasoning_extraction", explanation: "declined per policy" },
+      },
+    }
+    expect(SessionProcessor.readContentFilter(metadata)).toEqual({
+      category: "reasoning_extraction",
+      explanation: "declined per policy",
+    })
+  })
+
+  test("keeps only the fields that are present", () => {
+    const metadata = { anthropic: { stopDetails: { type: "refusal", category: "cyber" } } }
+    expect(SessionProcessor.readContentFilter(metadata)).toEqual({ category: "cyber" })
+  })
+
+  test("returns undefined when the refusal has no named category or explanation", () => {
+    const metadata = { anthropic: { stopDetails: { type: "refusal", category: null, explanation: null } } }
+    expect(SessionProcessor.readContentFilter(metadata)).toBeUndefined()
+  })
+
+  test("returns undefined without anthropic stopDetails", () => {
+    expect(SessionProcessor.readContentFilter(undefined)).toBeUndefined()
+    expect(SessionProcessor.readContentFilter({})).toBeUndefined()
+    expect(SessionProcessor.readContentFilter({ anthropic: {} })).toBeUndefined()
+    expect(SessionProcessor.readContentFilter({ openai: { stopDetails: { category: "cyber" } } })).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35736

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When Anthropic returns `stop_reason: "refusal"`, opencode maps it to a
`content-filter` finish and shows one hardcoded message — "The response was
blocked by the provider's content filter" — dropping the `stop_details` the
provider sends. As #35736 notes, that makes every refusal look identical even
though the categories call for different responses.

Anthropic's `stop_details.category` can be `cyber`, `bio`, `frontier_llm`, or
`reasoning_extraction` (see Anthropic's "Refusals and fallback" docs).
`@ai-sdk/anthropic` already surfaces these on the finish event's
`providerMetadata.anthropic.stopDetails`, but they were never read.

This PR:

- extends `ContentFilterError` with optional `category` and `explanation`
- reads the refusal details from the finish event in the session processor
- includes them in the error message (e.g. `Response refused by provider
  (reasoning_extraction): ...`) when present, falling back to the current
  message when they are not

No behavior change when `stop_details` is absent — every non-refusal stop, or a
refusal with no named category.

### How did you verify your code works?

- Reproduced a real `reasoning_extraction` refusal from `claude-fable-5` end to
  end. The surfaced error changed from the generic message to
  `Response refused by provider (reasoning_extraction): <explanation>`. Confirmed
  `providerMetadata.anthropic.stopDetails` arrives on the step-finish event with
  `category`/`explanation` and is read correctly.
- Added `test/session/content-filter.test.ts` covering the metadata parsing
  (category + explanation, partial, and the empty/absent cases); `bun test` passes.
- `bun typecheck` passes in `packages/core` and `packages/opencode`.

### Screenshots / recordings

N/A (error text change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
