### PR TITLE
fix(core): initialize provider state before catalog transforms

### DIFF
--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -176,6 +176,7 @@ export const OpenAIPlugin = define({
       draft.method.update(browser)
       draft.method.update(headless)
     })
+    yield* load()
     yield* ctx.catalog.transform((evt) => {
       for (const item of evt.provider.list()) {
         if (!ProviderV2.isAISDK(item.provider.package)) continue
@@ -213,7 +214,6 @@ export const OpenAIPlugin = define({
       Stream.runForEach(refresh),
       Effect.forkScoped({ startImmediately: true }),
     )
-    yield* refresh().pipe(Effect.forkScoped)
     yield* ctx.aisdk.hook(
       "sdk",
       Effect.fn(function* (evt) {

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -114,7 +114,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
       draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key (service account)" } })
     })
 
-    connected = (yield* ctx.integration.connection.active("opencode")) !== undefined
+    yield* load()
     yield* ctx.catalog.transform((catalog) => {
       for (const [providerID, item] of Object.entries(providers ?? {})) {
         catalog.provider.update(providerID, (provider) => {
@@ -194,7 +194,6 @@ export const OpencodePlugin = define<HttpClient.HttpClient | EventV2.Service | S
       Stream.runForEach(refresh),
       Effect.forkScoped({ startImmediately: true }),
     )
-    yield* refresh()
   }),
 })
 

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -29,20 +29,6 @@ function required<T>(value: T | undefined): T {
   return value
 }
 
-function eventually<A>(
-  effect: Effect.Effect<A>,
-  predicate: (value: A) => boolean,
-  remaining = 1000,
-): Effect.Effect<A, Error> {
-  return Effect.gen(function* () {
-    const value = yield* effect
-    if (predicate(value)) return value
-    if (remaining === 0) return yield* Effect.fail(new Error("Timed out waiting for value"))
-    yield* Effect.promise(() => Bun.sleep(1))
-    return yield* eventually(effect, predicate, remaining - 1)
-  })
-}
-
 function fakeSelectorSdk(calls: string[]) {
   const make = (method: string) => (id: string) => {
     calls.push(`${method}:${id}`)
@@ -219,12 +205,8 @@ describe("OpenAIPlugin", () => {
       })
       yield* addPlugin()
 
-      const eligible = required(
-        yield* eventually(
-          catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.5")),
-          (model) => model?.cost.length === 0,
-        ),
-      )
+      const eligible = required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.5")))
+      expect(eligible.cost).toEqual([])
       expect(eligible.enabled).toBe(true)
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.5-pro"))).enabled).toBe(
         false,
@@ -260,9 +242,6 @@ describe("OpenAIPlugin", () => {
         value: Credential.Key.make({ type: "key", key: "sk-test" }),
       })
       yield* addPlugin()
-      // The connection refresh is asynchronous; give it time to settle before
-      // asserting nothing was filtered.
-      yield* Effect.promise(() => Bun.sleep(25))
 
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-5.5"))).enabled).toBe(true)
       expect(required(yield* catalog.model.get(ProviderV2.ID.openai, ModelV2.ID.make("gpt-4.1"))).enabled).toBe(true)


### PR DESCRIPTION
## What

Initialize OpenAI and OpenCode provider connection state before registering their catalog transforms, so the first catalog materialization reflects the active credential and remote provider configuration.

## Before / After

**Before:** Each plugin registered its catalog transform with default local state, then forked or ran a refresh afterward. The initial catalog could therefore expose unfiltered models or omit connected OpenCode provider configuration until a debounced background reload completed. Under the Effect test clock, that reload could remain pending and provider tests timed out.

**After:** Each plugin loads its initial connection state before registering the catalog transform. Plugin activation returns with the initial catalog projection materialized; later connection updates retain the existing `load -> catalog.reload` path.

## How

- `packages/core/src/plugin/provider/openai.ts`: run `load()` before catalog transform registration and remove the redundant startup refresh fiber.
- `packages/core/src/plugin/provider/opencode.ts`: replace the partial startup connection check with the existing full `load()` and remove the redundant post-registration refresh.
- `packages/core/test/plugin/provider-openai.test.ts`: assert startup catalog state directly without wall-clock polling or sleeps.

## Scope

This deliberately keeps the lifecycle logic local to each provider. It does not add a catalog API or shared projection helper.

## Testing

- `bun run test test/plugin/provider-openai.test.ts test/plugin/provider-opencode.test.ts test/plugin/provider-github-copilot.test.ts` (32 passed)
- `bun run typecheck` in `packages/core`
- Root `bun run typecheck` (32 packages passed)
- Focused `oxlint` (0 errors; 10 pre-existing warnings)
- `git diff --check`
