### PR TITLE
fix(session): ignore hidden user turns

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -588,7 +588,13 @@ export function latest(msgs: WithParts[]) {
   let finished: Assistant | undefined
   for (const msg of msgs) {
     const info = msg.info
-    if (info.role === "user" && (!user || info.id > user.id)) user = info
+    if (
+      info.role === "user" &&
+      !(msg.parts.length > 0 && msg.parts.every((part) => "ignored" in part && part.ignored)) &&
+      (!user || info.id > user.id)
+    ) {
+      user = info
+    }
     if (info.role === "assistant" && (!assistant || info.id > assistant.id)) assistant = info
     if (info.role === "assistant" && info.finish && (!finished || info.id > finished.id)) finished = info
   }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -460,6 +460,28 @@ noLLMServer.instance(
   { config: cfg },
 )
 
+noLLMServer.instance(
+  "loop ignores user messages with only ignored parts",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      const seeded = yield* seed(chat.id, { finish: "stop" })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "internal status", ignored: true }],
+      })
+
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      expect(result.info.id).toBe(seeded.assistant.id)
+    }),
+  { config: cfg },
+)
+
 it.instance("loop exits without an LLM request for interrupted orphan tool calls", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #37200

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fully ignored user messages are removed from model context, but `MessageV2.latest()` still treated them as new user work. That mismatch could start a phantom model turn after the prior assistant response had finished.

This skips user messages whose non-empty parts are all marked `ignored` when selecting the latest actionable turn. The regression test inserts such a message after a completed response and confirms the loop returns the existing assistant response without contacting the model again.

### How did you verify your code works?

- `bun test test/session/prompt.test.ts --test-name-pattern "loop ignores user messages"`
- `bun typecheck`

### Screenshots / recordings

Not applicable; this is session-loop behavior with no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
