### PR TITLE
test(core): reproduce hot reload regressions

### DIFF
--- a/packages/core/test/agent.test.ts
+++ b/packages/core/test/agent.test.ts
@@ -23,18 +23,18 @@ const it = testEffect(
 )
 
 describe("AgentV2", () => {
-  it.effect("publishes an updated event after agent changes", () =>
+  it.effect("publishes an updated event after agent changes are visible", () =>
     Effect.gen(function* () {
       const agent = yield* AgentV2.Service
       const events = yield* EventV2.Service
       const updated = yield* events
         .subscribe(AgentV2.Event.Updated)
-        .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
+        .pipe(Stream.take(1), Stream.runHead, Effect.andThen(agent.get(AgentV2.ID.make("reviewer"))), Effect.forkScoped)
       yield* Effect.yieldNow
 
       yield* agent.transform((editor) => editor.update(AgentV2.ID.make("reviewer"), () => {}))
 
-      expect(yield* Fiber.join(updated)).toMatchObject([{ location: { directory: testLocation.directory } }])
+      expect(yield* Fiber.join(updated)).toMatchObject({ id: "reviewer" })
     }),
   )
 

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -31,18 +31,23 @@ const catalogLayer = AppNodeBuilder.build(
 const it = testEffect(catalogLayer)
 
 describe("CatalogV2", () => {
-  it.effect("publishes an updated event after catalog changes", () =>
+  it.effect("publishes an updated event after catalog changes are visible", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service
       const events = yield* EventV2.Service
       const updated = yield* events
         .subscribe(Catalog.Event.Updated)
-        .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
+        .pipe(
+          Stream.take(1),
+          Stream.runHead,
+          Effect.andThen(catalog.provider.get(ProviderV2.ID.make("test"))),
+          Effect.forkScoped,
+        )
       yield* Effect.yieldNow
 
       yield* catalog.transform((editor) => editor.provider.update(ProviderV2.ID.make("test"), () => {}))
 
-      expect((yield* Fiber.join(updated)).length).toBe(1)
+      expect(yield* Fiber.join(updated)).toMatchObject({ id: "test" })
     }),
   )
 

--- a/packages/core/test/command.test.ts
+++ b/packages/core/test/command.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import { CommandV2 } from "@opencode-ai/core/command"
 import { Config } from "@opencode-ai/core/config"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { EventV2 } from "@opencode-ai/core/event"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Location } from "@opencode-ai/core/location"
 import { MCP } from "@opencode-ai/core/mcp/index"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -11,7 +13,7 @@ import { emptyConfigLayer, emptyMcpLayer, testLocationLayer } from "./fixture/mc
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(
-  AppNodeBuilder.build(CommandV2.node, [
+  AppNodeBuilder.build(LayerNode.group([CommandV2.node, EventV2.node]), [
     [MCP.node, emptyMcpLayer],
     [Config.node, emptyConfigLayer],
     [Location.node, testLocationLayer],
@@ -19,6 +21,21 @@ const it = testEffect(
 )
 
 describe("CommandV2", () => {
+  it.effect("publishes an updated event after command changes are visible", () =>
+    Effect.gen(function* () {
+      const command = yield* CommandV2.Service
+      const events = yield* EventV2.Service
+      const updated = yield* events
+        .subscribe(CommandV2.Event.Updated)
+        .pipe(Stream.take(1), Stream.runHead, Effect.andThen(command.get("review")), Effect.forkScoped)
+      yield* Effect.yieldNow
+
+      yield* command.transform((editor) => editor.update("review", (item) => (item.template = "Review")))
+
+      expect(yield* Fiber.join(updated)).toMatchObject({ name: "review", template: "Review" })
+    }),
+  )
+
   it.effect("applies command transforms and preserves later overrides", () =>
     Effect.gen(function* () {
       const command = yield* CommandV2.Service

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -98,6 +98,40 @@ const provider = {
 }
 
 describe("Config", () => {
+  it.live("publishes updates for changed files inside config directories", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const global = path.join(tmp.path, "global")
+          yield* Effect.promise(() => fs.mkdir(path.join(global, "commands"), { recursive: true }))
+          const updates = yield* PubSub.unbounded<Watcher.Update>()
+          const watcher = Layer.succeed(
+            Watcher.Service,
+            Watcher.Service.of({ subscribe: () => Stream.fromPubSub(updates) }),
+          )
+
+          return yield* Effect.gen(function* () {
+            const events = yield* EventV2.Service
+            const changed = yield* events
+              .subscribe(ConfigSchema.Event.Updated)
+              .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped)
+            yield* Effect.sleep("10 millis")
+
+            yield* PubSub.publish(updates, {
+              type: "update",
+              path: path.join(global, "commands", "review.md"),
+            } satisfies Watcher.Update)
+
+            expect(yield* Fiber.join(changed).pipe(Effect.timeout("1 second"))).toHaveLength(1)
+          }).pipe(Effect.provide(testLayer(tmp.path, global, undefined, undefined, watcher)))
+        }),
+      ),
+    ),
+  )
+
   it.live("reloads external config and publishes directory updates", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/public-import.test.ts
+++ b/packages/core/test/public-import.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test"
+
+test("imports the public skill module in a fresh process", async () => {
+  const child = Bun.spawn([process.execPath, "-e", 'await import("@opencode-ai/core/skill")'], {
+    cwd: import.meta.dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [exitCode, stderr] = await Promise.all([child.exited, new Response(child.stderr).text()])
+
+  expect(stderr).toBe("")
+  expect(exitCode).toBe(0)
+})

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -54,6 +54,22 @@ function waitForSkillUpdate() {
 }
 
 describe("SkillV2", () => {
+  it.live("publishes an updated event after skill source changes are visible", () =>
+    Effect.gen(function* () {
+      const skill = yield* SkillV2.Service
+      const events = yield* EventV2.Service
+      const source = { type: "directory" as const, path: AbsolutePath.make("/tmp/opencode-skills") }
+      const updated = yield* events
+        .subscribe(SkillV2.Event.Updated)
+        .pipe(Stream.take(1), Stream.runHead, Effect.andThen(skill.sources()), Effect.forkScoped)
+      yield* Effect.yieldNow
+
+      yield* skill.transform((editor) => editor.source(source))
+
+      expect(yield* Fiber.join(updated)).toContainEqual(source)
+    }),
+  )
+
   it.live("publishes updates when skill sources change", () =>
     Effect.gen(function* () {
       const skill = yield* SkillV2.Service


### PR DESCRIPTION
## What

Adds deterministic red tests for two V2 hot-reload blockers:

- update events can be observed before the corresponding rebuilt state is readable (#37422)
- importing `@opencode-ai/core/skill` first in a fresh process crashes through an ESM initialization cycle (#37424)
- changes inside watched config directories are ignored when parsed config entries remain equal (#37429)

This is intentionally a draft, red-test PR. It establishes the contracts and keeps the failures visible while fixes are developed separately.

## Before / After

**Before**

A domain rebuild calls its `State.finalize` callback, the callback publishes `*.updated`, and only afterward does State assign the rebuilt snapshot. A client reacting to the event can immediately refetch the previous agent, command, skill-source, or provider/model catalog.

A fresh process importing the public skill module can enter `skill -> permission -> session -> skill`; `Session.SkillNotFoundError` eagerly reads `SkillV2.ID` while that binding is still uninitialized.

A watcher update for `.opencode/commands/review.md` rediscovers the same Config entry list, so `Config.reload` returns before publishing `config.updated`; config-backed plugins never rescan the changed file.

**After this test PR**

The required behavior is executable and currently red:

- every observed update event must imply that the corresponding read API exposes the new snapshot
- every public Core module must be safe to import first in a fresh process

## How

- `packages/core/test/agent.test.ts` reads the registered agent immediately after `agent.updated`.
- `packages/core/test/command.test.ts` reads the registered command immediately after `command.updated`.
- `packages/core/test/skill.test.ts` reads registered skill sources immediately after `skill.updated`.
- `packages/core/test/catalog.test.ts` reads the provider immediately after `catalog.updated`.
- `packages/core/test/config/config.test.ts` publishes a watcher update for a file inside a Config directory and waits for `config.updated`.
- `packages/core/test/public-import.test.ts` imports `@opencode-ai/core/skill` in a fresh Bun process so module caching cannot hide the cycle.

```mermaid
sequenceDiagram
    participant State
    participant Events
    participant Client
    participant API

    State->>State: build next snapshot
    State->>Events: publish *.updated
    Events->>Client: invalidate catalog
    Client->>API: list immediately
    API-->>Client: previous snapshot
    State->>State: assign next snapshot
```

## Scope

This PR does not fix either failure and is not merge-ready while the tests are red.

Missing but non-regressed hot-reload surfaces are tracked separately:

- MCP server config: #37421
- external TUI config and custom themes: #37423
- TUI plugin config and local sources: #37425
- global, external, and HTTP skill sources: #37426

## Testing

Expected red tests:

```text
bun run --cwd packages/core test test/agent.test.ts --test-name-pattern "after agent changes are visible"
bun run --cwd packages/core test test/catalog.test.ts --test-name-pattern "after catalog changes are visible"
bun run --cwd packages/core test test/command.test.ts --test-name-pattern "after command changes are visible"
bun run --cwd packages/core test test/skill.test.ts --test-name-pattern "after skill source changes are visible"
bun run --cwd packages/core test test/config/config.test.ts --test-name-pattern "changed files inside config directories"
bun run --cwd packages/core test test/public-import.test.ts
```

The first four observe the previous snapshot. The Config test times out waiting for `config.updated`. The public-import test observes `ReferenceError: Cannot access 'ID' before initialization`.

Passing validation:

```text
bun turbo typecheck --concurrency=3
bunx prettier --check packages/core/test/agent.test.ts packages/core/test/catalog.test.ts packages/core/test/command.test.ts packages/core/test/skill.test.ts packages/core/test/config/config.test.ts packages/core/test/public-import.test.ts
git diff --check
```
