### PR TITLE
fix(app): remove legacy file tree from v2

### DIFF
--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -361,18 +361,6 @@ export const SettingsGeneralV2: Component<{
 
       <SettingsListV2>
         <SettingsRowV2
-          title={language.t("settings.general.row.showFileTree.title")}
-          description={language.t("settings.general.row.showFileTree.description")}
-        >
-          <div data-action="settings-show-file-tree">
-            <Switch
-              checked={settings.general.showFileTree()}
-              onChange={(checked) => settings.general.setShowFileTree(checked)}
-            />
-          </div>
-        </SettingsRowV2>
-
-        <SettingsRowV2
           title={language.t("settings.general.row.showSearch.title")}
           description={language.t("settings.general.row.showSearch.description")}
         >

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -454,6 +454,7 @@ export default function Page() {
   )
   const desktopFileTreeOpen = createMemo(
     () =>
+      !newSessionDesign() &&
       isDesktop() &&
       shouldShowFileTree({
         visible: settings.visibility.fileTree(),

--- a/packages/app/src/pages/session/session-side-panel.tsx
+++ b/packages/app/src/pages/session/session-side-panel.tsx
@@ -95,6 +95,7 @@ export function SessionSidePanel(props: {
   const reviewOpen = createMemo(() => isDesktop() && view().reviewPanel.opened())
   const fileOpen = createMemo(
     () =>
+      !settings.general.newLayoutDesigns() &&
       isDesktop() &&
       shouldShowFileTree({
         visible: shown(),

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -88,7 +88,6 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
   })
   const activeFileTab = tabState.activeFileTab
   const closableTab = tabState.closableTab
-  const shown = settings.visibility.fileTree
 
   const messages = () => {
     const id = params.id
@@ -515,7 +514,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
       keybind: "mod+shift+r",
       onSelect: () => view().reviewPanel.toggle(),
     }),
-    ...(shown()
+    ...(!settings.general.newLayoutDesigns()
       ? [
           viewCommand({
             id: "fileTree.toggle",


### PR DESCRIPTION
## Summary
- prevent the legacy persistent file tree from rendering in V2 sessions
- keep the file-tree command restricted to the legacy layout
- remove the obsolete file-tree visibility setting from V2 settings

## Testing
- bun run test:e2e:local -- e2e/regression/file-browser-sidebar-tab-switch.spec.ts
- bun typecheck
- bun run typecheck:e2e
- targeted V2 session-switch production benchmark
- bun turbo typecheck (pre-push hook)