### PR TITLE
fix(session): clear reasoning state when forking

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -724,6 +724,21 @@ const layer: Layer.Layer<
             messageID: cloned.id,
             sessionID: session.id,
           }
+          if (p.type === "reasoning" && p.metadata) {
+            p.metadata = Object.fromEntries(
+              Object.entries(p.metadata).map(([key, value]) => {
+                if (!value || typeof value !== "object" || !("reasoningEncryptedContent" in value)) {
+                  return [key, value]
+                }
+                return [
+                  key,
+                  Object.fromEntries(
+                    Object.entries(value).filter(([name]) => name !== "itemId" && name !== "reasoningEncryptedContent"),
+                  ),
+                ]
+              }),
+            )
+          }
           if (p.type === "compaction" && p.tail_start_id) {
             p.tail_start_id = idMap.get(p.tail_start_id)
           }

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -238,6 +238,76 @@ describe("Session", () => {
     }),
   )
 
+  it.instance("drops OpenAI reasoning continuation metadata on fork", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const created = yield* Effect.acquireRelease(session.create({ title: "reasoning-meta" }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+      const userID = MessageID.ascending()
+      yield* session.updateMessage({
+        id: userID,
+        sessionID: created.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "test",
+        model: { providerID: "openai", modelID: "gpt-5" },
+        tools: {},
+        mode: "",
+      } as unknown as SessionV1.Info)
+      const assistantID = MessageID.ascending()
+      yield* session.updateMessage({
+        id: assistantID,
+        sessionID: created.id,
+        role: "assistant",
+        time: { created: Date.now() },
+        parentID: userID,
+        modelID: "gpt-5",
+        providerID: "openai",
+        mode: "",
+        agent: "default",
+        path: { cwd: "/", root: "/" },
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      } as unknown as SessionV1.Info)
+      yield* session.updatePart({
+        id: PartID.ascending(),
+        sessionID: created.id,
+        messageID: assistantID,
+        type: "reasoning",
+        text: "summary",
+        time: { start: Date.now(), end: Date.now() },
+        metadata: {
+          openai: {
+            itemId: "rs_old",
+            reasoningEncryptedContent: "legacy-encrypted-state",
+            other: "keep",
+          },
+          anthropic: { signature: "keep" },
+        },
+      })
+
+      const fork = yield* Effect.acquireRelease(session.fork({ sessionID: created.id }), (info) =>
+        session.remove(info.id).pipe(Effect.ignore),
+      )
+      const original = (yield* session.messages({ sessionID: created.id })).flatMap((msg) => msg.parts)
+      const copied = (yield* session.messages({ sessionID: fork.id })).flatMap((msg) => msg.parts)
+      const source = original.find((part) => part.type === "reasoning")
+      const reasoning = copied.find((part) => part.type === "reasoning")
+
+      expect(source?.metadata?.openai).toEqual({
+        itemId: "rs_old",
+        reasoningEncryptedContent: "legacy-encrypted-state",
+        other: "keep",
+      })
+      expect(reasoning?.text).toBe("summary")
+      expect(reasoning?.metadata).toEqual({
+        openai: { other: "keep" },
+        anthropic: { signature: "keep" },
+      })
+    }),
+  )
+
   it.instance("omits metadata when not provided", () =>
     Effect.gen(function* () {
       const session = yield* SessionNs.Service


### PR DESCRIPTION
### Issue for this PR

Closes #37444

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Forked sessions copied OpenAI reasoning `itemId` and `reasoningEncryptedContent` from the source session. Some Responses-compatible endpoints reject that opaque state in the new session.

This removes those two fields while cloning reasoning parts. It keeps the reasoning summary, unrelated metadata, and the source session unchanged.

### How did you verify your code works?

- Added a regression test for the copied metadata and source-session preservation.
- Ran the related session tests: 95 passed.
- Ran `bun typecheck` and the pre-push workspace typecheck: 30/30 packages passed.
- Reproduced the original failure against a database backup and confirmed a new fork works after the change.

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
