### PR TITLE
fix(tui): keep truncateMiddle within maxLength when maxLength is 1 or 2

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -75,7 +75,7 @@ export function truncateMiddle(str: string, maxLength: number = 35): string {
   const keepStart = Math.ceil((maxLength - ellipsis.length) / 2)
   const keepEnd = Math.floor((maxLength - ellipsis.length) / 2)
 
-  return str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)
+  return str.slice(0, keepStart) + ellipsis + str.slice(str.length - keepEnd)
 }
 
 export function pluralize(count: number, singular: string, plural: string): string {

--- a/packages/tui/test/util/locale.test.ts
+++ b/packages/tui/test/util/locale.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test"
+import { truncateMiddle } from "../../src/util/locale"
+
+describe("truncateMiddle", () => {
+  test("returns the input untouched when it already fits", () => {
+    expect(truncateMiddle("abc", 3)).toBe("abc")
+    expect(truncateMiddle("abc", 10)).toBe("abc")
+  })
+
+  test("truncates through the middle", () => {
+    expect(truncateMiddle("abcdefghij", 3)).toBe("a…j")
+    expect(truncateMiddle("abcdefghij", 5)).toBe("ab…ij")
+    expect(truncateMiddle("abcdefghij", 9)).toBe("abcd…ghij")
+  })
+
+  test("never exceeds maxLength", () => {
+    const str = "abcdefghij"
+    for (let max = 1; max <= str.length; max++) {
+      expect(truncateMiddle(str, max).length).toBeLessThanOrEqual(max)
+    }
+  })
+
+  test("handles a maxLength too small to keep any trailing characters", () => {
+    expect(truncateMiddle("abcdefghij", 1)).toBe("…")
+    expect(truncateMiddle("abcdefghij", 2)).toBe("a…")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #37458

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`truncateMiddle` hands back a string longer than `maxLength` when `maxLength` is 1 or 2:

```
truncateMiddle("abcdefghij", 1) -> "…abcdefghij"
truncateMiddle("abcdefghij", 2) -> "a…abcdefghij"
```

The last line is `str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)`. `keepEnd` comes out as 0 for those two cases, and `slice(-0)` is just `slice(0)` in JS, so you get the whole string back where an empty tail was meant to go.

Swapped it for `str.slice(str.length - keepEnd)`, which is `slice(str.length)` -> `""` when `keepEnd` is 0. For anything >= 1 the two are the same expression, so `maxLength >= 3` doesn't move.

I ran into this from `dialog-select.tsx:701`:

```ts
Locale.truncateMiddle(detail, Math.max(1, Math.min(76, dimensions().width - 12)))
```

The `Math.max(1, ...)` is there to keep the width sane on small terminals, except 1 is the value that breaks. So under ~15 columns the detail line printed in full and ran past the dialog. `splash.ts:203` does the same `Math.max(1, ...)` thing.

#37369 fixes the identical `-0` slip in `truncateLeft`. This is the sibling it doesn't touch.

### How did you verify your code works?

Added `packages/tui/test/util/locale.test.ts`. Put the old line back and 2 of the 4 fail:

```
✗ handles a maxLength too small to keep any trailing characters
  Expected: "…"
  Received: "…abcdefghij"
```

With the fix, 4 pass.

Diffed old vs new across `maxLength` 1..12 on a 10-char string. Only 1 and 2 move:

```
1  "…abcdefghij"  -> "…"
2  "a…abcdefghij" -> "a…"
3  "a…j"          -> "a…j"
5  "ab…ij"        -> "ab…ij"
```

Also ran the `dialog-select.tsx:701` expression itself at widths 10-20. Widths 13 and 14 gave back 40 and 41 chars before, correct output after.

`packages/tui`: 195 pass, 0 fail. Pre-push typecheck: 30/30 packages.

### Screenshots / recordings

Nothing to show really — text that should have been truncated now is.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
