### PR TITLE
fix(app): restore terminal toggle shortcut

### DIFF
--- a/packages/app/e2e/regression/terminal-hidden.spec.ts
+++ b/packages/app/e2e/regression/terminal-hidden.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
 import { mockOpenCodeServer } from "../utils/mock-server"
 import { expectSessionTitle } from "../utils/waits"
 
@@ -7,11 +7,59 @@ const projectID = "proj_hidden_terminal_regression"
 const sessionID = "ses_hidden_terminal_regression"
 const title = "Hidden terminal regression"
 
-test("toggles the terminal with the macOS Cmd+J shortcut", async ({ page }) => {
+test("unmounts the terminal panel while it is hidden", async ({ page }) => {
+  await page.setViewportSize({ width: 1400, height: 900 })
+  await setupTerminal(page)
+
+  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+  await expectSessionTitle(page, title)
+
+  await page.keyboard.press("Control+Backquote")
+  const panel = page.locator("#terminal-panel")
+  await expect(panel).toHaveAttribute("aria-hidden", "false")
+  await expect(page.locator('[data-component="terminal"]')).toBeVisible()
+
+  await page.keyboard.press("Control+Backquote")
+  await expect(panel).toHaveCount(0)
+  await expect(page.locator('[data-component="terminal"]')).toHaveCount(0)
+
+  await page.setViewportSize({ width: 1200, height: 700 })
+  await expect(page.locator('[data-component="terminal"]')).toHaveCount(0)
+
+  await page.keyboard.press("Control+Backquote")
+  await expect(panel).toBeVisible()
+  await expect(page.locator('[data-component="terminal"]')).toBeVisible()
+})
+
+test("toggles the terminal with Cmd+J after visiting shortcut settings on macOS", async ({ page }) => {
   await page.setViewportSize({ width: 1400, height: 900 })
   await page.addInitScript(() => {
     Object.defineProperty(navigator, "platform", { configurable: true, get: () => "MacIntel" })
   })
+  await setupTerminal(page)
+
+  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+  await expectSessionTitle(page, title)
+
+  await page.keyboard.press("Meta+,")
+  const settings = page.getByRole("dialog")
+  await expect(settings).toBeVisible()
+  await settings.getByRole("tab", { name: "Shortcuts" }).click()
+  await expect(settings.getByText("Toggle terminal", { exact: true })).toBeVisible()
+  await page.keyboard.press("Escape")
+  await expect(settings).toHaveCount(0)
+
+  const panel = page.locator("#terminal-panel")
+  await page.keyboard.press("Meta+j")
+  await expect(panel).toHaveAttribute("aria-hidden", "false")
+  await expect(page.locator('[data-component="terminal"]')).toBeVisible()
+
+  await page.keyboard.press("Meta+j")
+  await expect(panel).toHaveCount(0)
+  await expect(page.locator('[data-component="terminal"]')).toHaveCount(0)
+})
+
+async function setupTerminal(page: Page) {
   await mockOpenCodeServer(page, {
     directory,
     project: {
@@ -57,34 +105,7 @@ test("toggles the terminal with the macOS Cmd+J shortcut", async ({ page }) => {
     route.fulfill({ status: 200, contentType: "application/json", body: "{}" }),
   )
   await page.routeWebSocket("**/pty/pty_hidden_terminal/connect", () => undefined)
-
-  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
-  await expectSessionTitle(page, title)
-
-  await page.keyboard.press("Meta+,")
-  const settings = page.getByRole("dialog")
-  await expect(settings).toBeVisible()
-  await settings.getByRole("tab", { name: "Shortcuts" }).click()
-  await expect(settings.getByText("Toggle terminal", { exact: true })).toBeVisible()
-  await page.keyboard.press("Escape")
-  await expect(settings).toHaveCount(0)
-
-  await page.keyboard.press("Meta+j")
-  const panel = page.locator("#terminal-panel")
-  await expect(panel).toHaveAttribute("aria-hidden", "false")
-  await expect(page.locator('[data-component="terminal"]')).toBeVisible()
-
-  await page.keyboard.press("Meta+j")
-  await expect(panel).toHaveCount(0)
-  await expect(page.locator('[data-component="terminal"]')).toHaveCount(0)
-
-  await page.setViewportSize({ width: 1200, height: 700 })
-  await expect(page.locator('[data-component="terminal"]')).toHaveCount(0)
-
-  await page.keyboard.press("Meta+j")
-  await expect(panel).toBeVisible()
-  await expect(page.locator('[data-component="terminal"]')).toBeVisible()
-})
+}
 
 function base64Encode(value: string) {
   return Buffer.from(value, "utf8").toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "")

--- a/packages/app/e2e/regression/terminal-hidden.spec.ts
+++ b/packages/app/e2e/regression/terminal-hidden.spec.ts
@@ -7,8 +7,11 @@ const projectID = "proj_hidden_terminal_regression"
 const sessionID = "ses_hidden_terminal_regression"
 const title = "Hidden terminal regression"
 
-test("unmounts the terminal panel while it is hidden", async ({ page }) => {
+test("toggles the terminal with the macOS Cmd+J shortcut", async ({ page }) => {
   await page.setViewportSize({ width: 1400, height: 900 })
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "platform", { configurable: true, get: () => "MacIntel" })
+  })
   await mockOpenCodeServer(page, {
     directory,
     project: {
@@ -58,19 +61,27 @@ test("unmounts the terminal panel while it is hidden", async ({ page }) => {
   await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
   await expectSessionTitle(page, title)
 
-  await page.keyboard.press("Control+Backquote")
+  await page.keyboard.press("Meta+,")
+  const settings = page.getByRole("dialog")
+  await expect(settings).toBeVisible()
+  await settings.getByRole("tab", { name: "Shortcuts" }).click()
+  await expect(settings.getByText("Toggle terminal", { exact: true })).toBeVisible()
+  await page.keyboard.press("Escape")
+  await expect(settings).toHaveCount(0)
+
+  await page.keyboard.press("Meta+j")
   const panel = page.locator("#terminal-panel")
   await expect(panel).toHaveAttribute("aria-hidden", "false")
   await expect(page.locator('[data-component="terminal"]')).toBeVisible()
 
-  await page.keyboard.press("Control+Backquote")
+  await page.keyboard.press("Meta+j")
   await expect(panel).toHaveCount(0)
   await expect(page.locator('[data-component="terminal"]')).toHaveCount(0)
 
   await page.setViewportSize({ width: 1200, height: 700 })
   await expect(page.locator('[data-component="terminal"]')).toHaveCount(0)
 
-  await page.keyboard.press("Control+Backquote")
+  await page.keyboard.press("Meta+j")
   await expect(panel).toBeVisible()
   await expect(page.locator('[data-component="terminal"]')).toBeVisible()
 })

--- a/packages/app/src/components/settings-dialog.tsx
+++ b/packages/app/src/components/settings-dialog.tsx
@@ -3,6 +3,7 @@ import { onCleanup } from "solid-js"
 import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { DEFAULT_KEYBINDS } from "@/default-keybinds"
 
 export function useSettingsDialog(defaultValue?: string) {
   const dialog = useDialog()
@@ -34,7 +35,7 @@ export function useSettingsCommand() {
       id: "settings.open",
       title: language.t("command.settings.open"),
       category: language.t("command.category.settings"),
-      keybind: "mod+comma",
+      keybind: DEFAULT_KEYBINDS["settings.open"],
       onSelect: show,
     },
   ])

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -19,7 +19,7 @@ import { terminalWriter } from "@/utils/terminal-writer"
 import { terminalWebSocketURL } from "@/utils/terminal-websocket-url"
 
 const TOGGLE_TERMINAL_ID = "terminal.toggle"
-const DEFAULT_TOGGLE_TERMINAL_KEYBIND = "ctrl+`"
+const DEFAULT_TOGGLE_TERMINAL_KEYBIND = "mod+j,ctrl+`"
 export interface TerminalProps extends ComponentProps<"div"> {
   pty: LocalPTY
   autoFocus?: boolean

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -17,9 +17,10 @@ import type { LocalPTY } from "@/context/terminal"
 import { disposeIfDisposable, getHoveredLinkText, setOptionIfSupported } from "@/utils/runtime-adapters"
 import { terminalWriter } from "@/utils/terminal-writer"
 import { terminalWebSocketURL } from "@/utils/terminal-websocket-url"
+import { DEFAULT_KEYBINDS } from "@/default-keybinds"
 
 const TOGGLE_TERMINAL_ID = "terminal.toggle"
-const DEFAULT_TOGGLE_TERMINAL_KEYBIND = "mod+j,ctrl+`"
+const DEFAULT_TOGGLE_TERMINAL_KEYBIND = DEFAULT_KEYBINDS["terminal.toggle"]
 export interface TerminalProps extends ComponentProps<"div"> {
   pty: LocalPTY
   autoFocus?: boolean

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -28,6 +28,7 @@ import { tabKey, useTabs } from "@/context/tabs"
 import type { PromptSession } from "@/context/prompt"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "./command-tooltip-keybind"
+import { DEFAULT_KEYBINDS } from "@/default-keybinds"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -163,14 +164,14 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
       id: "common.goBack",
       title: language.t("common.goBack"),
       category: language.t("command.category.view"),
-      keybind: "mod+[",
+      keybind: DEFAULT_KEYBINDS["common.goBack"],
       onSelect: back,
     },
     {
       id: "common.goForward",
       title: language.t("common.goForward"),
       category: language.t("command.category.view"),
-      keybind: "mod+]",
+      keybind: DEFAULT_KEYBINDS["common.goForward"],
       onSelect: forward,
     },
   ])

--- a/packages/app/src/context/command-keybind.test.ts
+++ b/packages/app/src/context/command-keybind.test.ts
@@ -51,6 +51,13 @@ describe("command keybind helpers", () => {
     ).toBe(true)
   })
 
+  test("matchKeybind supports alternative shortcut combinations", () => {
+    const keybinds = parseKeybind("mod+j,ctrl+`")
+
+    expect(matchKeybind(keybinds, new KeyboardEvent("keydown", { key: "j", metaKey: true }))).toBe(true)
+    expect(matchKeybind(keybinds, new KeyboardEvent("keydown", { key: "`", ctrlKey: true }))).toBe(true)
+  })
+
   test("formatKeybind returns human readable output", () => {
     const display = formatKeybind("ctrl+alt+arrowup")
 

--- a/packages/app/src/default-keybinds.ts
+++ b/packages/app/src/default-keybinds.ts
@@ -1,0 +1,38 @@
+type DesktopMenuPlatform = "macos" | "windows"
+
+export const DEFAULT_KEYBINDS = {
+  "common.goBack": "mod+[",
+  "common.goForward": "mod+]",
+  "project.next": "mod+alt+arrowdown",
+  "project.open": "mod+o",
+  "project.previous": "mod+alt+arrowup",
+  "session.new": "mod+shift+s",
+  "session.next": "alt+arrowdown",
+  "session.previous": "alt+arrowup",
+  "settings.open": "mod+comma",
+  "terminal.toggle": "mod+j,ctrl+`",
+} as const
+
+export type DefaultKeybindCommand = keyof typeof DEFAULT_KEYBINDS
+
+export function desktopAccelerator(command: DefaultKeybindCommand, platform: DesktopMenuPlatform) {
+  const keybind = DEFAULT_KEYBINDS[command].split(",")[0]!
+  const parts = keybind.split("+")
+  const key = parts.pop()!
+  const modifiers = parts.map((part) => {
+    if (part === "mod") return platform === "macos" ? "Cmd" : "Ctrl"
+    if (part === "alt") return platform === "macos" ? "Option" : "Alt"
+    if (part === "shift") return "Shift"
+    if (part === "ctrl") return "Ctrl"
+    if (part === "meta") return "Cmd"
+    return part
+  })
+
+  const keys: Record<string, string> = {
+    arrowdown: "Down",
+    arrowup: "Up",
+    comma: ",",
+  }
+
+  return [...modifiers, keys[key] ?? key.toUpperCase()].join("+")
+}

--- a/packages/app/src/desktop-menu.test.ts
+++ b/packages/app/src/desktop-menu.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, test } from "bun:test"
 import { DESKTOP_MENU } from "./desktop-menu"
 
 describe("desktop menu", () => {
+  test("uses Cmd+J to toggle the terminal on macOS", () => {
+    const item = DESKTOP_MENU.flatMap((menu) => menu.items ?? []).find(
+      (item) => item.type === "item" && item.command === "terminal.toggle",
+    )
+
+    expect(item).toMatchObject({ accelerator: { macos: "Cmd+J" } })
+  })
+
   test("exports logs through the desktop command registry", () => {
     const items = DESKTOP_MENU.flatMap((menu) => menu.items ?? []).filter(
       (item) => item.type === "item" && item.label === "Export Logs...",

--- a/packages/app/src/desktop-menu.test.ts
+++ b/packages/app/src/desktop-menu.test.ts
@@ -1,13 +1,26 @@
 import { describe, expect, test } from "bun:test"
-import { DESKTOP_MENU } from "./desktop-menu"
+import { DEFAULT_KEYBINDS, desktopAccelerator } from "./default-keybinds"
+import { DESKTOP_MENU, type DesktopMenuItem } from "./desktop-menu"
 
 describe("desktop menu", () => {
-  test("uses Cmd+J to toggle the terminal on macOS", () => {
-    const item = DESKTOP_MENU.flatMap((menu) => menu.items ?? []).find(
-      (item) => item.type === "item" && item.command === "terminal.toggle",
+  test("converts shared keybinds to native accelerators", () => {
+    expect(desktopAccelerator("terminal.toggle", "macos")).toBe("Cmd+J")
+    expect(desktopAccelerator("settings.open", "macos")).toBe("Cmd+,")
+    expect(desktopAccelerator("settings.open", "windows")).toBe("Ctrl+,")
+    expect(desktopAccelerator("project.previous", "macos")).toBe("Cmd+Option+Up")
+  })
+
+  test("derives command accelerators from the shared defaults", () => {
+    const items = DESKTOP_MENU.flatMap((menu) => menu.items ?? []).filter(
+      (item): item is DesktopMenuItem & { command: keyof typeof DEFAULT_KEYBINDS } =>
+        item.type === "item" && !!item.command && item.command in DEFAULT_KEYBINDS,
     )
 
-    expect(item).toMatchObject({ accelerator: { macos: "Cmd+J" } })
+    for (const item of items) {
+      for (const [platform, accelerator] of Object.entries(item.accelerator ?? {})) {
+        expect(accelerator).toBe(desktopAccelerator(item.command, platform as "macos" | "windows"))
+      }
+    }
   })
 
   test("exports logs through the desktop command registry", () => {

--- a/packages/app/src/desktop-menu.ts
+++ b/packages/app/src/desktop-menu.ts
@@ -1,3 +1,5 @@
+import { desktopAccelerator } from "./default-keybinds"
+
 export type DesktopMenuPlatform = "macos" | "windows"
 
 export type DesktopMenuAction =
@@ -77,7 +79,12 @@ export const DESKTOP_MENU: DesktopMenu[] = [
     items: [
       { type: "item", role: "about" },
       { type: "item", label: "Check for Updates...", action: "app.checkForUpdates", enabled: "updater" },
-      { type: "item", label: "Settings", command: "settings.open", accelerator: { macos: "Cmd+," } },
+      {
+        type: "item",
+        label: "Settings",
+        command: "settings.open",
+        accelerator: { macos: desktopAccelerator("settings.open", "macos") },
+      },
       { type: "item", label: "Reload Webview", action: "view.reload" },
       { type: "item", label: "Restart", action: "app.relaunch" },
       { type: "item", label: "Export Logs...", command: "logs.export" },
@@ -97,14 +104,19 @@ export const DESKTOP_MENU: DesktopMenu[] = [
         type: "item",
         label: "New Session",
         command: "session.new",
-        accelerator: { macos: "Shift+Cmd+S" },
+        accelerator: { macos: desktopAccelerator("session.new", "macos") },
       },
-      { type: "item", label: "Open Project...", command: "project.open", accelerator: { macos: "Cmd+O" } },
+      {
+        type: "item",
+        label: "Open Project...",
+        command: "project.open",
+        accelerator: { macos: desktopAccelerator("project.open", "macos") },
+      },
       {
         type: "item",
         label: "Settings",
         command: "settings.open",
-        accelerator: { windows: "Ctrl+," },
+        accelerator: { windows: desktopAccelerator("settings.open", "windows") },
         platforms: ["windows"],
       },
       {
@@ -142,7 +154,12 @@ export const DESKTOP_MENU: DesktopMenu[] = [
     label: "View",
     items: [
       { type: "item", label: "Toggle Sidebar", command: "sidebar.toggle" },
-      { type: "item", label: "Toggle Terminal", command: "terminal.toggle", accelerator: { macos: "Cmd+J" } },
+      {
+        type: "item",
+        label: "Toggle Terminal",
+        command: "terminal.toggle",
+        accelerator: { macos: desktopAccelerator("terminal.toggle", "macos") },
+      },
       { type: "item", label: "Toggle File Tree", command: "fileTree.toggle" },
       { type: "separator" },
       { type: "item", label: "Reload", action: "view.reload", role: "reload" },
@@ -165,23 +182,43 @@ export const DESKTOP_MENU: DesktopMenu[] = [
     id: "go",
     label: "Go",
     items: [
-      { type: "item", label: "Back", command: "common.goBack", accelerator: { macos: "Cmd+[" } },
-      { type: "item", label: "Forward", command: "common.goForward", accelerator: { macos: "Cmd+]" } },
+      {
+        type: "item",
+        label: "Back",
+        command: "common.goBack",
+        accelerator: { macos: desktopAccelerator("common.goBack", "macos") },
+      },
+      {
+        type: "item",
+        label: "Forward",
+        command: "common.goForward",
+        accelerator: { macos: desktopAccelerator("common.goForward", "macos") },
+      },
       { type: "separator" },
-      { type: "item", label: "Previous Session", command: "session.previous", accelerator: { macos: "Option+Up" } },
-      { type: "item", label: "Next Session", command: "session.next", accelerator: { macos: "Option+Down" } },
+      {
+        type: "item",
+        label: "Previous Session",
+        command: "session.previous",
+        accelerator: { macos: desktopAccelerator("session.previous", "macos") },
+      },
+      {
+        type: "item",
+        label: "Next Session",
+        command: "session.next",
+        accelerator: { macos: desktopAccelerator("session.next", "macos") },
+      },
       { type: "separator" },
       {
         type: "item",
         label: "Previous Project",
         command: "project.previous",
-        accelerator: { macos: "Cmd+Option+Up" },
+        accelerator: { macos: desktopAccelerator("project.previous", "macos") },
       },
       {
         type: "item",
         label: "Next Project",
         command: "project.next",
-        accelerator: { macos: "Cmd+Option+Down" },
+        accelerator: { macos: desktopAccelerator("project.next", "macos") },
       },
     ],
   },

--- a/packages/app/src/desktop-menu.ts
+++ b/packages/app/src/desktop-menu.ts
@@ -142,7 +142,7 @@ export const DESKTOP_MENU: DesktopMenu[] = [
     label: "View",
     items: [
       { type: "item", label: "Toggle Sidebar", command: "sidebar.toggle" },
-      { type: "item", label: "Toggle Terminal", command: "terminal.toggle", accelerator: { macos: "Ctrl+`" } },
+      { type: "item", label: "Toggle Terminal", command: "terminal.toggle", accelerator: { macos: "Cmd+J" } },
       { type: "item", label: "Toggle File Tree", command: "fileTree.toggle" },
       { type: "separator" },
       { type: "item", label: "Reload", action: "view.reload", role: "reload" },

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -48,6 +48,7 @@ import { setNavigate } from "@/utils/notification-click"
 import { Worktree as WorktreeState } from "@/utils/worktree"
 import { setSessionHandoff } from "@/pages/session/handoff"
 import { SessionRouteKey, SessionStateKey } from "@/utils/server-scope"
+import { DEFAULT_KEYBINDS } from "@/default-keybinds"
 
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
@@ -907,21 +908,21 @@ export default function LegacyLayout(props: ParentProps) {
         id: "project.open",
         title: language.t("command.project.open"),
         category: language.t("command.category.project"),
-        keybind: "mod+o",
+        keybind: DEFAULT_KEYBINDS["project.open"],
         onSelect: () => chooseProject(),
       },
       {
         id: "project.previous",
         title: language.t("command.project.previous"),
         category: language.t("command.category.project"),
-        keybind: "mod+alt+arrowup",
+        keybind: DEFAULT_KEYBINDS["project.previous"],
         onSelect: () => navigateProjectByOffset(-1),
       },
       {
         id: "project.next",
         title: language.t("command.project.next"),
         category: language.t("command.category.project"),
-        keybind: "mod+alt+arrowdown",
+        keybind: DEFAULT_KEYBINDS["project.next"],
         onSelect: () => navigateProjectByOffset(1),
       },
       {
@@ -940,21 +941,21 @@ export default function LegacyLayout(props: ParentProps) {
         id: "settings.open",
         title: language.t("command.settings.open"),
         category: language.t("command.category.settings"),
-        keybind: "mod+comma",
+        keybind: DEFAULT_KEYBINDS["settings.open"],
         onSelect: () => openSettings(),
       },
       {
         id: "session.previous",
         title: language.t("command.session.previous"),
         category: language.t("command.category.session"),
-        keybind: "alt+arrowup",
+        keybind: DEFAULT_KEYBINDS["session.previous"],
         onSelect: () => navigateSessionByOffset(-1),
       },
       {
         id: "session.next",
         title: language.t("command.session.next"),
         category: language.t("command.category.session"),
-        keybind: "alt+arrowdown",
+        keybind: DEFAULT_KEYBINDS["session.next"],
         onSelect: () => navigateSessionByOffset(1),
       },
       {

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -497,7 +497,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     viewCommand({
       id: "terminal.toggle",
       title: language.t("command.terminal.toggle"),
-      keybind: "ctrl+`",
+      keybind: "mod+j,ctrl+`",
       slash: "terminal",
       onSelect: () => {
         if (view().terminal.opened()) {

--- a/packages/app/src/pages/session/use-session-commands.tsx
+++ b/packages/app/src/pages/session/use-session-commands.tsx
@@ -15,6 +15,7 @@ import { useTerminal } from "@/context/terminal"
 import { showToast } from "@/utils/toast"
 import { findLast } from "@opencode-ai/core/util/array"
 import { createSessionTabs } from "@/pages/session/helpers"
+import { DEFAULT_KEYBINDS } from "@/default-keybinds"
 import { extractPromptFromParts } from "@/utils/prompt"
 import { UserMessage } from "@opencode-ai/sdk/v2"
 import { useSessionLayout } from "@/pages/session/session-layout"
@@ -417,7 +418,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     sessionCommand({
       id: "session.new",
       title: language.t("command.session.new"),
-      keybind: "mod+shift+s",
+      keybind: DEFAULT_KEYBINDS["session.new"],
       slash: "new",
       onSelect: (source) => {
         if (settings.general.newLayoutDesigns()) {
@@ -497,7 +498,7 @@ export const useSessionCommands = (actions: SessionCommandContext) => {
     viewCommand({
       id: "terminal.toggle",
       title: language.t("command.terminal.toggle"),
-      keybind: "mod+j,ctrl+`",
+      keybind: DEFAULT_KEYBINDS["terminal.toggle"],
       slash: "terminal",
       onSelect: () => {
         if (view().terminal.opened()) {


### PR DESCRIPTION
## Summary
- restore Cmd+J as the primary macOS terminal-toggle shortcut
- retain Ctrl+` as a compatible fallback for existing users
- replace duplicated browser/native-menu defaults with one shared registry for every desktop-menu command
- add a macOS browser integration regression test for the Settings → terminal toggle flow

## Root cause
The browser command registry and native desktop menu each declared shortcut defaults independently. The terminal’s definitions drifted: the menu and expected macOS behavior used Cmd+J, while the command default used Ctrl+`.

## Validation
- `git diff --check`
- Directly exercised the shared accelerator resolver: `terminal.toggle` resolves to `Cmd+J` on macOS
- Added unit coverage for shared accelerator derivation and menu consistency
- Added Playwright coverage that emulates macOS, visits Settings → Shortcuts, exits, and verifies Cmd+J opens, closes, and reopens the terminal
- Not run: workspace dependencies are absent; Bun cannot install them in the local temporary-directory sandbox (`PermissionDenied`).