### PR TITLE
fix(acp): return configOptions from setSessionModel and setSessionMode

### DIFF
--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -458,15 +458,21 @@ export function make(input: {
     if (!snapshot.availableModes.some((mode) => mode.id === params.modeId)) {
       return yield* new ACPError.InvalidModeError({ mode: params.modeId })
     }
-    yield* session.setMode(params.sessionId, params.modeId)
-    return {}
+    const state = yield* session.setMode(params.sessionId, params.modeId)
+    return {
+      configOptions: configOptions(snapshot, {
+        model: state.model ?? selectDefaultModel(snapshot),
+        variant: state.variant,
+        modeId: state.modeId,
+      }),
+    }
   })
 
   const setSessionModel = Effect.fn("ACP.setSessionModel")(function* (params: SetSessionModelRequest) {
     const current = yield* session.get(params.sessionId)
     const snapshot = yield* configSnapshot(current)
     const selected = yield* parseSelectedModel(snapshot, params.modelId)
-    yield* session
+    const state = yield* session
       .setVariant(
         params.sessionId,
         Directory.variants(snapshot, selected.model)
@@ -474,7 +480,13 @@ export function make(input: {
           : undefined,
       )
       .pipe(Effect.andThen(session.setModel(params.sessionId, selected.model)))
-    return {}
+    return {
+      configOptions: configOptions(snapshot, {
+        model: state.model ?? selected.model,
+        variant: state.variant,
+        modeId: state.modeId,
+      }),
+    }
   })
 
   return {


### PR DESCRIPTION
Issue for this PR

Closes https://github.com/anomalyco/opencode/issues/31961

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When Zed initializes an ACP session, it calls `setSessionModel` (or `setSessionMode`) to apply the user's configured model. Before this fix, both handlers returned `{}` — no `configOptions`. Since the client relies on `configOptions` in the response to discover available effort/reasoning levels for the current model, the reasoning selector was missing until the user manually triggered a config change via `setSessionConfigOption`.

The fix:

- **`setSessionMode`**: capture the `Info` returned by `session.setMode()`, then call `configOptions(snapshot, state)` to build the response.
- **`setSessionModel`**: capture the `Info` returned by the `setVariant → setModel` chain, then return `configOptions(snapshot, state)`.

Both follow the exact same pattern already used by `setSessionConfigOption` (model/effort/mode branches), `loadSession`, `newSession`, `forkSession`, etc. — these two handlers were simply the only ones missing the field.

### How did you verify your code works?

- Manual testing in Zed: after applying the fix, the reasoning effort selector appears immediately on session init, without requiring a manual model switch.
- Verified all existing ACP config option tests still pass.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR