### PR TITLE
docs: Adding opencode-lightpanda plugin/tool to ecosystem page.

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-lightpanda](https://github.com/skatkov/opencode-lightpanda)                               | A Lightpanda browser plugin/tool for OpenCode. Lightpanda browser is like WebFetch tool on steroids. |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

doesn't close anything, it's just a small addition to documentation

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a link to the opencode-lightpanda plugin to the ecosystem/plugins page. 

Lightpanda is a browser for AI agents/automation, that offers more performant alternative to opencode's WebFetch tool.

### How did you verify your code works?

I'm running this plugin myself in my own workflow. Also wrote a blog post on my motivation to have WebFetch alternative deeply integrated with opencode here:
https://skatkov.com/posts/2026-07-15-snooping-on-githits


### Screenshots / recordings

<img width="848" height="400" alt="image" src="https://github.com/user-attachments/assets/7f61fb97-49cf-4c3e-b186-a15002109c3e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

