### PR TITLE
test(cli): cover managed reconnect ensure-on-first-failure

### DIFF
--- a/packages/cli/src/services/server-connection.ts
+++ b/packages/cli/src/services/server-connection.ts
@@ -49,10 +49,12 @@ export const resolve = Effect.fn("cli.server-connection.resolve")(function* (arg
   } satisfies Resolved
 })
 
+/** Passive reconnect: ensure-running with no version replacement authority. */
+export const managedReconnect = (options: EnsureOptions) => Service.ensure({ ...options, version: undefined })
+
 function managedService(options: EnsureOptions) {
-  const reconnectOptions = { ...options, version: undefined }
   return {
-    reconnect: () => Service.ensure(reconnectOptions),
+    reconnect: () => managedReconnect(options),
     restart: () =>
       Effect.gen(function* () {
         yield* Service.stop(options)

--- a/packages/cli/test/server-connection.test.ts
+++ b/packages/cli/test/server-connection.test.ts
@@ -1,13 +1,68 @@
 import { NodeFileSystem } from "@effect/platform-node"
+import type { EnsureReason } from "@opencode-ai/client/effect/service"
 import { Global } from "@opencode-ai/core/global"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { expect, test } from "bun:test"
 import { Effect, FileSystem, Scope } from "effect"
+import { createServer } from "node:http"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { ServerConnection } from "../src/services/server-connection"
 import { ServiceConfig } from "../src/services/service-config"
+
+test("managed reconnect ensures the service on the first failure", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-reconnect-"))
+  const starts: EnsureReason[] = []
+  try {
+    const exit = await Effect.runPromise(
+      ServerConnection.managedReconnect({
+        file: path.join(root, "service.json"),
+        onStart: (reason) => {
+          starts.push(reason)
+          throw new Error("service ensure invoked")
+        },
+      }).pipe(Effect.provide(NodeFileSystem.layer), Effect.exit),
+    )
+    expect(exit._tag).toBe("Failure")
+    expect(starts).toEqual(["missing"])
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("managed reconnect reuses a healthy service from another version", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-reconnect-version-"))
+  const server = createServer((request, response) => {
+    if (request.url !== "/api/health") {
+      response.writeHead(404).end()
+      return
+    }
+    response.writeHead(200, { "content-type": "application/json" })
+    response.end(JSON.stringify({ healthy: true, version: "older", pid: process.pid }))
+  })
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  if (address === null || typeof address === "string") throw new Error("Expected TCP server address")
+  const file = path.join(root, "service.json")
+  const url = `http://127.0.0.1:${address.port}`
+  await Bun.write(file, JSON.stringify({ url, pid: process.pid, version: "older" }))
+  try {
+    const endpoint = await Effect.runPromise(
+      ServerConnection.managedReconnect({
+        file,
+        version: "newer",
+        command: [path.join(root, "must-not-start")],
+      }).pipe(Effect.provide(NodeFileSystem.layer)),
+    )
+    expect(endpoint.url).toBe(url)
+  } finally {
+    await new Promise<void>((resolve, reject) =>
+      server.close((error) => (error === undefined ? resolve() : reject(error))),
+    )
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
 
 test("resolution groups Effect-native lifecycle operations only for the managed service", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-server-resolution-"))


### PR DESCRIPTION
### Issue for this PR

Closes #36581

https://github.com/anomalyco/opencode/issues/36581

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The reconnect delay itself already landed via the service lifecycle work. This adds the missing regression coverage from that issue: first failed reconnect runs ensure immediately, and passive reconnect reuses a healthy service from another version instead of replacing it.

Also exports `ServerConnection.managedReconnect` so that policy is testable without going through the full resolve path.

### How did you verify your code works?

- `bun test test/server-connection.test.ts --timeout 30000`
- `bun run typecheck` in `packages/cli`

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Made with [Cursor](https://cursor.com)