### PR TITLE
fix(snapshot): handle info/exclude write failure gracefully instead of orDie

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -188,8 +188,12 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
           ]
             .filter(Boolean)
             .join("\n")
-          yield* fs.ensureDir(path.join(state.gitdir, "info")).pipe(Effect.orDie)
-          yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.orDie)
+          yield* fs.ensureDir(path.join(state.gitdir, "info")).pipe(Effect.catch((err) =>
+            Effect.logWarning("failed to ensure snapshot info dir", err)
+          ))
+          yield* fs.writeFileString(target, text ? `${text}\n` : "").pipe(Effect.catch((err) =>
+            Effect.logWarning("failed to write snapshot excludes", err)
+          ))
         })
 
         // Reuse the hashes for the git storage between the original repo and snapshot


### PR DESCRIPTION
### Issue for this PR

Closes #37493

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Snapshot.sync` writes to `info/exclude` inside the snapshot gitdir with `Effect.orDie`, so any `EACCES` (from UID mismatch when the snapshot directory is shared between a container and the host, or from concurrent writes across sessions) crashes the `SessionProcessor` mid-conversation with:

```
PlatformError: PermissionDenied: FileSystem.writeFile (.../info/exclude)
cause: EACCES: permission denied, open .../info/exclude
```

Changes both write sites (`ensureDir` + `writeFileString`) to `Effect.catch` with `Effect.logWarning` instead of `Effect.orDie`. The exclude file is advisory — a write failure should log and continue, not kill the session.

### How did you verify your code works?

- `tsgo --noEmit` passes
- Existing tests in `packages/opencode` pass
- Running `opencode` from source confirms errors are logged as warnings instead of crashing

### Screenshots / recordings

N/A.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR