### PR TITLE
fix(cli): stabilize Windows ARM64 Node builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,7 +135,7 @@ jobs:
           - target: darwin-arm64
             host: macos-26
           - target: windows-arm64
-            host: windows-2025
+            host: blacksmith-4vcpu-windows-2025
           - target: windows-x64
             host: blacksmith-4vcpu-windows-2025
     runs-on: ${{ matrix.settings.host }}

--- a/packages/cli/script/build-node.ts
+++ b/packages/cli/script/build-node.ts
@@ -170,8 +170,10 @@ async function resolveTargetNode(target: NodeTarget, host?: string) {
   await rm(temporary, { recursive: true, force: true })
   await mkdir(temporary)
   if (target.platform !== "win32") run("tar", ["-xzf", archive, "-C", temporary])
-  else if (process.platform === "win32") run("tar", ["-xf", archive, "-C", temporary])
-  else run("unzip", ["-q", archive, "-d", temporary])
+  if (target.platform === "win32" && process.platform === "win32") {
+    run(path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "tar.exe"), ["-xf", archive, "-C", temporary])
+  }
+  if (target.platform === "win32" && process.platform !== "win32") run("unzip", ["-q", archive, "-d", temporary])
   await rm(targetDirectory, { recursive: true, force: true })
   await rename(path.join(temporary, archiveName), targetDirectory)
   await writeFile(path.join(targetDirectory, ".verified"), `${expected}\n`)


### PR DESCRIPTION
Run the Windows ARM64 package build on the Blacksmith Windows runner to avoid slow dependency installation on GitHub-hosted Windows machines.

Use the Windows system tar executable when extracting Node archives so drive-letter paths are not interpreted as remote hosts by Git's GNU tar.
