### PR TITLE
fix(opencode): plain plugin spinner output outside TTY

### DIFF
--- a/packages/opencode/src/cli/cmd/plug.ts
+++ b/packages/opencode/src/cli/cmd/plug.ts
@@ -17,6 +17,19 @@ type Spin = {
   stop: (msg: string, code?: number) => void
 }
 
+type Output = {
+  readonly isTTY?: boolean
+  write: (chunk: string) => unknown
+}
+
+export function plugSpinner(output: Output = process.stdout): Spin {
+  if (output.isTTY) return spinner()
+  return {
+    start: (msg) => output.write(msg + "\n"),
+    stop: (msg) => output.write(msg + "\n"),
+  }
+}
+
 export type PlugDeps = {
   spinner: () => Spin
   log: {
@@ -45,7 +58,7 @@ export type PlugCtx = {
 }
 
 const defaultPlugDeps: PlugDeps = {
-  spinner: () => spinner(),
+  spinner: () => plugSpinner(),
   log: {
     error: (msg) => log.error(msg),
     info: (msg) => log.info(msg),

--- a/packages/opencode/test/plugin/install.test.ts
+++ b/packages/opencode/test/plugin/install.test.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises"
 import path from "path"
 import { parse as parseJsonc } from "jsonc-parser"
 import { Filesystem } from "@/util/filesystem"
-import { createPlugTask, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
+import { createPlugTask, plugSpinner, type PlugCtx, type PlugDeps } from "../../src/cli/cmd/plug"
 import { tmpdir } from "../fixture/fixture"
 
 function deps(global: string, target: string | Error): PlugDeps {
@@ -107,6 +107,22 @@ async function read(file: string) {
     plugin?: unknown[]
   }>(file)
 }
+
+test("plugin spinner writes plain lines outside a TTY", () => {
+  for (const isTTY of [false, undefined] as const) {
+    const chunks: string[] = []
+    const spin = plugSpinner({
+      isTTY,
+      write: (chunk) => chunks.push(chunk),
+    })
+
+    spin.start("Installing plugin package...")
+    spin.stop("Plugin package ready", 1)
+
+    expect(chunks.join("")).toBe("Installing plugin package...\nPlugin package ready\n")
+    expect(chunks.join("")).not.toContain("\x1b")
+  }
+})
 
 describe("plugin.install.task", () => {
   test("writes both server and tui config entries", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #27908

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode plugin install` used Clack's animated spinner even when stdout was not a TTY, so non-interactive shells printed spinner frames and ANSI junk.

This change keeps the animated spinner on TTY, and writes plain one-line start/stop messages otherwise.

### How did you verify your code works?

From `packages/opencode`:

- `bun test test/plugin/install.test.ts` — 22 pass
- `bun typecheck` — pass
- pre-push/turbo typecheck across packages — pass

Independent read-only Codex review (`gpt-5.6-sol`) returned PASS after applying a small test NIT for `isTTY: undefined` and `stop(..., code)`.

### Screenshots / recordings

N/A — CLI non-TTY behavior; covered by unit test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR