### PR TITLE
fix(github action): don't die on rate-limited version lookup

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -44,8 +44,10 @@ runs:
     - name: Get opencode version
       id: version
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+        VERSION=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4 || true)
         echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
 
     - name: Cache opencode


### PR DESCRIPTION
## Problem

The GitHub action's version step:

```bash
VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
```

`shell: bash` composite steps run with `-e -o pipefail`, so when the unauthenticated curl is rate-limited (GitHub-hosted runners share IP pools against the 60 req/hr unauthenticated API limit, so this happens regularly), the failed command substitution kills the step and the `${VERSION:-latest}` fallback on the next line is unreachable. The consumer's whole job fails at setup. We hit this intermittently in CI: the action step exits 1 about 23s in, and a plain re-run goes green.

## Fix

Two small changes to the version step, nothing caller-facing:

1. Authenticate the lookup with `github.token` (always available inside composite actions; a public-repo read needs no scopes). This removes the rate-limit cause.
2. `|| true` on the substitution so the documented `${VERSION:-latest}` fallback is actually reachable if the lookup still fails for any other reason (e.g. a token that is not valid for api.github.com on GHES runners).

Worst case becomes what the code already intended: fall back to `latest` and let the install script resolve the version.
