### PR TITLE
fix(provider): support Kimi K3 reasoning effort

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1704,6 +1704,8 @@ function reasoningEffort(model: Provider.Model, effort: string) {
 }
 
 function anthropicEffort(model: Provider.Model, effort: string) {
+  // K3's Anthropic-compatible endpoint exposes adaptive thinking through output_config.effort.
+  if (model.family === "kimi-k3") return { thinking: { type: "adaptive" }, effort }
   if (["opus-4-5", "opus-4.5"].some((value) => model.api.id.includes(value))) return { effort }
   if (!anthropicAdaptiveEfforts(model.api.id)) return
   return {

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1514,6 +1514,15 @@ test("models.dev reasoning options replace generated variants and unsupported op
         limit: { context: 128_000, output: 64_000 },
         experimental: { modes: { fast: {} } },
       },
+      k3: {
+        id: "k3",
+        name: "Kimi K3",
+        family: "kimi-k3",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["low", "high", "max"] }],
+        provider: { npm: "@ai-sdk/anthropic" },
+        limit: { context: 1_048_576, output: 131_072 },
+      },
     },
   } as unknown as ModelsDev.Provider
 
@@ -1531,6 +1540,11 @@ test("models.dev reasoning options replace generated variants and unsupported op
     high: { thinkingConfig: { includeThoughts: true, thinkingLevel: "high" } },
   })
   expect(models["gemini-3-pro-fast"].variants).toEqual(models.override.variants)
+  expect(models.k3.variants).toEqual({
+    low: { thinking: { type: "adaptive" }, effort: "low" },
+    high: { thinking: { type: "adaptive" }, effort: "high" },
+    max: { thinking: { type: "adaptive" }, effort: "max" },
+  })
 })
 
 test("public provider info omits invalid models", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3028,8 +3028,8 @@ describe("ProviderTransform.temperature - Cohere North", () => {
 
 describe("ProviderTransform.reasoningVariants", () => {
   const model = (reasoning_options: ModelsDev.Model["reasoning_options"]) => ({ reasoning_options }) as ModelsDev.Model
-  const target = (npm: string, id = "test-model") =>
-    ({ id, api: { id, npm, url: "" }, capabilities: { reasoning: true }, limit: { output: 64_000 } }) as any
+  const target = (npm: string, id = "test-model", family?: string) =>
+    ({ id, family, api: { id, npm, url: "" }, capabilities: { reasoning: true }, limit: { output: 64_000 } }) as any
 
   test("respects explicitly empty reasoning options", () => {
     expect(ProviderTransform.reasoningVariants(model([]), target("@ai-sdk/openai"))).toEqual({})
@@ -3101,6 +3101,19 @@ describe("ProviderTransform.reasoningVariants", () => {
         target("@ai-sdk/anthropic", "claude-opus-4-5"),
       ),
     ).toEqual({ high: { effort: "high" } })
+  })
+
+  test("uses adaptive effort for Kimi K3", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "effort", values: ["low", "high", "max"] }]),
+        target("@ai-sdk/anthropic", "k3", "kimi-k3"),
+      ),
+    ).toEqual({
+      low: { thinking: { type: "adaptive" }, effort: "low" },
+      high: { thinking: { type: "adaptive" }, effort: "high" },
+      max: { thinking: { type: "adaptive" }, effort: "max" },
+    })
   })
 
   test("leaves legacy Anthropic effort options to budget fallback", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #37418

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Kimi K3 declares `low`, `high`, and `max` effort levels in models.dev, but the Anthropic-compatible provider did not recognize the `kimi-k3` family. The effort conversion returned no variants and OpenCode fell back to Anthropic budget-token variants.

This change maps Kimi K3 effort metadata to adaptive thinking options so the Anthropic SDK sends `thinking.type = adaptive` with the selected `output_config.effort`. It also adds transform and provider regression coverage for all three levels.

### How did you verify your code works?

- `cd packages/opencode && bun test test/provider/transform.test.ts test/provider/provider.test.ts`: 445 passed, 0 failed
- `cd packages/opencode && bun run typecheck`: passed
- Sent sanitized live requests through the Kimi Code endpoint for `low`, `high`, and `max`; each request used adaptive thinking with the matching effort and was accepted

### Screenshots / recordings

Not applicable; this change only affects provider request options.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
