### PR TITLE
feat(tui): expose session composer top slot

### DIFF
--- a/.changeset/fresh-composers-slot.md
+++ b/.changeset/fresh-composers-slot.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/cli": patch
+---
+
+Expose a TUI plugin slot above the session composer.

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -68,6 +68,7 @@ import { nextThinkingMode, reasoningSummary, type ThinkingMode } from "../../con
 import { getScrollAcceleration } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { usePluginRuntime } from "../../plugin/runtime"
+import { PluginSlot } from "../../plugin/context"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
@@ -932,6 +933,7 @@ export function Session() {
               </Show>
             </scrollbox>
             <box flexShrink={0}>
+              <PluginSlot name="session.composer.top" input={{ sessionID: route.sessionID }} />
               <Composer
                 sessionID={route.sessionID}
                 open={composer.open || (!!session()?.parentID && forms().length === 0)}


### PR DESCRIPTION
## What

Adds a V2 TUI plugin slot immediately above the session composer. Plugins can use `session.composer.top` for transient session context, workflow status, warnings, or controls without replacing the prompt.

```tsx
context.ui.slot("session.composer.top", ({ sessionID }) => (
  <text>Session context for {String(sessionID)}</text>
))
```

## How

- Mounts `PluginSlot` inside the fixed composer region, directly before `Composer`.
- Passes the active `sessionID` to every registered contribution.
- Adds a CLI patch changeset.

## Scope

This PR only exposes the generic host position. It does not add a built-in contribution, change plugin loading, or alter the composer and prompt replacement slots.

## Testing

- `bun typecheck` in `packages/tui`.
- `bun run test` in `packages/tui`: 265 passed, 1 skipped.
- Pre-push `bun turbo typecheck --concurrency=3`: 32 package tasks passed.
- `git diff --check` passed.

## Demo

A temporary local recap plugin renders through `session.composer.top`. The demo contribution is not included in this PR.

![Session composer top plugin slot](https://github.com/user-attachments/assets/5d8247d3-1edc-49e5-a815-aabd20bbaf00)
