### PR TITLE
fix(provider): honor reasoning option semantics

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1586,16 +1586,16 @@ export function reasoningVariants(model: ModelsDev.Model, target: Provider.Model
   if (options.length === 0) return {}
 
   const effort = options.find((option) => option.type === "effort")
-  if (effort) return nonEmptyVariants(effortVariants(target, effort.values))
+  if (effort) return effortVariants(target, effort.values)
 
   const toggle = options.some((option) => option.type === "toggle")
   const budget = options.find((option) => option.type === "budget_tokens")
-  if (!budget) return toggle ? nonEmptyVariants(reasoningToggle(target)) : undefined
+  if (!budget) return toggle ? reasoningToggle(target) : {}
 
-  return nonEmptyVariants({
+  return {
     ...(toggle ? reasoningToggle(target) : {}),
     ...budgetVariants(target, budget.min, budget.max),
-  })
+  }
 }
 
 function effortVariants(model: Provider.Model, values: readonly unknown[]) {
@@ -1627,11 +1627,12 @@ function budgetVariants(model: Provider.Model, min?: number, max?: number) {
   )
 }
 
-function nonEmptyVariants(variants: NonNullable<Provider.Model["variants"]>): Provider.Model["variants"] {
-  return Object.keys(variants).length > 0 ? variants : undefined
-}
-
 function reasoningToggle(model: Provider.Model): NonNullable<Provider.Model["variants"]> {
+  if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/google-vertex/anthropic")
+    return {
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "adaptive" } },
+    }
   if (model.api.npm === "@ai-sdk/alibaba")
     return {
       none: { enableThinking: false },
@@ -1651,7 +1652,7 @@ function reasoningEffort(model: Provider.Model, effort: string) {
       return { reasoning: { effort } }
     case "@ai-sdk/anthropic":
     case "@ai-sdk/google-vertex/anthropic":
-      return anthropicEffort(model, effort)
+      return anthropicEffort(model, effort) ?? { effort }
     case "@ai-sdk/google":
     case "@ai-sdk/google-vertex":
       return { thinkingConfig: { includeThoughts: true, thinkingLevel: effort } }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1590,12 +1590,12 @@ export function reasoningVariants(model: ModelsDev.Model, target: Provider.Model
 
   const toggle = options.some((option) => option.type === "toggle")
   const budget = options.find((option) => option.type === "budget_tokens")
-  if (!budget) return toggle ? reasoningToggle(target) : {}
+  if (!budget) return toggle ? nonEmptyVariants(reasoningToggle(target)) : undefined
 
-  return {
+  return nonEmptyVariants({
     ...(toggle ? reasoningToggle(target) : {}),
     ...budgetVariants(target, budget.min, budget.max),
-  }
+  })
 }
 
 function effortVariants(model: Provider.Model, values: readonly unknown[]) {
@@ -1627,12 +1627,11 @@ function budgetVariants(model: Provider.Model, min?: number, max?: number) {
   )
 }
 
+function nonEmptyVariants(variants: NonNullable<Provider.Model["variants"]>): Provider.Model["variants"] {
+  return Object.keys(variants).length > 0 ? variants : undefined
+}
+
 function reasoningToggle(model: Provider.Model): NonNullable<Provider.Model["variants"]> {
-  if (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/google-vertex/anthropic")
-    return {
-      none: { thinking: { type: "disabled" } },
-      thinking: { thinking: { type: "adaptive" } },
-    }
   if (model.api.npm === "@ai-sdk/alibaba")
     return {
       none: { enableThinking: false },

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1477,7 +1477,7 @@ test("models.dev normalization fills required response fields", () => {
   expect(model.release_date).toBe("")
 })
 
-test("models.dev reasoning options replace generated variants", () => {
+test("models.dev reasoning options replace generated variants and unsupported toggles fall back", () => {
   const provider = {
     id: "reasoning",
     name: "Reasoning",
@@ -1534,7 +1534,7 @@ test("models.dev reasoning options replace generated variants", () => {
     },
   })
   expect(models.empty.variants).toEqual({})
-  expect(models.fallback.variants).toEqual({})
+  expect(Object.keys(models.fallback.variants ?? {})).toEqual(["none", "low", "medium", "high", "xhigh"])
   expect(models.override.variants).toEqual({
     high: { thinkingConfig: { includeThoughts: true, thinkingLevel: "high" } },
   })

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1477,7 +1477,7 @@ test("models.dev normalization fills required response fields", () => {
   expect(model.release_date).toBe("")
 })
 
-test("models.dev reasoning options replace generated variants and unsupported options fall back", () => {
+test("models.dev reasoning options replace generated variants", () => {
   const provider = {
     id: "reasoning",
     name: "Reasoning",
@@ -1514,6 +1514,14 @@ test("models.dev reasoning options replace generated variants and unsupported op
         limit: { context: 128_000, output: 64_000 },
         experimental: { modes: { fast: {} } },
       },
+      anthropicCompatible: {
+        id: "k3",
+        name: "Anthropic Compatible",
+        reasoning: true,
+        reasoning_options: [{ type: "effort", values: ["max"] }],
+        provider: { npm: "@ai-sdk/anthropic" },
+        limit: { context: 1_048_576, output: 131_072 },
+      },
     },
   } as unknown as ModelsDev.Provider
 
@@ -1526,10 +1534,11 @@ test("models.dev reasoning options replace generated variants and unsupported op
     },
   })
   expect(models.empty.variants).toEqual({})
-  expect(Object.keys(models.fallback.variants ?? {})).toEqual(["none", "low", "medium", "high", "xhigh"])
+  expect(models.fallback.variants).toEqual({})
   expect(models.override.variants).toEqual({
     high: { thinkingConfig: { includeThoughts: true, thinkingLevel: "high" } },
   })
+  expect(models.anthropicCompatible.variants).toEqual({ max: { effort: "max" } })
   expect(models["gemini-3-pro-fast"].variants).toEqual(models.override.variants)
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3103,13 +3103,20 @@ describe("ProviderTransform.reasoningVariants", () => {
     ).toEqual({ high: { effort: "high" } })
   })
 
-  test("leaves legacy Anthropic effort options to budget fallback", () => {
+  test("uses explicit effort metadata for Anthropic-compatible models", () => {
     expect(
       ProviderTransform.reasoningVariants(
         model([{ type: "effort", values: ["high"] }]),
         target("@ai-sdk/anthropic", "claude-sonnet-4"),
       ),
-    ).toBeUndefined()
+    ).toEqual({ high: { effort: "high" } })
+
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "effort", values: ["max"] }]),
+        target("@ai-sdk/anthropic", "k3"),
+      ),
+    ).toEqual({ max: { effort: "max" } })
   })
 
   test("uses adaptive reasoning config for Anthropic models on Bedrock", () => {
@@ -3129,13 +3136,13 @@ describe("ProviderTransform.reasoningVariants", () => {
     })
   })
 
-  test("leaves legacy Anthropic Bedrock effort options to budget fallback", () => {
+  test("does not replace unsupported Anthropic Bedrock effort options with token budgets", () => {
     expect(
       ProviderTransform.reasoningVariants(
         model([{ type: "effort", values: ["high"] }]),
         target("@ai-sdk/amazon-bedrock", "anthropic.claude-sonnet-4-v1:0"),
       ),
-    ).toBeUndefined()
+    ).toEqual({})
   })
 
   test.each([
@@ -3166,6 +3173,20 @@ describe("ProviderTransform.reasoningVariants", () => {
   })
 
   test.each([
+    [
+      "@ai-sdk/anthropic",
+      {
+        none: { thinking: { type: "disabled" } },
+        thinking: { thinking: { type: "adaptive" } },
+      },
+    ],
+    [
+      "@ai-sdk/google-vertex/anthropic",
+      {
+        none: { thinking: { type: "disabled" } },
+        thinking: { thinking: { type: "adaptive" } },
+      },
+    ],
     ["@ai-sdk/alibaba", { none: { enableThinking: false }, high: { enableThinking: true } }],
     [
       "@ai-sdk/cohere",
@@ -3256,11 +3277,11 @@ describe("ProviderTransform.reasoningVariants", () => {
     })
   })
 
-  test("leaves unsupported options for heuristic fallback", () => {
+  test("does not replace unsupported options with heuristic variants", () => {
     expect(
       ProviderTransform.reasoningVariants(model([{ type: "effort", values: ["high"] }]), target("@ai-sdk/perplexity")),
-    ).toBeUndefined()
-    expect(ProviderTransform.reasoningVariants(model([{ type: "toggle" }]), target("@ai-sdk/openai"))).toBeUndefined()
+    ).toEqual({})
+    expect(ProviderTransform.reasoningVariants(model([{ type: "toggle" }]), target("@ai-sdk/openai"))).toEqual({})
   })
 
   test("uses model-family options for gateway and GitHub Copilot", () => {
@@ -3275,7 +3296,7 @@ describe("ProviderTransform.reasoningVariants", () => {
     })
     expect(
       ProviderTransform.reasoningVariants(effort, target("@ai-sdk/github-copilot", "gemini-3-pro")),
-    ).toBeUndefined()
+    ).toEqual({})
   })
 
   test.each(["@ai-sdk/cohere", "@ai-sdk/perplexity", "@ai-sdk/vercel", "@ai-sdk/alibaba", "gitlab-ai-provider"])(
@@ -3283,7 +3304,7 @@ describe("ProviderTransform.reasoningVariants", () => {
     (npm) => {
       expect(
         ProviderTransform.reasoningVariants(model([{ type: "effort", values: ["high"] }]), target(npm)),
-      ).toBeUndefined()
+      ).toEqual({})
     },
   )
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3173,20 +3173,6 @@ describe("ProviderTransform.reasoningVariants", () => {
   })
 
   test.each([
-    [
-      "@ai-sdk/anthropic",
-      {
-        none: { thinking: { type: "disabled" } },
-        thinking: { thinking: { type: "adaptive" } },
-      },
-    ],
-    [
-      "@ai-sdk/google-vertex/anthropic",
-      {
-        none: { thinking: { type: "disabled" } },
-        thinking: { thinking: { type: "adaptive" } },
-      },
-    ],
     ["@ai-sdk/alibaba", { none: { enableThinking: false }, high: { enableThinking: true } }],
     [
       "@ai-sdk/cohere",
@@ -3277,11 +3263,14 @@ describe("ProviderTransform.reasoningVariants", () => {
     })
   })
 
-  test("does not replace unsupported options with heuristic variants", () => {
+  test("does not replace unsupported effort options with heuristic variants", () => {
     expect(
       ProviderTransform.reasoningVariants(model([{ type: "effort", values: ["high"] }]), target("@ai-sdk/perplexity")),
     ).toEqual({})
-    expect(ProviderTransform.reasoningVariants(model([{ type: "toggle" }]), target("@ai-sdk/openai"))).toEqual({})
+  })
+
+  test("leaves unsupported toggle options for heuristic fallback", () => {
+    expect(ProviderTransform.reasoningVariants(model([{ type: "toggle" }]), target("@ai-sdk/openai"))).toBeUndefined()
   })
 
   test("uses model-family options for gateway and GitHub Copilot", () => {


### PR DESCRIPTION
## Summary

- treat declared models.dev effort options as authoritative instead of falling back to heuristic variants when conversion yields no settings
- map Anthropic-compatible effort options to native `output_config.effort` without inventing token budgets
- preserve existing toggle and budget fallback behavior for MiniMax, Kimi, Claude, and other providers

Fixes #37418

## Testing

- `bun test test/provider/transform.test.ts test/provider/provider.test.ts`
- `bun typecheck`
- `git diff --check`