### PR TITLE
feat(tui): expose session header slot

### DIFF
--- a/.changeset/calm-sessions-header.md
+++ b/.changeset/calm-sessions-header.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/cli": patch
+---
+
+Expose a TUI plugin slot at the top of the session view.

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -68,6 +68,7 @@ import { nextThinkingMode, reasoningSummary, type ThinkingMode } from "../../con
 import { getScrollAcceleration } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { usePluginRuntime } from "../../plugin/runtime"
+import { PluginSlot } from "../../plugin/context"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
@@ -888,6 +889,7 @@ export function Session() {
     >
       <box flexDirection="row" flexGrow={1} minHeight={0}>
         <box flexGrow={1} minHeight={0} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
+          <PluginSlot name="session.header" input={{ sessionID: route.sessionID }} />
           <Show when={session()}>
             <scrollbox
               ref={(r) => (scroll = r)}


### PR DESCRIPTION
## What

Adds a V2 TUI plugin slot at the top of the active session view. Plugins can use `session.header` for persistent session-level context such as environment, branch, workflow mode, or warnings.

```tsx
context.ui.slot("session.header", ({ sessionID }) => (
  <text>Review mode · {String(sessionID)}</text>
))
```

## How

- Mounts `PluginSlot` before the session transcript region.
- Passes the active `sessionID` to every registered contribution.
- Adds a CLI patch changeset.

## Scope

This PR only exposes the generic host position. It does not add a built-in contribution or change plugin loading.

## Testing

- `bun typecheck` in `packages/tui`.
- `bun run test` in `packages/tui`: 265 passed, 1 skipped.
- Pre-push `bun turbo typecheck --concurrency=3`: 32 package tasks passed.
- `git diff --check` passed.

## Demo

A temporary local plugin renders session-level review state through `session.header`. The demo contribution is not included in this PR.

![Session header plugin slot](https://github.com/user-attachments/assets/34d3867e-f94c-4c90-8fef-7bf1e08e37a9)
