### PR TITLE
fix(simulation): normalize named key presses

### DIFF
--- a/packages/simulation/src/frontend/actions.ts
+++ b/packages/simulation/src/frontend/actions.ts
@@ -1,7 +1,14 @@
 import { tmpdir } from "node:os"
 import { extname, join, resolve } from "node:path"
 import type { CliRenderer, Renderable } from "@opentui/core"
-import { createMockKeys, createMockMouse, type MockInput, type MockMouse } from "@opentui/core/testing"
+import {
+  createMockKeys,
+  createMockMouse,
+  KeyCodes,
+  type KeyInput,
+  type MockInput,
+  type MockMouse,
+} from "@opentui/core/testing"
 import { Config, Effect, FileSystem } from "effect"
 import type { SimulationProtocol } from "../protocol"
 import { SimulationRenderer } from "./renderer"
@@ -25,6 +32,15 @@ type RenderBuffer = {
 }
 
 const decoder = new TextDecoder()
+
+function isKeyCode(key: string): key is keyof typeof KeyCodes {
+  return Object.hasOwn(KeyCodes, key)
+}
+
+function keyInput(key: string): KeyInput {
+  const named = key.toUpperCase()
+  return isKeyCode(named) ? named : key
+}
 
 function children(renderable: Renderable) {
   return renderable.getChildren().filter((child): child is Renderable => "num" in child)
@@ -154,7 +170,7 @@ export const execute = Effect.fn("SimulationActions.execute")(function* (harness
       yield* Effect.tryPromise(() => harness.mockInput.typeText(action.text))
       break
     case "ui.press":
-      harness.mockInput.pressKey(action.key, action.modifiers)
+      harness.mockInput.pressKey(keyInput(action.key), action.modifiers)
       break
     case "ui.enter":
       harness.mockInput.pressEnter()

--- a/packages/simulation/test/actions.test.ts
+++ b/packages/simulation/test/actions.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
-import { matches } from "../src/frontend/actions"
+import { Effect } from "effect"
+import { execute, type Harness, matches } from "../src/frontend/actions"
 
 test("matches literal screen text", () => {
   const harness = { screen: () => "OpenCode [ready].*" }
@@ -8,4 +9,33 @@ test("matches literal screen text", () => {
   expect(matches(harness, "[ready].*")).toBe(true)
   expect(matches(harness, "OpenCode.*ready")).toBe(false)
   expect(matches(harness, "opencode")).toBe(false)
+})
+
+test("normalizes named keys for OpenTUI", async () => {
+  const pressed: Array<readonly [string, object | undefined]> = []
+  const harness = {
+    renderer: {
+      root: { getChildren: () => [] },
+      currentFocusedRenderable: undefined,
+      currentFocusedEditor: undefined,
+    },
+    mockInput: {
+      pressKey: (key: string, modifiers?: object) => pressed.push([key, modifiers]),
+    },
+    renderOnce: async () => {},
+  } as unknown as Harness
+
+  await Effect.runPromise(
+    execute(harness, {
+      type: "ui.press",
+      key: "escape",
+      modifiers: { ctrl: true },
+    }),
+  )
+  await Effect.runPromise(execute(harness, { type: "ui.press", key: "x" }))
+
+  expect(pressed).toEqual([
+    ["ESCAPE", { ctrl: true }],
+    ["x", undefined],
+  ])
 })


### PR DESCRIPTION
## What

Make `ui.press` interpret lowercase semantic key names such as `escape` through OpenTUI's named-key table instead of typing the name as literal text.

Closes #37511.

## Before / After

**Before:** `ui.press({ key: "escape" })` forwarded `escape` directly to OpenTUI's case-sensitive test input API, which emitted the seven literal characters. Callers had to send the raw escape byte instead.

**After:** recognized named keys are normalized to OpenTUI's canonical token (`escape` to `ESCAPE`) at the adapter boundary. Printable input such as `x` remains unchanged, and key modifiers are preserved.

## How

- `packages/simulation/src/frontend/actions.ts` checks the uppercased semantic name against OpenTUI's installed `KeyCodes` table before pressing it.
- `packages/simulation/test/actions.test.ts` covers named-key normalization, modifier forwarding, and printable-key preservation through `SimulationActions.execute`.

## Scope

The simulation protocol remains `key: string`; this does not add aliases or invent terminal sequences for names absent from OpenTUI's key table.

## Testing

- `bun test` in `packages/simulation`: 27 passed
- `bun run typecheck` in `packages/simulation`
- Pre-push workspace typecheck: 32 packages passed
