### PR TITLE
fix(session): encode persisted output formats

### DIFF
--- a/packages/opencode/test/server/session-messages.test.ts
+++ b/packages/opencode/test/server/session-messages.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect } from "bun:test"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { HttpClientResponse } from "effect/unstable/http"
 import { Session as SessionNs } from "@/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -124,6 +124,53 @@ describe("session messages endpoint", () => {
       }),
     ),
     { git: true },
+  )
+
+  it.instance(
+    "returns persisted output formats",
+    withoutWatcher(
+      Effect.gen(function* () {
+        const session = yield* sessionScoped
+        const service = yield* SessionNs.Service
+        const formats = [
+          { type: "text" as const },
+          {
+            type: "json_schema" as const,
+            schema: { type: "object", properties: { answer: { type: "string" } } },
+            retryCount: 2,
+          },
+        ]
+
+        yield* Effect.forEach(formats, (format, index) =>
+          Effect.gen(function* () {
+            const id = MessageID.ascending()
+            yield* service.updateMessage({
+              id,
+              sessionID: session.id,
+              role: "user",
+              time: { created: Date.now() + index },
+              agent: "test",
+              model,
+              format: Schema.decodeUnknownSync(SessionV1.Format)(format),
+            })
+            yield* service.updatePart({
+              id: PartID.ascending(),
+              sessionID: session.id,
+              messageID: id,
+              type: "text",
+              text: `m${index}`,
+            })
+          }),
+        )
+
+        const res = yield* request(`/session/${session.id}/message`)
+        expect(res.status).toBe(200)
+        const body = yield* json<SessionV1.WithParts[]>(res)
+        expect(body.map((item) => item.info.role === "user" && item.info.format)).toEqual(formats)
+      }),
+    ),
+    { git: true },
+    60_000,
   )
 
   it.instance(

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -62,15 +62,17 @@ export const ContentFilterError = namedError("ContentFilterError", {
   message: Schema.String,
 })
 
-export class OutputFormatText extends Schema.Class<OutputFormatText>("OutputFormatText")({
+export const OutputFormatText = Schema.Struct({
   type: Schema.Literal("text"),
-}) {}
+}).annotate({ identifier: "OutputFormatText" })
+export type OutputFormatText = Schema.Schema.Type<typeof OutputFormatText>
 
-export class OutputFormatJsonSchema extends Schema.Class<OutputFormatJsonSchema>("OutputFormatJsonSchema")({
+export const OutputFormatJsonSchema = Schema.Struct({
   type: Schema.Literal("json_schema"),
   schema: Schema.Record(Schema.String, Schema.Any).annotate({ identifier: "JSONSchema" }),
   retryCount: NonNegativeInt.pipe(Schema.optional, Schema.withDecodingDefault(Effect.succeed(2))),
-}) {}
+}).annotate({ identifier: "OutputFormatJsonSchema" })
+export type OutputFormatJsonSchema = Schema.Schema.Type<typeof OutputFormatJsonSchema>
 
 export const Format = Schema.Union([OutputFormatText, OutputFormatJsonSchema]).annotate({
   discriminator: "type",


### PR DESCRIPTION
### Issue for this PR

Closes #26929

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Persisted V1 messages hydrate output formats as plain objects. The response encoder previously used `Schema.Class`, which requires class instances and returned HTTP 400 when history contained either a `text` or `json_schema` format.

This changes those two wire schemas to `Schema.Struct`, preserving the JSON shape while allowing persisted plain objects to encode. It also adds an endpoint regression test that saves both formats, reloads them through the database, and reads them through `GET /session/:id/message`.

This supersedes the encoding portion of #29632. Credit to @trevorWieland for the original diagnosis and fix.

### How did you verify your code works?

- `bun test --timeout 60000 test/server/session-messages.test.ts` in `packages/opencode` — 6 passed
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/schema`
- Focused oxlint and Prettier checks
- Built the Windows x64 executable and verified a live save/read round trip for both output formats

The repo-wide pre-push typecheck cannot complete in this Windows checkout because the existing `packages/enterprise/src/custom-elements.d.ts` symlink is checked out as literal text; both changed packages typecheck successfully.

### Screenshots / recordings

Not applicable; this is an HTTP response-encoding fix with no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR