### PR TITLE
fix(ai): parse OpenAI-compatible reasoning deltas (v2)

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -145,6 +145,7 @@ type OpenAIChatToolCallDelta = Schema.Schema.Type<typeof OpenAIChatToolCallDelta
 const OpenAIChatDelta = Schema.Struct({
   content: optionalNull(Schema.String),
   reasoning_content: optionalNull(Schema.String),
+  reasoning: optionalNull(Schema.String),
   tool_calls: optionalNull(Schema.Array(OpenAIChatToolCallDelta)),
 })
 
@@ -412,8 +413,9 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
 
     let lifecycle = state.lifecycle
 
-    if (delta?.reasoning_content)
-      lifecycle = Lifecycle.reasoningDelta(lifecycle, events, "reasoning-0", delta.reasoning_content)
+    const reasoning = delta?.reasoning_content ?? delta?.reasoning
+    if (reasoning)
+      lifecycle = Lifecycle.reasoningDelta(lifecycle, events, "reasoning-0", reasoning)
 
     if (delta?.content) {
       lifecycle = Lifecycle.reasoningEnd(lifecycle, events, "reasoning-0")

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -566,6 +566,32 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("parses OpenAI-compatible reasoning deltas", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        { choices: [{ delta: { reasoning: "thinking" } }] },
+        { choices: [{ delta: { content: "Hello" } }] },
+        { choices: [{ delta: {}, finish_reason: "stop" }] },
+      )
+
+      const response = yield* LLMClient.generate(request).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.reasoning).toBe("thinking")
+      expect(response.text).toBe("Hello")
+      expect(response.events).toMatchObject([
+        { type: "step-start", index: 0 },
+        { type: "reasoning-start", id: "reasoning-0" },
+        { type: "reasoning-delta", id: "reasoning-0", text: "thinking" },
+        { type: "reasoning-end", id: "reasoning-0" },
+        { type: "text-start", id: "text-0" },
+        { type: "text-delta", id: "text-0", text: "Hello" },
+        { type: "text-end", id: "text-0" },
+        { type: "step-finish", index: 0, reason: "stop" },
+        { type: "finish", reason: "stop" },
+      ])
+    }),
+  )
+
   it.effect("assembles streamed tool call input", () =>
     Effect.gen(function* () {
       const body = sseEvents(


### PR DESCRIPTION
### Issue for this PR

Closes #37553
Fixes https://github.com/anomalyco/opencode/issues/37553

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some OpenAI-compatible providers return streamed reasoning in `delta.reasoning` instead of `delta.reasoning_content`.

This adds `reasoning` to the stream schema and parses it as a fallback when `reasoning_content` is absent. This matches the behavior of the AI SDK's OpenAI-compatible provider while preserving `reasoning_content` precedence.
This is a regression from `v1` behaviour, `v1` supports `reasoning` for vllm compatibility.

### How did you verify your code works?

Added a regression test using an SSE stream containing `delta.reasoning`, followed by normal response text.

Ran from `packages/ai`:

```bash
bun test test/provider/openai-chat.test.ts
```
Screenshots / recordings
Not applicable; this is a protocol parsing fix.
Checklist
- I have tested my changes locally
- I have not included unrelated changes in this PR