### PR TITLE
docs: add Agent Sessions to Ecosystem → Projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Agent Sessions](https://github.com/jazzyalex/agent-sessions)                              | Native macOS app to browse, search, and resume OpenCode sessions |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

n/a — docs addition.

### Type of change

- [x] Documentation

### What does this PR do?

Adds one row to the Ecosystem → Projects table for Agent Sessions, a macOS app that reads OpenCode's local session history — both the `opencode.db` SQLite backend and the older JSON under `~/.local/share/opencode/storage/session`. It gives that history full-text search across sessions, readable transcripts, and resume into Terminal/iTerm2/Warp.

English page only; localized copies are left to the usual translation sync.

Disclosure: I'm the author. MIT, local-only.

### How did you verify your code works?

Docs-only change, one table row. Verified the Projects table still renders and the repo link resolves.

### Screenshots / recordings

n/a — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
