### PR TITLE
fix(github): reply in the triggering review thread

### DIFF
--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -1263,6 +1263,23 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
 
     async function createComment(body: string) {
       // Only called for non-schedule events, so issueId is defined
+      if (commentType === "pr_review") {
+        const comment = (payload as PullRequestReviewCommentEvent).comment
+        console.log("Creating review thread reply...")
+        try {
+          return await octoRest.rest.pulls.createReplyForReviewComment({
+            owner,
+            repo,
+            pull_number: issueId!,
+            // Replies must target the thread's root comment; a reply's own id is rejected
+            comment_id: comment.in_reply_to_id ?? comment.id,
+            body,
+          })
+        } catch (error) {
+          // Fall through to a top-level comment so the response is never lost
+          console.error(`Failed to reply in the review thread: ${error}`)
+        }
+      }
       console.log("Creating comment...")
       return await octoRest.rest.issues.createComment({
         owner,


### PR DESCRIPTION
### Issue for this PR

Closes #37560

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- fix #37560

When opencode is triggered from an inline review comment (`pull_request_review_comment` event), the reply is posted to the PR conversation as a top-level comment instead of the review thread it was asked in.

---

the `createComment()` always calls `issues.createComment`

https://github.com/anomalyco/opencode/blob/45cd8d76920839e4a7b6b931c4e26b52e1495636/packages/opencode/src/cli/cmd/github.handler.ts#L1264-L1273

which should be `pulls.createReplyForReviewComment` for review comment,
like the `addReaction`, using the `reactions.createForPullRequestReviewComment`
https://github.com/anomalyco/opencode/blob/45cd8d76920839e4a7b6b931c4e26b52e1495636/packages/opencode/src/cli/cmd/github.handler.ts#L1178-L1189

And I also add a try-catch block to prevent failure (such as no permission or the comment being deleted) and fall back to old behavior.

the `comment.in_reply_to_id` is the root of the thread, also refer to #26689, but I think its on the wrong file

### How did you verify your code works?

(The verification was done with the help of opencode)

- Ran the fixed code locally via the handler's built-in mock-event mode: `opencode github run --event <json>`, which feeds a webhook payload into the exact code path that runs in GitHub Actions.
`USE_GITHUB_TOKEN=true GITHUB_TOKEN=$(gh auth token) MODEL=<provider/model> GITHUB_RUN_ID=0 SHARE=false bun run --conditions=browser packages/opencode/src/index.ts github run --event "$(cat event.json)"`

- All comments were created by real GitHub API calls on a real PR (throwaway repo) — no mocking of the GitHub API.
`gh api repos/<owner>/<repo>/pulls/comments/<comment_id> | jq '{eventName:"pull_request_review_comment", actor:"<you>", repo:{owner:"<owner>",repo:"<repo>"}, payload:{comment:(. + {body:"/oc <prompt>"}), pull_request:{number:<PR>, title:"test"}}}' > event.json`

- Test on a closed PR
	- Top-level review comment (click + on a diff line) → reply lands inside the review thread
	- Reply inside an existing thread → reply attaches to the thread's root comment
	- File-level comment ("Add comment on file", subject_type: file) → reply lands inside that thread
	- Regular timeline comment (issue_comment event) → still posts as a top-level comment (unchanged behavior)

BTW: I found an unrelated bug on the reaction emoji with `use_github_token` during the verification, maybe I will report it later 😄 

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
