### PR TITLE
fix(session): bound consecutive overflow compaction cycles in the prompt loop

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1083,6 +1083,10 @@ const layer = Layer.effect(
         const ctx = yield* InstanceState.context
         let structured: unknown
         let step = 0
+        // Consecutive provider context-overflow -> compaction cycles with no
+        // successful turn in between. Bounds the overflow-compaction retry so a
+        // summary that fails to shrink the request cannot loop forever.
+        let overflowCompactions = 0
         const session = yield* sessions.get(sessionID).pipe(Effect.orDie)
 
         while (true) {
@@ -1318,6 +1322,17 @@ const layer = Layer.effect(
 
             if (result === "stop") return "break" as const
             if (result === "compact") {
+              overflowCompactions++
+              if (overflowCompactions > 2) {
+                handle.message.error = new SessionV1.ContextOverflowError({
+                  message:
+                    "Context still exceeds the model limit after repeated compaction attempts. Stopping to avoid a compaction loop.",
+                }).toObject()
+                handle.message.finish = "error"
+                yield* sessions.updateMessage(handle.message)
+                yield* events.publish(Session.Event.Error, { sessionID, error: handle.message.error })
+                return "break" as const
+              }
               yield* compaction.create({
                 sessionID,
                 agent: lastUser.agent,
@@ -1325,6 +1340,8 @@ const layer = Layer.effect(
                 auto: true,
                 overflow: !handle.message.finish,
               })
+            } else {
+              overflowCompactions = 0
             }
             return "continue" as const
           }).pipe(


### PR DESCRIPTION
### Issue for this PR

Closes #27924

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bounds the overflow compaction retry cycle in the SessionPrompt run loop.

When a provider rejects a turn with a context overflow, the loop requests compaction and retries the turn. There is no attempt limit and no check that compaction reduced the request, so when the summary completes but does not shrink context below the limit, the session compacts forever. I hit this on 1.18.2: my session DB shows 35 consecutive assistant messages with mode "compaction", one every 30 to 90 seconds for over an hour, all finishing stop with no error, with the following turn overflowing each time.

The fix counts consecutive overflow to compaction cycles in the run loop. After 3 with no successful turn in between, it fails the assistant message with ContextOverflowError and stops instead of compacting again. Any result other than "compact" resets the counter, so long sessions that legitimately compact many times are unaffected. This works because the only way the counter reaches 3 is three provider overflows in a row with a compaction between each, which means compaction is not making progress and retrying again cannot succeed.

Note #34029 and #34261 fix related gaps in packages/core, but this loop is in packages/opencode/src/session/prompt.ts, which the server prompt handler uses, so it needs its own guard. Complementary, not a duplicate.

### How did you verify your code works?

bun run typecheck passes in packages/opencode. I have been running this patch in a source build since 2026-07-17 on the same cron workloads that previously looped: the loop no longer reproduces and multi-compaction sessions still complete. I did not find a test harness for the SessionPrompt run loop; happy to add a test if you point me at the preferred fixture approach.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR