### PR TITLE
refactor(desktop): add typed ipc contract bridge

### DIFF
--- a/packages/desktop/src/preload/ipc-contract.test.ts
+++ b/packages/desktop/src/preload/ipc-contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test, vi } from "bun:test"
+import { invokeIpcWith, handleIpcWith } from "./ipc-contract"
+
+describe("Desktop IPC Contract", () => {
+  test("invokeIpcWith calls renderer with typed payload and receives response", async () => {
+    const mockInvoke = vi.fn().mockResolvedValue("https://127.0.0.1:4096")
+    const mockRenderer = { invoke: mockInvoke } as any
+
+    const result = await invokeIpcWith(mockRenderer, "get-default-server-url", undefined)
+
+    expect(mockInvoke).toHaveBeenCalledWith("get-default-server-url", undefined)
+    expect(result).toBe("https://127.0.0.1:4096")
+  })
+
+  test("handleIpcWith registers handler with ipcMain and forwards payload", async () => {
+    const mockHandle = vi.fn()
+    const mockMain = { handle: mockHandle } as any
+
+    handleIpcWith(mockMain, "set-default-server-url", async (url) => {
+      return url
+    })
+
+    expect(mockHandle).toHaveBeenCalledWith("set-default-server-url", expect.any(Function))
+
+    const registeredHandler = mockHandle.mock.calls[0][1]
+    const response = await registeredHandler({}, "http://localhost:8080")
+    expect(response).toBe("http://localhost:8080")
+  })
+})

--- a/packages/desktop/src/preload/ipc-contract.ts
+++ b/packages/desktop/src/preload/ipc-contract.ts
@@ -1,0 +1,43 @@
+import type { ServerReadyData } from "./types"
+
+export interface DesktopIpcContract {
+  "kill-sidecar": { request: void; response: void }
+  "await-initialization": { request: void; response: ServerReadyData }
+  "consume-initial-deep-links": { request: void; response: string[] }
+  "get-default-server-url": { request: void; response: string | null }
+  "set-default-server-url": { request: string | null; response: void }
+  "is-first-launch-onboarding-pending": { request: void; response: boolean }
+  "finish-first-launch-onboarding": { request: boolean; response: string | null }
+  "is-old-layout-eligible": { request: void; response: boolean }
+  "get-display-backend": { request: void; response: string | null }
+  "set-display-backend": { request: string | null; response: void }
+  "parse-markdown": { request: string; response: string }
+  "check-app-exists": { request: string; response: boolean }
+  "resolve-app-path": { request: string; response: string | null }
+  "set-background-color": { request: string; response: void }
+  "export-debug-logs": { request: void; response: string }
+  "store-get": { request: { name: string; key: string }; response: string | null }
+  "store-set": { request: { name: string; key: string; value: string }; response: void }
+  "store-delete": { request: { name: string; key: string }; response: void }
+  "store-clear": { request: { name: string }; response: void }
+  "store-keys": { request: { name: string }; response: string[] }
+  "store-length": { request: { name: string }; response: number }
+}
+
+export type IpcChannel = keyof DesktopIpcContract
+
+export async function invokeIpcWith<K extends IpcChannel>(
+  ipcRenderer: { invoke(channel: string, ...args: any[]): Promise<any> },
+  channel: K,
+  request: DesktopIpcContract[K]["request"],
+): Promise<DesktopIpcContract[K]["response"]> {
+  return ipcRenderer.invoke(channel, request)
+}
+
+export function handleIpcWith<K extends IpcChannel>(
+  ipcMain: { handle(channel: string, listener: (event: any, request: any) => any): void },
+  channel: K,
+  handler: (request: DesktopIpcContract[K]["request"]) => Promise<DesktopIpcContract[K]["response"]> | DesktopIpcContract[K]["response"],
+) {
+  ipcMain.handle(channel, (_event, request) => handler(request))
+}


### PR DESCRIPTION
### Summary
Introduces a end-to-end typed IPC contract bridge (\DesktopIpcContract\) for desktop IPC calls between preload and main process.

### Details
- Establishes static type mapping for desktop IPC channels and request/response payloads.
- Exports typed helpers (\invokeIpcWith\, \handleIpcWith\) for runtime invocation and main process IPC registration.
- Prevents channel name typos and parameter mismatches across preload and main.