### PR TITLE
fix(web): New Session button on fresh start / no-opened-projects

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -367,9 +367,21 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
                 const project = global.ensureServerCtx(conn).projects.list()[0]
                 return project ? [{ server: ServerConnection.key(conn), project }] : []
               })[0]
-              if (!fallback) return
+              if (fallback) {
+                tabs.newDraft({ server: fallback.server, directory: fallback.project.worktree }, "")
+                return
+              }
 
-              tabs.newDraft({ server: fallback.server, directory: fallback.project.worktree }, "")
+              // Last resort: use server-registered projects from sync data when
+              // no projects have been opened yet (fresh web start)
+              const conn = global.servers.list()[0] ?? server.current
+              if (conn) {
+                const ctx = global.ensureServerCtx(conn)
+                const registered = ctx.sync.data.project[0]
+                if (registered) {
+                  tabs.newDraft({ server: ServerConnection.key(conn), directory: registered.worktree }, "")
+                }
+              }
             }
             const toggleHome = () => tabs.toggleHome({ home: layout.route().type === "home", current: currentTab() })
 

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -332,7 +332,8 @@ export function NewHome() {
     () =>
       selectedProject() ??
       projects().find((project) => project.worktree === focusedServerCtx()?.projects.last()) ??
-      projects()[0],
+      projects()[0] ??
+      focusedSync().data.project[0] as LocalProject | undefined,
   )
   const directories = (project: LocalProject) => [project.worktree, ...(project.sandboxes ?? [])]
   const projectDirectories = createMemo(() => {


### PR DESCRIPTION
## Problem

When you run `opencode web` for the **first time** (or with no persisted project state), the Web UI becomes unusable because:

1. **Titlebar "New Session" button (＋)**: Clicking does nothing — the handler (`openNewTab`) falls through 5 cases and silently returns when none find a project directory.

2. **Home page "New Session" buttons**: Hidden entirely because `newSessionProject()` returns `undefined` when `projects()` (persisted opened-projects list) is empty.

The issue persists even though the server **does** have registered projects (returned by `GET /project`).

### Root Cause

The web UI stores opened projects in `localStorage` (`opencode.global.dat:server` → `projects.<scope>`). On fresh start:

- `global.servers.list()` may be populated (via `entry.tsx` `servers={[server]}`), but
- `global.ensureServerCtx(conn).projects.list()` reads only **persisted** projects — which are empty on first launch.

The server-registered projects (from `sync.data.project`, populated by the `/project` API) are **never consulted** as a fallback for session creation.

### Reproduce

```bash
opencode web --port 4096
# Open http://127.0.0.1:4096/
# Click "New Session"  →  nothing happens
```

### Fix

Two targeted changes:

1. **`packages/app/src/pages/home.tsx`** — `newSessionProject()`:
   - Add a final `?? focusedSync().data.project[0]` fallback.
   - When no project is opened, picks the first server-registered project so the empty-state and in-list "New Session" buttons appear and work.

2. **`packages/app/src/components/titlebar.tsx`** — `openNewTab()`:
   - After the 5-case fallback chain fails, add a **Case 6** that reads `global.ensureServerCtx(conn).sync.data.project[0]`.
   - Uses the server-registered projects as the last-resort directory for creating a new draft session.

### Verification

Manually tested on `opencode web --port 19820` with cleared localStorage:
- Page loads with server-registered project visible as the source for new sessions
- Titlebar "New Session" button navigates to `/new-session?draftId=...`
- Home page show "New Session" buttons in both the empty state and session list
- All API requests return HTTP 200