### PR TITLE
fix(tui): exit composer picker with up arrow

### DIFF
--- a/packages/tui/src/routes/session/composer/index.tsx
+++ b/packages/tui/src/routes/session/composer/index.tsx
@@ -22,6 +22,7 @@ interface Tab {
 const ComposerContext = createContext<{
   register: (tab: Tab) => () => void
   active: (id: string) => boolean
+  close: () => void
 }>()
 
 export function useComposerTab() {
@@ -73,6 +74,7 @@ export function Composer(props: ComposerProps) {
     active(id: string) {
       return props.open && store.active === id
     },
+    close,
   }
 
   const keymap = Keymap.use()

--- a/packages/tui/src/routes/session/composer/shell-tab.tsx
+++ b/packages/tui/src/routes/session/composer/shell-tab.tsx
@@ -59,9 +59,11 @@ export function ShellTab(props: { sessionID: string }) {
         group: "Composer",
         bind: "up",
         run() {
-          const list = entries()
-          if (list.length === 0) return
-          setStore("selected", (prev) => (prev - 1 + list.length) % list.length)
+          if (store.selected === 0) {
+            composer.close()
+            return
+          }
+          setStore("selected", (prev) => prev - 1)
         },
       },
       {

--- a/packages/tui/src/routes/session/composer/subagents-tab.tsx
+++ b/packages/tui/src/routes/session/composer/subagents-tab.tsx
@@ -160,9 +160,11 @@ export function SubagentsTab(props: { sessionID: string }) {
         group: "Composer",
         bind: "up",
         run() {
-          const list = entries()
-          if (list.length === 0) return
-          moveTo((store.selected - 1 + list.length) % list.length, true)
+          if (store.selected === 0) {
+            composer.close()
+            return
+          }
+          moveTo(store.selected - 1, true)
         },
       },
       {


### PR DESCRIPTION
## Summary
- close the V2 shell/subagent composer when Up is pressed at the first row
- preserve normal upward navigation from later rows
- return focus to the prompt for empty pickers as well

## Tests
- `bun typecheck` in `packages/tui`
- `bun test` in `packages/tui`