### PR TITLE
feat(core): publish pending MCP status during connect

### DIFF
--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -482,6 +482,10 @@ export const layer = Layer.effect(
 
     const startServer = (name: ServerName, entry: ServerEntry) =>
       Effect.gen(function* () {
+        // Announce the handshake so connect() and credential reconnects don't show a stale
+        // disabled/failed status for the duration of the connection attempt.
+        entry.status = { status: "pending" }
+        yield* events.publish(McpEvent.StatusChanged, { server: name }).pipe(Effect.ignore)
         const scope = yield* Scope.fork(root)
         entry.scope = scope
         const authProvider = yield* connectProvider(entry)


### PR DESCRIPTION
Follow-up to #37308, addressing known trade-off #1 (no pending status during connect).

`startServer` now sets `status: "pending"` and publishes `StatusChanged` before opening the connection, so `servers()` and event subscribers see an accurate status for the duration of the handshake instead of the stale prior status (`disabled`/`failed`) for up to the startup timeout.

Placing this at the top of `startServer` covers all four entry points uniformly:

- initial layer startup (was already `pending`, now also announced)
- `add()` (new entries are announced at admission rather than only when the handshake settles)
- `connect()` (previously showed the stale prior status mid-handshake)
- credential-triggered reconnect (same)

Cost: transitions now emit two `StatusChanged` events (`pending`, then the outcome) instead of one. `pending` is an existing status the app already maps.

No mid-handshake observability in tests: asserting the transient `pending` state deterministically needs a fixture server with controllable connect latency (same limitation as trade-off #6). Existing suite passes (18/18), typecheck clean.