### PR TITLE
feat(codemode): native coercion parity in interpreter

### DIFF
--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -80,7 +80,7 @@ ultimate source of truth.
 - [x] Expression and block function bodies.
 - [x] User callbacks for the supported Array, Map, Set, URLSearchParams, sort, string-replacement, and `Array.from`
       mapper APIs, with one shared acceptance rule everywhere including promise reactions.
-- [x] `Boolean`, `Number`, `String`, `parseInt`, `parseFloat`, and URI helpers as callbacks.
+- [x] `Boolean`, `Number`, `String`, `parseInt`, `parseFloat`, `isFinite`, `isNaN`, and URI helpers as callbacks.
 - [x] Built-in method references as callbacks, such as `values.map(Math.abs)`, `records.map(JSON.stringify)`,
       `items.forEach(console.log)`, and `Promise.resolve(-1).then(Math.abs)`. Extra callback arguments a built-in
       does not consume are ignored, like JS; consumed arguments stay strictly validated (`Math.floor` still rejects a
@@ -210,9 +210,12 @@ ultimate source of truth.
 - [x] `localeCompare`; locale and options arguments are currently ignored.
 - [x] `toString`, `length`, numeric indexing, spread, and `for...of` by Unicode code point.
 - [x] Static `String.fromCharCode` and `String.fromCodePoint`.
-- [ ] Native argument coercion for supported String methods; for example, `includes(1)` and `slice("1")` currently
-      reject instead of coercing.
-- [ ] Native no-argument parity for `match()` and `search()`.
+- [x] Native argument coercion for supported String methods; for example, `includes(1)` and `slice("1")` coerce like
+      native JS, `split(undefined)` returns the whole string, and `includes`/`startsWith`/`endsWith` reject regular
+      expressions with a native-style `TypeError`. Opaque runtime references still reject as data errors, and
+      `repeat` still requires a finite non-negative count.
+- [x] Native no-argument parity for `match()`, `matchAll()`, and `search()`; all behave as an empty pattern. Present
+      arguments must still be a regular expression or string pattern.
 
 ## Numbers and Math
 
@@ -226,13 +229,16 @@ ultimate source of truth.
 - [x] Math methods: `random`, `max`, `min`, `abs`, `acos`, `acosh`, `asin`, `asinh`, `atan`, `atan2`, `atanh`,
       `floor`, `ceil`, `round`, `trunc`, `sign`, `sqrt`, `cbrt`, `pow`, `hypot`, `cos`, `cosh`, `sin`, `sinh`,
       `tan`, `tanh`, `log`, `log2`, `log10`, `log1p`, `exp`, `expm1`, `f16round`, `fround`, `clz32`, and `imul`.
-- [ ] Native zero-argument behavior for `Number()` and `String()`; they currently do not produce `0` and `""`.
-- [ ] `++` and `--` must use CodeMode numeric coercion and reject opaque runtime references; they currently call host
-      `Number(...)` directly.
-- [ ] Unknown static members must read as `undefined` for feature detection; some currently appear callable or throw
-      during property access.
+- [x] Native zero-argument behavior for `Number()` and `String()`: they produce `0` and `""`, while
+      `Number(undefined)` stays `NaN` and `String(undefined)` stays `"undefined"`.
+- [x] `++` and `--` use CodeMode numeric coercion (numeric strings increment, plain data objects become `NaN`, Dates
+      use their epoch time) and reject opaque runtime references as data errors.
+- [x] Unknown static members on global namespaces and on `Number`/`String`/the coercion functions read as `undefined`
+      for feature detection. Calling any undefined value reports a native-style `TypeError` naming the callee, for
+      example `Math.sumPrecise is not a function.` Blocked members (`constructor`, `__proto__`, ...) still throw,
+      and unknown `Promise` statics keep their descriptive error.
 - [ ] `Math.sumPrecise`.
-- [ ] Global coercing `isFinite` and `isNaN`.
+- [x] Global coercing `isFinite` and `isNaN`; opaque runtime references reject as data errors, like `Number(...)`.
 
 ## JSON and console
 

--- a/packages/codemode/src/interpreter/methods.ts
+++ b/packages/codemode/src/interpreter/methods.ts
@@ -137,25 +137,23 @@ export const invokeGlobalMethod = (ref: GlobalMethodReference, args: Array<unkno
   return invokeJsonMethod(ref.name, args, node)
 }
 
-const invokeStringMethod = (value: string, name: string, args: Array<unknown>, node: AstNode): unknown => {
-  // Native argument coercion: includes(1) and slice("1") coerce like real JS. Opaque
-  // runtime references (functions, tools, un-awaited promises) still reject.
-  const data = (index: number): unknown => {
-    const arg = args[index]
-    if (containsOpaqueReference(arg)) {
-      throw new InterpreterRuntimeError(
-        `String.${name} expects argument ${index + 1} to be a data value.`,
-        node,
-        "InvalidDataValue",
-      )
-    }
-    return arg
+const requireDataArgument = (name: string, index: number, arg: unknown, node: AstNode): unknown => {
+  if (containsOpaqueReference(arg)) {
+    throw new InterpreterRuntimeError(
+      `String.${name} expects argument ${index + 1} to be a data value.`,
+      node,
+      "InvalidDataValue",
+    )
   }
-  const str = (index: number): string => coerceToString(data(index))
-  const num = (index: number): number => coerceToNumber(data(index))
+  return arg
+}
+
+const invokeStringMethod = (value: string, name: string, args: Array<unknown>, node: AstNode): unknown => {
+  // Coerce arguments like native JS; opaque runtime references still reject.
+  const str = (index: number): string => coerceToString(requireDataArgument(name, index, args[index], node))
+  const num = (index: number): number => coerceToNumber(requireDataArgument(name, index, args[index], node))
   const optNum = (index: number): number | undefined => (args[index] === undefined ? undefined : num(index))
   const optStr = (index: number): string | undefined => (args[index] === undefined ? undefined : str(index))
-  // Native TypeError parity: these methods refuse regular expressions.
   const rejectRegex = (): void => {
     if (args[0] instanceof CodeModeRegExp) {
       throw new InterpreterRuntimeError(
@@ -420,16 +418,9 @@ const invokeStringReplacer = <R>(
     if (name === "replace") value.replace(pattern.regex, collect)
     else value.replaceAll(pattern.regex, collect)
   } else {
-    // Same native argument coercion as the plain-replacement path in invokeStringMethod.
-    if (containsOpaqueReference(pattern)) {
-      throw new InterpreterRuntimeError(
-        `String.${name} expects argument 1 to be a data value.`,
-        node,
-        "InvalidDataValue",
-      )
-    }
-    if (name === "replace") value.replace(coerceToString(pattern), collect)
-    else value.replaceAll(coerceToString(pattern), collect)
+    const search = coerceToString(requireDataArgument(name, 0, pattern, node))
+    if (name === "replace") value.replace(search, collect)
+    else value.replaceAll(search, collect)
   }
 
   return Effect.gen(function* () {

--- a/packages/codemode/src/interpreter/methods.ts
+++ b/packages/codemode/src/interpreter/methods.ts
@@ -12,7 +12,7 @@ import {
   PromiseNamespace,
   UriFunction,
 } from "./model.js"
-import { rejectCircularInsertion, typeofValue } from "./references.js"
+import { containsOpaqueReference, rejectCircularInsertion, typeofValue } from "./references.js"
 import { isBlockedMember, type SafeObject } from "../tool-runtime.js"
 import {
   CodeModeDate,
@@ -138,20 +138,32 @@ export const invokeGlobalMethod = (ref: GlobalMethodReference, args: Array<unkno
 }
 
 const invokeStringMethod = (value: string, name: string, args: Array<unknown>, node: AstNode): unknown => {
-  const str = (index: number): string => {
+  // Native argument coercion: includes(1) and slice("1") coerce like real JS. Opaque
+  // runtime references (functions, tools, un-awaited promises) still reject.
+  const data = (index: number): unknown => {
     const arg = args[index]
-    if (typeof arg !== "string")
-      throw new InterpreterRuntimeError(`String.${name} expects argument ${index + 1} to be a string.`, node)
+    if (containsOpaqueReference(arg)) {
+      throw new InterpreterRuntimeError(
+        `String.${name} expects argument ${index + 1} to be a data value.`,
+        node,
+        "InvalidDataValue",
+      )
+    }
     return arg
   }
-  const num = (index: number): number => {
-    const arg = args[index]
-    if (typeof arg !== "number")
-      throw new InterpreterRuntimeError(`String.${name} expects argument ${index + 1} to be a number.`, node)
-    return arg
-  }
+  const str = (index: number): string => coerceToString(data(index))
+  const num = (index: number): number => coerceToNumber(data(index))
   const optNum = (index: number): number | undefined => (args[index] === undefined ? undefined : num(index))
   const optStr = (index: number): string | undefined => (args[index] === undefined ? undefined : str(index))
+  // Native TypeError parity: these methods refuse regular expressions.
+  const rejectRegex = (): void => {
+    if (args[0] instanceof CodeModeRegExp) {
+      throw new InterpreterRuntimeError(
+        `String.${name} cannot take a regular expression; use regex.test(string) or String.search instead.`,
+        node,
+      ).as("TypeError")
+    }
+  }
 
   let result: unknown
   switch (name) {
@@ -187,8 +199,11 @@ const invokeStringMethod = (value: string, name: string, args: Array<unknown>, n
       break
     }
     case "split": {
-      if (args.length === 0) {
-        result = [value]
+      // Native: an undefined separator returns the whole string, not a split on "undefined",
+      // unless the limit truncates to zero.
+      if (args[0] === undefined) {
+        const requestedLimit = optNum(1)
+        result = requestedLimit !== undefined && requestedLimit >>> 0 === 0 ? [] : [value]
         break
       }
       if (args[0] instanceof CodeModeRegExp) {
@@ -203,12 +218,15 @@ const invokeStringMethod = (value: string, name: string, args: Array<unknown>, n
       result = value.slice(optNum(0), optNum(1))
       break
     case "includes":
+      rejectRegex()
       result = value.includes(str(0), optNum(1))
       break
     case "startsWith":
+      rejectRegex()
       result = value.startsWith(str(0), optNum(1))
       break
     case "endsWith":
+      rejectRegex()
       result = value.endsWith(str(0), optNum(1))
       break
     case "indexOf":
@@ -263,7 +281,7 @@ const invokeStringMethod = (value: string, name: string, args: Array<unknown>, n
     case "repeat": {
       const count = num(0)
       if (!Number.isFinite(count) || count < 0)
-        throw new InterpreterRuntimeError("String.repeat expects a finite non-negative count.", node)
+        throw new InterpreterRuntimeError("String.repeat expects a finite non-negative count.", node).as("RangeError")
       result = value.repeat(count)
       break
     }
@@ -300,6 +318,8 @@ const invokeStringMethod = (value: string, name: string, args: Array<unknown>, n
   }
   return boundedData(result, `String.${name} result`)
 }
+
+export const arrayStatics = new Set(["isArray", "of", "from"])
 
 const invokeArrayStatic = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   switch (name) {
@@ -400,11 +420,16 @@ const invokeStringReplacer = <R>(
     if (name === "replace") value.replace(pattern.regex, collect)
     else value.replaceAll(pattern.regex, collect)
   } else {
-    if (typeof pattern !== "string") {
-      throw new InterpreterRuntimeError(`String.${name} expects argument 1 to be a string.`, node)
+    // Same native argument coercion as the plain-replacement path in invokeStringMethod.
+    if (containsOpaqueReference(pattern)) {
+      throw new InterpreterRuntimeError(
+        `String.${name} expects argument 1 to be a data value.`,
+        node,
+        "InvalidDataValue",
+      )
     }
-    if (name === "replace") value.replace(pattern, collect)
-    else value.replaceAll(pattern, collect)
+    if (name === "replace") value.replace(coerceToString(pattern), collect)
+    else value.replaceAll(coerceToString(pattern), collect)
   }
 
   return Effect.gen(function* () {

--- a/packages/codemode/src/interpreter/model.ts
+++ b/packages/codemode/src/interpreter/model.ts
@@ -105,7 +105,7 @@ export class GlobalMethodReference {
 }
 
 export class CoercionFunction {
-  constructor(readonly name: "Number" | "String" | "Boolean" | "parseInt" | "parseFloat") {}
+  constructor(readonly name: "Number" | "String" | "Boolean" | "parseInt" | "parseFloat" | "isFinite" | "isNaN") {}
 }
 
 export class UriFunction {

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -10,6 +10,7 @@ import {
   ErrorConstructorReference,
   GlobalMethodReference,
   GlobalNamespace,
+  type GlobalNamespaceName,
   getArray,
   getBoolean,
   getNode,
@@ -34,7 +35,7 @@ import {
   UriFunction,
 } from "./model.js"
 import { caughtErrorValue, constructErrorValue } from "./errors.js"
-import { type CallbackRunner, invokeArrayFrom, invokeGlobalMethod, invokeIntrinsic } from "./methods.js"
+import { arrayStatics, type CallbackRunner, invokeArrayFrom, invokeGlobalMethod, invokeIntrinsic } from "./methods.js"
 import {
   constructPromise,
   invokePromiseInstanceMethod,
@@ -46,10 +47,11 @@ import { containsOpaqueReference, isRuntimeReference, rejectCircularInsertion, t
 import { ScopeStack } from "./scope.js"
 import { arrayMethods, mapMethods, setMethods, spreadItems } from "../stdlib/collections.js"
 import { consoleMethods, formatConsoleMessage } from "../stdlib/console.js"
-import { dateMethods } from "../stdlib/date.js"
-import { mathConstants } from "../stdlib/math.js"
+import { dateMethods, dateStatics } from "../stdlib/date.js"
+import { jsonMethods } from "../stdlib/json.js"
+import { mathConstants, mathMethods } from "../stdlib/math.js"
 import { numberConstants, numberMethods, numberStatics } from "../stdlib/number.js"
-import { objectMethodsPreservingIdentity } from "../stdlib/object.js"
+import { objectMethodsPreservingIdentity, objectStatics } from "../stdlib/object.js"
 import { promiseStatics } from "../stdlib/promise.js"
 import { escapeRegexHint, regexpMethods, regexpProperties, regexFailureReason } from "../stdlib/regexp.js"
 import { stringMethods, stringStatics } from "../stdlib/string.js"
@@ -57,6 +59,7 @@ import {
   urlMethods,
   urlProperties,
   urlSearchParamsMethods,
+  urlStatics,
   urlWritableProperties,
   invokeUriFunction,
   uriArgument,
@@ -82,6 +85,34 @@ import {
   CodeModeURL,
   CodeModeURLSearchParams,
 } from "../values.js"
+
+// Supported static members per global namespace. Property reads outside these sets are
+// undefined, matching native feature detection; namespaces without statics are omitted.
+const globalStaticMembers: Partial<Record<GlobalNamespaceName, Set<string>>> = {
+  Object: objectStatics,
+  Math: mathMethods,
+  JSON: jsonMethods,
+  Array: arrayStatics,
+  console: consoleMethods,
+  Date: dateStatics,
+  URL: urlStatics,
+}
+
+const calleeDescription = (callee: AstNode): string => {
+  if (callee.type === "Identifier") return getString(callee, "name")
+  if (callee.type === "MemberExpression") {
+    const object = getNode(callee, "object")
+    const property = getNode(callee, "property")
+    const key =
+      callee.computed !== true && property.type === "Identifier"
+        ? getString(property, "name")
+        : property.type === "Literal" && typeof property.value === "string"
+          ? property.value
+          : undefined
+    if (object.type === "Identifier" && key !== undefined) return `${getString(object, "name")}.${key}`
+  }
+  return "The called value"
+}
 
 const instanceofValue = (lhs: unknown, rhs: unknown, node: AstNode): boolean => {
   if (rhs instanceof ErrorConstructorReference) {
@@ -199,6 +230,8 @@ export class Interpreter<R> {
     globalScope.set("console", { mutable: false, value: new GlobalNamespace("console") })
     globalScope.set("parseInt", { mutable: false, value: new CoercionFunction("parseInt") })
     globalScope.set("parseFloat", { mutable: false, value: new CoercionFunction("parseFloat") })
+    globalScope.set("isFinite", { mutable: false, value: new CoercionFunction("isFinite") })
+    globalScope.set("isNaN", { mutable: false, value: new CoercionFunction("isNaN") })
     globalScope.set("Date", { mutable: false, value: new GlobalNamespace("Date") })
     globalScope.set("RegExp", { mutable: false, value: new GlobalNamespace("RegExp") })
     globalScope.set("Map", { mutable: false, value: new GlobalNamespace("Map") })
@@ -1454,10 +1487,23 @@ export class Interpreter<R> {
       throw new InterpreterRuntimeError(`Unsupported update operator '${operator}'.`, node)
     }
 
+    // CodeMode numeric coercion, not host Number(): null-prototype data objects would make
+    // the host throw during ToPrimitive, and opaque runtime references must reject clearly.
+    const operand = (current: unknown): number => {
+      if (containsOpaqueReference(current)) {
+        throw new InterpreterRuntimeError(
+          `'${operator}' requires a data value in CodeMode.`,
+          argument,
+          "InvalidDataValue",
+        )
+      }
+      return coerceToNumber(current)
+    }
+
     if (argument.type === "Identifier") {
       return Effect.sync(() => {
         const name = getString(argument, "name")
-        const current = Number(this.scopes.get(name, argument))
+        const current = operand(this.scopes.get(name, argument))
         const next = current + increment
         this.scopes.set(name, next, argument)
         return prefix ? next : current
@@ -1466,7 +1512,7 @@ export class Interpreter<R> {
 
     if (argument.type === "MemberExpression") {
       return this.modifyMember(argument, (current) => {
-        const value = Number(current)
+        const value = operand(current)
         const next = value + increment
         return Effect.succeed({ write: true, next, result: prefix ? next : value })
       })
@@ -1562,6 +1608,10 @@ export class Interpreter<R> {
       if (callable instanceof PromiseCapabilityFunction) {
         callable.settle(args[0])
         return undefined
+      }
+      // Any undefined/null callee (unknown static members included) reports the native message.
+      if (callable === undefined || callable === null) {
+        throw new InterpreterRuntimeError(`${calleeDescription(callee)} is not a function.`, callee).as("TypeError")
       }
       throw new InterpreterRuntimeError("Only tools are callable in CodeMode.", callee)
     })
@@ -1833,16 +1883,18 @@ export class Interpreter<R> {
       }
 
       if (objectValue instanceof GlobalNamespace) {
-        if (typeof key !== "string" || isBlockedMember(key)) {
-          throw new InterpreterRuntimeError(
-            `${objectValue.name}.${String(key)} is not available in CodeMode.`,
-            propertyNode,
-          )
+        if (typeof key === "string" && isBlockedMember(key)) {
+          throw new InterpreterRuntimeError(`${objectValue.name}.${key} is not available in CodeMode.`, propertyNode)
         }
+        if (typeof key !== "string") return new ComputedValue(undefined)
         if (objectValue.name === "Math" && mathConstants.has(key)) {
           return new ComputedValue((Math as unknown as Record<string, number>)[key])
         }
-        return new GlobalMethodReference(objectValue.name, key)
+        if (globalStaticMembers[objectValue.name]?.has(key)) {
+          return new GlobalMethodReference(objectValue.name, key)
+        }
+        // Unknown static members read as undefined so feature detection works like native JS.
+        return new ComputedValue(undefined)
       }
 
       if (typeof objectValue === "string") {
@@ -1858,12 +1910,18 @@ export class Interpreter<R> {
         return new ComputedValue(undefined)
       }
 
-      if (objectValue instanceof CoercionFunction && typeof key === "string" && !isBlockedMember(key)) {
-        if (objectValue.name === "Number" && numberConstants.has(key)) {
+      if (objectValue instanceof CoercionFunction && !(typeof key === "string" && isBlockedMember(key))) {
+        if (objectValue.name === "Number" && typeof key === "string" && numberConstants.has(key)) {
           return new ComputedValue((Number as unknown as Record<string, number>)[key])
         }
-        if (objectValue.name === "Number" && numberStatics.has(key)) return new GlobalMethodReference("Number", key)
-        if (objectValue.name === "String" && stringStatics.has(key)) return new GlobalMethodReference("String", key)
+        if (objectValue.name === "Number" && typeof key === "string" && numberStatics.has(key)) {
+          return new GlobalMethodReference("Number", key)
+        }
+        if (objectValue.name === "String" && typeof key === "string" && stringStatics.has(key)) {
+          return new GlobalMethodReference("String", key)
+        }
+        // Unknown static members read as undefined so feature detection works like native JS.
+        return new ComputedValue(undefined)
       }
 
       if (objectValue instanceof CodeModeDate) {

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -48,7 +48,7 @@ import { ScopeStack } from "./scope.js"
 import { arrayMethods, mapMethods, setMethods, spreadItems } from "../stdlib/collections.js"
 import { consoleMethods, formatConsoleMessage } from "../stdlib/console.js"
 import { dateMethods, dateStatics } from "../stdlib/date.js"
-import { jsonMethods } from "../stdlib/json.js"
+import { jsonStatics } from "../stdlib/json.js"
 import { mathConstants, mathMethods } from "../stdlib/math.js"
 import { numberConstants, numberMethods, numberStatics } from "../stdlib/number.js"
 import { objectMethodsPreservingIdentity, objectStatics } from "../stdlib/object.js"
@@ -86,12 +86,10 @@ import {
   CodeModeURLSearchParams,
 } from "../values.js"
 
-// Supported static members per global namespace. Property reads outside these sets are
-// undefined, matching native feature detection; namespaces without statics are omitted.
 const globalStaticMembers: Partial<Record<GlobalNamespaceName, Set<string>>> = {
   Object: objectStatics,
   Math: mathMethods,
-  JSON: jsonMethods,
+  JSON: jsonStatics,
   Array: arrayStatics,
   console: consoleMethods,
   Date: dateStatics,
@@ -1609,7 +1607,6 @@ export class Interpreter<R> {
         callable.settle(args[0])
         return undefined
       }
-      // Any undefined/null callee (unknown static members included) reports the native message.
       if (callable === undefined || callable === null) {
         throw new InterpreterRuntimeError(`${calleeDescription(callee)} is not a function.`, callee).as("TypeError")
       }
@@ -1910,17 +1907,20 @@ export class Interpreter<R> {
         return new ComputedValue(undefined)
       }
 
-      if (objectValue instanceof CoercionFunction && !(typeof key === "string" && isBlockedMember(key))) {
-        if (objectValue.name === "Number" && typeof key === "string" && numberConstants.has(key)) {
+      if (objectValue instanceof CoercionFunction) {
+        if (typeof key === "string" && isBlockedMember(key)) {
+          throw new InterpreterRuntimeError(`${objectValue.name}.${key} is not available in CodeMode.`, propertyNode)
+        }
+        if (typeof key !== "string") return new ComputedValue(undefined)
+        if (objectValue.name === "Number" && numberConstants.has(key)) {
           return new ComputedValue((Number as unknown as Record<string, number>)[key])
         }
-        if (objectValue.name === "Number" && typeof key === "string" && numberStatics.has(key)) {
+        if (objectValue.name === "Number" && numberStatics.has(key)) {
           return new GlobalMethodReference("Number", key)
         }
-        if (objectValue.name === "String" && typeof key === "string" && stringStatics.has(key)) {
+        if (objectValue.name === "String" && stringStatics.has(key)) {
           return new GlobalMethodReference("String", key)
         }
-        // Unknown static members read as undefined so feature detection works like native JS.
         return new ComputedValue(undefined)
       }
 

--- a/packages/codemode/src/stdlib/date.ts
+++ b/packages/codemode/src/stdlib/date.ts
@@ -23,6 +23,8 @@ export const dateMethods = new Set([
   "getTimezoneOffset",
 ])
 
+export const dateStatics = new Set(["now", "parse", "UTC"])
+
 export const invokeDateStatic = (name: string, args: Array<unknown>, node: AstNode): number => {
   switch (name) {
     case "now":

--- a/packages/codemode/src/stdlib/json.ts
+++ b/packages/codemode/src/stdlib/json.ts
@@ -2,6 +2,8 @@ import { type AstNode, InterpreterRuntimeError, supportedSyntaxMessage } from ".
 import { typeofValue } from "../interpreter/references.js"
 import { copyIn, copyOut } from "../tool-runtime.js"
 
+export const jsonMethods = new Set(["parse", "stringify"])
+
 export const invokeJsonMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   switch (name) {
     case "stringify": {

--- a/packages/codemode/src/stdlib/json.ts
+++ b/packages/codemode/src/stdlib/json.ts
@@ -2,7 +2,7 @@ import { type AstNode, InterpreterRuntimeError, supportedSyntaxMessage } from ".
 import { typeofValue } from "../interpreter/references.js"
 import { copyIn, copyOut } from "../tool-runtime.js"
 
-export const jsonMethods = new Set(["parse", "stringify"])
+export const jsonStatics = new Set(["parse", "stringify"])
 
 export const invokeJsonMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   switch (name) {

--- a/packages/codemode/src/stdlib/object.ts
+++ b/packages/codemode/src/stdlib/object.ts
@@ -6,6 +6,8 @@ import { boundedData, coerceToString } from "./value.js"
 
 export const objectMethodsPreservingIdentity = new Set(["assign", "values", "entries", "fromEntries"])
 
+export const objectStatics = new Set(["keys", "values", "entries", "hasOwn", "is", "assign", "fromEntries"])
+
 export const invokeObjectMethod = (name: string, args: Array<unknown>, node: AstNode): unknown => {
   const requireObject = (): Record<string, unknown> => {
     const input = args[0]

--- a/packages/codemode/src/stdlib/regexp.ts
+++ b/packages/codemode/src/stdlib/regexp.ts
@@ -19,6 +19,8 @@ export const escapeRegexHint =
   'To match special characters like ( ) [ ] { } + * ? . literally, escape them with a backslash (e.g. "\\\\(") or test for them with String.includes instead.'
 
 export const toHostRegex = (arg: unknown, method: string, node: AstNode, extraFlags = ""): RegExp => {
+  // Native no-argument parity: match()/search() behave as if given an empty pattern.
+  if (arg === undefined) return new RegExp("", extraFlags)
   if (arg instanceof CodeModeRegExp) return arg.regex
   if (typeof arg === "string") {
     try {

--- a/packages/codemode/src/stdlib/regexp.ts
+++ b/packages/codemode/src/stdlib/regexp.ts
@@ -19,7 +19,7 @@ export const escapeRegexHint =
   'To match special characters like ( ) [ ] { } + * ? . literally, escape them with a backslash (e.g. "\\\\(") or test for them with String.includes instead.'
 
 export const toHostRegex = (arg: unknown, method: string, node: AstNode, extraFlags = ""): RegExp => {
-  // Native no-argument parity: match()/search() behave as if given an empty pattern.
+  // Native parity: an undefined pattern behaves as an empty pattern.
   if (arg === undefined) return new RegExp("", extraFlags)
   if (arg instanceof CodeModeRegExp) return arg.regex
   if (typeof arg === "string") {

--- a/packages/codemode/src/stdlib/value.ts
+++ b/packages/codemode/src/stdlib/value.ts
@@ -61,10 +61,19 @@ export const coerceToString = (value: unknown): string => {
 export const coerceToNumber = (value: unknown): number => {
   if (value instanceof CodeModeDate) return value.time
   if (isCodeModeValue(value)) return Number.NaN
-  return value !== null && typeof value === "object" && !Array.isArray(value) ? Number.NaN : Number(value)
+  // Arrays coerce through our own string coercion: host Number(array) joins with host
+  // ToPrimitive, which throws on the null-prototype objects the interpreter produces.
+  if (Array.isArray(value)) return Number(coerceToString(value))
+  return value !== null && typeof value === "object" ? Number.NaN : Number(value)
 }
 
 export const invokeCoercion = (ref: CoercionFunction, args: Array<unknown>, node: AstNode): unknown => {
+  // Native zero-argument behavior: Number() is 0 and String() is "", unlike Number(undefined).
+  // The other coercers already match native through the undefined-argument path below.
+  if (args.length === 0) {
+    if (ref.name === "Number") return 0
+    if (ref.name === "String") return ""
+  }
   const raw = args[0]
   // Error values are plain SafeObjects; the boundedData path below would strip their brand.
   if (ref.name === "String" && errorBrandName(raw) !== undefined) return coerceToString(raw)
@@ -72,12 +81,16 @@ export const invokeCoercion = (ref: CoercionFunction, args: Array<unknown>, node
     if (ref.name === "Boolean") return true
     if (ref.name === "Number") return coerceToNumber(raw)
     if (ref.name === "String") return coerceToString(raw)
+    if (ref.name === "isFinite") return Number.isFinite(coerceToNumber(raw))
+    if (ref.name === "isNaN") return Number.isNaN(coerceToNumber(raw))
     if (ref.name === "parseInt") return parseInt(coerceToString(raw))
     return parseFloat(coerceToString(raw))
   }
   const value = boundedData(raw, `${ref.name} input`)
   if (ref.name === "Number") return coerceToNumber(value)
   if (ref.name === "Boolean") return Boolean(value)
+  if (ref.name === "isFinite") return Number.isFinite(coerceToNumber(value))
+  if (ref.name === "isNaN") return Number.isNaN(coerceToNumber(value))
   if (ref.name === "parseInt") {
     const radix = args[1]
     if (radix !== undefined && typeof radix !== "number") {

--- a/packages/codemode/src/stdlib/value.ts
+++ b/packages/codemode/src/stdlib/value.ts
@@ -68,8 +68,8 @@ export const coerceToNumber = (value: unknown): number => {
 }
 
 export const invokeCoercion = (ref: CoercionFunction, args: Array<unknown>, node: AstNode): unknown => {
-  // Native zero-argument behavior: Number() is 0 and String() is "", unlike Number(undefined).
-  // The other coercers already match native through the undefined-argument path below.
+  // Native: Number() is 0 and String() is "", unlike their undefined-argument forms; the
+  // other coercers match native through the undefined-argument path below.
   if (args.length === 0) {
     if (ref.name === "Number") return 0
     if (ref.name === "String") return ""

--- a/packages/codemode/test/parity.test.ts
+++ b/packages/codemode/test/parity.test.ts
@@ -669,3 +669,178 @@ describe("destructuring assignment", () => {
     expect(err.message).toContain("Property key must be a string or number")
   })
 })
+
+describe("coercion parity: zero-argument Number() and String()", () => {
+  test("Number() is 0 and String() is empty, unlike their undefined-argument forms", async () => {
+    expect(await value(`return Number()`)).toBe(0)
+    expect(await value(`return String()`)).toBe("")
+    expect(await value(`return Boolean()`)).toBe(false)
+    expect(await value(`return Number.isNaN(Number(undefined))`)).toBe(true)
+    expect(await value(`return String(undefined)`)).toBe("undefined")
+  })
+
+  test("parseInt() and parseFloat() stay NaN with no argument", async () => {
+    expect(await value(`return Number.isNaN(parseInt())`)).toBe(true)
+    expect(await value(`return Number.isNaN(parseFloat())`)).toBe(true)
+  })
+})
+
+describe("coercion parity: global isFinite and isNaN", () => {
+  test("coerce their argument like native JS, unlike the Number statics", async () => {
+    expect(await value(`return isFinite("42")`)).toBe(true)
+    expect(await value(`return Number.isFinite("42")`)).toBe(false)
+    expect(await value(`return isNaN("oops")`)).toBe(true)
+    expect(await value(`return isNaN("42")`)).toBe(false)
+    expect(await value(`return isFinite(Infinity)`)).toBe(false)
+    expect(await value(`return isNaN(null)`)).toBe(false)
+  })
+
+  test("zero-argument forms match native", async () => {
+    expect(await value(`return isFinite()`)).toBe(false)
+    expect(await value(`return isNaN()`)).toBe(true)
+  })
+
+  test("read as functions", async () => {
+    expect(await value(`return typeof isFinite`)).toBe("function")
+    expect(await value(`return typeof isNaN`)).toBe("function")
+  })
+})
+
+describe("coercion parity: String method arguments coerce like native JS", () => {
+  test("includes and indexOf coerce numbers", async () => {
+    expect(await value(`return "v1.2".includes(1)`)).toBe(true)
+    expect(await value(`return "a2b".indexOf(2)`)).toBe(1)
+    expect(await value(`return "abc".includes("d")`)).toBe(false)
+  })
+
+  test("slice, repeat, and padStart coerce numeric strings", async () => {
+    expect(await value(`return "abc".slice("1")`)).toBe("bc")
+    expect(await value(`return "ab".repeat("2")`)).toBe("abab")
+    expect(await value(`return "7".padStart("3", 0)`)).toBe("007")
+  })
+
+  test("split coerces separators but treats undefined as absent", async () => {
+    expect(await value(`return "a1b".split(1)`)).toEqual(["a", "b"])
+    expect(await value(`return "a,b".split(undefined)`)).toEqual(["a,b"])
+    expect(await value(`return "a,b".split()`)).toEqual(["a,b"])
+  })
+
+  test("replace coerces search and replacement values", async () => {
+    expect(await value(`return "a1b".replace(1, 2)`)).toBe("a2b")
+  })
+
+  test("includes, startsWith, and endsWith reject regular expressions with a TypeError", async () => {
+    expect(await value(`try { "abc".includes(/a/) } catch (e) { return e.name }`)).toBe("TypeError")
+    expect(await value(`try { "abc".startsWith(/a/) } catch (e) { return e.name }`)).toBe("TypeError")
+    expect(await value(`try { "abc".endsWith(/a/) } catch (e) { return e.name }`)).toBe("TypeError")
+  })
+
+  test("opaque runtime references still reject as data errors", async () => {
+    const err = await error(`const f = () => 1; return "abc".includes(f)`)
+    expect(err.message).toContain("data value")
+  })
+})
+
+describe("coercion parity: match() and search() with no argument", () => {
+  test("behave as an empty pattern like native JS", async () => {
+    expect(await value(`return "abc".search()`)).toBe(0)
+    expect(await value(`const m = "abc".match(); return { first: m[0], index: m.index }`)).toEqual({
+      first: "",
+      index: 0,
+    })
+  })
+})
+
+describe("coercion parity: ++ and -- use CodeMode numeric coercion", () => {
+  test("numeric strings increment like native JS", async () => {
+    expect(await value(`let x = "5"; x++; return x`)).toBe(6)
+    expect(await value(`let x = "5"; return ++x`)).toBe(6)
+    expect(await value(`const o = { n: "2" }; o.n--; return o.n`)).toBe(1)
+  })
+
+  test("dates increment through their epoch time", async () => {
+    expect(await value(`let d = new Date(5); d++; return d`)).toBe(6)
+  })
+
+  test("plain data objects become NaN instead of crashing", async () => {
+    expect(await value(`let x = {}; x++; return Number.isNaN(x)`)).toBe(true)
+    expect(await value(`const o = { a: {} }; o.a++; return Number.isNaN(o.a)`)).toBe(true)
+  })
+
+  test("opaque runtime references reject with a clear error", async () => {
+    const err = await error(`let f = () => 1; f++`)
+    expect(err.message).toContain("data value")
+  })
+})
+
+describe("coercion parity: unknown static members read as undefined", () => {
+  test("feature detection on missing statics works like native JS", async () => {
+    expect(await value(`return typeof Math.sumPrecise`)).toBe("undefined")
+    expect(await value(`return Object.groupBy === undefined`)).toBe(true)
+    expect(await value(`return RegExp.escape === undefined`)).toBe(true)
+    expect(await value(`return Number.range === undefined`)).toBe(true)
+    expect(await value(`return String.raw === undefined`)).toBe(true)
+    expect(await value(`return isFinite.something === undefined`)).toBe(true)
+    expect(await value(`return Math.sumPrecise?.([1]) ?? "fallback"`)).toBe("fallback")
+  })
+
+  test("known statics still resolve and run", async () => {
+    expect(await value(`return typeof Math.max`)).toBe("function")
+    expect(await value(`return typeof console.log`)).toBe("function")
+    expect(await value(`return typeof Date.now`)).toBe("function")
+    expect(await value(`return Math.max(1, 2)`)).toBe(2)
+    expect(await value(`return URL.canParse("https://example.com")`)).toBe(true)
+    expect(await value(`return Number.isInteger(3)`)).toBe(true)
+    expect(await value(`return Number.MAX_SAFE_INTEGER`)).toBe(Number.MAX_SAFE_INTEGER)
+  })
+
+  test("calling an unknown static reports a native-style TypeError", async () => {
+    expect(await value(`try { Math.sumPrecise([1]) } catch (e) { return e.name + ": " + e.message }`)).toBe(
+      "TypeError: Math.sumPrecise is not a function.",
+    )
+  })
+
+  test("blocked members still throw instead of reading as undefined", async () => {
+    const err = await error(`return Math.constructor`)
+    expect(err.message).toContain("not available")
+  })
+})
+
+describe("coercion parity: isFinite and isNaN as callbacks", () => {
+  test("filter with the coercing global predicates", async () => {
+    expect(await value(`return [1, "2", "x", Infinity].filter(isFinite)`)).toEqual([1, "2"])
+    expect(await value(`return ["1", "x"].map(isNaN)`)).toEqual([false, true])
+  })
+})
+
+describe("coercion parity: review-hardened edges", () => {
+  test("arrays containing objects coerce to NaN instead of crashing on host ToPrimitive", async () => {
+    expect(await value(`let x = [{}]; x++; return Number.isNaN(x)`)).toBe(true)
+    expect(await value(`return isFinite([{}])`)).toBe(false)
+    expect(await value(`return "abc".slice([{}])`)).toBe("abc")
+    expect(await value(`return Number([5])`)).toBe(5)
+    expect(await value(`return Number([])`)).toBe(0)
+    expect(await value(`return Number.isNaN(Number([1, 2]))`)).toBe(true)
+  })
+
+  test("replace with a callback replacer coerces the search value too", async () => {
+    expect(await value(`return "a1b".replace(1, () => "x")`)).toBe("axb")
+    const err = await error(`const f = () => 1; return "a".replace(f, () => "x")`)
+    expect(err.message).toContain("data value")
+  })
+
+  test("split(undefined, limit) honors a zero limit", async () => {
+    expect(await value(`return "a,b".split(undefined, 0)`)).toEqual([])
+    expect(await value(`return "a,b".split(undefined, 1)`)).toEqual(["a,b"])
+  })
+
+  test("repeat rejections carry the native RangeError name", async () => {
+    expect(await value(`try { "a".repeat(-1) } catch (e) { return e.name }`)).toBe("RangeError")
+  })
+
+  test("computed string keys still name the callee in the TypeError", async () => {
+    expect(await value(`try { Math["sumPrecise"]([1]) } catch (e) { return e.message }`)).toBe(
+      "Math.sumPrecise is not a function.",
+    )
+  })
+})

--- a/packages/codemode/test/parity.test.ts
+++ b/packages/codemode/test/parity.test.ts
@@ -670,7 +670,7 @@ describe("destructuring assignment", () => {
   })
 })
 
-describe("coercion parity: zero-argument Number() and String()", () => {
+describe("coercion parity: zero-argument coercion functions", () => {
   test("Number() is 0 and String() is empty, unlike their undefined-argument forms", async () => {
     expect(await value(`return Number()`)).toBe(0)
     expect(await value(`return String()`)).toBe("")
@@ -704,6 +704,25 @@ describe("coercion parity: global isFinite and isNaN", () => {
     expect(await value(`return typeof isFinite`)).toBe("function")
     expect(await value(`return typeof isNaN`)).toBe("function")
   })
+
+  test("work as array callbacks", async () => {
+    expect(await value(`return [1, "2", "x", Infinity].filter(isFinite)`)).toEqual([1, "2"])
+    expect(await value(`return ["1", "x"].map(isNaN)`)).toEqual([false, true])
+  })
+})
+
+describe("coercion parity: arrays coerce to numbers through their string form", () => {
+  test("arrays with objects become NaN instead of crashing on host ToPrimitive", async () => {
+    expect(await value(`let x = [{}]; x++; return Number.isNaN(x)`)).toBe(true)
+    expect(await value(`return isFinite([{}])`)).toBe(false)
+    expect(await value(`return "abc".slice([{}])`)).toBe("abc")
+  })
+
+  test("single-element and empty arrays match native Number()", async () => {
+    expect(await value(`return Number([5])`)).toBe(5)
+    expect(await value(`return Number([])`)).toBe(0)
+    expect(await value(`return Number.isNaN(Number([1, 2]))`)).toBe(true)
+  })
 })
 
 describe("coercion parity: String method arguments coerce like native JS", () => {
@@ -723,10 +742,17 @@ describe("coercion parity: String method arguments coerce like native JS", () =>
     expect(await value(`return "a1b".split(1)`)).toEqual(["a", "b"])
     expect(await value(`return "a,b".split(undefined)`)).toEqual(["a,b"])
     expect(await value(`return "a,b".split()`)).toEqual(["a,b"])
+    expect(await value(`return "a,b".split(undefined, 0)`)).toEqual([])
+    expect(await value(`return "a,b".split(undefined, 1)`)).toEqual(["a,b"])
   })
 
   test("replace coerces search and replacement values", async () => {
     expect(await value(`return "a1b".replace(1, 2)`)).toBe("a2b")
+    expect(await value(`return "a1b".replace(1, () => "x")`)).toBe("axb")
+  })
+
+  test("repeat rejections carry the native RangeError name", async () => {
+    expect(await value(`try { "a".repeat(-1) } catch (e) { return e.name }`)).toBe("RangeError")
   })
 
   test("includes, startsWith, and endsWith reject regular expressions with a TypeError", async () => {
@@ -738,6 +764,8 @@ describe("coercion parity: String method arguments coerce like native JS", () =>
   test("opaque runtime references still reject as data errors", async () => {
     const err = await error(`const f = () => 1; return "abc".includes(f)`)
     expect(err.message).toContain("data value")
+    const replacerErr = await error(`const f = () => 1; return "a".replace(f, () => "x")`)
+    expect(replacerErr.message).toContain("data value")
   })
 })
 
@@ -781,6 +809,11 @@ describe("coercion parity: unknown static members read as undefined", () => {
     expect(await value(`return Number.range === undefined`)).toBe(true)
     expect(await value(`return String.raw === undefined`)).toBe(true)
     expect(await value(`return isFinite.something === undefined`)).toBe(true)
+    expect(await value(`return console.group === undefined`)).toBe(true)
+    expect(await value(`return Date.moment === undefined`)).toBe(true)
+    expect(await value(`return JSON.rawJSON === undefined`)).toBe(true)
+    expect(await value(`return URL.createObjectURL === undefined`)).toBe(true)
+    expect(await value(`return Map.groupBy === undefined`)).toBe(true)
     expect(await value(`return Math.sumPrecise?.([1]) ?? "fallback"`)).toBe("fallback")
   })
 
@@ -798,49 +831,15 @@ describe("coercion parity: unknown static members read as undefined", () => {
     expect(await value(`try { Math.sumPrecise([1]) } catch (e) { return e.name + ": " + e.message }`)).toBe(
       "TypeError: Math.sumPrecise is not a function.",
     )
+    expect(await value(`try { Math["sumPrecise"]([1]) } catch (e) { return e.message }`)).toBe(
+      "Math.sumPrecise is not a function.",
+    )
   })
 
   test("blocked members still throw instead of reading as undefined", async () => {
     const err = await error(`return Math.constructor`)
     expect(err.message).toContain("not available")
-  })
-})
-
-describe("coercion parity: isFinite and isNaN as callbacks", () => {
-  test("filter with the coercing global predicates", async () => {
-    expect(await value(`return [1, "2", "x", Infinity].filter(isFinite)`)).toEqual([1, "2"])
-    expect(await value(`return ["1", "x"].map(isNaN)`)).toEqual([false, true])
-  })
-})
-
-describe("coercion parity: review-hardened edges", () => {
-  test("arrays containing objects coerce to NaN instead of crashing on host ToPrimitive", async () => {
-    expect(await value(`let x = [{}]; x++; return Number.isNaN(x)`)).toBe(true)
-    expect(await value(`return isFinite([{}])`)).toBe(false)
-    expect(await value(`return "abc".slice([{}])`)).toBe("abc")
-    expect(await value(`return Number([5])`)).toBe(5)
-    expect(await value(`return Number([])`)).toBe(0)
-    expect(await value(`return Number.isNaN(Number([1, 2]))`)).toBe(true)
-  })
-
-  test("replace with a callback replacer coerces the search value too", async () => {
-    expect(await value(`return "a1b".replace(1, () => "x")`)).toBe("axb")
-    const err = await error(`const f = () => 1; return "a".replace(f, () => "x")`)
-    expect(err.message).toContain("data value")
-  })
-
-  test("split(undefined, limit) honors a zero limit", async () => {
-    expect(await value(`return "a,b".split(undefined, 0)`)).toEqual([])
-    expect(await value(`return "a,b".split(undefined, 1)`)).toEqual(["a,b"])
-  })
-
-  test("repeat rejections carry the native RangeError name", async () => {
-    expect(await value(`try { "a".repeat(-1) } catch (e) { return e.name }`)).toBe("RangeError")
-  })
-
-  test("computed string keys still name the callee in the TypeError", async () => {
-    expect(await value(`try { Math["sumPrecise"]([1]) } catch (e) { return e.message }`)).toBe(
-      "Math.sumPrecise is not a function.",
-    )
+    const coercionErr = await error(`return Number.constructor`)
+    expect(coercionErr.message).toContain("Number.constructor is not available")
   })
 })


### PR DESCRIPTION
Closes six coercion-parity gaps from `interpreter-support.md` where ordinary model-written JavaScript failed in CodeMode but works natively.

## Changes

- **String method argument coercion**: `"v1.2".includes(1)`, `"abc".slice("1")`, `"a1b".replace(1, 2)` coerce like native JS (including the callback-replacer path). Opaque runtime references still reject as data errors; `includes`/`startsWith`/`endsWith` reject regular expressions with a native-style `TypeError`; `split(undefined)` returns the whole string with zero limits honored.
- **Zero-argument `Number()` and `String()`** produce `0` and `""`; `Number(undefined)` stays `NaN`.
- **Global coercing `isFinite`/`isNaN`**, usable as callbacks (`values.filter(isFinite)`).
- **`match()`/`matchAll()`/`search()` with no argument** behave as an empty pattern.
- **`++`/`--` use CodeMode numeric coercion** instead of host `Number(...)`. This also fixes a real crash: `x = {}; x++` previously surfaced a raw host `TypeError` because SafeObjects are null-prototype and host `ToPrimitive` throws. `coerceToNumber` now routes arrays through interpreter string coercion for the same reason (`[{}]` no longer leaks "No default value").
- **Unknown static members read as `undefined`** on global namespaces and the coercion functions, so feature detection (`typeof Math.sumPrecise`, `Object.groupBy === undefined`) works like native JS. Reads are gated on the same known-member sets the invoke switches use; calling an undefined value reports a native-style `TypeError` naming the callee (`Math.sumPrecise is not a function.`). Blocked members (`constructor`, `__proto__`, ...) still throw, and unknown `Promise` statics keep their descriptive error.

Deliberate documented deviations kept: `repeat` still requires a finite non-negative count (now branded `RangeError`), `match`/`search` arguments must still be a regex or string pattern, and opaque runtime references reject everywhere coercion happens.

## Testing

- ~45 new direct behavior tests in `test/parity.test.ts`, with odd edges (`split(undefined, 0)`, `padStart("3", 0)`, `"abc".match().index`) cross-checked against native JS.
- 910 tests pass from `packages/codemode`; typecheck clean.
- `interpreter-support.md` checklist updated in the same PR.