### PR TITLE
fix(app): list folders in empty project picker

### DIFF
--- a/packages/app/src/components/directory-picker-domain.test.ts
+++ b/packages/app/src/components/directory-picker-domain.test.ts
@@ -152,6 +152,35 @@ test("resolves directory autocomplete from the current browser root", async () =
   expect(directories).toEqual(["/repo", "/repo/src"])
 })
 
+test("lists the current directory when the search is empty", async () => {
+  const calls: string[] = []
+  const sdk = {
+    client: {
+      file: {
+        list: (input: { directory: string }) => {
+          calls.push(`list:${input.directory}`)
+          return Promise.resolve({
+            data: [
+              { name: "src", absolute: "/repo/src", type: "directory" },
+              { name: "README.md", absolute: "/repo/README.md", type: "file" },
+            ],
+          })
+        },
+      },
+      find: {
+        files: () => {
+          calls.push("find")
+          return Promise.resolve({ data: [] })
+        },
+      },
+    },
+  } as unknown as Parameters<typeof createDirectorySearch>[0]["sdk"]
+  const search = createDirectorySearch({ sdk, home: () => "/home/luke", base: () => "/repo" })
+
+  expect(await search("")).toEqual(["/repo/src"])
+  expect(calls).toEqual(["list:/repo"])
+})
+
 test("identifies the next directory level to preload", () => {
   expect(
     preloadTreeDirectories("src/", [

--- a/packages/app/src/components/directory-picker-domain.ts
+++ b/packages/app/src/components/directory-picker-domain.ts
@@ -368,7 +368,7 @@ export function createDirectorySearch(args: { sdk: ServerSDK; base: () => string
     const input = scoped(value)
     if (!input) return [] as string[]
     const raw = normalizePickerDrive(value)
-    const pathInput = raw.startsWith("~") || !!pickerRoot(raw) || raw.includes("/")
+    const pathInput = !raw || raw.startsWith("~") || !!pickerRoot(raw) || raw.includes("/")
     const query = normalizePickerDrive(input.path)
     if (!pathInput) {
       const results = await args.sdk.client.find


### PR DESCRIPTION
### Issue for this PR

Closes #37611

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Treats an empty directory-picker filter as directory browsing instead of fuzzy search. The initial Add Project dialog now calls `file.list()` for its base directory and displays child folders immediately.

Non-empty name searches still use `find.files()`.

### How did you verify your code works?

- Reproduced with `opencode web --hostname 0.0.0.0 --port 8088`: the picker initially requested `find/file` with an empty query and displayed no folders.
- Ran the patched app against that server in an isolated Chrome context.
- Verified Add Project immediately listed the home-directory folders with no input.
- Selected `~/IdeaProjects`; the dialog closed and the project appeared in the sidebar.
- Ran the directory-picker unit tests (20 passed), app typecheck, and Prettier checks.

### Screenshots / recordings

Verified in the Web UI that the initial picker lists folders before any search text is entered.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
