### PR TITLE
fix(desktop): refresh legacy session panel on session switch

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2311,9 +2311,13 @@ export default function Page() {
               )}
             </Show>
           ) : (
-            <SessionPanelFrame newLayout={false} raised={!!params.id}>
-              {sessionPanelContent()}
-            </SessionPanelFrame>
+            <Show when={sessionPanelKey() ?? "new"} keyed>
+              {(_) => (
+                <SessionPanelFrame newLayout={false} raised={!!params.id}>
+                  <ErrorBoundary fallback={sessionErrorFallback}>{sessionPanelContent()}</ErrorBoundary>
+                </SessionPanelFrame>
+              )}
+            </Show>
           )}
 
           <Show when={desktopSessionResizeOpen()}>


### PR DESCRIPTION
Fixes #37534

Remounts the legacy session panel when the active session changes so stale content is not reused after switching projects. Also adds the same error boundary used by the new layout.

Testing:
- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/desktop`

No visual design changes.