### PR TITLE
fix(desktop): use custom titlebar on linux

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -84,8 +84,8 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
 
   const mac = createMemo(() => platform.platform === "desktop" && platform.os === "macos")
   const windows = createMemo(() => platform.platform === "desktop" && platform.os === "windows")
-  const electronWindows = createMemo(() => windows() && !tauriApi())
   const linux = createMemo(() => platform.platform === "desktop" && platform.os === "linux")
+  const electronWindows = createMemo(() => (windows() || linux()) && !tauriApi())
   const web = createMemo(() => platform.platform === "web")
   const zoom = () => platform.webviewZoom?.() ?? 1
   const titlebarZoom = () => (windows() ? Math.max(zoom(), minTitlebarZoom) : zoom())

--- a/packages/desktop/src/main/windows.ts
+++ b/packages/desktop/src/main/windows.ts
@@ -76,6 +76,7 @@ export function setBackgroundColor(color: string) {
   BrowserWindow.getAllWindows().forEach((win) => {
     win.setBackgroundColor(color)
     if (process.platform === "darwin") win.invalidateShadow()
+    if (process.platform === "linux") updateTitlebar(win)
   })
 }
 
@@ -103,7 +104,7 @@ function defaultBackgroundColor() {
 function overlay(theme: Partial<TitlebarTheme> = {}, zoom = 1) {
   const mode = theme.mode ?? tone()
   return {
-    color: "#00000000",
+    color: process.platform === "linux" ? (backgroundColor ?? defaultBackgroundColor()) : "#00000000",
     symbolColor: mode === "dark" ? "white" : "black",
     height: Math.max(titlebarHeight, Math.round(titlebarHeight * zoom)),
   }
@@ -122,7 +123,7 @@ export function setTitlebar(win: BrowserWindow, theme: Partial<TitlebarTheme> = 
 }
 
 export function updateTitlebar(win: BrowserWindow) {
-  if (process.platform !== "win32") return
+  if (process.platform !== "win32" && process.platform !== "linux") return
   win.setTitleBarOverlay(overlay(titlebarThemes.get(win), win.webContents.getZoomFactor()))
 }
 
@@ -187,7 +188,7 @@ export function createMainWindow(id: string = randomUUID()) {
           trafficLightPosition: { x: 14, y: 14 },
         }
       : {}),
-    ...(process.platform === "win32"
+    ...(process.platform === "win32" || process.platform === "linux"
       ? {
           frame: false,
           titleBarStyle: "hidden" as const,


### PR DESCRIPTION
### Issue for this PR

Closes #36225

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Linux Electron windows previously fell back to native GTK decorations because the custom titlebar configuration only covered macOS and Windows. This enables the existing frameless titlebar overlay on Linux, keeps its background in sync with the app theme, and reserves space for the window controls.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/app`
- Ran `bun typecheck` in `packages/desktop`
- Ran `bun run build` in `packages/desktop`
- Tested the equivalent packaged build on GNOME

### Screenshots / recordings

<img width="2611" height="658" alt="image" src="https://github.com/user-attachments/assets/2769a3e8-f97b-450e-ae40-9cf865881b65" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR