### PR TITLE
fix(nix): update v2 x86_64-linux node modules hash

### DIFF
--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-F1luclnqCPQk9yxfmeSYGaM/nScf28yBu9K3Fv+Xd24=",
+    "x86_64-linux": "sha256-kncHLja4ylJFtmKdOzMRDByE6TYoRSq3HyV73VfFf7I=",
     "aarch64-linux": "sha256-XW0XZnsCRkU3MFJH9TjMRYZHffzVy3cQyiNCkec2gl4=",
     "aarch64-darwin": "sha256-bf8kvORs3Fs2UYLp3PekF+AJR7NKOcHb+fIQA79RtMk=",
     "x86_64-darwin": "sha256-sBdQPkzd7JXNW6Lbi9JHiAsfHwdLwTKWY+uPeXAv2Nw="


### PR DESCRIPTION
### Issue for this PR

Closes #37623

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On `v2` at `deb5b144c3b0f575e478f02f8b9d979cf8d01b8c`, the x86_64 Linux node_modules fixed-output hash no longer matches the output of the locked Bun install. This PR replaces the stale entry with the hash reported by the fixed-output derivation, allowing the flake to build.

### How did you verify your code works?

Built `#node_modules_updater` from the affected revision locally. Nix reported `sha256-kncHLja4ylJFtmKdOzMRDByE6TYoRSq3HyV73VfFf7I=`, which is the value in this change. A full package build was retried but Bun failed while extracting the upstream `app-builder-bin` tarball.

### Screenshots / recordings

Not applicable; this is a Nix packaging change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR