### PR TITLE
fix: skip empty reasoning steps in replayed history

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -360,6 +360,9 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             })
         }
         if (part.type === "reasoning") {
+          // A provider can open and close a reasoning stream without emitting a delta.
+          // Replaying that empty step creates an assistant message with no usable content.
+          if (part.text === "" && !part.metadata) continue
           if (differentModel) {
             if (part.text.trim().length > 0)
               assistantMessage.parts.push({

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1151,6 +1151,53 @@ describe("session.message-v2.toModelMessage", () => {
     ])
   })
 
+  test("does not replay an empty assistant step between duplicate step-start boundaries", async () => {
+    const assistantID = "m-assistant"
+    const kimiModel: Provider.Model = {
+      ...model,
+      id: ModelV2.ID.make("kimi-k3"),
+      providerID: ProviderV2.ID.make("opencode-go"),
+      api: {
+        id: "kimi-k3",
+        url: "https://opencode.ai/zen/go/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+      capabilities: {
+        ...model.capabilities,
+        reasoning: true,
+        interleaved: { field: "reasoning_content" },
+      },
+    }
+
+    const input: SessionV1.WithParts[] = [
+      {
+        info: assistantInfo(assistantID, "m-parent", undefined, {
+          providerID: kimiModel.providerID,
+          modelID: kimiModel.api.id,
+        }),
+        parts: [
+          { ...basePart(assistantID, "p1"), type: "step-start" },
+          { ...basePart(assistantID, "p2"), type: "reasoning", text: "" },
+          { ...basePart(assistantID, "p3"), type: "step-start" },
+          { ...basePart(assistantID, "p4"), type: "reasoning", text: "thinking" },
+          { ...basePart(assistantID, "p5"), type: "text", text: "answer" },
+        ] satisfies SessionV1.Part[],
+      },
+    ]
+
+    expect(ProviderTransform.message(await MessageV2.toModelMessages(input, kimiModel), kimiModel, {})).toStrictEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer" }],
+        providerOptions: {
+          openaiCompatible: {
+            reasoning_content: "thinking",
+          },
+        },
+      },
+    ])
+  })
+
   test("drops messages that only contain step-start parts", async () => {
     const assistantID = "m-assistant"
 


### PR DESCRIPTION
### Issue for this PR

Fixes #37651

Context: #37552 documented two independent 400 paths for Kimi K3 on OpenCode Go. The `temperature` path was fixed in models.dev#3331; this PR fixes the remaining history-replay path, now tracked in #37651.

### Type of change

- [x] Bug fix

### What does this PR do?

Skips metadata-free empty reasoning parts while rebuilding model history. Some providers can open and close a reasoning stream without emitting a delta; replaying that boundary previously produced an empty assistant message before the next step.

### How did you verify your code works?

- Added a regression test for the duplicate `step-start` / empty-reasoning sequence.
- `bun test test/session/message-v2.test.ts`: 37 passed.
- Replayed the affected Kimi K3 max session through the patched CLI; it continued for 26 steps and finished normally.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
