### PR TITLE
fix(mcp): drain stderr pipe, limit spawn concurrency, add retry with backoff

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -350,8 +350,8 @@ const layer = Layer.effect(
 
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         if (attempt > 0) {
-          // Exponential backoff: 1s, 2s
-          yield* Effect.sleep(`${Math.pow(2, attempt - 1)}s`)
+          // Exponential backoff: 1000ms, 2000ms
+          yield* Effect.sleep(`${Math.pow(2, attempt - 1) * 1000} millis`)
           yield* Effect.logWarning("Retrying MCP connection", { key, attempt })
         }
 

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -344,29 +344,53 @@ const layer = Layer.effect(
       const [cmd, ...args] = mcp.command
       const baseDir = yield* InstanceState.directory
       const cwd = mcp.cwd ? path.resolve(baseDir, mcp.cwd) : baseDir
-      const transport = new StdioClientTransport({
-        stderr: "pipe",
-        command: cmd,
-        args,
-        cwd,
-        env: {
-          ...process.env,
-          ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
-          ...mcp.environment,
-        },
-      })
-
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
-      return yield* connectTransport(transport, connectTimeout).pipe(
-        Effect.map((client): { client: MCPClient | undefined; status: Status } => ({
-          client,
-          status: { status: "connected" },
-        })),
-        Effect.catch((error): Effect.Effect<{ client: MCPClient | undefined; status: Status }> => {
-          const msg = error instanceof Error ? error.message : String(error)
-          return Effect.succeed({ client: undefined, status: { status: "failed", error: msg } })
-        }),
-      )
+      const maxRetries = 2
+      let lastError: unknown
+
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        if (attempt > 0) {
+          // Exponential backoff: 1s, 2s
+          yield* Effect.sleep(`${Math.pow(2, attempt - 1)}s`)
+          yield* Effect.logWarning("Retrying MCP connection", { key, attempt })
+        }
+
+        // Create a fresh transport per attempt — connectTransport closes it on failure
+        const transport = new StdioClientTransport({
+          stderr: "pipe",
+          command: cmd,
+          args,
+          cwd,
+          env: {
+            ...process.env,
+            ...(cmd === "opencode" ? { BUN_BE_BUN: "1" } : {}),
+            ...mcp.environment,
+          },
+        })
+
+        // Drain the stderr PassThrough stream to prevent the OS pipe buffer
+        // from filling up and blocking/killing the child process. The MCP SDK
+        // creates a PassThrough for stderr but never reads from it — on Windows
+        // the 4KB pipe buffer fills up within seconds for chatty servers.
+        transport.stderr?.on("data", () => {})
+
+        const result = yield* connectTransport(transport, connectTimeout).pipe(
+          Effect.map((client): { client: MCPClient | undefined; status: Status } => ({
+            client,
+            status: { status: "connected" },
+          })),
+          Effect.catch((error): Effect.Effect<{ client: MCPClient | undefined; status: Status }> => {
+            lastError = error
+            const msg = error instanceof Error ? error.message : String(error)
+            return Effect.succeed({ client: undefined, status: { status: "failed", error: msg } })
+          }),
+        )
+
+        if (result.client) return result
+      }
+
+      const msg = lastError instanceof Error ? lastError.message : String(lastError)
+      return { client: undefined, status: { status: "failed", error: msg } } as { client: MCPClient | undefined; status: Status }
     })
 
     const create = Effect.fn("MCP.create")(
@@ -525,7 +549,7 @@ const layer = Layer.effect(
                 watch(s, key, result.mcpClient, bridge, mcp.timeout)
               }
             }),
-          { concurrency: "unbounded" },
+          { concurrency: 4 },
         )
 
         yield* Effect.addFinalizer(() =>
@@ -549,7 +573,7 @@ const layer = Layer.effect(
                   }
                   yield* Effect.tryPromise(() => client.close()).pipe(Effect.ignore)
                 }),
-              { concurrency: "unbounded" },
+              { concurrency: 4 },
             )
             pendingOAuthTransports.clear()
           }),


### PR DESCRIPTION
### Issue for this PR

Closes #16449

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Three fixes for stdio MCP server connection failures (`-32000: Connection closed`), primarily affecting Windows:

| Fix | What | Why |
|-----|------|-----|
| **Drain stderr** | `transport.stderr?.on("data", () => {})` | MCP SDK creates PassThrough but nobody reads it. Windows 4KB pipe buffer fills in ~100ms → blocks child → `-32000`. |
| **Limit concurrency** | `concurrency: 'unbounded'` → `concurrency: 4` | Process stampede when spawning all servers at once on Windows (fork+exec emulation is expensive). |
| **Retry with backoff** | 3 attempts, 1s/2s exponential backoff, fresh transport per attempt | Single failure was permanent. |

The stderr drain is the primary fix. The MCP SDK (`StdioClientTransport` in `stdio.js`) creates a `PassThrough` stream for stderr when `stderr: 'pipe'` is set, but nothing reads from it. On Windows, the 4KB pipe buffer fills up within seconds for chatty servers, blocking the child process.

### How did you verify your code works?

Reproduced by running OpenCode with a GitNexus MCP server that indexes 16 repos (heavy stderr output during startup). Before: `-32000: Connection closed` within 2 seconds. After: stable connection for 5+ minutes.

### Screenshots / recordings

_N/A — backend change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
