### PR TITLE
fix(cli): harden managed service election

### DIFF
--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -54,7 +54,7 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
       }
       const password =
         options.mode === "service"
-          ? yield* ServiceConfig.password()
+          ? config.password || randomBytes(32).toString("base64url")
           : environmentPassword
             ? Redacted.value(environmentPassword)
             : randomBytes(32).toString("base64url")
@@ -69,7 +69,11 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
           serviceOptions === undefined
             ? undefined
             : {
-                onListen: (address, shutdown) => register(address, password, instanceID, serviceOptions.file, shutdown),
+                onListen: (address, shutdown) =>
+                  Effect.gen(function* () {
+                    if (!config.password) yield* ServiceConfig.password(password)
+                    return yield* register(address, password, instanceID, serviceOptions.file, shutdown)
+                  }),
               },
       }).pipe(
         Effect.provide(Logger.layer([], { mergeWithExisting: false })),
@@ -155,7 +159,7 @@ const recognizeIncumbent = Effect.fnUntraced(function* (options: DiscoverOptions
   const found = yield* Service.incumbent({ ...options, url: serviceURL(hostname, port) }).pipe(
     Effect.filterOrFail((value) => value !== undefined),
     Effect.retry(Schedule.spaced("100 millis")),
-    Effect.timeoutOption("6 seconds"),
+    Effect.timeoutOption("15 seconds"),
   )
   return Option.isSome(found)
 })

--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -154,8 +154,8 @@ const register = Effect.fnUntraced(function* (
 const recognizeIncumbent = Effect.fnUntraced(function* (options: DiscoverOptions, hostname: string, port: number) {
   const found = yield* Service.incumbent({ ...options, url: serviceURL(hostname, port) }).pipe(
     Effect.filterOrFail((value) => value !== undefined),
-    Effect.retry(Schedule.max([Schedule.spaced("100 millis"), Schedule.recurs(60)])),
-    Effect.option,
+    Effect.retry(Schedule.spaced("100 millis")),
+    Effect.timeoutOption("6 seconds"),
   )
   return Option.isSome(found)
 })

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -302,7 +302,7 @@ test("configured managed service port overrides the channel default", async () =
 
 test("unrelated managed port occupancy reports an actionable conflict", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-conflict-"))
-  const listener = Bun.serve({ port: 0, fetch: () => new Response("unrelated") })
+  const listener = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("unrelated") })
   const port = listener.port
   const registration = path.join(root, "state", "opencode", "service-local.json")
   await fs.mkdir(path.join(root, "config", "opencode"), { recursive: true })

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -4,6 +4,7 @@ import { Database } from "@opencode-ai/core/database/database"
 import { EventV2 } from "@opencode-ai/core/event"
 import { EventTable } from "@opencode-ai/core/event/sql"
 import { Global } from "@opencode-ai/core/global"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Project } from "@opencode-ai/core/project"
 import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -225,6 +226,7 @@ test("concurrent service processes elect one server", async () => {
     )
 
     expect(exited).toEqual(losers.map(() => true))
+    expect(losers.map((process) => process.exitCode)).toEqual(losers.map(() => 0))
     expect(winner?.exitCode).toBe(null)
     expect(new URL(info.url).port).toBe(String(port))
     expect(await Bun.file(registration + ".lock").exists()).toBe(false)
@@ -244,6 +246,7 @@ test("concurrent service processes elect one server", async () => {
         Bun.sleep(10_000).then(() => false),
       ])
       expect(contenderExited).toBe(true)
+      expect(contender.exitCode).toBe(0)
       expect((await waitForInfo(registration)).id).toBe(info.id)
     } finally {
       contender.kill("SIGTERM")
@@ -326,6 +329,96 @@ test("unrelated managed port occupancy reports an actionable conflict", async ()
   }
 }, 30_000)
 
+test("unresponsive managed port occupancy reports a bounded conflict", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-unresponsive-conflict-"))
+  const listener = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => new Promise<Response>(() => {}),
+  })
+  const registration = path.join(root, "state", "opencode", "service-local.json")
+  await fs.mkdir(path.join(root, "config", "opencode"), { recursive: true })
+  await fs.mkdir(path.dirname(registration), { recursive: true })
+  await fs.writeFile(
+    path.join(root, "config", "opencode", "service-local.json"),
+    JSON.stringify({ port: listener.port }),
+  )
+  const stale = {
+    id: "stale",
+    version: InstallationVersion,
+    url: "http://127.0.0.1:1",
+    pid: process.pid,
+    password: "stale",
+  }
+  await fs.writeFile(registration, JSON.stringify(stale))
+  const contender = Bun.spawn(
+    [process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"],
+    {
+      env: serviceEnv(root),
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+
+  try {
+    const exitCode = await Promise.race([contender.exited, Bun.sleep(30_000).then(() => undefined)])
+    expect(exitCode).not.toBeUndefined()
+    const output = (await new Response(contender.stdout).text()) + (await new Response(contender.stderr).text())
+    expect(output).toContain(`Managed service port ${listener.port} on 127.0.0.1 is already in use by another process`)
+    expect(await Bun.file(registration).json()).toEqual(stale)
+  } finally {
+    listener.stop(true)
+    contender.kill("SIGTERM")
+    await contender.exited
+    await fs.rm(root, { recursive: true, force: true })
+  }
+}, 45_000)
+
+test("port contender recognizes an incumbent registered during the bind race", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-bind-race-"))
+  const listener = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => Response.json({ healthy: true, version: InstallationVersion, pid: process.pid }, { status: 503 }),
+  })
+  const registration = path.join(root, "state", "opencode", "service-local.json")
+  const config = path.join(root, "config", "opencode", "service-local.json")
+  await fs.mkdir(path.dirname(config), { recursive: true })
+  await fs.writeFile(config, JSON.stringify({ port: listener.port }))
+  const contender = Bun.spawn(
+    [process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"],
+    {
+      env: serviceEnv(root),
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+
+  try {
+    const password = await waitForPassword(config)
+    const info = {
+      id: "incumbent",
+      version: InstallationVersion,
+      url: `http://127.0.0.1:${listener.port}`,
+      pid: process.pid,
+      password,
+    }
+    await fs.mkdir(path.dirname(registration), { recursive: true })
+    await fs.writeFile(registration, JSON.stringify(info))
+
+    expect(await contender.exited).toBe(0)
+    expect(await Bun.file(registration).json()).toEqual(info)
+    expect((await new Response(contender.stdout).text()) + (await new Response(contender.stderr).text())).not.toContain(
+      "already in use by another process",
+    )
+  } finally {
+    listener.stop(true)
+    contender.kill("SIGTERM")
+    await contender.exited
+    await fs.rm(root, { recursive: true, force: true })
+  }
+}, 30_000)
+
 test("stale dead registration is replaced after binding the selected port", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-stale-"))
   const port = await availablePort()
@@ -375,10 +468,12 @@ test("a failed service stays registered and owns the selected port until stopped
 
   try {
     const info = await waitForInfo(registration)
+    await waitForFailed(info)
     expect(owner.exitCode).toBe(null)
 
     const contender = Bun.spawn(command, { env, stderr: "pipe", stdout: "ignore" })
     expect(await Promise.race([contender.exited.then(() => true), Bun.sleep(10_000).then(() => false)])).toBe(true)
+    expect(contender.exitCode).toBe(0)
     expect((await waitForInfo(registration)).id).toBe(info.id)
     expect(owner.exitCode).toBe(null)
 
@@ -451,6 +546,18 @@ async function waitForFailed(info: Info) {
     await Bun.sleep(50)
   }
   throw new Error("Timed out waiting for service boot failure")
+}
+
+async function waitForPassword(file: string) {
+  for (let attempt = 0; attempt < 400; attempt++) {
+    const password = await Bun.file(file)
+      .json()
+      .then((value) => value.password)
+      .catch(() => undefined)
+    if (typeof password === "string") return password
+    await Bun.sleep(50)
+  }
+  throw new Error("Timed out waiting for service password")
 }
 
 async function availablePort() {

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -213,9 +213,10 @@ test("concurrent service processes elect one server", async () => {
   const command = [process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"]
   const registration = path.join(root, "state", "opencode", "service-local.json")
   const port = await availablePort()
+  const config = path.join(root, "config", "opencode", "service-local.json")
   await fs.mkdir(path.join(root, "config", "opencode"), { recursive: true })
-  await fs.writeFile(path.join(root, "config", "opencode", "service-local.json"), JSON.stringify({ port }))
-  const processes = Array.from({ length: 10 }, () => Bun.spawn(command, { env, stderr: "pipe", stdout: "ignore" }))
+  await fs.writeFile(config, JSON.stringify({ port }))
+  const processes = Array.from({ length: 10 }, () => Bun.spawn(command, { env, stderr: "pipe", stdout: "pipe" }))
 
   try {
     const info = await waitForInfo(registration)
@@ -226,9 +227,18 @@ test("concurrent service processes elect one server", async () => {
     )
 
     expect(exited).toEqual(losers.map(() => true))
-    expect(losers.map((process) => process.exitCode)).toEqual(losers.map(() => 0))
+    const errors = await Promise.all(
+      losers.map(
+        async (process) => (await new Response(process.stdout).text()) + (await new Response(process.stderr).text()),
+      ),
+    )
+    expect(
+      losers.map((process) => process.exitCode),
+      errors.filter(Boolean).join("\n"),
+    ).toEqual(losers.map(() => 0))
     expect(winner?.exitCode).toBe(null)
     expect(new URL(info.url).port).toBe(String(port))
+    expect((await Bun.file(config).json()).password).toBe(info.password)
     expect(await Bun.file(registration + ".lock").exists()).toBe(false)
     expect(
       await fetch(new URL("/api/health", info.url), {
@@ -268,14 +278,11 @@ test("concurrent service processes elect one server", async () => {
     expect(await waitForExecutionStart(database, sessionID)).toBe(1)
     await Effect.runPromise(Service.stop({ file: registration }).pipe(Effect.provide(NodeFileSystem.layer)))
     await winner?.exited
+    expect(await Bun.file(registration).exists()).toBe(false)
   } finally {
     processes.forEach((process) => process.kill("SIGTERM"))
     await Promise.all(processes.map((process) => process.exited))
-    try {
-      expect(await Bun.file(registration).exists()).toBe(false)
-    } finally {
-      await fs.rm(root, { recursive: true, force: true })
-    }
+    await fs.rm(root, { recursive: true, force: true })
   }
 }, 120_000)
 
@@ -284,8 +291,9 @@ test("configured managed service port overrides the channel default", async () =
   const port = await availablePort()
   const env = serviceEnv(root)
   const registration = path.join(root, "state", "opencode", "service-local.json")
+  const config = path.join(root, "config", "opencode", "service-local.json")
   await fs.mkdir(path.join(root, "config", "opencode"), { recursive: true })
-  await fs.writeFile(path.join(root, "config", "opencode", "service-local.json"), JSON.stringify({ port }))
+  await fs.writeFile(config, JSON.stringify({ port, password: "" }))
   const owner = Bun.spawn([process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"], {
     env,
     stderr: "pipe",
@@ -294,6 +302,8 @@ test("configured managed service port overrides the channel default", async () =
   try {
     const info = await waitForInfo(registration)
     expect(new URL(info.url).port).toBe(String(port))
+    expect(info.password).not.toBe("")
+    expect((await Bun.file(config).json()).password).toBe(info.password)
     await Effect.runPromise(Service.stop({ file: registration }).pipe(Effect.provide(NodeFileSystem.layer)))
     await owner.exited
   } finally {
@@ -331,10 +341,16 @@ test("unrelated managed port occupancy reports an actionable conflict", async ()
 
 test("unresponsive managed port occupancy reports a bounded conflict", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-unresponsive-conflict-"))
-  const listener = Bun.serve({
+  const recognizing = Promise.withResolvers<void>()
+  const requests = { count: 0 }
+  using listener = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch: () => new Promise<Response>(() => {}),
+    fetch() {
+      requests.count += 1
+      if (requests.count === 2) recognizing.resolve()
+      return new Promise<Response>(() => {})
+    },
   })
   const registration = path.join(root, "state", "opencode", "service-local.json")
   await fs.mkdir(path.join(root, "config", "opencode"), { recursive: true })
@@ -351,23 +367,20 @@ test("unresponsive managed port occupancy reports a bounded conflict", async () 
     password: "stale",
   }
   await fs.writeFile(registration, JSON.stringify(stale))
-  const contender = Bun.spawn(
-    [process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"],
-    {
-      env: serviceEnv(root),
-      stderr: "pipe",
-      stdout: "pipe",
-    },
-  )
+  const contender = Bun.spawn([process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"], {
+    env: serviceEnv(root),
+    stderr: "pipe",
+    stdout: "pipe",
+  })
 
   try {
-    const exitCode = await Promise.race([contender.exited, Bun.sleep(30_000).then(() => undefined)])
-    expect(exitCode).not.toBeUndefined()
+    expect(await Promise.race([recognizing.promise.then(() => true), Bun.sleep(20_000).then(() => false)])).toBe(true)
+    const exitCode = await Promise.race([contender.exited, Bun.sleep(20_000).then(() => undefined)])
+    expect(exitCode).toBe(1)
     const output = (await new Response(contender.stdout).text()) + (await new Response(contender.stderr).text())
     expect(output).toContain(`Managed service port ${listener.port} on 127.0.0.1 is already in use by another process`)
     expect(await Bun.file(registration).json()).toEqual(stale)
   } finally {
-    listener.stop(true)
     contender.kill("SIGTERM")
     await contender.exited
     await fs.rm(root, { recursive: true, force: true })
@@ -376,48 +389,58 @@ test("unresponsive managed port occupancy reports a bounded conflict", async () 
 
 test("port contender recognizes an incumbent registered during the bind race", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-bind-race-"))
-  const listener = Bun.serve({
+  const recognizing = Promise.withResolvers<void>()
+  const requests = { count: 0 }
+  using listener = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch: () => Response.json({ healthy: true, version: InstallationVersion, pid: process.pid }, { status: 503 }),
+    fetch() {
+      requests.count += 1
+      if (requests.count === 2) recognizing.resolve()
+      return Response.json({ healthy: true, version: InstallationVersion, pid: process.pid }, { status: 503 })
+    },
   })
   const registration = path.join(root, "state", "opencode", "service-local.json")
   const config = path.join(root, "config", "opencode", "service-local.json")
   await fs.mkdir(path.dirname(config), { recursive: true })
   await fs.writeFile(config, JSON.stringify({ port: listener.port }))
-  const contender = Bun.spawn(
-    [process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"],
-    {
-      env: serviceEnv(root),
-      stderr: "pipe",
-      stdout: "pipe",
-    },
+  await fs.mkdir(path.dirname(registration), { recursive: true })
+  await fs.writeFile(
+    registration,
+    JSON.stringify({
+      id: "stale",
+      version: InstallationVersion,
+      url: "http://127.0.0.1:1",
+      pid: 2_147_483_647,
+      password: "stale",
+    }),
   )
+  const contender = Bun.spawn([process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"], {
+    env: serviceEnv(root),
+    stderr: "pipe",
+    stdout: "ignore",
+  })
 
   try {
-    const password = await waitForPassword(config)
+    expect(await Promise.race([recognizing.promise.then(() => true), Bun.sleep(20_000).then(() => false)])).toBe(true)
+    await Bun.sleep(8_000)
     const info = {
       id: "incumbent",
       version: InstallationVersion,
       url: `http://127.0.0.1:${listener.port}`,
       pid: process.pid,
-      password,
+      password: "incumbent",
     }
-    await fs.mkdir(path.dirname(registration), { recursive: true })
     await fs.writeFile(registration, JSON.stringify(info))
 
-    expect(await contender.exited).toBe(0)
+    expect(await Promise.race([contender.exited, Bun.sleep(20_000).then(() => undefined)])).toBe(0)
     expect(await Bun.file(registration).json()).toEqual(info)
-    expect((await new Response(contender.stdout).text()) + (await new Response(contender.stderr).text())).not.toContain(
-      "already in use by another process",
-    )
   } finally {
-    listener.stop(true)
     contender.kill("SIGTERM")
     await contender.exited
     await fs.rm(root, { recursive: true, force: true })
   }
-}, 30_000)
+}, 45_000)
 
 test("stale dead registration is replaced after binding the selected port", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-stale-"))
@@ -546,18 +569,6 @@ async function waitForFailed(info: Info) {
     await Bun.sleep(50)
   }
   throw new Error("Timed out waiting for service boot failure")
-}
-
-async function waitForPassword(file: string) {
-  for (let attempt = 0; attempt < 400; attempt++) {
-    const password = await Bun.file(file)
-      .json()
-      .then((value) => value.password)
-      .catch(() => undefined)
-    if (typeof password === "string") return password
-    await Bun.sleep(50)
-  }
-  throw new Error("Timed out waiting for service password")
 }
 
 async function availablePort() {


### PR DESCRIPTION
## What

Prevent stale or unresponsive managed-port owners from trapping service contenders, while preserving correct ownership during slow and highly concurrent startup. Incumbent recognition now has a true 15-second wall-clock bound, and only the process that wins the port bind persists the generated service password.

## Before / After

**Before:** incumbent recognition allowed 60 retries, but each authenticated health probe could take two seconds, stretching an intended short retry window to roughly two minutes. A strict six-second replacement proved too short under Windows CI and misclassified a legitimate owner that published registration after seven seconds. Concurrent first-start contenders also generated and wrote passwords before election; they raced on the shared config temp file, causing `ENOENT`, and could persist a loser password that did not authenticate the elected service.

**After:** recognition is interrupted after 15 seconds regardless of probe latency. A legitimate owner may publish registration eight seconds after the bind race begins and is still recognized; a stale registration plus a listener that never answers health fails with an actionable conflict in bounded time. Passwords are generated in contender memory but persisted only in the elected owner’s `onListen` path, before registration, so config and registration always carry the same credential.

## How

- `packages/cli/src/server-process.ts`: bound the complete incumbent-recognition retry operation with `Effect.timeoutOption("15 seconds")`.
- `packages/cli/src/server-process.ts`: defer first-time password persistence until after successful port binding and before publishing registration.
- `packages/cli/test/service.test.ts`: model a stale registration whose exact-port listener accepts health requests but never responds.
- `packages/cli/test/service.test.ts`: deterministically wait until post-bind incumbent polling begins, delay registration for eight seconds, and verify successful adoption.
- `packages/cli/test/service.test.ts`: require all election losers to exit successfully, include their output in failures, verify persisted and registered passwords match, preserve empty-password generation behavior, and prevent cleanup assertions from masking the primary failure.
- `packages/cli/test/service.test.ts`: bind foreign listeners explicitly to `127.0.0.1` so the reproducer is deterministic on macOS.

## Scope

This builds on the port-bind election and registration lease introduced by #37572 and #37576. It deliberately does not kill an unknown port owner: without a matching authenticated registration, signaling that PID could terminate an unrelated or PID-reused process. The safe outcome is a bounded, actionable conflict.

## Testing

- `bun run test test/service.test.ts` in `packages/cli` (17 passed)
- `bun run test test/service.test.ts --test-name-pattern "concurrent service processes elect one server" --rerun-each 20` in `packages/cli` (20 passed)
- `bun run test test/service.test.ts test/promise-service.test.ts` in `packages/client` (15 passed)
- `bun typecheck` in `packages/cli`
- push hook full-repository typecheck (32 packages passed)

The prior Windows run also hit an unrelated `packages/core/test/vcs.test.ts` timeout at 5006.92 ms against a 5000 ms default; no files in that package are changed here.