### PR TITLE
fix(opencode): batch shell output updates

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -446,6 +446,20 @@ export const ShellTool = Tool.define(
       let cut = false
       let expired = false
       let aborted = false
+      let outputVersion = 0
+      let publishedVersion = 0
+
+      const publish = Effect.fnUntraced(function* () {
+        if (publishedVersion === outputVersion) return
+        const version = outputVersion
+        const output = last
+        yield* ctx.metadata({
+          metadata: {
+            output,
+          },
+        })
+        publishedVersion = version
+      })
 
       const closeSink = Effect.fnUntraced(function* () {
         const stream = sink
@@ -483,7 +497,14 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const publisher = yield* Effect.gen(function* () {
+            while (true) {
+              yield* Effect.sleep("100 millis")
+              yield* publish()
+            }
+          }).pipe(Effect.forkScoped)
+
+          const output = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -496,6 +517,7 @@ export const ShellTool = Tool.define(
               }
 
               last = preview(last + chunk)
+              outputVersion++
 
               if (file) {
                 sink?.write(chunk)
@@ -511,22 +533,11 @@ export const ShellTool = Tool.define(
                         full = ""
                       }),
                     ),
-                    Effect.andThen(
-                      ctx.metadata({
-                        metadata: {
-                          output: last,
-                        },
-                      }),
-                    ),
                   )
                 }
               }
 
-              return ctx.metadata({
-                metadata: {
-                  output: last,
-                },
-              })
+              return Effect.void
             }),
           )
 
@@ -553,6 +564,13 @@ export const ShellTool = Tool.define(
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
+
+          yield* Fiber.await(output).pipe(
+            Effect.asVoid,
+            Effect.timeoutOrElse({ duration: "100 millis", orElse: () => Fiber.interrupt(output) }),
+          )
+          yield* Fiber.interrupt(publisher)
+          yield* publish()
 
           return exit.kind === "exit" ? exit.code : null
         }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1112,7 +1112,7 @@ describe("tool.shell abort", () => {
         const updates: string[] = []
         const result = yield* run(
           {
-            command: `echo first && sleep 0.1 && echo second`,
+            command: `echo first && sleep 0.25 && echo second`,
           },
           {
             ...ctx,
@@ -1126,6 +1126,85 @@ describe("tool.shell abort", () => {
         expect(result.output).toContain("first")
         expect(result.output).toContain("second")
         expect(updates.length).toBeGreaterThan(1)
+      }),
+    ),
+  )
+
+  it.live("coalesces frequent metadata updates without losing output", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const updates: string[] = []
+        const code = `for(let i=0;i<40;i++){process.stdout.write(i+String.fromCharCode(10));await Bun.sleep(10)}`
+        const result = yield* run(
+          {
+            command: `${bin} -e ${evalarg(code)}`,
+          },
+          {
+            ...ctx,
+            metadata: (input) =>
+              Effect.sync(() => {
+                updates.push(((input.metadata as { output?: string })?.output ?? "").trim())
+              }),
+          },
+        )
+
+        expect(result.output).toContain("0")
+        expect(result.output).toContain("39")
+        expect(updates.at(-1)).toContain("39")
+        expect(updates.length).toBeGreaterThan(1)
+        expect(updates.length).toBeLessThan(15)
+      }),
+    ),
+  )
+
+  it.live("flushes final output before returning and publishes nothing afterward", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const updates: string[] = []
+        const result = yield* run(
+          { command: fill("bytes", 1) },
+          {
+            ...ctx,
+            metadata: (input) =>
+              Effect.sync(() => {
+                updates.push((input.metadata as { output?: string })?.output ?? "")
+              }),
+          },
+        )
+
+        expect(result.output).toBe("a")
+        expect(result.metadata.output).toBe("a")
+        expect(updates[0]).toBe("")
+        expect(updates.at(-1)).toBe("a")
+        const count = updates.length
+        yield* Effect.sleep("150 millis")
+        expect(updates).toHaveLength(count)
+      }),
+    ),
+  )
+
+  it.live("does not publish repeated metadata for a quiet command", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const updates: string[] = []
+        const result = yield* run(
+          { command: fill("bytes", 0) },
+          {
+            ...ctx,
+            metadata: (input) =>
+              Effect.sync(() => {
+                updates.push((input.metadata as { output?: string })?.output ?? "")
+              }),
+          },
+        )
+
+        expect(result.output).toBe("(no output)")
+        expect(result.metadata.output).toBe("(no output)")
+        expect(result.metadata.exit).toBe(0)
+        expect(updates).toEqual([""])
       }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #30001

Related to #35543. This PR also coalesces metadata updates and uses a bounded trailing-output drain.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The shell tool currently awaits ctx.metadata for every decoded output chunk. For chatty commands, pipe chunking therefore controls durable update frequency, and process exit can win before trailing pipe output is consumed.

This change consumes output immediately, publishes the newest cumulative preview at most every 100 ms, then allows 100 ms for trailing output and performs a final flush before returning. The cumulative metadata.output contract is unchanged.

### How did you verify your code works?

- bun test test/tool/shell.test.ts: 26 pass
- bun typecheck
- 80 paced writes: 2.7x-3.7x fewer metadata updates and 8%-23% lower runtime depending on simulated metadata sink cost
- Patched output was complete in 18/18 runs; baseline lost final output in 11/12 delayed-sink runs

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR