### PR TITLE
fix(core): detach disposed MCP registrations from root scope

### DIFF
--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -209,7 +209,12 @@ export const layer = Layer.effect(
       entry.integrationID = integrationID
       owned.add(integrationID)
       const methodID = Integration.MethodID.make(suffix)
-      entry.registration = yield* integration
+      // Each registration gets its own child scope so disposal detaches it from the root scope
+      // entirely; registering directly on root would accumulate a dead finalizer per replaced or
+      // removed server for the lifetime of the layer.
+      const scope = yield* Scope.fork(root)
+      entry.registration = { dispose: Scope.close(scope, Exit.void) }
+      yield* integration
         .transform((draft) => {
           draft.update(integrationID, (ref) => {
             ref.name = name
@@ -220,7 +225,7 @@ export const layer = Layer.effect(
             authorize: () => MCPOAuth.authorize({ name, config: remote, methodID }),
           })
         })
-        .pipe(Scope.provide(root))
+        .pipe(Scope.provide(scope))
     })
     yield* Effect.forEach(runtime, ([name, entry]) => register(name, entry), { discard: true })
 


### PR DESCRIPTION
Follow-up to #37308, addressing known trade-off #8 (no-op finalizers accumulate in the root scope).

`register()` previously piped `integration.transform(...)` with `Scope.provide(root)`, parking the transform's cleanup finalizer on the layer's root scope. Disposing a registration (on `add()` replacement or `remove()`) made the transform inert but could not unregister that finalizer, so every replaced or removed remote OAuth server left one dead closure on the root scope until process exit — a slow, unbounded memory leak once add/remove become programmatically callable (HTTP endpoints, config reconciler).

Fix: fork one child scope per registration and make `entry.registration.dispose` close that scope. Closing the child runs the transform's dispose finalizer (identical registry cleanup and reload behavior as before) and detaches the scope from root, so nothing accumulates. Closing an already-closed scope is a no-op, preserving dispose idempotency.

No behavior change beyond the leak fix. Existing suite passes (18/18), typecheck clean.