### PR TITLE
fix: build Windows binaries natively to fix compatibility on Windows 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,10 +86,10 @@ jobs:
           opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
           opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
 
-      - name: Build
+      - name: Build (Unix only)
         id: build
         run: |
-          ./packages/opencode/script/build.ts ${{ (github.ref_name == 'beta' && '--sourcemaps') || '' }}
+          ./packages/opencode/script/build.ts --filter-os darwin,linux ${{ (github.ref_name == 'beta' && '--sourcemaps') || '' }}
           ./packages/cli/script/build.ts ${{ (github.ref_name == 'beta' && '--sourcemaps') || '' }}
         env:
           OPENCODE_VERSION: ${{ needs.version.outputs.version }}
@@ -106,20 +106,48 @@ jobs:
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: opencode-cli-windows
-          path: packages/opencode/dist/opencode-windows*
-
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
           name: opencode-preview-cli
           path: packages/cli/dist/cli-*
 
     outputs:
       version: ${{ needs.version.outputs.version }}
 
+  build-cli-windows:
+    needs: version
+    runs-on: blacksmith-4vcpu-windows-2025
+    if: github.repository == 'anomalyco/opencode'
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          fetch-tags: true
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Setup git committer
+        id: committer
+        uses: ./.github/actions/setup-git-committer
+        with:
+          opencode-app-id: ${{ vars.OPENCODE_APP_ID }}
+          opencode-app-secret: ${{ secrets.OPENCODE_APP_SECRET }}
+
+      - name: Build (Windows native)
+        id: build
+        run: |
+          bun packages/opencode/script/build.ts --filter-os win32
+        env:
+          OPENCODE_VERSION: ${{ needs.version.outputs.version }}
+          OPENCODE_RELEASE: ${{ needs.version.outputs.release }}
+          GH_REPO: ${{ needs.version.outputs.repo }}
+          GH_TOKEN: ${{ steps.committer.outputs.token }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: opencode-cli-windows
+          path: packages/opencode/dist/opencode-windows*
+
   sign-cli-windows:
     needs:
-      - build-cli
+      - build-cli-windows
       - version
     runs-on: blacksmith-4vcpu-windows-2025
     if: github.repository == 'anomalyco/opencode'
@@ -220,6 +248,7 @@ jobs:
   build-electron:
     needs:
       - build-cli
+      - build-cli-windows
       - version
     if: github.repository == 'anomalyco/opencode'
     continue-on-error: false
@@ -409,6 +438,7 @@ jobs:
     needs:
       - version
       - build-cli
+      - build-cli-windows
       - sign-cli-windows
       - build-electron
     if: always() && !failure() && !cancelled()

--- a/packages/opencode/bin/opencode
+++ b/packages/opencode/bin/opencode
@@ -186,14 +186,66 @@ function findBinary(startDir) {
   }
 }
 
-const resolved = envPath || (fs.existsSync(cached) ? cached : findBinary(scriptDir))
-if (!resolved) {
+function findAllBinaries(startDir) {
+  const found = []
+  let current = startDir
+  const seen = new Set()
+  for (;;) {
+    const modules = path.join(current, "node_modules")
+    if (fs.existsSync(modules)) {
+      for (const name of names) {
+        const candidate = path.join(modules, name, "bin", binary)
+        if (fs.existsSync(candidate) && !seen.has(candidate)) {
+          seen.add(candidate)
+          found.push(candidate)
+        }
+      }
+    }
+    const parent = path.dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  return found
+}
+
+function verifyBinary(binaryPath) {
+  try {
+    const result = childProcess.spawnSync(binaryPath, ["--version"], {
+      encoding: "utf8",
+      stdio: "ignore",
+      timeout: 5000,
+    })
+    return result.status === 0
+  } catch {
+    return false
+  }
+}
+
+function tryRun(binaryPath) {
+  if (verifyBinary(binaryPath)) {
+    run(binaryPath)
+    return true
+  }
+  return false
+}
+
+;(function main() {
+  const resolved = envPath || (fs.existsSync(cached) ? cached : null)
+  if (resolved && tryRun(resolved)) return
+
+  if (resolved) {
+    console.error("The installed opencode binary is not compatible with this system. Attempting fallback...")
+  }
+
+  const candidates = findAllBinaries(scriptDir)
+  for (const candidate of candidates) {
+    if (tryRun(candidate)) return
+  }
+
   console.error(
     "It seems that your package manager failed to install the right version of the opencode CLI for your platform. You can try manually installing " +
       names.map((n) => `\"${n}\"`).join(" or ") +
       " package",
   )
   process.exit(1)
-}
-
-run(resolved)
+})()

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -24,6 +24,9 @@ const sourcemapsFlag = process.argv.includes("--sourcemaps")
 const plugin = createSolidTransformPlugin()
 const skipEmbedWebUi = process.argv.includes("--skip-embed-web-ui")
 
+const filterOsIndex = process.argv.indexOf("--filter-os")
+const filterOs = filterOsIndex >= 0 ? process.argv[filterOsIndex + 1]?.split(",") : undefined
+
 const createEmbeddedWebUIBundle = async () => {
   console.log(`Building Web UI to embed in the binary`)
   const appDir = path.join(import.meta.dirname, "../../app")
@@ -113,7 +116,7 @@ const allTargets: {
   },
 ]
 
-const targets = singleFlag
+const targets = (singleFlag
   ? allTargets.filter((item) => {
       if (item.os !== process.platform || item.arch !== process.arch) {
         return false
@@ -133,6 +136,7 @@ const targets = singleFlag
       return true
     })
   : allTargets
+).filter((item) => !filterOs || filterOs.includes(item.os))
 
 await $`rm -rf dist`
 


### PR DESCRIPTION
### Issue for this PR

Closes #37628

### Type of change

- [x] Bug fix

### What does this PR do?

Two-part fix for Windows 11 compatibility error when installing `opencode-ai` globally:

**Root cause:** Windows `opencode.exe` was cross-compiled from Linux (Ubuntu) via Bun's `compile` feature with empty `windows: {}` options. Bun's Linux-to-Windows cross-compilation produced PE executables with incorrect headers that Windows rejects.

**1. Build pipeline (`build.ts` + `publish.yml`):** Added `--filter-os` flag to the build script so different OS targets can be built separately. The Windows build is now performed natively on a `blacksmith-4vcpu-windows-2025` runner instead of being cross-compiled from Linux. This ensures the PE headers are properly generated for Windows.

**2. Launcher (`bin/opencode`):** Added runtime binary verification. Before spawning, the launcher runs `--version` on the binary. If it fails (incompatible or corrupt binary), it falls back to the next variant in the priority list (e.g. x64 then x64-baseline). This provides a safety net even if the wrong binary variant gets installed.

### How did you verified your code works?

The build script change is a simple array filter. The launcher change follows the same `verifyBinary` pattern already used in `postinstall.mjs`. The CI workflow change mirrors the existing `sign-cli-windows` job setup.

### Screenshots / recordings

N/A

### Checklist

- [x] I have not included unrelated changes in this PR
