### PR TITLE
docs(ecosystem): add opencode-session-id-plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-session-id-plugin](https://github.com/hardes11/opencode-session-id-plugin)               | Show the session ID beneath the title in the OpenCode sidebar                                      |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #37676

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-session-id-plugin` to the ecosystem docs plugin list in `packages/web/src/content/docs/ecosystem.mdx`.

`opencode-session-id-plugin` is a TUI plugin that displays the session ID beneath the title in the OpenCode sidebar — restored for stable-channel users, since upstream only shows this line on dev/edge builds (gated behind `InstallationChannel !== "latest"`). The `sidebar_title` slot is an intentional extension point, so this is a legitimate use of the plugin surface rather than a patch over upstream behavior.

Project links:
- GitHub: https://github.com/hardes11/opencode-session-id-plugin
- npm: https://www.npmjs.com/package/opencode-session-id-plugin

### How did you verify your code works?

- Confirmed the docs entry was appended to the `Plugins` table in `packages/web/src/content/docs/ecosystem.mdx` (last row, after `opencode-goal-plugin`, matching the append-as-added ordering convention of the existing 37 entries)
- Verified the row's pipe positions column-align with all 37 existing rows (hand-padded to the table's max cell widths: Name=98, Description=98)
- Confirmed this PR only adds the new ecosystem entry with no unrelated changes

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
