### PR TITLE
fix(core): drop undefined metadata values from permission requests

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -170,6 +170,12 @@ const layer = Layer.effect(
       return { effect, rules: all }
     })
 
+    // Metadata is JSON-encoded; drop undefined values tools pass for absent optional inputs.
+    function metadata(value: AssertInput["metadata"]): Request["metadata"] {
+      if (!value) return value
+      return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined))
+    }
+
     function request(input: AssertInput): Request {
       return {
         id: input.id ?? ID.create(),
@@ -177,7 +183,7 @@ const layer = Layer.effect(
         action: input.action,
         resources: input.resources,
         save: input.save,
-        metadata: input.metadata,
+        metadata: metadata(input.metadata),
         source: input.source,
       }
     }

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -266,6 +266,17 @@ describe("PermissionV2", () => {
     }),
   )
 
+  it.effect("omits undefined metadata values from pending requests", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* PermissionV2.Service
+      yield* service.ask(assertion({ metadata: { root: ".", path: undefined, limit: undefined } }))
+      const request = yield* service.get(PermissionV2.ID.create("per_test"))
+      expect(request?.metadata).toEqual({ root: "." })
+      expect(Object.keys(request?.metadata ?? {})).toEqual(["root"])
+    }),
+  )
+
   it.effect("defects when an asked permission is declined", () =>
     Effect.gen(function* () {
       yield* setup()


### PR DESCRIPTION
### Issue for this PR

Closes #37650

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pending `glob` and `grep` permissions store absent optional inputs as `undefined` inside permission metadata (for example `metadata: { path: input.path, limit: input.limit }`). The metadata record is `Schema.Record(Schema.String, Schema.Unknown)` and the wire codec serializes `Unknown` as a JSON value, so `session.permission.list` fails to encode its response with `Expected JSON value, got undefined`.

This strips `undefined` values in `request()` in `packages/core/src/permission.ts`, the one place every pending request is constructed for both `assert` and `ask`. That fixes both tools at once and protects the event publish path as well as the list and get endpoints. I audited every `permission.assert` and `permission.ask` call site: these two tools are the only ones producing `undefined` values and all metadata is flat, so a shallow strip is sufficient. A deep JSON round trip was rejected because it would silently normalize values that should fail loudly.

### How did you verify your code works?

Added one regression test: ask for a permission whose metadata contains `undefined` values, then assert the pending request omits those keys. It fails without the fix and passes with it. I also reproduced the reported error (`Expected JSON value, got undefined at ["path"]`) against the JSON value codec using the old metadata shape and confirmed the stripped shape encodes cleanly. The permission and tool test suites in `packages/core` (111 tests) and `tsgo --noEmit` all pass.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
