### PR TITLE
fix(core): refresh stale plugin cache

### DIFF
--- a/packages/core/src/config/plugin/external.ts
+++ b/packages/core/src/config/plugin/external.ts
@@ -72,9 +72,10 @@ export const Plugin = define({
 
       for (const ref of configured) {
         yield* Effect.gen(function* () {
+          const pkg = Npm.normalizeRegistrySpec(ref.package)
           const entrypoint = path.isAbsolute(ref.package)
             ? pathToFileURL(ref.package).href
-            : (yield* npm.add(ref.package)).entrypoint
+            : (yield* npm.add(pkg)).entrypoint
           if (!entrypoint) return
 
           const mod = yield* Effect.promise(() => import(entrypoint))

--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -24,8 +24,12 @@ export interface EntryPoint {
   readonly entrypoint?: string
 }
 
+export interface AddOptions {
+  readonly refresh?: boolean
+}
+
 export interface Interface {
-  readonly add: (pkg: string) => Effect.Effect<EntryPoint, InstallFailedError | EffectFlock.LockError>
+  readonly add: (pkg: string, options?: AddOptions) => Effect.Effect<EntryPoint, InstallFailedError | EffectFlock.LockError>
   readonly install: (
     dir: string,
     input?: {
@@ -69,6 +73,24 @@ interface ArboristTree {
   edgesOut: Map<string, { to?: ArboristNode }>
 }
 
+export function normalizeRegistrySpec(spec: string) {
+  try {
+    const hit = npa(spec)
+    if (hit.name && hit.raw === hit.name) return `${hit.name}@latest`
+  } catch {}
+  return spec
+}
+
+export function isMutableRegistrySpec(spec: string) {
+  try {
+    const hit = npa(spec)
+    const target = hit.type === "alias" ? (hit as npa.AliasResult).subSpec : hit
+    return !!target.registry && target.type !== "version"
+  } catch {
+    return false
+  }
+}
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -90,6 +112,7 @@ const layer = Layer.effect(
           progress: false,
           savePrefix: "",
           ignoreScripts: true,
+          audit: false,
         })
         return yield* Effect.tryPromise({
           try: () =>
@@ -112,7 +135,31 @@ const layer = Layer.effect(
         }),
       )
 
-    const add = Effect.fn("Npm.add")(function* (pkg: string) {
+    const fetchLatestVersion = (dir: string, name: string) =>
+      Effect.gen(function* () {
+        const registryUrl = yield* NpmConfig.registry(dir)
+        const response = yield* Effect.tryPromise({
+          try: () =>
+            fetch(`${registryUrl}/-/package/${encodeURIComponent(name)}/dist-tags`, {
+              headers: { Accept: "application/json" },
+              signal: AbortSignal.timeout(5000),
+            }),
+          catch: () => null as Response | null,
+        })
+        if (!response || !response.ok) return undefined
+        return yield* Effect.tryPromise({
+          try: () => response.json() as Promise<{ latest?: string }>,
+          catch: () => undefined,
+        }).pipe(Effect.map((tags) => tags?.latest))
+      }).pipe(Effect.orElseSucceed(() => undefined))
+
+    const readInstalledVersion = (dir: string, name: string) =>
+      afs.readJson(path.join(dir, "node_modules", name, "package.json")).pipe(
+        Effect.map((pkg) => (pkg as { version?: string })?.version),
+        Effect.orElseSucceed(() => undefined),
+      )
+
+    const add = Effect.fn("Npm.add")(function* (pkg: string, options?: AddOptions) {
       const dir = directory(pkg)
       const name = (() => {
         try {
@@ -121,15 +168,28 @@ const layer = Layer.effect(
           return pkg
         }
       })()
+      const modulePath = path.join(dir, "node_modules", name)
 
-      if (yield* afs.existsSafe(path.join(dir, "node_modules", name))) {
-        return resolveEntryPoint(name, path.join(dir, "node_modules", name))
+      if (yield* afs.existsSafe(modulePath)) {
+        if (!options?.refresh && !isMutableRegistrySpec(pkg)) return resolveEntryPoint(name, modulePath)
+        if (!options?.refresh) {
+          const installed = yield* readInstalledVersion(dir, name)
+          const latest = yield* fetchLatestVersion(dir, name)
+          if (!latest || (installed && installed === latest)) return resolveEntryPoint(name, modulePath)
+        }
+        return yield* reify({ dir, add: [pkg] }).pipe(
+          Effect.map((tree) => {
+            const first = tree.edgesOut.values().next().value?.to
+            return first ? resolveEntryPoint(first.name, first.path) : resolveEntryPoint(name, modulePath)
+          }),
+          Effect.catch(() => Effect.succeed(resolveEntryPoint(name, modulePath))),
+        )
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
       const first = tree.edgesOut.values().next().value?.to
       if (!first) {
-        const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))
+        const result = resolveEntryPoint(name, modulePath)
         if (result.entrypoint) return result
         return yield* new InstallFailedError({ add: [pkg], dir })
       }

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -35,7 +35,53 @@ describe("Npm.sanitize", () => {
   })
 })
 
+describe("Npm.normalizeRegistrySpec", () => {
+  test("appends @latest to bare registry names", () => {
+    expect(Npm.normalizeRegistrySpec("acme")).toBe("acme@latest")
+    expect(Npm.normalizeRegistrySpec("@opencode/acme")).toBe("@opencode/acme@latest")
+  })
+
+  test("leaves specs with explicit versions unchanged", () => {
+    expect(Npm.normalizeRegistrySpec("acme@latest")).toBe("acme@latest")
+    expect(Npm.normalizeRegistrySpec("acme@^1.0.0")).toBe("acme@^1.0.0")
+    expect(Npm.normalizeRegistrySpec("acme@1.2.3")).toBe("acme@1.2.3")
+    expect(Npm.normalizeRegistrySpec("acme@beta")).toBe("acme@beta")
+  })
+
+  test("leaves non-registry and invalid specs unchanged", () => {
+    expect(Npm.normalizeRegistrySpec(`acme@file:${path.join("/tmp", "acme")}`)).toBe(`acme@file:${path.join("/tmp", "acme")}`)
+    expect(Npm.normalizeRegistrySpec("acme@git+https://github.com/opencode/acme.git")).toBe("acme@git+https://github.com/opencode/acme.git")
+    expect(Npm.normalizeRegistrySpec("alias@npm:other@latest")).toBe("alias@npm:other@latest")
+    expect(Npm.normalizeRegistrySpec("alias@npm:other@1.0.0")).toBe("alias@npm:other@1.0.0")
+    expect(Npm.normalizeRegistrySpec("not a valid spec!!!")).toBe("not a valid spec!!!")
+  })
+})
+
+describe("Npm.isMutableRegistrySpec", () => {
+  test("treats registry tags, ranges, and mutable aliases as mutable", () => {
+    expect(Npm.isMutableRegistrySpec("acme@latest")).toBe(true)
+    expect(Npm.isMutableRegistrySpec("acme@beta")).toBe(true)
+    expect(Npm.isMutableRegistrySpec("acme@^1.0.0")).toBe(true)
+    expect(Npm.isMutableRegistrySpec("@opencode/acme@latest")).toBe(true)
+    expect(Npm.isMutableRegistrySpec("acme@npm:other@latest")).toBe(true)
+    expect(Npm.isMutableRegistrySpec("acme")).toBe(true)
+  })
+
+  test("treats pinned versions and non-registry specs as immutable", () => {
+    expect(Npm.isMutableRegistrySpec("acme@1.2.3")).toBe(false)
+    expect(Npm.isMutableRegistrySpec("acme@git+https://github.com/opencode/acme.git")).toBe(false)
+    expect(Npm.isMutableRegistrySpec(`acme@file:${path.join("/tmp", "acme")}`)).toBe(false)
+    expect(Npm.isMutableRegistrySpec("acme@npm:other@1.0.0")).toBe(false)
+    expect(Npm.isMutableRegistrySpec("not a valid spec!!!")).toBe(false)
+  })
+})
+
 describe("Npm.add", () => {
+  const add = (spec: string, cache: string, options?: Npm.AddOptions) =>
+    Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      return yield* npm.add(spec, options)
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(cache)), Effect.runPromise)
   test("reifies when package cache directory exists without the package installed", async () => {
     await using tmp = await tmpdir()
     await fs.mkdir(path.join(tmp.path, "fixture-provider"))
@@ -48,12 +94,160 @@ describe("Npm.add", () => {
     const spec = `fixture-provider@file:${path.join(tmp.path, "fixture-provider")}`
     await fs.mkdir(path.join(tmp.path, "cache", "packages", Npm.sanitize(spec)), { recursive: true })
 
-    const entry = await Effect.gen(function* () {
-      const npm = yield* Npm.Service
-      return yield* npm.add(spec)
-    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "cache"))), Effect.runPromise)
+    const entry = await add(spec, path.join(tmp.path, "cache"))
 
     expect(entry.entrypoint).toBeDefined()
+  })
+
+  test("keeps the cache for pinned file specs without touching the lockfile", async () => {
+    await using tmp = await tmpdir()
+    const cache = path.join(tmp.path, "cache")
+    const source = path.join(tmp.path, "fixture-provider")
+    const spec = `fixture-provider@file:${source}`
+    const dir = path.join(cache, "packages", Npm.sanitize(spec))
+    const cached = path.join(dir, "node_modules", "fixture-provider")
+    const lockfile = path.join(dir, "package-lock.json")
+
+    await fs.mkdir(source, { recursive: true })
+    await writePackage(source, { name: "fixture-provider", version: "1.0.0", main: "index.js" })
+    await Bun.write(path.join(source, "index.js"), "export const fixture = true\n")
+    await fs.mkdir(cached, { recursive: true })
+    await writePackage(cached, { name: "fixture-provider", version: "1.0.0", main: "index.js" })
+    await Bun.write(path.join(cached, "index.js"), "export const cached = true\n")
+    await Bun.write(lockfile, "{}")
+
+    const entry = await add(spec, cache)
+    expect(entry.entrypoint).toBeDefined()
+    expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("1.0.0")
+    expect(await Bun.file(lockfile).exists()).toBe(true)
+  })
+
+  test("falls back to the cached install without deleting the lockfile when refresh fails", async () => {
+    await using tmp = await tmpdir()
+    const cache = path.join(tmp.path, "cache")
+    const spec = "fixture-provider@latest"
+    const name = "fixture-provider"
+    const dir = path.join(cache, "packages", Npm.sanitize(spec))
+    const cached = path.join(dir, "node_modules", name)
+    const lockfile = path.join(dir, "package-lock.json")
+
+    await fs.mkdir(cached, { recursive: true })
+    await writePackage(cached, { name, version: "1.0.0", main: "index.js" })
+    await Bun.write(path.join(cached, "index.js"), "export const cached = true\n")
+    await writePackage(dir, { dependencies: { [name]: "1.0.0" } })
+    await Bun.write(lockfile, "{}")
+
+    const registry = Bun.serve({
+      port: 0,
+      fetch: () => new Response("registry unavailable", { status: 503 }),
+    })
+    await Bun.write(path.join(dir, ".npmrc"), `registry=${registry.url.href}\nfetch-retries=0\n`)
+    try {
+      const entry = await add(spec, cache, { refresh: true })
+      expect(entry.entrypoint).toBeDefined()
+      expect(await Bun.file(lockfile).exists()).toBe(true)
+      expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("1.0.0")
+    } finally {
+      await registry.stop(true)
+    }
+  })
+
+  test("forces a cache refresh when the refresh option is set", async () => {
+    await using tmp = await tmpdir()
+    const cache = path.join(tmp.path, "cache")
+    const source = path.join(tmp.path, "fixture-provider")
+    const spec = `fixture-provider@file:${source}`
+    const dir = path.join(cache, "packages", Npm.sanitize(spec))
+    const cached = path.join(dir, "node_modules", "fixture-provider")
+    const lockfile = path.join(dir, "package-lock.json")
+
+    await fs.mkdir(source, { recursive: true })
+    await writePackage(source, { name: "fixture-provider", version: "2.0.0", main: "index.js" })
+    await Bun.write(path.join(source, "index.js"), "export const v = 2\n")
+    await fs.mkdir(cached, { recursive: true })
+    await writePackage(cached, { name: "fixture-provider", version: "1.0.0", main: "index.js" })
+    await Bun.write(path.join(cached, "index.js"), "export const cached = true\n")
+    await Bun.write(lockfile, "{}")
+
+    await add(spec, cache)
+    expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("1.0.0")
+
+    const entry = await add(spec, cache, { refresh: true })
+    expect(entry.entrypoint).toBeDefined()
+    expect(await Bun.file(lockfile).exists()).toBe(true)
+    expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("2.0.0")
+  })
+
+  test("skips reify when the installed version matches the latest dist-tag", async () => {
+    await using tmp = await tmpdir()
+    const cache = path.join(tmp.path, "cache")
+    const spec = "fixture-provider@latest"
+    const name = "fixture-provider"
+    const dir = path.join(cache, "packages", Npm.sanitize(spec))
+    const cached = path.join(dir, "node_modules", name)
+    const lockfile = path.join(dir, "package-lock.json")
+
+    await fs.mkdir(cached, { recursive: true })
+    await writePackage(cached, { name, version: "1.0.0", main: "index.js" })
+    await Bun.write(path.join(cached, "index.js"), "export const cached = true\n")
+    await Bun.write(lockfile, "{}")
+
+    let packumentRequests = 0
+    const registry = Bun.serve({
+      port: 0,
+      fetch: (request) => {
+        const url = new URL(request.url)
+        if (url.pathname.endsWith("/dist-tags")) return Response.json({ latest: "1.0.0" })
+        packumentRequests++
+        return new Response("not found", { status: 404 })
+      },
+    })
+    await Bun.write(path.join(dir, ".npmrc"), `registry=${registry.url.href}\nfetch-retries=0\n`)
+    try {
+      const entry = await add(spec, cache)
+      expect(entry.entrypoint).toBeDefined()
+      expect(packumentRequests).toBe(0)
+      expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("1.0.0")
+      expect(await Bun.file(lockfile).exists()).toBe(true)
+    } finally {
+      await registry.stop(true)
+    }
+  })
+
+  test("reifies when the installed version differs from the latest dist-tag", async () => {
+    await using tmp = await tmpdir()
+    const cache = path.join(tmp.path, "cache")
+    const spec = "fixture-provider@latest"
+    const name = "fixture-provider"
+    const dir = path.join(cache, "packages", Npm.sanitize(spec))
+    const cached = path.join(dir, "node_modules", name)
+    const lockfile = path.join(dir, "package-lock.json")
+
+    await fs.mkdir(cached, { recursive: true })
+    await writePackage(cached, { name, version: "1.0.0", main: "index.js" })
+    await Bun.write(path.join(cached, "index.js"), "export const cached = true\n")
+    await Bun.write(lockfile, "{}")
+
+    let packumentRequests = 0
+    const registry = Bun.serve({
+      port: 0,
+      fetch: (request) => {
+        const url = new URL(request.url)
+        if (url.pathname.endsWith("/dist-tags")) return Response.json({ latest: "2.0.0" })
+        packumentRequests++
+        return new Response("registry unavailable", { status: 503 })
+      },
+    })
+    await Bun.write(path.join(dir, ".npmrc"), `registry=${registry.url.href}\nfetch-retries=0\n`)
+    try {
+      const entry = await add(spec, cache)
+      expect(entry.entrypoint).toBeDefined()
+      expect(packumentRequests).toBeGreaterThan(0)
+      expect(JSON.parse(await Bun.file(path.join(cached, "package.json")).text()).version).toBe("1.0.0")
+      expect(await Bun.file(lockfile).exists()).toBe(true)
+    } finally {
+      await registry.stop(true)
+    }
   })
 })
 

--- a/packages/opencode/src/plugin/shared.ts
+++ b/packages/opencode/src/plugin/shared.ts
@@ -206,8 +206,7 @@ export async function checkPluginCompatibility(target: string, opencodeVersion: 
 
 export async function resolvePluginTarget(spec: string) {
   if (isPathPluginSpec(spec)) return resolvePathPluginTarget(spec)
-  const hit = parse(spec)
-  const pkg = hit?.name && hit.raw === hit.name ? `${hit.name}@latest` : spec
+  const pkg = Npm.normalizeRegistrySpec(spec)
   const result = await Npm.add(pkg)
   return result.directory
 }


### PR DESCRIPTION
### Issue for this PR

Closes #25293

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins declared with a floating `@latest` spec were pinned to the first installed version: `Npm.add` short-circuited on a directory-existence check (`afs.existsSafe`) and never re-resolved the dist-tag, so newer registry releases were silently ignored.

Two related problems are fixed:

1. **Cache directory mismatch.** The startup plugin loader (`external.ts`) passed config specs raw, while the CLI resolver (`resolvePluginTarget`) appended `@latest` to bare names. The same plugin ended up in two cache directories, so updates via one path were invisible to the other. A shared `Npm.normalizeRegistrySpec` now applies the same normalization in both paths.

2. **No version re-check on load.** For mutable registry specs (`@latest`, ranges, bare names), `Npm.add` now reads the installed `package.json` version, fetches `dist-tags.latest` from the registry (19-byte endpoint, 5s `AbortSignal.timeout`), and only runs `arborist.reify()` when the registry version differs from the installed one. When versions match, the cached install is returned without any `reify` or packument downloads. Pinned versions, aliases, and file/git/remote specs skip the check entirely. `AddOptions.refresh` forces a re-resolve for pinned/file specs.

`audit: false` is passed to the Arborist constructor so `reify` does not trigger npm's security-audit POST (which added ~20s of startup latency per refresh). Any registry failure collapses to `undefined` and keeps the cached install; if the refresh `reify` itself fails, `add` falls back to the still-present cached entry point instead of throwing.

### How did you verify your code works?

- `bun typecheck` (turbo, 30 packages): clean.
- `packages/core` full suite: 1083 pass, including new tests for `normalizeRegistrySpec` (bare names, explicit versions, non-registry specs), `isMutableRegistrySpec` (mutable vs immutable), a version-gated refresh that skips `reify` when installed matches `latest` and attempts it when they differ, a forced refresh that updates a cached file spec, and a fallback that returns the cached install when a `@latest` `reify` fails.
- `oxlint` on changed files: 0 errors.

### Screenshots / recordings

N/A (core only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
