### PR TITLE
fix(core): authorize relative external paths

### DIFF
--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -12,8 +12,8 @@ export const Kind = Schema.Literals(["file", "directory"])
 export type Kind = typeof Kind.Type
 
 /**
- * Mutation paths do not accept project references. Relative paths must stay
- * inside the active Location. Absolute paths outside it require separate
+ * Mutation paths do not accept project references. Relative paths resolve
+ * from the active Location. Paths outside it require separate
  * `external_directory` approval.
  */
 export const ResolveInput = Schema.Struct({
@@ -25,7 +25,7 @@ export type ResolveInput = typeof ResolveInput.Type
 
 export class PathError extends Schema.TaggedErrorClass<PathError>()("LocationMutation.PathError", {
   path: Schema.String,
-  reason: Schema.Literals(["relative_escape", "location_escape", "non_directory_ancestor"]),
+  reason: Schema.Literals(["location_escape", "non_directory_ancestor"]),
 }) {}
 
 export interface ExternalDirectoryAuthorization {
@@ -53,9 +53,9 @@ export interface Target {
 
 export interface Interface {
   /**
-   * Resolve a path and derive its permission resources. Relative paths must
-   * stay inside the Location. Absolute paths outside it require separate
-   * `external_directory` approval. This does not approve the mutation.
+   * Resolve a path and derive its permission resources. Relative paths resolve
+   * from the Location. Paths outside it require separate `external_directory`
+   * approval. This does not approve the mutation.
    */
   readonly resolve: (input: ResolveInput) => Effect.Effect<Target, PathError | FSUtil.Error>
 }
@@ -120,10 +120,8 @@ const layer = Layer.effect(
     })
 
     const resolve = Effect.fn("LocationMutation.resolve")(function* (input: ResolveInput) {
-      const relative = !path.isAbsolute(input.path)
       const absolute = path.resolve(location.directory, input.path)
       const lexicallyInternal = FSUtil.contains(location.directory, absolute)
-      if (relative && !lexicallyInternal) return yield* new PathError({ path: input.path, reason: "relative_escape" })
 
       const resolved = yield* resolvePath(absolute)
       if (lexicallyInternal && !FSUtil.contains(locationRoot, resolved.canonical)) {
@@ -146,10 +144,7 @@ const layer = Layer.effect(
               directory: externalDirectory,
               resource: externalResource,
               save: slash(
-                path.join(
-                  (yield* Project.root(fs, AbsolutePath.make(externalDirectory))) ?? externalDirectory,
-                  "*",
-                ),
+                path.join((yield* Project.root(fs, AbsolutePath.make(externalDirectory))) ?? externalDirectory, "*"),
               ),
             }
           : undefined,

--- a/packages/core/test/location-mutation.test.ts
+++ b/packages/core/test/location-mutation.test.ts
@@ -60,11 +60,19 @@ describe("LocationMutation", () => {
     ),
   )
 
-  it.live("rejects a relative lexical escape instead of promoting it to external authority", () =>
+  it.live("requires external-directory authorization for a relative lexical escape", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
-        const error = yield* Effect.flip((yield* LocationMutation.Service).resolve({ path: "../outside.txt" }))
-        expect(error).toMatchObject({ _tag: "LocationMutation.PathError", reason: "relative_escape" })
+        const target = yield* (yield* LocationMutation.Service).resolve({ path: "../outside.txt" })
+        const root = yield* Effect.promise(() => fs.realpath(path.dirname(directory)))
+        expect(target).toMatchObject({
+          canonical: path.join(root, "outside.txt"),
+          resource: path.join(root, "outside.txt").replaceAll("\\", "/"),
+        })
+        expect(target.externalDirectory).toMatchObject({
+          directory: root,
+          resource: path.join(root, "*").replaceAll("\\", "/"),
+        })
       }).pipe(provide(directory)),
     ),
   )

--- a/packages/core/test/tool-patch.test.ts
+++ b/packages/core/test/tool-patch.test.ts
@@ -277,6 +277,38 @@ describe("PatchTool", () => {
     ),
   )
 
+  it.live("approves a relative external target before reading update content", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),
+      ([active, outside]) => {
+        reset()
+        const target = path.join(outside.path, "external.txt")
+        const relative = path.relative(active.path, target)
+        return Effect.promise(() => fs.writeFile(target, "before\n")).pipe(
+          Effect.andThen(
+            withTool(active.path, (registry) =>
+              Effect.gen(function* () {
+                expect(
+                  yield* executeTool(
+                    registry,
+                    call(`*** Begin Patch\n*** Update File: ${relative}\n@@\n-before\n+after\n*** End Patch`),
+                  ),
+                ).toMatchObject({ type: "text" })
+                expect(assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
+                expect(readsBeforeEditApproval).toBe(0)
+                expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after\n")
+              }),
+            ),
+          ),
+        )
+      },
+      ([active, outside]) =>
+        Effect.promise(() =>
+          Promise.all([active[Symbol.asyncDispose](), outside[Symbol.asyncDispose]()]).then(() => undefined),
+        ),
+    ),
+  )
+
   it.live("approves one external directory scope for multiple files under the same parent", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),

--- a/specs/v2/schema-changelog.md
+++ b/specs/v2/schema-changelog.md
@@ -385,8 +385,8 @@ Affected schema:
 
 Change:
 
-- Resolve relative mutation paths within the active Location.
-- Accept absolute internal paths and require explicit `external_directory` approval before leaf approval for external absolute paths.
+- Resolve relative mutation paths from the active Location.
+- Require explicit `external_directory` approval before leaf approval for external paths.
 - Keep named references read-oriented and reject them for mutation.
 - Revalidate path authority immediately before write mechanics.
 


### PR DESCRIPTION
## What

Restore V1-compatible handling for relative paths that resolve outside the active Location. Tools now route those targets through `external_directory` authorization instead of rejecting them before permission evaluation.

## Before / After

**Before:** A patch targeting `../sibling/file.ts` failed before requesting permission and surfaced `Unable to apply patch at patch` internally (and a blank durable error in the reported session).

**After:** The path resolves to its canonical external target, requests `external_directory` before the leaf `edit` permission, and reads or mutates the target only after both approvals.

## How

- `packages/core/src/location-mutation.ts` lets explicit lexical relative escapes continue through the existing external-target authorization path while retaining rejection for hidden symlink escapes.
- `packages/core/test/location-mutation.test.ts` locks down canonical external authorization for `../outside.txt`.
- `packages/core/test/tool-patch.test.ts` verifies the user-visible regression: `external_directory` then `edit`, no pre-approval read, and a successful patch.
- `specs/v2/schema-changelog.md` documents that relative paths resolve from the active Location and all external targets require authorization.

## Scope

This addresses the relative external-path failure reported in #37687. It does not address malformed or truncated OpenAI Responses tool arguments, tracked separately in #36766 and #37159.

## Testing

- `bun run test test/tool-patch.test.ts test/location-mutation.test.ts` (20 passed)
- `bun run typecheck` in `packages/core`
- `bun run lint -- packages/core/src/location-mutation.ts packages/core/test/location-mutation.test.ts packages/core/test/tool-patch.test.ts`
- Push hook: full 39-package typecheck (32 tasks passed)
- Full Core suite: 1,338 passed, 6 skipped, 2 unrelated failures. `location-layer.test.ts` has a stale expected catalog missing `execute`; `config/plugin.test.ts` observes the user's global cmux plugins.
- Repository-wide Effect-pattern scan also reports seven pre-existing violations in unrelated files.

## Flow

```mermaid
flowchart TD
  A[Resolve path from active Location] --> B{Canonical target external?}
  B -- No --> C[Request leaf permission]
  B -- Yes --> D[Request external_directory]
  D --> C
  C --> E[Read and mutate target]
```
