### PR TITLE
docs: add opencode-plugin-office to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-plugin-office](https://github.com/bobaba99/opencode-office)                              | Word (.docx) and PowerPoint (.pptx) tools — read, anchored edits, create, render to PNG            |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — adds a community plugin to the ecosystem docs list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the community plugins table in `packages/web/src/content/docs/ecosystem.mdx` for [opencode-plugin-office](https://github.com/bobaba99/opencode-office), a plugin that gives opencode agents Word (.docx) and PowerPoint (.pptx) tools: structured read, anchor-validated edits with atomic saves, document/deck creation, and LibreOffice rendering. The row follows the existing table format and links to the plugin repo, same as the other entries.

### How did you verify your code works?

Checked the row renders consistently with the surrounding table markdown. The plugin itself is developed and tested in its own repo (99 tests, including an agent-level eval battery) and runs against opencode 1.18.3.

### Screenshots / recordings

N/A — one markdown table row in the docs.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR