### PR TITLE
feat(opencode): use adaptive thinking effort for kimi family on anthr…

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1175,7 +1175,7 @@ export function options(input: {
 
   // Moonshot's Anthropic-compatible API uses adaptive effort rather than token budgets.
   if (
-    input.model.api.npm === "@ai-sdk/anthropic" &&
+    ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(input.model.api.npm) &&
     (input.model.providerID === "moonshotai" || modelId.includes("kimi")) &&
     input.model.capabilities.reasoning
   ) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -26,6 +26,23 @@ export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
 }
 
+// Kimi family endpoints are Moonshot's Anthropic-compatible API
+// (api.moonshot.ai/cn, api.kimi.com) and model families (kimi-*, moonshot-*).
+// Detection drives endpoint-specific request shaping (e.g. adaptive thinking
+// effort), so it matches on provider, model, and endpoint URL alike.
+export function isKimiFamily(model: Provider.Model): boolean {
+  const providerID = model.providerID?.toLowerCase() ?? ""
+  if (providerID.includes("kimi") || providerID.includes("moonshot")) return true
+  const apiID = model.api.id?.toLowerCase() ?? ""
+  if (apiID.includes("kimi") || apiID.includes("moonshot")) return true
+  const modelID = model.id?.toLowerCase() ?? ""
+  if (modelID.includes("kimi") || modelID.includes("moonshot")) return true
+  const url = model.api.url?.toLowerCase() ?? ""
+  return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) =>
+    url.includes(host),
+  )
+}
+
 // Maps npm package to the key the AI SDK expects for providerOptions
 function sdkKey(npm: string): string | undefined {
   switch (npm) {
@@ -707,6 +724,17 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       max: { effort: "max" },
     }
   }
+  // Kimi family models on the Anthropic protocol implement the adaptive
+  // thinking contract (thinking.type="adaptive" + output_config.effort), so
+  // expose effort levels instead of budget-token variants.
+  if (isKimiFamily(model) && model.api.npm === "@ai-sdk/anthropic") {
+    return Object.fromEntries(
+      ["low", "medium", "high", "xhigh", "max"].flatMap((effort) => {
+        const settings = anthropicEffort(model, effort)
+        return settings ? [[effort, settings]] : []
+      }),
+    )
+  }
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||
@@ -1173,15 +1201,19 @@ export function options(input: {
     result["thinking"] = { type: "adaptive" }
   }
 
-  // Enable thinking by default for kimi models using anthropic SDK
+  // Enable adaptive thinking by default for kimi family models using the
+  // anthropic SDK. Moonshot's Anthropic-compatible endpoints implement the
+  // adaptive contract (thinking.type="adaptive" + output_config.effort,
+  // including xhigh and the display field), so effort is passed instead of
+  // budget tokens. Always request "summarized" so reasoning text is returned
+  // and can round-trip on replayed messages.
   if (
     (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
-    (modelId.includes("k2p") || modelId.includes("kimi-k2.") || modelId.includes("kimi-k2p"))
+    isKimiFamily(input.model) &&
+    input.model.capabilities.reasoning
   ) {
-    result["thinking"] = {
-      type: "enabled",
-      budgetTokens: Math.min(16_000, Math.floor(input.model.limit.output / 2 - 1)),
-    }
+    result["thinking"] = { type: "adaptive", display: "summarized" }
+    result["effort"] = "high"
   }
 
   // Enable thinking for reasoning models on alibaba-cn (DashScope).
@@ -1705,6 +1737,15 @@ function reasoningEffort(model: Provider.Model, effort: string) {
 
 function anthropicEffort(model: Provider.Model, effort: string) {
   if (["opus-4-5", "opus-4.5"].some((value) => model.api.id.includes(value))) return { effort }
+  // Kimi family endpoints implement the adaptive contract (verified against
+  // api.moonshot.cn/anthropic); always request "summarized" so reasoning text
+  // is returned and can round-trip on replayed messages.
+  if (isKimiFamily(model)) {
+    return {
+      thinking: { type: "adaptive", display: "summarized" },
+      effort,
+    }
+  }
   if (!anthropicAdaptiveEfforts(model.api.id)) return
   return {
     thinking: {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -27,10 +27,17 @@ export function sanitizeSurrogates(content: string) {
 }
 
 function isKimiFamily(model: Provider.Model) {
-  return [model.providerID, model.api.id].some((id) => {
-    const value = id.toLowerCase()
-    return value.includes("kimi") || value.includes("moonshot")
-  })
+  if (
+    [model.providerID, model.api.id].some((id) => {
+      const value = id.toLowerCase()
+      return value.includes("kimi") || value.includes("moonshot")
+    })
+  )
+    return true
+  const url = model.api.url.toLowerCase()
+  return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) =>
+    url.includes(host),
+  )
 }
 
 // Maps npm package to the key the AI SDK expects for providerOptions

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -26,21 +26,11 @@ export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
 }
 
-// Kimi family endpoints are Moonshot's Anthropic-compatible API
-// (api.moonshot.ai/cn, api.kimi.com) and model families (kimi-*, moonshot-*).
-// Detection drives endpoint-specific request shaping, so match provider,
-// model, and endpoint URL alike.
 function isKimiFamily(model: Provider.Model) {
-  const providerID = model.providerID?.toLowerCase() ?? ""
-  if (providerID.includes("kimi") || providerID.includes("moonshot")) return true
-  const apiID = model.api.id?.toLowerCase() ?? ""
-  if (apiID.includes("kimi") || apiID.includes("moonshot")) return true
-  const modelID = model.id?.toLowerCase() ?? ""
-  if (modelID.includes("kimi") || modelID.includes("moonshot")) return true
-  const url = model.api.url?.toLowerCase() ?? ""
-  return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) =>
-    url.includes(host),
-  )
+  return [model.providerID, model.api.id].some((id) => {
+    const value = id.toLowerCase()
+    return value.includes("kimi") || value.includes("moonshot")
+  })
 }
 
 // Maps npm package to the key the AI SDK expects for providerOptions
@@ -727,10 +717,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   // Kimi's Anthropic-compatible transports implement adaptive thinking effort.
   if (isKimiFamily(model) && ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
     return Object.fromEntries(
-      ["low", "medium", "high", "xhigh", "max"].flatMap((effort) => {
-        const settings = anthropicEffort(model, effort)
-        return settings ? [[effort, settings]] : []
-      }),
+      ["low", "medium", "high", "xhigh", "max"].map((effort) => [
+        effort,
+        { thinking: { type: "adaptive", display: "summarized" }, effort },
+      ]),
     )
   }
   if (

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -26,6 +26,14 @@ export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
 }
 
+function isKimiFamily(model: Provider.Model) {
+  const ids = [model.providerID, model.api.id, model.id].map((value) => value.toLowerCase())
+  if (ids.some((id) => id.includes("kimi") || id.includes("moonshot"))) return true
+  return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) =>
+    model.api.url.toLowerCase().includes(host),
+  )
+}
+
 // Maps npm package to the key the AI SDK expects for providerOptions
 function sdkKey(npm: string): string | undefined {
   switch (npm) {
@@ -707,6 +715,11 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       max: { effort: "max" },
     }
   }
+  if (isKimiFamily(model) && ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
+    return Object.fromEntries(
+      ["low", "medium", "high", "xhigh", "max"].map((effort) => [effort, anthropicEffort(model, effort)]),
+    )
+  }
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||
@@ -1176,7 +1189,7 @@ export function options(input: {
   // Moonshot's Anthropic-compatible API uses adaptive effort rather than token budgets.
   if (
     ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(input.model.api.npm) &&
-    (input.model.providerID === "moonshotai" || modelId.includes("kimi")) &&
+    isKimiFamily(input.model) &&
     input.model.capabilities.reasoning
   ) {
     result["thinking"] = { type: "adaptive", display: "summarized" }
@@ -1704,6 +1717,7 @@ function reasoningEffort(model: Provider.Model, effort: string) {
 
 function anthropicEffort(model: Provider.Model, effort: string) {
   if (["opus-4-5", "opus-4.5"].some((value) => model.api.id.includes(value))) return { effort }
+  if (isKimiFamily(model)) return { thinking: { type: "adaptive", display: "summarized" }, effort }
   if (!anthropicAdaptiveEfforts(model.api.id)) return
   return {
     thinking: {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -26,23 +26,6 @@ export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
 }
 
-// Kimi family endpoints are Moonshot's Anthropic-compatible API
-// (api.moonshot.ai/cn, api.kimi.com) and model families (kimi-*, moonshot-*).
-// Detection drives endpoint-specific request shaping (e.g. adaptive thinking
-// effort), so it matches on provider, model, and endpoint URL alike.
-export function isKimiFamily(model: Provider.Model): boolean {
-  const providerID = model.providerID?.toLowerCase() ?? ""
-  if (providerID.includes("kimi") || providerID.includes("moonshot")) return true
-  const apiID = model.api.id?.toLowerCase() ?? ""
-  if (apiID.includes("kimi") || apiID.includes("moonshot")) return true
-  const modelID = model.id?.toLowerCase() ?? ""
-  if (modelID.includes("kimi") || modelID.includes("moonshot")) return true
-  const url = model.api.url?.toLowerCase() ?? ""
-  return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) =>
-    url.includes(host),
-  )
-}
-
 // Maps npm package to the key the AI SDK expects for providerOptions
 function sdkKey(npm: string): string | undefined {
   switch (npm) {
@@ -724,17 +707,6 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       max: { effort: "max" },
     }
   }
-  // Kimi family models on the Anthropic protocol implement the adaptive
-  // thinking contract (thinking.type="adaptive" + output_config.effort), so
-  // expose effort levels instead of budget-token variants.
-  if (isKimiFamily(model) && model.api.npm === "@ai-sdk/anthropic") {
-    return Object.fromEntries(
-      ["low", "medium", "high", "xhigh", "max"].flatMap((effort) => {
-        const settings = anthropicEffort(model, effort)
-        return settings ? [[effort, settings]] : []
-      }),
-    )
-  }
   if (
     id.includes("deepseek-chat") ||
     id.includes("deepseek-reasoner") ||
@@ -1201,15 +1173,10 @@ export function options(input: {
     result["thinking"] = { type: "adaptive" }
   }
 
-  // Enable adaptive thinking by default for kimi family models using the
-  // anthropic SDK. Moonshot's Anthropic-compatible endpoints implement the
-  // adaptive contract (thinking.type="adaptive" + output_config.effort,
-  // including xhigh and the display field), so effort is passed instead of
-  // budget tokens. Always request "summarized" so reasoning text is returned
-  // and can round-trip on replayed messages.
+  // Moonshot's Anthropic-compatible API uses adaptive effort rather than token budgets.
   if (
-    (input.model.api.npm === "@ai-sdk/anthropic" || input.model.api.npm === "@ai-sdk/google-vertex/anthropic") &&
-    isKimiFamily(input.model) &&
+    input.model.api.npm === "@ai-sdk/anthropic" &&
+    (input.model.providerID === "moonshotai" || modelId.includes("kimi")) &&
     input.model.capabilities.reasoning
   ) {
     result["thinking"] = { type: "adaptive", display: "summarized" }
@@ -1737,15 +1704,6 @@ function reasoningEffort(model: Provider.Model, effort: string) {
 
 function anthropicEffort(model: Provider.Model, effort: string) {
   if (["opus-4-5", "opus-4.5"].some((value) => model.api.id.includes(value))) return { effort }
-  // Kimi family endpoints implement the adaptive contract (verified against
-  // api.moonshot.cn/anthropic); always request "summarized" so reasoning text
-  // is returned and can round-trip on replayed messages.
-  if (isKimiFamily(model)) {
-    return {
-      thinking: { type: "adaptive", display: "summarized" },
-      effort,
-    }
-  }
   if (!anthropicAdaptiveEfforts(model.api.id)) return
   return {
     thinking: {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -717,7 +717,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   }
   if (isKimiFamily(model) && ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
     return Object.fromEntries(
-      ["low", "medium", "high", "xhigh", "max"].map((effort) => [effort, anthropicEffort(model, effort)]),
+      ["low", "medium", "high", "xhigh", "max"].flatMap((effort) => {
+        const settings = anthropicEffort(model, effort)
+        return settings ? [[effort, settings]] : []
+      }),
     )
   }
   if (

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -27,10 +27,10 @@ export function sanitizeSurrogates(content: string) {
 }
 
 function isKimiFamily(model: Provider.Model) {
-  const ids = [model.providerID, model.api.id, model.id].map((value) => value.toLowerCase())
+  const ids = [model.providerID, model.api.id, model.id].map((value) => value?.toLowerCase() ?? "")
   if (ids.some((id) => id.includes("kimi") || id.includes("moonshot"))) return true
   return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) =>
-    model.api.url.toLowerCase().includes(host),
+    (model.api.url?.toLowerCase() ?? "").includes(host),
   )
 }
 

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -26,11 +26,20 @@ export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
 }
 
+// Kimi family endpoints are Moonshot's Anthropic-compatible API
+// (api.moonshot.ai/cn, api.kimi.com) and model families (kimi-*, moonshot-*).
+// Detection drives endpoint-specific request shaping, so match provider,
+// model, and endpoint URL alike.
 function isKimiFamily(model: Provider.Model) {
-  const ids = [model.providerID, model.api.id, model.id].map((value) => value?.toLowerCase() ?? "")
-  if (ids.some((id) => id.includes("kimi") || id.includes("moonshot"))) return true
+  const providerID = model.providerID?.toLowerCase() ?? ""
+  if (providerID.includes("kimi") || providerID.includes("moonshot")) return true
+  const apiID = model.api.id?.toLowerCase() ?? ""
+  if (apiID.includes("kimi") || apiID.includes("moonshot")) return true
+  const modelID = model.id?.toLowerCase() ?? ""
+  if (modelID.includes("kimi") || modelID.includes("moonshot")) return true
+  const url = model.api.url?.toLowerCase() ?? ""
   return ["api.kimi.com", "api.moonshot.ai", "api.moonshot.cn", "api.moonshotai.cn"].some((host) =>
-    (model.api.url?.toLowerCase() ?? "").includes(host),
+    url.includes(host),
   )
 }
 
@@ -715,6 +724,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
       max: { effort: "max" },
     }
   }
+  // Kimi's Anthropic-compatible transports implement adaptive thinking effort.
   if (isKimiFamily(model) && ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)) {
     return Object.fromEntries(
       ["low", "medium", "high", "xhigh", "max"].flatMap((effort) => {
@@ -1190,6 +1200,7 @@ export function options(input: {
   }
 
   // Moonshot's Anthropic-compatible API uses adaptive effort rather than token budgets.
+  // Request summaries so thinking content survives replay on subsequent turns.
   if (
     ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(input.model.api.npm) &&
     isKimiFamily(input.model) &&
@@ -1720,6 +1731,7 @@ function reasoningEffort(model: Provider.Model, effort: string) {
 
 function anthropicEffort(model: Provider.Model, effort: string) {
   if (["opus-4-5", "opus-4.5"].some((value) => model.api.id.includes(value))) return { effort }
+  // Kimi defaults to omitting adaptive thinking text unless summarized display is requested.
   if (isKimiFamily(model)) return { thinking: { type: "adaptive", display: "summarized" }, effort }
   if (!anthropicAdaptiveEfforts(model.api.id)) return
   return {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -5172,6 +5172,14 @@ describe("ProviderTransform.options - kimi family adaptive thinking", () => {
     expect(JSON.stringify(result)).not.toContain("budgetTokens")
   })
 
+  test("uses adaptive thinking through Google Vertex Anthropic", () => {
+    const model = createModel()
+    model.api.npm = "@ai-sdk/google-vertex/anthropic"
+    const result = ProviderTransform.options({ model, sessionID: "s1", providerOptions: {} })
+    expect(result.thinking).toEqual({ type: "adaptive", display: "summarized" })
+    expect(result.effort).toBe("high")
+  })
+
   test("does not enable thinking for kimi models without reasoning capability", () => {
     const model = createModel()
     model.capabilities.reasoning = false

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3029,7 +3029,13 @@ describe("ProviderTransform.temperature - Cohere North", () => {
 describe("ProviderTransform.reasoningVariants", () => {
   const model = (reasoning_options: ModelsDev.Model["reasoning_options"]) => ({ reasoning_options }) as ModelsDev.Model
   const target = (npm: string, id = "test-model") =>
-    ({ id, api: { id, npm, url: "" }, capabilities: { reasoning: true }, limit: { output: 64_000 } }) as any
+    ({
+      id,
+      providerID: "test",
+      api: { id, npm, url: "" },
+      capabilities: { reasoning: true },
+      limit: { output: 64_000 },
+    }) as any
 
   test("respects explicitly empty reasoning options", () => {
     expect(ProviderTransform.reasoningVariants(model([]), target("@ai-sdk/openai"))).toEqual({})

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3119,6 +3119,19 @@ describe("ProviderTransform.reasoningVariants", () => {
     ).toEqual({ max: { effort: "max" } })
   })
 
+  test("maps Kimi effort metadata to adaptive thinking", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "effort", values: ["low", "high", "max"] }]),
+        target("@ai-sdk/anthropic", "kimi-k3"),
+      ),
+    ).toEqual({
+      low: { thinking: { type: "adaptive", display: "summarized" }, effort: "low" },
+      high: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      max: { thinking: { type: "adaptive", display: "summarized" }, effort: "max" },
+    })
+  })
+
   test("uses adaptive reasoning config for Anthropic models on Bedrock", () => {
     expect(
       ProviderTransform.reasoningVariants(
@@ -5189,6 +5202,10 @@ describe("ProviderTransform.options - kimi family adaptive thinking", () => {
         ]),
       ),
     )
+
+    const model = createModel()
+    model.api.npm = "@ai-sdk/openai-compatible"
+    expect(ProviderTransform.variants(model)).toEqual({})
   })
 
   test("does not enable thinking for kimi models without reasoning capability", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3119,6 +3119,19 @@ describe("ProviderTransform.reasoningVariants", () => {
     ).toEqual({ max: { effort: "max" } })
   })
 
+  test("maps models.dev effort options to adaptive thinking for kimi family targets", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "effort", values: ["low", "high", "max"] }]),
+        target("@ai-sdk/anthropic", "kimi-k3"),
+      ),
+    ).toEqual({
+      low: { thinking: { type: "adaptive", display: "summarized" }, effort: "low" },
+      high: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      max: { thinking: { type: "adaptive", display: "summarized" }, effort: "max" },
+    })
+  })
+
   test("uses adaptive reasoning config for Anthropic models on Bedrock", () => {
     expect(
       ProviderTransform.reasoningVariants(
@@ -5134,5 +5147,117 @@ describe("ProviderTransform.providerOptions - ai-gateway-provider", () => {
     // which @ai-sdk/openai-compatible never reads, silently dropping reasoningEffort.
     const result = ProviderTransform.providerOptions(createModel(), { reasoningEffort: "high" })
     expect(result).toEqual({ openaiCompatible: { reasoningEffort: "high" } })
+  })
+})
+
+describe("ProviderTransform.options - kimi family adaptive thinking", () => {
+  const createModel = (overrides: Record<string, any> = {}) =>
+    ({
+      id: "moonshotai/kimi-k2-thinking",
+      providerID: "moonshotai",
+      api: {
+        id: "kimi-k2-thinking",
+        url: "https://api.moonshot.ai/anthropic",
+        npm: "@ai-sdk/anthropic",
+      },
+      name: "Kimi K2 Thinking",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+      limit: { context: 262144, output: 262144 },
+      status: "active",
+      options: {},
+      headers: {},
+      ...overrides,
+    }) as any
+
+  test("uses adaptive thinking with effort instead of budget tokens", () => {
+    const result = ProviderTransform.options({ model: createModel(), sessionID: "s1", providerOptions: {} })
+    expect(result.thinking).toEqual({ type: "adaptive", display: "summarized" })
+    expect(result.effort).toBe("high")
+    expect(JSON.stringify(result)).not.toContain("budgetTokens")
+  })
+
+  test("does not enable thinking for kimi models without reasoning capability", () => {
+    const model = createModel()
+    model.capabilities.reasoning = false
+    const result = ProviderTransform.options({ model, sessionID: "s1", providerOptions: {} })
+    expect(result.thinking).toBeUndefined()
+  })
+
+  test("does not set thinking defaults for non-kimi anthropic models", () => {
+    const model = createModel({
+      id: "anthropic/claude-sonnet-4-5",
+      providerID: "anthropic",
+      api: {
+        id: "claude-sonnet-4-5",
+        url: "https://api.anthropic.com",
+        npm: "@ai-sdk/anthropic",
+      },
+    })
+    const result = ProviderTransform.options({ model, sessionID: "s1", providerOptions: {} })
+    expect(result.thinking).toBeUndefined()
+    expect(result.effort).toBeUndefined()
+  })
+
+  test("does not set adaptive thinking for kimi on openai-compatible", () => {
+    const model = createModel()
+    model.api = {
+      id: "kimi-k2-thinking",
+      url: "https://api.moonshot.ai/v1",
+      npm: "@ai-sdk/openai-compatible",
+    }
+    const result = ProviderTransform.options({ model, sessionID: "s1", providerOptions: {} })
+    expect(result.thinking).toBeUndefined()
+  })
+})
+
+describe("ProviderTransform.variants - kimi family adaptive thinking", () => {
+  const createModel = (npm: string) =>
+    ({
+      id: "moonshotai/kimi-k2-thinking",
+      providerID: "moonshotai",
+      api: {
+        id: "kimi-k2-thinking",
+        url: "https://api.moonshot.ai/anthropic",
+        npm,
+      },
+      name: "Kimi K2 Thinking",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: false,
+        toolcall: true,
+        input: { text: true, audio: false, image: false, video: false, pdf: false },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
+      limit: { context: 262144, output: 262144 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  test("exposes effort levels instead of budget variants on the anthropic protocol", () => {
+    const result = ProviderTransform.variants(createModel("@ai-sdk/anthropic"))
+    expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+    for (const effort of Object.keys(result)) {
+      expect(result[effort]).toEqual({
+        thinking: { type: "adaptive", display: "summarized" },
+        effort,
+      })
+    }
+  })
+
+  test("keeps openai-compatible kimi without thinking variants", () => {
+    expect(ProviderTransform.variants(createModel("@ai-sdk/openai-compatible"))).toEqual({})
   })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -5180,6 +5180,17 @@ describe("ProviderTransform.options - kimi family adaptive thinking", () => {
     expect(result.effort).toBe("high")
   })
 
+  test("provides adaptive effort variants without models.dev metadata", () => {
+    expect(ProviderTransform.variants(createModel())).toEqual(
+      Object.fromEntries(
+        ["low", "medium", "high", "xhigh", "max"].map((effort) => [
+          effort,
+          { thinking: { type: "adaptive", display: "summarized" }, effort },
+        ]),
+      ),
+    )
+  })
+
   test("does not enable thinking for kimi models without reasoning capability", () => {
     const model = createModel()
     model.capabilities.reasoning = false

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3119,19 +3119,6 @@ describe("ProviderTransform.reasoningVariants", () => {
     ).toEqual({ max: { effort: "max" } })
   })
 
-  test("maps models.dev effort options to adaptive thinking for kimi family targets", () => {
-    expect(
-      ProviderTransform.reasoningVariants(
-        model([{ type: "effort", values: ["low", "high", "max"] }]),
-        target("@ai-sdk/anthropic", "kimi-k3"),
-      ),
-    ).toEqual({
-      low: { thinking: { type: "adaptive", display: "summarized" }, effort: "low" },
-      high: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
-      max: { thinking: { type: "adaptive", display: "summarized" }, effort: "max" },
-    })
-  })
-
   test("uses adaptive reasoning config for Anthropic models on Bedrock", () => {
     expect(
       ProviderTransform.reasoningVariants(
@@ -5216,48 +5203,5 @@ describe("ProviderTransform.options - kimi family adaptive thinking", () => {
     }
     const result = ProviderTransform.options({ model, sessionID: "s1", providerOptions: {} })
     expect(result.thinking).toBeUndefined()
-  })
-})
-
-describe("ProviderTransform.variants - kimi family adaptive thinking", () => {
-  const createModel = (npm: string) =>
-    ({
-      id: "moonshotai/kimi-k2-thinking",
-      providerID: "moonshotai",
-      api: {
-        id: "kimi-k2-thinking",
-        url: "https://api.moonshot.ai/anthropic",
-        npm,
-      },
-      name: "Kimi K2 Thinking",
-      capabilities: {
-        temperature: true,
-        reasoning: true,
-        attachment: false,
-        toolcall: true,
-        input: { text: true, audio: false, image: false, video: false, pdf: false },
-        output: { text: true, audio: false, image: false, video: false, pdf: false },
-        interleaved: false,
-      },
-      cost: { input: 0.001, output: 0.002, cache: { read: 0.0001, write: 0.0002 } },
-      limit: { context: 262144, output: 262144 },
-      status: "active",
-      options: {},
-      headers: {},
-    }) as any
-
-  test("exposes effort levels instead of budget variants on the anthropic protocol", () => {
-    const result = ProviderTransform.variants(createModel("@ai-sdk/anthropic"))
-    expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
-    for (const effort of Object.keys(result)) {
-      expect(result[effort]).toEqual({
-        thinking: { type: "adaptive", display: "summarized" },
-        effort,
-      })
-    }
-  })
-
-  test("keeps openai-compatible kimi without thinking variants", () => {
-    expect(ProviderTransform.variants(createModel("@ai-sdk/openai-compatible"))).toEqual({})
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

 Kimi/Moonshot's Anthropic-compatible endpoints implement Anthropic's adaptive thinking contract (`thinking.type="adaptive"` + `output_config.effort`, including `xhigh` and the `display` field). Today opencode sends manual thinking
with a hardcoded `budgetTokens: 16000` default for kimi models on `@ai-sdk/anthropic`, and exposes no effort variants for them.

 Changes:

 - Default options for kimi family models on the anthropic protocol now send `{type: "adaptive", display: "summarized"}` with `effort: "high"` instead of budget tokens. `display: "summarized"` matters because newer adaptive models
default to omitting thinking text, and that text is what gets replayed on subsequent requests.
 - `variants()` exposes `low/medium/high/xhigh/max` for kimi models on `@ai-sdk/anthropic`, each mapping to adaptive thinking + effort.
 - `anthropicEffort` treats kimi family as adaptive. This also fixes models.dev-declared effort options (e.g. `kimi-k3` low/high/max) being silently dropped — the anthropic branch previously returned `undefined` for non-Claude model
ids.

 Why it works: `@ai-sdk/anthropic` already lowers `providerOptions.anthropic.thinking = {type: "adaptive"}` and `providerOptions.anthropic.effort` to `thinking` + `output_config.effort` on the wire, so no SDK change is needed. Kimi
family detection matches providerID / api id / model id / api url (`isKimiFamily`). OpenAI-compatible kimi paths are untouched, and user-selected variants still override the default (merge order unchanged).

 Note: an identical `isKimiFamily` helper also appears in my other PR (preserve unsigned thinking). They are independent; whichever lands second rebases to keep a single copy.

 ### How did you verify your code works?

 - Unit tests in `test/provider/transform.test.ts`: default adaptive+effort for kimi on anthropic npm (asserting no `budgetTokens`), no thinking default for non-reasoning kimi / non-kimi anthropic / kimi on openai-compatible, the
five effort variants' shape, and models.dev effort options mapping for a kimi-k3-like entry. `bun test test/provider/transform.test.ts` → 352 pass, plus `bun typecheck` from `packages/opencode`.
 - End-to-end through the installed `@ai-sdk/anthropic@3.0.82` with a stub fetch capturing the request body: with the providerOptions this PR emits, the outgoing body contains `thinking: {"type":"adaptive","display":"summarized"}`
and `output_config: {"effort":"high"}`. (No live Moonshot call — worth a quick manual check with a real key before merge.)

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
