### PR TITLE
fix(core): import legacy drizzle migration journals without a name column

### DIFF
--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -40,6 +40,22 @@ export function apply(db: Database) {
   )
 }
 
+// Drizzle-kit derives a migration's filename prefix from the same timestamp
+// it stores as `created_at` in the journal, so the prefix can be recovered
+// from journals that predate the `name` column.
+function timestampPrefix(millis: number) {
+  const date = new Date(millis)
+  const pad = (value: number) => value.toString().padStart(2, "0")
+  return [
+    date.getUTCFullYear(),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+  ].join("")
+}
+
 export function applyOnly(db: Database, input: Migration[]) {
   return Effect.gen(function* () {
     yield* db.run(
@@ -54,12 +70,51 @@ export function applyOnly(db: Database, input: Migration[]) {
       if (
         yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${"__drizzle_migrations"}`)
       ) {
-        yield* db.run(sql`
-          INSERT OR IGNORE INTO ${sql.identifier("migration")} (id, time_completed)
-          SELECT name, ${Date.now()}
-          FROM ${sql.identifier("__drizzle_migrations")}
-          WHERE name IS NOT NULL
-        `)
+        const columns = yield* db.all<{ name: string }>(
+          sql`SELECT name FROM pragma_table_info(${"__drizzle_migrations"})`,
+        )
+        if (columns.some((column) => column.name === "name")) {
+          yield* db.run(sql`
+            INSERT OR IGNORE INTO ${sql.identifier("migration")} (id, time_completed)
+            SELECT name, ${Date.now()}
+            FROM ${sql.identifier("__drizzle_migrations")}
+            WHERE name IS NOT NULL
+          `)
+        } else {
+          // Journals written by drizzle-orm's stock migrator (before the
+          // `name` column existed) only carry `created_at`. Map it back to
+          // the migration id's timestamp prefix, mirroring the v0 -> v1
+          // journal upgrade in effect-drizzle-sqlite, instead of crashing
+          // with "no such column: name".
+          const ids = new Map<string, string>()
+          for (const migration of input) {
+            const prefix = migration.id.split("_")[0]
+            if (prefix) ids.set(prefix, migration.id)
+          }
+          const rows = yield* db.all<{ created_at: number | string }>(
+            sql`SELECT created_at FROM ${sql.identifier("__drizzle_migrations")} WHERE created_at IS NOT NULL`,
+          )
+          const matched: string[] = []
+          const unmatched: (number | string)[] = []
+          for (const row of rows) {
+            const stringified = String(row.created_at)
+            const millis = Number(stringified.substring(0, stringified.length - 3) + "000")
+            const id = Number.isFinite(millis) ? ids.get(timestampPrefix(millis)) : undefined
+            if (id) matched.push(id)
+            else unmatched.push(row.created_at)
+          }
+          if (unmatched.length > 0) {
+            yield* Effect.die(
+              `Found ${unmatched.length} drizzle journal entries (created_at: ${unmatched.join(", ")}) that do not match any known migration. The database was likely created by a different version of opencode.`,
+            )
+          } else {
+            yield* Effect.forEach(matched, (id) =>
+              db.run(
+                sql`INSERT OR IGNORE INTO ${sql.identifier("migration")} (id, time_completed) VALUES (${id}, ${Date.now()})`,
+              ),
+            )
+          }
+        }
         completed = new Set(
           (yield* db.all<{ id: string }>(sql`SELECT id FROM ${sql.identifier("migration")}`)).map((row) => row.id),
         )

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -583,6 +583,40 @@ describe("DatabaseMigration", () => {
     )
   })
 
+  test("imports legacy drizzle journals without a name column", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* db.run(sql`CREATE TABLE session (id text PRIMARY KEY, metadata text)`)
+        yield* db.run(
+          sql`CREATE TABLE __drizzle_migrations (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at numeric)`,
+        )
+        yield* db.run(
+          sql`INSERT INTO __drizzle_migrations (hash, created_at) VALUES ('', ${Date.UTC(2026, 4, 11, 17, 34, 37)})`,
+        )
+
+        yield* DatabaseMigration.applyOnly(db, [sessionMetadataMigration])
+
+        expect(yield* db.all(sql`SELECT id FROM migration`)).toEqual([{ id: "20260511173437_session-metadata" }])
+      }),
+    )
+  })
+
+  test("fails with a clear error for unmatched legacy drizzle journal entries", async () => {
+    await expect(
+      run(
+        Effect.gen(function* () {
+          const db = yield* makeDb
+          yield* db.run(
+            sql`CREATE TABLE __drizzle_migrations (id SERIAL PRIMARY KEY, hash text NOT NULL, created_at numeric)`,
+          )
+          yield* db.run(sql`INSERT INTO __drizzle_migrations (hash, created_at) VALUES ('', 1234567890000)`)
+          yield* DatabaseMigration.applyOnly(db, [sessionMetadataMigration])
+        }),
+      ),
+    ).rejects.toThrow("do not match any known migration")
+  })
+
   test("does not replay a migrated session metadata column", async () => {
     await run(
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #31119

### Type of change

- [x] Bug fix

### What does this PR do?

Databases whose `__drizzle_migrations` journal was written by drizzle-orm's stock migrator have the old `(id, hash, created_at)` schema — no `name` column. On these databases every startup crashes with `no such column: name`. In the TUI the error never reaches the screen, so it looks like a silent freeze (blank/unresponsive, empty log file); `opencode models` prints the error directly.

The crash is in `DatabaseMigration.applyOnly`: when the `migration` table is empty it seeds it with `SELECT name FROM __drizzle_migrations`, assuming the journal is already at v1. The v0 -> v1 journal upgrade exists in `effect-drizzle-sqlite` (`upgradeIfNeeded`), but it only runs inside that package's `migrate()`, which core no longer calls for these databases — so v0 journals never get upgraded and the seed query dies.

Fix: introspect the journal's columns before seeding. If `name` is missing, map each row's `created_at` back to the timestamp prefix of the TypeScript migration ids. This is the same value the v0 -> v1 upgrader matches on: drizzle-kit derives the migration filename prefix from the same timestamp it stores in `created_at`. Rows that map to no known migration abort with a descriptive error instead of the raw SQL error.

### How did you verify your code works?

- Two new tests in `database-migration.test.ts` reproduce the legacy journal schema taken from a real affected database (including the empty `hash` values). Without the fix they fail with exactly `no such column: name`; with it the file passes 17/17.
- Ran the patched CLI against a copy of a real broken database from an affected install: the 6 legacy journal rows seeded to the correct migration ids, the remaining 32 migrations applied on top, `pragma quick_check` returns ok, and existing session/project rows are intact.
- `tsgo --noEmit`, oxlint, and prettier are clean (no new warnings).

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR