### PR TITLE
mini: fix shell tool output display

### DIFF
--- a/packages/cli/src/mini/noninteractive.ts
+++ b/packages/cli/src/mini/noninteractive.ts
@@ -2,6 +2,7 @@ import type { EventSubscribeOutput, OpenCodeClient } from "@opencode-ai/client/p
 import { SessionMessage } from "@opencode-ai/schema/session-message"
 import { EOL } from "node:os"
 import { readFile } from "node:fs/promises"
+import { toolOutputText } from "./tool"
 import { UI } from "./ui"
 import type { MiniToolPart } from "./types"
 
@@ -274,10 +275,7 @@ export async function runNonInteractivePrompt(input: Input) {
           state: {
             status: "completed",
             input: current.input,
-            output: event.data.content
-              .filter((item) => item.type === "text")
-              .map((item) => item.text)
-              .join("\n"),
+            output: toolOutputText(current.tool, event.data.content),
             title: current.tool,
             metadata: {
               structured: event.data.structured,

--- a/packages/cli/src/mini/stream-v2.subagent.ts
+++ b/packages/cli/src/mini/stream-v2.subagent.ts
@@ -23,6 +23,7 @@ import type {
 } from "@opencode-ai/client/promise"
 import { Locale } from "@opencode-ai/tui/util/locale"
 import type { FooterSubagentDetail, FooterSubagentState, FooterSubagentTab, MiniToolPart, StreamCommit } from "./types"
+import { toolOutputText } from "./tool"
 
 const CHILD_MESSAGE_LIMIT = 80
 const CHILD_FRAME_LIMIT = 80
@@ -31,10 +32,6 @@ const FAMILY_LIST_LIMIT = 100
 const FALLBACK_LABEL = "Subagent"
 
 type V2Event = EventSubscribeOutput
-
-export function outputText(content: ReadonlyArray<{ type: string; text?: string }>) {
-  return content.flatMap((item) => (item.type === "text" && item.text ? [item.text] : [])).join("\n")
-}
 
 export function miniTool(input: {
   sessionID: string
@@ -82,7 +79,7 @@ export function miniTool(input: {
       state: {
         status: "completed",
         input: tool.state.input,
-        output: outputText(tool.state.content),
+        output: toolOutputText(tool.name, tool.state.content),
         title: tool.name,
         metadata: {
           structured: tool.state.structured,

--- a/packages/cli/src/mini/tool.ts
+++ b/packages/cli/src/mini/tool.ts
@@ -177,6 +177,12 @@ function text(v: unknown): string {
   return typeof v === "string" ? v : ""
 }
 
+export function toolOutputText(name: string, content: ReadonlyArray<{ type: string; text?: string }>) {
+  // V2 shell content appends model-only status after the user-visible command output.
+  if (name === "shell") return content.find((item) => item.type === "text")?.text ?? ""
+  return content.flatMap((item) => (item.type === "text" && item.text ? [item.text] : [])).join("\n")
+}
+
 function num(v: unknown): number | undefined {
   if (typeof v !== "number" || !Number.isFinite(v)) {
     return undefined

--- a/packages/cli/test/mini.test.ts
+++ b/packages/cli/test/mini.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import path from "node:path"
 import { mergeInteractiveInput, mergeNonInteractiveInput, parseRunModel, pickRunModel } from "../src/mini"
-import { toolInlineInfo, toolView } from "../src/mini/tool"
+import { toolInlineInfo, toolOutputText, toolView } from "../src/mini/tool"
 
 async function cli(args: string[]) {
   const child = Bun.spawn([process.execPath, "run", "src/index.ts", ...args], {
@@ -34,6 +34,24 @@ describe("mini command", () => {
 
     expect(toolView(part.tool)).toEqual({ output: true, final: false })
     expect(toolInlineInfo(part)).toMatchObject({ icon: "$", title: "pwd", mode: "block" })
+  })
+
+  test("uses non-empty V2 shell output without the model-facing status", () => {
+    expect(
+      toolOutputText("shell", [
+        { type: "text", text: "mini-output\n" },
+        { type: "text", text: "Command exited with code 0." },
+      ]),
+    ).toBe("mini-output\n")
+  })
+
+  test("keeps empty V2 shell output empty", () => {
+    expect(
+      toolOutputText("shell", [
+        { type: "text", text: "" },
+        { type: "text", text: "Command exited with code 0." },
+      ]),
+    ).toBe("")
   })
 
   test("uses piped stdin as the initial prompt", () => {


### PR DESCRIPTION
shell content appends a model-only exit status after the real
command output. Joining every text part showed that status in the
CLI; take only the first text part for shell tools.