### PR TITLE
fix(opencode): exit plan mode for custom agents

### DIFF
--- a/packages/opencode/src/session/prompt/build-switch.txt
+++ b/packages/opencode/src/session/prompt/build-switch.txt
@@ -1,5 +1,3 @@
 <system-reminder>
-Your operational mode has changed from plan to build.
-You are no longer in read-only mode.
-You are permitted to make file changes, run shell commands, and utilize your arsenal of tools as needed.
+Plan mode has ended. The active agent's tools and permissions now govern what actions are available.
 </system-reminder>

--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -22,6 +22,7 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   const sessions = yield* Session.Service
   const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
   if (!userMessage) return input.messages
+  const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
 
   if (!flags.experimentalPlanMode) {
     if (input.agent.name === "plan") {
@@ -34,8 +35,7 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
         synthetic: true,
       })
     }
-    const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-    if (wasPlan && input.agent.name === "build") {
+    if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
       userMessage.parts.push({
         id: PartID.ascending(),
         messageID: userMessage.info.id,
@@ -48,7 +48,6 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
     return input.messages
   }
 
-  const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
   if (input.agent.name !== "plan" && assistantMessage?.info.agent === "plan") {
     const ctx = yield* InstanceState.context
     const plan = Session.plan(input.session, ctx)

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -514,6 +514,62 @@ it.instance("loop calls LLM and returns assistant message", () =>
   }),
 )
 
+it.instance(
+  "legacy plan transition reminder applies once to a custom agent without persisting",
+  () =>
+    Effect.gen(function* () {
+      const { llm } = yield* useServerConfig((url) => ({
+        ...providerCfg(url),
+        agent: {
+          orchestrator: {
+            model: "test/test-model",
+          },
+        },
+      }))
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+      const reminder = "Plan mode has ended. The active agent's tools and permissions now govern"
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "plan",
+        noReply: true,
+        parts: [{ type: "text", text: "make a plan" }],
+      })
+      yield* llm.text("the plan")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const transition = yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "orchestrator",
+        noReply: true,
+        parts: [{ type: "text", text: "execute it" }],
+      })
+      yield* llm.text("executed")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const transitionRequest = JSON.stringify((yield* llm.hits)[1]?.body)
+      expect(transitionRequest).toContain(reminder)
+      expect(transition.parts.some((part) => part.type === "text" && part.text.includes(reminder))).toBe(false)
+      const stored = yield* MessageV2.get({ sessionID: chat.id, messageID: transition.info.id })
+      expect(stored.parts.some((part) => part.type === "text" && part.text.includes(reminder))).toBe(false)
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "orchestrator",
+        noReply: true,
+        parts: [{ type: "text", text: "continue" }],
+      })
+      yield* llm.text("continued")
+      yield* prompt.loop({ sessionID: chat.id })
+
+      const laterRequest = JSON.stringify((yield* llm.hits)[2]?.body)
+      expect(laterRequest).not.toContain(reminder)
+    }),
+  30_000,
+)
+
 withMcpInstructions.instance(
   "loop includes MCP instructions in model system context",
   () =>


### PR DESCRIPTION
## Summary

- detect legacy plan exits from the immediately preceding assistant instead of any historical plan turn
- support transitions from plan to custom non-plan agents, not only build
- make the shared transition reminder agent- and capability-neutral
- cover custom-agent delivery, legacy non-persistence, and one-time injection

## Regression

A session that switched from `plan` to a custom primary agent such as `orchestrator` persisted the new agent correctly, but the legacy prompt path omitted the plan-exit counter-reminder because it was hard-coded to `build`. The model could therefore continue treating old synthetic plan instructions as active.

## Validation

- `bun test test/session/prompt.test.ts` (57 passed, 1 skipped)
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck` (30 packages)
- targeted Prettier and Oxlint (0 touched-file errors)