### PR TITLE
feat(tui): optionally share plan and build model

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -63,6 +63,9 @@ export const Info = Schema.Struct({
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  share_plan_build_model: Schema.optional(Schema.Boolean).annotate({
+    description: "Share manually selected models between the Plan and Build agents (default: false)",
+  }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 

--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -13,6 +13,7 @@ import { useTheme } from "./theme"
 import { useToast } from "../ui/toast"
 import { useRoute } from "./route"
 import { usePermission } from "./permission"
+import { useTuiConfig } from "../config"
 
 export type LocalTheme = {
   secondary: RGBA
@@ -48,6 +49,25 @@ export function recentModels(
     .map((item) => ({ providerID: item.providerID, modelID: item.modelID }))
 }
 
+export function selectModel<T extends Record<string, { providerID: string; modelID: string }>>(
+  models: T,
+  agent: string,
+  model: { providerID: string; modelID: string },
+  sharePlanBuild: boolean,
+) {
+  if (!sharePlanBuild || (agent !== "plan" && agent !== "build")) {
+    return {
+      ...models,
+      [agent]: model,
+    }
+  }
+  return {
+    ...models,
+    plan: model,
+    build: model,
+  }
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
@@ -60,6 +80,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     const args = useArgs()
     const event = useEvent()
     const permission = usePermission()
+    const tuiConfig = useTuiConfig()
 
     function isModelValid(model: { providerID: string; modelID: string }) {
       const provider = sync.data.provider.find((item) => item.id === model.providerID)
@@ -285,7 +306,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!val) return
           const a = agent.current()
           if (!a) return
-          setModelStore("model", a.name, { ...val })
+          setModelStore("model", (models) =>
+            selectModel(models, a.name, { ...val }, !!tuiConfig.share_plan_build_model),
+          )
         },
         cycleFavorite(direction: 1 | -1) {
           const favorites = modelStore.favorite.filter((item) => isModelValid(item))
@@ -313,7 +336,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           if (!next) return
           const a = agent.current()
           if (!a) return
-          setModelStore("model", a.name, { ...next })
+          setModelStore("model", (models) =>
+            selectModel(models, a.name, { ...next }, !!tuiConfig.share_plan_build_model),
+          )
           setModelStore("recent", recentModels(next, modelStore.recent))
           save()
         },
@@ -329,7 +354,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             }
             const a = agent.current()
             if (!a) return
-            setModelStore("model", a.name, model)
+            setModelStore("model", (models) => selectModel(models, a.name, model, !!tuiConfig.share_plan_build_model))
             if (options?.recent) {
               setModelStore("recent", recentModels(model, modelStore.recent))
               save()

--- a/packages/tui/test/context/local.test.ts
+++ b/packages/tui/test/context/local.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { parseModel, recentModels } from "../../src/context/local"
+import { parseModel, recentModels, selectModel } from "../../src/context/local"
 
 test("parses model IDs containing slashes", () => {
   expect(parseModel("provider/family/model")).toEqual({
@@ -19,4 +19,66 @@ test("moves a model to the front, deduplicates, and limits recents", () => {
     ...recent.slice(0, 5),
     ...recent.slice(6, 10),
   ])
+})
+
+test("keeps model selection per agent by default", () => {
+  const selected = { providerID: "provider", modelID: "selected" }
+
+  expect(
+    selectModel(
+      {
+        plan: { providerID: "provider", modelID: "plan" },
+        build: { providerID: "provider", modelID: "build" },
+      },
+      "plan",
+      selected,
+      false,
+    ),
+  ).toEqual({
+    plan: selected,
+    build: { providerID: "provider", modelID: "build" },
+  })
+})
+
+test("shares model selection between plan and build when enabled", () => {
+  const custom = { providerID: "provider", modelID: "custom" }
+  const selected = { providerID: "provider", modelID: "selected" }
+
+  expect(
+    selectModel(
+      {
+        plan: { providerID: "provider", modelID: "plan" },
+        build: { providerID: "provider", modelID: "build" },
+        custom,
+      },
+      "build",
+      selected,
+      true,
+    ),
+  ).toEqual({
+    plan: selected,
+    build: selected,
+    custom,
+  })
+})
+
+test("keeps custom agent model selection independent", () => {
+  const selected = { providerID: "provider", modelID: "selected" }
+
+  expect(
+    selectModel(
+      {
+        plan: { providerID: "provider", modelID: "plan" },
+        build: { providerID: "provider", modelID: "build" },
+        custom: { providerID: "provider", modelID: "custom" },
+      },
+      "custom",
+      selected,
+      true,
+    ),
+  ).toEqual({
+    plan: { providerID: "provider", modelID: "plan" },
+    build: { providerID: "provider", modelID: "build" },
+    custom: selected,
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #36640

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional `share_plan_build_model` TUI setting.

When enabled, selecting a model while using the Plan or Build agent applies that selection to both agents. This includes direct model selection and cycling through recent or favorite models.

The setting defaults to `false`, preserving existing per-agent behavior. Custom agents continue to maintain independent model selections.

### How did you verify your code works?

Ran the TUI tests and typecheck:

```bash
bun run --cwd packages/tui test test/context/local.test.ts test/config.test.tsx
bun run --cwd packages/tui typecheck
```

Added coverage for:

- Existing per-agent behavior when disabled
- Shared Plan/Build selection when enabled
- Independent custom-agent selection

### Screenshots / recordings

Not applicable. This changes model-selection behavior without adding or changing UI elements.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR