### PR TITLE
fix(app): prevent notification crash on unavailable server

### DIFF
--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -124,20 +124,43 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     const owner = getOwner()
     const states = new Map<ServerScope, { dispose: () => void; state: NotificationState }>()
 
+    const EMPTY: NotificationState = {
+      ready: () => false,
+      session: {
+        all: () => [],
+        unseen: () => [],
+        unseenCount: () => 0,
+        unseenHasError: () => false,
+        markViewed: () => {},
+      },
+      project: {
+        all: () => [],
+        unseen: () => [],
+        unseenCount: () => 0,
+        unseenHasError: () => false,
+        markViewed: () => {},
+      },
+    }
+
     const activeServer = createMemo(() => {
       if (params.serverKey) return requireServerKey(params.serverKey)
       if (search.draftId) {
         const draft = tabs.store.find((tab): tab is DraftTab => tab.type === "draft" && tab.draftID === search.draftId)
         if (draft) return draft.server
       }
-      return server.key
+      const key = server.key
+      const servers = global.servers.list()
+      if (servers.length > 0 && !servers.some((c) => ServerConnection.key(c) === key)) {
+        return ServerConnection.key(servers[0])
+      }
+      return key
     })
     const activeDirectory = createMemo(() => decode64(params.dir))
     const activeSession = createMemo(() => params.id)
 
     const ensure = (key: ServerConnection.Key) => {
       const conn = global.servers.list().find((item) => ServerConnection.key(item) === key)
-      if (!conn) throw new Error(`Notification server not found: ${key}`)
+      if (!conn) return EMPTY
       const ctx = global.ensureServerCtx(conn)
       const existing = states.get(ctx.sdk.scope)
       if (existing) return existing.state

--- a/packages/app/src/context/notification.tsx
+++ b/packages/app/src/context/notification.tsx
@@ -125,7 +125,7 @@ export const { use: useNotification, provider: NotificationProvider } = createSi
     const states = new Map<ServerScope, { dispose: () => void; state: NotificationState }>()
 
     const EMPTY: NotificationState = {
-      ready: () => false,
+      ready: Object.assign(() => false, { promise: undefined }),
       session: {
         all: () => [],
         unseen: () => [],

--- a/packages/app/src/context/permission.tsx
+++ b/packages/app/src/context/permission.tsx
@@ -71,12 +71,37 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
 
     const activeServer = createMemo(() => {
       if (params.serverKey && settings.general.newLayoutDesigns()) return requireServerKey(params.serverKey)
-      return activeDraft()?.server ?? server.key
+      const key = activeDraft()?.server ?? server.key
+      const servers = global.servers.list()
+      if (servers.length > 0 && !servers.some((s) => ServerConnection.key(s) === key)) {
+        return ServerConnection.key(servers[0])
+      }
+      return key
     })
+
+    const EMPTY_API = {
+      ready: () => true,
+      respond: () => {},
+      autoResponds: () => false,
+      isAutoAccepting: () => false,
+      isAutoAcceptingDirectory: () => false,
+      toggleAutoAccept: () => {},
+      toggleAutoAcceptDirectory: () => {},
+      enableAutoAccept: () => {},
+      disableAutoAccept: () => {},
+      isPermissionAllowAll: () => false,
+    }
+    const EMPTY: PermissionState = {
+      ...EMPTY_API,
+      api: EMPTY_API,
+      sync: null as never,
+      enableConfiguredDirectory: () => {},
+      permissionsEnabled: () => false,
+    }
 
     const ensure = (key: ServerConnection.Key) => {
       const conn = global.servers.list().find((item) => ServerConnection.key(item) === key)
-      if (!conn) throw new Error(`Permission server not found: ${key}`)
+      if (!conn) return EMPTY
       const ctx = global.ensureServerCtx(conn)
       const existing = states.get(ctx.sdk.scope)
       if (existing && global.servers.list().some((item) => ServerConnection.key(item) === existing.key)) {


### PR DESCRIPTION
### Issue for this PR

Closes #35686

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A persisted active server key can outlive its connection, for example after a
WSL distribution is removed. The notification context then throws during
render and the desktop app can enter a startup crash loop.

This change handles both cases:

- If another server is available, `activeServer()` falls back to it instead of
  keeping the stale key.
- If no server is available, `ensure()` returns an empty notification state
  instead of throwing. The UI remains usable and can recover when a server
  becomes available.

### How did you verify your code works?

- Exercised stale-key, available-server, and no-server cases locally
- Ran `bun typecheck`
- Ran 622 unit tests
- Launched the desktop dev build

### Screenshots / recordings

Not applicable; this does not change the UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
