### PR TITLE
docs(opencode): add @rrr2010/opencode-roundtable to ecosystem

### DIFF
--- a/packages/web/src/content/docs/pt-br/ecosystem.mdx
+++ b/packages/web/src/content/docs/pt-br/ecosystem.mdx
@@ -49,6 +49,7 @@ Você também pode conferir [awesome-opencode](https://github.com/awesome-openco
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Conjunto de orquestração multi-agente – 16 componentes, uma instalação                                                         |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Worktrees git sem atrito para OpenCode                                                                                         |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Rastreie e depure seus agentes de IA com o Sentry AI Monitoring                                                                |
+| [@rrr2010/opencode-roundtable](https://github.com/rrr2010/opencode-roundtable) | Multi-agent round-robin debate plugin — agents discuss topics turn by turn with built-in observer and extend mode |
 
 ---
 


### PR DESCRIPTION
Adds the roundtable plugin to the community plugins list.

**@rrr2010/opencode-roundtable** is an OpenCode plugin that orchestrates multi-agent round-robin debates. Agents discuss topics turn by turn, sharing context while keeping their own system prompts and tools. Features include:

- Built-in observer for executive summaries
- Extend mode to continue debates with additional rounds
- Stuck session auto-recovery
- Parallel roundtables and user intervention support

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds two new rows to the Plugins table in the ecosystem page (English and pt-BR) for the roundtable plugin, a multi-agent debate orchestration tool.

### How did you verify your code works?

Checked the markdown rendering locally and confirmed the table syntax matches the existing entries.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR