### PR TITLE
docs(opencode): add @rrr2010/opencode-roundtable to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,7 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
-
+| [@rrr2010/opencode-roundtable](https://github.com/rrr2010/opencode-roundtable) | Multi-agent round-robin debate plugin — agents discuss topics turn by turn with built-in observer and extend mode |
 ---
 
 ## Projects


### PR DESCRIPTION
Adds the roundtable plugin to the community plugins list.

**@rrr2010/opencode-roundtable** is an OpenCode plugin that orchestrates multi-agent round-robin debates. Agents discuss topics turn by turn, sharing context while keeping their own system prompts and tools. Features include:

- Built-in observer for executive summaries
- Extend mode to continue debates with additional rounds
- Stuck session auto-recovery
- Parallel roundtables and user intervention support

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds two new rows to the Plugins table in the ecosystem page (English and pt-BR) for the roundtable plugin, a multi-agent debate orchestration tool.

### How did you verify your code works?

Checked the markdown rendering locally and confirmed the table syntax matches the existing entries.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR