### PR TITLE
fix(lsp): attach language servers to extensionless files

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -3,7 +3,7 @@ import { pathToFileURL, fileURLToPath } from "url"
 import { createMessageConnection, StreamMessageReader, StreamMessageWriter } from "vscode-jsonrpc/node"
 import type { Diagnostic as VSCodeDiagnostic } from "vscode-languageserver-types"
 import { Process } from "@/util/process"
-import { LANGUAGE_EXTENSIONS } from "./language"
+import { languageId } from "./language"
 import { Effect, Schema } from "effect"
 import type * as LSPServer from "./server"
 import { withTimeout } from "../util/timeout"
@@ -556,8 +556,7 @@ export async function create(input: {
           path.isAbsolute(request.path) ? request.path : path.resolve(input.directory, request.path),
         )
         const text = await Filesystem.readText(request.path)
-        const extension = path.extname(request.path)
-        const languageId = LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
+        const language = languageId(request.path)
 
         const document = files[request.path]
         if (document !== undefined) {
@@ -611,7 +610,7 @@ export async function create(input: {
         await connection.sendNotification("textDocument/didOpen", {
           textDocument: {
             uri: pathToFileURL(request.path).href,
-            languageId,
+            languageId: language,
             version: 0,
             text,
           },

--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -1,3 +1,5 @@
+import path from "path"
+
 export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".abap": "abap",
   ".bat": "bat",
@@ -23,6 +25,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".patch": "diff",
   ".dart": "dart",
   ".dockerfile": "dockerfile",
+  Dockerfile: "dockerfile",
   ".ex": "elixir",
   ".exs": "elixir",
   ".erl": "erlang",
@@ -119,3 +122,9 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".typ": "typst",
   ".typc": "typst",
 } as const
+
+// Resolve a file to its LSP languageId. Files with no extension (Dockerfile, ...) fall back to the
+// basename so they still map to a language instead of "plaintext".
+export function languageId(file: string): string {
+  return LANGUAGE_EXTENSIONS[path.extname(file) || path.basename(file)] ?? "plaintext"
+}

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -210,7 +210,7 @@ const layer = Layer.effect(
       if (!containsPath(file, ctx)) return [] as LSPClient.Info[]
       const s = yield* InstanceState.get(state)
       const clients = yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = path.parse(file).ext || path.basename(file)
         const result: LSPClient.Info[] = []
         let updated = 0
 
@@ -329,7 +329,7 @@ const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const s = yield* InstanceState.get(state)
       return yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = path.parse(file).ext || path.basename(file)
         for (const server of Object.values(s.servers)) {
           if (server.extensions.length && !server.extensions.includes(extension)) continue
           const root = await server.root(file, ctx)

--- a/packages/opencode/test/lsp/language.test.ts
+++ b/packages/opencode/test/lsp/language.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test"
+import { languageId } from "@/lsp/language"
+
+test("languageId resolves known extensions", () => {
+  expect(languageId("foo.ts")).toBe("typescript")
+  expect(languageId("/proj/src/app.py")).toBe("python")
+})
+
+test("languageId resolves extensionless files by basename", () => {
+  // Regression for #33372 / #27604: a file literally named "Dockerfile" has no extension,
+  // so extname() is empty and it used to resolve to "plaintext".
+  expect(languageId("Dockerfile")).toBe("dockerfile")
+  expect(languageId("/proj/Dockerfile")).toBe("dockerfile")
+})
+
+test("languageId falls back to plaintext for unknown files", () => {
+  expect(languageId("notes.unknownext")).toBe("plaintext")
+  expect(languageId("randomfile")).toBe("plaintext")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33372
Closes #27604

### Type of change

- [x] Bug fix

### What does this PR do?

Files with no extension (e.g. `Dockerfile`) never got LSP support, for two reasons:

1. **The server never matched.** The matcher used `path.parse(file).ext || file`, so for an extensionless file the "extension" became the whole file path, which no server's `extensions` list contains. The bundled `dockerfile` server already declares `extensions: [".dockerfile", "Dockerfile"]`, but that `"Dockerfile"` entry could never match. Fixed by falling back to the basename.
2. **The languageId was wrong.** Even once matched, the languageId was `LANGUAGE_EXTENSIONS[path.extname(file)]`, which is empty for extensionless files, so the server received `languageId: "plaintext"` and wouldn't analyze the file. Added a small `languageId()` helper that falls back to the basename, plus the `Dockerfile` → `dockerfile` mapping.

The matcher change (1) is the same one in #33690; this PR also fixes the languageId (2) so the server actually analyzes the file, and adds a test.

### How did you verify your code works?

- Added `test/lsp/language.test.ts` covering `languageId()`: known extensions, extensionless files (`Dockerfile`, with and without a directory), and the `plaintext` fallback.
- `bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
