### PR TITLE
fix(ui): fix progress circle v2 stroke colors for visibility

### DIFF
--- a/packages/ui/src/v2/components/progress-circle-v2.css
+++ b/packages/ui/src/v2/components/progress-circle-v2.css
@@ -4,10 +4,10 @@
 }
 
 [data-component="progress-circle-v2"] [data-slot="progress-circle-v2-background"] {
-  stroke: var(--v2-background-bg-layer-04);
+  stroke: var(--border-weak-base);
 }
 
 [data-component="progress-circle-v2"] [data-slot="progress-circle-v2-progress"] {
-  stroke: var(--v2-icon-icon-muted);
+  stroke: var(--border-active);
   transition: stroke-dashoffset 0.35s cubic-bezier(0.65, 0, 0.35, 1);
 }


### PR DESCRIPTION
### Issue for this PR

Closes #37122

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The V2 progress circle uses --v2-background-bg-layer-04 for the background stroke and --v2-icon-icon-muted for the progress stroke. These tokens blend into the v2 surface background in dark mode, making progress levels indistinguishable.

Changed the background stroke to --border-weak-base and the progress stroke to --border-active, which provide proper contrast against the surface.

### How did you verify your code works?

Applied the same two-line CSS change to the bundled renderer CSS in the OpenCode Desktop ASAR and visually confirmed the progress indicator renders correctly at various levels. The upstream dev branch has the identical issue.

### Screenshots / recordings

N/A — CSS-only color change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR