### PR TITLE
fix(cli): stop web command from opening the browser

### DIFF
--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -3,7 +3,6 @@ import { UI } from "../ui"
 import { effectCmd } from "../effect-cmd"
 import { withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
-import open from "open"
 import { networkInterfaces } from "os"
 
 function getNetworkIPs() {
@@ -70,13 +69,9 @@ export const WebCommand = effectCmd({
           `${opts.mdnsDomain}:${server.port}`,
         )
       }
-
-      // Open localhost in browser
-      open(localhostUrl).catch(() => {})
     } else {
       const displayUrl = server.url.toString()
       UI.println(UI.Style.TEXT_INFO_BOLD + "  Web interface:    ", UI.Style.TEXT_NORMAL, displayUrl)
-      open(displayUrl).catch(() => {})
     }
 
     yield* Effect.never


### PR DESCRIPTION
# Draft upstream PR — do not submit without Batin approval

**Repository:** `anomalyco/opencode`  
**Base:** `dev`  
**Head:** `kanazawahere:opencode:atp-patches`  
**Compare:** https://github.com/anomalyco/opencode/compare/dev...kanazawahere:opencode:atp-patches

## Proposed title

`fix(cli): stop web command from opening the browser`

## Proposed body

### Summary

- keep `opencode web` as the same long-running web server command;
- stop automatically asking the OS to open the web URL;
- retain existing network options and URL output so users can open the interface explicitly.

### Why

`opencode web` is also useful as a managed long-running process. When a service manager or watchdog restarts that process, automatically opening the URL creates another browser tab on every restart. Browser launch is a desktop side effect and should not be coupled to server recovery.

The command still prints local, network, mDNS, or configured-host URLs exactly as before.

### Validation

- `bun run --cwd packages/opencode typecheck`
- `bun test test/cli/help/help-snapshots.test.ts` from `packages/opencode`
- `./packages/opencode/script/build.ts --single --skip-install`
- Linux x64 binary smoke test
- `opencode web --pure --hostname 127.0.0.1 --port 2198`
  - `/` and `/doc` return HTTP 200
  - HTML contains `<title>OpenCode</title>`
  - `strace -f -e execve` records no browser or opener process

### Scope

Only `packages/opencode/src/cli/cmd/web.ts` changes. No service, server, API, or frontend behavior changes.
