### PR TITLE
docs(ecosystem): add opencode-show-timestamps plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -51,6 +51,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                             |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                           |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Trace and debug your AI agents with Sentry AI Monitoring                                           |
+| [opencode-show-timestamps](https://github.com/mauriciorojassan/opencode-show-timestamps)          | Show timestamps for the last user message and last AI response, right next to your input. Configurable display slot via command palette. |
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |


### PR DESCRIPTION
### Issue for this PR

N/A — this is a documentation addition, not a bug fix or feature.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-show-timestamps](https://github.com/mauriciorojassan/opencode-show-timestamps) to the community plugins table on the Ecosystem page.

This is a TUI plugin that shows timestamps for the last user and AI message, right next to the input. The slot is configurable via the command palette (`Cmd+K` → "select slot") or a JSON config file.

### How did you verify your code works?

The plugin is published on npm as `@aii4all/opencode-show-timestamps`, has 14 passing tests (`npx vitest run`), passed gitleaks scanning, and underwent adversarial review (Judgment Day — 3 rounds, all APPROVED). The change to the ecosystem page is a single-line addition to the table.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR