### PR TITLE
docs(providers): add DaoXE

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -703,6 +703,35 @@ Cloudflare Workers AI lets you run AI models on Cloudflare's global network dire
 
 ---
 
+### DaoXE
+
+[DaoXE](https://daoxe.com) is an OpenAI-compatible, multi-protocol LLM gateway (Chat Completions, OpenAI Responses, and Anthropic Messages) that exposes Claude, GPT, Gemini, DeepSeek, Kimi and more behind a single API key. It's already in the [models.dev](https://models.dev) catalog opencode reads.
+
+1. Head over to [DaoXE](https://daoxe.com), create an account, and generate an API key.
+
+2. Run the `/connect` command and search for **DaoXE**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your DaoXE API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model.
+
+   ```txt
+   /models
+   ```
+
+---
+
 ### DeepSeek
 
 1. Head over to the [DeepSeek console](https://platform.deepseek.com/), create an account, and click **Create new API key**.


### PR DESCRIPTION
Adds DaoXE to the Providers directory, alongside existing OpenAI-compatible gateways (302.AI, Helicone, OpenRouter, Vercel AI Gateway).

DaoXE is already in the models.dev catalog opencode reads (providers/daoxe), so it can be selected natively via `/connect` — this PR just documents it in the directory, mirroring the 302.AI entry. DaoXE is an OpenAI-compatible, multi-protocol gateway (Chat Completions / OpenAI Responses / Anthropic Messages) at https://daoxe.com/v1.

Disclosure: DaoXE is a service we operate. Not available in mainland China.

Made with [Cursor](https://cursor.com)