### PR TITLE
fix(app): restore settings panel scrollbars

### DIFF
--- a/packages/app/src/components/settings-v2/settings-v2.css
+++ b/packages/app/src/components/settings-v2/settings-v2.css
@@ -19,16 +19,11 @@
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
-  scrollbar-width: none;
   user-select: none;
 }
 
 .settings-v2-panel :is(input, textarea, [contenteditable="true"]) {
   user-select: text;
-}
-
-.settings-v2-panel::-webkit-scrollbar {
-  display: none;
 }
 
 .settings-v2-tab-header {


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### What does this PR do?

The settings panel currently hides native scrollbars by using:

- scrollbar-width: none
- ::-webkit-scrollbar { display: none; }

This PR removes those rules so native scrollbars are no longer explicitly hidden when the settings panel overflows.

### How did you verify your code works?

I wasn't able to test the desktop app locally. Since this change only removes the CSS rules that hide the scrollbar, I'd appreciate confirmation from a maintainer that it resolves the issue on macOS.

### Screenshots/recordings

None.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
