### PR TITLE
docs(tui): explain session scrollbar options

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -417,6 +417,16 @@ The TUI can request attention for questions, permissions, session errors, and co
 
 You can customize various aspects of the TUI view using the command palette (`ctrl+p`). These settings persist across restarts.
 
+#### Session scrollbar
+
+The full TUI manages its own scroll area, so your terminal's native scrollbar may not reflect the session history. To show OpenCode's session scrollbar, open the command palette, search for "Toggle session scrollbar", and select it. The setting persists across TUI sessions.
+
+To use your terminal's native scrollback instead, start the minimal interactive interface.
+
+```bash
+opencode --mini
+```
+
 ---
 
 #### Username display


### PR DESCRIPTION
### Issue for this PR

Closes #30651

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Explains that the full TUI manages its own scroll area, shows how to enable the persisted session scrollbar through `ctrl+p`, and points users who prefer native terminal scrollback to `opencode --mini`. This is a focused follow-up to cleanup-closed #30654.

### How did you verify your code works?

- `npx --yes prettier@3.6.2 --check packages/web/src/content/docs/tui.mdx`
- `git diff --check`

The full Astro build was not run because Bun is unavailable in the local environment.

### Screenshots / recordings

Not applicable; this is a documentation-only text change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR