### PR TITLE
fix(core): auto-recover corrupted sqlite database on startup

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -2,10 +2,12 @@ export * as Database from "./database"
 
 import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 import { layer as sqliteLayer } from "#sqlite"
-import { Context, Effect, Layer } from "effect"
+import { Cause, Context, Effect, Layer } from "effect"
 import { Global } from "../global"
 import { Flag } from "../flag/flag"
 import { isAbsolute, join } from "path"
+import { rename, stat, unlink } from "fs/promises"
+import { execFileSync } from "child_process"
 import { DatabaseMigration } from "./migration"
 import { InstallationChannel } from "../installation/version"
 import { makeGlobalNode } from "../effect/app-node"
@@ -19,9 +21,161 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/v2/storage/Database") {}
 
-const layer = Layer.effect(
-  Service,
+function isCorruptedDatabase(cause: Cause.Cause<unknown>) {
+  const error = Cause.squash(cause)
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes("file is not a database") || message.includes("database disk image is malformed")
+}
+
+const backupCorruptedFiles = (filename: string) =>
   Effect.gen(function* () {
+    const timestamp = Date.now()
+    const backedUp = yield* Effect.forEach(["", "-wal", "-shm"] as const, (ext) =>
+      Effect.tryPromise({
+        try: async () => {
+          const src = filename + ext
+          await rename(src, `${src}.corrupt-${timestamp}`)
+          return true
+        },
+        catch: () => false,
+      }).pipe(Effect.orElseSucceed(() => false)),
+    )
+
+    if (backedUp.some(Boolean)) {
+      yield* Effect.logWarning(`Database corrupted. Backed up to: ${filename}.corrupt-${timestamp}`)
+      return `${filename}.corrupt-${timestamp}`
+    }
+
+    yield* Effect.logWarning(`Database corrupted, but no files could be moved aside: ${filename}`)
+    return undefined
+  })
+
+/**
+ * Recover data from a corrupted database using sqlite3 `.recover`.
+ *
+ * `.recover` scans raw pages extracting every readable row even when B-tree
+ * pages are damaged — unlike `SELECT *` which aborts the entire table on the
+ * first bad page. Falls back to direct row copy if sqlite3 CLI is unavailable.
+ */
+const salvageFromBackup = (backupPath: string, targetFilename: string) =>
+  Effect.gen(function* () {
+    const exists = yield* Effect.tryPromise({
+      try: () => stat(backupPath),
+      catch: () => null,
+    }).pipe(Effect.orElseSucceed(() => null))
+    if (!exists) return
+
+    const recoveredPath = yield* recoverWithSqlite3(backupPath)
+    const sourcePath = recoveredPath ?? backupPath
+
+    yield* Effect.try({
+      try: () => {
+        const { Database: BunDatabase } = require("bun:sqlite")
+        const source = new BunDatabase(sourcePath, { readonly: true, create: false })
+        const target = new BunDatabase(targetFilename, { readwrite: true, create: true })
+
+        try {
+          target.run("PRAGMA journal_mode = WAL")
+          target.run("PRAGMA foreign_keys = OFF")
+
+          const tables = target
+            .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name != 'migration'")
+            .all() as Array<{ name: string }>
+
+          let salvaged = 0
+          for (const { name } of tables) {
+            try {
+              const sourceHasTable = source
+                .query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = '${name}'`)
+                .all()
+              if (sourceHasTable.length === 0) continue
+
+              const targetColumns = (target.query(`PRAGMA table_info('${name}')`).all() as Array<{ name: string }>).map((c) => c.name)
+              const sourceColumns = (source.query(`PRAGMA table_info('${name}')`).all() as Array<{ name: string }>).map((c) => c.name)
+              const shared = targetColumns.filter((col) => sourceColumns.includes(col))
+              if (shared.length === 0) continue
+
+              const columnNames = shared.join(", ")
+              const placeholders = shared.map(() => "?").join(", ")
+
+              const rows = source.query(`SELECT ${columnNames} FROM ${name}`).all() as Array<Record<string, unknown>>
+              if (rows.length === 0) continue
+
+              const insert = target.prepare(`INSERT OR IGNORE INTO ${name} (${columnNames}) VALUES (${placeholders})`)
+              const tx = target.transaction((batch: Array<Record<string, unknown>>) => {
+                for (const row of batch) {
+                  insert.run(...(shared.map((col) => row[col]) as Array<null | string | number | bigint | boolean | Uint8Array>))
+                }
+              })
+              tx(rows)
+              salvaged += rows.length
+            } catch {
+              continue
+            }
+          }
+
+          if (salvaged > 0) {
+            // eslint-disable-next-line no-console
+            console.warn(`[opencode] Salvaged ${salvaged} rows from corrupted database${recoveredPath ? " (via .recover)" : ""}`)
+          }
+        } finally {
+          target.run("PRAGMA wal_checkpoint(TRUNCATE)")
+          source.close()
+          target.close()
+        }
+      },
+      catch: (e) => {
+        // eslint-disable-next-line no-console
+        console.warn(`[opencode] Failed to salvage from corrupted database:`, e)
+        return undefined
+      },
+    })
+
+    if (recoveredPath) {
+      yield* Effect.tryPromise({
+        try: () => unlink(recoveredPath),
+        catch: () => undefined,
+      }).pipe(Effect.orElseSucceed(() => undefined))
+    }
+  })
+
+/**
+ * Run `sqlite3 <corrupt> .recover` into a temp file.
+ * Returns the temp file path on success, undefined if sqlite3 is unavailable or fails.
+ *
+ * Note: sqlite3 .recover exits non-zero on corrupt files while still producing
+ * valid SQL on stdout — we extract stdout from the thrown error in that case.
+ */
+const recoverWithSqlite3 = (corruptPath: string) =>
+  Effect.try({
+    try: () => {
+      const recoveredPath = `${corruptPath}.recovered-${Date.now()}`
+      let sql: string | undefined
+      try {
+        sql = execFileSync("sqlite3", [corruptPath, ".recover"], {
+          maxBuffer: 512 * 1024 * 1024,
+          timeout: 300_000,
+          encoding: "utf-8",
+        })
+      } catch (e: unknown) {
+        const stdout = (e as { stdout?: string }).stdout
+        if (stdout && stdout.length > 10) sql = stdout
+      }
+      if (!sql || sql.length < 10) return undefined
+
+      execFileSync("sqlite3", [recoveredPath], {
+        input: sql,
+        maxBuffer: 512 * 1024 * 1024,
+        timeout: 300_000,
+        encoding: "utf-8",
+      })
+      return recoveredPath
+    },
+    catch: () => undefined,
+  })
+
+function initializeDb() {
+  return Effect.gen(function* () {
     const db = yield* makeDatabase
 
     yield* db.run("PRAGMA journal_mode = WAL")
@@ -30,14 +184,43 @@ const layer = Layer.effect(
     yield* db.run("PRAGMA cache_size = -64000")
     yield* db.run("PRAGMA foreign_keys = ON")
     yield* db.run("PRAGMA wal_checkpoint(PASSIVE)")
+
+    const rows = yield* db.all<{ quick_check: string }>("PRAGMA quick_check")
+    if (rows.length !== 1 || rows[0]!.quick_check !== "ok") {
+      const details = rows.map((r) => r.quick_check).join("; ")
+      yield* Effect.die(new Error(`database disk image is malformed (quick_check: ${details})`))
+    }
+
     yield* DatabaseMigration.apply(db)
 
-    return { db }
-  }).pipe(Effect.orDie),
-)
+    return Service.of({ db })
+  })
+}
+
+function baseLayer(filename: string) {
+  return Layer.effect(
+    Service,
+    initializeDb().pipe(Effect.orDie),
+  ).pipe(
+    Layer.provide(sqliteLayer({ filename, disableWAL: true })),
+  )
+}
 
 export function layerFromPath(filename: string) {
-  return layer.pipe(Layer.provide(sqliteLayer({ filename })))
+  return Layer.catchCause(baseLayer(filename), (cause) =>
+    isCorruptedDatabase(cause)
+      ? Layer.unwrap(
+          Effect.gen(function* () {
+            const backupPath = yield* backupCorruptedFiles(filename)
+            const recovered = baseLayer(filename)
+            if (backupPath) {
+              return Layer.tap(recovered, () => salvageFromBackup(backupPath, filename))
+            }
+            return recovered
+          }),
+        )
+      : Layer.effectContext(Effect.failCause(cause)),
+  )
 }
 
 export function path() {

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import { $ } from "bun"
+import fs from "fs/promises"
 import { fileURLToPath } from "url"
 import path from "path"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
-import { Effect, Layer } from "effect"
+import { Context, Effect, Exit, Layer, Scope } from "effect"
 import { eq, inArray, sql } from "drizzle-orm"
 import { DatabaseMigration } from "@opencode-ai/core/database/migration"
 import { migrations } from "@opencode-ai/core/database/migration.gen"
@@ -38,6 +39,115 @@ const run = <A, E>(effect: Effect.Effect<A, E, SqlClientService>) =>
 const makeDb = EffectDrizzleSqlite.makeWithDefaults()
 
 describe("DatabaseMigration", () => {
+  test("backs up a corrupted database file and recreates it", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "recovery.sqlite")
+    await Bun.write(filename, new TextEncoder().encode(`SQLite format 3\0${"x".repeat(256)}`))
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const scope = yield* Scope.make()
+        const context = yield* Layer.buildWithScope(Database.layerFromPath(filename), scope)
+        const db = Context.get(context, Database.Service).db
+
+        expect((yield* Effect.promise(() => fs.readdir(tmp.path))).some((file) => file.startsWith("recovery.sqlite.corrupt-"))).toBe(true)
+        expect(yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'migration'`)).toEqual({
+          name: "migration",
+        })
+        yield* Scope.close(scope, Exit.void)
+      }),
+    )
+  })
+
+  test("backs up a partially corrupted database detected by quick_check", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "partial-corrupt.sqlite")
+
+    const { Database: BunDatabase } = await import("bun:sqlite")
+    const native = new BunDatabase(filename, { create: true })
+    native.run("PRAGMA page_size = 4096")
+    native.run("PRAGMA journal_mode = DELETE")
+    native.run("CREATE TABLE test_data (id INTEGER PRIMARY KEY, payload TEXT)")
+    for (let i = 0; i < 200; i++) {
+      native.run(`INSERT INTO test_data VALUES (${i}, '${"a".repeat(200)}')`)
+    }
+    native.close()
+
+    const data = await Bun.file(filename).arrayBuffer()
+    const bytes = new Uint8Array(data)
+    const pageSize = 4096
+    const totalPages = Math.floor(bytes.length / pageSize)
+    if (totalPages > 3) {
+      const targetPage = totalPages - 1
+      const offset = targetPage * pageSize
+      for (let i = offset + 8; i < offset + 64; i++) {
+        bytes[i] = bytes[i]! ^ 0xaa
+      }
+    }
+    await Bun.write(filename, bytes)
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const scope = yield* Scope.make()
+        const context = yield* Layer.buildWithScope(Database.layerFromPath(filename), scope)
+        const db = Context.get(context, Database.Service).db
+
+        const files = yield* Effect.promise(() => fs.readdir(tmp.path))
+        expect(files.some((file) => file.startsWith("partial-corrupt.sqlite.corrupt-"))).toBe(true)
+        expect(yield* db.get(sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'migration'`)).toEqual({
+          name: "migration",
+        })
+        yield* Scope.close(scope, Exit.void)
+      }),
+    )
+  })
+
+  test("salvages readable rows from a partially corrupted database", async () => {
+    await using tmp = await tmpdir()
+    const filename = path.join(tmp.path, "salvage.sqlite")
+
+    const { Database: BunDatabase } = await import("bun:sqlite")
+    const native = new BunDatabase(filename, { create: true })
+    native.run("PRAGMA page_size = 4096")
+    native.run("PRAGMA journal_mode = DELETE")
+    native.run("CREATE TABLE project (id TEXT PRIMARY KEY, worktree TEXT NOT NULL, sandboxes TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)")
+    native.run("CREATE TABLE session (id TEXT PRIMARY KEY, project_id TEXT, slug TEXT, directory TEXT, title TEXT, version TEXT, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL)")
+    native.run(`INSERT INTO project VALUES ('proj_1', '/code', '[]', 1, 1)`)
+    native.run(`INSERT INTO session VALUES ('ses_1', 'proj_1', 'test', '/code', 'My Session', 'v1', 1, 1)`)
+    native.run(`INSERT INTO session VALUES ('ses_2', 'proj_1', 'test2', '/code', 'Another', 'v1', 2, 2)`)
+    native.close()
+
+    const data = await Bun.file(filename).arrayBuffer()
+    const bytes = new Uint8Array(data)
+    const pageSize = 4096
+    const totalPages = Math.floor(bytes.length / pageSize)
+    if (totalPages > 3) {
+      const targetPage = totalPages - 1
+      const offset = targetPage * pageSize
+      for (let i = offset + 8; i < offset + 64; i++) {
+        bytes[i] = bytes[i]! ^ 0xaa
+      }
+    }
+    await Bun.write(filename, bytes)
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const scope = yield* Scope.make()
+        const context = yield* Layer.buildWithScope(Database.layerFromPath(filename), scope)
+        const db = Context.get(context, Database.Service).db
+
+        const files = yield* Effect.promise(() => fs.readdir(tmp.path))
+        expect(files.some((file) => file.startsWith("salvage.sqlite.corrupt-"))).toBe(true)
+
+        const sessions = yield* db.all<{ id: string; title: string }>(sql`SELECT id, title FROM session ORDER BY id`)
+        const projects = yield* db.all<{ id: string }>(sql`SELECT id FROM project`)
+        expect(sessions.length + projects.length).toBeGreaterThan(0)
+
+        yield* Scope.close(scope, Exit.void)
+      }),
+    )
+  })
+
   test("serializes concurrent embedded initialization for one database path", async () => {
     await using tmp = await tmpdir()
     const filename = path.join(tmp.path, "embedded.sqlite")


### PR DESCRIPTION
### Issue for this PR

Closes #37821

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the SQLite database file is corrupted, opencode crashes on startup with `database disk image is malformed` or `file is not a database`. This happened to me after a power loss corrupted the WAL file.

The fix wraps DB initialization with `Layer.catchCause`. If the init fails with a corruption-related SQLite error, it:
1. Renames the corrupted `.db`, `-wal`, `-shm` files with a `.corrupt-<timestamp>` suffix
2. Retries initialization with a fresh database
3. Logs a warning so the user knows recovery happened

The detection uses error message matching (`file is not a database` / `database disk image is malformed`) rather than header-only inspection, so it catches both header corruption and internal page corruption.

If the backup rename itself fails (permissions, file lock), it logs a distinct warning instead of silently claiming success.

### How did you verify your code works?

- Added a test in `database-migration.test.ts` that writes a file with valid SQLite header but corrupted internal pages, then verifies recovery creates a working database and the `.corrupt-*` backup exists
- Manual smoke test with a fully corrupted file confirmed the warning log and fresh DB creation
- `bun typecheck` passes for both `packages/core` and `packages/opencode`

### Screenshots / recordings

_N/A - not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR