### PR TITLE
fix(app): register open project and new worktree shortcuts in new layout

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -28,6 +28,8 @@ import { tabKey, useTabs } from "@/context/tabs"
 import type { PromptSession } from "@/context/prompt"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "./command-tooltip-keybind"
+import { useDirectoryPicker } from "@/components/directory-picker"
+import { homeProjectDirectories } from "@/pages/layout/helpers"
 
 type TauriDesktopWindow = {
   startDragging?: () => Promise<void>
@@ -253,6 +255,7 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
           {(_) => {
             const layout = useLayout()
             const global = useGlobal()
+            const pickDirectory = useDirectoryPicker()
 
             const tabs = useTabs()
             const tabsStore = tabs.store
@@ -372,6 +375,35 @@ export function Titlebar(props: { update?: TitlebarUpdate }) {
               tabs.newDraft({ server: fallback.server, directory: fallback.project.worktree }, "")
             }
             const toggleHome = () => tabs.toggleHome({ home: layout.route().type === "home", current: currentTab() })
+
+            const chooseProject = () => {
+              const conn = server.current
+              if (!conn) return
+              pickDirectory({
+                server: conn,
+                title: language.t("command.project.open"),
+                multiple: true,
+                onSelect: (result) => {
+                  const directories = homeProjectDirectories(result)
+                  const directory = directories[0]
+                  if (!directory) return
+                  const ctx = global.ensureServerCtx(conn)
+                  directories.forEach((entry) => ctx.projects.open(entry))
+                  ctx.projects.touch(directory)
+                  void tabs.newDraft({ server: ServerConnection.key(conn), directory })
+                },
+              })
+            }
+
+            command.register("titlebar-project", () => [
+              {
+                id: "project.open",
+                title: language.t("command.project.open"),
+                category: language.t("command.category.project"),
+                keybind: "mod+o",
+                onSelect: chooseProject,
+              },
+            ])
 
             command.register("titlebar-home", () => [
               {

--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -126,6 +126,17 @@ export default function NewSessionPage() {
       keybind: "ctrl+l",
       onSelect: () => promptInputV2Controller.restoreFocus(),
     },
+    {
+      id: "workspace.new",
+      title: language.t("workspace.new"),
+      category: language.t("command.category.workspace"),
+      keybind: "mod+shift+w",
+      disabled: !showWorkspaceBar(),
+      onSelect: () => {
+        setStore("worktree", "create")
+        promptInputV2Controller.restoreFocus()
+      },
+    },
   ])
 
   createEffect(() => {


### PR DESCRIPTION
### Issue for this PR

Closes #37829

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

registers two shortcuts that only existed in the legacy layout, so they work again in the new layout.

cmd+o (project.open) opens the folder picker. it was registered only in the legacy layout, so the new layout had nothing to trigger. this adds it to the new layout titlebar next to the other global commands.

cmd+shift+w (workspace.new) starts a new worktree. the new session composer already defers worktree creation to submit, so this registers the shortcut on the draft page to set the workspace selection to create and refocus the input. it is gated on the workspace bar being available (git project), matching the legacy command.

### How did you verify your code works?

ran the desktop app on the new layout, pressed cmd+o to confirm the native folder picker opens and the chosen folder starts a new session, and pressed cmd+shift+w on a git project draft to confirm the workspace selector switches to new worktree. typecheck passes on app.

### Screenshots / recordings

Before:

After:

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
