### PR TITLE
fix(provider): add NVIDIA NIM DeepSeek request compatibility

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -79,6 +79,13 @@ function normalizeMessages(
   model: Provider.Model,
   _options: Record<string, unknown>,
 ): ModelMessage[] {
+  // NVIDIA NIM rejects developer messages when chat_template_kwargs is present.
+  // Use system role instead for NVIDIA-hosted OpenAI-compatible models.
+  if (model.providerID === "nvidia") {
+    msgs = msgs.map((msg) =>
+      (msg as { role?: string }).role === "developer" ? ({ ...msg, role: "system" } as ModelMessage) : msg,
+    )
+  }
   const sanitizeToolResultOutput = (content: ToolResultPart) => {
     if (content.output.type === "text" || content.output.type === "error-text") {
       content.output.value = sanitizeSurrogates(content.output.value)

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1226,6 +1226,16 @@ export function options(input: {
     result["enable_thinking"] = true
   }
 
+  // NVIDIA NIM DeepSeek V4 requires chat_template_kwargs to stream reasoning.
+  if (input.model.providerID === "nvidia" && input.model.api.npm === "@ai-sdk/openai-compatible") {
+    if (modelId.includes("deepseek-v4")) {
+      result["chat_template_kwargs"] = {
+        thinking: true,
+        reasoning_effort: "high",
+      }
+    }
+
+  }
   if (input.model.api.npm === "@ai-sdk/azure" && input.model.api.id.includes("gpt-5.5")) {
     result["reasoningSummary"] = "auto"
     return result


### PR DESCRIPTION
### Issue for this PR

Closes #24264

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

DeepSeek V4 models on NVIDIA NIM (`deepseek-ai/deepseek-v4-flash`, `deepseek-ai/deepseek-v4-pro`) hang instead of streaming a response. NIM only streams reasoning tokens for these models when the request body includes `chat_template_kwargs`. Since the AI SDK drops unknown top-level config keys, there's no way to set this from `opencode.json`, so the field never reaches the wire and the request stalls.

Two changes in `transform.ts`:

1. In `options()`, for the `nvidia` provider on `@ai-sdk/openai-compatible`, I set `chat_template_kwargs: { thinking: true, reasoning_effort: "high" }` for `deepseek-v4` models. This lands directly on the request body (same pattern as the existing `alibaba-cn` `enable_thinking` block right above it), so it isn't stripped by the SDK.

2. In `normalizeMessages()`, I remap any `developer` role message to `system` for the `nvidia` provider. NIM returns a 500 on the `developer` role once `chat_template_kwargs` is present, so without this the first change just turns the hang into a 500.

I confirmed the field names against NVIDIA's own DeepSeek V4 docs (they use `chat_template_kwargs` with `thinking`, not `enable_thinking`, which is a different NIM model family).

### How did you verify your code works?

Ran the patched build locally (`bun run dev:desktop`) against NVIDIA NIM with my own API key.

- Before: `deepseek-v4-flash` hung until timeout.
- After: it streams normally.
- No more `developer`-role 500s.
- The only errors I hit afterward were NVIDIA-side quota (`ResourceExhausted`), which confirms the request is actually reaching the backend now instead of stalling on malformed body.

I couldn't re-verify against NVIDIA-hosted Kimi because that model returns a 404 "function not found for account" for my key right now, so I scoped this PR to DeepSeek only.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
