### PR TITLE
docs: add director to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [director](https://github.com/colinsurprenant/director)                                            | Coordination ledger: decisions, open loops, handoffs; one log across OpenCode, Claude Code, Codex  |
 
 ---
 


### PR DESCRIPTION
Adds director to the plugins list.

Director is an Apache-2.0 coordination ledger for coding-agent work: sessions record decisions, open loops, and handoffs to an append-only log, and the current state is injected into every new session as ground truth. The OpenCode integration is a managed plugin: `director install --opencode` drops a self-contained plugin at `~/.config/opencode/plugin/director.js` plus the `/director-*` custom commands, with no config files merged or modified. The same log is shared with its Claude Code and Codex integrations, so mixed-harness setups coordinate through one ledger.

Repo: https://github.com/colinsurprenant/director
