### PR TITLE
fix(core): authorize relative external paths

### DIFF
--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -10,8 +10,8 @@ export const Kind = Schema.Literals(["file", "directory"])
 export type Kind = typeof Kind.Type
 
 /**
- * Mutation paths do not accept project references. Relative paths must stay
- * inside the active Location. Absolute paths outside it require separate
+ * Mutation paths do not accept project references. Relative paths resolve
+ * from the active Location. Paths outside it require separate
  * `external_directory` approval.
  */
 export const ResolveInput = Schema.Struct({
@@ -23,7 +23,7 @@ export type ResolveInput = typeof ResolveInput.Type
 
 export class PathError extends Schema.TaggedErrorClass<PathError>()("LocationMutation.PathError", {
   path: Schema.String,
-  reason: Schema.Literals(["relative_escape", "location_escape", "non_directory_ancestor"]),
+  reason: Schema.Literals(["location_escape", "non_directory_ancestor"]),
 }) {}
 
 export interface ExternalDirectoryAuthorization {
@@ -51,9 +51,9 @@ export interface Target {
 
 export interface Interface {
   /**
-   * Resolve a path and derive its permission resources. Relative paths must
-   * stay inside the Location. Absolute paths outside it require separate
-   * `external_directory` approval. This does not approve the mutation.
+   * Resolve a path and derive its permission resources. Relative paths resolve
+   * from the Location. Paths outside it require separate `external_directory`
+   * approval. This does not approve the mutation.
    */
   readonly resolve: (input: ResolveInput) => Effect.Effect<Target, PathError | FSUtil.Error>
 }
@@ -118,10 +118,8 @@ const layer = Layer.effect(
     })
 
     const resolve = Effect.fn("LocationMutation.resolve")(function* (input: ResolveInput) {
-      const relative = !path.isAbsolute(input.path)
       const absolute = path.resolve(location.directory, input.path)
       const lexicallyInternal = FSUtil.contains(location.directory, absolute)
-      if (relative && !lexicallyInternal) return yield* new PathError({ path: input.path, reason: "relative_escape" })
 
       const resolved = yield* resolvePath(absolute)
       if (lexicallyInternal && !FSUtil.contains(locationRoot, resolved.canonical)) {

--- a/packages/core/test/location-mutation.test.ts
+++ b/packages/core/test/location-mutation.test.ts
@@ -60,11 +60,19 @@ describe("LocationMutation", () => {
     ),
   )
 
-  it.live("rejects a relative lexical escape instead of promoting it to external authority", () =>
+  it.live("requires external-directory authorization for a relative lexical escape", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
-        const error = yield* Effect.flip((yield* LocationMutation.Service).resolve({ path: "../outside.txt" }))
-        expect(error).toMatchObject({ _tag: "LocationMutation.PathError", reason: "relative_escape" })
+        const target = yield* (yield* LocationMutation.Service).resolve({ path: "../outside.txt" })
+        const root = yield* Effect.promise(() => fs.realpath(path.dirname(directory)))
+        expect(target).toMatchObject({
+          canonical: path.join(root, "outside.txt"),
+          resource: path.join(root, "outside.txt").replaceAll("\\", "/"),
+        })
+        expect(target.externalDirectory).toMatchObject({
+          directory: root,
+          resource: path.join(root, "*").replaceAll("\\", "/"),
+        })
       }).pipe(provide(directory)),
     ),
   )

--- a/specs/v2/schema-changelog.md
+++ b/specs/v2/schema-changelog.md
@@ -260,8 +260,8 @@ Affected schema:
 
 Change:
 
-- Resolve relative mutation paths within the active Location.
-- Accept absolute internal paths and require explicit `external_directory` approval before leaf approval for external absolute paths.
+- Resolve relative mutation paths from the active Location.
+- Accept absolute internal paths and require explicit `external_directory` approval before leaf approval for external paths.
 - Keep named references read-oriented and reject them for mutation.
 - Revalidate path authority immediately before write mechanics.
 


### PR DESCRIPTION
### Issue for this PR

Fixes #37687

### Type of change

- [x] Bug fix

### What does this PR do?

A relative mutation path that lexically escapes the active Location (e.g. `../sibling/file`) was rejected before permission evaluation, so a valid `apply_patch`/`edit` against an approved external sibling target failed with an empty durable error instead of routing through `external_directory` authorization.

Relative paths now resolve from the active Location, and any external target flows through the existing `external_directory` -> leaf approval path. The unused `relative_escape` reason is removed.

Ports the V2 fix (#37689) to `dev`.

### How did you verify your code works?

- `bun test test/location-mutation.test.ts` — 10 passed (the relative-escape case now asserts `external_directory` authorization).
- `bun run typecheck` in `packages/core`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR