### PR TITLE
fix(ai): tolerate empty-string tool call id/name in streaming deltas

### DIFF
--- a/packages/ai/src/protocols/utils/tool-stream.ts
+++ b/packages/ai/src/protocols/utils/tool-stream.ts
@@ -131,6 +131,11 @@ export const start = <K extends StreamKey>(
  * identity on the first delta instead of a separate start event. OpenAI Chat has
  * this shape: `tool_calls[].index` is the stream key, and `id` / `name` may only
  * appear on the first delta for that index.
+ *
+ * Some OpenAI-compatible APIs (e.g. DashScope token-plan) send empty strings
+ * for `id` / `name` on subsequent deltas instead of omitting them. Treat
+ * empty strings as absent so the accumulated identity from the first delta
+ * is preserved.
  */
 export const appendOrStart = <K extends StreamKey>(
   route: string,
@@ -140,8 +145,8 @@ export const appendOrStart = <K extends StreamKey>(
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
   const current = tools[key]
-  const id = delta.id ?? current?.id
-  const name = delta.name ?? current?.name
+  const id = (delta.id || undefined) ?? current?.id
+  const name = (delta.name || undefined) ?? current?.name
   if (!id || !name) return eventError(route, missingToolMessage)
 
   const tool = {

--- a/packages/ai/test/tool-stream.test.ts
+++ b/packages/ai/test/tool-stream.test.ts
@@ -36,6 +36,44 @@ describe("ToolStream", () => {
     }),
   )
 
+  it.effect("tolerates empty-string id and name on subsequent deltas", () =>
+    Effect.gen(function* () {
+      const first = ToolStream.appendOrStart(
+        ADAPTER,
+        ToolStream.empty<number>(),
+        0,
+        { id: "call_1", name: "calculator", text: "{" },
+        "missing tool",
+      )
+      if (ToolStream.isError(first)) return yield* first
+      // DashScope token-plan sends id:"" and name:"" on continuation deltas
+      const second = ToolStream.appendOrStart(
+        ADAPTER,
+        first.tools,
+        0,
+        { id: "", name: "", text: '"expression": "2+3"}' },
+        "missing tool",
+      )
+      if (ToolStream.isError(second)) return yield* second
+      const finished = yield* ToolStream.finish(ADAPTER, second.tools, 0)
+
+      expect(first.events).toEqual([
+        { type: "tool-input-start", id: "call_1", name: "calculator" },
+        { type: "tool-input-delta", id: "call_1", name: "calculator", text: "{" },
+      ])
+      expect(second.events).toEqual([
+        { type: "tool-input-delta", id: "call_1", name: "calculator", text: '"expression": "2+3"}' },
+      ])
+      expect(finished).toEqual({
+        tools: {},
+        events: [
+          { type: "tool-input-end", id: "call_1", name: "calculator" },
+          { type: "tool-call", id: "call_1", name: "calculator", input: { expression: "2+3" } },
+        ],
+      })
+    }),
+  )
+
   it.effect("fails appendExisting when the provider skipped the tool start", () =>
     Effect.gen(function* () {
       const error = ToolStream.appendExisting(ADAPTER, ToolStream.empty<number>(), 0, "{}", "missing tool")


### PR DESCRIPTION
### Issue for this PR

Closes #37841

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Some OpenAI-compatible APIs (e.g. DashScope token-plan / GLM-5.2) send empty strings for `id` and `function.name` on subsequent tool call deltas instead of omitting them or sending `null`. `ToolStream.appendOrStart` uses `??` (nullish coalescing) to fall back to accumulated identity from the first delta, but `""` is not nullish so the fallback never triggers, and `!id` / `!name` then fails with "OpenAI Chat tool call delta is missing id or name".

The fix treats empty strings as absent by using `||` before `??`:

```ts
const id = (delta.id || undefined) ?? current?.id
const name = (delta.name || undefined) ?? current?.name
```

This preserves the accumulated identity from the first delta (which does contain valid `id` and `name`) when subsequent deltas send empty strings.

### How did you verify your code works?

- Added a test case simulating the DashScope token-plan streaming format (first delta with valid id/name, subsequent deltas with empty strings). All 8 tests in `tool-stream.test.ts` pass.
- Verified against the real token-plan API (`token-plan.cn-beijing.maas.aliyuncs.com`) with GLM-5.2 by curling a streaming tool call request and confirming the empty-string delta pattern.
- Built a local binary and confirmed tool calls work end-to-end with the fix.

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR