### PR TITLE
fix(core): fail empty provider output

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -314,7 +314,14 @@ const layer = Layer.effect(
             yield* withPublication(publisher.failUnsettledTools(`Tool execution failed: ${message}`))
           }
           const stepSettlement = publisher.stepSettlement()
-          if (stepSettlement && !publisher.hasProviderError()) {
+          const emptyOutput =
+            stream._tag === "Success" &&
+            !publisher.hasProviderError() &&
+            stepSettlement !== undefined &&
+            !publisher.hasUsableOutput()
+          if (emptyOutput)
+            yield* withPublication(publisher.failAssistant("Provider returned no usable assistant output"))
+          if (stepSettlement && !publisher.hasProviderError() && !emptyOutput) {
             const endSnapshot = yield* snapshots.capture()
             const files =
               startSnapshot && endSnapshot

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -69,6 +69,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
   let assistantActive = false
   let assistantFailed = false
   let providerFailed = false
+  let usableOutput = false
   let stepSettlement: { readonly finish: string; readonly tokens: ReturnType<typeof tokens> } | undefined
 
   const startAssistant = Effect.fnUntraced(function* () {
@@ -253,6 +254,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
         })
         return
       case "text-delta":
+        if (event.text.trim().length > 0) usableOutput = true
         yield* text.append(event.id, event.text)
         yield* events.publish(SessionEvent.Text.Delta, {
           sessionID: input.sessionID,
@@ -318,6 +320,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
           return yield* Effect.die(`Tool call name changed for ${event.id}: ${tool.name} -> ${event.name}`)
         if (tool.called) return yield* Effect.die(`Duplicate tool call: ${event.id}`)
         tool.called = true
+        usableOutput = true
         tool.providerExecuted = event.providerExecuted === true
         tool.providerMetadata = event.providerMetadata
         yield* events.publish(SessionEvent.Tool.Called, {
@@ -416,6 +419,7 @@ export const createLLMEventPublisher = (events: EventV2.Interface, input: Input)
     hasActiveAssistant: () => assistantActive,
     hasAssistantStarted: () => assistantMessageID !== undefined,
     hasProviderError: () => providerFailed,
+    hasUsableOutput: () => usableOutput,
     stepSettlement: () => stepSettlement,
     startAssistant,
     assistantMessageID: assistantMessageIDForTool,

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -437,16 +437,20 @@ const fragmentFixture = (kind: FragmentKind, id: string, chunks: readonly string
         ...chunks.map((text) => LLMEvent.reasoningDelta({ id, text })),
       ]
       const expectedContent = { type: "reasoning", id, text }
+      const visibleContent = { type: "text", text: "Done" }
       return {
         delta: SessionEvent.Reasoning.Delta,
         partialEvents,
         completeEvents: [
           ...partialEvents,
           LLMEvent.reasoningEnd({ id }),
+          LLMEvent.textStart({ id: `${id}-text` }),
+          LLMEvent.textDelta({ id: `${id}-text`, text: visibleContent.text }),
+          LLMEvent.textEnd({ id: `${id}-text` }),
           LLMEvent.stepFinish({ index: 0, reason: "stop" }),
           LLMEvent.finish({ reason: "stop" }),
         ],
-        expectedAssistant: { type: "assistant", finish: "stop", content: [expectedContent] },
+        expectedAssistant: { type: "assistant", finish: "stop", content: [expectedContent, visibleContent] },
         expectedContent,
       }
     }
@@ -1529,6 +1533,9 @@ describe("SessionRunnerLLM", () => {
           id: "reasoning-openai",
           providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
         }),
+        LLMEvent.textStart({ id: "reasoning-final" }),
+        LLMEvent.textDelta({ id: "reasoning-final", text: "Done" }),
+        LLMEvent.textEnd({ id: "reasoning-final" }),
         LLMEvent.stepFinish({ index: 0, reason: "stop" }),
         LLMEvent.finish({ reason: "stop" }),
       ]
@@ -1546,6 +1553,7 @@ describe("SessionRunnerLLM", () => {
               text: "Encrypted thought",
               providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
             },
+            { type: "text", text: "Done" },
           ],
         },
       ])
@@ -1561,6 +1569,7 @@ describe("SessionRunnerLLM", () => {
           text: "Encrypted thought",
           providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
         },
+        { type: "text", text: "Done" },
       ])
     }),
   )
@@ -2637,6 +2646,9 @@ describe("SessionRunnerLLM", () => {
         ],
         [
           LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.textStart({ id: "text-blocked" }),
+          LLMEvent.textDelta({ id: "text-blocked", text: "Done" }),
+          LLMEvent.textEnd({ id: "text-blocked" }),
           LLMEvent.stepFinish({ index: 0, reason: "stop" }),
           LLMEvent.finish({ reason: "stop" }),
         ],
@@ -2653,7 +2665,7 @@ describe("SessionRunnerLLM", () => {
             { type: "tool", id: "call-blocked", state: { status: "error", error: { message: "Permission blocked" } } },
           ],
         },
-        { type: "assistant", finish: "stop" },
+        { type: "assistant", finish: "stop", content: [{ type: "text", text: "Done" }] },
       ])
     }),
   )
@@ -2730,6 +2742,9 @@ describe("SessionRunnerLLM", () => {
         ],
         [
           LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.textStart({ id: "text-corrected" }),
+          LLMEvent.textDelta({ id: "text-corrected", text: "Done" }),
+          LLMEvent.textEnd({ id: "text-corrected" }),
           LLMEvent.stepFinish({ index: 0, reason: "stop" }),
           LLMEvent.finish({ reason: "stop" }),
         ],
@@ -2746,7 +2761,7 @@ describe("SessionRunnerLLM", () => {
             { type: "tool", id: "call-corrected", state: { status: "error", error: { message: "Use another tool" } } },
           ],
         },
-        { type: "assistant", finish: "stop" },
+        { type: "assistant", finish: "stop", content: [{ type: "text", text: "Done" }] },
       ])
     }),
   )
@@ -3134,6 +3149,78 @@ describe("SessionRunnerLLM", () => {
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Fail raw stream durably" },
         { type: "assistant", finish: "error", error: { type: "unknown", message: "Provider unavailable" } },
+      ])
+    }),
+  )
+
+  it.effect("fails a successful provider step that produces no usable assistant output", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Answer visibly" }), resume: false })
+      response = [
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+        LLMEvent.finish({ reason: "stop" }),
+      ]
+      yield* session.resume(sessionID)
+
+      const { db } = yield* Database.Service
+      const types = (
+        yield* db
+          .select({ type: EventTable.type })
+          .from(EventTable)
+          .where(eq(EventTable.aggregate_id, sessionID))
+          .orderBy(asc(EventTable.seq))
+          .all()
+          .pipe(Effect.orDie)
+      ).map((row) => row.type)
+      expect(types.some((type) => type.startsWith("session.next.step.failed"))).toBe(true)
+      expect(types.some((type) => type.startsWith("session.next.step.ended"))).toBe(false)
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user", text: "Answer visibly" },
+        {
+          type: "assistant",
+          finish: "error",
+          error: { type: "unknown", message: "Provider returned no usable assistant output" },
+        },
+      ])
+    }),
+  )
+
+  it.effect("fails reasoning-only output even with whitespace text and nonzero tokens", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Answer visibly" }), resume: false })
+      response = [
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.reasoningStart({ id: "reasoning-only" }),
+        LLMEvent.reasoningDelta({ id: "reasoning-only", text: "Still thinking" }),
+        LLMEvent.reasoningEnd({ id: "reasoning-only" }),
+        LLMEvent.textStart({ id: "text-whitespace" }),
+        LLMEvent.textDelta({ id: "text-whitespace", text: " \n\t" }),
+        LLMEvent.textEnd({ id: "text-whitespace" }),
+        LLMEvent.stepFinish({
+          index: 0,
+          reason: "stop",
+          usage: { outputTokens: 6, reasoningTokens: 62 },
+        }),
+        LLMEvent.finish({ reason: "stop" }),
+      ]
+      yield* session.resume(sessionID)
+
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user", text: "Answer visibly" },
+        {
+          type: "assistant",
+          finish: "error",
+          error: { type: "unknown", message: "Provider returned no usable assistant output" },
+          content: [
+            { type: "reasoning", text: "Still thinking" },
+            { type: "text", text: " \n\t" },
+          ],
+        },
       ])
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Fixes #37372

### Type of change

- [x] Bug fix

### What does this PR do?

A successful provider step that reached `step-finish` with no visible text and no tool calls was recorded as a successful completion. Downstream clients received neither an answer nor a failure, so the user's turn was silently dropped even when the response reported nonzero output tokens.

The LLM event publisher now tracks usable assistant output (non-whitespace text or a tool call). When a finished step produced none, the assistant step is failed (`session.next.step.failed`) instead of ended (`session.next.step.ended`), and the run does not continue. Reasoning and whitespace-only text are still preserved on the failed assistant message.

Ports the V2 fix (#37379) to `dev`, adapted to `dev`'s error/event model.

### How did you verify your code works?

- `bun test test/session-runner.test.ts` — 85 passed, including new regression tests for an empty finished step and a reasoning-only response with whitespace text and nonzero tokens.
- `bun test test/session-projector.test.ts test/session-runner-message.test.ts test/session-runner-recorded.test.ts test/session-runner-tool-events.test.ts test/session-runner-model.test.ts test/session-runner-tool-registry.test.ts` — 51 passed.
- `bun run typecheck` in `packages/core`.
- `oxlint` on the changed files (0 errors).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR