### PR TITLE
fix(codemode): parse canonical index keys

### DIFF
--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -197,8 +197,8 @@ ultimate source of truth.
 - [x] `length`, numeric indexing, index assignment, spread, and `for...of`.
 - [x] The `thisArg` argument of `Array.from` is accepted and ignored, like JS arrows.
 - [ ] `Array.prototype.toSpliced`.
-- [ ] Canonical array/string index parsing: a key such as `"01"` must remain an ordinary property key rather than
-      aliasing index `1`.
+- [x] Canonical array/string index parsing: keys such as `"01"` remain non-index properties rather than aliasing index
+      `1`; arbitrary array-property assignment remains unsupported.
 - [x] `Array.prototype.sort` preserves trailing holes, while `toSorted` densifies holes into `undefined` elements,
       like JavaScript.
 

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -96,6 +96,13 @@ const globalStaticMembers: Partial<Record<GlobalNamespaceName, Set<string>>> = {
   URL: urlStatics,
 }
 
+const canonicalArrayIndex = (key: string | number): number | undefined => {
+  const property = String(key)
+  const index = Number(property)
+  if (!Number.isInteger(index) || index < 0 || index >= 2 ** 32 - 1 || String(index) !== property) return undefined
+  return index
+}
+
 const calleeDescription = (callee: AstNode): string => {
   if (callee.type === "Identifier") return getString(callee, "name")
   if (callee.type === "MemberExpression") {
@@ -1916,8 +1923,8 @@ export class Interpreter<R> {
 
       if (typeof objectValue === "string") {
         if (key === "length") return new ComputedValue(objectValue.length)
-        if (typeof key === "number") return new ComputedValue(objectValue[key])
-        if (typeof key === "string" && /^\d+$/.test(key)) return new ComputedValue(objectValue[Number(key)])
+        const index = canonicalArrayIndex(key)
+        if (index !== undefined) return new ComputedValue(objectValue[index])
         if (typeof key === "string" && stringMethods.has(key)) return new IntrinsicReference(objectValue, key)
         return new ComputedValue(undefined)
       }
@@ -2011,18 +2018,14 @@ export class Interpreter<R> {
 
       if (Array.isArray(objectValue)) {
         if (operation === "delete") return { target: objectValue, key }
-        if (
-          key !== "length" &&
-          !(typeof key === "string" && arrayMethods.has(key)) &&
-          typeof key !== "number" &&
-          !/^\d+$/.test(key)
-        ) {
+        const index = canonicalArrayIndex(key)
+        if (key !== "length" && !(typeof key === "string" && arrayMethods.has(key)) && index === undefined) {
           if (typeof key === "string" && Object.hasOwn(objectValue, key)) {
             return new ComputedValue((objectValue as Record<string, unknown> & Array<unknown>)[key])
           }
           return new ComputedValue(undefined)
         }
-        return { target: objectValue, key }
+        return { target: objectValue, key: index ?? key }
       }
 
       return { target: objectValue as SafeObject, key }
@@ -2046,7 +2049,7 @@ export class Interpreter<R> {
         if (typeof reference.key === "string" && arrayMethods.has(reference.key)) {
           return new IntrinsicReference(reference.target, reference.key)
         }
-        return reference.key === "length" ? reference.target.length : reference.target[Number(reference.key)]
+        return reference.key === "length" ? reference.target.length : reference.target[reference.key as number]
       }
       if (reference.target instanceof CodeModeURL) {
         return (reference.target.url as unknown as Record<string, unknown>)[String(reference.key)]
@@ -2109,7 +2112,7 @@ export class Interpreter<R> {
           throw new InterpreterRuntimeError("Array methods cannot be assigned in CodeMode.", node)
         }
       }
-      const key = Array.isArray(reference.target) ? Number(reference.key) : String(reference.key)
+      const key = Array.isArray(reference.target) ? reference.key : String(reference.key)
       const current =
         reference.target instanceof CodeModeURL
           ? (reference.target.url as unknown as Record<string, unknown>)[key]
@@ -2124,9 +2127,9 @@ export class Interpreter<R> {
     if (Array.isArray(reference.target)) {
       const target = reference.target
       const index = key as number
-      if (!Number.isInteger(index) || index < 0) {
+      if (!Number.isInteger(index) || index < 0 || index >= 2 ** 32 - 1) {
         throw new InterpreterRuntimeError(
-          "Array assignment index must be a non-negative integer.",
+          "Array assignment index must be a valid array index.",
           node,
           "InvalidDataValue",
         )

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -96,11 +96,14 @@ const globalStaticMembers: Partial<Record<GlobalNamespaceName, Set<string>>> = {
   URL: urlStatics,
 }
 
-const canonicalArrayIndex = (key: string | number): number | undefined => {
+// Array lengths are unsigned 32-bit integers, so the largest index is one less than the maximum length.
+const MAX_ARRAY_INDEX = 4_294_967_294
+
+const parseArrayIndex = (key: string | number): number | undefined => {
   const property = String(key)
+  if (!/^(0|[1-9]\d*)$/.test(property)) return undefined
   const index = Number(property)
-  if (!Number.isInteger(index) || index < 0 || index >= 2 ** 32 - 1 || String(index) !== property) return undefined
-  return index
+  return index <= MAX_ARRAY_INDEX ? index : undefined
 }
 
 const calleeDescription = (callee: AstNode): string => {
@@ -1923,7 +1926,7 @@ export class Interpreter<R> {
 
       if (typeof objectValue === "string") {
         if (key === "length") return new ComputedValue(objectValue.length)
-        const index = canonicalArrayIndex(key)
+        const index = parseArrayIndex(key)
         if (index !== undefined) return new ComputedValue(objectValue[index])
         if (typeof key === "string" && stringMethods.has(key)) return new IntrinsicReference(objectValue, key)
         return new ComputedValue(undefined)
@@ -2018,7 +2021,7 @@ export class Interpreter<R> {
 
       if (Array.isArray(objectValue)) {
         if (operation === "delete") return { target: objectValue, key }
-        const index = canonicalArrayIndex(key)
+        const index = parseArrayIndex(key)
         if (key !== "length" && !(typeof key === "string" && arrayMethods.has(key)) && index === undefined) {
           if (typeof key === "string" && Object.hasOwn(objectValue, key)) {
             return new ComputedValue((objectValue as Record<string, unknown> & Array<unknown>)[key])
@@ -2046,10 +2049,9 @@ export class Interpreter<R> {
       )
         return reference
       if (Array.isArray(reference.target)) {
-        if (typeof reference.key === "string" && arrayMethods.has(reference.key)) {
-          return new IntrinsicReference(reference.target, reference.key)
-        }
-        return reference.key === "length" ? reference.target.length : reference.target[reference.key as number]
+        if (reference.key === "length") return reference.target.length
+        if (typeof reference.key === "string") return new IntrinsicReference(reference.target, reference.key)
+        return reference.target[reference.key]
       }
       if (reference.target instanceof CodeModeURL) {
         return (reference.target.url as unknown as Record<string, unknown>)[String(reference.key)]
@@ -2126,8 +2128,7 @@ export class Interpreter<R> {
   private assignToReference(reference: MemberReference, key: number | string, next: unknown, node: AstNode): void {
     if (Array.isArray(reference.target)) {
       const target = reference.target
-      const index = key as number
-      if (!Number.isInteger(index) || index < 0 || index >= 2 ** 32 - 1) {
+      if (typeof key !== "number" || parseArrayIndex(key) === undefined) {
         throw new InterpreterRuntimeError(
           "Array assignment index must be a valid array index.",
           node,
@@ -2135,7 +2136,7 @@ export class Interpreter<R> {
         )
       }
       rejectCircularInsertion(target, next, "Array assignment result", node)
-      target[index] = next
+      target[key] = next
       return
     }
     if (reference.target instanceof CodeModeURL) {

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -96,14 +96,13 @@ const globalStaticMembers: Partial<Record<GlobalNamespaceName, Set<string>>> = {
   URL: urlStatics,
 }
 
-// Array lengths are unsigned 32-bit integers, so the largest index is one less than the maximum length.
-const MAX_ARRAY_INDEX = 4_294_967_294
+const MAX_ARRAY_LENGTH = 4_294_967_295
 
 const parseArrayIndex = (key: string | number): number | undefined => {
   const property = String(key)
   if (!/^(0|[1-9]\d*)$/.test(property)) return undefined
   const index = Number(property)
-  return index <= MAX_ARRAY_INDEX ? index : undefined
+  return index < MAX_ARRAY_LENGTH ? index : undefined
 }
 
 const calleeDescription = (callee: AstNode): string => {

--- a/packages/codemode/test/parity.test.ts
+++ b/packages/codemode/test/parity.test.ts
@@ -42,6 +42,15 @@ describe("H2: string property access reads as undefined (not a throw)", () => {
   test("unknown property on a number is undefined", async () => {
     expect(await value(`return (5).foo ?? "n"`)).toBe("n")
   })
+
+  test("only canonical string index keys access characters", async () => {
+    expect(
+      await value(`
+        const text = "abc"
+        return [text[1], text["1"], text["01"], text["1.0"], text[-0], text["-0"]]
+      `),
+    ).toEqual(["b", "b", null, null, "a", null])
+  })
 })
 
 describe("H3: array property access reads as undefined (not a throw)", () => {
@@ -61,6 +70,38 @@ describe("H3: array property access reads as undefined (not a throw)", () => {
   test("array indexing still works", async () => {
     expect(await value(`return [1,2,3][9] === undefined`)).toBe(true)
     expect(await value(`return [1,2,3][9]`)).toBeNull()
+  })
+
+  test("only canonical array index keys access elements", async () => {
+    expect(
+      await value(`
+        const values = ["a", "b"]
+        return [values[1], values["1"], values["01"], values["1.0"], values[-0], values["-0"]]
+      `),
+    ).toEqual(["b", "b", null, null, "a", null])
+  })
+
+  test("noncanonical keys cannot mutate or delete an aliased element", async () => {
+    expect(
+      await value(`
+        const values = ["a", "b"]
+        let writes = 0
+        try { values["01"] = ++writes } catch {}
+        const removed = delete values["01"]
+        return [writes, removed, values]
+      `),
+    ).toEqual([0, true, ["a", "b"]])
+  })
+
+  test("the maximum array length is not accepted as an array index", async () => {
+    expect(
+      await value(`
+        const values = []
+        let writes = 0
+        try { values["4294967295"] = ++writes } catch {}
+        return [writes, values.length]
+      `),
+    ).toEqual([0, 0])
   })
 })
 


### PR DESCRIPTION
## Summary
- recognize only canonical array index property keys
- prevent noncanonical string keys from aliasing array and string indices
- enforce the JavaScript array-index upper bound and update the support matrix

## Testing
- `bun test`
- `bun typecheck`
- `bunx prettier --check src/interpreter/runtime.ts test/parity.test.ts interpreter-support.md`