### PR TITLE
feat(cli): estimate and hint about Code context at Plan exit

### DIFF
--- a/packages/app/src/pages/session/composer/session-question-dock.tsx
+++ b/packages/app/src/pages/session/composer/session-question-dock.tsx
@@ -33,6 +33,7 @@ function Option(props: {
   picked: boolean
   label: string
   description?: string
+  recommended?: boolean
   disabled: boolean
   ref?: (el: HTMLButtonElement) => void
   onFocus?: VoidFunction
@@ -53,6 +54,9 @@ function Option(props: {
       <Mark multi={props.multi} picked={props.picked} />
       <span data-slot="question-option-main">
         <span data-slot="option-label">{props.label}</span>
+        <Show when={props.recommended}>
+          <span data-slot="option-recommended">(Recommended)</span>
+        </Show>
         <Show when={props.description}>
           <span data-slot="option-description">{props.description}</span>
         </Show>
@@ -551,6 +555,7 @@ export const SessionQuestionDock: Component<{ request: QuestionRequest; onSubmit
                 picked={picked(opt.label)}
                 label={opt.label}
                 description={opt.description}
+                recommended={opt.recommended}
                 disabled={sending()}
                 ref={(el) => (optsRef[i()] = el)}
                 onFocus={() => setStore("focus", i())}

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -2705,7 +2705,11 @@ export type QuestionsListRequestsOutput = {
     readonly questions: ReadonlyArray<{
       readonly question: string
       readonly header: string
-      readonly options: ReadonlyArray<{ readonly label: string; readonly description: string }>
+      readonly options: ReadonlyArray<{
+        readonly label: string
+        readonly description: string
+        readonly recommended?: boolean
+      }>
       readonly multiple?: boolean
       readonly custom?: boolean
     }>
@@ -2722,7 +2726,11 @@ export type QuestionsListOutput = {
     readonly questions: ReadonlyArray<{
       readonly question: string
       readonly header: string
-      readonly options: ReadonlyArray<{ readonly label: string; readonly description: string }>
+      readonly options: ReadonlyArray<{
+        readonly label: string
+        readonly description: string
+        readonly recommended?: boolean
+      }>
       readonly multiple?: boolean
       readonly custom?: boolean
     }>

--- a/packages/opencode/src/cli/cmd/run/footer.question.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.question.tsx
@@ -407,6 +407,9 @@ export function RunQuestionBody(props: {
                               >
                                 {info()?.multiple ? `[${hit() ? "✓" : " "}] ${item.label}` : item.label}
                               </text>
+                              <Show when={item.recommended}>
+                                <text fg={props.theme.success}> (Recommended)</text>
+                              </Show>
                             </box>
                             <Show when={!info()?.multiple}>
                               <text fg={props.theme.success}>{hit() ? " ✓" : ""}</text>

--- a/packages/opencode/src/tool/plan-context.ts
+++ b/packages/opencode/src/tool/plan-context.ts
@@ -1,0 +1,44 @@
+import { Effect } from "effect"
+import type { Agent } from "@/agent/agent"
+import type { Provider } from "@/provider/provider"
+import type { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import type { SessionV1 } from "@opencode-ai/core/v1/session"
+import { isOverflow } from "@/session/overflow"
+
+export function tokenCount(tokens: SessionV1.Assistant["tokens"]) {
+  return tokens.total || tokens.input + tokens.output + tokens.cache.read + tokens.cache.write
+}
+
+export function estimateContext(input: {
+  cfg: ConfigV1.Info
+  model: Provider.Model
+  tokens: SessionV1.Assistant["tokens"]
+}) {
+  if (input.model.limit.context === 0) return undefined
+
+  const count = tokenCount(input.tokens)
+  if (count === 0) return undefined
+
+  const context = input.model.limit.input || input.model.limit.context
+  if (context === 0) return undefined
+
+  return {
+    percent: Math.round((count / context) * 100),
+    recommended: isOverflow({ cfg: input.cfg, tokens: input.tokens, model: input.model }),
+  }
+}
+
+export function resolveBuildModel(input: {
+  agent?: Pick<Agent.Info, "model">
+  provider: Pick<Provider.Interface, "defaultModel" | "getModel">
+}) {
+  return Effect.gen(function* () {
+    const selected =
+      input.agent?.model ?? (yield* input.provider.defaultModel().pipe(Effect.catch(() => Effect.succeed(undefined))))
+    if (!selected) return undefined
+
+    return yield* input.provider
+      .getModel(selected.providerID, selected.modelID)
+      .pipe(Effect.catch(() => Effect.succeed(undefined)))
+  })
+}

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -4,11 +4,13 @@ import { Effect, Schema } from "effect"
 import * as Tool from "./tool"
 import { Question } from "../question"
 import { Session } from "@/session/session"
-import { MessageV2 } from "../session/message-v2"
 import { Provider } from "@/provider/provider"
+import { Agent } from "@/agent/agent"
+import { Config } from "@/config/config"
 import { InstanceState } from "@/effect/instance-state"
 import { MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
+import { estimateContext, resolveBuildModel } from "./plan-context"
 
 export const Parameters = Schema.Struct({})
 
@@ -18,6 +20,8 @@ export const PlanExitTool = Tool.define(
     const session = yield* Session.Service
     const question = yield* Question.Service
     const provider = yield* Provider.Service
+    const agents = yield* Agent.Service
+    const configService = yield* Config.Service
 
     return {
       description: EXIT_DESCRIPTION,
@@ -27,6 +31,17 @@ export const PlanExitTool = Tool.define(
           const instance = yield* InstanceState.context
           const info = yield* session.get(ctx.sessionID)
           const plan = path.relative(instance.worktree, Session.plan(info, instance))
+          const messages = yield* session.messages({ sessionID: ctx.sessionID }).pipe(Effect.orDie)
+          const config = yield* configService.get()
+          const build = yield* agents.get("build").pipe(Effect.catch(() => Effect.succeed(undefined)))
+          const buildModel = yield* resolveBuildModel({ agent: build, provider })
+          const assistant = messages.findLast(
+            (item) => item.info.role === "assistant" && item.info.finish && !item.info.error,
+          )
+          const context =
+            buildModel && assistant?.info.role === "assistant"
+              ? estimateContext({ cfg: config, model: buildModel, tokens: assistant.info.tokens })
+              : undefined
           const answers = yield* question.ask({
             sessionID: ctx.sessionID,
             questions: [
@@ -35,8 +50,21 @@ export const PlanExitTool = Tool.define(
                 header: "Build Agent",
                 custom: false,
                 options: [
-                  { label: "Yes", description: "Switch to build agent and start implementing the plan" },
-                  { label: "No", description: "Stay with plan agent to continue refining the plan" },
+                  {
+                    label: "Yes",
+                    description: context
+                      ? `Switch to build agent and start implementing the plan (using ${context.percent}% of Code mode context)`
+                      : "Switch to build agent and start implementing the plan",
+                  },
+                  {
+                    label: "No",
+                    description: "Stay with plan agent to continue refining the plan",
+                  },
+                  {
+                    label: "Start new session",
+                    description: "Switch to build agent and start implementing the plan in a fresh session",
+                    ...(context?.recommended ? { recommended: true } : {}),
+                  },
                 ],
               },
             ],
@@ -45,24 +73,31 @@ export const PlanExitTool = Tool.define(
 
           if (answers[0]?.[0] === "No") yield* new Question.RejectedError()
 
-          const messages = yield* session.messages({ sessionID: ctx.sessionID }).pipe(Effect.orDie)
           const lastUser = messages.findLast((item) => item.info.role === "user" && item.info.model)
-          const model =
+          const handoffModel =
             lastUser?.info.role === "user" && lastUser.info.model ? lastUser.info.model : yield* provider.defaultModel()
+          const fresh = answers[0]?.[0] === "Start new session"
+          const target = fresh
+            ? yield* session.create({
+                parentID: ctx.sessionID,
+                agent: "build",
+                model: { id: handoffModel.modelID, providerID: handoffModel.providerID },
+              })
+            : undefined
 
           const msg: SessionV1.User = {
             id: MessageID.ascending(),
-            sessionID: ctx.sessionID,
+            sessionID: target?.id ?? ctx.sessionID,
             role: "user",
             time: { created: Date.now() },
             agent: "build",
-            model,
+            model: handoffModel,
           }
           yield* session.updateMessage(msg)
           yield* session.updatePart({
             id: PartID.ascending(),
             messageID: msg.id,
-            sessionID: ctx.sessionID,
+            sessionID: msg.sessionID,
             type: "text",
             text: `The plan at ${plan} has been approved, you can now edit files. Execute the plan`,
             synthetic: true,
@@ -70,7 +105,9 @@ export const PlanExitTool = Tool.define(
 
           return {
             title: "Switching to build agent",
-            output: "User approved switching to build agent. Wait for further instructions.",
+            output: fresh
+              ? `Created a fresh build session (${target?.id}). Continue implementation there.`
+              : "User approved switching to build agent. Wait for further instructions.",
             metadata: {},
           }
         }).pipe(Effect.orDie),

--- a/packages/opencode/test/tool/plan-context.test.ts
+++ b/packages/opencode/test/tool/plan-context.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { Provider } from "@/provider/provider"
+import { estimateContext, resolveBuildModel, tokenCount } from "@/tool/plan-context"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import type { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import type { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ProviderTest } from "../fake/provider"
+
+const config: ConfigV1.Info = {}
+
+function tokens(input: Partial<SessionV1.Assistant["tokens"]> = {}): SessionV1.Assistant["tokens"] {
+  return {
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cache: { read: 0, write: 0 },
+    ...input,
+  }
+}
+
+describe("plan context", () => {
+  test("preserves total token accounting and falls back to component totals", () => {
+    expect(tokenCount(tokens({ total: 12, input: 20, output: 3 }))).toBe(12)
+    expect(tokenCount(tokens({ input: 20, output: 3, cache: { read: 4, write: 5 } }))).toBe(32)
+  })
+
+  test("calculates usage from the input limit and recommends at overflow", () => {
+    const model = ProviderTest.model({ limit: { context: 100, output: 10 } })
+
+    expect(estimateContext({ cfg: config, model, tokens: tokens({ input: 90 }) })).toEqual({
+      percent: 90,
+      recommended: true,
+    })
+
+    const inputLimited = ProviderTest.model({ limit: { context: 200, input: 100, output: 10 } })
+    expect(estimateContext({ cfg: config, model: inputLimited, tokens: tokens({ input: 75 }) })).toEqual({
+      percent: 75,
+      recommended: false,
+    })
+  })
+
+  test("returns no estimate for zero context or unavailable usage", () => {
+    const model = ProviderTest.model({ limit: { context: 0, output: 10 } })
+    expect(estimateContext({ cfg: config, model, tokens: tokens({ input: 10 }) })).toBeUndefined()
+
+    const bounded = ProviderTest.model({ limit: { context: 100, output: 10 } })
+    expect(estimateContext({ cfg: config, model: bounded, tokens: tokens() })).toBeUndefined()
+  })
+
+  test("resolves the build model and falls back to the provider default", async () => {
+    const explicit = ProviderTest.model({ id: ModelV2.ID.make("explicit-model") })
+    const fallback = ProviderTest.model({ id: ModelV2.ID.make("fallback-model") })
+    const provider = {
+      defaultModel: () => Effect.succeed({ providerID: fallback.providerID, modelID: fallback.id }),
+      getModel: (_providerID: string, modelID: string) => Effect.succeed(modelID === explicit.id ? explicit : fallback),
+    } satisfies Pick<Provider.Interface, "defaultModel" | "getModel">
+
+    await expect(
+      Effect.runPromise(
+        resolveBuildModel({
+          agent: { model: { providerID: explicit.providerID, modelID: explicit.id } },
+          provider,
+        }),
+      ),
+    ).resolves.toBe(explicit)
+
+    await expect(Effect.runPromise(resolveBuildModel({ agent: {}, provider }))).resolves.toBe(fallback)
+  })
+
+  test("does not block when model resolution fails", async () => {
+    const provider = {
+      defaultModel: () => Effect.fail(new Provider.NoProvidersError()),
+      getModel: (providerID: string, modelID: string) =>
+        Effect.fail(
+          new Provider.ModelNotFoundError({
+            providerID: ProviderV2.ID.make(providerID),
+            modelID: ModelV2.ID.make(modelID),
+          }),
+        ),
+    } satisfies Pick<Provider.Interface, "defaultModel" | "getModel">
+
+    await expect(Effect.runPromise(resolveBuildModel({ agent: {}, provider }))).resolves.toBeUndefined()
+  })
+})

--- a/packages/schema/src/question.ts
+++ b/packages/schema/src/question.ts
@@ -22,6 +22,7 @@ export type ID = typeof ID.Type
 export const Option = Schema.Struct({
   label: Schema.String.annotate({ description: "Display text (1-5 words, concise)" }),
   description: Schema.String.annotate({ description: "Explanation of choice" }),
+  recommended: Schema.Boolean.pipe(optional).annotate({ description: "Whether this choice is recommended" }),
 }).annotate({ identifier: "QuestionV2.Option" })
 export interface Option extends Schema.Schema.Type<typeof Option> {}
 

--- a/packages/schema/src/v1/question.ts
+++ b/packages/schema/src/v1/question.ts
@@ -15,6 +15,7 @@ export const ID = Schema.String.check(Schema.isStartsWith("que")).pipe(
 export const Option = Schema.Struct({
   label: Schema.String.annotate({ description: "Display text (1-5 words, concise)" }),
   description: Schema.String.annotate({ description: "Explanation of choice" }),
+  recommended: Schema.optional(Schema.Boolean).annotate({ description: "Whether this choice is recommended" }),
 }).annotate({ identifier: "QuestionOption" })
 
 const base = {

--- a/packages/schema/test/question-option.test.ts
+++ b/packages/schema/test/question-option.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test"
+import { Schema } from "effect"
+import { Question } from "../src/question"
+import { QuestionV1 } from "../src/question-v1"
+
+test("question options accept optional recommendations without changing answers", () => {
+  const input = {
+    label: "Start new session",
+    description: "Implement with a clean context",
+    recommended: true,
+  }
+
+  expect(Schema.decodeUnknownSync(Question.Option)(input)).toEqual(input)
+  expect(Schema.decodeUnknownSync(QuestionV1.Option)(input)).toEqual(input)
+  expect(Schema.decodeUnknownSync(Question.Option)({ label: "Continue", description: "Continue here" })).toEqual({
+    label: "Continue",
+    description: "Continue here",
+  })
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -701,6 +701,7 @@ export type QuestionOption = {
    * Explanation of choice
    */
   description: string
+  recommended?: boolean
 }
 
 export type QuestionInfo = {
@@ -3132,6 +3133,7 @@ export type QuestionV2Option = {
    * Explanation of choice
    */
   description: string
+  recommended?: boolean
 }
 
 export type QuestionV2Info = {

--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -384,6 +384,9 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
                           <text fg={active() ? theme.secondary : picked() ? theme.success : theme.text}>
                             {multi() ? `[${picked() ? "✓" : " "}] ${opt.label}` : opt.label}
                           </text>
+                          <Show when={opt.recommended}>
+                            <text fg={theme.success}> (Recommended)</text>
+                          </Show>
                         </box>
                         <Show when={!multi()}>
                           <text fg={theme.success}>{picked() ? " ✓" : ""}</text>


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

At Plan exit, OpenCode estimates how much of the configured Code-mode model context the current session has used. The existing follow-up question now shows that estimate when the user chooses to continue in the current session.

When the estimate reaches the existing automatic-compaction threshold, the option to start a new session is marked as recommended. The new session path preserves the planned work by seeding the child session with the finalized plan.

The change also adds the optional `recommended` question option field and renders it consistently in the CLI, TUI, and app.

### How did you verify your code works?

- Added tests for model resolution, provider-default fallback, token aggregation, percentage calculation, unknown context limits, and compaction-threshold recommendations.
- Ran focused tests for the plan, question, and notification flows.
- Ran typechecks for the affected packages.
- Ran the client generator and legacy JavaScript SDK generator.
- Ran `git diff --check`.

### Screenshots / recordings

Not applicable; this changes the existing CLI/TUI/app question prompt and its option metadata.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
