### PR TITLE
refactor(tui): bound collapsed output scanning

### DIFF
--- a/packages/tui/src/util/collapse-tool-output.ts
+++ b/packages/tui/src/util/collapse-tool-output.ts
@@ -1,19 +1,33 @@
 export function collapseToolOutput(output: string, maxLines: number, maxChars: number) {
-  const lines = output.split("\n")
-  if (lines.length <= maxLines && Array.from(output).length <= maxChars) {
-    return { output, overflow: false }
-  }
-
-  const preview = lines.slice(0, maxLines).join("\n")
-  if (Array.from(preview).length > maxChars) {
-    return {
-      output:
-        Array.from(preview)
-          .slice(0, Math.max(0, maxChars - 1))
-          .join("") + "…",
-      overflow: true,
+  if (!Number.isSafeInteger(maxLines) || maxLines < 0 || !Number.isSafeInteger(maxChars) || maxChars < 0) {
+    const lines = output.split("\n")
+    if (lines.length <= maxLines && Array.from(output).length <= maxChars) return { output, overflow: false }
+    const preview = lines.slice(0, maxLines).join("\n")
+    if (Array.from(preview).length > maxChars) {
+      return {
+        output:
+          Array.from(preview)
+            .slice(0, Math.max(0, maxChars - 1))
+            .join("") + "…",
+        overflow: true,
+      }
     }
+    return { output: [...lines.slice(0, maxLines), "…"].join("\n"), overflow: true }
+  }
+  if (maxLines === 0) return { output: "…", overflow: true }
+
+  const preview: string[] = []
+  let lines = 1
+  for (const char of output) {
+    if (char === "\n" && lines >= maxLines) {
+      return { output: `${preview.join("")}\n…`, overflow: true }
+    }
+    preview.push(char)
+    if (preview.length > maxChars) {
+      return { output: preview.slice(0, Math.max(0, maxChars - 1)).join("") + "…", overflow: true }
+    }
+    if (char === "\n") lines++
   }
 
-  return { output: [...lines.slice(0, maxLines), "…"].join("\n"), overflow: true }
+  return { output, overflow: false }
 }

--- a/packages/tui/test/util/collapse-tool-output.test.ts
+++ b/packages/tui/test/util/collapse-tool-output.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { collapseToolOutput } from "../../src/util/collapse-tool-output"
+
+describe("collapseToolOutput", () => {
+  test.each([
+    ["short output", "hello", 3, 10, { output: "hello", overflow: false }],
+    ["empty output", "", 3, 10, { output: "", overflow: false }],
+    ["character limit", "abcdef", 3, 4, { output: "abc…", overflow: true }],
+    ["zero character limit", "a", 3, 0, { output: "…", overflow: true }],
+    ["emoji code points", "😀😀😀", 3, 2, { output: "😀…", overflow: true }],
+    ["combining code points", "e\u0301x", 3, 2, { output: "e…", overflow: true }],
+    ["line limit", "a\nb\nc", 2, 20, { output: "a\nb\n…", overflow: true }],
+    ["character limit before line limit", "abcd\nrest", 1, 3, { output: "ab…", overflow: true }],
+    ["line limit at exact character limit", "abc\nrest", 1, 3, { output: "abc\n…", overflow: true }],
+    ["trailing newline", "a\n", 1, 20, { output: "a\n…", overflow: true }],
+    ["CRLF line", "a\r\nb", 1, 20, { output: "a\r\n…", overflow: true }],
+    ["zero line limit", "a", 0, 20, { output: "…", overflow: true }],
+    ["fractional line limit", "a\nb", 1.5, 20, { output: "a\n…", overflow: true }],
+    ["negative line limit", "a\nb\nc", -1, 20, { output: "a\nb\n…", overflow: true }],
+    ["NaN character limit", "ab", 3, Number.NaN, { output: "ab\n…", overflow: true }],
+  ])("handles %s", (_name, output, maxLines, maxChars, expected) => {
+    expect(collapseToolOutput(output as string, maxLines as number, maxChars as number)).toEqual(expected)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #37860

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes collapsed TUI tool previews scan only until line or character overflow is known, instead of splitting and converting the complete output. The fast path preserves Unicode code-point counting, line/character precedence, trailing-newline behavior, and the existing ellipsis output. A compatibility fallback retains the historical behavior for invalid numeric limits.

Benchmarks:

- 10 MB single line: 661.915 ms -> 0.136 ms
- one million short lines: 28.532 ms -> 0.052 ms

This is compatible with the CR normalization in #37710; that PR may cause a small rebase conflict because it adds another export to the same utility.

### How did you verify your code works?

- `bun test` in `packages/tui` (203 pass, 1 skip)
- focused collapse tests (15 pass)
- package typecheck
- Prettier and `git diff --check`
- 100,000 deterministic differential cases against the previous implementation
- independent correctness review

### Screenshots / recordings

Not applicable; rendered preview behavior is unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR