### PR TITLE
fix: optimize ripgrep callback from O(files^2) to O(files)

### DIFF
--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -40,9 +40,16 @@ export const ripgrepLayer = Layer.effect(
         onEntry: (entry) =>
           Effect.sync(() => {
             state.files.push(entry.path)
-            const parts = entry.path.split("/")
-            parts.slice(0, -1).forEach((_, index) => directories.add(parts.slice(0, index + 1).join("/") + path.sep))
-            state.directories = Array.from(directories)
+            let start = 0
+            while (true) {
+              const idx = entry.path.indexOf("/", start)
+              if (idx === -1) break
+              const dir = entry.path.slice(0, idx) + path.sep
+              const size = directories.size
+              directories.add(dir)
+              if (directories.size > size) state.directories.push(dir)
+              start = idx + 1
+            }
           }),
       })
       .pipe(Effect.orDie, Effect.asVoid, Effect.forkIn(scope))


### PR DESCRIPTION
### Issue for this PR

Closes #37869

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Improve time complexity from roughly `O(N²)` to `O(N)`, where N=files.

### How did you verify your code works?

Ran `OPENCODE_DISABLE_FFF=1 bun dev web`. Check:
- "Add project" from the Web UI still provides path completion.
- Ask the model to use the Grep tool and it works as expected.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
