### PR TITLE
docs(ecosystem): add superpowers-controller

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [superpowers-controller](https://github.com/goodjin/superpowers-controller)                      | Stateful Superpowers workflow controller with gates, recovery, and node agents                 |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #37872

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `superpowers-controller` to the Ecosystem Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

`superpowers-controller` is an OpenCode plugin that runs Superpowers as a stateful workflow: project-local state, gates, recovery, and node agents behind the `superpowers-agent` entrypoint. npm: `superpowers-controller`.

### How did you verify your code works?

Checked the markdown table row formatting and confirmed the GitHub link opens correctly.

### Screenshots / recordings

_N/A — docs-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR