### PR TITLE
fix(opencode): retry certificate verification errors

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -699,6 +699,17 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case e instanceof Error && e.message.toLowerCase().includes("unknown certificate verification error"):
+      return new APIError(
+        {
+          message: e.message,
+          isRetryable: true,
+          metadata: {
+            message: e.message,
+          },
+        },
+        { cause: e },
+      ).toObject()
     case e instanceof Error:
       return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
     default:

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -182,6 +182,15 @@ describe("session.retry.retryable", () => {
     })
   })
 
+  test("retries unknown certificate verification errors", () => {
+    const request = MessageV2.fromError(new Error("unknown certificate verification error"), { providerID })
+
+    expect(SessionV1.APIError.isInstance(request)).toBe(true)
+    expect(SessionRetry.retryable(request, retryProvider)).toEqual({
+      message: "unknown certificate verification error",
+    })
+  })
+
   test("does not retry context overflow errors", () => {
     const error = new SessionV1.ContextOverflowError({
       message: "Input exceeds context window of this model",


### PR DESCRIPTION
### Issue for this PR

Closes #37884

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`unknown certificate verification error` was classified as `UnknownError`, so it bypassed the existing session retry policy and stopped the turn.

This change classifies that specific transport failure as a retryable `APIError`. It preserves the original error message and reuses the existing retry backoff. TLS verification remains enabled, and other certificate errors are unchanged.

### How did you verify your code works?

- Added a regression test covering error classification and retry detection.
- Ran `bun test test/session/retry.test.ts` from `packages/opencode`: 34 tests passed.
- Ran `bun typecheck` from `packages/opencode`.
- Ran the pre-push monorepo typecheck: 30 packages passed.
- Ran Prettier and diff checks on the changed files.

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
