### PR TITLE
fix: handle GitHub OIDC format and error handling

### DIFF
--- a/packages/function/src/api.ts
+++ b/packages/function/src/api.ts
@@ -276,9 +276,10 @@ export default new Hono<{ Bindings: Env }>()
         audience: EXPECTED_AUDIENCE,
       })
       const sub = payload.sub // e.g. 'repo:my-org/my-repo:ref:refs/heads/main'
+      // immutable sub claims append numeric ids, e.g. 'repo:my-org@123456/my-repo@456789:ref:refs/heads/main'
       const parts = sub.split(":")[1].split("/")
-      owner = parts[0]
-      repo = parts[1]
+      owner = parts[0].split("@")[0]
+      repo = parts[1].split("@")[0]
     } catch (err) {
       console.error("Token verification failed:", err)
       return c.json({ error: "Invalid or expired token" }, { status: 403 })

--- a/packages/function/src/api.ts
+++ b/packages/function/src/api.ts
@@ -294,10 +294,13 @@ export default new Hono<{ Bindings: Env }>()
 
     // Lookup installation
     const octokit = new Octokit({ auth: appAuth.token })
-    const { data: installation } = await octokit.apps.getRepoInstallation({
-      owner,
-      repo,
-    })
+    let installation
+    try {
+      installation = (await octokit.apps.getRepoInstallation({ owner, repo })).data
+    } catch (err) {
+      console.error("Installation lookup failed:", err)
+      return c.json({ error: `Failed to find GitHub app installation for ${owner}/${repo}` }, { status: 404 })
+    }
 
     // Get installation token
     const installationAuth = await auth({

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -640,8 +640,13 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
         msg = e.message
       }
       if (isUserEvent) {
-        await createComment(`${msg}${footer()}`)
-        await removeReaction(commentType)
+        // posting the error comment is best-effort
+        try {
+          await createComment(`${msg}${footer()}`)
+          await removeReaction(commentType)
+        } catch (commentError) {
+          console.error("Failed to post error comment:", commentError)
+        }
       }
       core.setFailed(msg)
       // Also output the clean error message for the action to capture
@@ -1004,8 +1009,14 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
           })
 
       if (!response.ok) {
-        const responseJson = (await response.json()) as { error?: string }
-        throw new Error(`App token exchange failed: ${response.status} ${response.statusText} - ${responseJson.error}`)
+        const body = await response.text()
+        let message = body
+        try {
+          message = (JSON.parse(body) as { error?: string }).error ?? body
+        } catch {
+          // response body is not JSON (e.g. an HTML error page)
+        }
+        throw new Error(`App token exchange failed: ${response.status} ${response.statusText} - ${message}`)
       }
 
       const responseJson = (await response.json()) as { token: string }


### PR DESCRIPTION
### Issue for this PR

Closes #37823

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- fix #37823 

The GitHub OIDC tokens changed from `repo:octocat/my-repo:ref:refs/heads/main` to `repo:octocat@123456/my-repo@456789:ref:refs/heads/main` (according to the GitHub [changelog](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/)), breaking the `exchange_github_app_token` endpoint and causing a cryptic failure chain in the GitHub Action log.

```
> Run opencode github run
Failed to parse JSON
Creating comment...
Error: Unexpected error

undefined is not an object (evaluating 'p.rest')
```

The root cause is a three-link chain (detailed analysis in the issue #37823):

1. **`api.ts` — owner/repo parsed incorrectly from new sub format**
New format `repo:octocat@123456/my-repo@456789:ref:…` was split as-is, producing `octocat@123456` / `my-repo@456789`, which fails the installation lookup.
2. **`api.ts` — uncaught installation lookup error returns non-JSON 500**
The failed `getRepoInstallation` call throws through Hono without a catch, so the client receives an HTML/text error page.
3. **`github.handler.ts` — client assumes JSON response, masks the real error**
`response.json()` fails on the text body → `Failed to parse JSON`. Then the catch block calls `createComment` with an uninitialized `octoRest` → `undefined is not an object (evaluating 'p.rest')`, which buries the real cause.

---

This PR fixes the parsing of new OIDC tokens and adding error handling to expose the real error message.

### How did you verify your code works?

The `api.ts` cannot be tested end-to-end before deployment.
I only tested the error handling part using a test repo with test workflow: [GitHub Actions logs](https://github.com/chAwater/oc-github-test/actions/runs/29724238551)

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
