### PR TITLE
refactor(codemode): bound retained console logs

### DIFF
--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -605,7 +605,7 @@ class Interpreter<R> {
   // Enumerable namespace/tool names at a node of the host tool tree, threaded from
   // ToolRuntime.make like invokeTool: the interpreter never holds the tree itself.
   private readonly toolKeys: (path: ReadonlyArray<string>) => ReadonlyArray<string>
-  private readonly logs: Array<string>
+  private readonly logs: ConsoleLogCapture
   private lastValue: unknown
   // Caps how many eagerly forked tool calls run at once (the parallel-call concurrency cap).
   private readonly callPermits: Semaphore.Semaphore
@@ -617,7 +617,7 @@ class Interpreter<R> {
   constructor(
     invokeTool: (path: ReadonlyArray<string>, args: Array<unknown>) => Effect.Effect<unknown, unknown, R>,
     toolKeys: (path: ReadonlyArray<string>) => ReadonlyArray<string>,
-    logs: Array<string> = [],
+    logs: ConsoleLogCapture,
   ) {
     const globalScope = new Map<string, Binding>()
     this.scopes = [globalScope]
@@ -1957,7 +1957,7 @@ class Interpreter<R> {
   private invokeConsole(name: string, args: Array<unknown>, node: AstNode): undefined {
     if (!consoleMethods.has(name))
       throw new InterpreterRuntimeError(`console.${name} is not available in CodeMode.`, node)
-    this.logs.push(publicErrorMessage(this.formatConsoleMessage(name, args, node)))
+    this.logs.add(publicErrorMessage(this.formatConsoleMessage(name, args, node)))
     return undefined
   }
 
@@ -3352,8 +3352,8 @@ export const executeWithLimits = <const Tools extends Record<string, unknown>>(
     searchIndex,
     hooks,
   )
-  const logs: Array<string> = []
-  const logged = () => (logs.length > 0 ? { logs: [...logs] } : {})
+  const logs = new ConsoleLogCapture(limits.maxOutputBytes)
+  const logged = () => (logs.lines.length > 0 ? { logs: [...logs.lines] } : {})
 
   if (options.code.trim().length === 0) {
     return Effect.succeed({
@@ -3402,11 +3402,39 @@ export const executeWithLimits = <const Tools extends Record<string, unknown>>(
             toolCalls: tools.calls,
           } satisfies Result),
     ),
-    Effect.map((result) => (limits.maxOutputBytes === undefined ? result : boundOutput(result, limits.maxOutputBytes))),
+    Effect.map((result) =>
+      limits.maxOutputBytes === undefined ? result : boundOutput(result, limits.maxOutputBytes, logs.totalLines),
+    ),
   )
 }
 
 const utf8ByteLength = (value: string): number => new TextEncoder().encode(value).byteLength
+
+class ConsoleLogCapture {
+  readonly lines: Array<string> = []
+  totalLines = 0
+  private retainedBytes = 0
+  private retaining = true
+
+  constructor(private readonly maxBytes: number | undefined) {}
+
+  add(line: string): void {
+    this.totalLines += 1
+    if (!this.retaining) return
+    if (this.maxBytes === undefined) {
+      this.lines.push(line)
+      return
+    }
+
+    const lineBytes = utf8ByteLength(line) + 1
+    if (this.retainedBytes + lineBytes > this.maxBytes) {
+      this.retaining = false
+      return
+    }
+    this.retainedBytes += lineBytes
+    this.lines.push(line)
+  }
+}
 
 // Truncates to a UTF-8 byte budget without splitting a code point (a split multi-byte
 // sequence decodes to a replacement character, which is dropped).
@@ -3424,7 +3452,7 @@ const utf8Truncate = (value: string, maxBytes: number): string => {
  * fails the execution; `truncated: true` marks affected results. Only runs when the host set
  * `maxOutputBytes` - with the limit absent, output passes through unbounded.
  */
-const boundOutput = (result: Result, maxOutputBytes: number): Result => {
+const boundOutput = (result: Result, maxOutputBytes: number, totalLogLines: number): Result => {
   let truncated = false
 
   let value: DataValue = null
@@ -3452,9 +3480,9 @@ const boundOutput = (result: Result, maxOutputBytes: number): Result => {
     logBytes += lineBytes
     kept.push(line)
   }
-  if (kept.length < logs.length) {
+  if (kept.length < totalLogLines) {
     truncated = true
-    kept.push(`[logs truncated: showing ${kept.length} of ${logs.length} lines]`)
+    kept.push(`[logs truncated: showing ${kept.length} of ${totalLogLines} lines]`)
   }
 
   if (!truncated) return result

--- a/packages/codemode/test/codemode.test.ts
+++ b/packages/codemode/test/codemode.test.ts
@@ -386,6 +386,100 @@ describe("CodeMode output budget", () => {
     expect(result.logs).toStrictEqual(["first line", "[logs truncated: showing 1 of 2 lines]"])
   })
 
+  test("keeps an exact-fit line on success using UTF-8 bytes plus one", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `console.log("abc"); console.log("later"); return "ok"`,
+        limits: { maxOutputBytes: 8 },
+      }),
+    )
+
+    expect(result).toStrictEqual({
+      ok: true,
+      value: "ok",
+      logs: ["abc", "[logs truncated: showing 1 of 2 lines]"],
+      truncated: true,
+      toolCalls: [],
+    })
+  })
+
+  test("accounts for multibyte log lines on failure", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `console.log("é"); console.log("x"); throw new Error("boom")`,
+        limits: { maxOutputBytes: 3 },
+      }),
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.logs).toStrictEqual(["é", "[logs truncated: showing 1 of 2 lines]"])
+    expect(result.truncated).toBe(true)
+  })
+
+  test("bounds logs captured before timeout", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `console.log("abc"); console.log("later"); while (true) {}`,
+        limits: { maxOutputBytes: 4, timeoutMs: 50 },
+      }),
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.kind).toBe("TimeoutExceeded")
+    expect(result.logs).toStrictEqual(["abc", "[logs truncated: showing 1 of 2 lines]"])
+    expect(result.truncated).toBe(true)
+  })
+
+  test("retains no lines at a zero-byte limit", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `console.log("a"); console.log("b"); return null`,
+        limits: { maxOutputBytes: 0 },
+      }),
+    )
+
+    expect(result.logs).toStrictEqual(["[logs truncated: showing 0 of 2 lines]"])
+    expect(result.truncated).toBe(true)
+  })
+
+  test("stops retaining after an oversized first line", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `console.log("first line is too large"); console.log("x"); return "ok"`,
+        limits: { maxOutputBytes: 8 },
+      }),
+    )
+
+    expect(result.logs).toStrictEqual(["[logs truncated: showing 0 of 2 lines]"])
+    expect(result.truncated).toBe(true)
+  })
+
+  test("applies the return-value budget before retained logs", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `console.log("abc"); return "ok"`,
+        limits: { maxOutputBytes: 6 },
+      }),
+    )
+
+    expect(result.logs).toStrictEqual(["[logs truncated: showing 0 of 1 lines]"])
+    expect(result.truncated).toBe(true)
+  })
+
+  test("counts embedded newlines as bytes in one captured entry", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `console.log("a\\nb"); console.log("c"); return null`,
+        limits: { maxOutputBytes: 8 },
+      }),
+    )
+
+    expect(result.logs).toStrictEqual(["a\nb", "[logs truncated: showing 1 of 2 lines]"])
+    expect(result.truncated).toBe(true)
+  })
+
   test("does not mark results within the budget", async () => {
     const result = await Effect.runPromise(
       CodeMode.execute({
@@ -393,6 +487,7 @@ describe("CodeMode output budget", () => {
         console.log("fits")
         return { fits: true }
       `,
+        limits: { maxOutputBytes: 100 },
       }),
     )
     expect(result).toStrictEqual({


### PR DESCRIPTION
### Issue for this PR

Closes #37898

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bounds cumulative console-log retention inside the `codemode` package whenever `maxOutputBytes` is configured. It retains only the leading whole entries that could fit the full budget, stops after the first non-fitting entry, and tracks total attempted entries for the existing truncation marker.

Success, failure, timeout, UTF-8 accounting, embedded newlines, return-value precedence, and no-limit behavior remain unchanged. OpenCode host policy is intentionally untouched.

In a 300,000-line, 16-byte-budget stress run, peak RSS changed from 485.4 MB to 420.7 MB (13.3%) and runtime from 3.98 s to 2.51 s. These are workload-specific measurements.

### How did you verify your code works?

- complete codemode suite: 270 pass
- package typecheck
- Prettier and `git diff --check`
- 970 deterministic old/new differential cases
- independent output-equivalence and memory review

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR