### PR TITLE
feat(tui): show assistant turn completion time

### DIFF
--- a/packages/opencode/src/cli/cmd/run/footer.ts
+++ b/packages/opencode/src/cli/cmd/run/footer.ts
@@ -397,6 +397,7 @@ export class RunFooter implements FooterApi {
             agent: this.options.agentLabel,
             model: current ? modelInfo(this.providers(), current).model : this.state().model,
             duration: next.duration,
+            time: next.time,
           }),
         )
         .catch((error) => {

--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -229,11 +229,13 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
             }
 
             if (sent.mode !== "shell") {
-              const duration = Locale.duration(Math.max(0, Date.now() - start))
+              const end = Date.now()
+              const duration = Locale.duration(Math.max(0, end - start))
               emit(
                 {
                   type: "turn.duration",
                   duration,
+                  time: Locale.time(end),
                 },
                 {
                   duration,

--- a/packages/opencode/src/cli/cmd/run/scrollback.surface.ts
+++ b/packages/opencode/src/cli/cmd/run/scrollback.surface.ts
@@ -420,7 +420,7 @@ export class RunScrollbackStream {
     this.markRendered(await this.finishActive(trailingNewline))
   }
 
-  public async writeTurnSummary(input: { agent: string; model: string; duration: string }): Promise<void> {
+  public async writeTurnSummary(input: { agent: string; model: string; duration: string; time?: string }): Promise<void> {
     await this.append(turnSummaryCommit(input))
   }
 

--- a/packages/opencode/src/cli/cmd/run/scrollback.writer.tsx
+++ b/packages/opencode/src/cli/cmd/run/scrollback.writer.tsx
@@ -333,7 +333,7 @@ export function spacerWriter(): ScrollbackWriter {
   })
 }
 
-export function turnSummaryWriter(input: { agent: string; model: string; duration: string; theme: RunTheme }) {
+export function turnSummaryWriter(input: { agent: string; model: string; duration: string; time?: string; theme: RunTheme }) {
   return createScrollbackWriter(
     () => (
       <box width="100%" height={1}>
@@ -342,7 +342,7 @@ export function turnSummaryWriter(input: { agent: string; model: string; duratio
           <span style={{ fg: input.theme.block.text }}>{input.agent}</span>
           <span style={{ fg: input.theme.block.muted }}>
             {" "}
-            · {input.model} · {input.duration}
+            · {input.model} · {input.duration}{input.time ? ` · ${input.time}` : ""}
           </span>
         </text>
       </box>

--- a/packages/opencode/src/cli/cmd/run/turn-summary.ts
+++ b/packages/opencode/src/cli/cmd/run/turn-summary.ts
@@ -6,17 +6,19 @@ export function turnSummaryCommit(input: {
   agent: string
   model: string
   duration: string
+  time?: string
   messageID?: string
 }): StreamCommit {
   return {
     kind: "system",
-    text: `▣ ${input.agent} · ${input.model} · ${input.duration}`,
+    text: `▣ ${input.agent} · ${input.model} · ${input.duration}${input.time ? ` · ${input.time}` : ""}`,
     phase: "final",
     source: "system",
     summary: {
       agent: input.agent,
       model: input.model,
       duration: input.duration,
+      time: input.time,
     },
     messageID: input.messageID,
   }
@@ -42,6 +44,7 @@ export function messageTurnSummaryCommit(
     agent: Locale.titlecase(info.agent),
     model: model ?? info.modelID,
     duration: Locale.duration(completed - info.time.created),
+    time: Locale.time(completed),
     messageID: info.id,
   })
 }

--- a/packages/opencode/src/cli/cmd/run/types.ts
+++ b/packages/opencode/src/cli/cmd/run/types.ts
@@ -101,6 +101,7 @@ export type TurnSummary = {
   agent: string
   model: string
   duration: string
+  time?: string
 }
 
 export type ScrollbackOptions = {
@@ -266,6 +267,7 @@ export type FooterEvent =
   | {
       type: "turn.duration"
       duration: string
+      time: string
     }
   | {
       type: "stream.patch"

--- a/packages/opencode/test/cli/run/scrollback.surface.test.ts
+++ b/packages/opencode/test/cli/run/scrollback.surface.test.ts
@@ -128,6 +128,23 @@ test("turn summary starts at the left edge", async () => {
   }
 })
 
+test("turn summary appends completion time after duration", async () => {
+  const out = await setup()
+
+  try {
+    await out.scrollback.writeTurnSummary({ agent: "Build", model: "Little Frank", duration: "2.2s", time: "3:41 PM" })
+
+    const commits = claim(out.renderer)
+    try {
+      expect(renderRows(commits.at(-1)!)[0]).toBe("▣ Build · Little Frank · 2.2s · 3:41 PM")
+    } finally {
+      destroy(commits)
+    }
+  } finally {
+    out.scrollback.destroy()
+  }
+})
+
 test("theme swaps restyle active reasoning without resetting the stream", async () => {
   const previousSyntax = SyntaxStyle.fromStyles({ default: { fg: "#123456" } })
   const nextSyntax = SyntaxStyle.fromStyles({ default: { fg: "#abcdef" } })

--- a/packages/opencode/test/cli/run/session-replay.test.ts
+++ b/packages/opencode/test/cli/run/session-replay.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { replayLocalRows, replaySession } from "@/cli/cmd/run/session-replay"
 import type { SessionMessages } from "@/cli/cmd/run/session.shared"
 import type { RunProvider } from "@/cli/cmd/run/types"
+import * as Locale from "@/util/locale"
 
 function userMessage(id: string, text: string): SessionMessages[number] {
   return {
@@ -279,7 +280,7 @@ describe("run session replay", () => {
       }),
       expect.objectContaining({
         kind: "system",
-        text: "▣ Build · gpt-5 · 2.8s",
+        text: `▣ Build · gpt-5 · 2.8s · ${Locale.time(3000)}`,
         phase: "final",
         source: "system",
         messageID: "msg-1",
@@ -287,6 +288,7 @@ describe("run session replay", () => {
           agent: "Build",
           model: "gpt-5",
           duration: "2.8s",
+          time: Locale.time(3000),
         },
       }),
     ])
@@ -314,11 +316,12 @@ describe("run session replay", () => {
     expect(out.commits.at(-1)).toEqual(
       expect.objectContaining({
         kind: "system",
-        text: "▣ Build · Little Frank · 2.8s",
+        text: `▣ Build · Little Frank · 2.8s · ${Locale.time(3000)}`,
         summary: {
           agent: "Build",
           model: "Little Frank",
           duration: "2.8s",
+          time: Locale.time(3000),
         },
       }),
     )
@@ -346,7 +349,7 @@ describe("run session replay", () => {
     expect(out.commits.filter((commit) => commit.summary)).toEqual([
       expect.objectContaining({
         kind: "system",
-        text: "▣ Build · gpt-5 · 2.0s",
+        text: `▣ Build · gpt-5 · 2.0s · ${Locale.time(3000)}`,
         messageID: "msg-step-2",
       }),
     ])

--- a/packages/opencode/test/cli/run/turn-summary.test.ts
+++ b/packages/opencode/test/cli/run/turn-summary.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { turnSummaryCommit } from "@/cli/cmd/run/turn-summary"
+
+test("turn summary commit appends completion time after duration", () => {
+  const commit = turnSummaryCommit({ agent: "Sisyphus - Ultraworker", model: "GPT-5.5", duration: "6.2s", time: "3:41 PM" })
+
+  expect(commit.text).toBe("▣ Sisyphus - Ultraworker · GPT-5.5 · 6.2s · 3:41 PM")
+  expect(commit.summary).toEqual({
+    agent: "Sisyphus - Ultraworker",
+    model: "GPT-5.5",
+    duration: "6.2s",
+    time: "3:41 PM",
+  })
+})
+
+test("turn summary commit keeps existing text without completion time", () => {
+  expect(turnSummaryCommit({ agent: "Sisyphus - Ultraworker", model: "GPT-5.5", duration: "6.2s" }).text).toBe(
+    "▣ Sisyphus - Ultraworker · GPT-5.5 · 6.2s",
+  )
+})

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1471,6 +1471,11 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     if (!user || !user.time) return 0
     return props.message.time.completed - user.time.created
   })
+  const completedTime = createMemo(() => {
+    if (!duration()) return ""
+    if (!props.message.time.completed) return ""
+    return Locale.time(props.message.time.completed)
+  })
 
   const childShortcut = useCommandShortcut("session.child.first")
   const backgroundShortcut = useCommandShortcut("session.background")
@@ -1549,6 +1554,7 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               <span style={{ fg: theme.textMuted }}> · {model()}</span>
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
+                <span style={{ fg: theme.textMuted }}> · {completedTime()}</span>
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>

--- a/packages/tui/test/cli/tui/__snapshots__/inline-tool-wrap-snapshot.test.tsx.snap
+++ b/packages/tui/test/cli/tui/__snapshots__/inline-tool-wrap-snapshot.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`TUI inline tool wrapping separates a task row from a preceding inline d
 `;
 
 exports[`TUI inline tool wrapping separates an inline row from the previous assistant summary 1`] = `
-"   ▣ Build · Little Frank · 53.1s
+"   ▣ Build · Little Frank · 53.1s · 3:41 PM
 
    ✓ Build Task — Review changes
      ↳ 48 toolcalls · 1m 40s"

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -144,7 +144,7 @@ function AssistantSummaryBeforeInlineFixture() {
   return (
     <box flexDirection="column" width={72}>
       <box ref={(el: BoxRenderable) => alwaysSeparate.add(el)} paddingLeft={3}>
-        <text>▣ Build · Little Frank · 53.1s</text>
+        <text>▣ Build · Little Frank · 53.1s · 3:41 PM</text>
       </box>
       <InlineToolRow icon="✓" complete={true} pending="">
         {"Build Task — Review changes\n↳ 48 toolcalls · 1m 40s"}


### PR DESCRIPTION
### Issue for this PR

Closes #35348.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Summary

Appends the wall-clock completion time after the duration in the TUI turn-summary line. The format follows the user's locale settings via the existing `Locale.time()` helper.

**Before:** `▣ Build · gpt-5 · 2.8s`
**After:** `▣ Build · gpt-5 · 2.8s · 3:41 PM`

### Motivation

Issue #35348 requests start/completion timestamps for messages. The TUI turn-summary line shows agent + model + duration but no wall-clock time, making it hard to scan when each turn ran — especially across multi-day sessions or when reviewing persisted history.

### Implementation

Threads an optional `time: string` through the turn-summary pipeline:

- `runtime.queue.ts` computes `time: Locale.time(end)` at the same `Date.now()` capture used for duration, and emits it on the `turn.duration` `FooterEvent`.
- `types.ts` adds `time?: string` to `TurnSummary` and `time: string` to the `turn.duration` event variant.
- `footer.ts` forwards `next.time` into `writeTurnSummary`.
- `scrollback.surface.ts` and `turn-summary.ts` accept and append ` · \${time}` to the summary text when present.
- `scrollback.writer.tsx` renders the optional suffix via the same ternary.
- `session-replay.ts` already calls `messageTurnSummaryCommit`; that function now passes `time: Locale.time(completed)` so replayed history also shows the timestamp.
- `packages/tui/src/routes/session/index.tsx` `AssistantMessage` adds a `completedTime` memo and renders it inside the existing `<Show when={duration()}>` block — this is the path users actually see for completed turns.

### Tests

- New `test/cli/run/turn-summary.test.ts` — unit test on `turnSummaryCommit` (with and without `time`).
- New case in `scrollback.surface.test.ts` — exercises `writeTurnSummary` with `time` and asserts the rendered row.
- Updated 3 turn-summary assertions in `session-replay.test.ts` to expect ` · \${Locale.time(3000)}` suffix.
- Updated `inline-tool-wrap-snapshot.test.tsx` fixture + snapshot to include the time suffix.

All 33 package tests pass; the 17 TUI snapshot tests pass.

### Revival of #32771

This is a faithful revival of #32771, which was auto-closed by the `needs:compliance` bot within 2 hours of being opened because the description did not match the issue template headers. The bot action was procedural, not a rejection on merits. The original implementation, scope, and tests are preserved here. Attribution to the original author and agent is retained.

Co-authored-by: joeyparis <joeyparis@users.noreply.github.com>
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>