### PR TITLE
fix(app): shrink Windows drawer close button

### DIFF
--- a/packages/app/src/components/help-button.tsx
+++ b/packages/app/src/components/help-button.tsx
@@ -87,11 +87,11 @@ export function TabsInfoPopup() {
           <DrawerClose
             as={IconButtonV2}
             type="button"
-            size="large"
+            size="small"
             variant="neutral"
             aria-label="Close"
             icon={<IconV2 name="xmark-small" />}
-            class="absolute top-[6px] left-[-44px]"
+            class="absolute top-[10px] left-[-36px]"
           />
         </Show>
         <div


### PR DESCRIPTION
## Summary
- use the 20px close button for the Windows upgrade drawer
- keep it centered against the 40px header with a 16px panel gap

## Testing
- bun typecheck (packages/app)
- bunx prettier --check packages/app/src/components/help-button.tsx