### PR TITLE
chore(app): bump ghostty-web

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#513463a6f1190253057e8a3f0dac8f6ee8393553",
+        "ghostty-web": "github:anomalyco/ghostty-web#0dcf95815d9200761bc543f27df09c9e4232032a",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",
@@ -3845,7 +3845,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#513463a", {}, "anomalyco-ghostty-web-513463a", "sha512-GZR8LSmgGzViWnBJrqRI8MpAZRCJxhcr1Hi9Tyeh7YRooHZQjK9J97FQRD3tbBaM2wjq05gzGY2UEsG+JtZeBw=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#0dcf958", {}, "anomalyco-ghostty-web-0dcf958", "sha512-KK0mXG+XVoIq+bc/KgeypxvfkN06r+t+OzSECwRh2nTJqBLKVHSaE9P6tP3IbjIqU6LJnOIQafnEgFUKpKR63w=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#513463a6f1190253057e8a3f0dac8f6ee8393553",
+    "ghostty-web": "github:anomalyco/ghostty-web#0dcf95815d9200761bc543f27df09c9e4232032a",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",


### PR DESCRIPTION
## Summary

- pin `ghostty-web` to merged `main` commit `0dcf95815d9200761bc543f27df09c9e4232032a`
- update the Bun lockfile integrity for the new artifact

Includes the physical-pixel rendering and native Ghostty sprite work from anomalyco/ghostty-web#3.

## Verification

- `bun install --frozen-lockfile`
- `bun typecheck` from `packages/app`
- `bun run build` from `packages/app`
- repository pre-push typecheck hook
