### PR TITLE
fix: remove 0.6s copilot overhead when copilot is not in enabled_providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1395,6 +1395,7 @@ const layer = Layer.effect(
           if (!p || !models) continue
 
           const providerID = ProviderV2.ID.make(p.id)
+          if (enabled && !enabled.has(providerID)) continue
           if (disabled.has(providerID)) continue
 
           const provider = database[providerID]
@@ -1544,7 +1545,9 @@ const layer = Layer.effect(
         for (const plugin of plugins) {
           if (!plugin.auth) continue
           const providerID = ProviderV2.ID.make(plugin.auth.provider)
-          if (disabled.has(providerID)) continue
+          if (!isProviderAllowed(providerID)) continue
+          const data = database[providerID]
+          if (!data) continue
 
           const stored = yield* auth.get(providerID).pipe(Effect.orDie)
           if (!stored) continue
@@ -1553,7 +1556,7 @@ const layer = Layer.effect(
           const options = yield* Effect.promise(() =>
             plugin.auth!.loader!(
               () => bridge.promise(auth.get(providerID).pipe(Effect.orDie)) as any,
-              toPublicInfo(database[plugin.auth!.provider]),
+              toPublicInfo(data),
             ),
           )
           const opts = options ?? {}

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -153,6 +153,21 @@ it.instance(
 )
 
 it.instance(
+  "enabled_providers skips auth loaders for filtered providers",
+  Effect.gen(function* () {
+    yield* setProcessEnv(
+      "OPENCODE_AUTH_CONTENT",
+      JSON.stringify({
+        google: { type: "oauth", refresh: "dummy", access: "dummy", expires: 9999999999999 },
+      }),
+    )
+    const providers = yield* list
+    expect(providers[ProviderV2.ID.google]).toBeUndefined()
+  }),
+  { config: { enabled_providers: ["anthropic"] } },
+)
+
+it.instance(
   "model whitelist filters models for provider",
   Effect.gen(function* () {
     yield* setProcessEnv("ANTHROPIC_API_KEY", "test-api-key")


### PR DESCRIPTION
### Issue for this PR

Closes #37922

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Auth plugins (e.g. GitHub Copilot) should respect the `enabled_providers` config, not just `disabled_providers` config.

The GitHub Copilot plugin can add noticable overhead (e.g. 0.6s) downloading `api.githubcopilot.com/models`. If it's not enabled in `enabled_providers`, the overhead should disappear.

### How did you verify your code works?

On Linux, use `strace -p $(pidof opencode)`. Before this change, downloading `api.githubcopilot.com/models` occurs. After this change, downloading `api.githubcopilot.com/models` disappears. 

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

