### PR TITLE
fix(core): isolate invalid plugin tools during materialize

### DIFF
--- a/packages/core/src/tool/registry.ts
+++ b/packages/core/src/tool/registry.ts
@@ -245,11 +245,30 @@ const registryLayer = Layer.effect(
         }
         const execute =
           codemode.size > 0 && !whollyDisabled("execute", rules) ? ExecuteTool.create(codemode) : undefined
+        // Build each tool definition defensively. A plugin can register a structurally
+        // invalid tool (missing description, undecodable input schema, opaque object from
+        // a different module copy, etc.) that only fails when its definition is read.
+        // Throwing here used to break every model step in the Location because no
+        // definition list could be produced. Isolate the bad tool: log once and omit it
+        // so the rest of the catalog stays usable. See
+        // https://github.com/anomalyco/opencode/issues/35963
+        const definitions: ToolDefinition[] = []
+        for (const [name, registration] of direct) {
+          try {
+            definitions.push(definition(name, registration.tool))
+          } catch (error) {
+            yield* Effect.logWarning("failed to materialize tool definition; skipping", {
+              tool: name,
+              error: error instanceof Error ? error.message : String(error),
+            })
+            // Drop the bad registration so later materializations and settle() do not
+            // surface it as a usable tool.
+            direct.delete(name)
+          }
+        }
+        if (execute) definitions.push(definition("execute", execute))
         return {
-          definitions: [
-            ...Array.from(direct, ([name, registration]) => definition(name, registration.tool)),
-            ...(execute ? [definition("execute", execute)] : []),
-          ],
+          definitions,
           settle: (input) => {
             if (input.call.name === "execute" && execute) return settleTool(input, execute)
             const registration = direct.get(input.call.name)

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -490,4 +490,32 @@ describe("ToolRegistry", () => {
       expect(executed).toEqual(["old:request"])
     }),
   )
+
+  // Regression coverage for https://github.com/anomalyco/opencode/issues/35963
+  // A structurally invalid tool registration used to throw inside materialize() and break
+  // every subsequent model step in the Location. The registry must isolate the bad tool:
+  // log it, drop it, and keep the rest of the catalog usable.
+  it.effect("isolates invalid tool definitions during materialize (#35963)", () =>
+    Effect.gen(function* () {
+      const service = yield* ToolRegistry.Service
+      const good = make()
+      // Construct a tool-like object whose `definition()` reads will throw: `input` is
+      // missing so `inputJsonSchema(tool.input)` dereferences undefined.
+      const broken = { description: "broken" } as unknown as Parameters<typeof Tool.make>[0]
+      yield* service.register({ good }, { codemode: false })
+      yield* service.register({ broken: Tool.make(broken) }, { codemode: false })
+
+      const materialized = yield* service.materialize()
+      const names = materialized.definitions.map((definition) => definition.name)
+      expect(names).toEqual(["good"])
+      expect(names).not.toContain("broken")
+
+      // Settling the dropped tool surfaces as "Unknown tool" rather than re-throwing.
+      const settlement = yield* settleTool(service, call("broken"))
+      expect(settlement.result).toEqual({ type: "error", value: "Unknown tool: broken" })
+      // The good tool still executes.
+      const goodSettlement = yield* settleTool(service, call("good"))
+      expect(goodSettlement.result).toMatchObject({ type: "text", value: "good" })
+    }),
+  )
 })


### PR DESCRIPTION
Closes #35963

### Type of change

- [x] Bug fix

### What does this PR do?

A structurally invalid plugin tool (missing description, undecodable schema, opaque object from a different module copy) throws inside `materialize()` and breaks every subsequent model step in the Location because no definition list can be produced.

`materialize()` now wraps each `definition()` call in try/catch. On failure: log a warning with the tool name and error, drop the registration from the `direct` map so later settle() calls do not surface it as usable, and continue building the rest of the catalog. The dropped tool settles as `Unknown tool: <name>` instead of re-throwing.

### How did you verify your code works?

```
cd packages/core && bun test test/session-runner-tool-registry.test.ts   # 17 pass, 0 fail
bun turbo typecheck --filter=@opencode-ai/core...                         # 17/17 green
```

Reverse verification: reverting `packages/core/src/tool/registry.ts` makes the new test fail with `TypeError: Cannot read properties of undefined (reading '~context')` from inside `materialize()`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR