### PR TITLE
feat(app): sync embedded terminal theme

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#9332dba5b189db5220511623524aeadbd4af7182",
+        "ghostty-web": "github:anomalyco/ghostty-web#44a68aecf452b5c4851731177042e70cbe575958",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",
@@ -3845,7 +3845,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#9332dba", {}, "anomalyco-ghostty-web-9332dba", "sha512-ViEuxfNXiJItlAWzekMLlsqCiwCCZQ3HSB5zahB7AXea09kqQ1gpnvW9JTT49sOba10uk1/NSbEODLw2niybsQ=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#44a68ae", {}, "anomalyco-ghostty-web-44a68ae", "sha512-uMTSqP+OceYM8zDG0gSg+SXg0NdPiAVdtrT7ZIv/dTqICzyJeYV+cpw2fWf9wZykTMjwBLDF0DZOM1FiqvkFcw=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#e32bac9e08a6bf659b0ba4447a15d5c4d695435a",
+        "ghostty-web": "github:anomalyco/ghostty-web#83c0a07b8628b748aed073b232cb4b52a6ca11c1",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",
@@ -3845,7 +3845,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#e32bac9", {}, "anomalyco-ghostty-web-e32bac9", "sha512-vc2/oF90NJMOJU3svhGZRVcmk0kBYeBvEEzrfiUFy6SQmG6gMIoBnzjJIg3s7D7vLTUrwqrg8XRm2T3VvTM46Q=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#83c0a07", {}, "anomalyco-ghostty-web-83c0a07", "sha512-Lf2v1agHkVUpMpHBWWuCZrhOEmcwwin5/Hboc9rZwQ7/CKkIh5rU1r1CvfLlhkMoFv+ed8z52RZ8hkzGZZj3MQ=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#5a1e426ecc9ba57a379ed7ad69754bb2821073da",
+        "ghostty-web": "github:anomalyco/ghostty-web#e32bac9e08a6bf659b0ba4447a15d5c4d695435a",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",
@@ -3845,7 +3845,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#5a1e426", {}, "anomalyco-ghostty-web-5a1e426", "sha512-eHfnoO8CSK/E5VuMYWAJqi7H0u+9FhxUg8ujHRIq2noWyRq/kJVyp9WOUKdRPXh1iYxsaG5yR61pLXgjhqu4VQ=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#e32bac9", {}, "anomalyco-ghostty-web-e32bac9", "sha512-vc2/oF90NJMOJU3svhGZRVcmk0kBYeBvEEzrfiUFy6SQmG6gMIoBnzjJIg3s7D7vLTUrwqrg8XRm2T3VvTM46Q=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#78bf9c790ed4a645ff4deee3cb1c888d63c78b01",
+        "ghostty-web": "github:anomalyco/ghostty-web#5a1e426ecc9ba57a379ed7ad69754bb2821073da",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",
@@ -3845,7 +3845,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#78bf9c7", {}, "anomalyco-ghostty-web-78bf9c7", "sha512-/MNZHGkDgMCHAjmq/BfPPg8JmwoOnIVOIayUNhejVrEcJgxuvD4HFzdnEOdOD2ZrrLtn7SCo/zctPQrdL2yZtA=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#5a1e426", {}, "anomalyco-ghostty-web-5a1e426", "sha512-eHfnoO8CSK/E5VuMYWAJqi7H0u+9FhxUg8ujHRIq2noWyRq/kJVyp9WOUKdRPXh1iYxsaG5yR61pLXgjhqu4VQ=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#513463a6f1190253057e8a3f0dac8f6ee8393553",
+        "ghostty-web": "github:anomalyco/ghostty-web#9332dba5b189db5220511623524aeadbd4af7182",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",
@@ -3845,7 +3845,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#513463a", {}, "anomalyco-ghostty-web-513463a", "sha512-GZR8LSmgGzViWnBJrqRI8MpAZRCJxhcr1Hi9Tyeh7YRooHZQjK9J97FQRD3tbBaM2wjq05gzGY2UEsG+JtZeBw=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#9332dba", {}, "anomalyco-ghostty-web-9332dba", "sha512-ViEuxfNXiJItlAWzekMLlsqCiwCCZQ3HSB5zahB7AXea09kqQ1gpnvW9JTT49sOba10uk1/NSbEODLw2niybsQ=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,7 +65,7 @@
         "diff": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "catalog:",
-        "ghostty-web": "github:anomalyco/ghostty-web#44a68aecf452b5c4851731177042e70cbe575958",
+        "ghostty-web": "github:anomalyco/ghostty-web#78bf9c790ed4a645ff4deee3cb1c888d63c78b01",
         "luxon": "catalog:",
         "marked": "catalog:",
         "marked-shiki": "catalog:",
@@ -3845,7 +3845,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#44a68ae", {}, "anomalyco-ghostty-web-44a68ae", "sha512-uMTSqP+OceYM8zDG0gSg+SXg0NdPiAVdtrT7ZIv/dTqICzyJeYV+cpw2fWf9wZykTMjwBLDF0DZOM1FiqvkFcw=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#78bf9c7", {}, "anomalyco-ghostty-web-78bf9c7", "sha512-/MNZHGkDgMCHAjmq/BfPPg8JmwoOnIVOIayUNhejVrEcJgxuvD4HFzdnEOdOD2ZrrLtn7SCo/zctPQrdL2yZtA=="],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#78bf9c790ed4a645ff4deee3cb1c888d63c78b01",
+    "ghostty-web": "github:anomalyco/ghostty-web#5a1e426ecc9ba57a379ed7ad69754bb2821073da",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#9332dba5b189db5220511623524aeadbd4af7182",
+    "ghostty-web": "github:anomalyco/ghostty-web#44a68aecf452b5c4851731177042e70cbe575958",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#e32bac9e08a6bf659b0ba4447a15d5c4d695435a",
+    "ghostty-web": "github:anomalyco/ghostty-web#83c0a07b8628b748aed073b232cb4b52a6ca11c1",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#513463a6f1190253057e8a3f0dac8f6ee8393553",
+    "ghostty-web": "github:anomalyco/ghostty-web#9332dba5b189db5220511623524aeadbd4af7182",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#5a1e426ecc9ba57a379ed7ad69754bb2821073da",
+    "ghostty-web": "github:anomalyco/ghostty-web#e32bac9e08a6bf659b0ba4447a15d5c4d695435a",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
     "diff": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "catalog:",
-    "ghostty-web": "github:anomalyco/ghostty-web#44a68aecf452b5c4851731177042e70cbe575958",
+    "ghostty-web": "github:anomalyco/ghostty-web#78bf9c790ed4a645ff4deee3cb1c888d63c78b01",
     "luxon": "catalog:",
     "marked": "catalog:",
     "marked-shiki": "catalog:",

--- a/packages/app/src/addons/serialize.test.ts
+++ b/packages/app/src/addons/serialize.test.ts
@@ -37,6 +37,14 @@ function writeAndWait(term: Terminal, data: string): Promise<void> {
 }
 
 describe("SerializeAddon", () => {
+  test("preserves color scheme reporting mode", async () => {
+    const { term, addon } = createTerminal()
+    await writeAndWait(term, "\x1b[?2031h")
+
+    expect(addon.serialize().startsWith("\x1b[?2031h")).toBe(true)
+    expect(addon.serialize({ excludeModes: true }).startsWith("\x1b[?2031h")).toBe(false)
+  })
+
   describe("ANSI color preservation", () => {
     test("should preserve text attributes (bold, italic, underline)", async () => {
       const { term, addon } = createTerminal()

--- a/packages/app/src/addons/serialize.ts
+++ b/packages/app/src/addons/serialize.ts
@@ -89,6 +89,13 @@ const getTerminalBuffers = (value: ITerminalCore): TerminalBuffers | undefined =
   return { active, normal, alternate }
 }
 
+const getTerminalMode = (value: ITerminalCore, mode: number) => {
+  if (!isRecord(value)) return false
+  const terminal = value.wasmTerm
+  if (!isRecord(terminal) || typeof terminal.getMode !== "function") return false
+  return terminal.getMode(mode) === true
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -544,7 +551,8 @@ export class SerializeAddon implements ITerminalAddon {
       return ""
     }
 
-    let content = options?.range
+    let content = !options?.excludeModes && getTerminalMode(this._terminal, 2031) ? "\u001b[?2031h" : ""
+    content += options?.range
       ? this._serializeBufferByRange(normalBuffer, options.range, true)
       : this._serializeBufferByScrollback(normalBuffer, options?.scrollback)
 

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -603,6 +603,7 @@ export const Terminal = (props: TerminalProps) => {
           tries = 0
           local.onConnect?.()
           scheduleSize(t.cols, t.rows)
+          if (t.getMode(2031)) t.write("\x1b[?996n")
         }
 
         const handleMessage = (event: MessageEvent) => {

--- a/packages/app/src/components/terminal.tsx
+++ b/packages/app/src/components/terminal.tsx
@@ -292,7 +292,12 @@ export const Terminal = (props: TerminalProps) => {
 
   const scheduleSize = (cols: number, rows: number) => {
     if (disposed) return
-    if (lastSize?.cols === cols && lastSize?.rows === rows) return
+    if (lastSize?.cols === cols && lastSize?.rows === rows) {
+      pendingSize = undefined
+      if (sizeTimer !== undefined) clearTimeout(sizeTimer)
+      sizeTimer = undefined
+      return
+    }
 
     pendingSize = { cols, rows }
 
@@ -317,8 +322,10 @@ export const Terminal = (props: TerminalProps) => {
 
   createEffect(() => {
     const colors = terminalColors()
+    const mode = theme.mode() === "dark" ? "dark" : "light"
     if (!term) return
     setOptionIfSupported(term, "theme", colors)
+    setOptionIfSupported(term, "colorScheme", mode)
   })
 
   createEffect(() => {
@@ -396,6 +403,7 @@ export const Terminal = (props: TerminalProps) => {
       }
       _ghostty = g
       term = t
+      setOptionIfSupported(t, "colorScheme", theme.mode() === "dark" ? "dark" : "light")
       output = terminalWriter((data, done) =>
         t.write(data, () => {
           done?.()

--- a/packages/core/src/pty/pty.node.ts
+++ b/packages/core/src/pty/pty.node.ts
@@ -4,7 +4,10 @@ import type { Opts, Proc } from "./pty"
 export type { Disp, Exit, Opts, Proc } from "./pty"
 
 export function spawn(file: string, args: string[], opts: Opts): Proc {
-  const proc = pty.spawn(file, args, opts)
+  const proc = pty.spawn(file, args, {
+    ...opts,
+    ...(process.platform === "win32" ? { useConptyDll: true } : {}),
+  })
   return {
     pid: proc.pid,
     onData(listener) {

--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -144,6 +144,9 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     }
 
     onMount(() => {
+      // Desktop PTYs may start before their terminal frontend attaches. These bytes are
+      // replayed on attach, avoiding the terminal capability probe's startup timeout.
+      process.stdout.write("\x1b[?2031h\x1b[?996n")
       void Promise.allSettled([resolveSystemTheme(store.mode), syncCustomThemes()]).finally(() => {
         setStore("ready", true)
       })
@@ -246,6 +249,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     unsubscribeRefresh = themes.subscribeRefresh?.(refresh)
 
     onCleanup(() => {
+      process.stdout.write("\x1b[?2031l")
       renderer.off(CliRenderEvents.THEME_MODE, handle)
       renderer.removeInputHandler(handleThemeNotification)
       unsubscribeRefresh?.()

--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -144,9 +144,6 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     }
 
     onMount(() => {
-      // Desktop PTYs may start before their terminal frontend attaches. These bytes are
-      // replayed on attach, avoiding the terminal capability probe's startup timeout.
-      process.stdout.write("\x1b[?2031h\x1b[?996n")
       void Promise.allSettled([resolveSystemTheme(store.mode), syncCustomThemes()]).finally(() => {
         setStore("ready", true)
       })
@@ -249,7 +246,6 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     unsubscribeRefresh = themes.subscribeRefresh?.(refresh)
 
     onCleanup(() => {
-      process.stdout.write("\x1b[?2031l")
       renderer.off(CliRenderEvents.THEME_MODE, handle)
       renderer.removeInputHandler(handleThemeNotification)
       unsubscribeRefresh?.()


### PR DESCRIPTION
Depends on anomalyco/ghostty-web#4. Syncs the embedded terminal palette and semantic light/dark scheme with the app theme, preserves color reporting across terminal remounts, and fixes stale PTY sizing after rapid zoom changes. On Windows, selects node-pty bundled OpenConsole because the inbox ConPTY backend drops OSC color responses; an A/B PTY test confirmed the bundled backend forwards them and OpenTUI emits the expected light theme event. Verified with app/core/desktop typechecks, targeted app tests, full push-hook typechecks, and a desktop production build.