### PR TITLE
fix(console): add CORS headers and OPTIONS preflight to Zen/Go API endpoints

### DIFF
--- a/packages/console/app/src/routes/zen/go/v1/chat/completions.ts
+++ b/packages/console/app/src/routes/zen/go/v1/chat/completions.ts
@@ -1,6 +1,11 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { handler } from "~/routes/zen/util/handler"
+import { corsHeaders } from "~/routes/zen/util/cors"
 import { parseOpenAiVariant } from "~/routes/zen/util/variant"
+
+export function OPTIONS(_input: APIEvent) {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}
 
 export function POST(input: APIEvent) {
   return handler(input, {

--- a/packages/console/app/src/routes/zen/go/v1/messages.ts
+++ b/packages/console/app/src/routes/zen/go/v1/messages.ts
@@ -1,6 +1,11 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { handler } from "~/routes/zen/util/handler"
+import { corsHeaders } from "~/routes/zen/util/cors"
 import { parseAnthropicVariant } from "~/routes/zen/util/variant"
+
+export function OPTIONS(_input: APIEvent) {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}
 
 export function POST(input: APIEvent) {
   return handler(input, {

--- a/packages/console/app/src/routes/zen/go/v1/responses.ts
+++ b/packages/console/app/src/routes/zen/go/v1/responses.ts
@@ -1,6 +1,11 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { handler } from "~/routes/zen/util/handler"
+import { corsHeaders } from "~/routes/zen/util/cors"
 import { parseOpenAiVariant } from "~/routes/zen/util/variant"
+
+export function OPTIONS(_input: APIEvent) {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}
 
 export function POST(input: APIEvent) {
   return handler(input, {

--- a/packages/console/app/src/routes/zen/util/cors.ts
+++ b/packages/console/app/src/routes/zen/util/cors.ts
@@ -1,0 +1,5 @@
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+}

--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -15,6 +15,7 @@ import { UserTable } from "@opencode-ai/console-core/schema/user.sql.js"
 import { ModelTable } from "@opencode-ai/console-core/schema/model.sql.js"
 import { ProviderTable } from "@opencode-ai/console-core/schema/provider.sql.js"
 import { logger } from "./logger"
+import { corsHeaders } from "./cors"
 import {
   AuthError,
   CreditsError,
@@ -304,6 +305,9 @@ export async function handler(
         resHeaders.set(k, v)
       }
     }
+    for (const [k, v] of Object.entries(corsHeaders)) {
+      resHeaders.set(k, v)
+    }
     logger.debug("STATUS: " + res.status + " " + res.statusText)
 
     // Handle non-streaming response
@@ -450,7 +454,7 @@ export async function handler(
     // metric and 500 and return a quiet client-closed response.
     if (input.request.signal.aborted || error?.name === "AbortError") {
       logger.debug("REQUEST ABORTED BY CALLER")
-      return new Response(null, { status: 499 })
+      return new Response(null, { status: 499, headers: corsHeaders })
     }
 
     logger.metric({
@@ -472,7 +476,7 @@ export async function handler(
           type: "error",
           error: { type: error.constructor.name, message: error.message },
         }),
-        { status: 403 },
+        { status: 403, headers: corsHeaders },
       )
 
     // Note: both top level "type" and "error.type" fields are used by the @ai-sdk/anthropic client to render the error message.
@@ -488,7 +492,7 @@ export async function handler(
           type: "error",
           error: { type: error.constructor.name, message: error.message },
         }),
-        { status: 401 },
+        { status: 401, headers: corsHeaders },
       )
 
     if (
@@ -498,6 +502,9 @@ export async function handler(
       error instanceof BlackUsageLimitError
     ) {
       const headers = new Headers()
+      for (const [k, v] of Object.entries(corsHeaders)) {
+        headers.set(k, v)
+      }
       if (error.retryAfter) {
         headers.set("retry-after", String(error.retryAfter))
       }
@@ -528,7 +535,7 @@ export async function handler(
           message: "Internal server error",
         },
       }),
-      { status: 500 },
+      { status: 500, headers: corsHeaders },
     )
   }
 

--- a/packages/console/app/src/routes/zen/util/modelsHandler.ts
+++ b/packages/console/app/src/routes/zen/util/modelsHandler.ts
@@ -1,11 +1,9 @@
+import { corsHeaders } from "./cors"
+
 export async function buildOptionsResponse() {
   return new Response(null, {
     status: 200,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
+    headers: corsHeaders,
   })
 }
 
@@ -25,6 +23,7 @@ export async function buildModelsResponse(models: string[]) {
     {
       headers: {
         "Content-Type": "application/json",
+        ...corsHeaders,
       },
     },
   )

--- a/packages/console/app/src/routes/zen/v1/chat/completions.ts
+++ b/packages/console/app/src/routes/zen/v1/chat/completions.ts
@@ -1,6 +1,11 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { handler } from "~/routes/zen/util/handler"
+import { corsHeaders } from "~/routes/zen/util/cors"
 import { parseOpenAiVariant } from "~/routes/zen/util/variant"
+
+export function OPTIONS(_input: APIEvent) {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}
 
 export function POST(input: APIEvent) {
   return handler(input, {

--- a/packages/console/app/src/routes/zen/v1/messages.ts
+++ b/packages/console/app/src/routes/zen/v1/messages.ts
@@ -1,6 +1,11 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { handler } from "~/routes/zen/util/handler"
+import { corsHeaders } from "~/routes/zen/util/cors"
 import { parseAnthropicVariant } from "~/routes/zen/util/variant"
+
+export function OPTIONS(_input: APIEvent) {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}
 
 export function POST(input: APIEvent) {
   return handler(input, {

--- a/packages/console/app/src/routes/zen/v1/models/[model].ts
+++ b/packages/console/app/src/routes/zen/v1/models/[model].ts
@@ -1,6 +1,11 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { handler } from "~/routes/zen/util/handler"
+import { corsHeaders } from "~/routes/zen/util/cors"
 import { parseGoogleVariant } from "~/routes/zen/util/variant"
+
+export function OPTIONS(_input: APIEvent) {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}
 
 export function POST(input: APIEvent) {
   return handler(input, {

--- a/packages/console/app/src/routes/zen/v1/responses.ts
+++ b/packages/console/app/src/routes/zen/v1/responses.ts
@@ -1,6 +1,11 @@
 import type { APIEvent } from "@solidjs/start/server"
 import { handler } from "~/routes/zen/util/handler"
+import { corsHeaders } from "~/routes/zen/util/cors"
 import { parseOpenAiVariant } from "~/routes/zen/util/variant"
+
+export function OPTIONS(_input: APIEvent) {
+  return new Response(null, { status: 200, headers: corsHeaders })
+}
 
 export function POST(input: APIEvent) {
   return handler(input, {

--- a/packages/console/app/test/cors.test.ts
+++ b/packages/console/app/test/cors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import { corsHeaders } from "../src/routes/zen/util/cors"
+import { buildModelsResponse, buildOptionsResponse } from "../src/routes/zen/util/modelsHandler"
+
+describe("corsHeaders", () => {
+  test("allows all origins", () => {
+    expect(corsHeaders["Access-Control-Allow-Origin"]).toBe("*")
+  })
+
+  test("allows GET, POST, and OPTIONS", () => {
+    expect(corsHeaders["Access-Control-Allow-Methods"]).toBe("GET, POST, OPTIONS")
+  })
+
+  test("allows content-type and authorization headers", () => {
+    expect(corsHeaders["Access-Control-Allow-Headers"]).toBe("Content-Type, Authorization")
+  })
+})
+
+describe("buildOptionsResponse", () => {
+  test("returns 200 with CORS headers", async () => {
+    const response = await buildOptionsResponse()
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET, POST, OPTIONS")
+    expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type, Authorization")
+  })
+})
+
+describe("buildModelsResponse", () => {
+  test("returns models with CORS headers", async () => {
+    const response = await buildModelsResponse(["model-1", "model-2"])
+    expect(response.status).toBe(200)
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+    expect(response.headers.get("Content-Type")).toBe("application/json")
+
+    const body = await response.json()
+    expect(body.data.map((model: { id: string }) => model.id)).toEqual(["model-1", "model-2"])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #31041

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Zen/Go API endpoints return 404 on CORS preflight (OPTIONS) requests because only /zen/v1/models and /zen/go/v1/models had OPTIONS handlers. Browser clients were blocked from calling the chat completions, messages, and responses endpoints.

This PR:
- Adds a shared corsHeaders constant in packages/console/app/src/routes/zen/util/cors.ts.
- Adds OPTIONS handlers to all Zen/Go inference routes:
  - /zen/v1/chat/completions
  - /zen/v1/messages
  - /zen/v1/responses
  - /zen/v1/models/[model]
  - /zen/go/v1/chat/completions
  - /zen/go/v1/messages
  - /zen/go/v1/responses
- Adds CORS headers to all POST/streaming/error responses from packages/console/app/src/routes/zen/util/handler.ts.
- Adds CORS headers to the GET /zen/v1/models and GET /zen/go/v1/models responses.

### How did you verify your code works?

- bun test cors.test.ts in packages/console/app passes (5 tests).
- bun test in packages/console/app passes (12 tests across all console app test files).
- bun run typecheck in packages/console/app passes.

### Screenshots / recordings

N/A - no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
