### PR TITLE
fix(tui): adapt file badge accent to theme mode

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1647,7 +1647,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
   const data = useData()
   const local = useLocal()
   const files = createMemo(() => props.message.files ?? [])
-  const { themeV2 } = useTheme().contextual("elevated")
+  const { themeV2, mode } = useTheme().contextual("elevated")
   const [hover, setHover] = createSignal(false)
   const color = createMemo(() => local.agent.color(data.session.get(ctx.sessionID)?.agent ?? "build"))
   const queued = createMemo(
@@ -1697,7 +1697,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
                     <text fg={themeV2.text()}>
                       <span
                         style={{
-                          bg: themeV2.hue.accent(500),
+                          bg: themeV2.hue.accent(mode() === "light" ? 700 : 200),
                           fg: themeV2.background(),
                           bold: true,
                         }}


### PR DESCRIPTION
## Summary
- use a darker accent step for submitted file badges in light mode
- use a lighter accent step for submitted file badges in dark mode
- preserve the existing badge foreground and filename surface styling

## Color mapping
- light: `accent(700)`
- dark: `accent(200)`

## Verification
- `bun typecheck`
- `git diff --check origin/v2...HEAD`
- visually verified the submitted `diagram.png` badge in light mode with OpenCode Drive