### PR TITLE
docs(ecosystem): add opencode-hypa plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-hypa](https://github.com/kipyin/opencode-hypa)                                            | Hardwire Hypa into bash/shell tool calls for local, deterministic output compression               |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-hypa` to the Ecosystem plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

`opencode-hypa` is an OpenCode plugin that intercepts `bash` / `shell` tool calls and rewrites them through [Hypa](https://github.com/Hypabolic/Hypa) (`hypa rewrite --json`) for local, deterministic command-output compression. It uses the same hardwire pattern Hypa ships for Claude, Codex, and Pi, but via OpenCode's plugin API — no MCP required.

- Repo: https://github.com/kipyin/opencode-hypa
- npm: https://www.npmjs.com/package/opencode-hypa
- License: MIT

### How did you verify your code works?

- Row follows the existing table format (name link + one-line description) used by the other plugin entries.
- Confirmed the GitHub and npm links resolve.
- Rendered locally via the docs toolchain conventions in the repo; the table row is a single-line markdown addition consistent with neighbours.

### Screenshots / recordings

N/A — docs table edit, no UI change beyond a new row.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR