### PR TITLE
fix(core): omit undefined optional keys from glob/grep permission metadata

### DIFF
--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -65,8 +65,8 @@ const layer = Layer.effectDiscard(
                 save: ["*"],
                 metadata: {
                   root: input.path ?? ".",
-                  path: input.path,
-                  limit: input.limit,
+                  ...(input.path !== undefined && { path: input.path }),
+                  ...(input.limit !== undefined && { limit: input.limit }),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -84,9 +84,9 @@ const layer = Layer.effectDiscard(
                 save: ["*"],
                 metadata: {
                   root: ".",
-                  path: input.path,
-                  include: input.include,
-                  limit: input.limit,
+                  ...(input.path !== undefined && { path: input.path }),
+                  ...(input.include !== undefined && { include: input.include }),
+                  ...(input.limit !== undefined && { limit: input.limit }),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,

--- a/packages/core/test/tool-glob.test.ts
+++ b/packages/core/test/tool-glob.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Location } from "@opencode-ai/core/location"
+import { PermissionV2 } from "@opencode-ai/core/permission"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { SessionV2 } from "@opencode-ai/core/session"
+import { GlobTool } from "@opencode-ai/core/tool/glob"
+import { ToolRegistry } from "@opencode-ai/core/tool/registry"
+import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
+import { location } from "./fixture/location"
+import { testEffect } from "./lib/effect"
+import { toolIdentity, executeTool } from "./lib/tool"
+
+const sessionID = SessionV2.ID.make("ses_glob_test")
+const assertions: PermissionV2.AssertInput[] = []
+
+const permission = Layer.succeed(
+  PermissionV2.Service,
+  PermissionV2.Service.of({
+    assert: (input) => Effect.sync(() => assertions.push(input)),
+    ask: () => Effect.die("unused"),
+    reply: () => Effect.die("unused"),
+    get: () => Effect.die("unused"),
+    forSession: () => Effect.die("unused"),
+    list: () => Effect.die("unused"),
+  }),
+)
+const ripgrep = Layer.succeed(
+  Ripgrep.Service,
+  Ripgrep.Service.of({
+    find: () => Effect.die("unused"),
+    glob: () => Effect.succeed([]),
+    grep: () => Effect.die("unused"),
+  }),
+)
+const current = Layer.succeed(
+  Location.Service,
+  Location.Service.of(location({ directory: AbsolutePath.make("/project") })),
+)
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([ToolRegistry.node, ToolRegistry.toolsNode, GlobTool.node]), [
+    [PermissionV2.node, permission],
+    [Ripgrep.node, ripgrep],
+    [Location.node, current],
+    [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
+  ]),
+)
+
+const call = (input: typeof GlobTool.Input.Encoded) => ({
+  sessionID,
+  ...toolIdentity,
+  call: { type: "tool-call" as const, id: "call-glob", name: "glob", input },
+})
+
+describe("GlobTool permission metadata", () => {
+  it.effect("omits absent optional fields so the metadata bag holds no undefined values", () =>
+    Effect.gen(function* () {
+      assertions.length = 0
+      const registry = yield* ToolRegistry.Service
+      yield* executeTool(registry, call({ pattern: "**/*.txt" }))
+
+      expect(assertions).toHaveLength(1)
+      const metadata = assertions[0].metadata!
+      expect(metadata).toEqual({ root: "." })
+      // toEqual ignores undefined-valued keys, so guard the actual keys directly:
+      // undefined entries break JSON encoding of session.permission.list.
+      expect(Object.keys(metadata)).toEqual(["root"])
+    }),
+  )
+
+  it.effect("keeps provided optional fields", () =>
+    Effect.gen(function* () {
+      assertions.length = 0
+      const registry = yield* ToolRegistry.Service
+      yield* executeTool(registry, call({ pattern: "**/*.ts", path: "src", limit: 10 }))
+
+      expect(assertions[0].metadata).toEqual({ root: "src", path: "src", limit: 10 })
+    }),
+  )
+})

--- a/packages/core/test/tool-grep.test.ts
+++ b/packages/core/test/tool-grep.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Location } from "@opencode-ai/core/location"
+import { PermissionV2 } from "@opencode-ai/core/permission"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { SessionV2 } from "@opencode-ai/core/session"
+import { GrepTool } from "@opencode-ai/core/tool/grep"
+import { ToolRegistry } from "@opencode-ai/core/tool/registry"
+import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
+import { location } from "./fixture/location"
+import { testEffect } from "./lib/effect"
+import { toolIdentity, executeTool } from "./lib/tool"
+
+const sessionID = SessionV2.ID.make("ses_grep_test")
+const assertions: PermissionV2.AssertInput[] = []
+
+const permission = Layer.succeed(
+  PermissionV2.Service,
+  PermissionV2.Service.of({
+    assert: (input) => Effect.sync(() => assertions.push(input)),
+    ask: () => Effect.die("unused"),
+    reply: () => Effect.die("unused"),
+    get: () => Effect.die("unused"),
+    forSession: () => Effect.die("unused"),
+    list: () => Effect.die("unused"),
+  }),
+)
+const ripgrep = Layer.succeed(
+  Ripgrep.Service,
+  Ripgrep.Service.of({
+    find: () => Effect.die("unused"),
+    glob: () => Effect.die("unused"),
+    grep: () => Effect.succeed([]),
+  }),
+)
+const current = Layer.succeed(
+  Location.Service,
+  Location.Service.of(location({ directory: AbsolutePath.make("/project") })),
+)
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([ToolRegistry.node, ToolRegistry.toolsNode, GrepTool.node]), [
+    [PermissionV2.node, permission],
+    [Ripgrep.node, ripgrep],
+    [Location.node, current],
+    [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
+  ]),
+)
+
+const call = (input: typeof GrepTool.Input.Encoded) => ({
+  sessionID,
+  ...toolIdentity,
+  call: { type: "tool-call" as const, id: "call-grep", name: "grep", input },
+})
+
+describe("GrepTool permission metadata", () => {
+  it.effect("omits absent optional fields so the metadata bag holds no undefined values", () =>
+    Effect.gen(function* () {
+      assertions.length = 0
+      const registry = yield* ToolRegistry.Service
+      yield* executeTool(registry, call({ pattern: "needle" }))
+
+      expect(assertions).toHaveLength(1)
+      const metadata = assertions[0].metadata!
+      expect(metadata).toEqual({ root: "." })
+      // toEqual ignores undefined-valued keys, so guard the actual keys directly:
+      // undefined entries break JSON encoding of session.permission.list.
+      expect(Object.keys(metadata)).toEqual(["root"])
+    }),
+  )
+
+  it.effect("keeps provided optional fields", () =>
+    Effect.gen(function* () {
+      assertions.length = 0
+      const registry = yield* ToolRegistry.Service
+      yield* executeTool(registry, call({ pattern: "needle", path: "src", include: "*.ts", limit: 5 }))
+
+      expect(assertions[0].metadata).toEqual({ root: ".", path: "src", include: "*.ts", limit: 5 })
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #37650

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`glob` and `grep` copied omitted optional inputs into pending permission metadata as explicit `undefined` values. Permission metadata must be JSON, so `session.permission.list` could fail schema encoding while one of those requests was waiting for approval.

This change conditionally includes `path`, `include`, and `limit` only when callers provide them. The required metadata remains unchanged, and supplied optional values are still preserved for permission display and persistence.

### How did you verify your code works?

- `bun test test/tool-glob.test.ts test/tool-grep.test.ts` from `packages/core`: 4 tests pass. The tests execute the real tools and verify both omitted and supplied optional metadata fields.
- `bun typecheck` from `packages/core`: passes.

### Screenshots / recordings

N/A, this changes permission metadata encoding only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
