### PR TITLE
fix(app): add project to sidebar on direct session URL

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -246,6 +246,7 @@ function ResolvedTargetSessionRoute() {
   const params = useParams<{ serverKey: string; id: string }>()
   const tabs = useTabs()
   const sync = useServerSync()
+  const layout = useLayout()
   const serverKey = createMemo(() => requireServerKey(params.serverKey))
   const current = createSessionLineage(
     () => params.id,
@@ -261,6 +262,7 @@ function ResolvedTargetSessionRoute() {
       server: serverKey(),
       sessionId: session.root.id,
     })
+    layout.projects.open(session.session.directory)
   })
 
   return (


### PR DESCRIPTION
### Issue for this PR

Closes #37981

### Type of change

- [x] Bug fix

### Motivation / use case

I'm running opencode in a hosted sandbox environment and want to link users directly to a specific session via its URL. The session itself loads fine, but because the project never gets added to the sidebar on direct navigation, the project and session list are missing — so users land in a session with no surrounding context to navigate to sibling sessions or see which project they're in. This PR closes that gap so a direct session link produces the same sidebar state as opening the session through the app.

### What does this PR do?

Navigating directly to a session URL (`/server/:serverKey/session/:id`) loads the session fine but never adds its project to the sidebar. The sidebar is driven by `layout.projects.list()`, which is only populated by `layout.projects.open()` — and that's called when opening a project from Home, the project picker, or deep links, but not from the session route. The session URL only carries the server key and session id, and the directory is resolved lazily from the session lineage after load, so nothing bridged that resolved directory back into the persisted projects list.

The fix adds `layout.projects.open(session.session.directory)` to the existing effect in `ResolvedTargetSessionRoute` (session.tsx), right alongside the `addSessionTab` call. That effect already runs only after the lineage resolves, so the directory is known at that point. `layout.projects.open` already resolves the worktree root, guards against duplicates, loads sessions, and persists to localStorage — so this reuses the same code path as the other entry points, with no new logic and no risk of duplicate entries.

### How did you verify your code works?

Opened a session by URL directly with no prior sidebar entry and confirmed the project now appears in the sidebar and persists across reload. Also opened a session whose project was already in the sidebar and confirmed no duplicate entry is created.

### Screenshots / recordings

<!-- TODO: add a before/after recording of the sidebar populating on direct session navigation -->

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
