### PR TITLE
fix(core): reload config directory changes

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -337,7 +337,7 @@ export const layer = (options?: Options) => Layer.effect(
 
     const initial = yield* discover()
     let configs = initial
-    const updates = yield* PubSub.unbounded<Watcher.Update>()
+    const updates = yield* PubSub.unbounded<{ readonly target: Watcher.WatchInput; readonly update: Watcher.Update }>()
     const subscriptions = new Map<string, Effect.Effect<unknown>>()
     const reconcile = Effect.fn("Config.reconcileWatches")(function* (entries: readonly Entry[]) {
       const directories = entries.flatMap((entry) => (entry.type === "directory" ? [entry.path] : []))
@@ -357,20 +357,21 @@ export const layer = (options?: Options) => Layer.effect(
       for (const [key, target] of next) {
         if (subscriptions.has(key)) continue
         const fiber = yield* watcher.subscribe(target).pipe(
-          Stream.runForEach((update) => PubSub.publish(updates, update)),
+          Stream.runForEach((update) => PubSub.publish(updates, { target, update })),
           Effect.forkScoped({ startImmediately: true }),
         )
         subscriptions.set(key, Fiber.interrupt(fiber))
       }
     })
 
-    const reload = Effect.fn("Config.reload")(() =>
+    const reload = Effect.fn("Config.reload")((force = false) =>
       reloadLock.withPermit(
         Effect.gen(function* () {
           const next = yield* discover()
-          if (isDeepStrictEqual(configs, next)) return
+          const changed = !isDeepStrictEqual(configs, next)
+          if (!changed && !force) return
           configs = next
-          yield* reconcile(next)
+          if (changed) yield* reconcile(next)
           yield* events.publish(ConfigSchema.Event.Updated, {})
         }),
       ),
@@ -378,8 +379,8 @@ export const layer = (options?: Options) => Layer.effect(
 
     yield* Stream.fromPubSub(updates).pipe(
       Stream.debounce("100 millis"),
-      Stream.runForEach((update) =>
-        reload().pipe(
+      Stream.runForEach(({ target, update }) =>
+        reload(target.type === "directory").pipe(
           Effect.catchCause((cause) => Effect.logError("failed to reload config", { path: update.path, cause })),
         ),
       ),

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import fs from "fs/promises"
 import { describe, expect } from "bun:test"
-import { Effect, Fiber, Layer, PubSub, Schema, Stream } from "effect"
+import { Effect, Fiber, Layer, PubSub, Schedule, Schema, Stream } from "effect"
 import { FastCheck } from "effect/testing"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigModel } from "@opencode-ai/core/config/model"
@@ -28,6 +28,7 @@ import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.empty)
+const describeWatcher = Watcher.hasNativeBinding() && !process.env.CI ? describe : describe.skip
 const selection = Schema.decodeUnknownSync(ConfigModel.Selection)
 
 const emptyCredentialNode = makeGlobalNode({
@@ -181,6 +182,93 @@ describe("Config", () => {
             ),
           )
       }),
+    ),
+  )
+
+  it.live("publishes updates for config-backed files inside config directories", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const global = path.join(tmp.path, "global")
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(() => Promise.all([fs.mkdir(global), fs.mkdir(project)]))
+          const updates = yield* PubSub.unbounded<Watcher.Update>()
+          const watcher = Layer.succeed(
+            Watcher.Service,
+            Watcher.Service.of({
+              subscribe: () => Stream.fromPubSub(updates),
+            }),
+          )
+
+          return yield* Effect.gen(function* () {
+            const events = yield* EventV2.Service
+            yield* Effect.forEach(
+              [
+                { type: "create" as const, path: path.join(global, "commands", "review.md") },
+                { type: "update" as const, path: path.join(global, "agents", "reviewer.md") },
+                { type: "delete" as const, path: path.join(global, "plugins", "local.ts") },
+              ],
+              (update) =>
+                Effect.gen(function* () {
+                  const changed = yield* events
+                    .subscribe(ConfigSchema.Event.Updated)
+                    .pipe(Stream.take(1), Stream.runCollect, Effect.timeout("2 seconds"), Effect.forkScoped)
+                  yield* Effect.sleep("10 millis")
+                  yield* PubSub.publish(updates, update satisfies Watcher.Update)
+                  expect(yield* Fiber.join(changed)).toHaveLength(1)
+                }),
+              { discard: true },
+            )
+          }).pipe(Effect.provide(testLayer(project, global, project, undefined, watcher)))
+        }),
+      ),
+    ),
+  )
+
+  it.live("coalesces config directory updates from one editor save", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const global = path.join(tmp.path, "global")
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(() => Promise.all([fs.mkdir(global), fs.mkdir(project)]))
+          const updates = yield* PubSub.unbounded<Watcher.Update>()
+          const watcher = Layer.succeed(
+            Watcher.Service,
+            Watcher.Service.of({
+              subscribe: () => Stream.fromPubSub(updates),
+            }),
+          )
+
+          return yield* Effect.gen(function* () {
+            const events = yield* EventV2.Service
+            const changed: (typeof ConfigSchema.Event.Updated.Type)[] = []
+            yield* events.subscribe(ConfigSchema.Event.Updated).pipe(
+              Stream.runForEach((event) => Effect.sync(() => changed.push(event))),
+              Effect.forkScoped({ startImmediately: true }),
+            )
+            yield* Effect.sleep("10 millis")
+
+            yield* Effect.forEach(
+              [
+                { type: "delete" as const, path: path.join(global, "commands", "review.md") },
+                { type: "create" as const, path: path.join(global, "commands", "release.md") },
+              ],
+              (update) => PubSub.publish(updates, update satisfies Watcher.Update),
+              { discard: true },
+            )
+            yield* Effect.sleep("250 millis")
+
+            expect(changed).toHaveLength(1)
+          }).pipe(Effect.provide(testLayer(project, global, project, undefined, watcher)))
+        }),
+      ),
     ),
   )
 
@@ -1229,5 +1317,41 @@ describe("Config", () => {
         })
       }),
     ),
+  )
+})
+
+describeWatcher("Config native watcher", () => {
+  it.live(
+    "publishes updates for files created inside config directories",
+    () =>
+      Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      ).pipe(
+        Effect.flatMap((tmp) =>
+          Effect.gen(function* () {
+            const global = path.join(tmp.path, "global")
+            const project = path.join(tmp.path, "project")
+            const commands = path.join(global, "commands")
+            yield* Effect.promise(() => Promise.all([fs.mkdir(commands, { recursive: true }), fs.mkdir(project)]))
+
+            return yield* Effect.gen(function* () {
+              const config = yield* Config.Service
+              const events = yield* EventV2.Service
+              yield* config.entries()
+              const changed = yield* events
+                .subscribe(ConfigSchema.Event.Updated)
+                .pipe(Stream.take(1), Stream.runCollect, Effect.timeout("5 seconds"), Effect.forkScoped)
+
+              const writes = yield* Effect.suspend(() =>
+                Effect.promise(() => fs.writeFile(path.join(commands, "review.md"), `Review files ${Math.random()}`)),
+              ).pipe(Effect.repeat(Schedule.spaced("50 millis")), Effect.forkScoped)
+
+              expect(yield* Fiber.join(changed).pipe(Effect.ensuring(Fiber.interrupt(writes)))).toHaveLength(1)
+            }).pipe(Effect.provide(testLayer(project, global, project)))
+          }),
+        ),
+      ),
+    10_000,
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #37429

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Config directories were only treated as changed when their discovered entry list changed. That missed edits inside existing directory-backed config roots.

This keeps the changed watcher targets through debounce and publishes config.updated when a directory-backed config root changes. Watched entries are still reconciled only when the discovered entry set changes.

### How did you verify your code works?

Ran the focused config and command tests: 26 passed and 0 failed. Also ran the core package typecheck, Prettier check, and git diff check.

### Screenshots / recordings

Not applicable. This is a non-UI core behavior change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR