### PR TITLE
fix(core): serialize prompt settlement

### DIFF
--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -3,6 +3,7 @@ export * as Form from "./form"
 import { Form } from "@opencode-ai/schema/form"
 import { Cache, Context, Deferred, Duration, Effect, Exit, Layer, Option, Schema } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { KeyedMutex } from "./effect/keyed-mutex"
 import { EventV2 } from "./event"
 
 const RETENTION = Duration.minutes(10)
@@ -100,6 +101,7 @@ export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2.Service
+    const settlements = KeyedMutex.makeUnsafe<ID>()
     const forms = yield* Cache.makeWith<ID, Entry>(
       () => Effect.die(new Error("Form cache must be used via set/getSuccess, never get")),
       {
@@ -186,7 +188,7 @@ export const layer = Layer.effect(
           yield* events.publish(Event.Replied, { id: input.id, sessionID: entry.form.sessionID, answer: input.answer })
           yield* Cache.set(forms, input.id, { ...entry, state: next })
           yield* Deferred.succeed(entry.deferred, next)
-        }),
+        }).pipe(settlements.withLock(input.id)),
       ),
     )
 
@@ -199,7 +201,7 @@ export const layer = Layer.effect(
           yield* events.publish(Event.Cancelled, { id, sessionID: entry.form.sessionID })
           yield* Cache.set(forms, id, { ...entry, state: next })
           yield* Deferred.succeed(entry.deferred, next)
-        }),
+        }).pipe(settlements.withLock(id)),
       ),
     )
 

--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -1,7 +1,7 @@
 export * as PermissionV2 from "./permission"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Context, Deferred, Effect, Layer, Schema } from "effect"
+import { Context, Deferred, Effect, Layer, Schema, Semaphore } from "effect"
 import { Permission } from "@opencode-ai/schema/permission"
 import { EventV2 } from "./event"
 import { Location } from "./location"
@@ -124,6 +124,9 @@ const layer = Layer.effect(
     const sessions = yield* SessionStore.Service
     const saved = yield* PermissionSaved.Service
     const pending = new Map<ID, Pending>()
+    // Reject and saved "always" replies can settle other pending requests, so
+    // permission settlement must be serialized across the whole service.
+    const settlements = Semaphore.makeUnsafe(1)
 
     yield* Effect.addFinalizer(() =>
       Effect.forEach(pending.values(), (item) => Deferred.fail(item.deferred, new DeclinedError()), {
@@ -293,7 +296,7 @@ const layer = Layer.effect(
             yield* Deferred.succeed(item.deferred, undefined)
             pending.delete(id)
           }
-        }),
+        }).pipe((effect) => settlements.withPermit(effect)),
       ),
     )
 

--- a/packages/core/src/question.ts
+++ b/packages/core/src/question.ts
@@ -3,6 +3,7 @@ export * as QuestionV2 from "./question"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Context, Deferred, Effect, Layer, Schema } from "effect"
 import { Question } from "@opencode-ai/schema/question"
+import { KeyedMutex } from "./effect/keyed-mutex"
 import { EventV2 } from "./event"
 import { SessionSchema } from "./session/schema"
 
@@ -77,6 +78,7 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const events = yield* EventV2.Service
     const pending = new Map<ID, Pending>()
+    const settlements = KeyedMutex.makeUnsafe<ID>()
 
     yield* Effect.addFinalizer(() =>
       Effect.forEach(pending.values(), (item) => Deferred.fail(item.deferred, new RejectedError()), {
@@ -121,7 +123,7 @@ const layer = Layer.effect(
           })
           yield* Deferred.succeed(existing.deferred, input.answers)
           pending.delete(input.requestID)
-        }),
+        }).pipe(settlements.withLock(input.requestID)),
       ),
     )
 
@@ -136,7 +138,7 @@ const layer = Layer.effect(
           })
           yield* Deferred.fail(existing.deferred, new RejectedError())
           pending.delete(requestID)
-        }),
+        }).pipe(settlements.withLock(requestID)),
       ),
     )
 

--- a/packages/core/test/form.test.ts
+++ b/packages/core/test/form.test.ts
@@ -343,4 +343,34 @@ describe("Form", () => {
       expect(yield* service.state(formID)).toEqual({ status: "answered", answer: { name: "Ava" } })
     }),
   )
+
+  it.effect("serializes competing settlements for the same form", () =>
+    Effect.gen(function* () {
+      const service = yield* Form.Service
+      const events = yield* EventV2.Service
+      yield* service.create(input)
+      const terminal = new Array<string>()
+      const unsubscribe = yield* events.listen((event) => {
+        if (event.type !== Form.Event.Replied.type && event.type !== Form.Event.Cancelled.type) return Effect.void
+        return Effect.sync(() => {
+          terminal.push(event.type)
+        }).pipe(Effect.andThen(Effect.promise(() => Bun.sleep(10))))
+      })
+      yield* Effect.addFinalizer(() => unsubscribe)
+
+      const exits = yield* Effect.all(
+        [
+          service.reply({ id: formID, answer: { name: "Ava" } }).pipe(Effect.exit),
+          service.cancel(formID).pipe(Effect.exit),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      expect(exits.filter(Exit.isSuccess)).toHaveLength(1)
+      expect(exits.filter(Exit.isFailure)).toHaveLength(1)
+      if (Exit.isFailure(exits[0])) expect(exits[0].cause.toString()).toContain("Form.AlreadySettledError")
+      if (Exit.isFailure(exits[1])) expect(exits[1].cause.toString()).toContain("Form.AlreadySettledError")
+      expect(terminal).toHaveLength(1)
+    }),
+  )
 })

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Cause, Deferred, Effect, Fiber, Layer } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
 import { Database } from "@opencode-ai/core/database/database"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -263,6 +263,36 @@ describe("PermissionV2", () => {
       yield* Fiber.join(fiber)
       expect(yield* service.list()).toEqual([])
       expect(yield* service.get(request.id)).toBeUndefined()
+    }),
+  )
+
+  it.effect("serializes competing replies for the same permission", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const { service, request } = yield* waitForRequest()
+      const events = yield* EventV2.Service
+      const replies = new Array<PermissionV2.Reply>()
+      const unsubscribe = yield* events.listen((event) => {
+        if (event.type !== PermissionV2.Event.Replied.type) return Effect.void
+        return Effect.sync(() => {
+          replies.push((event.data as { readonly reply: PermissionV2.Reply }).reply)
+        }).pipe(Effect.andThen(Effect.promise(() => Bun.sleep(10))))
+      })
+      yield* Effect.addFinalizer(() => unsubscribe)
+
+      const exits = yield* Effect.all(
+        [
+          service.reply({ requestID: request.id, reply: "once" }).pipe(Effect.exit),
+          service.reply({ requestID: request.id, reply: "reject" }).pipe(Effect.exit),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      expect(exits.filter(Exit.isSuccess)).toHaveLength(1)
+      expect(exits.filter(Exit.isFailure)).toHaveLength(1)
+      if (Exit.isFailure(exits[0])) expect(exits[0].cause.toString()).toContain("PermissionV2.NotFoundError")
+      if (Exit.isFailure(exits[1])) expect(exits[1].cause.toString()).toContain("PermissionV2.NotFoundError")
+      expect(replies).toHaveLength(1)
     }),
   )
 

--- a/packages/core/test/question.test.ts
+++ b/packages/core/test/question.test.ts
@@ -111,4 +111,35 @@ describe("QuestionV2", () => {
       yield* Scope.close(secondScope, Exit.void)
     }),
   )
+
+  it.effect("serializes competing settlements for the same question", () =>
+    Effect.gen(function* () {
+      const service = yield* QuestionV2.Service
+      const events = yield* EventV2.Service
+      const terminal = new Array<string>()
+      const unsubscribe = yield* events.listen((event) => {
+        if (event.type !== QuestionV2.Event.Replied.type && event.type !== QuestionV2.Event.Rejected.type)
+          return Effect.void
+        return Effect.sync(() => {
+          terminal.push(event.type)
+        }).pipe(Effect.andThen(Effect.promise(() => Bun.sleep(10))))
+      })
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const { request } = yield* waitForAsk(service, { sessionID, questions: [question] })
+
+      const exits = yield* Effect.all(
+        [
+          service.reply({ requestID: request.id, answers: [["One"]] }).pipe(Effect.exit),
+          service.reject(request.id).pipe(Effect.exit),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      expect(exits.filter(Exit.isSuccess)).toHaveLength(1)
+      expect(exits.filter(Exit.isFailure)).toHaveLength(1)
+      if (Exit.isFailure(exits[0])) expect(exits[0].cause.toString()).toContain("QuestionV2.NotFoundError")
+      if (Exit.isFailure(exits[1])) expect(exits[1].cause.toString()).toContain("QuestionV2.NotFoundError")
+      expect(terminal).toHaveLength(1)
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #34853

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Concurrent replies could settle the same form, question, or permission request more than once.

This serializes form and question settlement by request ID. Permission replies are serialized service-wide because reject and saved always replies can settle additional requests. Regression tests verify that only one concurrent settlement succeeds and emits a terminal event.

### How did you verify your code works?

Ran the form, question, and permission tests 20 times each: 560 passed and 0 failed. Also ran the core package typecheck, Prettier check, and git diff check.

### Screenshots / recordings

Not applicable. This is a non-UI core behavior change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR