### PR TITLE
fix(core): publish domain updates after committed state is readable

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -165,8 +165,8 @@ const layer = Layer.effect(
             }
           }
         }
-        yield* events.publish(Event.Updated, {})
       }),
+      notify: () => events.publish(Event.Updated, {}).pipe(Effect.asVoid),
     })
     const result: Interface = {
       transform: state.transform,

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -282,7 +282,7 @@ export const locationLayer = Layer.effect(
           },
         },
       }),
-      finalize: () => events.publish(Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => events.publish(Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     const resolveConnections = (entry: Entry | undefined, saved: readonly Credential.Info[]) => {

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -106,8 +106,8 @@ const layer = Layer.effect(
               Effect.forkIn(scope),
             )
           }
-          yield* events.publish(Event.Updated, {})
         }),
+      notify: () => events.publish(Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     return Service.of({

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -46,8 +46,15 @@ export interface Options<State, DraftApi> {
   readonly initial: () => State
   /** Wraps mutable state in a domain-specific draft API. */
   readonly draft: MakeDraft<State, DraftApi>
-  /** Runs after all active transforms and before the rebuilt state becomes visible. */
+  /**
+   * Completes the rebuilt state before it becomes visible. Do not publish
+   * update events here: a finalizer runs before `get` exposes the new state,
+   * so a client reacting to the event could refetch the stale snapshot. Emit
+   * update events from `notify` instead.
+   */
   readonly finalize?: (draft: DraftApi) => Effect.Effect<void>
+  /** Runs after the rebuilt state becomes visible; publish update events here. */
+  readonly notify?: () => Effect.Effect<void>
 }
 
 export interface Interface<State, DraftApi> extends Transformable<DraftApi> {
@@ -67,6 +74,7 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
     const api = options.draft(next)
     if (options.finalize) yield* options.finalize(api)
     state = next
+    if (options.notify) yield* options.notify()
   })
 
   const apply = (transform: TransformCallback<DraftApi>, draft: DraftApi) =>

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -112,4 +112,33 @@ describe("State", () => {
       expect(finalized).toBe(2)
     }),
   )
+
+  it.effect("exposes the committed state to notify while finalize still sees the previous state", () =>
+    Effect.gen(function* () {
+      const observed: { finalize?: string[]; notify?: string[] } = {}
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        finalize: () =>
+          Effect.sync(() => {
+            observed.finalize = [...state.get().values]
+          }),
+        notify: () =>
+          Effect.sync(() => {
+            observed.notify = [...state.get().values]
+          }),
+      })
+
+      yield* state.transform((editor) => {
+        editor.add("registered")
+      })
+
+      // finalize completes the rebuild before it becomes readable.
+      expect(observed.finalize).toEqual([])
+      // notify runs after get() exposes the rebuilt state, so an update event
+      // emitted here is a safe invalidation boundary: a client refetch sees it.
+      expect(observed.notify).toEqual(["registered"])
+      expect(state.get().values).toEqual(["registered"])
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Fixes #37422 on `dev`. #38983 fixes the same issue on `v2`.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

State domains could publish update events from `finalize` before the rebuilt state replaced the readable snapshot. A subscriber reacting immediately to a catalog, integration, or reference event could therefore refetch the previous value with no later event to invalidate it.

This change adds a post-commit `notify` hook that runs only after `state = next`. Catalog, integration, and reference event publication moves to that hook, while asynchronous finalization still completes before the new snapshot becomes visible. An observed update event is therefore a safe boundary for refetching committed state.

### How did you verify your code works?

- State, catalog, integration, and reference tests: 30 pass, including a regression that refetches state from the update-event handler and observes the committed snapshot.
- `bun typecheck` from `packages/core`: passes.

### Screenshots / recordings

N/A, this changes state/event ordering only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
