### PR TITLE
feat: replace Intelephense with PHPantom as default PHP LSP

### DIFF
--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -44,7 +44,7 @@ export const builtinServerIds = [
   "kotlin-ls",
   "yaml-ls",
   "lua-ls",
-  "php intelephense",
+  "phpantom",
   "prisma",
   "dart",
   "ocaml-lsp",

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -1512,33 +1512,74 @@ export const LuaLS: Info = {
   },
 }
 
-export const PHPIntelephense: Info = {
-  id: "php intelephense",
+export const PHPantom: Info = {
+  id: "phpantom",
   extensions: [".php"],
-  root: NearestRoot(["composer.json", "composer.lock", ".php-version"]),
+  root: NearestRoot(["composer.json", "composer.lock", ".php-version", ".phpantom.toml"]),
   async spawn(root, _ctx, flags) {
-    let binary = which("intelephense")
-    const args: string[] = []
-    if (!binary) {
+    let bin = which("phpantom_lsp")
+
+    if (!bin) {
       if (flags.disableLspDownload) return
-      const resolved = await Npm.which("intelephense")
-      if (!resolved) return
-      binary = resolved
+
+      const response = await fetch("https://api.github.com/repos/PHPantom-dev/phpantom_lsp/releases/latest")
+      if (!response.ok) return
+
+      const release = (await response.json()) as {
+        tag_name?: string
+        assets?: { name?: string; browser_download_url?: string }[]
+      }
+      const version = release.tag_name?.replace("v", "")
+      if (!version) return
+
+      const platform = process.platform
+      const arch = process.arch
+
+      const rustArch = arch === "arm64" ? "aarch64" : "x86_64"
+      const rustTarget =
+        platform === "darwin"
+          ? `${rustArch}-apple-darwin`
+          : platform === "win32"
+            ? `${rustArch}-pc-windows-msvc`
+            : `${rustArch}-unknown-linux-gnu`
+      const ext = platform === "win32" ? "zip" : "tar.gz"
+      const assetName = `phpantom_lsp-${rustTarget}.${ext}`
+
+      const assets = release.assets ?? []
+      const asset = assets.find((a) => a.name === assetName)
+      if (!asset?.browser_download_url) return
+
+      const downloadResponse = await fetch(asset.browser_download_url)
+      if (!downloadResponse.ok) return
+
+      const tempPath = path.join(Global.Path.bin, assetName)
+      if (downloadResponse.body) await Filesystem.writeStream(tempPath, downloadResponse.body)
+
+      if (ext === "zip") {
+        const ok = await Archive.extractZip(tempPath, Global.Path.bin)
+          .then(() => true)
+          .catch(() => false)
+        if (!ok) return
+      }
+      if (ext === "tar.gz") {
+        await run(["tar", "-xzf", tempPath], { cwd: Global.Path.bin })
+      }
+
+      await fs.rm(tempPath, { force: true })
+
+      bin = path.join(Global.Path.bin, "phpantom_lsp" + (platform === "win32" ? ".exe" : ""))
+
+      if (!(await Filesystem.exists(bin))) return
+
+      if (platform !== "win32") {
+        await fs.chmod(bin, 0o755).catch(() => {})
+      }
     }
-    args.push("--stdio")
-    const proc = spawn(binary, args, {
-      cwd: root,
-      env: {
-        ...process.env,
-      },
-    })
+
     return {
-      process: proc,
-      initialization: {
-        telemetry: {
-          enabled: false,
-        },
-      },
+      process: spawn(bin, ["--stdio"], {
+        cwd: root,
+      }),
     }
   },
 }

--- a/packages/web/src/content/docs/ar/lsp.mdx
+++ b/packages/web/src/content/docs/ar/lsp.mdx
@@ -32,7 +32,7 @@ description: يتكامل OpenCode مع خوادم LSP لديك.
 | nixd               | .nix                                                                | توفر أمر `nixd`                                      |
 | ocaml-lsp          | .ml, .mli                                                           | توفر أمر `ocamllsp`                                  |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | وجود تبعية `oxlint` في المشروع                       |
-| php intelephense   | .php                                                                | يثبت تلقائيا لمشاريع PHP                             |
+| phpantom            | .php                                                                | يُثبَّت تلقائيًا من إصدارات GitHub                    |
 | prisma             | .prisma                                                             | توفر أمر `prisma`                                    |
 | pyright            | .py, .pyi                                                           | تثبيت تبعية `pyright`                                |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | توفر أمري `ruby` و `gem`                             |
@@ -193,15 +193,3 @@ description: يتكامل OpenCode مع خوادم LSP لديك.
 }
 ```
 
----
-
-## معلومات إضافية
-
-### PHP Intelephense
-
-يوفر PHP Intelephense ميزات مدفوعة عبر مفتاح ترخيص. يمكنك تزويده بمفتاح الترخيص عبر وضع (فقط) المفتاح داخل ملف نصي في:
-
-- على macOS/Linux: `$HOME/intelephense/license.txt`
-- على Windows: `%USERPROFILE%/intelephense/license.txt`
-
-يجب أن يحتوي الملف على مفتاح الترخيص فقط دون أي محتوى إضافي.

--- a/packages/web/src/content/docs/bs/lsp.mdx
+++ b/packages/web/src/content/docs/bs/lsp.mdx
@@ -31,7 +31,7 @@ OpenCode dolazi sa nekoliko ugrađenih LSP servera za popularne jezike:
 | nixd               | .nix                                                                | `nixd` komanda dostupna                                  |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` komanda dostupna                              |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` zavisnost u projektu                            |
-| php intelephense   | .php                                                                | Automatske instalacije za PHP projekte                   |
+| phpantom            | .php                                                                | Automatska instalacija iz GitHub izdanja                  |
 | prisma             | .prisma                                                             | `prisma` komanda dostupna                                |
 | pyright            | .py, .pyi                                                           | `pyright` ovisnost instalirana                           |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | `ruby` i `gem` komande dostupne                          |
@@ -191,14 +191,3 @@ Možete dodati prilagođene LSP servere navodeći ekstenzije naredbe i datoteke:
 }
 ```
 
----
-
-## Dodatne informacije
-
-### PHP Intelephense
-
-PHP Intelephense nudi vrhunske funkcije putem licencnog ključa. Možete dati licencni ključ postavljanjem (samo) ključa u tekstualnu datoteku na:
-
-- Na macOS/Linuxu: `$HOME/intelephense/license.txt`
-- Na Windowsima: `%USERPROFILE%/intelephense/license.txt`
-  Datoteka treba da sadrži samo licencni ključ bez dodatnog sadržaja.

--- a/packages/web/src/content/docs/da/lsp.mdx
+++ b/packages/web/src/content/docs/da/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode leveres med flere indbyggede LSP-servere til populære sprog:
 | nixd               | .nix                                                      | `nixd` kommando tilgængelig                                     |
 | ocaml-lsp          | .ml,.mli                                                  | `ocamllsp` kommando tilgængelig                                 |
 | oxlint             | .ts,.tsx,.js,.jsx,.mjs,.cjs,.mts,.cts,.vue,.astro,.svelte | `oxlint` afhængighed i projekt                                  |
-| php intelephense   | .php                                                      | Automatiske installationer til PHP-projekter                    |
+| phpantom            | .php                                                      | Auto-installerer fra GitHub-udgivelser                          |
 | prisma             | .prisma                                                   | `prisma` kommando tilgængelig                                   |
 | pyright            | .py,.pyi                                                  | `pyright` afhængig installeret                                  |
 | ruby-lsp (rubocop) | .rb,.rake,.gemspec,.ru                                    | `ruby` og `gem` kommandoer tilgængelige                         |
@@ -194,15 +194,3 @@ Du kan tilføje brugerdefinerede LSP-servere ved at angive kommandoen og filtype
 }
 ```
 
----
-
-## Yderligere oplysninger
-
-### PHP Intelephense
-
-PHP Intelephense tilbyder premium funktioner gennem en licensnøgle. Du kan angive en licensnøgle ved at placere (kun) nøglen i en tekstfil på:
-
-- På macOS/Linux: `$HOME/intelephense/license.txt`
-- På Windows: `%USERPROFILE%/intelephense/license.txt`
-
-Filen bør kun indeholde licensnøglen uden yderligere indhold.

--- a/packages/web/src/content/docs/de/lsp.mdx
+++ b/packages/web/src/content/docs/de/lsp.mdx
@@ -32,7 +32,7 @@ OpenCode verfügt über mehrere integrierte LSP-Server für gängige Sprachen:
 | nixd               | .nix                                                                | `nixd`-Befehl verfügbar                                                   |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp`-Befehl verfügbar                                               |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` dependency in project                                            |
-| php intelephense   | .php                                                                | Automatische Installation für PHP-Projekte                                |
+| phpantom            | .php                                                                | Automatische Installation aus GitHub-Releases                             |
 | prisma             | .prisma                                                             | `prisma`-Befehl verfügbar                                                 |
 | pyright            | .py, .pyi                                                           | `pyright` dependency installed                                            |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | Befehle `ruby` und `gem` verfügbar                                        |
@@ -193,15 +193,3 @@ Sie können einen benutzerdefinierten LSP-Server hinzufügen, indem Sie den Befe
 }
 ```
 
----
-
-## Weitere Informationen
-
-### PHP Intelephense
-
-PHP Intelepense bietet Premium-Funktionen über einen Lizenzschlüssel. Sie können einen Lizenzschlüssel bereitstellen, indem Sie (nur) den Schlüssel in eine Textdatei einfügen unter:
-
-- Auf macOS/Linux: `$HOME/intelephense/license.txt`
-- Unter Windows: `%USERPROFILE%/intelephense/license.txt`
-
-Die Datei sollte nur den Lizenzschlüssel ohne zusätzlichen Inhalt enthalten.

--- a/packages/web/src/content/docs/es/lsp.mdx
+++ b/packages/web/src/content/docs/es/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode viene con varios servidores LSP integrados para idiomas populares:
 | nixd               | .nix                                                                | Comando `nixd` disponible                                                |
 | ocaml-lsp          | .ml, .mli                                                           | Comando `ocamllsp` disponible                                            |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` dependencia en proyecto                                         |
-| php intelephense   | .php                                                                | Autoinstalaciones para proyectos PHP                                     |
+| phpantom            | .php                                                                | Autoinstalación desde versiones de GitHub                                 |
 | prisma             | .prisma                                                             | Comando `prisma` disponible                                              |
 | pyright            | .py, .pyi                                                           | Dependencia `pyright` instalada                                          |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | Comandos `ruby` y `gem` disponibles                                      |
@@ -194,15 +194,3 @@ Puede agregar servidores LSP personalizados especificando el comando y las exten
 }
 ```
 
----
-
-## Información adicional
-
-### PHP Intelephense
-
-PHP Intelephense ofrece funciones premium a través de una clave de licencia. Puede proporcionar una clave de licencia colocando (únicamente) la clave en un archivo de texto en:
-
-- En macOS/Linux: `$HOME/intelephense/license.txt`
-- En Windows: `%USERPROFILE%/intelephense/license.txt`
-
-El archivo debe contener sólo la clave de licencia sin contenido adicional.

--- a/packages/web/src/content/docs/fr/lsp.mdx
+++ b/packages/web/src/content/docs/fr/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode est livré avec plusieurs serveurs LSP intégrés pour les langages pop
 | nixd               | .nix                                                                | Commande `nixd` disponible                                              |
 | ocaml-lsp          | .ml, .mli                                                           | Commande `ocamllsp` disponible                                          |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | Dépendance `oxlint` dans le projet                                      |
-| php intelephense   | .php                                                                | Installation automatique pour les projets PHP                           |
+| phpantom            | .php                                                                | Installation automatique depuis les releases GitHub                     |
 | prisma             | .prisma                                                             | Commande `prisma` disponible                                            |
 | pyright            | .py, .pyi                                                           | Dépendance `pyright` installée                                          |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | Commandes `ruby` et `gem` disponibles                                   |
@@ -194,15 +194,3 @@ Vous pouvez ajouter des serveurs LSP personnalisés en spécifiant les extension
 }
 ```
 
----
-
-## Informations supplémentaires
-
-### PHP Intelephense
-
-PHP Intelephense offre des fonctionnalités premium via une clé de licence. Vous pouvez fournir une clé de licence en plaçant (uniquement) la clé dans un fichier texte à l'adresse :
-
-- macOS/Linux : `$HOME/intelephense/license.txt`
-- Windows : `%USERPROFILE%/intelephense/license.txt`
-
-Le fichier doit contenir uniquement la clé de licence sans contenu supplémentaire.

--- a/packages/web/src/content/docs/it/lsp.mdx
+++ b/packages/web/src/content/docs/it/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode include diversi server LSP integrati per linguaggi popolari:
 | nixd               | .nix                                                                | comando `nixd` disponibile                                               |
 | ocaml-lsp          | .ml, .mli                                                           | comando `ocamllsp` disponibile                                           |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | dipendenza `oxlint` nel progetto                                         |
-| php intelephense   | .php                                                                | Installazione automatica per progetti PHP                                |
+| phpantom            | .php                                                                | Installazione automatica dalle release di GitHub                         |
 | prisma             | .prisma                                                             | comando `prisma` disponibile                                             |
 | pyright            | .py, .pyi                                                           | dipendenza `pyright` installata                                          |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | comandi `ruby` e `gem` disponibili                                       |
@@ -194,15 +194,3 @@ Puoi aggiungere server LSP personalizzati specificando il comando e le estension
 }
 ```
 
----
-
-## Informazioni aggiuntive
-
-### PHP Intelephense
-
-PHP Intelephense offre funzionalita premium tramite una chiave di licenza. Puoi fornire la chiave inserendo (solo) la chiave in un file di testo in:
-
-- Su macOS/Linux: `$HOME/intelephense/license.txt`
-- Su Windows: `%USERPROFILE%/intelephense/license.txt`
-
-Il file deve contenere solo la chiave di licenza, senza contenuti aggiuntivi.

--- a/packages/web/src/content/docs/ja/lsp.mdx
+++ b/packages/web/src/content/docs/ja/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode には、一般的な言語用のいくつかの組み込み LSP サー
 | nixd               | .nix                                                                | `nixd` command available                                     |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` command available                                 |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` dependency in project                               |
-| php intelephense   | .php                                                                | Auto-installs for PHP projects                               |
+| phpantom            | .php                                                                | Auto-installs from GitHub releases                           |
 | prisma             | .prisma                                                             | `prisma` command available                                   |
 | pyright            | .py, .pyi                                                           | `pyright` dependency installed                               |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | `ruby` and `gem` commands available                          |
@@ -194,15 +194,3 @@ LSP サーバーの起動時に `env` プロパティを使用して環境変数
 }
 ```
 
----
-
-## 追加情報
-
-### PHP Intelephense
-
-PHP Intelephense は、ライセンスキーを通じてプレミアム機能を提供します。ライセンスキーを指定するには、次の場所にあるテキストファイルにキー (のみ) を配置します。
-
-- macOS/Linux の場合: `$HOME/intelephense/license.txt`
-- Windows の場合: `%USERPROFILE%/intelephense/license.txt`
-
-ファイルにはライセンスキーのみが含まれており、追加のコンテンツは含まれていません。

--- a/packages/web/src/content/docs/ko/lsp.mdx
+++ b/packages/web/src/content/docs/ko/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode는 널리 사용되는 언어를 위해 여러 built-in LSP 서버를 �
 | nixd               | .nix                                                                | `nixd` 명령 사용 가능                                      |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` 명령 사용 가능                                  |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | 프로젝트에 `oxlint` dependency 존재                        |
-| php intelephense   | .php                                                                | PHP 프로젝트에서 자동 설치                                 |
+| phpantom            | .php                                                                | GitHub 릴리스에서 자동 설치                                |
 | prisma             | .prisma                                                             | `prisma` 명령 사용 가능                                    |
 | pyright            | .py, .pyi                                                           | `pyright` dependency 설치됨                                |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | `ruby` 및 `gem` 명령 사용 가능                             |
@@ -194,15 +194,3 @@ OpenCode config의 `lsp` 섹션에서 LSP 서버를 활성화하고 사용자 �
 }
 ```
 
----
-
-## 추가 정보
-
-### PHP Intelephense
-
-PHP Intelephense는 라이선스 키를 통해 프리미엄 기능을 제공합니다. 텍스트 파일에 키만 저장해 라이선스 키를 제공할 수 있습니다.
-
-- macOS/Linux: `$HOME/intelephense/license.txt`
-- Windows: `%USERPROFILE%/intelephense/license.txt`
-
-파일에는 추가 내용 없이 라이선스 키만 포함하는 것이 좋습니다.

--- a/packages/web/src/content/docs/lsp.mdx
+++ b/packages/web/src/content/docs/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode comes with several built-in LSP servers for popular languages:
 | nixd               | .nix                                                                | `nixd` command available                                     |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` command available                                 |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` dependency in project                               |
-| php intelephense   | .php                                                                | Auto-installs for PHP projects                               |
+| phpantom            | .php                                                                | Auto-installs from GitHub releases                           |
 | prisma             | .prisma                                                             | `prisma` command available                                   |
 | pyright            | .py, .pyi                                                           | `pyright` dependency installed                               |
 | razor              | .razor, .cshtml                                                     | `.NET SDK` and VS Code C# extension installed                |
@@ -200,15 +200,4 @@ You can add custom LSP servers by specifying the command and file extensions:
 }
 ```
 
----
 
-## Additional Information
-
-### PHP Intelephense
-
-PHP Intelephense offers premium features through a license key. You can provide a license key by placing (only) the key in a text file at:
-
-- On macOS/Linux: `$HOME/intelephense/license.txt`
-- On Windows: `%USERPROFILE%/intelephense/license.txt`
-
-The file should contain only the license key with no additional content.

--- a/packages/web/src/content/docs/nb/lsp.mdx
+++ b/packages/web/src/content/docs/nb/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode kommer med flere innebygde LSP-servere for populære språk:
 | nixd               | .nix                                                                | `nixd` kommando tilgjengelig                                            |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` kommando tilgjengelig                                        |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` avhengighet i prosjekt                                         |
-| php intelephense   | .php                                                                | Installeres automatisk for PHP-prosjekter                               |
+| phpantom            | .php                                                                | Auto-installeres fra GitHub-utgivelser                                  |
 | prisma             | .prisma                                                             | `prisma` kommando tilgjengelig                                          |
 | pyright            | .py, .pyi                                                           | `pyright` avhengighet installert                                        |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | `ruby` og `gem` kommandoer tilgjengelig                                 |
@@ -194,15 +194,3 @@ Du kan legge til egendefinerte LSP-servere ved å spesifisere kommandoen og filt
 }
 ```
 
----
-
-## Tilleggsinformasjon
-
-### PHP Intelephense
-
-PHP Intelephense tilbyr førsteklasses funksjoner gjennom en lisensnøkkel. Du kan oppgi en lisensnøkkel ved å plassere (bare) nøkkelen i en tekstfil på:
-
-- På macOS/Linux: `$HOME/intelephense/license.txt`
-- På Windows: `%USERPROFILE%/intelephense/license.txt`
-
-Filen skal bare inneholde lisensnøkkelen uten ekstra innhold.

--- a/packages/web/src/content/docs/pl/lsp.mdx
+++ b/packages/web/src/content/docs/pl/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode posiada kilka wbudowanych serwerów LSP dla następujących języków:
 | nixd               | .nix                                                                | Dostępne polecenie `nixd`                                                |
 | ocaml-lsp          | .ml, .mli                                                           | Dostępne polecenie `ocamllsp`                                            |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | Zależność `oxlint` w projekcie                                           |
-| php intelephense   | .php                                                                | Automatyczna instalacja dla PHP                                          |
+| phpantom            | .php                                                                | Automatyczna instalacja z wydań GitHub                                   |
 | prisma             | .prisma                                                             | Dostępne polecenie `prisma`                                              |
 | pyright            | .py, .pyi                                                           | Zainstalowana zależność `pyright`                                        |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | Dostępne polecenie `ruby` i `gem`                                        |
@@ -194,15 +194,3 @@ Możesz dodać niestandardowe serwery LSP, podając polecenie i rozszerzenia pli
 }
 ```
 
----
-
-## Dodatkowe informacje
-
-### PHP Intelephense
-
-PHP Intelephense oferuje funkcje premium poprzez klucz licencyjny. Możesz użyć klucza licencyjnego, umieszczając go (sam klucz) w pliku tekstowym pod adresem:
-
-- macOS/Linux: `$HOME/intelephense/license.txt`
-- Windows: `%USERPROFILE%/intelephense/license.txt`
-
-Plik powinien zawierać wyłącznie klucz licencyjny, bez białych znaków.

--- a/packages/web/src/content/docs/pt-br/lsp.mdx
+++ b/packages/web/src/content/docs/pt-br/lsp.mdx
@@ -33,7 +33,7 @@ O opencode vem com vários servidores LSP integrados para linguagens populares:
 | nixd               | .nix                                                                | Comando `nixd` disponível                                                |
 | ocaml-lsp          | .ml, .mli                                                           | Comando `ocamllsp` disponível                                            |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | Dependência `oxlint` no projeto                                          |
-| php intelephense   | .php                                                                | Instala automaticamente para projetos PHP                                |
+| phpantom            | .php                                                                | Instalação automática a partir de releases do GitHub                     |
 | prisma             | .prisma                                                             | Comando `prisma` disponível                                              |
 | pyright            | .py, .pyi                                                           | Dependência `pyright` instalada                                          |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | Comandos `ruby` e `gem` disponíveis                                      |
@@ -194,15 +194,3 @@ Você pode adicionar servidores LSP personalizados especificando o comando e as 
 }
 ```
 
----
-
-## Informações Adicionais
-
-### PHP Intelephense
-
-PHP Intelephense oferece recursos premium através de uma chave de licença. Você pode fornecer uma chave de licença colocando (apenas) a chave em um arquivo de texto em:
-
-- No macOS/Linux: `$HOME/intelephense/license.txt`
-- No Windows: `%USERPROFILE%/intelephense/license.txt`
-
-O arquivo deve conter apenas a chave de licença sem conteúdo adicional.

--- a/packages/web/src/content/docs/ru/lsp.mdx
+++ b/packages/web/src/content/docs/ru/lsp.mdx
@@ -32,7 +32,7 @@ opencode поставляется с несколькими встроенным
 | nixd               | .nix                                                                | `nixd` команда доступна                                                   |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` команда доступна                                               |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` зависимость в проекте                                            |
-| php intelephense   | .php                                                                | Автоматически устанавливается для проектов PHP                            |
+| phpantom            | .php                                                                | Автоматически устанавливается из релизов GitHub                           |
 | prisma             | .prisma                                                             | `prisma` команда доступна                                                 |
 | pyright            | .py, .pyi                                                           | `pyright` зависимость установлена                                         |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | `ruby` и `gem` команды доступны                                           |
@@ -193,15 +193,3 @@ LSP может помочь агенту находить и исправлят�
 }
 ```
 
----
-
-## Дополнительная информация
-
-### PHP Intelephense
-
-PHP Intelephense предлагает дополнительные функции через лицензионный ключ. Вы можете предоставить лицензионный ключ, поместив (только) ключ в текстовый файл по адресу:
-
-- В macOS/Linux: `$HOME/intelephense/license.txt`
-- В Windows: `%USERPROFILE%/intelephense/license.txt`
-
-Файл должен содержать только лицензионный ключ без какого-либо дополнительного содержимого.

--- a/packages/web/src/content/docs/th/lsp.mdx
+++ b/packages/web/src/content/docs/th/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode มาพร้อมกับเซิร์ฟเวอร์ LSP ใ
 | nixd               | .nix                                                                | `nixd` คำสั่งใช้ได้                                     |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` คำสั่งใช้ได้                                 |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | `oxlint` การพึ่งพาในโครงการ                             |
-| php intelephense   | .php                                                                | ติดตั้งอัตโนมัติสำหรับโครงการ PHP                       |
+| phpantom            | .php                                                                | ติดตั้งอัตโนมัติจากรีลีส GitHub                        |
 | prisma             | .prisma                                                             | `prisma` คำสั่งใช้ได้                                   |
 | pyright            | .py, .pyi                                                           | `pyright` ติดตั้งการพึ่งพาแล้ว                          |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | มีคำสั่ง `ruby` และ `gem`                               |
@@ -194,15 +194,3 @@ LSP สามารถช่วยให้ agent ค้นหาและแก
 }
 ```
 
----
-
-## ข้อมูลเพิ่มเติม
-
-### PHP อินเทเลฟินส์
-
-PHP Intelephense นำเสนอคุณสมบัติระดับพรีเมียมผ่านรหัสลิขสิทธิ์ คุณสามารถระบุรหัสสัญญาอนุญาตได้โดยการวาง (เท่านั้น) รหัสในไฟล์ข้อความที่:
-
-- บน macOS/Linux: `$HOME/intelephense/license.txt`
-- บน Windows: `%USERPROFILE%/intelephense/license.txt`
-
-ไฟล์ควรมีเฉพาะรหัสลิขสิทธิ์โดยไม่มีเนื้อหาเพิ่มเติม

--- a/packages/web/src/content/docs/tr/lsp.mdx
+++ b/packages/web/src/content/docs/tr/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode, popüler diller için çeşitli yerleşik LSP sunucularıyla birlikte 
 | nixd               | .nix                                                                | `nixd` komutu mevcut                                                  |
 | ocaml-lsp          | .ml, .mli                                                           | `ocamllsp` komutu mevcut                                              |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | Projede `oxlint` bağımlılığı                                          |
-| php intelephense   | .php                                                                | PHP projeleri için otomatik yüklemeler                                |
+| phpantom            | .php                                                                | GitHub sürümlerinden otomatik yüklenir                                |
 | prisma             | .prisma                                                             | `prisma` komutu mevcut                                                |
 | pyright            | .py, .pyi                                                           | `pyright` bağımlılığı kurulu                                          |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | `ruby` ve `gem` komutları mevcut                                      |
@@ -194,15 +194,3 @@ Komutu ve dosya uzantılarını belirterek özel LSP sunucuları ekleyebilirsini
 }
 ```
 
----
-
-## Ek Bilgiler
-
-### PHP Intelephense
-
-PHP Intelephense, bir lisans anahtarı aracılığıyla premium özellikler sunar. Anahtarı (yalnızca) şu adresteki bir metin dosyasına yerleştirerek bir lisans anahtarı sağlayabilirsiniz:
-
-- macOS/Linux'ta: `$HOME/intelephense/license.txt`
-- Windows'ta: `%USERPROFILE%/intelephense/license.txt`
-
-Dosya, ek içerik olmadan yalnızca lisans anahtarını içermelidir.

--- a/packages/web/src/content/docs/zh-cn/lsp.mdx
+++ b/packages/web/src/content/docs/zh-cn/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode 内置了多种适用于主流语言的 LSP 服务器：
 | nixd               | .nix                                                                | 需要 `nixd` 命令可用                                  |
 | ocaml-lsp          | .ml, .mli                                                           | 需要 `ocamllsp` 命令可用                              |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | 项目中需要 `oxlint` 依赖                              |
-| php intelephense   | .php                                                                | 为 PHP 项目自动安装                                   |
+| phpantom            | .php                                                                | 从 GitHub 发布自动安装                                |
 | prisma             | .prisma                                                             | 需要 `prisma` 命令可用                                |
 | pyright            | .py, .pyi                                                           | 需要已安装 `pyright` 依赖                             |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | 需要 `ruby` 和 `gem` 命令可用                         |
@@ -194,15 +194,3 @@ LSP 可以通过语言服务器诊断帮助 agent 发现并修复问题。这对
 }
 ```
 
----
-
-## 补充信息
-
-### PHP Intelephense
-
-PHP Intelephense 通过许可证密钥提供高级功能。你可以将许可证密钥单独放在以下路径的文本文件中：
-
-- macOS/Linux：`$HOME/intelephense/license.txt`
-- Windows：`%USERPROFILE%/intelephense/license.txt`
-
-该文件应仅包含许可证密钥，不要添加其他任何内容。

--- a/packages/web/src/content/docs/zh-tw/lsp.mdx
+++ b/packages/web/src/content/docs/zh-tw/lsp.mdx
@@ -33,7 +33,7 @@ OpenCode 內建了多種適用於主流語言的 LSP 伺服器：
 | nixd               | .nix                                                                | 需要 `nixd` 指令可用                                  |
 | ocaml-lsp          | .ml, .mli                                                           | 需要 `ocamllsp` 指令可用                              |
 | oxlint             | .ts, .tsx, .js, .jsx, .mjs, .cjs, .mts, .cts, .vue, .astro, .svelte | 專案中需要 `oxlint` 相依套件                          |
-| php intelephense   | .php                                                                | 為 PHP 專案自動安裝                                   |
+| phpantom            | .php                                                                | 從 GitHub 發布自動安裝                                |
 | prisma             | .prisma                                                             | 需要 `prisma` 指令可用                                |
 | pyright            | .py, .pyi                                                           | 需要已安裝 `pyright` 相依套件                         |
 | ruby-lsp (rubocop) | .rb, .rake, .gemspec, .ru                                           | 需要 `ruby` 和 `gem` 指令可用                         |
@@ -194,15 +194,3 @@ LSP 可以透過語言伺服器診斷幫助 agent 發現並修復問題。這對
 }
 ```
 
----
-
-## 補充資訊
-
-### PHP Intelephense
-
-PHP Intelephense 透過授權金鑰提供進階功能。您可以將授權金鑰單獨放在以下路徑的文字檔案中：
-
-- macOS/Linux：`$HOME/intelephense/license.txt`
-- Windows：`%USERPROFILE%/intelephense/license.txt`
-
-該檔案應僅包含授權金鑰，不要新增其他任何內容。


### PR DESCRIPTION
### Issue for this PR

Closes N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Replace the Intelephense PHP language server with [PHPantom](https://github.com/PHPantom-dev/phpantom_lsp), a fast, MIT-licensed Rust-based PHP language server with deep type intelligence, generics, Laravel support, and PHPStan annotations.

PHPantom is free and fully featured without a paid license, starts in seconds, and uses a fraction of the RAM. The new server auto-downloads the correct platform binary from GitHub releases when phpantom_lsp is not already on PATH.

### How did you verify your code works?

Removed my configuration and tested that the default works.

### Screenshots / recordings

<img width="147" height="74" alt="image" src="https://github.com/user-attachments/assets/7a656183-d267-437d-8708-53673257d7f1" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
