### PR TITLE
feat(codemode): support BigInt arithmetic

### DIFF
--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -38,7 +38,9 @@ ultimate source of truth.
 - [x] BigInt literals (decimal, binary, octal, hexadecimal, and numeric separators) and BigInt behavior for the
       supported arithmetic, bitwise, unary, update, assignment, equality, and ordering operators. Mixed Number/BigInt
       arithmetic throws. BigInt remains invalid in program results, `JSON.stringify`, and tool arguments/results; the
-      `BigInt` constructor and other BigInt-specific standard-library APIs are not exposed.
+      `BigInt` constructor and other BigInt-specific standard-library APIs are not exposed. In-interpreter BigInts are
+      limited to 4,096 bits; multiplication, exponentiation, and size-increasing shifts conservatively reject before
+      native evaluation when their result may exceed that limit.
 - [ ] Symbol primitive values and symbol-keyed properties.
 - [ ] Tagged-template calls.
 - [ ] Getter and setter definitions in object literals.

--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -35,7 +35,10 @@ ultimate source of truth.
 - [x] Template literals with interpolation.
 - [x] Regular-expression literals.
 - [x] `NaN` and `Infinity` globals.
-- [ ] BigInt literals and in-interpreter BigInt arithmetic; BigInt remains invalid at JSON-like host boundaries.
+- [x] BigInt literals (decimal, binary, octal, hexadecimal, and numeric separators) and BigInt behavior for the
+      supported arithmetic, bitwise, unary, update, assignment, equality, and ordering operators. Mixed Number/BigInt
+      arithmetic throws. BigInt remains invalid in program results, `JSON.stringify`, and tool arguments/results; the
+      `BigInt` constructor and other BigInt-specific standard-library APIs are not exposed.
 - [ ] Symbol primitive values and symbol-keyed properties.
 - [ ] Tagged-template calls.
 - [ ] Getter and setter definitions in object literals.

--- a/packages/codemode/interpreter-support.md
+++ b/packages/codemode/interpreter-support.md
@@ -40,7 +40,8 @@ ultimate source of truth.
       arithmetic throws. BigInt remains invalid in program results, `JSON.stringify`, and tool arguments/results; the
       `BigInt` constructor and other BigInt-specific standard-library APIs are not exposed. In-interpreter BigInts are
       limited to 4,096 bits; multiplication, exponentiation, and size-increasing shifts conservatively reject before
-      native evaluation when their result may exceed that limit.
+      native evaluation when their result may exceed that limit, and necessarily oversized literal tokens are rejected
+      by a bounded source scan before TypeScript or Acorn parses them.
 - [ ] Symbol primitive values and symbol-keyed properties.
 - [ ] Tagged-template calls.
 - [ ] Getter and setter definitions in object literals.

--- a/packages/codemode/src/interpreter/execute.ts
+++ b/packages/codemode/src/interpreter/execute.ts
@@ -1,8 +1,19 @@
 import { parse } from "acorn"
 import { Cause, Effect, Scope } from "effect"
-import { DiagnosticCategory, ModuleKind, ScriptTarget, flattenDiagnosticMessageText, transpileModule } from "typescript"
+import {
+  DiagnosticCategory,
+  ModuleKind,
+  ScriptKind,
+  ScriptTarget,
+  SyntaxKind,
+  createSourceFile,
+  flattenDiagnosticMessageText,
+  forEachChild,
+  transpileModule,
+  type Node,
+} from "typescript"
 import type { DataValue, Diagnostic, ExecuteOptions, ResolvedExecutionLimits, Result } from "../codemode.js"
-import { copyIn, copyOut, ToolRuntime, type Services } from "../tool-runtime.js"
+import { copyIn, copyOut, MAX_BIGINT_BITS, ToolRuntime, type Services } from "../tool-runtime.js"
 import type { Tools } from "../tools.js"
 import { normalizeError } from "./errors.js"
 import { InterpreterRuntimeError, isRecord, type ProgramNode } from "./model.js"
@@ -119,6 +130,7 @@ export const executeWithLimits = <const Provided extends Record<string, unknown>
 }
 
 const parseProgram = (code: string): ProgramNode => {
+  assertBigIntLiteralSourcesBounded(code)
   const transpiled = transpileModule(`async function __codemode__() {\n${code}\n}`, {
     reportDiagnostics: true,
     compilerOptions: {
@@ -152,6 +164,129 @@ const parseProgram = (code: string): ProgramNode => {
   }
 
   return parsed as ProgramNode
+}
+
+const decimalBigIntLimit = ((1n << BigInt(MAX_BIGINT_BITS)) - 1n).toString()
+
+// TypeScript and Acorn materialize BigInt tokens before the interpreter can apply its value limit.
+// Find necessarily oversized digit runs without constructing a BigInt, replace them with small
+// sentinels, and parse only that shortened source to distinguish literals from identical text in
+// strings, comments, templates, and regexps. Neither real parser sees an oversized BigInt token.
+const assertBigIntLiteralSourcesBounded = (code: string): void => {
+  const candidates = oversizedBigIntSources(code)
+  if (candidates.length === 0) return
+
+  let sourceEnd = 0
+  let maskedEnd = 0
+  const starts = new Set<number>()
+  const chunks = candidates.map((candidate) => {
+    const chunk = `${code.slice(sourceEnd, candidate.start)}0n`
+    starts.add(maskedEnd + chunk.length - 2)
+    sourceEnd = candidate.end
+    maskedEnd += chunk.length
+    return chunk
+  })
+  const masked = `${chunks.join("")}${code.slice(sourceEnd)}`
+  const prefix = "async function __codemode__() {\n"
+  const source = createSourceFile("codemode.ts", `${prefix}${masked}\n}`, ScriptTarget.ESNext, false, ScriptKind.TS)
+  let oversized = false
+  const visit = (node: Node): void => {
+    if (node.kind === SyntaxKind.BigIntLiteral && starts.has(node.getStart(source) - prefix.length)) {
+      oversized = true
+      return
+    }
+    if (!oversized) forEachChild(node, visit)
+  }
+  visit(source)
+  if (!oversized) return
+  throw new InterpreterRuntimeError(
+    `BigInt literal source exceeds CodeMode's ${MAX_BIGINT_BITS}-bit limit before parsing.`,
+    undefined,
+    "InvalidDataValue",
+  )
+}
+
+const oversizedBigIntSources = (code: string) => {
+  const candidates: Array<{ start: number; end: number }> = []
+  for (let start = 0; start < code.length; start++) {
+    if (code[start] < "0" || code[start] > "9" || isIdentifierPart(code[start - 1])) continue
+    const prefix = code[start] === "0" ? code[start + 1]?.toLowerCase() : undefined
+    const radix = prefix === "b" ? 2 : prefix === "o" ? 8 : prefix === "x" ? 16 : 10
+    const radixBits = radix === 2 ? 1 : radix === 8 ? 3 : radix === 16 ? 4 : 0
+    const digitsStart = radix === 10 ? start : start + 2
+    let end = digitsStart
+    let valid = true
+    let separator = false
+    let significantStart = -1
+    let significantDigits = 0
+    let firstSignificant = 0
+    while (end < code.length) {
+      const digit = digitValue(code[end])
+      if (digit >= 0 && digit < radix) {
+        if (digit !== 0 || significantStart !== -1) {
+          if (significantStart === -1) {
+            significantStart = end
+            firstSignificant = digit
+          }
+          significantDigits++
+        }
+        separator = false
+        end++
+        continue
+      }
+      if (code[end] !== "_") break
+      if (end === digitsStart || separator) valid = false
+      separator = true
+      end++
+    }
+    if (separator || code[end] !== "n") valid = false
+    if (radix === 10 && end > start + 1 && code[start] === "0") valid = false
+    if (code[end] === "n") end++
+    if (
+      valid &&
+      !isIdentifierPart(code[end]) &&
+      sourceBigIntExceedsLimit(code, significantStart, end - 1, significantDigits, firstSignificant, radixBits)
+    ) {
+      candidates.push({ start, end })
+    }
+    start = Math.max(start, end - 1)
+  }
+  return candidates
+}
+
+const isIdentifierPart = (character: string | undefined): boolean =>
+  character !== undefined && (/[A-Za-z0-9_$]/.test(character) || character.charCodeAt(0) > 127)
+
+const digitValue = (character: string | undefined): number => {
+  if (character === undefined) return -1
+  const value = character.charCodeAt(0)
+  if (value >= 48 && value <= 57) return value - 48
+  if (value >= 65 && value <= 70) return value - 55
+  if (value >= 97 && value <= 102) return value - 87
+  return -1
+}
+
+const sourceBigIntExceedsLimit = (
+  code: string,
+  significantStart: number,
+  suffix: number,
+  significantDigits: number,
+  firstSignificant: number,
+  radixBits: number,
+): boolean => {
+  if (radixBits !== 0) {
+    if (significantDigits === 0) return false
+    return (significantDigits - 1) * radixBits + firstSignificant.toString(2).length > MAX_BIGINT_BITS
+  }
+  if (significantDigits !== decimalBigIntLimit.length) return significantDigits > decimalBigIntLimit.length
+  let compared = 0
+  for (let position = significantStart; position < suffix; position++) {
+    if (code[position] === "_") continue
+    const difference = code.charCodeAt(position) - decimalBigIntLimit.charCodeAt(compared)
+    if (difference !== 0) return difference > 0
+    compared++
+  }
+  return false
 }
 
 const utf8ByteLength = (value: string): number => new TextEncoder().encode(value).byteLength

--- a/packages/codemode/src/interpreter/execute.ts
+++ b/packages/codemode/src/interpreter/execute.ts
@@ -9,6 +9,7 @@ import {
   createSourceFile,
   flattenDiagnosticMessageText,
   forEachChild,
+  isIdentifierPart,
   transpileModule,
   type Node,
 } from "typescript"
@@ -209,7 +210,7 @@ const assertBigIntLiteralSourcesBounded = (code: string): void => {
 const oversizedBigIntSources = (code: string) => {
   const candidates: Array<{ start: number; end: number }> = []
   for (let start = 0; start < code.length; start++) {
-    if (code[start] < "0" || code[start] > "9" || isIdentifierPart(code[start - 1])) continue
+    if (code[start] < "0" || code[start] > "9" || isSourceIdentifierPartBefore(code, start)) continue
     const prefix = code[start] === "0" ? code[start + 1]?.toLowerCase() : undefined
     const radix = prefix === "b" ? 2 : prefix === "o" ? 8 : prefix === "x" ? 16 : 10
     const radixBits = radix === 2 ? 1 : radix === 8 ? 3 : radix === 16 ? 4 : 0
@@ -244,7 +245,7 @@ const oversizedBigIntSources = (code: string) => {
     if (code[end] === "n") end++
     if (
       valid &&
-      !isIdentifierPart(code[end]) &&
+      !isSourceIdentifierPartAt(code, end) &&
       sourceBigIntExceedsLimit(code, significantStart, end - 1, significantDigits, firstSignificant, radixBits)
     ) {
       candidates.push({ start, end })
@@ -254,8 +255,18 @@ const oversizedBigIntSources = (code: string) => {
   return candidates
 }
 
-const isIdentifierPart = (character: string | undefined): boolean =>
-  character !== undefined && (/[A-Za-z0-9_$]/.test(character) || character.charCodeAt(0) > 127)
+const isSourceIdentifierPartBefore = (code: string, index: number): boolean => {
+  if (index === 0) return false
+  const previous = code.charCodeAt(index - 1)
+  const high = index > 1 ? code.charCodeAt(index - 2) : 0
+  const start = previous >= 0xdc00 && previous <= 0xdfff && high >= 0xd800 && high <= 0xdbff ? index - 2 : index - 1
+  return isSourceIdentifierPartAt(code, start)
+}
+
+const isSourceIdentifierPartAt = (code: string, index: number): boolean => {
+  const point = code.codePointAt(index)
+  return point !== undefined && isIdentifierPart(point, ScriptTarget.ESNext)
+}
 
 const digitValue = (character: string | undefined): number => {
   if (character === undefined) return -1

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -1533,7 +1533,7 @@ export class Interpreter<R> {
 
     // CodeMode numeric coercion, not host Number(): null-prototype data objects would make
     // the host throw during ToPrimitive, and opaque runtime references must reject clearly.
-    const operand = (current: unknown): number => {
+    const operand = (current: unknown): number | bigint => {
       if (containsOpaqueReference(current)) {
         throw new InterpreterRuntimeError(
           `'${operator}' requires a data value in CodeMode.`,
@@ -1541,14 +1541,17 @@ export class Interpreter<R> {
           "InvalidDataValue",
         )
       }
-      return coerceToNumber(current)
+      return typeof current === "bigint" ? current : coerceToNumber(current)
     }
+
+    const update = (current: number | bigint): number | bigint =>
+      typeof current === "bigint" ? current + (increment === 1 ? 1n : -1n) : current + increment
 
     if (argument.type === "Identifier") {
       return Effect.sync(() => {
         const name = getString(argument, "name")
         const current = operand(this.scopes.get(name, argument))
-        const next = current + increment
+        const next = update(current)
         this.scopes.set(name, next, argument)
         return prefix ? next : current
       })
@@ -1557,7 +1560,7 @@ export class Interpreter<R> {
     if (argument.type === "MemberExpression") {
       return this.modifyMember(argument, (current) => {
         const value = operand(current)
-        const next = value + increment
+        const next = update(value)
         return Effect.succeed({ write: true, next, result: prefix ? next : value })
       })
     }

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -1,5 +1,12 @@
 import { Cause, Effect } from "effect"
-import { isBlockedMember, ToolReference, ToolRuntimeError, type SafeObject } from "../tool-runtime.js"
+import {
+  bigintBitLength,
+  isBlockedMember,
+  MAX_BIGINT_BITS,
+  ToolReference,
+  ToolRuntimeError,
+  type SafeObject,
+} from "../tool-runtime.js"
 import {
   type AstNode,
   asNode,
@@ -168,6 +175,29 @@ const instanceofValue = (lhs: unknown, rhs: unknown, node: AstNode): boolean => 
   throw new InterpreterRuntimeError(
     "The right-hand side of 'instanceof' must be a constructor CodeMode knows: Error (or a specific error type like TypeError), Date, RegExp, Map, Set, URL, URLSearchParams, Array, Object, or Promise.",
     node,
+  )
+}
+
+const assertSafeBigIntOperation = (operator: string, lhs: unknown, rhs: unknown, node: AstNode): void => {
+  if (typeof lhs !== "bigint" || typeof rhs !== "bigint") return
+  const leftBits = bigintBitLength(lhs)
+  const rightBits = bigintBitLength(rhs)
+  const exceedsLimit = (() => {
+    if (operator === "*") return lhs !== 0n && rhs !== 0n && leftBits + rightBits > MAX_BIGINT_BITS
+    if (operator === "**") {
+      if (rhs <= 0n || lhs === 0n || lhs === 1n || lhs === -1n) return false
+      return rhs > BigInt(Math.floor(MAX_BIGINT_BITS / leftBits))
+    }
+    if (operator !== "<<" && operator !== ">>") return false
+    if (lhs === 0n) return false
+    const growth = operator === "<<" ? rhs : -rhs
+    return growth > BigInt(MAX_BIGINT_BITS - leftBits)
+  })()
+  if (!exceedsLimit) return
+  throw new InterpreterRuntimeError(
+    `BigInt operation '${operator}' may exceed CodeMode's ${MAX_BIGINT_BITS}-bit limit.`,
+    node,
+    "InvalidDataValue",
   )
 }
 
@@ -1342,6 +1372,7 @@ export class Interpreter<R> {
     const bothObjects = lhs !== null && typeof lhs === "object" && rhs !== null && typeof rhs === "object"
     const l = coerceOperand(lhs)
     const r = coerceOperand(rhs)
+    assertSafeBigIntOperation(operator, l, r, node)
     switch (operator) {
       case "+":
         return (l as string) + (r as string)
@@ -1544,8 +1575,11 @@ export class Interpreter<R> {
       return typeof current === "bigint" ? current : coerceToNumber(current)
     }
 
-    const update = (current: number | bigint): number | bigint =>
-      typeof current === "bigint" ? current + (increment === 1 ? 1n : -1n) : current + increment
+    const update = (current: number | bigint): unknown =>
+      boundedData(
+        typeof current === "bigint" ? current + (increment === 1 ? 1n : -1n) : current + increment,
+        "Update expression result",
+      )
 
     if (argument.type === "Identifier") {
       return Effect.sync(() => {

--- a/packages/codemode/src/interpreter/runtime.ts
+++ b/packages/codemode/src/interpreter/runtime.ts
@@ -183,9 +183,16 @@ const assertSafeBigIntOperation = (operator: string, lhs: unknown, rhs: unknown,
   const leftBits = bigintBitLength(lhs)
   const rightBits = bigintBitLength(rhs)
   const exceedsLimit = (() => {
-    if (operator === "*") return lhs !== 0n && rhs !== 0n && leftBits + rightBits > MAX_BIGINT_BITS
+    if (operator === "*") {
+      if (lhs === 0n || lhs === 1n || lhs === -1n || rhs === 0n || rhs === 1n || rhs === -1n) return false
+      return leftBits + rightBits > MAX_BIGINT_BITS
+    }
     if (operator === "**") {
       if (rhs <= 0n || lhs === 0n || lhs === 1n || lhs === -1n) return false
+      const magnitude = lhs < 0n ? -lhs : lhs
+      if ((magnitude & (magnitude - 1n)) === 0n) {
+        return BigInt(leftBits - 1) * rhs + 1n > BigInt(MAX_BIGINT_BITS)
+      }
       return rhs > BigInt(Math.floor(MAX_BIGINT_BITS / leftBits))
     }
     if (operator !== "<<" && operator !== ">>") return false

--- a/packages/codemode/src/tool-runtime.ts
+++ b/packages/codemode/src/tool-runtime.ts
@@ -101,6 +101,13 @@ export class ToolReference {
 }
 
 const MAX_VALUE_DEPTH = 32
+export const MAX_BIGINT_BITS = 4_096
+
+export const bigintBitLength = (value: bigint): number => {
+  if (value === 0n) return 0
+  const binary = value.toString(2)
+  return binary[0] === "-" ? binary.length - 1 : binary.length
+}
 
 export class ToolRuntimeError extends Error {
   constructor(
@@ -147,13 +154,19 @@ const copyBounded = (
   if (depth > MAX_VALUE_DEPTH) {
     throw new ToolRuntimeError("InvalidDataValue", `${label} exceeds the maximum value depth of ${MAX_VALUE_DEPTH}.`)
   }
+  if (preserveCodeModeValues && typeof value === "bigint") {
+    if (bigintBitLength(value) > MAX_BIGINT_BITS) {
+      throw new ToolRuntimeError("InvalidDataValue", `${label} exceeds CodeMode's ${MAX_BIGINT_BITS}-bit BigInt limit.`)
+    }
+    return value
+  }
+
   if (
     value === null ||
     value === undefined ||
     typeof value === "string" ||
     typeof value === "boolean" ||
-    typeof value === "number" ||
-    (preserveCodeModeValues && typeof value === "bigint")
+    typeof value === "number"
   ) {
     return value
   }

--- a/packages/codemode/src/tool-runtime.ts
+++ b/packages/codemode/src/tool-runtime.ts
@@ -152,7 +152,8 @@ const copyBounded = (
     value === undefined ||
     typeof value === "string" ||
     typeof value === "boolean" ||
-    typeof value === "number"
+    typeof value === "number" ||
+    (preserveCodeModeValues && typeof value === "bigint")
   ) {
     return value
   }

--- a/packages/codemode/test/bigint-test262.test.ts
+++ b/packages/codemode/test/bigint-test262.test.ts
@@ -206,3 +206,69 @@ describe("BigInt JSON-like boundaries", () => {
     if (!result.ok) expect(result.error.kind).toBe("InvalidToolOutput")
   })
 })
+
+describe("BigInt resource bound", () => {
+  test("limits in-interpreter BigInts to 4,096 bits", async () => {
+    const maximum = await execute(`return ${`0b1${"0".repeat(4_095)}n`} === ${`0b1${"0".repeat(4_095)}n`}`)
+    expect(maximum.ok).toBe(true)
+    if (maximum.ok) expect(maximum.value).toBe(true)
+
+    const oversized = await execute(`return ${`0b1${"0".repeat(4_096)}n`} === 0n`)
+    expect(oversized.ok).toBe(false)
+    if (!oversized.ok) {
+      expect(oversized.error.kind).toBe("InvalidDataValue")
+      expect(oversized.error.message).toContain("4096-bit BigInt limit")
+    }
+  })
+
+  test("rejects expensive operations before native evaluation", async () => {
+    for (const code of [
+      `const value = 1n << 2_048n; return value * value`,
+      `return 16n ** 1_024n`,
+      `return 1n << 4_096n`,
+      `return 1n >> -4_096n`,
+    ]) {
+      const result = await execute(code)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe("InvalidDataValue")
+        expect(result.error.message).toContain("may exceed CodeMode's 4096-bit limit")
+      }
+    }
+  })
+
+  test("rejects oversized results from non-preflighted operations", async () => {
+    for (const code of [
+      `const value = 1n << 4_095n; return value + value`,
+      `let value = ${`0b${"1".repeat(4_096)}n`}; value++; return true`,
+    ]) {
+      const result = await execute(code)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe("InvalidDataValue")
+        expect(result.error.message).toContain("exceeds CodeMode's 4096-bit BigInt limit")
+      }
+    }
+  })
+
+  test("does not let synchronous BigInt work bypass a one-millisecond timeout", async () => {
+    const result = await Effect.runPromise(
+      CodeMode.execute({
+        code: `
+          for (let index = 0; index < 20; index++) {
+            const huge = 1n << 499_999n
+            huge * huge
+          }
+          return true
+        `,
+        tools: {},
+        limits: { timeoutMs: 1 },
+      }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.kind).toBe("InvalidDataValue")
+      expect(result.error.message).toContain("may exceed CodeMode's 4096-bit limit")
+    }
+  })
+})

--- a/packages/codemode/test/bigint-test262.test.ts
+++ b/packages/codemode/test/bigint-test262.test.ts
@@ -1,0 +1,208 @@
+/*
+ * Portions adapted from Test262 at revision 250f204f23a9249ff204be2baec29600faae7b75:
+ * - test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hds-nsl-hds.js
+ * - test/language/expressions/addition/bigint-arithmetic.js
+ * - test/language/expressions/addition/bigint-and-number.js
+ * - test/language/expressions/subtraction/bigint-arithmetic.js
+ * - test/language/expressions/multiplication/bigint-arithmetic.js
+ * - test/language/expressions/division/bigint-arithmetic.js
+ * - test/language/expressions/division/bigint-complex-infinity.js
+ * - test/language/expressions/modulus/bigint-arithmetic.js
+ * - test/language/expressions/exponentiation/bigint-arithmetic.js
+ * - test/language/expressions/exponentiation/bigint-negative-exponent-throws.js
+ * - test/language/expressions/equals/bigint-and-number.js
+ * - test/language/expressions/less-than/bigint-and-number.js
+ * - test/language/expressions/bitwise-and/bigint.js
+ * - test/language/expressions/bitwise-or/bigint.js
+ * - test/language/expressions/bitwise-xor/bigint.js
+ * - test/language/expressions/left-shift/bigint.js
+ * - test/language/expressions/right-shift/bigint.js
+ * - test/language/expressions/prefix-increment/bigint.js
+ * - test/language/expressions/unary-plus/bigint-throws.js
+ * - test/language/expressions/unsigned-right-shift/bigint.js
+ *
+ * Copyright (C) 2017 Josh Wolfe. All rights reserved.
+ * Copyright (C) 2017 Robin Templeton. All rights reserved.
+ * Copyright (C) 2018 Igalia, S.L. All rights reserved.
+ * Copyright (C) 2019 Leo Balter. All rights reserved.
+ * Test262 portions are governed by the BSD license in LICENSE.test262.
+ * Assertions are grouped into CodeMode programs and return booleans or strings
+ * because BigInt intentionally cannot cross CodeMode's JSON-like boundary.
+ */
+import { describe, expect, test } from "bun:test"
+import { Effect, Schema } from "effect"
+import { CodeMode, Tool } from "../src/index.js"
+
+const execute = (code: string) => Effect.runPromise(CodeMode.execute({ code, tools: {} }))
+
+const value = async (code: string) => {
+  const result = await execute(code)
+  if (!result.ok) throw new Error(`expected success, got ${result.error.kind}: ${result.error.message}`)
+  return result.value
+}
+
+describe("BigInt Test262 parity", () => {
+  test("supports literal bases and numeric separators", async () => {
+    expect(
+      await value(`
+        return [
+          0n === 0x0n,
+          255n === 0xffn,
+          10n === 0b1010n,
+          63n === 0o77n,
+          1_000_000n === 1000000n,
+          0x01_00n === 0X0100n,
+          typeof 1n === "bigint",
+        ]
+      `),
+    ).toEqual([true, true, true, true, true, true, true])
+  })
+
+  test("applies BigInt arithmetic, unary, bitwise, shift, and assignment operators", async () => {
+    expect(
+      await value(`
+        let assigned = 5n
+        assigned += 2n
+        assigned **= 2n
+        assigned >>= 1n
+        return [
+          0xFEDCBA9876543210n + 0x1234n === 0xFEDCBA9876544444n,
+          9n - 14n === -5n,
+          12n * 11n === 132n,
+          0x1234n / 0x3n === 0x611n,
+          -7n / 3n === -2n,
+          -7n % 3n === -1n,
+          3n ** 5n === 243n,
+          -(-8n) === 8n,
+          ~0n === -1n,
+          (0b1100n & 0b1010n) === 0b1000n,
+          (0b1100n | 0b0011n) === 0b1111n,
+          (0b1100n ^ 0b1010n) === 0b0110n,
+          (0b101n << 3n) === 0b101000n,
+          (-5n << -1n) === -3n,
+          (-9n >> 2n) === -3n,
+          assigned === 24n,
+        ]
+      `),
+    ).toEqual(new Array(16).fill(true))
+  })
+
+  test("preserves BigInt through updates and nested interpreter data", async () => {
+    expect(
+      await value(`
+        let direct = 0n
+        const record = { value: 0x1fffffffffffff00n }
+        const nested = [null, [null, null, 0n]]
+        const before = direct++
+        const after = --direct
+        const recordValue = ++record.value
+        const nestedValue = ++nested[1][2]
+        return [
+          before === 0n,
+          after === 0n,
+          direct === 0n,
+          recordValue === 0x1fffffffffffff01n,
+          record.value === 0x1fffffffffffff01n,
+          nestedValue === 1n,
+          nested[1][2] === 1n,
+        ]
+      `),
+    ).toEqual(new Array(7).fill(true))
+  })
+
+  test("supports BigInt comparisons and string interactions", async () => {
+    expect(
+      await value(`
+        return [
+          1n == 1,
+          1n !== 1,
+          0n < 0.000000000001,
+          0.999999999999 < 1n,
+          10n > 9,
+          10n >= 10,
+          -1n <= -1,
+          1n == "1",
+          1n != "1.5",
+          1n + " item" === "1 item",
+          \`value=\${255n}\` === "value=255",
+        ]
+      `),
+    ).toEqual(new Array(11).fill(true))
+  })
+
+  test("throws for mixed numeric arithmetic and unsupported BigInt operations", async () => {
+    expect(
+      await value(`
+        const typeError = (operation) => {
+          try {
+            operation()
+            return false
+          } catch (error) {
+            return error instanceof TypeError
+          }
+        }
+        const rangeError = (operation) => {
+          try {
+            operation()
+            return false
+          } catch (error) {
+            return error instanceof RangeError
+          }
+        }
+        return [
+          typeError(() => 1n + 1),
+          typeError(() => 1 - 1n),
+          typeError(() => 1n * true),
+          typeError(() => 1n & 1),
+          typeError(() => 1n << 1),
+          typeError(() => +1n),
+          typeError(() => 5n >>> 1n),
+          rangeError(() => 1n / 0n),
+          rangeError(() => 2n ** -1n),
+        ]
+      `),
+    ).toEqual(new Array(9).fill(true))
+  })
+})
+
+describe("BigInt JSON-like boundaries", () => {
+  test("rejects BigInt program results", async () => {
+    for (const code of [`return 1n`, `return { value: 1n }`, `return [1n]`]) {
+      const result = await execute(code)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.error.kind).toBe("InvalidDataValue")
+    }
+  })
+
+  test("rejects BigInt in JSON.stringify and tool arguments", async () => {
+    const stringified = await execute(`return JSON.stringify({ value: 1n })`)
+    expect(stringified.ok).toBe(false)
+    if (!stringified.ok) expect(stringified.error.kind).toBe("InvalidDataValue")
+
+    const capture = Tool.make({
+      description: "Capture an input",
+      input: Schema.Unknown,
+      output: Schema.String,
+      run: () => Effect.succeed("ok"),
+    })
+    const argument = await Effect.runPromise(
+      CodeMode.execute({ code: `return await tools.capture({ value: 1n })`, tools: { capture } }),
+    )
+    expect(argument.ok).toBe(false)
+    if (!argument.ok) expect(argument.error.kind).toBe("InvalidDataValue")
+  })
+
+  test("rejects BigInt tool results", async () => {
+    const provide = Tool.make({
+      description: "Return a BigInt",
+      input: Schema.Struct({}),
+      output: Schema.Unknown,
+      run: () => Effect.succeed(1n),
+    })
+    const result = await Effect.runPromise(
+      CodeMode.execute({ code: `return await tools.provide({})`, tools: { provide } }),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe("InvalidToolOutput")
+  })
+})

--- a/packages/codemode/test/bigint-test262.test.ts
+++ b/packages/codemode/test/bigint-test262.test.ts
@@ -208,23 +208,92 @@ describe("BigInt JSON-like boundaries", () => {
 })
 
 describe("BigInt resource bound", () => {
-  test("limits in-interpreter BigInts to 4,096 bits", async () => {
-    const maximum = await execute(`return ${`0b1${"0".repeat(4_095)}n`} === ${`0b1${"0".repeat(4_095)}n`}`)
-    expect(maximum.ok).toBe(true)
-    if (maximum.ok) expect(maximum.value).toBe(true)
+  const separate = (digits: string) => digits.match(/.{1,32}/g)!.join("_")
+  const decimalMaximum = ((1n << 4_096n) - 1n).toString()
 
-    const oversized = await execute(`return ${`0b1${"0".repeat(4_096)}n`} === 0n`)
-    expect(oversized.ok).toBe(false)
-    if (!oversized.ok) {
-      expect(oversized.error.kind).toBe("InvalidDataValue")
-      expect(oversized.error.message).toContain("4096-bit BigInt limit")
+  test("accepts 4,096-bit literal boundaries for every radix and separators", async () => {
+    for (const literal of [
+      `${separate(decimalMaximum)}n`,
+      `0x${separate(`8${"0".repeat(1_023)}`)}n`,
+      `0o${separate(`1${"0".repeat(1_365)}`)}n`,
+      `0b${separate(`1${"0".repeat(4_095)}`)}n`,
+    ]) {
+      const result = await Effect.runPromise(
+        CodeMode.execute({ code: `return typeof ${literal} === "bigint"`, tools: {}, limits: { timeoutMs: 1 } }),
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.value).toBe(true)
     }
+  })
+
+  test("rejects necessarily oversized literal boundaries before parsing", async () => {
+    for (const literal of [
+      `${1n << 4_096n}n`,
+      `0x1${"0".repeat(1_024)}n`,
+      `0o2${"0".repeat(1_365)}n`,
+      `0b${separate(`1${"0".repeat(4_096)}`)}n`,
+    ]) {
+      const result = await Effect.runPromise(
+        CodeMode.execute({ code: `return ${literal}`, tools: {}, limits: { timeoutMs: 1 } }),
+      )
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe("InvalidDataValue")
+        expect(result.error.message).toContain("literal source")
+        expect(result.error.message).toContain("before parsing")
+      }
+    }
+  })
+
+  test("ignores BigInt-shaped text outside numeric literals", async () => {
+    const oversized = `0b1${"0".repeat(4_096)}n`
+    expect(await value(`const text = "${oversized}"; return text.length`)).toBe(4_100)
+    expect(await value(`/* ${oversized} */ return true`)).toBe(true)
+    expect(await value(`return \`${oversized}\`.length`)).toBe(4_100)
+    expect(await value(`return /${oversized}/.test("no")`)).toBe(false)
+    expect(await value(`if (true) /${oversized}/.test("no"); return true`)).toBe(true)
+  })
+
+  test("rejects very large literal source promptly despite a one-millisecond timeout", async () => {
+    const started = performance.now()
+    for (const digits of [500_000, 2_000_000]) {
+      const result = await Effect.runPromise(
+        CodeMode.execute({
+          code: `return 0b1${"0".repeat(digits)}n`,
+          tools: {},
+          limits: { timeoutMs: 1 },
+        }),
+      )
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe("InvalidDataValue")
+        expect(result.error.message).toContain("before parsing")
+      }
+    }
+    expect(performance.now() - started).toBeLessThan(2_000)
+  })
+
+  test("accepts precise safe multiplication and power-of-two exponentiation boundaries", async () => {
+    const maximumBit = `0b1${"0".repeat(4_095)}n`
+    expect(
+      await value(`
+        const value = ${maximumBit}
+        return [
+          value * 1n === value,
+          value * -1n === -value,
+          1n * value === value,
+          -1n * value === -value,
+          2n ** 4095n === value,
+        ]
+      `),
+    ).toEqual(new Array(5).fill(true))
   })
 
   test("rejects expensive operations before native evaluation", async () => {
     for (const code of [
       `const value = 1n << 2_048n; return value * value`,
       `return 16n ** 1_024n`,
+      `return 2n ** 4_096n`,
       `return 1n << 4_096n`,
       `return 1n >> -4_096n`,
     ]) {

--- a/packages/codemode/test/bigint-test262.test.ts
+++ b/packages/codemode/test/bigint-test262.test.ts
@@ -273,6 +273,26 @@ describe("BigInt resource bound", () => {
     expect(performance.now() - started).toBeLessThan(2_000)
   })
 
+  test("rejects huge literals after Unicode whitespace", async () => {
+    const literal = `0b1${"0".repeat(500_000)}n`
+    for (const whitespace of ["\u00a0", "\u2003"]) {
+      const result = await Effect.runPromise(
+        CodeMode.execute({ code: `return${whitespace}${literal}`, tools: {}, limits: { timeoutMs: 1 } }),
+      )
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe("InvalidDataValue")
+        expect(result.error.message).toContain("before parsing")
+      }
+    }
+  })
+
+  test("keeps Unicode identifier adjacency distinct from literals", async () => {
+    const suffix = `0b1${"0".repeat(4_096)}n`
+    expect(await value(`const π${suffix} = 1; return true`)).toBe(true)
+    expect(await value(`const 𐐀${suffix} = 1; return true`)).toBe(true)
+  })
+
   test("accepts precise safe multiplication and power-of-two exponentiation boundaries", async () => {
     const maximumBit = `0b1${"0".repeat(4_095)}n`
     expect(


### PR DESCRIPTION
## Summary
- support decimal, binary, octal, hexadecimal, and separated BigInt literals inside CodeMode
- preserve BigInt semantics for supported arithmetic, bitwise, comparison, assignment, and update operators within a 4,096-bit magnitude cap
- reject necessarily oversized BigInt literal tokens before TypeScript or Acorn receives them
- preflight multiplication, exponentiation, and size-increasing shifts before native evaluation
- keep BigInt rejected in program results, JSON.stringify, tool arguments, and tool results

## Test262 coverage
Adapted focused cases from Test262 revision `250f204f23a9249ff204be2baec29600faae7b75` for literals, arithmetic, shifts, comparisons, updates, and mixed Number/BigInt errors. The existing `LICENSE.test262` applies.

## Resource safety
Every in-interpreter BigInt is capped at 4,096 bits. A bounded source pass counts accepted decimal/radix digits without constructing a BigInt, masks necessarily oversized candidates with `0n`, and parses only the shortened sentinel source to distinguish actual literals from strings, comments, template raw text, and regexps. Decimal boundaries are compared to `2^4096 - 1`; binary/octal/hex widths account for significant digits and the leading digit. Candidate boundaries use TypeScript’s Unicode identifier classifier, including astral code points, so Unicode whitespace such as U+00A0 and U+2003 cannot suppress rejection.

Multiplication admits zero and unit operands before applying its conservative width estimate. Exponentiation computes exact width for power-of-two bases, so `2n ** 4095n` is accepted while `2n ** 4096n` is rejected before native evaluation. Focused probes reject 500,000-digit literals after U+00A0 and U+2003 under `timeoutMs: 1` in milliseconds.

## Deliberate boundaries
This does not expose the `BigInt` constructor or BigInt-specific standard-library APIs and does not claim complete ECMAScript BigInt parity. Near-limit non-unit multiplication and non-power-of-two exponentiation may still be conservatively rejected. Symbol, typed arrays, and broader coercion work remain out of scope.

## Verification
- `bun test` (986 pass)
- `bun typecheck`
- Prettier passed
- focused Unicode whitespace reviewer probe passed