### PR TITLE
fix(core): resolve npm plugin entry point as file URL on Windows

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -1,6 +1,7 @@
 export * as Npm from "./npm"
 
 import path from "path"
+import { pathToFileURL } from "url"
 import npa from "npm-package-arg"
 import { Effect, Schema, Context, Layer, Option, FileSystem } from "effect"
 import { NodeFileSystem } from "@effect/platform-node"
@@ -50,7 +51,8 @@ export function sanitize(pkg: string) {
 const resolveEntryPoint = (name: string, dir: string): EntryPoint => {
   let entrypoint: string | undefined
   try {
-    entrypoint = typeof Bun !== "undefined" ? import.meta.resolve(name, dir) : import.meta.resolve(dir)
+    const resolved = typeof Bun !== "undefined" ? import.meta.resolve(name, dir) : import.meta.resolve(dir)
+    entrypoint = resolved.startsWith("file://") ? resolved : pathToFileURL(resolved).href
   } catch {
     entrypoint = undefined
   }


### PR DESCRIPTION
### Issue for this PR

Closes #38021

### Type of change

- [x] Bug fix

### What does this PR do?

On Windows, `import.meta.resolve()` returns a raw filesystem path (e.g. `C:\...\index.js`) instead of a `file://` URL. The resolved entry point was stored as-is in `resolveEntryPoint()` (`packages/core/src/npm.ts`), breaking downstream code that expects a `file://` URL.

**Fix:** If the resolved path doesn't already start with `file://`, wrap it with `pathToFileURL(resolved).href`. This mirrors the conversion that already exists in the `config.ts` fallback path.

Related: #16559 tracks the display side (`config.ts:1250`); this PR fixes the loading side.

### How did you verify your code works?

- Built and ran on Windows with an npm-installed plugin
- Confirmed the resolved entry point is now a `file://` URL
- Plugin loads and displays correctly after the fix

### Screenshots / recordings

N/A — non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

### 关联 Issue

Closes #38021

### 变更类型

- [x] Bug 修复

### 本 PR 做了什么？

在 Windows 上，`import.meta.resolve()` 返回原始文件系统路径（如 `C:\...\index.js`）而非 `file://` URL。`resolveEntryPoint()`（`packages/core/src/npm.ts`）原样存储该路径，导致期望 `file://` URL 的下游代码失效。

**修复：** 若解析结果不以 `file://` 开头，则用 `pathToFileURL(resolved).href` 转换。与 `config.ts` 回退路径中已有的转换逻辑一致。

相关：#16559 追踪显示侧（`config.ts:1250`）；本 PR 修复加载侧。

### 如何验证代码有效？

- 在 Windows 上构建并运行，加载 npm 安装的插件
- 确认解析后的入口点为 `file://` URL
- 修复后插件正常加载和显示

### 截图 / 录制

N/A —— 非 UI 改动。

### 检查清单

- [x] 我已在本地测试改动
- [x] 我未在本 PR 中纳入无关改动
