### PR TITLE
docs(ecosystem): add opencode-rmux to plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,7 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
-
+| [opencode-rmux](https://github.com/shiyouming/opencode-rmux)                                       | Cross-platform subagent pane management and RMUX control tools for OpenCode
 ---
 
 ## Projects


### PR DESCRIPTION
### Issue for this PR

N/A — ecosystem addition

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds opencode-rmux to the ecosystem plugins list. opencode-rmux is a cross-platform plugin for the RMUX terminal multiplexer that provides subagent pane management and 9 RMUX control tools (list_sessions, create_session, send_keys, capture, wait_for_text, find_panes, pane_info, observe, observe_multi). Unlike existing tmux plugins, it works natively on Windows, macOS, and Linux via the RMUX TypeScript SDK.

### How did you verify your code works?

Tested locally on Windows with opencode --port 0 and RMUX. Published to npm at https://www.npmjs.com/package/opencode-rmux. All 97 tests pass.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR