### PR TITLE
feat(app): draggable project rows

### DIFF
--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -1060,6 +1060,7 @@ function HomeProjectList(props: {
   const global = useGlobal()
   let listRef!: HTMLDivElement
   let snapshot: string[] | undefined
+  let selectOnDrop: string | undefined
   const projects = () => global.ensureServerCtx(props.server).projects
 
   // Constant-speed edge scrolling. dnd-kit's AutoScroller is deliberately not
@@ -1108,8 +1109,12 @@ function HomeProjectList(props: {
         ...defaults.filter((plugin) => plugin !== Accessibility && plugin !== AutoScroller),
         Feedback.configure({ dropAnimation: null }),
       ]}
-      onDragStart={() => {
+      onDragStart={(event) => {
         snapshot = props.projects.map((project) => project.worktree)
+        selectOnDrop =
+          props.selected.server === ServerConnection.key(props.server)
+            ? undefined
+            : event.operation.source?.id.toString()
         let el = listRef.parentElement
         while (el && !(el.scrollHeight > el.clientHeight && /(auto|scroll)/.test(getComputedStyle(el).overflowY)))
           el = el.parentElement
@@ -1158,7 +1163,10 @@ function HomeProjectList(props: {
           const restore = snapshot
           restore.forEach((worktree, index) => projects().move(worktree, index))
         }
+        const directory = selectOnDrop
         snapshot = undefined
+        selectOnDrop = undefined
+        if (!event.canceled && directory) props.selectProject(props.server, directory)
       }}
     >
       <div class="flex min-w-0 flex-col gap-1" ref={listRef}>
@@ -1177,6 +1185,7 @@ function HomeProjectList(props: {
                 project={project()!}
                 server={props.server}
                 index={index}
+                serverSelected={props.selected.server === ServerConnection.key(props.server)}
                 selected={
                   props.selected.server === ServerConnection.key(props.server) &&
                   props.selected.directory === worktree
@@ -1274,6 +1283,7 @@ function HomeProjectRow(props: {
   project: LocalProject
   server: ServerConnection.Any
   index: () => number
+  serverSelected: boolean
   selected: boolean
   unseenCount: number
   selectProject: (server: ServerConnection.Any, directory: string) => void
@@ -1329,12 +1339,15 @@ function HomeProjectRow(props: {
         aria-current={props.selected ? "page" : undefined}
         disabled={serverUnreachable()}
         onPointerDown={(event) => {
-          // Mouse selection happens on pointerdown (like tabs), but only ever
-          // selects; selectProject toggles, and deselecting here would fire on
-          // every drag of the selected row before the drag threshold is met.
-          // Touch is excluded so flick-scrolling the list cannot select rows.
+          // Same-server mouse selection happens on pointerdown (like tabs),
+          // but only ever selects; selectProject toggles, and deselecting here
+          // would fire on every drag before the threshold is met. Cross-server
+          // selection waits for click so reordering a remote server's projects
+          // does not focus that server and load its session index. Touch is
+          // excluded so flick-scrolling the list cannot select rows.
           pointerDownSelected = undefined
           if (event.button !== 0 || event.pointerType === "touch") return
+          if (!props.serverSelected) return
           pointerDownSelected = props.selected
           if (!props.selected) props.selectProject(props.server, props.project.worktree)
         }}

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -82,8 +82,6 @@ import {
 } from "@/context/global-sync/home-session-index"
 
 const HOME_SESSION_LIMIT = 64
-const HOME_PROJECT_EDGE_SCROLL_BAND = 16
-const HOME_PROJECT_EDGE_SCROLL_SPEED = 260
 const HOME_SESSION_HEADER_STICKY_TOP = 12
 const HOME_SESSION_HEADER_TEXT_HEIGHT = 16
 const HOME_SESSION_HEADER_FADE_DISTANCE = 16
@@ -1063,37 +1061,6 @@ function HomeProjectList(props: {
   let selectOnDrop: string | undefined
   const projects = () => global.ensureServerCtx(props.server).projects
 
-  // Constant-speed edge scrolling. dnd-kit's AutoScroller is deliberately not
-  // used: its activation zone is a percentage of the container height and its
-  // speed ramps with pointer depth, so large containers start creeping the
-  // scroll during ordinary drags. Here the scroll position is only touched
-  // while the pointer is within a fixed band at the container's edges (or past
-  // them), scrolling at a uniform rate.
-  let scroller: HTMLElement | undefined
-  let scrollDirection = 0
-  let scrollFrame: number | undefined
-  let scrollLast = 0
-
-  function stopEdgeScroll() {
-    if (scrollFrame !== undefined) cancelAnimationFrame(scrollFrame)
-    scrollFrame = undefined
-    scrollDirection = 0
-    scroller = undefined
-  }
-
-  function edgeScrollTick(timestamp: number) {
-    if (!scroller || !scrollDirection) {
-      scrollFrame = undefined
-      return
-    }
-    const dt = scrollLast ? (timestamp - scrollLast) / 1000 : 0
-    scrollLast = timestamp
-    scroller.scrollTop += scrollDirection * HOME_PROJECT_EDGE_SCROLL_SPEED * dt
-    scrollFrame = requestAnimationFrame(edgeScrollTick)
-  }
-
-  onCleanup(stopEdgeScroll)
-
   return (
     <DragDropProvider
       sensors={[
@@ -1106,7 +1073,8 @@ function HomeProjectList(props: {
       ]}
       modifiers={[RestrictToVerticalAxis, RestrictToElement.configure({ element: () => listRef })]}
       plugins={(defaults) => [
-        ...defaults.filter((plugin) => plugin !== Accessibility && plugin !== AutoScroller),
+        ...defaults.filter((plugin) => plugin !== Accessibility),
+        AutoScroller.configure({ acceleration: 8, threshold: { x: 0, y: 0.05 } }),
         Feedback.configure({ dropAnimation: null }),
       ]}
       onDragStart={(event) => {
@@ -1115,29 +1083,6 @@ function HomeProjectList(props: {
           props.selected.server === ServerConnection.key(props.server)
             ? undefined
             : event.operation.source?.id.toString()
-        let el = listRef.parentElement
-        while (el && !(el.scrollHeight > el.clientHeight && /(auto|scroll)/.test(getComputedStyle(el).overflowY)))
-          el = el.parentElement
-        scroller = el ?? undefined
-      }}
-      onDragMove={(event) => {
-        if (!scroller) return
-        // The operation position snapshot lags one event behind; event.to
-        // carries this move's coordinates.
-        const position = event.to ?? event.operation.position?.current
-        if (!position) return
-        const rect = scroller.getBoundingClientRect()
-        // Beyond the container counts as in-band: keep scrolling while the
-        // pointer is above/below it entirely.
-        scrollDirection =
-          position.y <= rect.top + HOME_PROJECT_EDGE_SCROLL_BAND
-            ? -1
-            : position.y >= rect.bottom - HOME_PROJECT_EDGE_SCROLL_BAND
-              ? 1
-              : 0
-        if (scrollDirection === 0 || scrollFrame !== undefined) return
-        scrollLast = 0
-        scrollFrame = requestAnimationFrame(edgeScrollTick)
       }}
       onDragOver={(event) => {
         // The Solid adapter expects the list state to be reordered here, during
@@ -1158,7 +1103,6 @@ function HomeProjectList(props: {
         projects().move(sourceId, next.indexOf(sourceId))
       }}
       onDragEnd={(event) => {
-        stopEdgeScroll()
         if (event.canceled && snapshot) {
           const restore = snapshot
           restore.forEach((worktree, index) => projects().move(worktree, index))

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -19,7 +19,6 @@ import { makeEventListener } from "@solid-primitives/event-listener"
 import { createStore, produce } from "solid-js/store"
 import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
 import { useSortable } from "@dnd-kit/solid/sortable"
-import { defaultSortableTransition } from "@dnd-kit/dom/sortable"
 import { move } from "@dnd-kit/helpers"
 import { Accessibility, AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
 import { RestrictToVerticalAxis } from "@dnd-kit/abstract/modifiers"
@@ -83,6 +82,8 @@ import {
 } from "@/context/global-sync/home-session-index"
 
 const HOME_SESSION_LIMIT = 64
+const HOME_PROJECT_EDGE_SCROLL_BAND = 16
+const HOME_PROJECT_EDGE_SCROLL_SPEED = 260
 const HOME_SESSION_HEADER_STICKY_TOP = 12
 const HOME_SESSION_HEADER_TEXT_HEIGHT = 16
 const HOME_SESSION_HEADER_FADE_DISTANCE = 16
@@ -1060,44 +1061,38 @@ function HomeProjectList(props: {
   let listRef!: HTMLDivElement
   let snapshot: string[] | undefined
   const projects = () => global.ensureServerCtx(props.server).projects
-  const flips = new WeakMap<HTMLElement, Animation>()
 
-  // Replicates dnd-kit's built-in sortable FLIP animation (Sortable.animate),
-  // which only fires when the OptimisticSortingPlugin moves the DOM itself.
-  // Since we reorder through the store instead, displaced rows would snap into
-  // place without this. Rows are matched by worktree, not element identity,
-  // because the enriched project objects are recreated on every store change
-  // so <For> remounts the row elements on reorder. Old-position measurements
-  // include any in-flight animation offset, keeping fast drags continuous.
-  function animateDisplacedRows(sourceId: string, applyMove: () => void) {
-    const slots = () =>
-      Array.from(listRef.querySelectorAll<HTMLElement>("[data-home-project-slot]:not([data-dnd-placeholder])"))
-    const before = new Map(
-      slots().map((el) => [el.dataset.homeProjectSlot, el.getBoundingClientRect().top] as const),
-    )
-    applyMove()
-    // dnd-kit's Feedback plugin repositions its placeholder from a mutation
-    // observer microtask queued by the DOM reorder above; measuring in a later
-    // microtask sees the settled layout.
-    queueMicrotask(() => {
-      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
-      for (const el of slots()) {
-        if (el.dataset.homeProjectSlot === sourceId) continue
-        const prev = before.get(el.dataset.homeProjectSlot)
-        if (prev === undefined) continue
-        const delta = prev - el.getBoundingClientRect().top
-        if (!delta) continue
-        flips.get(el)?.cancel()
-        flips.set(
-          el,
-          el.animate(
-            { translate: [`0 ${delta}px`, "0 0"] },
-            { duration: defaultSortableTransition.duration, easing: defaultSortableTransition.easing },
-          ),
-        )
-      }
-    })
+  // Constant-speed edge scrolling. dnd-kit's AutoScroller is deliberately not
+  // used: its activation zone is a percentage of the container height and its
+  // speed ramps with pointer depth, so large containers start creeping the
+  // scroll during ordinary drags. Here the scroll position is only touched
+  // while the pointer is within a fixed band at the container's edges (or past
+  // them), scrolling at a uniform rate.
+  let scroller: HTMLElement | undefined
+  let scrollDirection = 0
+  let scrollFrame: number | undefined
+  let scrollLast = 0
+
+  function stopEdgeScroll() {
+    if (scrollFrame !== undefined) cancelAnimationFrame(scrollFrame)
+    scrollFrame = undefined
+    scrollDirection = 0
+    scroller = undefined
   }
+
+  function edgeScrollTick(timestamp: number) {
+    if (!scroller || !scrollDirection) {
+      scrollFrame = undefined
+      return
+    }
+    const dt = scrollLast ? (timestamp - scrollLast) / 1000 : 0
+    scrollLast = timestamp
+    scroller.scrollTop += scrollDirection * HOME_PROJECT_EDGE_SCROLL_SPEED * dt
+    scrollFrame = requestAnimationFrame(edgeScrollTick)
+  }
+
+  onCleanup(stopEdgeScroll)
+
   return (
     <DragDropProvider
       sensors={[
@@ -1110,12 +1105,34 @@ function HomeProjectList(props: {
       ]}
       modifiers={[RestrictToVerticalAxis, RestrictToElement.configure({ element: () => listRef })]}
       plugins={(defaults) => [
-        ...defaults.filter((plugin) => plugin !== Accessibility),
-        AutoScroller.configure({ acceleration: 8, threshold: { x: 0, y: 0.05 } }),
+        ...defaults.filter((plugin) => plugin !== Accessibility && plugin !== AutoScroller),
         Feedback.configure({ dropAnimation: null }),
       ]}
       onDragStart={() => {
         snapshot = props.projects.map((project) => project.worktree)
+        let el = listRef.parentElement
+        while (el && !(el.scrollHeight > el.clientHeight && /(auto|scroll)/.test(getComputedStyle(el).overflowY)))
+          el = el.parentElement
+        scroller = el ?? undefined
+      }}
+      onDragMove={(event) => {
+        if (!scroller) return
+        // The operation position snapshot lags one event behind; event.to
+        // carries this move's coordinates.
+        const position = event.to ?? event.operation.position?.current
+        if (!position) return
+        const rect = scroller.getBoundingClientRect()
+        // Beyond the container counts as in-band: keep scrolling while the
+        // pointer is above/below it entirely.
+        scrollDirection =
+          position.y <= rect.top + HOME_PROJECT_EDGE_SCROLL_BAND
+            ? -1
+            : position.y >= rect.bottom - HOME_PROJECT_EDGE_SCROLL_BAND
+              ? 1
+              : 0
+        if (scrollDirection === 0 || scrollFrame !== undefined) return
+        scrollLast = 0
+        scrollFrame = requestAnimationFrame(edgeScrollTick)
       }}
       onDragOver={(event) => {
         // The Solid adapter expects the list state to be reordered here, during
@@ -1129,38 +1146,51 @@ function HomeProjectList(props: {
         if (next === order) return
         event.preventDefault()
         const sourceId = source.id.toString()
-        animateDisplacedRows(sourceId, () => projects().move(sourceId, next.indexOf(sourceId)))
+        // Displaced rows animate via dnd-kit's built-in sortable FLIP: the row
+        // elements persist across reorders (worktree-keyed <For>), so their
+        // sortable indices change and Sortable.animate transitions them from
+        // its cached shapes. This matches the titlebar tab strip's behavior.
+        projects().move(sourceId, next.indexOf(sourceId))
       }}
       onDragEnd={(event) => {
+        stopEdgeScroll()
         if (event.canceled && snapshot) {
           const restore = snapshot
-          animateDisplacedRows(event.operation.source?.id.toString() ?? "", () =>
-            restore.forEach((worktree, index) => projects().move(worktree, index)),
-          )
+          restore.forEach((worktree, index) => projects().move(worktree, index))
         }
         snapshot = undefined
       }}
     >
       <div class="flex min-w-0 flex-col gap-1" ref={listRef}>
-        <For each={props.projects}>
-          {(project, index) => (
-            <HomeProjectRow
-              project={project}
-              server={props.server}
-              index={index}
-              selected={
-                props.selected.server === ServerConnection.key(props.server) &&
-                props.selected.directory === project.worktree
-              }
-              unseenCount={props.unseenCount(props.server, project)}
-              selectProject={props.selectProject}
-              openNewSession={props.openNewSession}
-              editProject={props.editProject}
-              closeProject={props.closeProject}
-              clearNotifications={props.clearNotifications}
-              language={props.language}
-            />
-          )}
+        {/* Keyed on worktree strings: the enriched project objects are
+            recreated on every store or sync update, so iterating them directly
+            remounts all rows — killing any in-flight drag activation (the
+            row's sortable unregisters on unmount) and discarding animations.
+            String keys keep row elements alive and move them on reorder. */}
+        <For each={props.projects.map((project) => project.worktree)}>
+          {(worktree, index) => {
+            const project = createMemo<LocalProject | undefined>(
+              (prev) => props.projects.find((item) => item.worktree === worktree) ?? prev,
+            )
+            return (
+              <HomeProjectRow
+                project={project()!}
+                server={props.server}
+                index={index}
+                selected={
+                  props.selected.server === ServerConnection.key(props.server) &&
+                  props.selected.directory === worktree
+                }
+                unseenCount={props.unseenCount(props.server, project()!)}
+                selectProject={props.selectProject}
+                openNewSession={props.openNewSession}
+                editProject={props.editProject}
+                closeProject={props.closeProject}
+                clearNotifications={props.clearNotifications}
+                language={props.language}
+              />
+            )
+          }}
         </For>
       </div>
     </DragDropProvider>
@@ -1284,7 +1314,6 @@ function HomeProjectRow(props: {
   return (
     <div
       ref={sortable.ref}
-      data-home-project-slot={props.project.worktree}
       class="group/project relative flex h-7 min-w-0 items-center rounded-[6px]"
       classList={{ "z-10": sortable.isDragSource() }}
     >

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -17,6 +17,13 @@ import {
 } from "solid-js"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createStore, produce } from "solid-js/store"
+import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
+import { useSortable } from "@dnd-kit/solid/sortable"
+import { defaultSortableTransition } from "@dnd-kit/dom/sortable"
+import { move } from "@dnd-kit/helpers"
+import { Accessibility, AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
+import { RestrictToVerticalAxis } from "@dnd-kit/abstract/modifiers"
+import { RestrictToElement } from "@dnd-kit/dom/modifiers"
 import { useQuery } from "@tanstack/solid-query"
 import { Button } from "@opencode-ai/ui/button"
 import { Logo } from "@opencode-ai/ui/logo"
@@ -1049,28 +1056,114 @@ function HomeProjectList(props: {
   unseenCount: (server: ServerConnection.Any, project: LocalProject) => number
   language: ReturnType<typeof useLanguage>
 }) {
+  const global = useGlobal()
+  let listRef!: HTMLDivElement
+  let snapshot: string[] | undefined
+  const projects = () => global.ensureServerCtx(props.server).projects
+  const flips = new WeakMap<HTMLElement, Animation>()
+
+  // Replicates dnd-kit's built-in sortable FLIP animation (Sortable.animate),
+  // which only fires when the OptimisticSortingPlugin moves the DOM itself.
+  // Since we reorder through the store instead, displaced rows would snap into
+  // place without this. Rows are matched by worktree, not element identity,
+  // because the enriched project objects are recreated on every store change
+  // so <For> remounts the row elements on reorder. Old-position measurements
+  // include any in-flight animation offset, keeping fast drags continuous.
+  function animateDisplacedRows(sourceId: string, applyMove: () => void) {
+    const slots = () =>
+      Array.from(listRef.querySelectorAll<HTMLElement>("[data-home-project-slot]:not([data-dnd-placeholder])"))
+    const before = new Map(
+      slots().map((el) => [el.dataset.homeProjectSlot, el.getBoundingClientRect().top] as const),
+    )
+    applyMove()
+    // dnd-kit's Feedback plugin repositions its placeholder from a mutation
+    // observer microtask queued by the DOM reorder above; measuring in a later
+    // microtask sees the settled layout.
+    queueMicrotask(() => {
+      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return
+      for (const el of slots()) {
+        if (el.dataset.homeProjectSlot === sourceId) continue
+        const prev = before.get(el.dataset.homeProjectSlot)
+        if (prev === undefined) continue
+        const delta = prev - el.getBoundingClientRect().top
+        if (!delta) continue
+        flips.get(el)?.cancel()
+        flips.set(
+          el,
+          el.animate(
+            { translate: [`0 ${delta}px`, "0 0"] },
+            { duration: defaultSortableTransition.duration, easing: defaultSortableTransition.easing },
+          ),
+        )
+      }
+    })
+  }
   return (
-    <div class="flex min-w-0 flex-col gap-1">
-      <For each={props.projects}>
-        {(project) => (
-          <HomeProjectRow
-            project={project}
-            server={props.server}
-            selected={
-              props.selected.server === ServerConnection.key(props.server) &&
-              props.selected.directory === project.worktree
-            }
-            unseenCount={props.unseenCount(props.server, project)}
-            selectProject={props.selectProject}
-            openNewSession={props.openNewSession}
-            editProject={props.editProject}
-            closeProject={props.closeProject}
-            clearNotifications={props.clearNotifications}
-            language={props.language}
-          />
-        )}
-      </For>
-    </div>
+    <DragDropProvider
+      sensors={[
+        PointerSensor.configure({
+          activationConstraints: [new PointerActivationConstraints.Distance({ value: 4 })],
+          preventActivation: (event) =>
+            event.pointerType === "touch" ||
+            (event.target instanceof Element && !!event.target.closest("[data-action]")),
+        }),
+      ]}
+      modifiers={[RestrictToVerticalAxis, RestrictToElement.configure({ element: () => listRef })]}
+      plugins={(defaults) => [
+        ...defaults.filter((plugin) => plugin !== Accessibility),
+        AutoScroller.configure({ acceleration: 8, threshold: { x: 0, y: 0.05 } }),
+        Feedback.configure({ dropAnimation: null }),
+      ]}
+      onDragStart={() => {
+        snapshot = props.projects.map((project) => project.worktree)
+      }}
+      onDragOver={(event) => {
+        // The Solid adapter expects the list state to be reordered here, during
+        // dragover: it tracks this callback's re-render so dnd-kit's optimistic
+        // sorting plugin skips its own DOM manipulation, keeping Solid's <For>
+        // the sole owner of DOM order. Committing only on drag end desyncs them.
+        const source = event.operation.source
+        if (!source) return
+        const order = props.projects.map((project) => project.worktree)
+        const next = move(order, event)
+        if (next === order) return
+        event.preventDefault()
+        const sourceId = source.id.toString()
+        animateDisplacedRows(sourceId, () => projects().move(sourceId, next.indexOf(sourceId)))
+      }}
+      onDragEnd={(event) => {
+        if (event.canceled && snapshot) {
+          const restore = snapshot
+          animateDisplacedRows(event.operation.source?.id.toString() ?? "", () =>
+            restore.forEach((worktree, index) => projects().move(worktree, index)),
+          )
+        }
+        snapshot = undefined
+      }}
+    >
+      <div class="flex min-w-0 flex-col gap-1" ref={listRef}>
+        <For each={props.projects}>
+          {(project, index) => (
+            <HomeProjectRow
+              project={project}
+              server={props.server}
+              index={index}
+              selected={
+                props.selected.server === ServerConnection.key(props.server) &&
+                props.selected.directory === project.worktree
+              }
+              unseenCount={props.unseenCount(props.server, project)}
+              selectProject={props.selectProject}
+              openNewSession={props.openNewSession}
+              editProject={props.editProject}
+              closeProject={props.closeProject}
+              clearNotifications={props.clearNotifications}
+              language={props.language}
+            />
+          )}
+        </For>
+      </div>
+    </DragDropProvider>
   )
 }
 
@@ -1150,6 +1243,7 @@ function HomeRecentlyClosedRow(props: {
 function HomeProjectRow(props: {
   project: LocalProject
   server: ServerConnection.Any
+  index: () => number
   selected: boolean
   unseenCount: number
   selectProject: (server: ServerConnection.Any, directory: string) => void
@@ -1163,6 +1257,15 @@ function HomeProjectRow(props: {
   const platform = usePlatform()
   const serverUnreachable = () => global.servers.health[ServerConnection.key(props.server)]?.healthy === false
   const [state, setState] = createStore({ menuOpen: false })
+  const sortable = useSortable({
+    get id() {
+      return props.project.worktree
+    },
+    get index() {
+      return props.index()
+    },
+  })
+  let pointerDownSelected: boolean | undefined
   const canRevealInFileManager = () =>
     platform.platform === "desktop" && !!platform.openPath && ServerConnection.local(props.server)
   const fileManagerActionLabel = () =>
@@ -1179,15 +1282,47 @@ function HomeProjectRow(props: {
     )
   }
   return (
-    <div class="group/project relative flex h-7 min-w-0 items-center rounded-[6px]">
+    <div
+      ref={sortable.ref}
+      data-home-project-slot={props.project.worktree}
+      class="group/project relative flex h-7 min-w-0 items-center rounded-[6px]"
+      classList={{ "z-10": sortable.isDragSource() }}
+    >
       <button
         type="button"
         data-component="home-project-row"
         class={`${HOME_PROJECT_NAV_ROW} pr-16 disabled:opacity-60`}
+        classList={{
+          "bg-v2-background-bg-layer-01 text-v2-text-text-base [box-shadow:inset_0_0_0_0.5px_var(--v2-border-border-muted)]":
+            sortable.isDragSource(),
+        }}
         data-selected={props.selected ? "" : undefined}
         aria-current={props.selected ? "page" : undefined}
         disabled={serverUnreachable()}
-        onClick={() => props.selectProject(props.server, props.project.worktree)}
+        onPointerDown={(event) => {
+          // Mouse selection happens on pointerdown (like tabs), but only ever
+          // selects; selectProject toggles, and deselecting here would fire on
+          // every drag of the selected row before the drag threshold is met.
+          // Touch is excluded so flick-scrolling the list cannot select rows.
+          pointerDownSelected = undefined
+          if (event.button !== 0 || event.pointerType === "touch") return
+          pointerDownSelected = props.selected
+          if (!props.selected) props.selectProject(props.server, props.project.worktree)
+        }}
+        onClick={(event) => {
+          // The drag sensor calls preventDefault on post-drag clicks; never
+          // toggle selection as part of a reorder.
+          if (event.defaultPrevented) return
+          // Keyboard activation and touch taps keep the original toggle.
+          if (event.detail === 0 || pointerDownSelected === undefined) {
+            props.selectProject(props.server, props.project.worktree)
+            return
+          }
+          // Mouse: pointerdown already selected unselected rows; a plain click
+          // on an already-selected row toggles it off.
+          if (pointerDownSelected) props.selectProject(props.server, props.project.worktree)
+          pointerDownSelected = undefined
+        }}
       >
         <HomeProjectAvatar project={props.project} />
         <span class={HOME_PROJECT_NAV_LABEL}>{displayName(props.project)}</span>

--- a/packages/app/src/pages/home.tsx
+++ b/packages/app/src/pages/home.tsx
@@ -18,9 +18,8 @@ import {
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createStore, produce } from "solid-js/store"
 import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
-import { useSortable } from "@dnd-kit/solid/sortable"
-import { move } from "@dnd-kit/helpers"
-import { Accessibility, AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
+import { isSortable, useSortable } from "@dnd-kit/solid/sortable"
+import { AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
 import { RestrictToVerticalAxis } from "@dnd-kit/abstract/modifiers"
 import { RestrictToElement } from "@dnd-kit/dom/modifiers"
 import { useQuery } from "@tanstack/solid-query"
@@ -1043,7 +1042,7 @@ function HomeServerRow(props: {
   )
 }
 
-function HomeProjectList(props: {
+type HomeProjectListProps = {
   server: ServerConnection.Any
   projects: LocalProject[]
   selected: HomeProjectSelection
@@ -1054,63 +1053,38 @@ function HomeProjectList(props: {
   clearNotifications: (server: ServerConnection.Any, project: LocalProject) => void
   unseenCount: (server: ServerConnection.Any, project: LocalProject) => number
   language: ReturnType<typeof useLanguage>
-}) {
+}
+
+function HomeProjectList(props: HomeProjectListProps) {
   const global = useGlobal()
   let listRef!: HTMLDivElement
-  let snapshot: string[] | undefined
-  let selectOnDrop: string | undefined
   const projects = () => global.ensureServerCtx(props.server).projects
 
   return (
     <DragDropProvider
-      sensors={[
+      sensors={(defaults) => [
+        ...defaults.filter((sensor) => sensor !== PointerSensor),
         PointerSensor.configure({
-          activationConstraints: [new PointerActivationConstraints.Distance({ value: 4 })],
+          activationConstraints: (event) =>
+            event.pointerType === "touch"
+              ? [new PointerActivationConstraints.Delay({ value: 250, tolerance: 5 })]
+              : [new PointerActivationConstraints.Distance({ value: 4 })],
           preventActivation: (event) =>
-            event.pointerType === "touch" ||
-            (event.target instanceof Element && !!event.target.closest("[data-action]")),
+            event.target instanceof Element && !!event.target.closest("[data-action]"),
         }),
       ]}
       modifiers={[RestrictToVerticalAxis, RestrictToElement.configure({ element: () => listRef })]}
       plugins={(defaults) => [
-        ...defaults.filter((plugin) => plugin !== Accessibility),
+        ...defaults.filter((plugin) => plugin !== AutoScroller && plugin !== Feedback),
         AutoScroller.configure({ acceleration: 8, threshold: { x: 0, y: 0.05 } }),
         Feedback.configure({ dropAnimation: null }),
       ]}
-      onDragStart={(event) => {
-        snapshot = props.projects.map((project) => project.worktree)
-        selectOnDrop =
-          props.selected.server === ServerConnection.key(props.server)
-            ? undefined
-            : event.operation.source?.id.toString()
-      }}
-      onDragOver={(event) => {
-        // The Solid adapter expects the list state to be reordered here, during
-        // dragover: it tracks this callback's re-render so dnd-kit's optimistic
-        // sorting plugin skips its own DOM manipulation, keeping Solid's <For>
-        // the sole owner of DOM order. Committing only on drag end desyncs them.
-        const source = event.operation.source
-        if (!source) return
-        const order = props.projects.map((project) => project.worktree)
-        const next = move(order, event)
-        if (next === order) return
-        event.preventDefault()
-        const sourceId = source.id.toString()
-        // Displaced rows animate via dnd-kit's built-in sortable FLIP: the row
-        // elements persist across reorders (worktree-keyed <For>), so their
-        // sortable indices change and Sortable.animate transitions them from
-        // its cached shapes. This matches the titlebar tab strip's behavior.
-        projects().move(sourceId, next.indexOf(sourceId))
-      }}
       onDragEnd={(event) => {
-        if (event.canceled && snapshot) {
-          const restore = snapshot
-          restore.forEach((worktree, index) => projects().move(worktree, index))
-        }
-        const directory = selectOnDrop
-        snapshot = undefined
-        selectOnDrop = undefined
-        if (!event.canceled && directory) props.selectProject(props.server, directory)
+        const source = event.operation.source
+        if (event.canceled || !isSortable(source)) return
+        if (source.initialIndex !== source.index) projects().move(source.id.toString(), source.index)
+        if (props.selected.server !== ServerConnection.key(props.server))
+          props.selectProject(props.server, source.id.toString())
       }}
     >
       <div class="flex min-w-0 flex-col gap-1" ref={listRef}>
@@ -1120,33 +1094,43 @@ function HomeProjectList(props: {
             row's sortable unregisters on unmount) and discarding animations.
             String keys keep row elements alive and move them on reorder. */}
         <For each={props.projects.map((project) => project.worktree)}>
-          {(worktree, index) => {
-            const project = createMemo<LocalProject | undefined>(
-              (prev) => props.projects.find((item) => item.worktree === worktree) ?? prev,
-            )
-            return (
-              <HomeProjectRow
-                project={project()!}
-                server={props.server}
-                index={index}
-                serverSelected={props.selected.server === ServerConnection.key(props.server)}
-                selected={
-                  props.selected.server === ServerConnection.key(props.server) &&
-                  props.selected.directory === worktree
-                }
-                unseenCount={props.unseenCount(props.server, project()!)}
-                selectProject={props.selectProject}
-                openNewSession={props.openNewSession}
-                editProject={props.editProject}
-                closeProject={props.closeProject}
-                clearNotifications={props.clearNotifications}
-                language={props.language}
-              />
-            )
-          }}
+          {(worktree, index) => <HomeProjectSlot {...props} worktree={worktree} index={index} />}
         </For>
       </div>
     </DragDropProvider>
+  )
+}
+
+function HomeProjectSlot(
+  props: HomeProjectListProps & {
+    worktree: string
+    index: () => number
+  },
+) {
+  const project = createMemo(() => props.projects.find((item) => item.worktree === props.worktree))
+
+  return (
+    <Show when={project()}>
+      {(item) => (
+        <HomeProjectRow
+          project={item()}
+          server={props.server}
+          index={props.index}
+          serverSelected={props.selected.server === ServerConnection.key(props.server)}
+          selected={
+            props.selected.server === ServerConnection.key(props.server) &&
+            props.selected.directory === props.worktree
+          }
+          unseenCount={props.unseenCount(props.server, item())}
+          selectProject={props.selectProject}
+          openNewSession={props.openNewSession}
+          editProject={props.editProject}
+          closeProject={props.closeProject}
+          clearNotifications={props.clearNotifications}
+          language={props.language}
+        />
+      )}
+    </Show>
   )
 }
 


### PR DESCRIPTION
### Issue for this PR
N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
- Makes the projects list draggable
- Auto scroll transitions are not super clean, but that's a tradeoff I made in favor of simpler code (using `AutoScroller` instead of a custom implementation)
- Screen goes blank for a split second when switching between servers. Didn't touch this since it's unrelated

### How did you verify your code works?
- Ran the app locally and verified the updated UI manually
- Checked cases: mobile, scrollable container, multiple servers
- Ran type checks locally (`bun turbo typecheck`)

### Screenshots / recordings

https://github.com/user-attachments/assets/bbbe5bcf-2795-488c-97fc-b3cdb910b583

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
