### PR TITLE
fix(opencode): exclude denied MCP tools from provider requests

### DIFF
--- a/packages/opencode/src/session/tools.ts
+++ b/packages/opencode/src/session/tools.ts
@@ -55,6 +55,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
   const mcp = yield* MCP.Service
   const truncate = yield* Truncate.Service
   const flags = yield* RuntimeFlags.Service
+  const ruleset = Permission.merge(input.agent.permission, input.session.permission ?? [])
 
   const context = (args: Record<string, unknown>, options: ToolExecutionOptions): Tool.Context => ({
     sessionID: input.session.id,
@@ -84,7 +85,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
           ...req,
           sessionID: input.session.id,
           tool: { messageID: input.processor.message.id, callID: options.toolCallId },
-          ruleset: Permission.merge(input.agent.permission, input.session.permission ?? []),
+          ruleset,
         })
         .pipe(Effect.orDie),
   })
@@ -387,7 +388,7 @@ export const resolve = Effect.fn("SessionTools.resolve")(function* (input: {
 
   if (flags.experimentalCodeMode) return tools
 
-  for (const [key, entry] of Object.entries(yield* mcp.tools())) {
+  for (const [key, entry] of Object.entries(Permission.visibleTools(yield* mcp.tools(), ruleset))) {
     const item = McpCatalog.convertTool(entry.def, entry.client, entry.timeout)
     const execute = item.execute
     if (!execute) continue

--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test"
+import type { Tool as MCPToolDef } from "@modelcontextprotocol/sdk/types.js"
+import { Effect, Layer } from "effect"
+import { SessionTools } from "@/session/tools"
+import { MCP } from "@/mcp"
+import { Plugin } from "@/plugin"
+import { Permission } from "@/permission"
+import { ToolRegistry } from "@/tool/registry"
+import { Truncate } from "@/tool/truncate"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { MessageID, SessionID } from "@/session/schema"
+import type { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import type { Agent } from "@/agent/agent"
+import type { Provider } from "@/provider/provider"
+import type { Session } from "@/session/session"
+
+function mcpTool(name: string): MCP.McpTool {
+  return {
+    def: { name, description: name, inputSchema: { type: "object", properties: {} } } as MCPToolDef,
+    client: { callTool: async () => ({ content: [] }) } as unknown as MCP.McpTool["client"],
+  }
+}
+
+function resolveTools(input: { mcpTools: Record<string, MCP.McpTool>; permission: PermissionV1.Rule[] }) {
+  const harness = Layer.mergeAll(
+    Layer.mock(Plugin.Service, {
+      trigger: ((_name, _input, output) => Effect.succeed(output)) as Plugin.Interface["trigger"],
+    }),
+    Layer.mock(Permission.Service, {}),
+    Layer.mock(ToolRegistry.Service, {
+      tools: () => Effect.succeed([]),
+    }),
+    Layer.mock(Truncate.Service, {
+      output: (text: string) => Effect.succeed({ content: text, truncated: false as const }),
+    }),
+    Layer.mock(MCP.Service, {
+      tools: () => Effect.succeed(input.mcpTools),
+      clients: () => Effect.succeed({}),
+    }),
+    RuntimeFlags.layer(),
+  )
+  return Effect.runPromise(
+    SessionTools.resolve({
+      agent: { name: "build", permission: input.permission } as unknown as Agent.Info,
+      model: {
+        api: { id: "test-model", npm: "@ai-sdk/anthropic" },
+        providerID: "anthropic",
+      } as unknown as Provider.Model,
+      session: { id: SessionID.make("ses_tools_test"), permission: [] } as unknown as Session.Info,
+      processor: {
+        message: { id: MessageID.make("msg_tools_test") },
+        updateToolCall: () => Effect.void,
+        completeToolCall: () => Effect.void,
+      } as any,
+      bypassAgentCheck: false,
+      messages: [],
+      promptOps: {} as any,
+    }).pipe(Effect.provide(harness)),
+  )
+}
+
+describe("SessionTools.resolve MCP tool visibility", () => {
+  // `tools: { "postman*": false }` compiles to a wholly-deny permission rule
+  // `{ permission: "postman*", pattern: "*", action: "deny" }` (Permission.fromConfig).
+  // Such tools must not be advertised to the provider, matching code-mode (#37675).
+  test("excludes MCP tools denied by a wildcard permission rule", async () => {
+    const tools = await resolveTools({
+      mcpTools: { postman_search: mcpTool("search"), github_list: mcpTool("list") },
+      permission: [{ permission: "postman*", pattern: "*", action: "deny" }],
+    })
+    expect(Object.keys(tools)).toContain("github_list")
+    expect(Object.keys(tools)).not.toContain("postman_search")
+  })
+
+  test("keeps MCP tools when no denying rule matches", async () => {
+    const tools = await resolveTools({
+      mcpTools: { postman_search: mcpTool("search") },
+      permission: [],
+    })
+    expect(Object.keys(tools)).toContain("postman_search")
+  })
+
+  // A resource-scoped deny (pattern !== "*") only gates specific calls at ask time;
+  // it must not hide the tool, since it can still be allowed for other resources.
+  test("keeps MCP tools whose only matching deny rule is resource-scoped", async () => {
+    const tools = await resolveTools({
+      mcpTools: { postman_search: mcpTool("search") },
+      permission: [{ permission: "postman_search", pattern: "some/path", action: "deny" }],
+    })
+    expect(Object.keys(tools)).toContain("postman_search")
+  })
+
+  test("excludes only the denied tool, keeping siblings under the same server prefix", async () => {
+    const tools = await resolveTools({
+      mcpTools: { postman_search: mcpTool("search"), postman_other: mcpTool("other") },
+      permission: [{ permission: "postman_search", pattern: "*", action: "deny" }],
+    })
+    expect(Object.keys(tools)).toContain("postman_other")
+    expect(Object.keys(tools)).not.toContain("postman_search")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #37675

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The global `tools` key is documented so that `{ "mymcp_*": false }` (equivalent to `{ "*": "deny" }`) disables all of an MCP server's tools. But `SessionTools.resolve` added every `mcp.tools()` entry to the tool list sent to the provider regardless of permission. So a wholly-denied MCP tool was still advertised, and when its schema is one the provider rejects (the Moonshot 400 in the report) the whole session fails.

`Permission.visibleTools` already drops wholly-denied tools, and the experimental code-mode path already applies it to `mcp.tools()`. This applies the same filter in the normal path. Only tools denied with resource pattern `*` are hidden; `ask` and resource-scoped rules leave the tool advertised, so nothing else changes.

### How did you verify your code works?

Added `packages/opencode/test/session/tools.test.ts`, which drives `SessionTools.resolve` with mocked MCP tools and a permission ruleset:

- a `"postman*"` deny rule excludes `postman_search` but keeps `github_list`
- no matching rule keeps the tool
- a resource-scoped deny (`pattern != "*"`) keeps the tool
- an exact-match deny hides only that tool, not siblings under the same prefix

The deny-glob test fails before the change and passes after. Also ran `bun typecheck` and the related suites (`test/session/prompt.test.ts`, `test/permission/next.test.ts`, `test/tool/code-mode.test.ts`, `test/tool/registry.test.ts`, `test/mcp/`), all passing.

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
