### PR TITLE
fix(session): edge-trigger build-switch reminder instead of scanning full session history

### DIFF
--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -34,7 +34,22 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
         synthetic: true,
       })
     }
-    const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
+    // Use the immediately preceding assistant message's agent, not "was this
+    // session ever in plan mode" (input.messages.some(...) over the full
+    // uncompacted history). With only the built-in plan/build toggle these
+    // are nearly equivalent, but as soon as a third primary agent is in
+    // rotation (e.g. a custom read-only "ask" agent switched to via config,
+    // per https://opencode.ai/docs/agents), `.some()` keeps matching on
+    // every subsequent build turn for the rest of the session (or until
+    // compaction drops the old plan message from the window) even though
+    // the actual previous turn was a completely unrelated agent. That both
+    // mislabels the transition in the reminder text ("changed from plan to
+    // build" when it didn't) and, worse, can re-fire the same reminder on
+    // every build turn indefinitely, which trains the model to discount an
+    // otherwise high-signal reminder. Mirrors the findLast-based check the
+    // experimentalPlanMode branch below already uses.
+    const lastAssistant = input.messages.findLast((msg) => msg.info.role === "assistant")
+    const wasPlan = lastAssistant?.info.agent === "plan"
     if (wasPlan && input.agent.name === "build") {
       userMessage.parts.push({
         id: PartID.ascending(),


### PR DESCRIPTION
### Issue for this PR

Closes #38066

### Type of change

- [x] Bug fix

### What does this PR do?

`SessionReminders.apply` (packages/opencode/src/session/reminders.ts) decides whether to inject the "operational mode has changed from plan to build" reminder using:

```ts
const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
```

This checks "has this session ever contained a plan-agent message" (scanning the full uncompacted history), not "was the immediately preceding turn plan". With only the built-in plan/build toggle this rarely matters, but opencode supports custom primary agents (docs/agents). Once a third primary agent is used between plan and build, `wasPlan` stays true from the old plan message and the reminder both mislabels the transition and can re-fire on every subsequent build turn.

Fix: use `findLast` to check only the immediately preceding assistant message's agent, matching the pattern already used a few lines below in the `experimentalPlanMode` branch.

### How did you verify your code works?

Manually reproduced against a real session: switched plan -> custom read-only agent (several turns) -> build. Confirmed the stale "from plan to build" banner still fires on unpatched code, and with this one-line logic change it correctly reflects the immediately preceding agent instead. Did not run the full monorepo test suite in my environment; there's no existing test file for reminders.ts to extend, happy to add one if pointed at a similar fixture.

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
