### PR TITLE
feat(config): allow partial override of built-in commands without template

### DIFF
--- a/packages/core/src/config/command.ts
+++ b/packages/core/src/config/command.ts
@@ -3,7 +3,7 @@ export * as ConfigCommand from "./command"
 import { Schema } from "effect"
 
 export class Info extends Schema.Class<Info>("ConfigV2.Command")({
-  template: Schema.String,
+  template: Schema.String.pipe(Schema.optional),
   description: Schema.String.pipe(Schema.optional),
   agent: Schema.String.pipe(Schema.optional),
   model: Schema.String.pipe(Schema.optional),

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -27,22 +27,31 @@ export const Plugin = define({
             ]),
           )
         }).pipe(Effect.map((documents) => documents.flat()))
+        // Merge each command field-wise across documents first so a template-less
+        // entry is not dropped when another document supplies the template.
+        const merged = new Map<string, ConfigCommand.Info>()
         for (const document of documents) {
           for (const [name, command] of Object.entries(document.commands ?? {})) {
-            draft.update(name, (item) => {
-              item.template = command.template
-              if (command.description !== undefined) item.description = command.description
-              if (command.agent !== undefined) item.agent = command.agent
-              if (command.model !== undefined) {
-                const model = ModelV2.parse(command.model)
-                item.model = { id: model.modelID, providerID: model.providerID, variant: item.model?.variant }
-              }
-              if (command.variant !== undefined && item.model !== undefined) {
-                item.model.variant = ModelV2.VariantID.make(command.variant)
-              }
-              if (command.subtask !== undefined) item.subtask = command.subtask
-            })
+            merged.set(name, { ...merged.get(name), ...command })
           }
+        }
+        for (const [name, command] of merged) {
+          // Commands without a template partially override an existing command
+          // (e.g. set only `agent` on the built-in /review); skip them otherwise.
+          if (command.template === undefined && draft.get(name) === undefined) continue
+          draft.update(name, (item) => {
+            if (command.template !== undefined) item.template = command.template
+            if (command.description !== undefined) item.description = command.description
+            if (command.agent !== undefined) item.agent = command.agent
+            if (command.model !== undefined) {
+              const model = ModelV2.parse(command.model)
+              item.model = { id: model.modelID, providerID: model.providerID, variant: item.model?.variant }
+            }
+            if (command.variant !== undefined && item.model !== undefined) {
+              item.model.variant = ModelV2.VariantID.make(command.variant)
+            }
+            if (command.subtask !== undefined) item.subtask = command.subtask
+          })
         }
       }),
     )

--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -301,9 +301,10 @@ model: anthropic/claude-sonnet-4-6
 (command body in markdown: the prompt opencode runs, with $ARGUMENTS for the user's input)
 ```
 
-- `template` is the command body — everything below the frontmatter — and is required: it is the prompt opencode runs when the command is invoked. Do not also put a `template:` key in the frontmatter.
+- `template` is the command body — everything below the frontmatter — and is required for new commands: it is the prompt opencode runs when the command is invoked. Do not also put a `template:` key in the frontmatter.
 - `$ARGUMENTS` is replaced with everything the user typed after the command; `$1`, `$2`, … pull individual positional arguments.
 - Optional: `description`, `agent`, `model`, `variant`, `subtask`.
+- Built-in commands (`init`, `review`) can be partially overridden from `opencode.json` by omitting `template`, e.g. `"command": { "review": { "agent": "my-reviewer" } }` keeps the built-in review prompt but runs it with that agent.
 
 ## Plugins
 

--- a/packages/core/src/v1/config/command.ts
+++ b/packages/core/src/v1/config/command.ts
@@ -3,7 +3,7 @@ export * as ConfigCommandV1 from "./command"
 import { Schema } from "effect"
 
 export const Info = Schema.Struct({
-  template: Schema.String,
+  template: Schema.optional(Schema.String),
   description: Schema.optional(Schema.String),
   agent: Schema.optional(Schema.String),
   model: Schema.optional(Schema.String),

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -80,4 +80,53 @@ Review files`,
       ),
     ),
   )
+
+  it.effect("commands without a template partially override existing commands", () =>
+    Effect.gen(function* () {
+      const command = yield* CommandV2.Service
+      yield* command.transform((draft) => {
+        draft.update("review", (item) => {
+          item.template = "Built-in review"
+          item.description = "Built-in description"
+        })
+      })
+      yield* ConfigCommandPlugin.Plugin.effect(host({ command: { ...command, reload: command.reload } })).pipe(
+        Effect.provideService(
+          Config.Service,
+          Config.Service.of({
+            entries: () =>
+              Effect.succeed([
+                new Config.Document({
+                  type: "document",
+                  info: decode({
+                    commands: {
+                      review: { agent: "reviewer" },
+                      ghost: { agent: "reviewer" },
+                      split: { agent: "reviewer" },
+                    },
+                  }),
+                }),
+                new Config.Document({
+                  type: "document",
+                  info: decode({ commands: { split: { template: "Split template" } } }),
+                }),
+              ]),
+          }),
+        ),
+      )
+
+      expect(yield* command.get("review")).toEqual(
+        CommandV2.Info.make({
+          name: "review",
+          template: "Built-in review",
+          description: "Built-in description",
+          agent: "reviewer",
+        }),
+      )
+      expect(yield* command.get("ghost")).toBeUndefined()
+      expect(yield* command.get("split")).toEqual(
+        CommandV2.Info.make({ name: "split", template: "Split template", agent: "reviewer" }),
+      )
+    }),
+  )
 })

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -88,17 +88,34 @@ const layer = Layer.effect(
       }
 
       for (const [name, command] of Object.entries(cfg.command ?? {})) {
+        if (command.template !== undefined) {
+          const template = command.template
+          commands[name] = {
+            name,
+            agent: command.agent,
+            model: command.model,
+            description: command.description,
+            source: "command",
+            template,
+            subtask: command.subtask,
+            hints: hints(template),
+          }
+          continue
+        }
+        // Commands without a template partially override a built-in command
+        // (e.g. set only `agent` on /review); skip them if nothing to override.
+        const existing = commands[name]
+        if (existing === undefined || typeof existing.template !== "string") continue
+        const template = existing.template
         commands[name] = {
           name,
-          agent: command.agent,
-          model: command.model,
-          description: command.description,
+          agent: command.agent ?? existing.agent,
+          model: command.model ?? existing.model,
+          description: command.description ?? existing.description,
           source: "command",
-          get template() {
-            return command.template
-          },
-          subtask: command.subtask,
-          hints: hints(command.template),
+          template,
+          subtask: command.subtask ?? existing.subtask,
+          hints: hints(template),
         }
       }
 

--- a/packages/opencode/test/command/command.test.ts
+++ b/packages/opencode/test/command/command.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
+import { Command } from "../../src/command"
+import { provideTmpdirInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.mergeAll(LayerNode.compile(Command.node), LayerNode.compile(CrossSpawnSpawner.node)))
+
+const template = (command: Command.Info | undefined) => Effect.promise(async () => command?.template)
+
+describe("command", () => {
+  it.live("config without template partially overrides the built-in review command", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const commands = yield* Command.Service
+          const review = yield* commands.get("review")
+          expect(review?.agent).toBe("reviewer")
+          expect(review?.subtask).toBe(true)
+          expect(yield* template(review)).toContain("You are a code reviewer.")
+        }),
+      { config: { command: { review: { agent: "reviewer" } } } },
+    ),
+  )
+
+  it.live("config with template still fully overrides the built-in review command", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const commands = yield* Command.Service
+          const review = yield* commands.get("review")
+          expect(review?.agent).toBe("reviewer")
+          expect(review?.subtask).toBeUndefined()
+          expect(review?.description).toBeUndefined()
+          expect(yield* template(review)).toBe("Custom review")
+        }),
+      { config: { command: { review: { template: "Custom review", agent: "reviewer" } } } },
+    ),
+  )
+
+  it.live("config command without template and without a built-in counterpart is skipped", () =>
+    provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const commands = yield* Command.Service
+          expect(yield* commands.get("ghost")).toBeUndefined()
+        }),
+      { config: { command: { ghost: { agent: "reviewer" } } } },
+    ),
+  )
+})

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1886,7 +1886,7 @@ export type Config = {
   server?: ServerConfig
   command?: {
     [key: string]: {
-      template: string
+      template?: string
       description?: string
       agent?: string
       model?: string

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -21131,7 +21131,6 @@
                   "type": "boolean"
                 }
               },
-              "required": ["template"],
               "additionalProperties": false
             }
           },

--- a/packages/web/src/content/docs/commands.mdx
+++ b/packages/web/src/content/docs/commands.mdx
@@ -232,7 +232,7 @@ The `template` option defines the prompt that will be sent to the LLM when the c
 }
 ```
 
-This is a **required** config option.
+This is **required** when defining a new command. It can be omitted when overriding a [built-in command](#built-in), in which case the built-in template is kept and only the options you specify are overridden.
 
 ---
 
@@ -321,3 +321,15 @@ Custom commands can override built-in commands.
 :::
 
 If you define a custom command with the same name, it will override the built-in command.
+
+You can also partially override a built-in command by omitting the `template`. For example, to run `/review` with a specific agent while keeping the built-in review prompt:
+
+```json title="opencode.json"
+{
+  "command": {
+    "review": {
+      "agent": "my-reviewer"
+    }
+  }
+}
+```


### PR DESCRIPTION
### Issue for this PR

None (small feature, no existing issue).

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows specifying which agent runs a built-in command like `/review` from `opencode.json(c)` without re-supplying the whole prompt template:

```json
{
  "command": {
    "review": { "agent": "my-reviewer" }
  }
}
```

Previously `command.<name>.template` was required by the config schema, so overriding only the agent of the built-in `/review` forced users to copy the entire built-in review prompt. The docs (`docs/commands` "Agent" section) already showed a `review` override with only `agent`, but the schema rejected it.

Changes:

- Make `template` optional in the command config schema (v1 `ConfigCommandV1.Info` and v2 `ConfigCommand.Info`).
- v1 (`packages/opencode/src/command/index.ts`): a config command with a `template` keeps the existing full-replace behavior; without a `template` it partially overrides an existing built-in command (agent/model/description/subtask), and is skipped when there is nothing to override.
- v2 (`packages/core/src/config/plugin/command.ts`): merge command entries field-wise across config documents before applying, so a template-less entry in one document is not dropped when another document supplies the template; template-less entries with no existing command are skipped.
- Regenerated `packages/sdk/openapi.json` and the v2 SDK types.
- Updated `docs/commands` and the customize-opencode skill notes.

### How did you verify your code works?

- Added tests: `packages/opencode/test/command/command.test.ts` (partial override of built-in `/review`, full override unchanged, template-less unknown command skipped) and extended `packages/core/test/config/command.test.ts` (partial override, cross-document merge, skip).
- `bun test test/config test/command` in `packages/opencode` and `bun test test/config test/command.test.ts test/plugin/command.test.ts` in `packages/core` pass, plus `packages/opencode/test/session/prompt.test.ts`.
- `bun typecheck` clean in `packages/core`, `packages/sdk/js`; `packages/opencode` has only the pre-existing `src/bus/global.ts` error unrelated to this change.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
