### PR TITLE
fix: support dnf-based images in provider benchmark

### DIFF
--- a/script/provider-benchmark.sh
+++ b/script/provider-benchmark.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Cold OpenCode clone/install/typecheck benchmark for a fresh Ubuntu x86_64 VM.
+# Cold OpenCode clone/install/typecheck benchmark for a fresh x86_64 VM.
+# Supports apt-get and dnf based images.
 
 set -euo pipefail
 
@@ -79,13 +80,17 @@ else
 fi
 
 prepare() {
-  command -v apt-get >/dev/null || {
-    printf 'BENCH_ERROR\tprepare\tapt_get_required\n' >&2
+  if command -v apt-get >/dev/null; then
+    "${SUDO[@]}" apt-get update -qq
+    "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+      bash build-essential ca-certificates curl git python3 python3-setuptools unzip xz-utils
+  elif command -v dnf >/dev/null; then
+    "${SUDO[@]}" dnf install -y -q \
+      bash ca-certificates gcc gcc-c++ make git python3 python3-setuptools tar unzip xz
+  else
+    printf 'BENCH_ERROR\tprepare\tapt_get_or_dnf_required\n' >&2
     return 1
-  }
-  "${SUDO[@]}" apt-get update -qq
-  "${SUDO[@]}" env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
-    bash build-essential ca-certificates curl git python3 python3-setuptools unzip xz-utils
+  fi
   python3 -c 'import setuptools'
 
   if [[ "$(node --version 2>/dev/null || true)" != "v${NODE_VERSION}" ]]; then


### PR DESCRIPTION
### Issue for this PR

Closes #38078

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`prepare()` in `script/provider-benchmark.sh` asserts `apt-get` exists, dnf based sandboxes do not include this.

This PR adds support for `dnf` if `apt-get` does not exist. `build-essential` doesn't exist on dnf, so `gcc gcc-c++ make` is installed manually instead.

### How did you verify your code works?

Ran the full bench on a local `amazonlinux:2023` and `fedora:44` image locally. Ran the bench on a Vercel Sandbox.

### Screenshots / recordings

N/A, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR