### PR TITLE
feat(app): support bidirectional chat text

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1517,6 +1517,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
               role="textbox"
               aria-multiline="true"
               aria-label={placeholder()}
+              dir="auto"
               contenteditable="true"
               autocapitalize={store.mode === "normal" ? "sentences" : "off"}
               autocorrect={store.mode === "normal" ? "on" : "off"}

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -183,6 +183,8 @@
 
   [data-component="markdown-code"] {
     position: relative;
+    direction: ltr;
+    text-align: left;
   }
 
   [data-component="markdown-code"][data-code-kind="shell"] .shiki {
@@ -237,6 +239,8 @@
   }
 
   :not(pre) > code {
+    direction: ltr;
+    unicode-bidi: isolate;
     font-family: var(--font-family-mono);
     font-feature-settings: var(--font-family-mono--font-feature-settings);
     color: var(--v2-text-text-base);

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -504,6 +504,7 @@ export function Markdown(
   return (
     <div
       data-component="markdown"
+      dir="auto"
       classList={{
         ...local.classList,
         [local.class ?? ""]: !!local.class,

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -1347,7 +1347,11 @@ export function UserMessageDisplay(props: {
         }
       >
         <div data-slot="user-message-body">
-          <div data-slot="user-message-text" data-comments={messageComments().length > 0 ? "true" : undefined}>
+          <div
+            data-slot="user-message-text"
+            data-comments={messageComments().length > 0 ? "true" : undefined}
+            dir="auto"
+          >
             <HighlightedText text={text()} references={inlineFiles()} agents={agents()} />
             <Show when={messageComments().length > 0}>
               <UserMessageComments comments={messageComments()} bounded />

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -150,6 +150,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
             role="textbox"
             aria-multiline="true"
             aria-label="Prompt"
+            dir="auto"
             contenteditable={!props.disabled && !props.readOnly}
             autocapitalize={state.mode === "normal" ? "sentences" : "off"}
             autocorrect={state.mode === "normal" ? "on" : "off"}


### PR DESCRIPTION
### Issue for this PR

Closes #32726

Related: #35319 and #37249

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `dir="auto"` to user-message text and both the legacy and v2 prompt editors.

The browser determines direction from the first strong character, so Persian, Arabic, and Hebrew text renders RTL while English remains LTR. Mixed RTL/LTR text continues to use the browser's Unicode bidirectional handling.

This complements #37249, which handles rendered Markdown and tables but was opened before the current v2 prompt input was added.

### How did you verify your code works?

- Ran the `session-ui` test suite: 75 tests passed.
- Ran type checking for `packages/session-ui` and `packages/app`.
- Ran the full pre-push type check across 30 packages.
- Verified Persian and English text use the expected direction in user messages and the prompt editor.

### Screenshots / recordings

Before/after examples of the RTL rendering issue are available in #35319.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR