### PR TITLE
fix(tui): show slash command aliases in autocomplete suggestions

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -445,7 +445,19 @@ export function Autocomplete(props: {
   )
 
   const commands = createMemo((): AutocompleteOption[] => {
-    const results: AutocompleteOption[] = [...slashes()]
+    const results: AutocompleteOption[] = []
+    for (const slash of slashes()) {
+      results.push(slash)
+      if (slash.aliases) {
+        for (const alias of slash.aliases) {
+          results.push({
+            display: alias,
+            description: `(alias for ${slash.display.trimEnd()})`,
+            onSelect: slash.onSelect,
+          })
+        }
+      }
+    }
 
     for (const serverCommand of sync.data.command) {
       if (serverCommand.source === "skill") continue


### PR DESCRIPTION
### Issue for this PR
Closes #38043

### Type of change
- [x] Bug fix

### What does this PR do?
The TUI slash-command autocomplete popup only showed primary command names (e.g. `/new`, `/exit`, `/compact`). Aliases like `/clear`, `/quit`, `/q`, `/summarize` were functional when typed manually but invisible in the suggestions list.

This expands `slashAliases` into separate autocomplete entries so aliases appear alongside their primary commands in the popup.

### How did you verify your code works?
- Ran `bun install && bun dev` from the repo root
- Typed `/` in the TUI — aliases now appear in the suggestion list (e.g. `/clear`, `/quit`, `/q`, `/summarize`, `/resume`, `/continue`, `/mo`)
- Selected an alias and confirmed it triggers the same command as the primary name
- Fuzzy search still works for both primary names and aliases

### Screenshots / recordings
**Before:**
<img width="907" height="337" alt="before" src="https://github.com/user-attachments/assets/fdb23e27-0fe8-44ab-bf04-adac099dadb8" /> 

**After:**
<img width="876" height="373" alt="after" src="https://github.com/user-attachments/assets/96e9a0c6-e64b-4b04-a2f6-f066fd78278a" /> 

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR


