### PR TITLE
fix(app): support nested slash command autocomplete

### DIFF
--- a/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
@@ -26,17 +26,17 @@ describe("prompt input v2 interaction machine", () => {
     expect(closed.state.popover).toEqual({ type: "closed" })
   })
 
-  test("completes command names containing slashes", () => {
+  test("completes nested slash command names", () => {
     const open = transitionPromptInputV2(
       createPromptInputV2InteractionState(),
-      { type: "input.changed", value: "/ship/" },
+      { type: "input.changed", value: "/review/" },
       persisted(),
     )
-    const item = { ...command, label: "/ship/inline" }
-    const selected = transitionPromptInputV2(open.state, { type: "popover.select", item }, persisted("/ship/"))
+    const item = { ...command, label: "/review/nested" }
+    const selected = transitionPromptInputV2(open.state, { type: "popover.select", item }, persisted("/review/"))
 
-    expect(open.state.popover).toEqual({ type: "command-inline", query: "ship/" })
-    expect(selected.commands).toContainEqual({ type: "draft.setText", value: "/ship/inline " })
+    expect(open.state.popover).toEqual({ type: "command-inline", query: "review/" })
+    expect(selected.commands).toContainEqual({ type: "draft.setText", value: "/review/nested " })
   })
 
   test("opens context completion at the cursor", () => {

--- a/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
@@ -26,6 +26,19 @@ describe("prompt input v2 interaction machine", () => {
     expect(closed.state.popover).toEqual({ type: "closed" })
   })
 
+  test("completes command names containing slashes", () => {
+    const open = transitionPromptInputV2(
+      createPromptInputV2InteractionState(),
+      { type: "input.changed", value: "/ship/" },
+      persisted(),
+    )
+    const item = { ...command, label: "/ship/inline" }
+    const selected = transitionPromptInputV2(open.state, { type: "popover.select", item }, persisted("/ship/"))
+
+    expect(open.state.popover).toEqual({ type: "command-inline", query: "ship/" })
+    expect(selected.commands).toContainEqual({ type: "draft.setText", value: "/ship/inline " })
+  })
+
   test("opens context completion at the cursor", () => {
     const value = "alpha @sr omega"
     const input = persisted(value)

--- a/packages/session-ui/src/v2/components/prompt-input/machine.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.ts
@@ -102,7 +102,7 @@ function inputChanged(
     ])
   }
 
-  const command = value.match(/^\/([^\s/]*)$/)
+  const command = value.match(/^\/(\S*)$/)
   if (command) {
     const query = command[1] ?? ""
     return changed({ ...state, popover: { type: "command-inline", query }, focus: "editor" }, [
@@ -240,7 +240,7 @@ function populated(persisted: PromptInputV2PersistedState) {
 }
 
 function replaceTrigger(value: string, trigger: "@" | "/", replacement: string) {
-  const index = value.lastIndexOf(trigger)
+  const index = trigger === "/" ? value.indexOf(trigger) : value.lastIndexOf(trigger)
   return index < 0 ? replacement : value.slice(0, index) + replacement
 }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #38091

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allow `/` within slash-command queries and correctly replace the full command when selecting a nested suggestion.

Make it work the same as TUI.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Added tests and manual tested as video below.

### Screenshots / recordings

https://github.com/user-attachments/assets/4d3e0c5f-f21c-4082-b6c8-52693e39fc44

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR