### PR TITLE
fix(session): persist async prompts before responding

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -313,7 +313,11 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       payload: typeof PromptPayload.Type
     }) {
       yield* requireSession(ctx.params.sessionID)
-      yield* promptSvc.prompt({ ...ctx.payload, sessionID: ctx.params.sessionID }).pipe(
+      yield* promptSvc
+        .admit({ ...ctx.payload, sessionID: ctx.params.sessionID })
+        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+      if (ctx.payload.noReply === true) return HttpApiSchema.NoContent.make()
+      yield* promptSvc.loop({ sessionID: ctx.params.sessionID }).pipe(
         Effect.catchCause((cause) =>
           Effect.gen(function* () {
             yield* Effect.logError("prompt_async failed", { sessionID: ctx.params.sessionID, cause })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -101,6 +101,7 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
 
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
+  readonly admit: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
   readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
   readonly loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<SessionV1.WithParts, Session.BusyError>
@@ -1049,8 +1050,8 @@ const layer = Layer.effect(
       return { info, parts }
     }, Effect.scoped)
 
-    const prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error> = Effect.fn(
-      "SessionPrompt.prompt",
+    const admit: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error> = Effect.fn(
+      "SessionPrompt.admit",
     )(function* (input: PromptInput) {
       const session = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
       yield* revert.cleanup(session)
@@ -1066,6 +1067,13 @@ const layer = Layer.effect(
         yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
       }
 
+      return message
+    })
+
+    const prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error> = Effect.fn(
+      "SessionPrompt.prompt",
+    )(function* (input: PromptInput) {
+      const message = yield* admit(input)
       if (input.noReply === true) return message
       return yield* loop({ sessionID: input.sessionID })
     })
@@ -1482,6 +1490,7 @@ const layer = Layer.effect(
 
     return Service.of({
       cancel,
+      admit,
       prompt,
       loop,
       shell,

--- a/packages/opencode/test/server/httpapi-sdk.test.ts
+++ b/packages/opencode/test/server/httpapi-sdk.test.ts
@@ -757,6 +757,13 @@ describe("HttpApi SDK", () => {
         )
         const messages = yield* capture(() => sdk.session.messages({ sessionID }))
 
+        expect(asyncPrompt.status).toBe(204)
+        expect(
+          array(messages.data)
+            .flatMap((item) => array(record(item).parts))
+            .map((part) => record(part).text),
+        ).toContain("async hello")
+
         return {
           statuses: statuses({ session, prompt, asyncPrompt, messages }),
           promptRole: record(record(prompt.data).info).role,


### PR DESCRIPTION
### Issue for this PR

Closes #38092

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`prompt_async` could return 204 while the user message was still only inside a detached promise. This splits prompt admission from the model loop, awaits message and permission persistence, then leaves only the loop asynchronous. The existing synchronous prompt path uses the same admission helper.

### How did you verify your code works?

- `cd packages/opencode && bun test test/server/httpapi-sdk.test.ts -t 'matches generated SDK prompt no-reply routes'` — 1 passed
- `cd packages/opencode && bun typecheck` — passed
- The regression reads the session immediately after the 204 and finds the submitted text.

### Screenshots / recordings

Not applicable; no UI behavior changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
