### PR TITLE
fix(provider): recognize separator-free GLM 5.2 IDs

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -686,7 +686,7 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
   if (!model.capabilities.reasoning) return {}
 
   const id = model.id.toLowerCase()
-  const glm52 = ["glm-5.2", "glm-5-2", "glm-5p2"].some(
+  const glm52 = ["glm-5.2", "glm-5-2", "glm-5p2", "glm5.2", "glm5p2"].some(
     (name) => id.includes(name) || model.api.id.toLowerCase().includes(name),
   )
   if (

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3499,7 +3499,7 @@ describe("ProviderTransform.variants", () => {
   })
 
   test("recognizes GLM-5.2 provider model IDs", () => {
-    for (const id of ["accounts/fireworks/models/glm-5p2", "zai-org-glm-5-2", "umans-glm-5.2"]) {
+    for (const id of ["accounts/fireworks/models/glm-5p2", "zai-org-glm-5-2", "umans-glm-5.2", "glm5.2-fast"]) {
       const model = createMockModel({
         id: `test/${id}`,
         api: {


### PR DESCRIPTION
### Issue for this PR

Closes #38093

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The GLM 5.2 variant detector recognized separated IDs such as `glm-5.2`, but missed provider IDs such as `glm5.2-fast`. This adds the separator-free `glm5.2` and `glm5p2` spellings and a fixture for the reported ID.

### How did you verify your code works?

- `cd packages/opencode && bun test test/provider/transform.test.ts -t 'recognizes GLM-5.2 provider model IDs'` — 1 passed
- `cd packages/opencode && bun typecheck` — passed

### Screenshots / recordings

Not applicable; no UI behavior changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
