### PR TITLE
fix(tui): resolve task descriptions from metadata

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2237,11 +2237,20 @@ function Task(props: ToolProps) {
   )
 
   const status = createMemo(() => sync.data.session_status[sessionID() ?? ""])
+  const presentation = createMemo(() =>
+    taskPresentation(
+      props.input,
+      props.metadata,
+      props.part.state.status === "running" || props.part.state.status === "completed"
+        ? props.part.state.title
+        : undefined,
+    ),
+  )
   const isRunning = createMemo(() => {
     const value = status()
     return (
       props.part.state.status === "running" ||
-      (props.metadata.background === true && value !== undefined && value.type !== "idle")
+      (presentation().background && value !== undefined && value.type !== "idle")
     )
   })
   const retry = createMemo(() => {
@@ -2258,13 +2267,13 @@ function Task(props: ToolProps) {
   })
 
   const content = createMemo(() => {
-    const description = stringValue(props.input.description)
+    const description = presentation().description
     if (!description) return ""
     let content = [
       formatSubagentTitle(
         Locale.titlecase(stringValue(props.input.subagent_type) ?? "General"),
         description,
-        props.metadata.background === true,
+        presentation().background,
       ),
     ]
 
@@ -2292,7 +2301,7 @@ function Task(props: ToolProps) {
       separate={true}
       color={retry() ? theme.error : undefined}
       spinner={isRunning()}
-      complete={stringValue(props.input.description)}
+      complete={presentation().description}
       pending="Delegating..."
       part={props.part}
       onClick={() => {
@@ -2306,6 +2315,17 @@ function Task(props: ToolProps) {
       {content()}
     </InlineTool>
   )
+}
+
+export function taskPresentation(
+  input: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+  title?: unknown,
+) {
+  return {
+    description: stringValue(input.description) ?? stringValue(metadata.description) ?? stringValue(title),
+    background: metadata.background === true,
+  }
 }
 
 export function formatSubagentToolcalls(count: number) {

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -13,6 +13,7 @@ import {
   parseQuestionAnswers,
   parseQuestions,
   parseTodos,
+  taskPresentation,
   alwaysSeparate,
   toolDisplay,
 } from "../../../src/routes/session"
@@ -285,6 +286,17 @@ describe("TUI inline tool wrapping", () => {
     expect(formatSubagentTitle("Explore", "Inspect renderer", true)).toBe(
       "Explore Task (background) — Inspect renderer",
     )
+  })
+
+  test("resolves task descriptions from metadata and tool titles", () => {
+    expect(taskPresentation({}, { description: "Inspect task renderer", background: true })).toEqual({
+      description: "Inspect task renderer",
+      background: true,
+    })
+    expect(taskPresentation({}, {}, "Fallback title")).toEqual({
+      description: "Fallback title",
+      background: false,
+    })
   })
 
   test("keeps retry status ahead of wrapping messages", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #38094

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Task rows only read the description from tool input, so tasks whose description arrived through metadata could remain labeled `Delegating...`. The renderer now falls back from input description to metadata description and then the tool-state title. It also reads the canonical `metadata.background` flag.

### How did you verify your code works?

- `cd packages/tui && bun test test/cli/tui/inline-tool-wrap-snapshot.test.tsx -t 'resolves task descriptions from metadata and tool titles'` — 1 passed
- `cd packages/tui && bun typecheck` — passed
- The regression covers both metadata and title fallback paths.

### Screenshots / recordings

Not included. This changes the label's data fallback rather than its visual layout; the presentation result is covered by the focused renderer test.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
