### PR TITLE
fix(ui): improve progress circle contrast

### DIFF
--- a/packages/ui/src/v2/components/progress-circle-v2.css
+++ b/packages/ui/src/v2/components/progress-circle-v2.css
@@ -8,6 +8,6 @@
 }
 
 [data-component="progress-circle-v2"] [data-slot="progress-circle-v2-progress"] {
-  stroke: var(--v2-icon-icon-muted);
+  stroke: var(--v2-icon-icon-base);
   transition: stroke-dashoffset 0.35s cubic-bezier(0.65, 0, 0.35, 1);
 }


### PR DESCRIPTION
### Issue for this PR

Closes #37122

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes color of context icon on dark mode, keeping it consistent with the context tab that is working properly.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

Tested locally as following screenshots.

### Screenshots / recordings

Before:

<img width="1323" height="426" alt="image" src="https://github.com/user-attachments/assets/f94639ba-7f4b-44a4-92d7-959d2f32a924" />
<img width="1282" height="391" alt="image" src="https://github.com/user-attachments/assets/1a110680-b589-454e-a5cd-52c3e047c42f" />

After:

<img width="1759" height="298" alt="image" src="https://github.com/user-attachments/assets/811eb0ed-3406-4fb6-8c96-e05b222c321c" />
<img width="1756" height="289" alt="image" src="https://github.com/user-attachments/assets/93c2a311-7070-4200-8383-ead19852bb20" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
