### PR TITLE
fix: preserve runtime option defaults

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -552,7 +552,7 @@ export const layer = (options?: Options) => Layer.effect(
       ),
     )
 
-    const source = options?.url ?? "https://models.dev"
+    const source = options?.url || "https://models.dev"
     const fetch = options?.fetch ?? true
     const userAgent = `opencode/${InstallationChannel}/${InstallationVersion}/${options?.client ?? "cli"}`
     const filepath = path.join(

--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -236,6 +236,16 @@ describe("ModelsDev Service", () => {
     }),
   )
 
+  it.live("uses the default models URL when the configured URL is empty", () =>
+    Effect.gen(function* () {
+      const state = yield* Ref.make(initialState)
+      yield* ModelsDev.Service.use((service) => service.get()).pipe(
+        Effect.provide(buildLayer(state, { url: "", fetch: true })),
+      )
+      expect((yield* Ref.get(state)).calls[0]?.url).toBe("https://models.dev/api.json")
+    }),
+  )
+
   it.live("get() is single-flight under concurrent calls", () =>
     Effect.gen(function* () {
       yield* writeCache(fixture)

--- a/packages/server/src/options.ts
+++ b/packages/server/src/options.ts
@@ -7,7 +7,7 @@ export const ServerOptions = Schema.Struct({
   client: Schema.optional(Schema.String),
   hostname: Schema.optional(Schema.String),
   port: Schema.optional(
-    Schema.Int.check(Schema.isGreaterThanOrEqualTo(1), Schema.isLessThanOrEqualTo(65_535)),
+    Schema.Int.check(Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(65_535)),
   ),
   password: Schema.optional(Schema.String),
   simulation: Schema.optional(Schema.Boolean),

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -30,7 +30,7 @@ import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
 import { WellKnown } from "@opencode-ai/core/wellknown"
 import { Watcher } from "@opencode-ai/core/filesystem/watcher"
-import { HttpRouter, HttpServer } from "effect/unstable/http"
+import { HttpRouter } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Context, Effect, Layer, Option } from "effect"
 import { Api } from "./api"
@@ -143,5 +143,3 @@ function makeRoutes<AuthError, AuthServices>(
     }),
   )
 }
-
-export const webHandler = () => HttpRouter.toWebHandler(createRoutes().pipe(Layer.provide(HttpServer.layerServices)))

--- a/packages/server/test/options.test.ts
+++ b/packages/server/test/options.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { ServerOptions } from "@opencode-ai/server/options"
+import { Option, Schema } from "effect"
+
+const decode = Schema.decodeUnknownOption(ServerOptions)
+
+test("accepts ephemeral port zero", () => {
+  expect(Option.isSome(decode({ port: 0 }))).toBe(true)
+})
+
+test("rejects ports outside the valid range", () => {
+  expect(Option.isNone(decode({ port: -1 }))).toBe(true)
+  expect(Option.isNone(decode({ port: 65_536 }))).toBe(true)
+})


### PR DESCRIPTION
## Summary
- fall back to the public models.dev endpoint when an empty URL is configured
- allow port `0` so embedded servers can request an ephemeral port
- remove the unused `webHandler` export and its server-only dependency

## Testing
- `bun test test/models.test.ts` (`packages/core`)
- `bun typecheck` (`packages/core`)
- `bun test test/options.test.ts` (`packages/server`)
- `bun typecheck` (`packages/server`)
- push hook: full workspace typecheck (31 tasks)