### PR TITLE
fix(session): degrade unsupported attachment media types instead of failing the whole send

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -41,6 +41,7 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Truncate } from "@/tool/truncate"
 import { Image } from "@/image/image"
 import { decodeDataUrl } from "@/util/data-url"
+import { isMedia } from "@/util/media"
 import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Latch, Layer, Option, Scope, Context, Schema, Types } from "effect"
 import { InstanceState } from "@/effect/instance-state"
@@ -804,6 +805,21 @@ const layer = Layer.effect(
                   { ...part, messageID: info.id, sessionID: input.sessionID },
                 ]
               }
+              if (!isMedia(part.mime)) {
+                // Providers reject the whole message for unsupported file part
+                // media types ("file part media type ... functionality not
+                // supported"). Degrade to a synthetic notice instead — same
+                // treatment as unsupported binary MCP resources above.
+                return [
+                  {
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: `[Attachment omitted: "${part.filename ?? "file"}" (${part.mime}) is not a media type the model can ingest. Ask the user to place the file inside the workspace so it can be read with tools.]`,
+                  },
+                ]
+              }
               break
             case "file:": {
               yield* Effect.logInfo("file", { mime: part.mime })
@@ -943,6 +959,20 @@ const layer = Layer.effect(
                     text: exit.value.output,
                   },
                   { ...part, mime, messageID: info.id, sessionID: input.sessionID },
+                ]
+              }
+
+              if (!isMedia(mime)) {
+                // The file is already on disk — tell the agent where it is
+                // instead of forwarding a media type the provider will reject.
+                return [
+                  {
+                    messageID: info.id,
+                    sessionID: input.sessionID,
+                    type: "text",
+                    synthetic: true,
+                    text: `[Attachment on disk: "${part.filename ?? filepath}" (${mime}) at ${filepath}. This media type cannot be sent to the model directly — read the file with tools when its contents are needed.]`,
+                  },
                 ]
               }
 


### PR DESCRIPTION
## Problem

Attaching a file whose media type no provider accepts (xlsx, docx, zip, …) fails the entire message:

```
Opencode failed to send message with error: 'file part media type application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' functionality not supported.
```

`resolvePart` special-cases `text/plain` and directories, and `image.normalize` handles images — but any other mime is forwarded verbatim to the provider, which rejects the whole prompt. The user just loses the send.

## Fix

Mirror the treatment this file already gives unsupported **binary MCP resources** (`[Binary MCP resource omitted: … is not a supported attachment type]`):

- **`data:` file parts** with a non-media, non-text mime resolve to a synthetic text notice (`[Attachment omitted: "report.xlsx" (…) is not a media type the model can ingest. …]`) instead of being forwarded.
- **`file://` file parts** with an unsupported mime resolve to a synthetic text part pointing the agent at the on-disk path — the file is already in the workspace, so the agent can read it with tools (bash/python/read) instead of the send hard-failing.

`isMedia` comes from `@/util/media`, same helper `message-v2` uses for `stripMedia`.

Non-goal (possible follow-up): gating image/pdf parts on `model.capabilities.attachment` for text-only models — that flag is currently produced but never consumed on the send path.

## Testing

- `packages/opencode` `bun run typecheck` clean.
- Manually verified the placeholder text paths; behavior for text/plain, directories, and media attachments is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)