### PR TITLE
fix(core): enforce patch boundaries

### DIFF
--- a/packages/core/src/patch.ts
+++ b/packages/core/src/patch.ts
@@ -47,8 +47,8 @@ export function parse(patchText: string): Result.Result<ReadonlyArray<Hunk>, Par
   const lines = stripHeredoc(patchText.trim())
     .split("\n")
     .map((line) => (line.endsWith("\r") ? line.slice(0, -1) : line))
-  const begin = lines.findIndex((line) => line.trim() === "*** Begin Patch")
-  const end = lines.findIndex((line) => line.trim() === "*** End Patch")
+  const begin = lines[0]?.trim() === "*** Begin Patch" ? 0 : -1
+  const end = lines.at(-1)?.trim() === "*** End Patch" ? lines.length - 1 : -1
   if (begin === -1) return Result.fail(new BoundaryError({ boundary: "first" }))
   if (end === -1 || begin >= end) return Result.fail(new BoundaryError({ boundary: "last" }))
 

--- a/packages/core/test/patch.test.ts
+++ b/packages/core/test/patch.test.ts
@@ -44,6 +44,18 @@ describe("Patch", () => {
     expect(() => parse("*** Begin Patch\n*** Add File: add.txt\n+added")).toThrow(
       "The last line of the patch must be '*** End Patch'",
     )
+    expect(() => parse("extra\n*** Begin Patch\n*** End Patch")).toThrow(
+      "The first line of the patch must be '*** Begin Patch'",
+    )
+    expect(() => parse("*** Begin Patch\n*** Add File: add.txt\n+added\n*** End Patch\nextra")).toThrow(
+      "The last line of the patch must be '*** End Patch'",
+    )
+  })
+
+  test("allows whitespace after the end marker", () => {
+    expect(parse("*** Begin Patch\n*** Add File: add.txt\n+added\n*** End Patch\n \t\n")).toEqual([
+      { type: "add", path: "add.txt", contents: "added" },
+    ])
   })
 
   test("strips a heredoc wrapper", () => {


### PR DESCRIPTION
## Summary
- require begin and end markers to be the actual first and last non-whitespace lines
- reject content before or after the patch envelope
- port Codex trailing-content and trailing-whitespace coverage

## Testing
- `bun test test/patch.test.ts test/tool-patch.test.ts` (61 passed)

Stacked on #38134.