### PR TITLE
feat(app): show project name in session title

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -62,6 +62,7 @@ import { SessionContextUsage } from "@/components/session-context-usage"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
+import { displayName } from "@/pages/layout/helpers"
 import { useServerSDK } from "@/context/server-sdk"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
@@ -304,6 +305,7 @@ export function MessageTimeline(props: {
     return sync().data.message[id] ?? emptyMessages
   })
   const parentTitle = createMemo(() => sessionTitle(parent()?.title) ?? language.t("command.session.new"))
+  const projectLabel = createMemo(() => displayName(sync().project ?? { worktree: sdk().directory }))
   const getMsgParts = (msgId: string) => sync().data.part[msgId] ?? emptyParts
   const getMsgPart = (messageID: string, partID: string) => getMsgParts(messageID).find((part) => part.id === partID)
   const childTaskDescription = createMemo(() => {
@@ -1477,6 +1479,14 @@ export function MessageTimeline(props: {
                       />
                     </Show>
                   </Show>
+                  <span
+                    data-slot="session-title-project"
+                    class="ml-2 flex min-w-0 shrink items-center gap-1 text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-faint"
+                    title={projectLabel()}
+                  >
+                    <IconV2 name="folder" class="size-4 shrink-0" />
+                    <span class="min-w-0 truncate">{projectLabel()}</span>
+                  </span>
                 </div>
               </div>
               <Show when={sessionID()} keyed>


### PR DESCRIPTION
### Issue for this PR

Can't find a issue fitting

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Since V2 landed, I found myself having trouble figuring out in which project I currently am. I usually only can find out by hovering the tab, which is clumsy and slow.
This adds a faint project label (folder icon + name) after the session title so the active project is clear at a glance. 

I'm not sure, if we should have a different design for mobile, it works, but it leads to early truncation. We basically have the choice to remove it on mobile, keep it like this or move it to a differnt line (or place)

### How did you verify your code works?

Ran the web project locally and added a project to verify.

### Screenshots / recordings

<img width="705" height="189" alt="image" src="https://github.com/user-attachments/assets/75ceffe8-27e1-4256-9bcd-17e5e3059b10" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
