### PR TITLE
refactor(core): move database path policy

### DIFF
--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -4,7 +4,7 @@ import { NodeServices } from "@effect/platform-node"
 import { Service, type DiscoverOptions, type Info } from "@opencode-ai/client/effect/service"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Global } from "@opencode-ai/util/global"
-import { InstallationVersion } from "@opencode-ai/util/installation/version"
+import { InstallationChannel, InstallationVersion } from "@opencode-ai/util/installation/version"
 import { AppProcess } from "@opencode-ai/util/process"
 import { randomBytes, randomUUID } from "node:crypto"
 import path from "node:path"
@@ -75,7 +75,13 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
           password,
           simulation: truthy(process.env.OPENCODE_SIMULATE),
           database: {
-            path: process.env.OPENCODE_DB,
+            path:
+              process.env.OPENCODE_DB ??
+              (["latest", "beta", "prod"].includes(InstallationChannel) ||
+              process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
+              process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
+                ? "opencode.db"
+                : `opencode-${InstallationChannel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`),
           },
           models: {
             url: process.env.OPENCODE_MODELS_URL,

--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -6,7 +6,6 @@ import { Context, Effect, Layer, Schema } from "effect"
 import { Global } from "@opencode-ai/util/global"
 import { isAbsolute, join } from "path"
 import { DatabaseMigration } from "./migration"
-import { InstallationChannel } from "@opencode-ai/util/installation/version"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 
 const makeDatabase = EffectDrizzleSqlite.makeWithDefaults()
@@ -40,20 +39,12 @@ const databaseLayer = Layer.effect(
   }).pipe(Effect.orDie),
 )
 
-export function layer(options?: Options) {
+export function layer(options: Options = { path: ":memory:" }) {
   return Layer.suspend(() => {
     const provide = (filename: string) => databaseLayer.pipe(Layer.provide(sqliteLayer({ filename })))
-    if (options?.path === ":memory:" || (options?.path && isAbsolute(options.path))) return provide(options.path)
-    if (options?.path) return provide(join(Global.Path.data, options.path))
-    if (
-      ["latest", "beta", "prod"].includes(InstallationChannel) ||
-      process.env.OPENCODE_DISABLE_CHANNEL_DB === "1" ||
-      process.env.OPENCODE_DISABLE_CHANNEL_DB === "true"
-    )
-      return provide(join(Global.Path.data, "opencode.db"))
-    return provide(
-      join(Global.Path.data, `opencode-${InstallationChannel.replace(/[^a-zA-Z0-9._-]/g, "-")}.db`),
-    )
+    const filename = options.path ?? ":memory:"
+    if (filename === ":memory:" || isAbsolute(filename)) return provide(filename)
+    return provide(join(Global.Path.data, filename))
   })
 }
 


### PR DESCRIPTION
## Summary
- resolve release-channel database filenames in CLI startup
- remove installation-channel awareness from Core database construction
- default generic Core database construction to in-memory storage

## Testing
- full workspace typecheck
- CLI service suite: 17 passed; failed-boot registration test timed out before registration, including when run alone with explicit `OPENCODE_DB`