### PR TITLE
fix(core): align patch Unicode matching

### DIFF
--- a/packages/core/test/patch.test.ts
+++ b/packages/core/test/patch.test.ts
@@ -200,6 +200,22 @@ describe("Patch", () => {
     )
   })
 
+  test("does not normalize ellipses", () => {
+    expect(() =>
+      Patch.derive("ellipsis.txt", [{ oldLines: ["wait..."], newLines: ["done"] }], "wait…\n"),
+    ).toThrow("Failed to find expected lines")
+  })
+
+  test("prefers a later exact match over an earlier normalized match", () => {
+    expect(
+      Patch.derive(
+        "quotes.txt",
+        [{ oldLines: ['He said "hello"'], newLines: ['He said "goodbye"'] }],
+        'He said “hello”\nmiddle\nHe said "hello"\n',
+      ).content,
+    ).toBe('He said “hello”\nmiddle\nHe said "goodbye"\n')
+  })
+
   test("matches EOF-anchored chunks from the end", () => {
     expect(
       Patch.derive(

--- a/packages/util/src/patch.ts
+++ b/packages/util/src/patch.ts
@@ -228,7 +228,6 @@ const normalize = (value: string) =>
     .replace(/[‘’‚‛]/g, "'")
     .replace(/[“”„‟]/g, '"')
     .replace(/[‐‑‒–—―−]/g, "-")
-    .replace(/…/g, "...")
     .replace(/[\u00A0\u2002-\u200A\u202F\u205F\u3000]/g, " ")
 const splitBom = (text: string) =>
   text.startsWith("\uFEFF") ? { bom: true, text: text.slice(1) } : { bom: false, text }


### PR DESCRIPTION
## Summary
- stop treating Unicode ellipses and three ASCII periods as equivalent
- align the normalized character set with Codex
- verify later exact matches win over earlier normalized-only matches

## Testing
- `bun test test/patch.test.ts test/tool-patch.test.ts` (63 passed)
- `bun typecheck`