### PR TITLE
feat(ai): support Gemini thinking levels

### DIFF
--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -93,8 +93,10 @@ const GeminiToolConfig = Schema.Struct({
 
 const GeminiThinkingConfig = Schema.Struct({
   thinkingBudget: Schema.optional(Schema.Number),
+  thinkingLevel: Schema.optional(Schema.Literals(["minimal", "low", "medium", "high"])),
   includeThoughts: Schema.optional(Schema.Boolean),
 })
+type GeminiThinkingLevel = NonNullable<Schema.Schema.Type<typeof GeminiThinkingConfig>["thinkingLevel"]>
 
 const GeminiGenerationConfig = Schema.Struct({
   maxOutputTokens: Schema.optional(Schema.Number),
@@ -289,11 +291,16 @@ const lowerMessages = Effect.fn("Gemini.lowerMessages")(function* (request: LLMR
 
 const geminiOptions = (request: LLMRequest) => request.providerOptions?.gemini
 
+const isThinkingLevel = (value: unknown): value is GeminiThinkingLevel =>
+  value === "minimal" || value === "low" || value === "medium" || value === "high"
+
 const thinkingConfig = (request: LLMRequest) => {
   const value = geminiOptions(request)?.thinkingConfig
   if (!ProviderShared.isRecord(value)) return undefined
+  const thinkingLevel = value.thinkingLevel
   const result = {
     thinkingBudget: typeof value.thinkingBudget === "number" ? value.thinkingBudget : undefined,
+    thinkingLevel: isThinkingLevel(thinkingLevel) ? thinkingLevel : undefined,
     includeThoughts: typeof value.includeThoughts === "boolean" ? value.includeThoughts : undefined,
   }
   return Object.values(result).some((item) => item !== undefined) ? result : undefined

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -36,6 +36,20 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("prepares thinking level", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<Gemini.GeminiBody>(
+        LLM.request({
+          model,
+          prompt: "Say hello.",
+          providerOptions: { gemini: { thinkingConfig: { thinkingLevel: "minimal" } } },
+        }),
+      )
+
+      expect(prepared.body.generationConfig).toEqual({ thinkingConfig: { thinkingLevel: "minimal" } })
+    }),
+  )
+
   it.effect("lowers chronological system updates to wrapped user text in order", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<Gemini.GeminiBody>(


### PR DESCRIPTION
## What

Add Gemini `thinkingLevel` request support for models such as Gemini 3.6 Flash, which use level-based thinking controls instead of accepting a disabled legacy token budget.

## Before / After

**Before:** `providerOptions.gemini.thinkingConfig.thinkingLevel` was accepted by the provider-options container but dropped while lowering the request. Gemini 3.6 requests using the existing `thinkingBudget: 0` alternative failed with `400 INVALID_ARGUMENT`.

**After:** `minimal`, `low`, `medium`, and `high` thinking levels are validated and forwarded to `generationConfig.thinkingConfig`. Callers can request `thinkingLevel: "minimal"` and retain small output limits for latency-sensitive classification.

## How

- Extend `GeminiThinkingConfig` with the four supported thinking-level literals.
- Narrow unknown provider options before lowering `thinkingLevel` into the Gemini request body.
- Cover the prepared provider-native body in `packages/ai/test/provider/gemini.test.ts`.

## Scope

This does not select thinking levels automatically or change existing `thinkingBudget` behavior. Model-specific defaults remain owned by callers and model configuration.

## Testing

- `bun run test test/provider/gemini.test.ts` from `packages/ai`: 20 passed
- `bun run typecheck` from `packages/ai`: passed both package and public-type configs
- Push hook full workspace typecheck: 32 packages passed
- Live Gemini 3.6 eval verification: 295/295 requests completed with `thinkingLevel: "minimal"` and a 32-token output cap
