### PR TITLE
fix(opencode): replace exe stub with mjs launcher for Windows installs

### DIFF
--- a/packages/opencode/bin/opencode.mjs
+++ b/packages/opencode/bin/opencode.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "child_process"
+import { existsSync, readFileSync, realpathSync } from "fs"
+import { join, dirname } from "path"
+import { env } from "process"
+
+const forwardedSignals = ["SIGINT", "SIGTERM", "SIGHUP"]
+
+function printCorruptError(target) {
+  const line = "-".repeat(50)
+  console.error(`\n${line}`)
+  console.error("OpenCode installation is incomplete.")
+  console.error("")
+  console.error("The platform executable is missing or corrupted.")
+  console.error("")
+  console.error("The file at the following location is not a valid executable:")
+  console.error(`  ${target}`)
+  console.error("")
+  console.error("This usually means the postinstall step did not complete successfully.")
+  console.error("To fix this, reinstall without --ignore-scripts:")
+  console.error("  npm install -g opencode-ai")
+  console.error("")
+  console.error("Or run the postinstall script manually:")
+  console.error("  cd node_modules/opencode-ai && node postinstall.mjs")
+  console.error(`${line}\n`)
+}
+
+function run(target, args) {
+  let child
+  try {
+    child = spawn(target, args, { stdio: "inherit" })
+  } catch (error) {
+    printCorruptError(target)
+    process.exit(1)
+  }
+
+  child.on("error", (error) => {
+    if (error.code === "UNKNOWN" || error.code === "EINVAL" || error.code === "EBADF") {
+      printCorruptError(target)
+    } else {
+      console.error(`Failed to start OpenCode: ${error.message}`)
+    }
+    process.exit(1)
+  })
+
+  for (const signal of forwardedSignals) {
+    process.on(signal, () => {
+      try { child.kill(signal) } catch {}
+    })
+  }
+
+  child.on("exit", (code, signal) => {
+    for (const s of forwardedSignals) {
+      process.removeAllListeners(s)
+    }
+    if (signal) {
+      process.kill(process.pid, signal)
+      return
+    }
+    process.exit(typeof code === "number" ? code : 0)
+  })
+}
+
+const platformMap = { darwin: "darwin", linux: "linux", win32: "windows" }
+const archMap = { x64: "x64", arm64: "arm64", arm: "arm" }
+
+const osPlatform = platformMap[process.platform] ?? process.platform
+const osArch = archMap[process.arch] ?? process.arch
+const base = `opencode-${osPlatform}-${osArch}`
+const binaryName = process.platform === "win32" ? "opencode.exe" : "opencode"
+
+function supportsAvx2() {
+  if (osArch !== "x64") return false
+  if (osPlatform === "linux") {
+    try { return /(^|\s)avx2(\s|$)/i.test(readFileSync("/proc/cpuinfo", "utf8")) } catch { return false }
+  }
+  if (osPlatform === "darwin") {
+    try {
+      const r = spawnSync("sysctl", ["-n", "hw.optional.avx2_0"], { encoding: "utf8", timeout: 1500 })
+      if (r.status !== 0) return false
+      return (r.stdout || "").trim() === "1"
+    } catch { return false }
+  }
+  if (osPlatform === "windows") {
+    const cmd = '(Add-Type -MemberDefinition "[DllImport(""kernel32.dll"")] public static extern bool IsProcessorFeaturePresent(int ProcessorFeature);" -Name Kernel32 -Namespace Win32 -PassThru)::IsProcessorFeaturePresent(40)'
+    for (const exe of ["powershell.exe", "pwsh.exe", "pwsh", "powershell"]) {
+      try {
+        const r = spawnSync(exe, ["-NoProfile", "-NonInteractive", "-Command", cmd], { encoding: "utf8", timeout: 3000, windowsHide: true })
+        if (r.status !== 0) continue
+        const out = (r.stdout || "").trim().toLowerCase()
+        if (out === "true" || out === "1") return true
+        if (out === "false" || out === "0") return false
+      } catch { continue }
+    }
+    return false
+  }
+  return false
+}
+
+function isMusl() {
+  if (osPlatform !== "linux") return false
+  try { if (existsSync("/etc/alpine-release")) return true } catch {}
+  try {
+    const r = spawnSync("ldd", ["--version"], { encoding: "utf8" })
+    return `${r.stdout || ""}${r.stderr || ""}`.toLowerCase().includes("musl")
+  } catch { return false }
+}
+
+function packageNames() {
+  const avx2 = supportsAvx2()
+  const baseline = osArch === "x64" && !avx2
+
+  if (osPlatform === "linux") {
+    if (isMusl()) {
+      if (osArch === "x64") {
+        if (baseline) return [`${base}-baseline-musl`, `${base}-musl`, `${base}-baseline`, base]
+        return [`${base}-musl`, `${base}-baseline-musl`, base, `${base}-baseline`]
+      }
+      return [`${base}-musl`, base]
+    }
+    if (osArch === "x64") {
+      if (baseline) return [`${base}-baseline`, base, `${base}-baseline-musl`, `${base}-musl`]
+      return [base, `${base}-baseline`, `${base}-musl`, `${base}-baseline-musl`]
+    }
+    return [base, `${base}-musl`]
+  }
+
+  if (osArch === "x64") {
+    if (baseline) return [`${base}-baseline`, base]
+    return [base, `${base}-baseline`]
+  }
+  return [base]
+}
+
+function findInNodeModules(startDir) {
+  let current = startDir
+  while (true) {
+    const modulesDir = join(current, "node_modules")
+    if (existsSync(modulesDir)) {
+      for (const name of packageNames()) {
+        const candidate = join(modulesDir, name, "bin", binaryName)
+        if (existsSync(candidate)) return candidate
+      }
+    }
+    const parent = dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  return null
+}
+
+const scriptDir = dirname(realpathSync(process.argv[1]))
+const postinstallBinary = join(scriptDir, binaryName)
+const resolved =
+  env.OPENCODE_BIN_PATH ||
+  (existsSync(postinstallBinary) ? postinstallBinary : null) ||
+  findInNodeModules(scriptDir)
+
+if (!resolved || !existsSync(resolved)) {
+  const line = "-".repeat(50)
+  console.error(`\n${line}`)
+  console.error("OpenCode installation is incomplete.")
+  console.error("")
+  console.error("The platform executable has not been installed.")
+  console.error("")
+  console.error("This usually means the postinstall step did not complete successfully.")
+  console.error("This can happen when:")
+  console.error("  - Using --ignore-scripts during npm installation")
+  console.error("  - Using a package manager like pnpm that requires explicit postinstall")
+  console.error("  - The download was interrupted or failed")
+  console.error("  - Antivirus software removed the binary")
+  console.error("  - The platform package is missing from node_modules")
+  console.error("")
+  console.error("To fix this, reinstall without --ignore-scripts:")
+  console.error("  npm install -g opencode-ai")
+  console.error("")
+  console.error("Or run the postinstall script manually:")
+  console.error("  cd node_modules/opencode-ai && node postinstall.mjs")
+  console.error(`${line}\n`)
+  process.exit(1)
+}
+
+run(resolved, process.argv.slice(2))

--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -26,7 +26,7 @@ const platform = platformMap[os.platform()] ?? os.platform()
 const arch = archMap[os.arch()] ?? os.arch()
 const base = `opencode-${platform}-${arch}`
 const sourceBinary = platform === "windows" ? "opencode.exe" : "opencode"
-const targetBinary = path.join(__dirname, "bin", "opencode.exe")
+const targetBinary = path.join(__dirname, "bin", sourceBinary)
 
 function supportsAvx2() {
   if (arch !== "x64") return false

--- a/packages/opencode/script/publish.ts
+++ b/packages/opencode/script/publish.ts
@@ -35,28 +35,14 @@ await $`mkdir -p ./dist/${pkg.name}`
 await $`mkdir -p ./dist/${pkg.name}/bin`
 await $`cp ./script/postinstall.mjs ./dist/${pkg.name}/postinstall.mjs`
 await Bun.file(`./dist/${pkg.name}/LICENSE`).write(await Bun.file("../../LICENSE").text())
-await Bun.file(`./dist/${pkg.name}/bin/${pkg.name}.exe`).write(
-  [
-    `echo "Error: ${pkg.name}-ai's postinstall script was not run." >&2`,
-    'echo "" >&2',
-    'echo "This occurs when using --ignore-scripts during installation, or when using a" >&2',
-    'echo "package manager like pnpm that does not run postinstall scripts by default." >&2',
-    'echo "" >&2',
-    'echo "To fix this, run the postinstall script manually:" >&2',
-    `echo "  cd node_modules/${pkg.name}-ai && node postinstall.mjs" >&2`,
-    'echo "" >&2',
-    `echo "Or reinstall ${pkg.name}-ai without the --ignore-scripts flag." >&2`,
-    "exit 1",
-    "",
-  ].join("\n"),
-)
+await $`cp ./bin/opencode.mjs ./dist/${pkg.name}/bin/opencode.mjs`
 
 await Bun.file(`./dist/${pkg.name}/package.json`).write(
   JSON.stringify(
     {
       name: pkg.name + "-ai",
       bin: {
-        [pkg.name]: `./bin/${pkg.name}.exe`,
+        [pkg.name]: `./bin/${pkg.name}.mjs`,
       },
       scripts: {
         postinstall: "node ./postinstall.mjs",

--- a/packages/opencode/test/launcher/launcher.test.ts
+++ b/packages/opencode/test/launcher/launcher.test.ts
@@ -1,0 +1,99 @@
+import { spawnSync } from "child_process"
+import { mkdirSync, writeFileSync, chmodSync, realpathSync } from "fs"
+import { join, dirname } from "path"
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../fixture/fixture"
+
+const launcherPath = join(import.meta.dirname, "../../bin/opencode.mjs")
+const scriptDir = dirname(realpathSync(launcherPath))
+
+function createFakeBinary(dir: string, exitCode = 0, output = "opencode-test-version") {
+  const binaryName = process.platform === "win32" ? "opencode.exe" : "opencode"
+  mkdirSync(dir, { recursive: true })
+  const binPath = join(dir, binaryName)
+
+  if (process.platform === "win32") {
+    writeFileSync(binPath, `@echo off\r\necho ${output}\r\nexit /b ${exitCode}\r\n`)
+  } else {
+    writeFileSync(binPath, `#!/bin/sh\necho ${output}\nexit ${exitCode}\n`)
+    chmodSync(binPath, 0o755)
+  }
+
+  return binPath
+}
+
+function runLauncher(args: string[] = ["--version"], extraEnv?: Record<string, string>) {
+  return spawnSync(process.execPath, [launcherPath, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...extraEnv },
+    timeout: 10000,
+  })
+}
+
+describe("opencode.mjs launcher", () => {
+  test("resolves binary via OPENCODE_BIN_PATH env var", async () => {
+    await using tmp = await tmpdir()
+
+    const binaryName = process.platform === "win32" ? "opencode.exe" : "opencode"
+    const binPath = join(tmp.path, binaryName)
+    createFakeBinary(tmp.path)
+
+    const result = runLauncher(["--version"], { OPENCODE_BIN_PATH: binPath })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("opencode-test-version")
+  })
+
+  test("forwards arguments to the binary", async () => {
+    await using tmp = await tmpdir()
+
+    const binaryName = process.platform === "win32" ? "opencode.exe" : "opencode"
+    const binPath = join(tmp.path, binaryName)
+    mkdirSync(tmp.path, { recursive: true })
+
+    if (process.platform === "win32") {
+      writeFileSync(binPath, `@echo off\r\necho args: %*\r\nexit /b 0\r\n`)
+    } else {
+      writeFileSync(binPath, "#!/bin/sh\necho args: $@\nexit 0\n")
+      chmodSync(binPath, 0o755)
+    }
+
+    const result = runLauncher(["--version", "--model", "gpt-4"], { OPENCODE_BIN_PATH: binPath })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toContain("args: --version --model gpt-4")
+  })
+
+  test("propagates exit code from the binary", async () => {
+    await using tmp = await tmpdir()
+
+    const binPath = createFakeBinary(tmp.path, 42, "error occurred")
+    const result = runLauncher(["--version"], { OPENCODE_BIN_PATH: binPath })
+
+    expect(result.status).toBe(42)
+    expect(result.stdout).toContain("error occurred")
+  })
+
+  test("shows error when OPENCODE_BIN_PATH points to nonexistent path", async () => {
+    const badPath = join(scriptDir, "nonexistent-binary" + (process.platform === "win32" ? ".exe" : ""))
+    const result = runLauncher(["--version"], { OPENCODE_BIN_PATH: badPath })
+
+    // Should fail because the path doesn't exist
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain("OpenCode installation is incomplete")
+    expect(result.stderr).toContain("platform executable has not been installed")
+  })
+
+  test("loads platform package name for current system", () => {
+    // Verify the packageNames logic produces valid names
+    const platformMap: Record<string, string> = { darwin: "darwin", linux: "linux", win32: "windows" }
+    const archMap: Record<string, string> = { x64: "x64", arm64: "arm64", arm: "arm" }
+    const p = platformMap[process.platform] || process.platform
+    const a = archMap[process.arch] || process.arch
+
+    expect(p).toBeTruthy()
+    expect(a).toBeTruthy()
+    expect(p).toMatch(/^(darwin|linux|windows)$/)
+    expect(a).toMatch(/^(x64|arm64|arm)$/)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #38169

### Type of change

- [X] Bug fix

### What does this PR do?

Root Cause: The published opencode-ai npm package shipped bin/opencode.exe as a text-file placeholder stub. npm's generated wrappers invoked this .exe directly on Windows. When postinstall failed or was skipped (--ignore-scripts), the stub remained. Windows PE loader rejected the text file with 'not a valid application for this OS platform' and the meaningful error inside the stub was never displayed.

Fix: Replace the stub .exe with a Node.js .mjs launcher. npm generates 'node <script>' wrappers for .mjs entries, so the PE loader is never invoked. The launcher validates the real binary exists before spawning it and prints a clear actionable error if installation is incomplete.

### How did you verify your code works?

Verified empirically on Windows: old .exe entry produces PE loader error, new .mjs entry produces clear text error. All failure modes tested: missing binary, corrupt binary, missing platform package, failed postinstall, skipped postinstall.

### Screenshots / recordings

N/A (not a UI change)

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR