### PR TITLE
fix(config): escape substitutions before JSONC parsing

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -75,6 +75,7 @@ async function substituteWellKnownRemoteConfig(input: {
     dir: input.dir,
     source: input.source,
     env: input.env,
+    escape: false,
   })
   const headers = isRecord(input.value.headers)
     ? Object.fromEntries(
@@ -89,6 +90,7 @@ async function substituteWellKnownRemoteConfig(input: {
                 dir: input.dir,
                 source: input.source,
                 env: input.env,
+                escape: false,
               }),
             ]),
         ),
@@ -219,8 +221,8 @@ const layer = Layer.effect(
       const expanded = yield* Effect.promise(() =>
         ConfigVariable.substitute(
           "path" in options
-            ? { text, type: "path", path: options.path, env }
-            : { text, type: "virtual", ...options, env },
+            ? { text, type: "path", path: options.path, env, escape: true }
+            : { text, type: "virtual", ...options, env, escape: true },
         ),
       )
       const parsed = ConfigParse.jsonc(expanded, source)

--- a/packages/opencode/src/config/tui.ts
+++ b/packages/opencode/src/config/tui.ts
@@ -99,7 +99,13 @@ const loadState = Effect.fn("TuiConfig.loadState")(function* (ctx: { directory: 
   const load = (text: string, configFilepath: string): Effect.Effect<Info> =>
     Effect.gen(function* () {
       const expanded = yield* Effect.promise(() =>
-        ConfigVariable.substitute({ text, type: "path", path: configFilepath, missing: "empty" }),
+        ConfigVariable.substitute({
+          text,
+          type: "path",
+          path: configFilepath,
+          missing: "empty",
+          escape: true,
+        }),
       )
       const data = ConfigParse.jsonc(expanded, configFilepath)
       if (!isRecord(data)) return {} as Info

--- a/packages/opencode/src/config/variable.ts
+++ b/packages/opencode/src/config/variable.ts
@@ -20,6 +20,7 @@ type SubstituteInput = ParseSource & {
   text: string
   missing?: "error" | "empty"
   env?: Record<string, string>
+  escape: boolean
 }
 
 function source(input: ParseSource) {
@@ -30,11 +31,12 @@ function dir(input: ParseSource) {
   return input.type === "path" ? path.dirname(input.path) : input.dir
 }
 
-/** Apply {env:VAR} and {file:path} substitutions to config text. */
+/** Apply {env:VAR} and {file:path} substitutions. Escape values when the result will be parsed as JSONC. */
 export async function substitute(input: SubstituteInput) {
   const missing = input.missing ?? "error"
+  const render = input.escape ? (value: string) => JSON.stringify(value).slice(1, -1) : (value: string) => value
   let text = input.text.replace(/\{env:([^}]+)\}/g, (_, varName) => {
-    return (input.env?.[varName] ?? process.env[varName]) || ""
+    return render((input.env?.[varName] ?? process.env[varName]) || "")
   })
 
   const fileMatches = Array.from(text.matchAll(/\{file:[^}]+\}/g))
@@ -82,7 +84,7 @@ export async function substitute(input: SubstituteInput) {
       })
     ).trim()
 
-    out += JSON.stringify(fileContent).slice(1, -1)
+    out += render(fileContent)
     cursor = index + token.length
   }
 

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -505,6 +505,31 @@ it.instance("handles environment variable substitution", () =>
   ),
 )
 
+it.instance("escapes environment variables before parsing config", () =>
+  withProcessEnv(
+    "JSON_ENV_VAR",
+    'C:\\Users\\me\\AppData\\Local\\Tool\t"quoted"\nnext',
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      yield* FSUtil.use.writeWithDirs(
+        path.join(test.directory, "opencode.jsonc"),
+        `{
+          "username": "prefix-{env:JSON_ENV_VAR}-suffix",
+          "permission": {
+            "external_directory": {
+              "{env:JSON_ENV_VAR}/**": "allow"
+            }
+          }
+        }`,
+      )
+      const config = yield* Config.use.get()
+      const value = process.env.JSON_ENV_VAR!
+      expect(config.username).toBe(`prefix-${value}-suffix`)
+      expect(config.permission?.external_directory).toEqual({ [`${value}/**`]: "allow" })
+    }),
+  ),
+)
+
 it.instance("preserves env variables when adding $schema to config", () =>
   withProcessEnv(
     "PRESERVE_VAR",
@@ -1604,6 +1629,48 @@ remotePrecedenceWellKnown.it.instance(
     }),
 )
 
+const specialTokenWellKnown = wellKnown({
+  remoteConfig: {
+    url: "https://config.example.com/opencode.json",
+    headers: { Authorization: "Bearer {env:SPECIAL_TOKEN}" },
+  },
+  remote: {},
+})
+
+specialTokenWellKnown.it.instance("wellknown tokens are not JSON-escaped after parsing", () =>
+  withProcessEnv(
+    "SPECIAL_TOKEN",
+    'folder\\name"quoted"',
+    Effect.gen(function* () {
+      yield* Config.use.get()
+      const value = process.env.SPECIAL_TOKEN!
+      expect(specialTokenWellKnown.seen.remote).toBe("https://config.example.com/opencode.json")
+      expect(specialTokenWellKnown.seen.authorization).toBe(`Bearer ${value}`)
+    }),
+  ),
+)
+
+const wellKnownFile = path.join(os.tmpdir(), `opencode-wellknown-token-${process.pid}.txt`)
+const specialFileWellKnown = wellKnown({
+  remoteConfig: {
+    url: "https://config.example.com/opencode.json",
+    headers: { Authorization: `Bearer {file:${wellKnownFile}}` },
+  },
+  remote: {},
+})
+
+specialFileWellKnown.it.instance("wellknown file tokens are not JSON-escaped after parsing", () =>
+  Effect.acquireUseRelease(
+    FSUtil.use.writeWithDirs(wellKnownFile, 'folder\\name"quoted"'),
+    () =>
+      Effect.gen(function* () {
+        yield* Config.use.get()
+        expect(specialFileWellKnown.seen.authorization).toBe('Bearer folder\\name"quoted"')
+      }),
+    () => FSUtil.use.remove(wellKnownFile),
+  ),
+)
+
 const envIsolationWellKnown = wellKnown({
   remoteConfig: {
     url: "https://config.example.com/opencode.json",
@@ -1918,6 +1985,21 @@ describe("OPENCODE_CONFIG_CONTENT token substitution", () => {
         Effect.gen(function* () {
           const config = yield* Config.use.get()
           expect(config.username).toBe("test_api_key_12345")
+        }),
+      ),
+    ),
+  )
+
+  it.instance("escapes {env:} tokens in OPENCODE_CONFIG_CONTENT", () =>
+    withProcessEnv(
+      "TEST_CONFIG_VAR",
+      'C:\\Users\\me\t"quoted"\nnext',
+      withProcessEnv(
+        "OPENCODE_CONFIG_CONTENT",
+        `{"username":"{env:TEST_CONFIG_VAR}"}`,
+        Effect.gen(function* () {
+          const config = yield* Config.use.get()
+          expect(config.username).toBe(process.env.TEST_CONFIG_VAR)
         }),
       ),
     ),

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -703,6 +703,23 @@ it.instance("applies env and file substitutions in tui.json", () =>
   ),
 )
 
+it.instance("escapes environment variables before parsing tui config", () =>
+  withCleanState(
+    withEnv(
+      "TUI_THEME_TEST",
+      'C:\\themes\\"quoted"\nnext',
+      Effect.gen(function* () {
+        const fs = yield* FSUtil.Service
+        const test = yield* TestInstance
+        yield* fs.writeFileString(path.join(test.directory, "tui.jsonc"), `{"theme":"{env:TUI_THEME_TEST}"}`)
+
+        const config = yield* getTuiConfig(test.directory)
+        expect(config.theme).toBe(process.env.TUI_THEME_TEST)
+      }),
+    ),
+  ),
+)
+
 it.instance("applies file substitutions when first identical token is in a commented line", () =>
   withCleanState(
     Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #32695

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Config tokens are substituted before JSONC parsing. `{env:VAR}` values were inserted raw, so a native Windows path such as `C:\Users\me\...` produced invalid escapes and prevented OpenCode from starting. Quotes and control characters had the same problem.

This JSON-escapes env/file values only when the result is about to be parsed as JSONC. Well-known remote URL/header values are already parsed strings, so they keep raw substitution. The required `escape` flag makes every call site declare which context it uses.

### How did you verify your code works?

- `bun test test/config` (191 pass)
- `bun typecheck`
- Prettier check on all changed files
- Tests cover Windows paths in config values and permission keys, inline config, TUI config, and raw env/file values in well-known headers

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR