### PR TITLE
docs: add opencode-pollinations-plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -36,6 +36,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
+| [opencode-pollinations-plugin](https://github.com/fkom13/opencode-pollinations-plugin)             | Access Free and Enterprise Pollinations AI models (image, video, audio, TTS, STT, search)        |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -36,7 +36,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                      |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events               |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                              |
-| [opencode-pollinations-plugin](https://github.com/fkom13/opencode-pollinations-plugin)             | Access Free and Enterprise Pollinations AI models (image, video, audio, TTS, STT, search)        |
+| [opencode-pollinations-plugin](https://github.com/fkom13/opencode-pollinations-plugin)             | Free AI tools + premium models via Pollinations: image gen/edit, video, music, TTS, STT, search, quests, 1-click login, multilingual, cost guard |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection           |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                               |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                        |


### PR DESCRIPTION
### Issue for this PR

N/A — Plugin ecosystem addition.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-pollinations-plugin](https://github.com/fkom13/opencode-pollinations-plugin) to the Plugins list on the ecosystem documentation page.

The plugin provides:
- **Free AI tools** usable without any API key: image gen/edit, text-to-video, object remover, image upscaler/enhancer, background removal, QR codes, diagrams, palettes
- **Premium models** with generous hourly free tiers: image generation (Flux, Midjourney, Seedream, etc.), video generation (Wan, Veo, etc.), music, TTS/STT, web search
- **1-click login** via device flow (`/poll login`)
- **Cost Guard** protection and **Safety Net** auto-fallback to free models
- **6 languages** and quest/gamification system
- Transparent unified pricing (Pollen 🌻 currency)

### How did you verify your code works?

The change is a single row addition to a markdown table in the docs. Verified the file renders correctly.

### Screenshots / recordings

N/A — documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR