### PR TITLE
feat(session-ui): render mermaid code blocks as diagrams in chat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode",
@@ -818,6 +817,7 @@
         "marked": "catalog:",
         "marked-katex-extension": "5.1.6",
         "marked-shiki": "catalog:",
+        "mermaid": "11.16.0",
         "morphdom": "2.7.8",
         "motion": "12.34.5",
         "remeda": "catalog:",
@@ -1221,6 +1221,8 @@
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
 
     "@anycable/core": ["@anycable/core@0.9.2", "", { "dependencies": { "nanoevents": "^7.0.1" } }, "sha512-x5ZXDcW/N4cxWl93CnbHs/u7qq4793jS2kNPWm+duPrXlrva+ml2ZGT7X9tuOBKzyIHf60zWCdIK7TUgMPAwXA=="],
@@ -1443,11 +1445,15 @@
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
     "@bufbuild/protoplugin": ["@bufbuild/protoplugin@2.12.0", "", { "dependencies": { "@bufbuild/protobuf": "2.12.0", "@typescript/vfs": "^1.6.2", "typescript": "5.4.5" } }, "sha512-ORlDITp8AFUXzIhLRoMCG+ud+D3MPKWb5HQXBoskMMnjeyEjE1H1qLonVNPyOr8lkx3xSfYUo8a0dvOZJVAzow=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@2.4.0", "", { "dependencies": { "blob-to-buffer": "^1.2.8", "cross-fetch": "^3.0.4", "fontkit": "^2.0.2" } }, "sha512-GrSU71meACqcmIUxPYOJvGKF0yryjN/L1aCuE9DViCTJI7bfkjgYDPD1zbNDcINJwSSP6UaBZY9GAbYDO7re0Q=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@clack/core": ["@clack/core@1.0.0-alpha.1", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-rFbCU83JnN7l3W1nfgCqqme4ZZvTTgsiKQ6FM0l+r0P+o2eJpExcocBUWUIwnDzL76Aca9VhUdWmB2MbUv+Qyg=="],
 
@@ -1679,6 +1685,10 @@
 
     "@ibm/telemetry-js": ["@ibm/telemetry-js@1.11.0", "", { "bin": { "ibmtelemetry": "dist/collect.js" } }, "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
+
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
 
     "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
@@ -1824,6 +1834,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
@@ -2705,7 +2717,7 @@
 
     "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
 
-    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }, "sha512-7JjjA49VGNOsMRI8QRUhVudZmv0CnJ18SliSgK1ojszs/c3ijftgVkzvXdkSLN4miDTzbkXewf65D6ZBo6W+GQ=="],
+    "@solidjs/start": ["@solidjs/start@https://pkg.pr.new/@solidjs/start@dfb2020", { "dependencies": { "@babel/core": "^7.28.3", "@babel/traverse": "^7.28.3", "@babel/types": "^7.28.5", "@solidjs/meta": "^0.29.4", "@tanstack/server-functions-plugin": "1.134.5", "@types/babel__traverse": "^7.28.0", "@types/micromatch": "^4.0.9", "cookie-es": "^2.0.0", "defu": "^6.1.4", "error-stack-parser": "^2.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.25.3", "fast-glob": "^3.3.3", "h3": "npm:h3@2.0.1-rc.4", "html-to-image": "^1.11.13", "micromatch": "^4.0.8", "path-to-regexp": "^8.2.0", "pathe": "^2.0.3", "radix3": "^1.1.2", "seroval": "^1.3.2", "seroval-plugins": "^1.2.1", "shiki": "^1.26.1", "solid-js": "^1.9.9", "source-map-js": "^1.2.1", "srvx": "^0.9.1", "terracotta": "^1.0.6", "vite": "7.1.10", "vite-plugin-solid": "^2.11.9", "vitest": "^4.0.10" } }],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
 
@@ -2841,11 +2853,67 @@
 
     "@types/cross-spawn": ["@types/cross-spawn@6.0.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
     "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
 
     "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
 
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
     "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -2992,6 +3060,8 @@
     "@typespec/ts-http-runtime": ["@typespec/ts-http-runtime@0.3.5", "", { "dependencies": { "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "tslib": "^2.6.2" } }, "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@upstash/redis": ["@upstash/redis@1.38.0", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg=="],
 
@@ -3401,6 +3471,8 @@
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "crc": ["crc@3.8.0", "", { "dependencies": { "buffer": "^5.1.0" } }, "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
@@ -3429,21 +3501,77 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
     "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
 
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
     "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
 
     "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
 
     "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
 
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
     "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
 
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
     "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
 
     "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
 
     "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
@@ -3452,6 +3580,8 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "db0": ["db0@0.3.4", "", { "peerDependencies": { "@electric-sql/pglite": "*", "@libsql/client": "*", "better-sqlite3": "*", "drizzle-orm": "*", "mysql2": "*", "sqlite3": "*" }, "optionalPeers": ["@electric-sql/pglite", "@libsql/client", "better-sqlite3", "drizzle-orm", "mysql2", "sqlite3"] }, "sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw=="],
 
@@ -3482,6 +3612,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -3646,6 +3778,8 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
 
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
@@ -3845,7 +3979,7 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
-    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#83c0a07", {}, "anomalyco-ghostty-web-83c0a07", "sha512-Lf2v1agHkVUpMpHBWWuCZrhOEmcwwin5/Hboc9rZwQ7/CKkIh5rU1r1CvfLlhkMoFv+ed8z52RZ8hkzGZZj3MQ=="],
+    "ghostty-web": ["ghostty-web@github:anomalyco/ghostty-web#83c0a07", {}, "anomalyco-ghostty-web-83c0a07"],
 
     "giget": ["giget@2.0.0", "", { "dependencies": { "citty": "^0.1.6", "consola": "^3.4.0", "defu": "^6.1.4", "node-fetch-native": "^1.6.6", "nypm": "^0.6.0", "pathe": "^2.0.3" }, "bin": { "giget": "dist/cli.mjs" } }, "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA=="],
 
@@ -3884,6 +4018,8 @@
     "gtoken": ["gtoken@8.0.0", "", { "dependencies": { "gaxios": "^7.0.0", "jws": "^4.0.0" } }, "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw=="],
 
     "h3": ["h3@2.0.1-rc.4", "", { "dependencies": { "rou3": "^0.7.8", "srvx": "^0.9.1" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"] }, "sha512-vZq8pEUp6THsXKXrUXX44eOqfChic2wVQ1GlSzQCBr7DeFBkfIZAo2WyNND4GSv54TAa0E4LYIK73WSPdgKUgw=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
     "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
@@ -4209,6 +4345,8 @@
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
@@ -4220,6 +4358,8 @@
     "lang-map": ["lang-map@0.4.0", "", { "dependencies": { "language-map": "^1.1.0" } }, "sha512-oiSqZIEUnWdFeDNsp4HId4tAxdFbx5iMBOwA3666Fn2L8Khj8NiD9xRvMsGmKXopPVkaDFtSv3CJOmXFUB0Hcg=="],
 
     "language-map": ["language-map@1.5.0", "", {}, "sha512-n7gFZpe+DwEAX9cXVTw43i3wiudWDDtSn28RmdnS/HCPr284dQI/SztsamWanRr75oSlKSaGbV2nmWCTzGCoVg=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lazy-val": ["lazy-val@1.0.5", "", {}, "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="],
 
@@ -4258,6 +4398,8 @@
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
 
@@ -4372,6 +4514,8 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.16.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA=="],
 
     "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
 
@@ -4695,6 +4839,8 @@
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
@@ -4756,6 +4902,10 @@
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "poe-oauth": ["poe-oauth@0.0.8", "", {}, "sha512-zlaRVLR6vuxBIYUkZoTIVo3f8h3qd27gv9Ms+kmGiYEiiV4TdccddTdNcGyI0DnuJ9tVi+5LP3Bvzez59IFbjw=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -4997,15 +5147,21 @@
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.60.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.4", "@rollup/rollup-android-arm64": "4.60.4", "@rollup/rollup-darwin-arm64": "4.60.4", "@rollup/rollup-darwin-x64": "4.60.4", "@rollup/rollup-freebsd-arm64": "4.60.4", "@rollup/rollup-freebsd-x64": "4.60.4", "@rollup/rollup-linux-arm-gnueabihf": "4.60.4", "@rollup/rollup-linux-arm-musleabihf": "4.60.4", "@rollup/rollup-linux-arm64-gnu": "4.60.4", "@rollup/rollup-linux-arm64-musl": "4.60.4", "@rollup/rollup-linux-loong64-gnu": "4.60.4", "@rollup/rollup-linux-loong64-musl": "4.60.4", "@rollup/rollup-linux-ppc64-gnu": "4.60.4", "@rollup/rollup-linux-ppc64-musl": "4.60.4", "@rollup/rollup-linux-riscv64-gnu": "4.60.4", "@rollup/rollup-linux-riscv64-musl": "4.60.4", "@rollup/rollup-linux-s390x-gnu": "4.60.4", "@rollup/rollup-linux-x64-gnu": "4.60.4", "@rollup/rollup-linux-x64-musl": "4.60.4", "@rollup/rollup-openbsd-x64": "4.60.4", "@rollup/rollup-openharmony-arm64": "4.60.4", "@rollup/rollup-win32-arm64-msvc": "4.60.4", "@rollup/rollup-win32-ia32-msvc": "4.60.4", "@rollup/rollup-win32-x64-gnu": "4.60.4", "@rollup/rollup-win32-x64-msvc": "4.60.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "s-js": ["s-js@0.4.9", "", {}, "sha512-RtpOm+cM6O0sHg6IA70wH+UC3FZcND+rccBZpBAHzlUgNO2Bm5BN+FnM8+OBxzXdwpKWFwX11JGF0MFRkhSoIQ=="],
 
@@ -5236,6 +5392,8 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
@@ -5718,6 +5876,8 @@
     "@ai-sdk/xai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.13", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw=="],
 
     "@ai-sdk/xai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.35", "", { "dependencies": { "@ai-sdk/provider": "3.0.13", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg=="],
+
+    "@antfu/install-pkg/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "@astrojs/check/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -6253,6 +6413,16 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-dsv/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "dir-compare/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "dir-compare/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -6362,6 +6532,12 @@
     "matcher/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "md-to-react-email/marked": ["marked@7.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ=="],
+
+    "mermaid/dompurify": ["dompurify@3.4.12", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg=="],
+
+    "mermaid/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "micromark-extension-mdxjs/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -7053,6 +7229,12 @@
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
     "dir-compare/minimatch/brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
     "dir-compare/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
@@ -7128,6 +7310,8 @@
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
+    "mermaid/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "motion/framer-motion/motion-dom": ["motion-dom@12.40.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg=="],
 

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -59,6 +59,7 @@
     "marked": "catalog:",
     "marked-katex-extension": "5.1.6",
     "marked-shiki": "catalog:",
+    "mermaid": "11.16.0",
     "morphdom": "2.7.8",
     "motion": "12.34.5",
     "remeda": "catalog:",

--- a/packages/session-ui/src/components/markdown-mermaid-theme.ts
+++ b/packages/session-ui/src/components/markdown-mermaid-theme.ts
@@ -122,3 +122,47 @@ const light = withScales(
 export function mermaidThemeVariables(scheme: MermaidColorScheme) {
   return scheme === "dark" ? dark : light
 }
+
+type MermaidAccent = { fill: string; stroke: string }
+
+const darkAccents: Record<string, MermaidAccent> = {
+  info: { fill: "#243d5c", stroke: "#5b7fa6" },
+  success: { fill: "#2a3f22", stroke: "#6f9a62" },
+  warning: { fill: "#413620", stroke: "#8a7440" },
+  danger: { fill: "#46252e", stroke: "#b06a7a" },
+  muted: { fill: "#1a1d24", stroke: "#3d4451" },
+}
+
+const lightAccents: Record<string, MermaidAccent> = {
+  info: { fill: "#d8e4f3", stroke: "#7d9cc4" },
+  success: { fill: "#ddecd3", stroke: "#86ab78" },
+  warning: { fill: "#f1e7c6", stroke: "#b7a054" },
+  danger: { fill: "#f4dbe0", stroke: "#c2808f" },
+  muted: { fill: "#f8fafc", stroke: "#d3dae3" },
+}
+
+const storage: Record<MermaidColorScheme, MermaidAccent> = {
+  dark: { fill: "#3a2b4e", stroke: "#7d6a9e" },
+  light: { fill: "#e7def2", stroke: "#a48cc8" },
+}
+
+// Injected via mermaid's themeCSS, which stylis scopes under the rendered diagram's #id.
+// Flowchart nodes all carry class="node default", so semantics come from two layers:
+// shape buckets (polygons are decisions and other branch-like shapes, circles and stadium
+// groups are terminals, cylinder paths are storage) and author classes (`A:::warning`),
+// which mermaid passes through to the node without requiring a classDef. The doubled
+// class in semantic rules outranks the shape buckets; classDef inline styles still win.
+export function mermaidThemeCss(scheme: MermaidColorScheme) {
+  const accents = scheme === "dark" ? darkAccents : lightAccents
+  const shapes = [
+    `.node polygon.label-container { fill: ${accents.warning.fill}; stroke: ${accents.warning.stroke}; }`,
+    `.node circle.basic { fill: ${accents.info.fill}; stroke: ${accents.info.stroke}; }`,
+    `.node g.basic :is(path, circle) { fill: ${accents.info.fill}; stroke: ${accents.info.stroke}; }`,
+    `.node path.basic { fill: ${storage[scheme].fill}; stroke: ${storage[scheme].stroke}; }`,
+  ]
+  const semantic = Object.entries(accents).map(
+    ([name, accent]) =>
+      `.node.${name}.${name} :is(rect, polygon, circle, ellipse, path) { fill: ${accent.fill}; stroke: ${accent.stroke}; }`,
+  )
+  return [...shapes, ...semantic, `.node.muted.muted .label { opacity: 0.65; }`].join("\n")
+}

--- a/packages/session-ui/src/components/markdown-mermaid-theme.ts
+++ b/packages/session-ui/src/components/markdown-mermaid-theme.ts
@@ -1,0 +1,124 @@
+import type { MermaidColorScheme } from "./markdown-mermaid"
+
+// Slate theme for mermaid's "base" theme engine, tuned for parsing large charts:
+// neutral node surfaces, higher-contrast edges and borders, and desaturated categorical
+// hues (state/timeline/git scales) that stay distinguishable without overpowering labels.
+// Values must be concrete colors because mermaid derives unset tokens with color math.
+
+type MermaidThemeVariables = Record<string, string | boolean>
+
+function withScales(theme: MermaidThemeVariables, scale: string[], label: string) {
+  scale.forEach((color, index) => {
+    theme[`cScale${index}`] = color
+    theme[`cScaleLabel${index}`] = label
+    theme[`git${index}`] = color
+    theme[`gitBranchLabel${index}`] = label
+  })
+  return theme
+}
+
+const dark = withScales(
+  {
+    darkMode: true,
+    background: "#101014",
+    textColor: "#e2e8f0",
+    titleColor: "#f1f5f9",
+    lineColor: "#94a3b8",
+    defaultLinkColor: "#94a3b8",
+
+    mainBkg: "#1e293b",
+    nodeBorder: "#64748b",
+    nodeTextColor: "#e2e8f0",
+    primaryColor: "#1e293b",
+    primaryTextColor: "#e2e8f0",
+    primaryBorderColor: "#64748b",
+    secondaryColor: "#26324b",
+    secondaryBorderColor: "#5b6f96",
+    secondaryTextColor: "#dbe4f0",
+    tertiaryColor: "#1f3a37",
+    tertiaryBorderColor: "#4f7d76",
+    tertiaryTextColor: "#d7e8e5",
+
+    clusterBkg: "#161c28",
+    clusterBorder: "#475569",
+    edgeLabelBackground: "#101014",
+
+    noteBkgColor: "#382e1b",
+    noteTextColor: "#ecd9a8",
+    noteBorderColor: "#8a7440",
+
+    actorBkg: "#1e293b",
+    actorBorder: "#64748b",
+    actorTextColor: "#e2e8f0",
+    actorLineColor: "#64748b",
+    signalColor: "#94a3b8",
+    signalTextColor: "#cbd5e1",
+    labelBoxBkgColor: "#161c28",
+    labelBoxBorderColor: "#475569",
+    labelTextColor: "#cbd5e1",
+    loopTextColor: "#cbd5e1",
+    activationBkgColor: "#334155",
+    activationBorderColor: "#94a3b8",
+    sequenceNumberColor: "#0f172a",
+
+    errorBkgColor: "#3f1d1d",
+    errorTextColor: "#fca5a5",
+  },
+  ["#334155", "#243d5c", "#1c443c", "#413620", "#3a2b4e", "#46252e", "#2a3f22", "#1b4450"],
+  "#e2e8f0",
+)
+
+const light = withScales(
+  {
+    darkMode: false,
+    background: "#fafafa",
+    textColor: "#1e293b",
+    titleColor: "#0f172a",
+    lineColor: "#64748b",
+    defaultLinkColor: "#64748b",
+
+    mainBkg: "#f1f5f9",
+    nodeBorder: "#94a3b8",
+    nodeTextColor: "#1e293b",
+    primaryColor: "#f1f5f9",
+    primaryTextColor: "#1e293b",
+    primaryBorderColor: "#94a3b8",
+    secondaryColor: "#e5edf8",
+    secondaryBorderColor: "#8fa8c9",
+    secondaryTextColor: "#243b56",
+    tertiaryColor: "#e2f1ee",
+    tertiaryBorderColor: "#6fa298",
+    tertiaryTextColor: "#1f4d44",
+
+    clusterBkg: "#f8fafc",
+    clusterBorder: "#cbd5e1",
+    edgeLabelBackground: "#fafafa",
+
+    noteBkgColor: "#faf3dc",
+    noteTextColor: "#6a5518",
+    noteBorderColor: "#d3bc72",
+
+    actorBkg: "#f1f5f9",
+    actorBorder: "#94a3b8",
+    actorTextColor: "#1e293b",
+    actorLineColor: "#94a3b8",
+    signalColor: "#475569",
+    signalTextColor: "#334155",
+    labelBoxBkgColor: "#f8fafc",
+    labelBoxBorderColor: "#cbd5e1",
+    labelTextColor: "#334155",
+    loopTextColor: "#334155",
+    activationBkgColor: "#e2e8f0",
+    activationBorderColor: "#64748b",
+    sequenceNumberColor: "#f8fafc",
+
+    errorBkgColor: "#fee2e2",
+    errorTextColor: "#b91c1c",
+  },
+  ["#e2e8f0", "#d8e4f3", "#d5ebe4", "#f1e7c6", "#e7def2", "#f4dbe0", "#ddecd3", "#d3e7ee"],
+  "#1e293b",
+)
+
+export function mermaidThemeVariables(scheme: MermaidColorScheme) {
+  return scheme === "dark" ? dark : light
+}

--- a/packages/session-ui/src/components/markdown-mermaid-viewer.css
+++ b/packages/session-ui/src/components/markdown-mermaid-viewer.css
@@ -1,0 +1,69 @@
+[data-component="mermaid-viewer-overlay"] {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: var(--v2-overlay-simple-overlay-scrim);
+}
+
+[data-component="mermaid-viewer"] {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-content"] {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  outline: none;
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-toolbar"] {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 6px;
+  background: var(--v2-background-bg-layer-01);
+  border: 0.5px solid var(--v2-border-border-base);
+  box-shadow: var(--v2-elevation-floating);
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-zoom-level"] {
+  min-width: 44px;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: center;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--v2-text-text-muted);
+  cursor: pointer;
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-scroll"] {
+  flex: 1;
+  display: flex;
+  overflow: auto;
+  padding: 48px;
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-canvas"] {
+  box-sizing: content-box;
+  margin: auto;
+  padding: 24px;
+  border-radius: 8px;
+  background: var(--color-background-stronger);
+  border: 0.5px solid var(--v2-border-border-base);
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-canvas"] svg {
+  display: block;
+}

--- a/packages/session-ui/src/components/markdown-mermaid-viewer.css
+++ b/packages/session-ui/src/components/markdown-mermaid-viewer.css
@@ -59,6 +59,7 @@
   position: absolute;
   inset: 0;
   overflow: hidden;
+  outline: none;
   cursor: grab;
   touch-action: none;
   user-select: none;

--- a/packages/session-ui/src/components/markdown-mermaid-viewer.css
+++ b/packages/session-ui/src/components/markdown-mermaid-viewer.css
@@ -10,15 +10,22 @@
   inset: 0;
   z-index: 50;
   display: flex;
+  padding: 16px;
+  pointer-events: none;
 }
 
 [data-component="mermaid-viewer"] [data-slot="mermaid-viewer-content"] {
   position: relative;
   display: flex;
-  flex-direction: column;
   flex: 1;
   min-width: 0;
+  overflow: hidden;
   outline: none;
+  pointer-events: auto;
+  border-radius: 8px;
+  background: var(--color-background-stronger);
+  border: 0.5px solid var(--v2-border-border-base);
+  box-shadow: var(--v2-elevation-overlay);
 }
 
 [data-component="mermaid-viewer"] [data-slot="mermaid-viewer-toolbar"] {
@@ -48,22 +55,28 @@
   cursor: pointer;
 }
 
-[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-scroll"] {
-  flex: 1;
-  display: flex;
-  overflow: auto;
-  padding: 48px;
-}
-
 [data-component="mermaid-viewer"] [data-slot="mermaid-viewer-canvas"] {
-  box-sizing: content-box;
-  margin: auto;
-  padding: 24px;
-  border-radius: 8px;
-  background: var(--color-background-stronger);
-  border: 0.5px solid var(--v2-border-border-base);
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
 }
 
-[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-canvas"] svg {
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-canvas"][data-panning] {
+  cursor: grabbing;
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-stage"] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: 0 0;
+  will-change: transform;
+}
+
+[data-component="mermaid-viewer"] [data-slot="mermaid-viewer-stage"] svg {
   display: block;
+  pointer-events: none;
 }

--- a/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
+++ b/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
@@ -5,11 +5,12 @@ import { Icon } from "@opencode-ai/ui/v2/icon"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import {
-  clampMermaidZoom,
-  fitMermaidZoom,
+  fitMermaidCamera,
   mermaidColorScheme,
   renderMermaid,
   stepMermaidZoom,
+  zoomMermaidCamera,
+  type MermaidCamera,
 } from "./markdown-mermaid"
 
 export type MermaidViewerLabels = {
@@ -36,12 +37,12 @@ export function openMermaidViewer(input: { source: string; labels: MermaidViewer
 }
 
 function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onClose: () => void }) {
-  const [zoom, setZoom] = createSignal(1)
-  const [fit, setFit] = createSignal(1)
+  const [camera, setCamera] = createSignal({ zoom: 1, x: 0, y: 0 } satisfies MermaidCamera)
+  const [fit, setFit] = createSignal({ zoom: 1, x: 0, y: 0 } satisfies MermaidCamera)
   const [natural, setNatural] = createSignal<{ width: number; height: number }>()
   const [markup, setMarkup] = createSignal("")
-  let scroll: HTMLDivElement | undefined
   let canvas: HTMLDivElement | undefined
+  let panning: { id: number; x: number; y: number } | undefined
 
   createEffect(() => {
     const scheme = mermaidColorScheme()
@@ -50,10 +51,10 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
     })
   })
 
-  // Measure the fresh SVG and start at a fit-to-viewport zoom, but only fit once so
-  // theme-driven re-renders keep the user's zoom level.
+  // Measure the fresh SVG and start at a centered fit, but only once so theme-driven
+  // re-renders keep the user's camera.
   createEffect(() => {
-    if (!markup() || !canvas || !scroll) return
+    if (!markup() || !canvas) return
     const svg = canvas.querySelector("svg")
     if (!svg) return
     svg.style.maxWidth = "none"
@@ -64,29 +65,65 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
     const first = !natural()
     setNatural({ width: box.width, height: box.height })
     if (!first) return
-    const fitted = fitMermaidZoom(box, {
-      width: scroll.clientWidth - 96,
-      height: scroll.clientHeight - 96,
-    })
+    const fitted = fitMermaidCamera(box, { width: canvas.clientWidth, height: canvas.clientHeight })
     setFit(fitted)
-    setZoom(fitted)
+    setCamera(fitted)
   })
 
-  const width = () => {
-    const size = natural()
-    return size ? `${Math.round(size.width * zoom())}px` : "auto"
+  const localPoint = (event: { clientX: number; clientY: number }) => {
+    const rect = canvas!.getBoundingClientRect()
+    return { x: event.clientX - rect.left, y: event.clientY - rect.top }
   }
 
+  const center = () => ({ x: (canvas?.clientWidth ?? 0) / 2, y: (canvas?.clientHeight ?? 0) / 2 })
+
+  const zoomAt = (point: { x: number; y: number }, zoom: number) =>
+    setCamera((current) => zoomMermaidCamera(current, zoom, point))
+
+  // Figma-style input: plain wheel pans, ctrl/cmd + wheel (trackpad pinch) zooms at the cursor.
   const wheel = (event: WheelEvent) => {
-    if (!event.ctrlKey && !event.metaKey) return
     event.preventDefault()
-    setZoom((value) => clampMermaidZoom(value * Math.exp(-event.deltaY / 200)))
+    if (event.ctrlKey || event.metaKey) {
+      zoomAt(localPoint(event), camera().zoom * Math.exp(-event.deltaY / 150))
+      return
+    }
+    setCamera((current) => ({ ...current, x: current.x - event.deltaX, y: current.y - event.deltaY }))
+  }
+
+  const pointerDown = (event: PointerEvent) => {
+    if (event.button !== 0 || !canvas) return
+    canvas.setPointerCapture(event.pointerId)
+    canvas.dataset.panning = "true"
+    panning = { id: event.pointerId, x: event.clientX, y: event.clientY }
+  }
+
+  const pointerMove = (event: PointerEvent) => {
+    if (panning?.id !== event.pointerId) return
+    const dx = event.clientX - panning.x
+    const dy = event.clientY - panning.y
+    panning = { id: event.pointerId, x: event.clientX, y: event.clientY }
+    setCamera((current) => ({ ...current, x: current.x + dx, y: current.y + dy }))
+  }
+
+  const pointerUp = (event: PointerEvent) => {
+    if (panning?.id !== event.pointerId) return
+    panning = undefined
+    if (canvas) delete canvas.dataset.panning
+  }
+
+  const stageStyle = () => {
+    const size = natural()
+    const current = camera()
+    return {
+      width: size ? `${size.width}px` : "auto",
+      transform: `translate(${current.x}px, ${current.y}px) scale(${current.zoom})`,
+    }
   }
 
   return (
     <Dialog open modal onOpenChange={(open) => !open && props.onClose()}>
       <Dialog.Portal>
-        <Dialog.Overlay data-component="mermaid-viewer-overlay" />
+        <Dialog.Overlay data-component="mermaid-viewer-overlay" onClick={props.onClose} />
         <div data-component="mermaid-viewer">
           <Dialog.Content data-slot="mermaid-viewer-content">
             <div data-slot="mermaid-viewer-toolbar">
@@ -97,7 +134,7 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
                   variant="ghost-muted"
                   aria-label={props.labels.zoomOut}
                   icon={<Icon name="minus" />}
-                  onClick={() => setZoom((value) => stepMermaidZoom(value, -1))}
+                  onClick={() => zoomAt(center(), stepMermaidZoom(camera().zoom, -1))}
                 />
               </TooltipV2>
               <TooltipV2 placement="bottom" value={props.labels.zoomReset}>
@@ -105,9 +142,9 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
                   type="button"
                   data-slot="mermaid-viewer-zoom-level"
                   aria-label={props.labels.zoomReset}
-                  onClick={() => setZoom(fit())}
+                  onClick={() => setCamera(fit())}
                 >
-                  {Math.round(zoom() * 100)}%
+                  {Math.round(camera().zoom * 100)}%
                 </button>
               </TooltipV2>
               <TooltipV2 placement="bottom" value={props.labels.zoomIn}>
@@ -117,7 +154,7 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
                   variant="ghost-muted"
                   aria-label={props.labels.zoomIn}
                   icon={<Icon name="plus" />}
-                  onClick={() => setZoom((value) => stepMermaidZoom(value, 1))}
+                  onClick={() => zoomAt(center(), stepMermaidZoom(camera().zoom, 1))}
                 />
               </TooltipV2>
               <TooltipV2 placement="bottom" value={props.labels.close}>
@@ -132,12 +169,16 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
               </TooltipV2>
             </div>
             <div
-              data-slot="mermaid-viewer-scroll"
-              ref={scroll}
+              data-slot="mermaid-viewer-canvas"
+              ref={canvas}
               onWheel={wheel}
-              onClick={(event) => event.target === event.currentTarget && props.onClose()}
+              onPointerDown={pointerDown}
+              onPointerMove={pointerMove}
+              onPointerUp={pointerUp}
+              onPointerCancel={pointerUp}
+              onDblClick={(event) => zoomAt(localPoint(event), stepMermaidZoom(camera().zoom, 1))}
             >
-              <div data-slot="mermaid-viewer-canvas" ref={canvas} style={{ width: width() }} innerHTML={markup()} />
+              <div data-slot="mermaid-viewer-stage" style={stageStyle()} innerHTML={markup()} />
             </div>
           </Dialog.Content>
         </div>

--- a/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
+++ b/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
@@ -1,0 +1,147 @@
+import { Dialog } from "@kobalte/core/dialog"
+import { createEffect, createSignal } from "solid-js"
+import { render } from "solid-js/web"
+import { Icon } from "@opencode-ai/ui/v2/icon"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
+import {
+  clampMermaidZoom,
+  fitMermaidZoom,
+  mermaidColorScheme,
+  renderMermaid,
+  stepMermaidZoom,
+} from "./markdown-mermaid"
+
+export type MermaidViewerLabels = {
+  zoomIn: string
+  zoomOut: string
+  zoomReset: string
+  close: string
+}
+
+let active = false
+
+export function openMermaidViewer(input: { source: string; labels: MermaidViewerLabels }) {
+  if (active || typeof document !== "object") return
+  active = true
+  const host = document.createElement("div")
+  document.body.appendChild(host)
+  let dispose = () => {}
+  const close = () => {
+    active = false
+    dispose()
+    host.remove()
+  }
+  dispose = render(() => <MermaidViewer source={input.source} labels={input.labels} onClose={close} />, host)
+}
+
+function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onClose: () => void }) {
+  const [zoom, setZoom] = createSignal(1)
+  const [fit, setFit] = createSignal(1)
+  const [natural, setNatural] = createSignal<{ width: number; height: number }>()
+  const [markup, setMarkup] = createSignal("")
+  let scroll: HTMLDivElement | undefined
+  let canvas: HTMLDivElement | undefined
+
+  createEffect(() => {
+    const scheme = mermaidColorScheme()
+    void renderMermaid(props.source, scheme).then((result) => {
+      if (result.ok && scheme === mermaidColorScheme()) setMarkup(result.svg)
+    })
+  })
+
+  // Measure the fresh SVG and start at a fit-to-viewport zoom, but only fit once so
+  // theme-driven re-renders keep the user's zoom level.
+  createEffect(() => {
+    if (!markup() || !canvas || !scroll) return
+    const svg = canvas.querySelector("svg")
+    if (!svg) return
+    svg.style.maxWidth = "none"
+    svg.style.width = "100%"
+    svg.style.height = "auto"
+    const box = svg.viewBox.baseVal
+    if (!box?.width || !box?.height) return
+    const first = !natural()
+    setNatural({ width: box.width, height: box.height })
+    if (!first) return
+    const fitted = fitMermaidZoom(box, {
+      width: scroll.clientWidth - 96,
+      height: scroll.clientHeight - 96,
+    })
+    setFit(fitted)
+    setZoom(fitted)
+  })
+
+  const width = () => {
+    const size = natural()
+    return size ? `${Math.round(size.width * zoom())}px` : "auto"
+  }
+
+  const wheel = (event: WheelEvent) => {
+    if (!event.ctrlKey && !event.metaKey) return
+    event.preventDefault()
+    setZoom((value) => clampMermaidZoom(value * Math.exp(-event.deltaY / 200)))
+  }
+
+  return (
+    <Dialog open modal onOpenChange={(open) => !open && props.onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay data-component="mermaid-viewer-overlay" />
+        <div data-component="mermaid-viewer">
+          <Dialog.Content data-slot="mermaid-viewer-content">
+            <div data-slot="mermaid-viewer-toolbar">
+              <TooltipV2 placement="bottom" value={props.labels.zoomOut}>
+                <IconButtonV2
+                  type="button"
+                  size="normal"
+                  variant="ghost-muted"
+                  aria-label={props.labels.zoomOut}
+                  icon={<Icon name="minus" />}
+                  onClick={() => setZoom((value) => stepMermaidZoom(value, -1))}
+                />
+              </TooltipV2>
+              <TooltipV2 placement="bottom" value={props.labels.zoomReset}>
+                <button
+                  type="button"
+                  data-slot="mermaid-viewer-zoom-level"
+                  aria-label={props.labels.zoomReset}
+                  onClick={() => setZoom(fit())}
+                >
+                  {Math.round(zoom() * 100)}%
+                </button>
+              </TooltipV2>
+              <TooltipV2 placement="bottom" value={props.labels.zoomIn}>
+                <IconButtonV2
+                  type="button"
+                  size="normal"
+                  variant="ghost-muted"
+                  aria-label={props.labels.zoomIn}
+                  icon={<Icon name="plus" />}
+                  onClick={() => setZoom((value) => stepMermaidZoom(value, 1))}
+                />
+              </TooltipV2>
+              <TooltipV2 placement="bottom" value={props.labels.close}>
+                <IconButtonV2
+                  type="button"
+                  size="normal"
+                  variant="ghost-muted"
+                  aria-label={props.labels.close}
+                  icon={<Icon name="close" />}
+                  onClick={props.onClose}
+                />
+              </TooltipV2>
+            </div>
+            <div
+              data-slot="mermaid-viewer-scroll"
+              ref={scroll}
+              onWheel={wheel}
+              onClick={(event) => event.target === event.currentTarget && props.onClose()}
+            >
+              <div data-slot="mermaid-viewer-canvas" ref={canvas} style={{ width: width() }} innerHTML={markup()} />
+            </div>
+          </Dialog.Content>
+        </div>
+      </Dialog.Portal>
+    </Dialog>
+  )
+}

--- a/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
+++ b/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
@@ -136,7 +136,15 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
       <Dialog.Portal>
         <Dialog.Overlay data-component="mermaid-viewer-overlay" onClick={props.onClose} />
         <div data-component="mermaid-viewer">
-          <Dialog.Content data-slot="mermaid-viewer-content">
+          <Dialog.Content
+            data-slot="mermaid-viewer-content"
+            onOpenAutoFocus={(event) => {
+              // Keep focus inside the dialog so Escape still closes it, but on the canvas
+              // instead of the first toolbar button, which would flash a focus ring.
+              event.preventDefault()
+              canvas?.focus({ preventScroll: true })
+            }}
+          >
             <div data-slot="mermaid-viewer-toolbar">
               <TooltipV2 placement="bottom" value={props.labels.zoomOut}>
                 <IconButtonV2
@@ -182,6 +190,7 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
             <div
               data-slot="mermaid-viewer-canvas"
               ref={canvas}
+              tabindex="-1"
               onWheel={wheel}
               onPointerDown={pointerDown}
               onPointerMove={pointerMove}

--- a/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
+++ b/packages/session-ui/src/components/markdown-mermaid-viewer.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@kobalte/core/dialog"
-import { createEffect, createSignal } from "solid-js"
+import { createEffect, createSignal, onCleanup } from "solid-js"
 import { render } from "solid-js/web"
 import { Icon } from "@opencode-ai/ui/v2/icon"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
@@ -37,12 +37,34 @@ export function openMermaidViewer(input: { source: string; labels: MermaidViewer
 }
 
 function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onClose: () => void }) {
-  const [camera, setCamera] = createSignal({ zoom: 1, x: 0, y: 0 } satisfies MermaidCamera)
-  const [fit, setFit] = createSignal({ zoom: 1, x: 0, y: 0 } satisfies MermaidCamera)
-  const [natural, setNatural] = createSignal<{ width: number; height: number }>()
+  const [percent, setPercent] = createSignal(100)
   const [markup, setMarkup] = createSignal("")
   let canvas: HTMLDivElement | undefined
+  let stage: HTMLDivElement | undefined
+  let camera: MermaidCamera = { zoom: 1, x: 0, y: 0 }
+  let fit: MermaidCamera = { zoom: 1, x: 0, y: 0 }
+  let measured = false
+  let frame: number | undefined
   let panning: { id: number; x: number; y: number } | undefined
+
+  // Wheel and pointer events fire faster than the display refreshes, so camera updates
+  // coalesce into a single direct transform write per frame; only the toolbar percentage
+  // goes through a signal.
+  const apply = () => {
+    frame = undefined
+    if (!stage) return
+    stage.style.transform = `translate(${camera.x}px, ${camera.y}px) scale(${camera.zoom})`
+    setPercent(Math.round(camera.zoom * 100))
+  }
+
+  const update = (next: MermaidCamera) => {
+    camera = next
+    frame ??= requestAnimationFrame(apply)
+  }
+
+  onCleanup(() => {
+    if (frame !== undefined) cancelAnimationFrame(frame)
+  })
 
   createEffect(() => {
     const scheme = mermaidColorScheme()
@@ -54,20 +76,19 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
   // Measure the fresh SVG and start at a centered fit, but only once so theme-driven
   // re-renders keep the user's camera.
   createEffect(() => {
-    if (!markup() || !canvas) return
-    const svg = canvas.querySelector("svg")
+    if (!markup() || !canvas || !stage) return
+    const svg = stage.querySelector("svg")
     if (!svg) return
     svg.style.maxWidth = "none"
     svg.style.width = "100%"
     svg.style.height = "auto"
     const box = svg.viewBox.baseVal
     if (!box?.width || !box?.height) return
-    const first = !natural()
-    setNatural({ width: box.width, height: box.height })
-    if (!first) return
-    const fitted = fitMermaidCamera(box, { width: canvas.clientWidth, height: canvas.clientHeight })
-    setFit(fitted)
-    setCamera(fitted)
+    stage.style.width = `${box.width}px`
+    if (measured) return
+    measured = true
+    fit = fitMermaidCamera(box, { width: canvas.clientWidth, height: canvas.clientHeight })
+    update(fit)
   })
 
   const localPoint = (event: { clientX: number; clientY: number }) => {
@@ -77,17 +98,16 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
 
   const center = () => ({ x: (canvas?.clientWidth ?? 0) / 2, y: (canvas?.clientHeight ?? 0) / 2 })
 
-  const zoomAt = (point: { x: number; y: number }, zoom: number) =>
-    setCamera((current) => zoomMermaidCamera(current, zoom, point))
+  const zoomAt = (point: { x: number; y: number }, zoom: number) => update(zoomMermaidCamera(camera, zoom, point))
 
   // Figma-style input: plain wheel pans, ctrl/cmd + wheel (trackpad pinch) zooms at the cursor.
   const wheel = (event: WheelEvent) => {
     event.preventDefault()
     if (event.ctrlKey || event.metaKey) {
-      zoomAt(localPoint(event), camera().zoom * Math.exp(-event.deltaY / 150))
+      zoomAt(localPoint(event), camera.zoom * Math.exp(-event.deltaY / 150))
       return
     }
-    setCamera((current) => ({ ...current, x: current.x - event.deltaX, y: current.y - event.deltaY }))
+    update({ ...camera, x: camera.x - event.deltaX, y: camera.y - event.deltaY })
   }
 
   const pointerDown = (event: PointerEvent) => {
@@ -102,22 +122,13 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
     const dx = event.clientX - panning.x
     const dy = event.clientY - panning.y
     panning = { id: event.pointerId, x: event.clientX, y: event.clientY }
-    setCamera((current) => ({ ...current, x: current.x + dx, y: current.y + dy }))
+    update({ ...camera, x: camera.x + dx, y: camera.y + dy })
   }
 
   const pointerUp = (event: PointerEvent) => {
     if (panning?.id !== event.pointerId) return
     panning = undefined
     if (canvas) delete canvas.dataset.panning
-  }
-
-  const stageStyle = () => {
-    const size = natural()
-    const current = camera()
-    return {
-      width: size ? `${size.width}px` : "auto",
-      transform: `translate(${current.x}px, ${current.y}px) scale(${current.zoom})`,
-    }
   }
 
   return (
@@ -134,7 +145,7 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
                   variant="ghost-muted"
                   aria-label={props.labels.zoomOut}
                   icon={<Icon name="minus" />}
-                  onClick={() => zoomAt(center(), stepMermaidZoom(camera().zoom, -1))}
+                  onClick={() => zoomAt(center(), stepMermaidZoom(camera.zoom, -1))}
                 />
               </TooltipV2>
               <TooltipV2 placement="bottom" value={props.labels.zoomReset}>
@@ -142,9 +153,9 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
                   type="button"
                   data-slot="mermaid-viewer-zoom-level"
                   aria-label={props.labels.zoomReset}
-                  onClick={() => setCamera(fit())}
+                  onClick={() => update(fit)}
                 >
-                  {Math.round(camera().zoom * 100)}%
+                  {percent()}%
                 </button>
               </TooltipV2>
               <TooltipV2 placement="bottom" value={props.labels.zoomIn}>
@@ -154,7 +165,7 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
                   variant="ghost-muted"
                   aria-label={props.labels.zoomIn}
                   icon={<Icon name="plus" />}
-                  onClick={() => zoomAt(center(), stepMermaidZoom(camera().zoom, 1))}
+                  onClick={() => zoomAt(center(), stepMermaidZoom(camera.zoom, 1))}
                 />
               </TooltipV2>
               <TooltipV2 placement="bottom" value={props.labels.close}>
@@ -176,9 +187,9 @@ function MermaidViewer(props: { source: string; labels: MermaidViewerLabels; onC
               onPointerMove={pointerMove}
               onPointerUp={pointerUp}
               onPointerCancel={pointerUp}
-              onDblClick={(event) => zoomAt(localPoint(event), stepMermaidZoom(camera().zoom, 1))}
+              onDblClick={(event) => zoomAt(localPoint(event), stepMermaidZoom(camera.zoom, 1))}
             >
-              <div data-slot="mermaid-viewer-stage" style={stageStyle()} innerHTML={markup()} />
+              <div data-slot="mermaid-viewer-stage" ref={stage} innerHTML={markup()} />
             </div>
           </Dialog.Content>
         </div>

--- a/packages/session-ui/src/components/markdown-mermaid.test.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.test.ts
@@ -6,7 +6,7 @@ import {
   stepMermaidZoom,
   zoomMermaidCamera,
 } from "./markdown-mermaid"
-import { mermaidThemeVariables } from "./markdown-mermaid-theme"
+import { mermaidThemeCss, mermaidThemeVariables } from "./markdown-mermaid-theme"
 
 describe("isMermaidLanguage", () => {
   test("matches mermaid fences case-insensitively", () => {
@@ -50,6 +50,23 @@ describe("mermaidThemeVariables", () => {
       expect(scale.every((color) => typeof color === "string")).toBe(true)
       expect(theme.git0).toBe(theme.cScale0)
     }
+  })
+})
+
+describe("mermaidThemeCss", () => {
+  test("covers shape buckets and semantic author classes with concrete hex colors", () => {
+    for (const scheme of ["light", "dark"] as const) {
+      const css = mermaidThemeCss(scheme)
+      expect(css).toContain(".node polygon.label-container")
+      expect(css).toContain(".node path.basic")
+      for (const name of ["info", "success", "warning", "danger", "muted"]) {
+        expect(css).toContain(`.node.${name}.${name}`)
+      }
+      const colors = css.match(/#[0-9a-zA-Z]+/g) ?? []
+      expect(colors.length).toBeGreaterThan(0)
+      expect(colors.every((color) => /^#[0-9a-f]{6}$/i.test(color))).toBe(true)
+    }
+    expect(mermaidThemeCss("light")).not.toBe(mermaidThemeCss("dark"))
   })
 })
 

--- a/packages/session-ui/src/components/markdown-mermaid.test.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { isMermaidLanguage, mermaidThemeFor } from "./markdown-mermaid"
+
+describe("isMermaidLanguage", () => {
+  test("matches mermaid fences case-insensitively", () => {
+    expect(isMermaidLanguage("mermaid")).toBe(true)
+    expect(isMermaidLanguage("Mermaid")).toBe(true)
+    expect(isMermaidLanguage("  mermaid  ")).toBe(true)
+  })
+
+  test("ignores other languages", () => {
+    expect(isMermaidLanguage("ts")).toBe(false)
+    expect(isMermaidLanguage("markdown")).toBe(false)
+    expect(isMermaidLanguage("")).toBe(false)
+    expect(isMermaidLanguage(undefined)).toBe(false)
+  })
+})
+
+describe("mermaidThemeFor", () => {
+  test("maps the app color scheme to a mermaid theme", () => {
+    expect(mermaidThemeFor("dark")).toBe("dark")
+    expect(mermaidThemeFor("light")).toBe("default")
+  })
+})

--- a/packages/session-ui/src/components/markdown-mermaid.test.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.test.ts
@@ -3,10 +3,10 @@ import {
   clampMermaidZoom,
   fitMermaidCamera,
   isMermaidLanguage,
-  mermaidThemeFor,
   stepMermaidZoom,
   zoomMermaidCamera,
 } from "./markdown-mermaid"
+import { mermaidThemeVariables } from "./markdown-mermaid-theme"
 
 describe("isMermaidLanguage", () => {
   test("matches mermaid fences case-insensitively", () => {
@@ -23,10 +23,33 @@ describe("isMermaidLanguage", () => {
   })
 })
 
-describe("mermaidThemeFor", () => {
-  test("maps the app color scheme to a mermaid theme", () => {
-    expect(mermaidThemeFor("dark")).toBe("dark")
-    expect(mermaidThemeFor("light")).toBe("default")
+describe("mermaidThemeVariables", () => {
+  test("every color is concrete hex so mermaid's color derivation cannot throw", () => {
+    for (const scheme of ["light", "dark"] as const) {
+      for (const [key, value] of Object.entries(mermaidThemeVariables(scheme))) {
+        if (key === "darkMode") continue
+        expect(value).toMatch(/^#[0-9a-f]{6}$/i)
+      }
+    }
+  })
+
+  test("light and dark variants define the same tokens with different values", () => {
+    const light = mermaidThemeVariables("light")
+    const dark = mermaidThemeVariables("dark")
+    expect(Object.keys(light).sort()).toEqual(Object.keys(dark).sort())
+    expect(light.mainBkg).not.toBe(dark.mainBkg)
+    expect(light.darkMode).toBe(false)
+    expect(dark.darkMode).toBe(true)
+  })
+
+  test("categorical scales stay distinct for parsing large charts", () => {
+    for (const scheme of ["light", "dark"] as const) {
+      const theme = mermaidThemeVariables(scheme)
+      const scale = Array.from({ length: 8 }, (_, index) => theme[`cScale${index}`])
+      expect(new Set(scale).size).toBe(scale.length)
+      expect(scale.every((color) => typeof color === "string")).toBe(true)
+      expect(theme.git0).toBe(theme.cScale0)
+    }
   })
 })
 

--- a/packages/session-ui/src/components/markdown-mermaid.test.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test"
-import { clampMermaidZoom, fitMermaidZoom, isMermaidLanguage, mermaidThemeFor, stepMermaidZoom } from "./markdown-mermaid"
+import {
+  clampMermaidZoom,
+  fitMermaidCamera,
+  isMermaidLanguage,
+  mermaidThemeFor,
+  stepMermaidZoom,
+  zoomMermaidCamera,
+} from "./markdown-mermaid"
 
 describe("isMermaidLanguage", () => {
   test("matches mermaid fences case-insensitively", () => {
@@ -23,24 +30,39 @@ describe("mermaidThemeFor", () => {
   })
 })
 
-describe("mermaid viewer zoom", () => {
+describe("mermaid viewer camera", () => {
   test("steps zoom multiplicatively within limits", () => {
     expect(stepMermaidZoom(1, 1)).toBe(1.25)
     expect(stepMermaidZoom(1.25, -1)).toBe(1)
     expect(stepMermaidZoom(8, 1)).toBe(8)
-    expect(stepMermaidZoom(0.25, -1)).toBe(0.25)
+    expect(stepMermaidZoom(0.1, -1)).toBe(0.1)
   })
 
   test("clamps arbitrary zoom values", () => {
     expect(clampMermaidZoom(100)).toBe(8)
-    expect(clampMermaidZoom(0)).toBe(0.25)
+    expect(clampMermaidZoom(0)).toBe(0.1)
     expect(clampMermaidZoom(2)).toBe(2)
   })
 
-  test("fits diagrams to the viewport without upscaling", () => {
-    expect(fitMermaidZoom({ width: 400, height: 300 }, { width: 800, height: 600 })).toBe(1)
-    expect(fitMermaidZoom({ width: 1600, height: 300 }, { width: 800, height: 600 })).toBe(0.5)
-    expect(fitMermaidZoom({ width: 400, height: 1200 }, { width: 800, height: 600 })).toBe(0.5)
-    expect(fitMermaidZoom({ width: 0, height: 0 }, { width: 800, height: 600 })).toBe(1)
+  test("fit fills the padded canvas and centers the diagram", () => {
+    const fit = fitMermaidCamera({ width: 400, height: 300 }, { width: 896, height: 696 })
+    expect(fit.zoom).toBe(2)
+    expect(fit.x).toBe(48)
+    expect(fit.y).toBe(48)
+  })
+
+  test("fit shrinks oversized diagrams and survives degenerate sizes", () => {
+    expect(fitMermaidCamera({ width: 3200, height: 300 }, { width: 896, height: 696 }).zoom).toBe(0.25)
+    expect(fitMermaidCamera({ width: 0, height: 0 }, { width: 896, height: 696 })).toEqual({ zoom: 1, x: 0, y: 0 })
+  })
+
+  test("zooming keeps the content under the anchor point stationary", () => {
+    const camera = { zoom: 1, x: 0, y: 0 }
+    const zoomed = zoomMermaidCamera(camera, 2, { x: 100, y: 100 })
+    expect(zoomed).toEqual({ zoom: 2, x: -100, y: -100 })
+    // The content point that was at screen (100, 100) is still at (100, 100).
+    expect(((100 - zoomed.x) / zoomed.zoom) * zoomed.zoom + zoomed.x).toBe(100)
+    const back = zoomMermaidCamera(zoomed, 1, { x: 100, y: 100 })
+    expect(back).toEqual({ zoom: 1, x: 0, y: 0 })
   })
 })

--- a/packages/session-ui/src/components/markdown-mermaid.test.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { isMermaidLanguage, mermaidThemeFor } from "./markdown-mermaid"
+import { clampMermaidZoom, fitMermaidZoom, isMermaidLanguage, mermaidThemeFor, stepMermaidZoom } from "./markdown-mermaid"
 
 describe("isMermaidLanguage", () => {
   test("matches mermaid fences case-insensitively", () => {
@@ -20,5 +20,27 @@ describe("mermaidThemeFor", () => {
   test("maps the app color scheme to a mermaid theme", () => {
     expect(mermaidThemeFor("dark")).toBe("dark")
     expect(mermaidThemeFor("light")).toBe("default")
+  })
+})
+
+describe("mermaid viewer zoom", () => {
+  test("steps zoom multiplicatively within limits", () => {
+    expect(stepMermaidZoom(1, 1)).toBe(1.25)
+    expect(stepMermaidZoom(1.25, -1)).toBe(1)
+    expect(stepMermaidZoom(8, 1)).toBe(8)
+    expect(stepMermaidZoom(0.25, -1)).toBe(0.25)
+  })
+
+  test("clamps arbitrary zoom values", () => {
+    expect(clampMermaidZoom(100)).toBe(8)
+    expect(clampMermaidZoom(0)).toBe(0.25)
+    expect(clampMermaidZoom(2)).toBe(2)
+  })
+
+  test("fits diagrams to the viewport without upscaling", () => {
+    expect(fitMermaidZoom({ width: 400, height: 300 }, { width: 800, height: 600 })).toBe(1)
+    expect(fitMermaidZoom({ width: 1600, height: 300 }, { width: 800, height: 600 })).toBe(0.5)
+    expect(fitMermaidZoom({ width: 400, height: 1200 }, { width: 800, height: 600 })).toBe(0.5)
+    expect(fitMermaidZoom({ width: 0, height: 0 }, { width: 800, height: 600 })).toBe(1)
   })
 })

--- a/packages/session-ui/src/components/markdown-mermaid.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.ts
@@ -8,6 +8,20 @@ export function isMermaidLanguage(language: string | undefined) {
   return language?.trim().toLowerCase() === "mermaid"
 }
 
+export function clampMermaidZoom(zoom: number) {
+  return Math.min(8, Math.max(0.25, zoom))
+}
+
+export function stepMermaidZoom(zoom: number, direction: 1 | -1) {
+  return clampMermaidZoom(direction > 0 ? zoom * 1.25 : zoom / 1.25)
+}
+
+// Fit the diagram inside the viewport without ever upscaling past its natural size.
+export function fitMermaidZoom(natural: { width: number; height: number }, viewport: { width: number; height: number }) {
+  if (natural.width <= 0 || natural.height <= 0) return 1
+  return clampMermaidZoom(Math.min(1, viewport.width / natural.width, viewport.height / natural.height))
+}
+
 export function mermaidThemeFor(scheme: MermaidColorScheme) {
   return scheme === "dark" ? "dark" : "default"
 }

--- a/packages/session-ui/src/components/markdown-mermaid.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.ts
@@ -53,7 +53,8 @@ async function load(scheme: MermaidColorScheme) {
 }
 
 export function renderMermaid(source: string, scheme: MermaidColorScheme): Promise<MermaidRenderResult> {
-  const run = async (): Promise<MermaidRenderResult> => {
+  // The runner converts every failure into a result, so the queue never rejects.
+  const result = queue.then(async (): Promise<MermaidRenderResult> => {
     try {
       const mermaid = await load(scheme)
       const { svg } = await mermaid.render(`mermaid-diagram-${++sequence}`, source)
@@ -61,8 +62,7 @@ export function renderMermaid(source: string, scheme: MermaidColorScheme): Promi
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) }
     }
-  }
-  const result = queue.then(run, run)
-  queue = result.catch(() => {})
+  })
+  queue = result
   return result
 }

--- a/packages/session-ui/src/components/markdown-mermaid.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.ts
@@ -1,5 +1,5 @@
 import { createSignal } from "solid-js"
-import { mermaidThemeVariables } from "./markdown-mermaid-theme"
+import { mermaidThemeCss, mermaidThemeVariables } from "./markdown-mermaid-theme"
 
 export type MermaidColorScheme = "light" | "dark"
 
@@ -97,6 +97,7 @@ async function load(scheme: MermaidColorScheme) {
       securityLevel: "strict",
       theme: "base",
       themeVariables: { ...mermaidThemeVariables(scheme), fontFamily: appFontFamily(), fontSize: "14px" },
+      themeCSS: mermaidThemeCss(scheme),
     })
     initializedScheme = scheme
   }

--- a/packages/session-ui/src/components/markdown-mermaid.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.ts
@@ -8,18 +8,44 @@ export function isMermaidLanguage(language: string | undefined) {
   return language?.trim().toLowerCase() === "mermaid"
 }
 
+// Camera over the diagram canvas: a content point p renders at p * zoom + (x, y).
+export type MermaidCamera = { zoom: number; x: number; y: number }
+
 export function clampMermaidZoom(zoom: number) {
-  return Math.min(8, Math.max(0.25, zoom))
+  return Math.min(8, Math.max(0.1, zoom))
 }
 
 export function stepMermaidZoom(zoom: number, direction: 1 | -1) {
   return clampMermaidZoom(direction > 0 ? zoom * 1.25 : zoom / 1.25)
 }
 
-// Fit the diagram inside the viewport without ever upscaling past its natural size.
-export function fitMermaidZoom(natural: { width: number; height: number }, viewport: { width: number; height: number }) {
-  if (natural.width <= 0 || natural.height <= 0) return 1
-  return clampMermaidZoom(Math.min(1, viewport.width / natural.width, viewport.height / natural.height))
+// Fill the padded canvas and center the diagram; vector output stays crisp when upscaled,
+// matching zoom-to-fit in design tools.
+export function fitMermaidCamera(
+  natural: { width: number; height: number },
+  viewport: { width: number; height: number },
+  padding = 48,
+): MermaidCamera {
+  if (natural.width <= 0 || natural.height <= 0) return { zoom: 1, x: 0, y: 0 }
+  const zoom = clampMermaidZoom(
+    Math.min((viewport.width - padding * 2) / natural.width, (viewport.height - padding * 2) / natural.height),
+  )
+  return {
+    zoom,
+    x: (viewport.width - natural.width * zoom) / 2,
+    y: (viewport.height - natural.height * zoom) / 2,
+  }
+}
+
+// Keeps the content under `point` stationary while zooming, like canvas tools.
+export function zoomMermaidCamera(
+  camera: MermaidCamera,
+  zoom: number,
+  point: { x: number; y: number },
+): MermaidCamera {
+  const next = clampMermaidZoom(zoom)
+  const ratio = next / camera.zoom
+  return { zoom: next, x: point.x - (point.x - camera.x) * ratio, y: point.y - (point.y - camera.y) * ratio }
 }
 
 export function mermaidThemeFor(scheme: MermaidColorScheme) {

--- a/packages/session-ui/src/components/markdown-mermaid.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.ts
@@ -1,4 +1,5 @@
 import { createSignal } from "solid-js"
+import { mermaidThemeVariables } from "./markdown-mermaid-theme"
 
 export type MermaidColorScheme = "light" | "dark"
 
@@ -48,8 +49,13 @@ export function zoomMermaidCamera(
   return { zoom: next, x: point.x - (point.x - camera.x) * ratio, y: point.y - (point.y - camera.y) * ratio }
 }
 
-export function mermaidThemeFor(scheme: MermaidColorScheme) {
-  return scheme === "dark" ? "dark" : "default"
+// Mermaid measures text in-document, but theme values must be concrete, so the app font
+// token resolves once here instead of passing the CSS variable through.
+function appFontFamily() {
+  const fallback = "ui-sans-serif, system-ui, sans-serif"
+  if (typeof document !== "object") return fallback
+  const value = getComputedStyle(document.documentElement).getPropertyValue("--font-family-sans").trim()
+  return value || fallback
 }
 
 function readColorScheme(): MermaidColorScheme {
@@ -86,7 +92,12 @@ async function load(scheme: MermaidColorScheme) {
   loader ??= import("mermaid").then((module) => module.default)
   const mermaid = await loader
   if (initializedScheme !== scheme) {
-    mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: mermaidThemeFor(scheme) })
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: "base",
+      themeVariables: { ...mermaidThemeVariables(scheme), fontFamily: appFontFamily(), fontSize: "14px" },
+    })
     initializedScheme = scheme
   }
   return mermaid

--- a/packages/session-ui/src/components/markdown-mermaid.ts
+++ b/packages/session-ui/src/components/markdown-mermaid.ts
@@ -1,0 +1,68 @@
+import { createSignal } from "solid-js"
+
+export type MermaidColorScheme = "light" | "dark"
+
+export type MermaidRenderResult = { ok: true; svg: string } | { ok: false; error: string }
+
+export function isMermaidLanguage(language: string | undefined) {
+  return language?.trim().toLowerCase() === "mermaid"
+}
+
+export function mermaidThemeFor(scheme: MermaidColorScheme) {
+  return scheme === "dark" ? "dark" : "default"
+}
+
+function readColorScheme(): MermaidColorScheme {
+  if (typeof document !== "object") return "light"
+  const scheme = document.documentElement.dataset.colorScheme
+  if (scheme === "dark" || scheme === "light") return scheme
+  if (typeof window === "object" && window.matchMedia?.("(prefers-color-scheme: dark)").matches) return "dark"
+  return "light"
+}
+
+const [colorScheme, setColorScheme] = createSignal<MermaidColorScheme>(readColorScheme())
+let observing = false
+
+// Reading this inside a reactive scope re-renders diagrams when the app theme flips.
+export function mermaidColorScheme() {
+  if (!observing && typeof document === "object") {
+    observing = true
+    new MutationObserver(() => setColorScheme(readColorScheme())).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-color-scheme"],
+    })
+  }
+  return colorScheme()
+}
+
+let loader: Promise<typeof import("mermaid").default> | undefined
+let initializedScheme: MermaidColorScheme | undefined
+let sequence = 0
+// Mermaid keeps a single global config and appends scratch nodes to the document while
+// measuring text, so renders must run one at a time to avoid clobbering each other.
+let queue: Promise<unknown> = Promise.resolve()
+
+async function load(scheme: MermaidColorScheme) {
+  loader ??= import("mermaid").then((module) => module.default)
+  const mermaid = await loader
+  if (initializedScheme !== scheme) {
+    mermaid.initialize({ startOnLoad: false, securityLevel: "strict", theme: mermaidThemeFor(scheme) })
+    initializedScheme = scheme
+  }
+  return mermaid
+}
+
+export function renderMermaid(source: string, scheme: MermaidColorScheme): Promise<MermaidRenderResult> {
+  const run = async (): Promise<MermaidRenderResult> => {
+    try {
+      const mermaid = await load(scheme)
+      const { svg } = await mermaid.render(`mermaid-diagram-${++sequence}`, source)
+      return { ok: true, svg }
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) }
+    }
+  }
+  const result = queue.then(run, run)
+  queue = result.catch(() => {})
+  return result
+}

--- a/packages/session-ui/src/components/markdown-stream.test.ts
+++ b/packages/session-ui/src/components/markdown-stream.test.ts
@@ -177,6 +177,31 @@ describe("markdown stream", () => {
     ])
   })
 
+  test("keeps settled prose as a single full block", () => {
+    expect(stream("# Title\n\nBody", false)).toEqual([{ raw: "# Title\n\nBody", src: "# Title\n\nBody", mode: "full" }])
+  })
+
+  test("splits settled mermaid fences into standalone diagram blocks", () => {
+    const blocks = stream("Before\n\n```mermaid\ngraph TD;A-->B\n```\n\nAfter", false)
+    expect(blocks).toHaveLength(3)
+    expect(blocks[0]).toMatchObject({ mode: "full" })
+    expect(blocks[0]!.src).toContain("Before")
+    expect(blocks[1]).toMatchObject({ mode: "code", language: "mermaid", complete: true, src: "graph TD;A-->B" })
+    expect(blocks[2]).toMatchObject({ mode: "full" })
+    expect(blocks[2]!.src).toContain("After")
+  })
+
+  test("keeps non-mermaid settled code inside the full block", () => {
+    expect(stream("```ts\nconst x = 1\n```", false)).toEqual([
+      { raw: "```ts\nconst x = 1\n```", src: "```ts\nconst x = 1\n```", mode: "full" },
+    ])
+  })
+
+  test("does not split settled mermaid when reference definitions are present", () => {
+    const text = "```mermaid\ngraph TD;A-->B\n```\n\n[1]: https://example.com"
+    expect(stream(text, false)).toEqual([{ raw: text, src: text, mode: "full" }])
+  })
+
   test("closes tilde fences split across provider deltas", () => {
     const open = project(undefined, "~~~ts\nconst x = 1\n", true)
     const one = project(open, `${open.text}~`, true)

--- a/packages/session-ui/src/components/markdown-stream.test.ts
+++ b/packages/session-ui/src/components/markdown-stream.test.ts
@@ -197,6 +197,13 @@ describe("markdown stream", () => {
     ])
   })
 
+  test("splits settled mermaid fences regardless of case and indent", () => {
+    expect(stream("```Mermaid\ngraph TD;A-->B\n```", false)).toEqual([
+      { raw: "```Mermaid\ngraph TD;A-->B\n```", src: "graph TD;A-->B", mode: "code", language: "Mermaid", complete: true },
+    ])
+    expect(stream("  ~~~mermaid\ngraph TD;A-->B\n~~~", false)[0]).toMatchObject({ mode: "code", complete: true })
+  })
+
   test("does not split settled mermaid when reference definitions are present", () => {
     const text = "```mermaid\ngraph TD;A-->B\n```\n\n[1]: https://example.com"
     expect(stream(text, false)).toEqual([{ raw: text, src: text, mode: "full" }])

--- a/packages/session-ui/src/components/markdown-stream.ts
+++ b/packages/session-ui/src/components/markdown-stream.ts
@@ -49,8 +49,40 @@ function heal(text: string) {
   return remend(text, { linkMode: "text-only" })
 }
 
+function mermaid(lang: string | undefined) {
+  return language(lang)?.toLowerCase() === "mermaid"
+}
+
+// Settled messages render as one full block, but mermaid fences must become standalone code
+// blocks so they can be swapped for a rendered diagram. Everything else stays coalesced.
+function splitMermaid(text: string): Block[] {
+  if (refs(text)) return [{ raw: text, src: text, mode: "full" }]
+  const tokens = marked.lexer(text)
+  if (!tokens.some((token) => token.type === "code" && mermaid((token as Tokens.Code).lang)))
+    return [{ raw: text, src: text, mode: "full" }]
+
+  const blocks: Block[] = []
+  let buffer = ""
+  const flush = () => {
+    if (!buffer) return
+    blocks.push({ raw: buffer, src: buffer, mode: "full" })
+    buffer = ""
+  }
+  for (const token of tokens) {
+    const code = token.type === "code" ? (token as Tokens.Code) : undefined
+    if (code && mermaid(code.lang)) {
+      flush()
+      blocks.push({ raw: code.raw, src: code.text, mode: "code", language: language(code.lang), complete: true })
+      continue
+    }
+    buffer += token.raw
+  }
+  flush()
+  return blocks
+}
+
 export function stream(text: string, live: boolean): Block[] {
-  if (!live) return [{ raw: text, src: text, mode: "full" }] satisfies Block[]
+  if (!live) return splitMermaid(text)
   if (refs(text)) return [{ raw: text, src: heal(text), mode: "live" }] satisfies Block[]
   const tokens = marked.lexer(text)
   const tail = tokens.findLastIndex((token) => token.type !== "space")

--- a/packages/session-ui/src/components/markdown-stream.ts
+++ b/packages/session-ui/src/components/markdown-stream.ts
@@ -53,10 +53,13 @@ function mermaid(lang: string | undefined) {
   return language(lang)?.toLowerCase() === "mermaid"
 }
 
+const mermaidFence = /^[ \t]{0,3}(?:`{3,}|~{3,})[ \t]*mermaid\b/im
+
 // Settled messages render as one full block, but mermaid fences must become standalone code
-// blocks so they can be swapped for a rendered diagram. Everything else stays coalesced.
+// blocks so they can be swapped for a rendered diagram. Everything else stays coalesced, and
+// the fence pre-check keeps the settled path lexer-free for messages without diagrams.
 function splitMermaid(text: string): Block[] {
-  if (refs(text)) return [{ raw: text, src: text, mode: "full" }]
+  if (!mermaidFence.test(text) || refs(text)) return [{ raw: text, src: text, mode: "full" }]
   const tokens = marked.lexer(text)
   if (!tokens.some((token) => token.type === "code" && mermaid((token as Tokens.Code).lang)))
     return [{ raw: text, src: text, mode: "full" }]

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -199,6 +199,31 @@
     color: var(--markdown-shell-code-token-color) !important;
   }
 
+  [data-component="markdown-code"][data-code-kind="mermaid"] [data-slot="mermaid-diagram"] {
+    display: none;
+  }
+
+  [data-component="markdown-code"][data-code-kind="mermaid"][data-mermaid-state="rendered"] [data-slot="mermaid-diagram"] {
+    display: flex;
+    justify-content: center;
+    margin-top: 12px;
+    margin-bottom: 24px;
+    padding: 16px;
+    overflow-x: auto;
+    background: var(--color-background-stronger);
+    border: 0.5px solid var(--v2-border-border-base);
+    border-radius: 6px;
+  }
+
+  [data-component="markdown-code"][data-code-kind="mermaid"][data-mermaid-state="rendered"] [data-slot="mermaid-source"] {
+    display: none;
+  }
+
+  [data-component="markdown-code"][data-code-kind="mermaid"] [data-slot="mermaid-diagram"] svg {
+    max-width: 100%;
+    height: auto;
+  }
+
   [data-slot="markdown-copy-button"] {
     position: absolute;
     top: 4px;

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -224,6 +224,29 @@
     height: auto;
   }
 
+  [data-component="markdown-code"][data-code-kind="mermaid"][data-mermaid-state="rendered"] [data-slot="mermaid-diagram"] {
+    cursor: zoom-in;
+  }
+
+  [data-slot="mermaid-expand-button"] {
+    display: none;
+    position: absolute;
+    top: 4px;
+    right: 32px;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 1;
+  }
+
+  [data-component="markdown-code"][data-mermaid-state="rendered"] [data-slot="mermaid-expand-button"] {
+    display: block;
+  }
+
+  [data-component="markdown-code"]:hover [data-slot="mermaid-expand-button"],
+  [data-slot="mermaid-expand-button"]:focus-within {
+    opacity: 1;
+  }
+
   [data-slot="markdown-copy-button"] {
     position: absolute;
     top: 4px;

--- a/packages/session-ui/src/components/markdown.stories.tsx
+++ b/packages/session-ui/src/components/markdown.stories.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import * as mod from "./markdown"
 import { create } from "@opencode-ai/ui/storybook/scaffold"
-import { markdown } from "@opencode-ai/ui/storybook/fixtures"
+import { markdown, mermaidShapes } from "@opencode-ai/ui/storybook/fixtures"
 
 const docs = `### Overview
 Render sanitized Markdown with code blocks, inline code, and safe links.
@@ -51,3 +51,10 @@ export default {
 }
 
 export const Basic = story.Basic
+
+export const MermaidShapes = {
+  ...story.Basic,
+  args: {
+    text: mermaidShapes,
+  },
+}

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -182,7 +182,7 @@ function createExpandButton(label: string) {
           size="normal"
           variant="ghost-muted"
           aria-label={value()}
-          icon={<IconV2 name="outline-square-arrow" />}
+          icon={<IconV2 name="fullscreen" />}
         />
       </TooltipV2>
     )

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -406,23 +406,10 @@ export function Markdown(
           if (block.mode === "code") {
             const cached = completedCode.get(blockKey)
             if (block.complete && cached?.raw === block.raw) return cached
-            if (isMermaidLanguage(block.language)) {
-              const rendered = {
-                key: blockKey,
-                mode: block.mode,
-                raw: block.raw,
-                src: block.src,
-                hash: String(block.raw.length),
-                complete: !!block.complete,
-                language: "mermaid",
-                generation: 0,
-                stable: [] as MarkdownToken[],
-                unstable: [] as MarkdownToken[],
-              }
-              if (block.complete) completedCode.set(blockKey, rendered)
-              return rendered
-            }
-            const result = await code(block.src, block.language, blockKey, block.complete)
+            // Mermaid renders as a diagram from source, so it skips shiki tokenization.
+            const result = isMermaidLanguage(block.language)
+              ? { language: "mermaid", generation: 0, stable: [] as MarkdownToken[], unstable: [] as MarkdownToken[] }
+              : await code(block.src, block.language, blockKey, block.complete)
             const rendered = {
               key: blockKey,
               mode: block.mode,
@@ -690,14 +677,15 @@ function updateCodeBlock(
   container.appendChild(next)
 }
 
-type MermaidBlockState = {
+// Records the source and color scheme of the last render started per block, so identical
+// effect re-runs (including after a deterministic parse failure) do not re-render.
+type MermaidRenderState = {
   source: string
   scheme: MermaidColorScheme
-  status: "incomplete" | "rendering" | "rendered" | "error"
   request: number
 }
 
-const mermaidBlocks = new WeakMap<HTMLElement, MermaidBlockState>()
+const mermaidBlocks = new WeakMap<HTMLElement, MermaidRenderState>()
 
 function updateMermaidBlock(
   container: HTMLDivElement,
@@ -758,33 +746,23 @@ function ensureMermaidWrapper(next: HTMLElement, labels: CopyLabels) {
 }
 
 function renderMermaidBlock(next: HTMLElement, wrapper: HTMLElement, source: string, complete: boolean) {
-  const scheme = mermaidColorScheme()
-  const previous = mermaidBlocks.get(next)
-
   if (!complete) {
     wrapper.dataset.mermaidState = "source"
     delete wrapper.dataset.mermaidError
-    mermaidBlocks.set(next, { source, scheme, status: "incomplete", request: previous?.request ?? 0 })
     return
   }
 
-  if (
-    previous &&
-    (previous.status === "rendered" || previous.status === "rendering") &&
-    previous.source === source &&
-    previous.scheme === scheme
-  )
-    return
+  const scheme = mermaidColorScheme()
+  const previous = mermaidBlocks.get(next)
+  if (previous && previous.source === source && previous.scheme === scheme) return
 
   const request = (previous?.request ?? 0) + 1
-  mermaidBlocks.set(next, { source, scheme, status: "rendering", request })
+  mermaidBlocks.set(next, { source, scheme, request })
   if (wrapper.dataset.mermaidState !== "rendered") wrapper.dataset.mermaidState = "source"
 
   void renderMermaid(source, scheme).then((result) => {
-    const state = mermaidBlocks.get(next)
-    if (!state || state.request !== request || !next.isConnected) return
+    if (mermaidBlocks.get(next)?.request !== request || !next.isConnected) return
     if (!result.ok) {
-      mermaidBlocks.set(next, { ...state, status: "error" })
       wrapper.dataset.mermaidState = "source"
       wrapper.dataset.mermaidError = "true"
       return
@@ -792,7 +770,6 @@ function renderMermaidBlock(next: HTMLElement, wrapper: HTMLElement, source: str
     const diagram = wrapper.querySelector<HTMLElement>('[data-slot="mermaid-diagram"]')
     if (diagram) diagram.innerHTML = result.svg
     delete wrapper.dataset.mermaidError
-    mermaidBlocks.set(next, { ...state, status: "rendered" })
     wrapper.dataset.mermaidState = "rendered"
   })
 }

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -31,6 +31,7 @@ import { markdownBlockKey, type MarkdownToken } from "./markdown-worker-protocol
 import { shouldResetCodeTokens, type RenderedCodeState } from "./markdown-code-state"
 import { getCachedMarkdown, sanitizeMarkdown, touchCachedMarkdown, type MarkdownCacheEntry } from "./markdown-cache"
 import { inlineCodeKind } from "./markdown-inline-code-kind"
+import { isMermaidLanguage, mermaidColorScheme, renderMermaid, type MermaidColorScheme } from "./markdown-mermaid"
 
 type RenderedBlock =
   | (MarkdownCacheEntry & { key: string; mode: Exclude<Block["mode"], "code"> })
@@ -38,6 +39,7 @@ type RenderedBlock =
       key: string
       mode: "code"
       raw: string
+      src: string
       hash: string
       language: string
       complete: boolean
@@ -404,11 +406,28 @@ export function Markdown(
           if (block.mode === "code") {
             const cached = completedCode.get(blockKey)
             if (block.complete && cached?.raw === block.raw) return cached
+            if (isMermaidLanguage(block.language)) {
+              const rendered = {
+                key: blockKey,
+                mode: block.mode,
+                raw: block.raw,
+                src: block.src,
+                hash: String(block.raw.length),
+                complete: !!block.complete,
+                language: "mermaid",
+                generation: 0,
+                stable: [] as MarkdownToken[],
+                unstable: [] as MarkdownToken[],
+              }
+              if (block.complete) completedCode.set(blockKey, rendered)
+              return rendered
+            }
             const result = await code(block.src, block.language, blockKey, block.complete)
             const rendered = {
               key: blockKey,
               mode: block.mode,
               raw: block.raw,
+              src: block.src,
               hash: String(block.raw.length),
               complete: !!block.complete,
               ...result,
@@ -533,6 +552,7 @@ function pendingBlocks(
       key,
       mode: block.mode,
       raw: block.raw,
+      src: block.src,
       hash: String(block.raw.length),
       language: block.language ?? "text",
       complete: !!block.complete,
@@ -550,6 +570,10 @@ function disposeCode(key: string) {
 function updateBlock(container: HTMLDivElement, index: number, block: RenderedBlock, labels: CopyLabels) {
   const current = container.children[index]
   if (block.mode === "code") {
+    if (isMermaidLanguage(block.language)) {
+      updateMermaidBlock(container, current, block, labels)
+      return
+    }
     updateCodeBlock(container, current, block, labels)
     return
   }
@@ -664,6 +688,113 @@ function updateCodeBlock(
     return
   }
   container.appendChild(next)
+}
+
+type MermaidBlockState = {
+  source: string
+  scheme: MermaidColorScheme
+  status: "incomplete" | "rendering" | "rendered" | "error"
+  request: number
+}
+
+const mermaidBlocks = new WeakMap<HTMLElement, MermaidBlockState>()
+
+function updateMermaidBlock(
+  container: HTMLDivElement,
+  current: Element | undefined,
+  block: Extract<RenderedBlock, { mode: "code" }>,
+  labels: CopyLabels,
+) {
+  const existing = current instanceof HTMLDivElement && current.dataset.markdownKey === block.key ? current : undefined
+  const next = existing ?? document.createElement("div")
+  next.dataset.markdownBlock = ""
+  next.dataset.markdownKey = block.key
+  next.dataset.markdownHash = block.hash
+  next.dataset.markdownComplete = block.complete ? "true" : "false"
+  next.style.display = "contents"
+
+  const wrapper = ensureMermaidWrapper(next, labels)
+  const source = wrapper.querySelector<HTMLElement>('[data-slot="mermaid-source"] > code')
+  if (source && source.textContent !== block.src) source.textContent = block.src
+  renderMermaidBlock(next, wrapper, block.src, block.complete)
+
+  if (existing) return
+  if (current) {
+    disposeCopyButtons(current)
+    current.replaceWith(next)
+    return
+  }
+  container.appendChild(next)
+}
+
+function ensureMermaidWrapper(next: HTMLElement, labels: CopyLabels) {
+  const found = next.querySelector<HTMLElement>('[data-component="markdown-code"][data-code-kind="mermaid"]')
+  if (found) return found
+
+  disposeCopyButtons(next)
+  next.textContent = ""
+  const wrapper = document.createElement("div")
+  wrapper.setAttribute("data-component", "markdown-code")
+  wrapper.dataset.codeKind = "mermaid"
+  wrapper.dataset.mermaidState = "source"
+
+  // Source stays first so the shared copy handler's querySelector("code") always finds the
+  // mermaid source rather than anything inside the rendered SVG.
+  const pre = document.createElement("pre")
+  pre.className = "shiki OpenCode"
+  pre.setAttribute("data-slot", "mermaid-source")
+  const code = document.createElement("code")
+  code.className = "language-mermaid"
+  pre.appendChild(code)
+
+  const diagram = document.createElement("div")
+  diagram.setAttribute("data-slot", "mermaid-diagram")
+
+  wrapper.appendChild(pre)
+  wrapper.appendChild(diagram)
+  wrapper.appendChild(createCopyButton(labels))
+  next.appendChild(wrapper)
+  return wrapper
+}
+
+function renderMermaidBlock(next: HTMLElement, wrapper: HTMLElement, source: string, complete: boolean) {
+  const scheme = mermaidColorScheme()
+  const previous = mermaidBlocks.get(next)
+
+  if (!complete) {
+    wrapper.dataset.mermaidState = "source"
+    delete wrapper.dataset.mermaidError
+    mermaidBlocks.set(next, { source, scheme, status: "incomplete", request: previous?.request ?? 0 })
+    return
+  }
+
+  if (
+    previous &&
+    (previous.status === "rendered" || previous.status === "rendering") &&
+    previous.source === source &&
+    previous.scheme === scheme
+  )
+    return
+
+  const request = (previous?.request ?? 0) + 1
+  mermaidBlocks.set(next, { source, scheme, status: "rendering", request })
+  if (wrapper.dataset.mermaidState !== "rendered") wrapper.dataset.mermaidState = "source"
+
+  void renderMermaid(source, scheme).then((result) => {
+    const state = mermaidBlocks.get(next)
+    if (!state || state.request !== request || !next.isConnected) return
+    if (!result.ok) {
+      mermaidBlocks.set(next, { ...state, status: "error" })
+      wrapper.dataset.mermaidState = "source"
+      wrapper.dataset.mermaidError = "true"
+      return
+    }
+    const diagram = wrapper.querySelector<HTMLElement>('[data-slot="mermaid-diagram"]')
+    if (diagram) diagram.innerHTML = result.svg
+    delete wrapper.dataset.mermaidError
+    mermaidBlocks.set(next, { ...state, status: "rendered" })
+    wrapper.dataset.mermaidState = "rendered"
+  })
 }
 
 function sameToken(left: MarkdownToken, right: MarkdownToken | undefined) {

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -32,6 +32,7 @@ import { shouldResetCodeTokens, type RenderedCodeState } from "./markdown-code-s
 import { getCachedMarkdown, sanitizeMarkdown, touchCachedMarkdown, type MarkdownCacheEntry } from "./markdown-cache"
 import { inlineCodeKind } from "./markdown-inline-code-kind"
 import { isMermaidLanguage, mermaidColorScheme, renderMermaid, type MermaidColorScheme } from "./markdown-mermaid"
+import { openMermaidViewer } from "./markdown-mermaid-viewer"
 
 type RenderedBlock =
   | (MarkdownCacheEntry & { key: string; mode: Exclude<Block["mode"], "code"> })
@@ -87,6 +88,7 @@ async function code(text: string, language: string | undefined, key: string, com
 type CopyLabels = {
   copy: string
   copied: string
+  expand?: string
 }
 
 type CopyButtonState = {
@@ -158,15 +160,51 @@ function setCopyState(host: HTMLElement, labels: CopyLabels, copied: boolean) {
   host.removeAttribute("data-copied")
 }
 
+type ExpandButtonState = {
+  setLabel: Setter<string>
+  dispose: () => void
+}
+
+const expandButtonState = new WeakMap<HTMLElement, ExpandButtonState>()
+
+function createExpandButton(label: string) {
+  const host = document.createElement("div")
+  host.setAttribute("data-slot", "mermaid-expand-button")
+
+  const state: Partial<ExpandButtonState> = {}
+  const dispose = render(() => {
+    const [value, setValue] = createSignal(label)
+    state.setLabel = setValue
+    return (
+      <TooltipV2 placement="top" value={value()}>
+        <IconButtonV2
+          type="button"
+          size="normal"
+          variant="ghost-muted"
+          aria-label={value()}
+          icon={<IconV2 name="outline-square-arrow" />}
+        />
+      </TooltipV2>
+    )
+  }, host)
+  state.dispose = dispose
+  expandButtonState.set(host, state as ExpandButtonState)
+  return host
+}
+
+const actionButtonSelector = '[data-slot="markdown-copy-button"], [data-slot="mermaid-expand-button"]'
+
 function disposeCopyButton(host: HTMLElement) {
   copyButtonState.get(host)?.dispose()
   copyButtonState.delete(host)
+  expandButtonState.get(host)?.dispose()
+  expandButtonState.delete(host)
 }
 
 function disposeCopyButtons(root: Element) {
   const hosts = [
-    ...(root instanceof HTMLElement && root.getAttribute("data-slot") === "markdown-copy-button" ? [root] : []),
-    ...Array.from(root.querySelectorAll('[data-slot="markdown-copy-button"]')).filter(
+    ...(root instanceof HTMLElement && root.matches(actionButtonSelector) ? [root] : []),
+    ...Array.from(root.querySelectorAll(actionButtonSelector)).filter(
       (el): el is HTMLElement => el instanceof HTMLElement,
     ),
   ]
@@ -282,7 +320,7 @@ function decorate(root: HTMLDivElement, labels: CopyLabels) {
   markCodeLinks(root)
 }
 
-function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
+function setupCodeActions(root: HTMLDivElement, getLabels: () => CopyLabels, expand: (source: string) => void) {
   const timeouts = new Map<HTMLElement, ReturnType<typeof setTimeout>>()
 
   const updateLabel = (button: HTMLElement) => {
@@ -294,6 +332,15 @@ function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
   const handleClick = async (event: MouseEvent) => {
     const target = event.target
     if (!(target instanceof Element)) return
+
+    const trigger = target.closest('[data-slot="mermaid-expand-button"], [data-slot="mermaid-diagram"]')
+    if (trigger instanceof HTMLElement) {
+      const wrapper = trigger.closest('[data-component="markdown-code"]')
+      if (!(wrapper instanceof HTMLElement) || wrapper.dataset.mermaidState !== "rendered") return
+      const source = wrapper.querySelector('[data-slot="mermaid-source"] > code')?.textContent ?? ""
+      if (source) expand(source)
+      return
+    }
 
     const button = target.closest('[data-slot="markdown-copy-button"]')
     if (!(button instanceof HTMLElement)) return
@@ -477,6 +524,7 @@ export function Markdown(
     const labels = {
       copy: i18n.t("ui.message.copy"),
       copied: i18n.t("ui.message.copied"),
+      expand: i18n.t("ui.mermaid.expand"),
     }
     const nextCodeKeys = new Set(content.filter((block) => block.mode === "code").map((block) => block.key))
     activeCodeKeys.forEach((key) => {
@@ -494,11 +542,28 @@ export function Markdown(
     container
       .querySelectorAll<HTMLElement>('[data-slot="markdown-copy-button"]')
       .forEach((button) => setCopyState(button, labels, button.dataset.copied === "true"))
+    container
+      .querySelectorAll<HTMLElement>('[data-slot="mermaid-expand-button"]')
+      .forEach((button) => expandButtonState.get(button)?.setLabel(labels.expand))
     if (!copyCleanup)
-      copyCleanup = setupCodeCopy(container, () => ({
-        copy: i18n.t("ui.message.copy"),
-        copied: i18n.t("ui.message.copied"),
-      }))
+      copyCleanup = setupCodeActions(
+        container,
+        () => ({
+          copy: i18n.t("ui.message.copy"),
+          copied: i18n.t("ui.message.copied"),
+          expand: i18n.t("ui.mermaid.expand"),
+        }),
+        (source) =>
+          openMermaidViewer({
+            source,
+            labels: {
+              zoomIn: i18n.t("ui.mermaid.zoomIn"),
+              zoomOut: i18n.t("ui.mermaid.zoomOut"),
+              zoomReset: i18n.t("ui.mermaid.zoomReset"),
+              close: i18n.t("ui.common.close"),
+            },
+          }),
+      )
   })
 
   onCleanup(() => {
@@ -740,6 +805,7 @@ function ensureMermaidWrapper(next: HTMLElement, labels: CopyLabels) {
 
   wrapper.appendChild(pre)
   wrapper.appendChild(diagram)
+  wrapper.appendChild(createExpandButton(labels.expand ?? ""))
   wrapper.appendChild(createCopyButton(labels))
   next.appendChild(wrapper)
   return wrapper

--- a/packages/session-ui/src/styles/index.css
+++ b/packages/session-ui/src/styles/index.css
@@ -3,6 +3,7 @@
 @import "../components/basic-tool.css" layer(components);
 @import "../components/file.css" layer(components);
 @import "../components/markdown.css" layer(components);
+@import "../components/markdown-mermaid-viewer.css" layer(components);
 @import "../components/message-part.css" layer(components);
 @import "../components/message-nav.css" layer(components);
 @import "../components/session-review.css" layer(components);

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -182,6 +182,11 @@ export const dict: Record<string, string> = {
   "ui.message.queued": "Queued",
   "ui.message.attachment.alt": "attachment",
 
+  "ui.mermaid.expand": "Expand diagram",
+  "ui.mermaid.zoomIn": "Zoom in",
+  "ui.mermaid.zoomOut": "Zoom out",
+  "ui.mermaid.zoomReset": "Reset zoom",
+
   "ui.patch.action.deleted": "Deleted",
   "ui.patch.action.created": "Created",
   "ui.patch.action.moved": "Moved",

--- a/packages/ui/src/storybook/fixtures.ts
+++ b/packages/ui/src/storybook/fixtures.ts
@@ -42,6 +42,16 @@ export const markdown = [
   "export const value = 42",
   "```",
   "",
+  "## Diagram",
+  "Mermaid code blocks render as charts:",
+  "",
+  "```mermaid",
+  "flowchart LR",
+  "  A[Prompt] --> B{Streaming?}",
+  "  B -->|Yes| C[Show source]",
+  "  B -->|No| D[Render diagram]",
+  "```",
+  "",
   "More at https://example.com/docs",
 ].join("\n")
 

--- a/packages/ui/src/storybook/fixtures.ts
+++ b/packages/ui/src/storybook/fixtures.ts
@@ -59,3 +59,26 @@ export const changes = {
   additions: 18,
   deletions: 6,
 }
+
+// One minimal flowchart exercising every node shape, edge style, and grouping construct,
+// used to tune per-shape diagram coloring.
+export const mermaidShapes = [
+  "```mermaid",
+  "flowchart TD",
+  "  A([Start]) --> B[Process]",
+  "  B --> C{Decision?}",
+  "  C -->|yes| D[/Input/]",
+  "  C -->|no| E[[Subroutine]]",
+  "  C -->|maybe| M[Manual review]:::warning",
+  "  D --> F[(Database)]",
+  "  E -.-> G((Circle))",
+  "  F ==> H{{Hexagon}}",
+  "  subgraph Group",
+  "    I[Task one] --> J[Task two]",
+  "  end",
+  "  H --> I",
+  "  G --> K[\\Output\\]",
+  "  J --> L(((Done)))",
+  "  K --> L",
+  "```",
+].join("\n")

--- a/packages/ui/src/v2/components/icon.tsx
+++ b/packages/ui/src/v2/components/icon.tsx
@@ -49,6 +49,10 @@ const icons = {
     viewBox: "0 0 16 16",
     body: `<path d="M8 2.88867V13.1109" stroke="currentColor" stroke-linejoin="round"/><path d="M2.88867 8H13.1109" stroke="currentColor" stroke-linejoin="round"/>`,
   },
+  minus: {
+    viewBox: "0 0 16 16",
+    body: `<path d="M2.88867 8H13.1109" stroke="currentColor" stroke-linejoin="round"/>`,
+  },
   "settings-gear": {
     viewBox: "0 0 16 16",
     body: `<path d="M7.99998 1.3335L14 4.66683V11.3335L7.99998 14.6668L2 11.3335V4.66683L7.99998 1.3335Z" stroke="currentColor"/><path d="M9.99998 8.00016C9.99998 9.10476 9.10458 10.0002 7.99998 10.0002C6.89538 10.0002 5.99998 9.10476 5.99998 8.00016C5.99998 6.89556 6.89538 6.00016 7.99998 6.00016C9.10458 6.00016 9.99998 6.89556 9.99998 8.00016Z" stroke="currentColor"/>`,

--- a/packages/ui/src/v2/components/icon.tsx
+++ b/packages/ui/src/v2/components/icon.tsx
@@ -53,6 +53,10 @@ const icons = {
     viewBox: "0 0 16 16",
     body: `<path d="M2.88867 8H13.1109" stroke="currentColor" stroke-linejoin="round"/>`,
   },
+  fullscreen: {
+    viewBox: "0 0 16 16",
+    body: `<path d="M13.5 6V2.5H10M13.5 2.5L9.5 6.5" stroke="currentColor"/><path d="M2.5 6V2.5H6M2.5 2.5L6.5 6.5" stroke="currentColor"/><path d="M13.5 10V13.5H10M13.5 13.5L9.5 9.5" stroke="currentColor"/><path d="M2.5 10V13.5H6M2.5 13.5L6.5 9.5" stroke="currentColor"/>`,
+  },
   "settings-gear": {
     viewBox: "0 0 16 16",
     body: `<path d="M7.99998 1.3335L14 4.66683V11.3335L7.99998 14.6668L2 11.3335V4.66683L7.99998 1.3335Z" stroke="currentColor"/><path d="M9.99998 8.00016C9.99998 9.10476 9.10458 10.0002 7.99998 10.0002C6.89538 10.0002 5.99998 9.10476 5.99998 8.00016C5.99998 6.89556 6.89538 6.00016 7.99998 6.00016C9.10458 6.00016 9.99998 6.89556 9.99998 8.00016Z" stroke="currentColor"/>`,


### PR DESCRIPTION
## What

Mermaid fenced code blocks now render as diagrams by default in the chat markdown view. The code block keeps its copy button, which continues to copy the original mermaid **source** (not the rendered SVG).

This targets the desktop app, but the change lives in the shared `session-ui` `Markdown` component that powers desktop chat (and web), so both benefit at no cost to bundles that never show a diagram.

## UX

- Every ` ```mermaid ` block in a chat message renders as a chart.
- Hovering the block shows the existing copy button (top-right); clicking it copies the raw mermaid code.
- While a message is still streaming (or if the diagram fails to parse), the raw source is shown instead, so the block is never empty or broken.

## How it works

- `markdown-stream.ts`: settled (non-streaming) messages are one "full" block, so mermaid fences are now split into standalone `code` blocks. Both the streaming and settled paths therefore flow through a single diagram handler. Non-mermaid content stays coalesced, and messages with link reference definitions fall back to the existing single-block behavior.
- `markdown-mermaid.ts` (new): lazily `import("mermaid")` (code-split; only loaded when a diagram appears), serialized renders (mermaid keeps global state + scratch DOM), `securityLevel: "strict"`, and a reactive `data-color-scheme` signal so diagrams re-render when the app theme flips.
- `markdown.tsx`: mermaid `code` blocks are routed to an imperative renderer that keeps a hidden `<pre><code>` source (for copy + fallback) alongside the rendered SVG, guarded against stale async renders. No `morphdom` is involved for mermaid.
- `markdown.css`: source/diagram visibility driven by `data-mermaid-state`.

## Testing

- `bun test src` in `packages/session-ui` (83 pass), including new unit tests for the mermaid language/theme helpers and the settled-mode fence splitting.
- `bun typecheck` across the workspace (all 30 packages).
- Storybook: the `UI/Markdown` fixture now includes a mermaid flowchart for visual verification.

## Notes

- Diagrams use a curated slate theme (light + dark) on mermaid's `base` theme engine: neutral node surfaces, contrasty edges, and eight desaturated categorical hues for state/timeline/git scales. It does not yet adapt to custom OpenCode theme palettes (would need CSS-var probing; noted as a possible follow-up).
- Mermaid fences nested inside list items still render as code (same limitation as the streaming code splitter).

## Fullscreen viewer (added in iteration)

- Clicking a rendered diagram — or the hover-revealed expand button next to the copy button — opens a fullscreen viewer (Kobalte Dialog: Escape, focus trap, backdrop click all close it).
- Zoom in/out via toolbar buttons or Ctrl/⌘+wheel; the percentage readout resets to fit-to-viewport. Initial zoom fits the screen without upscaling small diagrams.
- The viewer re-renders the SVG with a fresh element ID (no ID collisions with the inline chart) and tracks theme changes while open.

