### PR TITLE
fix(github): remove eyes reaction when `use_github_token: true`

### DIFF
--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -435,6 +435,9 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
     let session: { id: SessionID; title: string; version: string }
     let shareId: string | undefined
     let exitCode = 0
+    // Id of the 👀 reaction we add, captured so removeReaction can delete it
+    // directly instead of re-finding it by author (which differs per auth path).
+    let reactionId: number | undefined
     type PromptFiles = Awaited<ReturnType<typeof getUserPrompt>>["promptFiles"]
     const triggerCommentId = isCommentEvent
       ? (payload as IssueCommentEvent | PullRequestReviewCommentEvent).comment.id
@@ -491,7 +494,8 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
       // Skip permission check and reactions for repo events (no actor to check, no issue to react to)
       if (isUserEvent) {
         await assertPermissions()
-        await addReaction(commentType)
+        const reaction = await addReaction(commentType)
+        reactionId = reaction.data.id
       }
 
       // Setup opencode session
@@ -1203,61 +1207,32 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
     }
 
     async function removeReaction(commentType?: "issue" | "pr_review") {
-      // Only called for non-schedule events, so triggerCommentId is defined
+      // Delete the exact reaction we created; skip if addReaction never ran.
+      if (!reactionId) return
       console.log("Removing reaction...")
       if (triggerCommentId) {
         if (commentType === "pr_review") {
-          const reactions = await octoRest.rest.reactions.listForPullRequestReviewComment({
-            owner,
-            repo,
-            comment_id: triggerCommentId!,
-            content: AGENT_REACTION,
-          })
-
-          const eyesReaction = reactions.data.find((r) => r.user?.login === AGENT_USERNAME)
-          if (!eyesReaction) return
-
           return await octoRest.rest.reactions.deleteForPullRequestComment({
             owner,
             repo,
             comment_id: triggerCommentId!,
-            reaction_id: eyesReaction.id,
+            reaction_id: reactionId,
           })
         }
-
-        const reactions = await octoRest.rest.reactions.listForIssueComment({
-          owner,
-          repo,
-          comment_id: triggerCommentId!,
-          content: AGENT_REACTION,
-        })
-
-        const eyesReaction = reactions.data.find((r) => r.user?.login === AGENT_USERNAME)
-        if (!eyesReaction) return
 
         return await octoRest.rest.reactions.deleteForIssueComment({
           owner,
           repo,
           comment_id: triggerCommentId!,
-          reaction_id: eyesReaction.id,
+          reaction_id: reactionId,
         })
       }
 
-      const reactions = await octoRest.rest.reactions.listForIssue({
+      return await octoRest.rest.reactions.deleteForIssue({
         owner,
         repo,
         issue_number: issueId!,
-        content: AGENT_REACTION,
-      })
-
-      const eyesReaction = reactions.data.find((r) => r.user?.login === AGENT_USERNAME)
-      if (!eyesReaction) return
-
-      await octoRest.rest.reactions.deleteForIssue({
-        owner,
-        repo,
-        issue_number: issueId!,
-        reaction_id: eyesReaction.id,
+        reaction_id: reactionId,
       })
     }
 


### PR DESCRIPTION
### Issue for this PR

Closes #21673

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- Fix #21673

When running opencode on GitHub Actions with `use_github_token: true`, the 👀 (eyes) reaction is added as a processing indicator, but it is never removed even after the run completes.

With `use_github_token: true`, the action identity becomes `github-actions[bot]` instead of `opencode-agent[bot]`.
The `removeReaction` locates the reaction to delete by matching the hardcoded `AGENT_USERNAME`, so `.find()` returns `undefined` and the function silently returns without deleting anything:
https://github.com/anomalyco/opencode/blob/4438f69aac46806c631866489a26b644488a784e/packages/opencode/src/cli/cmd/github.handler.ts#L1210-L1218

Fixing: Using the `id` of the reaction returned by the create call, and delete that exact reaction.

### How did you verify your code works?

I made a repo and PRs to demo the issue and test my fix:
- https://github.com/chAwater/oc-github-test/pull/6

### Screenshots / recordings

None

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
