### PR TITLE
fix(core): identify spawned subagents

### DIFF
--- a/packages/core/src/tool/subagent.ts
+++ b/packages/core/src/tool/subagent.ts
@@ -185,7 +185,11 @@ export const Plugin = {
 
                 const run = Effect.gen(function* () {
                   // The child session owns its agent/model (set at create); prompt only admits input.
-                  yield* runtime.session.prompt({ sessionID: child.id, text: input.prompt, resume: false })
+                  yield* runtime.session.prompt({
+                    sessionID: child.id,
+                    text: ["You are a subagent spawned by another session.", input.prompt].join("\n"),
+                    resume: false,
+                  })
                   yield* runtime.session.resume(child.id)
                   return yield* latestAssistantText(child.id)
                 }).pipe(Effect.onInterrupt(() => runtime.session.interrupt(child.id)))

--- a/packages/core/test/tool-subagent.test.ts
+++ b/packages/core/test/tool-subagent.test.ts
@@ -273,6 +273,9 @@ describe("SubagentTool", () => {
             agent: "reviewer",
             model: childModel,
           })
+          expect((yield* sessions.pending(child.id)).find((message) => message.type === "user")?.data.text).toBe(
+            "You are a subagent spawned by another session.\nreview this",
+          )
 
           const fallback = yield* settleTool(registry, {
             sessionID: parent.id,


### PR DESCRIPTION
## Summary
- prefix child prompts with explicit spawned-subagent context
- preserve the original requested prompt after the context line
- cover the durable admitted prompt in the subagent tool test

## Testing
- full workspace typecheck
- `bun test test/tool-subagent.test.ts`