### PR TITLE
fix(opencode): skip tui migration when tui.jsonc exists

### DIFF
--- a/packages/opencode/src/config/tui-migrate.ts
+++ b/packages/opencode/src/config/tui-migrate.ts
@@ -24,7 +24,7 @@ interface MigrateInput {
 /**
  * Migrates tui-specific keys (theme, keybinds, tui) from opencode.json files
  * into dedicated tui.json files. Migration is performed per-directory and
- * skips only locations where a tui.json already exists.
+ * skips locations where a tui.json or tui.jsonc already exists.
  */
 export async function migrateTuiConfig(input: MigrateInput) {
   const opencode = await opencodeFiles(input)
@@ -46,9 +46,11 @@ export async function migrateTuiConfig(input: MigrateInput) {
     const tui = extracted.tui ? normalizeTui(extracted.tui) : undefined
     if (extracted.theme === undefined && extracted.keybinds === undefined && !tui) continue
 
-    const target = path.join(path.dirname(file), "tui.json")
-    const targetExists = await Filesystem.exists(target)
-    if (targetExists) continue
+    const dir = path.dirname(file)
+    const target = path.join(dir, "tui.json")
+    // A user-managed tui.jsonc counts as already migrated; skip so we don't
+    // recreate a competing tui.json next to it.
+    if ((await Filesystem.exists(target)) || (await Filesystem.exists(path.join(dir, "tui.jsonc")))) continue
 
     const payload: Record<string, unknown> = {
       $schema: TUI_SCHEMA_URL,

--- a/packages/opencode/test/config/tui.test.ts
+++ b/packages/opencode/test/config/tui.test.ts
@@ -308,6 +308,33 @@ it.instance("skips migration when tui.json already exists", () =>
   ),
 )
 
+it.instance("skips migration when tui.jsonc already exists", () =>
+  withCleanState(
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const test = yield* TestInstance
+      yield* fs.writeJson(path.join(test.directory, "opencode.json"), { theme: "legacy" })
+      yield* fs.writeFileString(
+        path.join(test.directory, "tui.jsonc"),
+        `{
+  // user keeps comments in jsonc
+  "diff_style": "stacked"
+}`,
+      )
+
+      const config = yield* getTuiConfig(test.directory)
+      expect(config.diff_style).toBe("stacked")
+      expect(config.theme).toBeUndefined()
+
+      // A user-managed tui.jsonc must not trigger a competing tui.json.
+      expect(yield* fs.existsSafe(path.join(test.directory, "tui.json"))).toBe(false)
+      const server = JSON.parse(yield* fs.readFileString(path.join(test.directory, "opencode.json")))
+      expect(server.theme).toBe("legacy")
+      expect(yield* fs.existsSafe(path.join(test.directory, "opencode.json.tui-migration.bak"))).toBe(false)
+    }),
+  ),
+)
+
 it.instance("continues loading tui config when legacy source cannot be stripped", () =>
   withCleanState(
     Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Fixes #38167

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The legacy TUI migration only checked whether `tui.json` existed. When a user already had a commented `tui.jsonc`, startup created a competing `tui.json`; the normal config lookup then preferred that generated file and ignored the user-managed JSONC configuration.

This change treats either `tui.json` or `tui.jsonc` in the same directory as an existing migration target. Migration is skipped in both cases, so no competing file is created and the legacy TUI keys in `opencode.json` remain untouched.

### How did you verify your code works?

- Focused regression `skips migration when tui.jsonc already exists` in `test/config/tui.test.ts`: passes and verifies that `tui.jsonc` loads, `tui.json` is not created, and the source config is not rewritten or backed up.
- `bun typecheck` from `packages/opencode`: passes.

### Screenshots / recordings

N/A, this changes config migration behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
