### PR TITLE
fix(provider): cache all system messages instead of only first 2

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -333,7 +333,7 @@ function normalizeMessages(
 }
 
 function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
-  const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
+  const system = msgs.filter((msg) => msg.role === "system")
   const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
 
   const providerOptions = {


### PR DESCRIPTION
## Problem

`applyCaching()` in `provider/transform.ts` slices system messages to only the first 2:

```typescript
const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
```

This means additional system messages (from plugins via `experimental.chat.system.transform`, MCP instructions, AGENTS.md content, etc.) are never marked with `cacheControl`. Since the system prompt is the most stable prefix across turns, not caching the full prefix causes unnecessary cache misses and higher input token costs.

## Change

Remove the `.slice(0, 2)` limit so ALL system messages get cache markers:

```typescript
const system = msgs.filter((msg) => msg.role === "system")
```

## Impact

- 1 line changed
- Maximizes prefix cache reuse for Anthropic, Bedrock, OpenRouter, and other providers that support prompt caching
- The system prompt is identical across turns within a session, so caching the full prefix is always beneficial
- No functional change to model behavior