### PR TITLE
fix(tui): restore shell mode styling

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1300,10 +1300,15 @@ export function Prompt(props: PromptProps) {
 
   const highlight = createMemo(() => {
     if (leader()) return themeV2.border.default
-    if (store.mode === "shell") return themeV2.background.action.primary.default
+    if (store.mode === "shell") return themeV2.text.action.primary.selected
     const agent = local.agent.current()
     if (!agent) return themeV2.border.default
     return local.agent.color(agent.id)
+  })
+  const agentLabel = createMemo(() => {
+    if (store.mode === "shell") return "Shell"
+    const agent = local.agent.current()
+    return agent ? Locale.titlecase(agent.id) : undefined
   })
 
   const showVariant = createMemo(() => {
@@ -1313,7 +1318,7 @@ export function Prompt(props: PromptProps) {
     return !!current
   })
 
-  const agentMetaAlpha = createFadeIn(() => !!local.agent.current(), animationsEnabled)
+  const agentMetaAlpha = createFadeIn(() => store.mode === "shell" || !!local.agent.current(), animationsEnabled)
   const modelMetaAlpha = createFadeIn(() => !!local.agent.current() && store.mode === "normal", animationsEnabled)
   const variantMetaAlpha = createFadeIn(
     () => !!local.agent.current() && store.mode === "normal" && showVariant(),
@@ -1460,12 +1465,10 @@ export function Prompt(props: PromptProps) {
             />
             <box flexDirection="row" flexShrink={0} paddingTop={1} gap={1} justifyContent="space-between">
               <box flexDirection="row" gap={1}>
-                <Show when={local.agent.current()} fallback={<box height={1} />}>
-                  {(agent) => (
+                <Show when={agentLabel()} fallback={<box height={1} />}>
+                  {(label) => (
                     <>
-                      <text fg={fadeColor(highlight(), agentMetaAlpha())}>
-                        {store.mode === "shell" ? "Shell" : Locale.titlecase(agent().id)}
-                      </text>
+                      <text fg={fadeColor(highlight(), agentMetaAlpha())}>{label()}</text>
                       <Show when={store.mode === "normal" && local.permission.mode === "auto"}>
                         <text fg={fadeColor(themeV2.text.subdued, agentMetaAlpha())}>auto</text>
                       </Show>


### PR DESCRIPTION
## Summary
- restore the visible shell-mode accent using the selected primary text token
- show the `Shell` label even when no agent is selected
- keep the prompt border fade active while shell mode is selected

## Root cause
The V2 theme migration replaced legacy `theme.primary` with `background.action.primary.default`. Migrated V1 themes resolve that background token to transparent, causing the shell border and label to disappear.

## Testing
- `bun typecheck` in `packages/tui`
- `bun test test/theme/v2/v1-migrate.test.ts test/prompt/traits.test.ts` in `packages/tui`
- OpenCode Drive render against the historical pre-theme commit and the fixed current branch