### PR TITLE
docs(ecosystem): add opencode-orchestrator plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-orchestrator](https://github.com/tder311/opencode-orchestrator)                          | Spawn and supervise parallel agents in cmux tabs, each on its own git worktree                     |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — one-line addition to the ecosystem plugin list, no associated issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-orchestrator](https://github.com/tder311/opencode-orchestrator) to the Plugins table in `ecosystem.mdx`.

It's a plugin I wrote and use daily: it spawns and supervises parallel opencode agents in cmux tabs, each on its own git worktree. `spawnagent` does worktree + backgrounded tab + opencode boot; there's also `listagents`/`peekagent`/`sendtoagent`/`focusagent`/`closeagent`/`registerrepo`, an agent-side `reportstatus` tool, and an in-process watcher that wakes the spawning session when an agent reports.

Published on npm as `@tder311/opencode-orchestrator` (scoped — the unscoped name was already taken by an unrelated package).

### How did you verify your code works?

Docs-only table row. Checked the repo link resolves, the npm package is installable (`@tder311/opencode-orchestrator@0.1.0`), and the row matches the existing table's column alignment.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
