### PR TITLE
fix(desktop): load WSL shell environment

### DIFF
--- a/packages/desktop/src/main/wsl/sidecar-shell.test.ts
+++ b/packages/desktop/src/main/wsl/sidecar-shell.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { wslSidecarShell } from "./sidecar-shell"
+
+test("loads interactive WSL environment variables for the desktop server", async () => {
+  const home = await mkdtemp(join(tmpdir(), "opencode-wsl-env-"))
+  const opencode = join(home, "opencode")
+  await writeFile(join(home, ".profile"), 'source "$HOME/.bashrc"\n')
+  await writeFile(join(home, ".bashrc"), "export COMPANY_BASEURL=https://company.example\n")
+  await writeFile(opencode, '#!/usr/bin/env bash\nprintf "%s" "$COMPANY_BASEURL"\n')
+  await chmod(opencode, 0o755)
+
+  const shell = wslSidecarShell(opencode, 4096, "opencode", "secret", false)
+  const proc = Bun.spawn(shell.args, {
+    cwd: home,
+    env: { ...process.env, HOME: home },
+    stdin: new Blob([shell.script]),
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const output = await new Response(proc.stdout).text()
+  await new Response(proc.stderr).text()
+  const code = await proc.exited
+  await rm(home, { recursive: true, force: true })
+
+  expect({ code, output }).toEqual({ code: 0, output: "https://company.example" })
+})

--- a/packages/desktop/src/main/wsl/sidecar-shell.ts
+++ b/packages/desktop/src/main/wsl/sidecar-shell.ts
@@ -1,0 +1,28 @@
+import { shellEscape } from "./runtime"
+
+export function wslSidecarShell(opencode: string, port: number, username: string, password: string, packaged: boolean) {
+  return {
+    // Explicit WSL commands skip login startup files. Load the same user environment
+    // as a terminal launch, then replace the interactive shell before reading stdin.
+    args: [
+      "bash",
+      "--noprofile",
+      "--norc",
+      "-ic",
+      'for file in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do [[ ! -r "$file" ]] || { source "$file"; break; }; done; exec bash -se',
+    ],
+    script: [
+      "set -euo pipefail",
+      'cd "$HOME" || cd /',
+      'PATH=$(awk -v RS=: -v ORS=: \'$0 !~ /^\\/mnt\\//\' <<<"$PATH" | sed "s/:$//")',
+      "export PATH",
+      "export WSLENV=",
+      "export OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true",
+      "export OPENCODE_CLIENT=desktop",
+      `export OPENCODE_SERVER_USERNAME=${shellEscape(username)}`,
+      `export OPENCODE_SERVER_PASSWORD=${shellEscape(password)}`,
+      'export XDG_STATE_HOME="$HOME/.local/state"',
+      `exec ${shellEscape(opencode)} --print-logs --log-level ${packaged ? "WARN" : "INFO"} serve --hostname 0.0.0.0 --port ${port}`,
+    ].join("\n"),
+  }
+}

--- a/packages/desktop/src/main/wsl/sidecar.ts
+++ b/packages/desktop/src/main/wsl/sidecar.ts
@@ -3,7 +3,8 @@ import { randomUUID } from "node:crypto"
 import { createServer } from "node:net"
 import { app } from "electron"
 import { checkHealth } from "../server"
-import { type WslCommandLine, resolveWslOpencode, shellEscape, wslArgs } from "./runtime"
+import { type WslCommandLine, resolveWslOpencode, wslArgs } from "./runtime"
+import { wslSidecarShell } from "./sidecar-shell"
 import { pollWslHealth } from "./startup"
 
 export type WslSidecar = {
@@ -23,24 +24,12 @@ export async function spawnWslSidecar(
   const port = await allocatePort()
   const password = randomUUID()
   const username = "opencode"
-  const script = [
-    "set -euo pipefail",
-    'cd "$HOME" || cd /',
-    'PATH=$(awk -v RS=: -v ORS=: \'$0 !~ /^\\/mnt\\//\' <<<"$PATH" | sed "s/:$//")',
-    "export PATH",
-    "export WSLENV=",
-    "export OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true",
-    "export OPENCODE_CLIENT=desktop",
-    `export OPENCODE_SERVER_USERNAME=${shellEscape(username)}`,
-    `export OPENCODE_SERVER_PASSWORD=${shellEscape(password)}`,
-    'export XDG_STATE_HOME="$HOME/.local/state"',
-    `exec ${shellEscape(opencode)} --print-logs --log-level ${app.isPackaged ? "WARN" : "INFO"} serve --hostname 0.0.0.0 --port ${port}`,
-  ].join("\n")
-  const child = spawn("wsl", wslArgs(["bash", "-se"], distro), {
+  const shell = wslSidecarShell(opencode, port, username, password, app.isPackaged)
+  const child = spawn("wsl", wslArgs(shell.args, distro), {
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: true,
   })
-  child.stdin.end(script)
+  child.stdin.end(shell.script)
 
   const recentOutput: string[] = []
   const emit = (line: WslCommandLine) => {


### PR DESCRIPTION
## Summary

Fix the desktop WSL sidecar so it loads the user's WSL login environment before starting the OpenCode server.

When provider config uses environment interpolation such as:

```jsonc
{
  "providers": {
    "company": {
      "options": {
        "apiKey": "{env:COMPANY_KEY}",
        "baseURL": "{env:COMPANY_BASEURL}"
      }
    }
  }
}
```

OpenCode launched from a WSL terminal sees variables exported by the user's shell startup files, but the desktop sidecar did not. The desktop then resolved `baseURL` to an empty value and requests failed with errors such as `"/chat/completions" cannot be parsed as a URL`.

## Root cause

The desktop sidecar launched an explicit non-login shell:

```text
wsl ... -- bash -se
```

Explicit WSL commands do not load the user's login startup files, unlike the shell environment used to launch the TUI. As a result, the server processes had different environments depending on which client started them.

## Fix

- Build the sidecar shell command and server script at a pure, testable boundary.
- Start an isolated interactive Bash environment and source the first readable login file using Bash's normal precedence:
  - `~/.bash_profile`
  - `~/.bash_login`
  - `~/.profile`
- Replace that bootstrap shell with the existing strict `bash -se` server script so the long-running sidecar behavior remains unchanged.
- Preserve the existing PATH filtering, WSL-specific variables, authentication, logging, and health-check flow.

## Regression coverage

The new test creates a hermetic WSL-home fixture where `.profile` loads `.bashrc`, `.bashrc` exports `COMPANY_BASEURL`, and a fake OpenCode executable reports the value inherited by the real generated sidecar command.

Before the fix the test deterministically reports an empty value. After the fix it receives `https://company.example`.

## Verification

- `bun test src/main/wsl/sidecar-shell.test.ts src/main/wsl/servers.test.ts src/renderer/wsl/connections.test.ts` — 15 passed
- `bun typecheck` in `packages/desktop` — passed
- Full repository typecheck from the push hook — 30 packages passed
- Prettier check for all changed files — passed

The recording environment is Linux rather than a Windows host, so the videos use a hermetic reproduction of the exact shell boundary and generated sidecar command. They compare the TUI-style interactive shell with the desktop sidecar before and after the change.

## Before

https://github.com/anomalyco/opencode/releases/download/pr-38252-videos/wsl-env-before.mp4

## After

https://github.com/anomalyco/opencode/releases/download/pr-38252-videos/wsl-env-after.mp4
