### PR TITLE
docs: add opencode-statusline to ecosystem plugins list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -39,6 +39,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events                |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
+| [opencode-statusline](https://github.com/tang/opencode-statusline)                                    | Statusline TUI plugin showing session stats (tokens, cost, speed, context) with i18n support and interactive config |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                         |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control          |

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -38,6 +38,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | 针对权限请求、任务完成和错误事件的桌面通知与声音提醒                   |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | 基于 OpenCode 上下文的 AI 驱动自动 Zellij 会话命名                     |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | 允许 OpenCode 代理通过技能发现和注入按需延迟加载提示词                 |
+| [opencode-statusline](https://github.com/tang/opencode-statusline)                                    | 在侧栏底部显示会话状态（token、费用、上下文等）的 TUI 插件，支持中/英双语和交互式配置 |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | 使用 Supermemory 实现跨会话的持久记忆                                  |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | 支持可视化标注和私有/离线分享的交互式计划审查                          |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | 将 OpenCode /commands 扩展为具有精细流程控制的强大编排系统             |


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] New feature
- [ ] Documentation

### What does this PR do?

Adds [opencode-statusline](https://github.com/tsy-fred/opencode-statusline) to the ecosystem plugins table (both English and zh-CN). It's a TUI plugin that shows session stats (tokens, cost, speed, context, git branch) in the sidebar footer with i18n support (zh-CN/en) and interactive configuration.

### How did you verify your code works?

Reviewed the rendered markdown locally for correct table formatting.

### Screenshots / recordings

![statusline screenshot 1](https://litter.catbox.moe/poowpw.JPEG)
![statusline screenshot 2](https://litter.catbox.moe/yovy1u.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR