### PR TITLE
feat(desktop): add radio group button for switching agent mode

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -42,6 +42,7 @@ import { MenuV2 } from "@opencode-ai/ui/v2/menu-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Select } from "@opencode-ai/ui/select"
+import { RadioGroup } from "@opencode-ai/ui/radio-group"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { ModelSelectorPopover, ModelSelectorPopoverV2 } from "@/components/dialog-select-model"
 import { DialogSelectModelUnpaid } from "@/components/dialog-select-model-unpaid"
@@ -1656,20 +1657,38 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                       title={language.t("command.agent.cycle")}
                       keybind={command.keybind("agent.cycle")}
                     >
-                      <Select
-                        size="normal"
-                        options={props.controls.agents.options}
-                        current={props.controls.agents.current}
-                        onSelect={(value) => {
-                          props.controls.agents.select(value)
-                          restoreFocus()
-                        }}
-                        class="capitalize max-w-[160px] text-text-base"
-                        valueClass="truncate text-13-regular text-text-base"
-                        triggerStyle={control()}
-                        triggerProps={{ "data-action": "prompt-agent" }}
-                        variant="ghost"
-                      />
+                      <Show
+                        when={props.controls.agents.options.length === 2}
+                        fallback={
+                          <Select
+                            size="normal"
+                            options={props.controls.agents.options}
+                            current={props.controls.agents.current}
+                            onSelect={(value) => {
+                              props.controls.agents.select(value)
+                              restoreFocus()
+                            }}
+                            class="capitalize max-w-[160px] text-text-base"
+                            valueClass="truncate text-13-regular text-text-base"
+                            triggerStyle={control()}
+                            triggerProps={{ "data-action": "prompt-agent" }}
+                            variant="ghost"
+                          />
+                        }
+                      >
+                        <RadioGroup
+                          size="small"
+                          options={props.controls.agents.options}
+                          current={props.controls.agents.current}
+                          onSelect={(value) => {
+                            if (!value) return
+                            props.controls.agents.select(value)
+                            restoreFocus()
+                          }}
+                          class="capitalize"
+                          data-action="prompt-agent"
+                        />
+                      </Show>
                     </TooltipKeybind>
                   </div>
                 </Show>

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -8,6 +8,7 @@ import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
 import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
 import { MenuV2 } from "@opencode-ai/ui/v2/menu-v2"
+import { SegmentedControlItemV2, SegmentedControlV2 } from "@opencode-ai/ui/v2/segmented-control-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { AttachmentCardV2 } from "../attachment-card-v2"
 import { CommentCardV2 } from "../comment-card-v2"
@@ -212,7 +213,14 @@ export function PromptInputV2(props: PromptInputV2Props) {
             />
             <Show when={view.agent}>
               {(control) => (
-                <PromptInputV2ConfiguredSelect title="Choose agent" keybind={["Mod", "."]} control={control()} />
+                <Show
+                  when={control().options().length === 2}
+                  fallback={
+                    <PromptInputV2ConfiguredSelect title="Choose agent" keybind={["Mod", "."]} control={control()} />
+                  }
+                >
+                  <PromptInputV2SegmentedToggle title="Choose agent" keybind={["Mod", "."]} control={control()} />
+                </Show>
               )}
             </Show>
             <Show
@@ -528,6 +536,43 @@ function PromptInputV2ConfiguredSelect(props: {
       }
       onSelect={props.control.onSelect}
     />
+  )
+}
+
+function PromptInputV2SegmentedToggle(props: {
+  title: string
+  keybind?: string[]
+  control: PromptInputV2SelectControl
+}) {
+  const keybind = () => props.control.keybind?.() ?? props.keybind ?? []
+  return (
+    <TooltipV2
+      placement="top"
+      value={
+        <>
+          {props.title}
+          <KeybindV2 keys={keybind()} variant="neutral" />
+        </>
+      }
+    >
+      <SegmentedControlV2
+        value={props.control.current()}
+        onChange={(value) => {
+          if (value === null) return
+          props.control.onSelect(value)
+        }}
+        class="segmented-control-v2--compact"
+        aria-label={props.title}
+      >
+        <For each={props.control.options()}>
+          {(option) => (
+            <SegmentedControlItemV2 value={option.id} class="capitalize">
+              {option.label}
+            </SegmentedControlItemV2>
+          )}
+        </For>
+      </SegmentedControlV2>
+    </TooltipV2>
   )
 }
 

--- a/packages/ui/src/v2/components/segmented-control-v2.css
+++ b/packages/ui/src/v2/components/segmented-control-v2.css
@@ -2,6 +2,18 @@
   width: 100%;
 }
 
+[data-slot="segmented-control-v2"].segmented-control-v2--compact {
+  width: fit-content;
+  height: 24px;
+}
+
+.segmented-control-v2--compact [data-slot="segmented-control-v2-item"] {
+  flex: 0 0 auto;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
 [data-slot="segmented-control-v2"] {
   box-sizing: border-box;
   display: flex;


### PR DESCRIPTION
### Issue for this PR

Closes #38277

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds a toggle button to switch between the plan/build modes. It only shows as toggle button when there are exactly 2 options, in all other cases it will fallback to the dropdown behaviour. 
The new button reduces 1 click and is just easier to use when there only to options.
The scope is only the desktop app.

### How did you verify your code works?

Build the electron application locally and tested the changed views in the old v1 and new v2 ui.

### Screenshots / recordings

**Before:**
<img width="558" height="150" alt="image" src="https://github.com/user-attachments/assets/6969d7f8-d9de-4ca7-aa7a-31a2a5b7a5d9" />

**After:**
V1 ui: 
<img width="561" height="149" alt="image" src="https://github.com/user-attachments/assets/bae08a60-0513-436b-b8f7-3a2943b3f693" />

V2 ui:
<img width="543" height="117" alt="image" src="https://github.com/user-attachments/assets/4f2016a5-6a94-4ef4-909d-f311d1dfbb09" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

PS. The new UI currently has a bug causing it to hide the plan/build modes by default, this should be fixed in a separate PR.