### PR TITLE
feat(session-ui): collapsible JSON tree view for raw messages in context panel

### DIFF
--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -1,13 +1,12 @@
-import { createMemo, createEffect, on, onCleanup, For, Show } from "solid-js"
+import { createMemo, createEffect, on, onCleanup, onMount, For, Show } from "solid-js"
 import type { JSX } from "solid-js"
 import { useSync } from "@/context/sync"
-import { checksum } from "@opencode-ai/core/util/encode"
 import { findLast } from "@opencode-ai/core/util/array"
 import { same } from "@/utils/same"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Accordion } from "@opencode-ai/ui/accordion"
 import { StickyAccordionHeader } from "@opencode-ai/ui/sticky-accordion-header"
-import { File } from "@opencode-ai/session-ui/file"
+import { JsonViewer } from "@opencode-ai/session-ui/json-viewer"
 import { Markdown } from "@opencode-ai/session-ui/markdown"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import type { Message, Part, UserMessage } from "@opencode-ai/sdk/v2/client"
@@ -37,23 +36,19 @@ function Stat(props: { label: string; value: JSX.Element }) {
 }
 
 function RawMessageContent(props: { message: Message; getParts: (id: string) => Part[]; onRendered: () => void }) {
-  const file = createMemo(() => {
+  const contents = createMemo(() => {
     const parts = props.getParts(props.message.id)
-    const contents = JSON.stringify({ message: props.message, parts }, null, 2)
-    return {
-      name: `${props.message.role}-${props.message.id}.json`,
-      contents,
-      cacheKey: checksum(contents),
-    }
+    return JSON.stringify({ message: props.message, parts }, null, 2)
+  })
+
+  onMount(() => {
+    requestAnimationFrame(props.onRendered)
   })
 
   return (
-    <File
-      mode="text"
-      file={file()}
-      overflow="wrap"
+    <JsonViewer
+      json={contents()}
       class="select-text"
-      onRendered={() => requestAnimationFrame(props.onRendered)}
     />
   )
 }

--- a/packages/app/src/components/session/session-context-tab.tsx
+++ b/packages/app/src/components/session/session-context-tab.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createEffect, on, onCleanup, onMount, For, Show } from "solid-js"
+import { createMemo, createEffect, on, onCleanup, For, Show } from "solid-js"
 import type { JSX } from "solid-js"
 import { useSync } from "@/context/sync"
 import { findLast } from "@opencode-ai/core/util/array"
@@ -41,9 +41,11 @@ function RawMessageContent(props: { message: Message; getParts: (id: string) => 
     return JSON.stringify({ message: props.message, parts }, null, 2)
   })
 
-  onMount(() => {
-    requestAnimationFrame(props.onRendered)
-  })
+  createEffect(
+    on(contents, () => {
+      requestAnimationFrame(props.onRendered)
+    }),
+  )
 
   return (
     <JsonViewer

--- a/packages/session-ui/src/components/json-viewer.css
+++ b/packages/session-ui/src/components/json-viewer.css
@@ -1,0 +1,67 @@
+.json-viewer {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  line-height: var(--line-height-large);
+}
+
+.json-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0;
+  min-height: 24px;
+}
+
+.json-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  cursor: pointer;
+  color: var(--syntax-punctuation);
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  transform: rotate(0deg);
+  transition: transform 0.15s ease;
+}
+
+.json-toggle--expanded {
+  transform: rotate(90deg);
+}
+
+.json-toggle:hover {
+  color: var(--text-strong);
+}
+
+.json-key {
+  color: var(--syntax-property);
+  flex-shrink: 0;
+}
+
+.json-string {
+  color: var(--syntax-string);
+}
+
+.json-number {
+  color: var(--syntax-constant);
+}
+
+.json-boolean {
+  color: var(--syntax-primitive);
+}
+
+.json-null {
+  color: var(--syntax-comment);
+}
+
+.json-bracket {
+  color: var(--syntax-punctuation);
+}
+
+.json-ellipsis {
+  color: var(--syntax-comment);
+  margin: 0 2px;
+}

--- a/packages/session-ui/src/components/json-viewer.test.ts
+++ b/packages/session-ui/src/components/json-viewer.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import { jsonKeys, parseJson } from "./json-viewer"
+
+describe("parseJson", () => {
+  test.each(["false", "0", '""', "null"])("accepts root value %s", (json) => {
+    expect(parseJson(json).valid).toBe(true)
+  })
+
+  test("returns the parsed value", () => {
+    expect(parseJson('{"message":"hello"}')).toEqual({ value: { message: "hello" }, valid: true })
+  })
+
+  test("marks malformed JSON as invalid", () => {
+    expect(parseJson("{malformed")).toEqual({ value: null, valid: false })
+  })
+})
+
+describe("jsonKeys", () => {
+  test("returns stable string keys for arrays", () => {
+    expect(jsonKeys(["first", "second"])).toEqual(["0", "1"])
+  })
+
+  test("returns object keys without rebuilding value entries", () => {
+    expect(jsonKeys({ first: 1, second: 2 })).toEqual(["first", "second"])
+  })
+
+  test("returns no keys for primitive and empty values", () => {
+    expect(jsonKeys(false)).toEqual([])
+    expect(jsonKeys([])).toEqual([])
+    expect(jsonKeys({})).toEqual([])
+  })
+})

--- a/packages/session-ui/src/components/json-viewer.tsx
+++ b/packages/session-ui/src/components/json-viewer.tsx
@@ -1,4 +1,5 @@
-import { createMemo, createSignal, For, Show } from "solid-js"
+import { createEffect, createSignal, For, Show } from "solid-js"
+import { createStore, reconcile } from "solid-js/store"
 import { Icon } from "@opencode-ai/ui/icon"
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }
@@ -56,6 +57,7 @@ function JsonNode(props: { value: JsonValue; keyName?: string; depth: number }) 
           class="json-toggle"
           classList={{ "json-toggle--expanded": expanded() }}
           aria-expanded={expanded()}
+          aria-label={props.keyName !== undefined ? `Toggle ${props.keyName}` : "Toggle"}
           onClick={() => setExpanded((e) => !e)}
         >
           <Icon name="chevron-right" size="small" />
@@ -79,25 +81,21 @@ function JsonNode(props: { value: JsonValue; keyName?: string; depth: number }) 
 }
 
 export function JsonViewer(props: { json: string; class?: string }) {
-  const parsed = createMemo<JsonValue | undefined>(() => {
+  const [state, setState] = createStore<{ value: JsonValue; valid: boolean }>({ value: null, valid: false })
+
+  createEffect(() => {
     try {
-      return JSON.parse(props.json)
+      setState(reconcile({ value: JSON.parse(props.json), valid: true }))
     } catch {
-      return undefined
+      setState("valid", false)
     }
   })
 
   return (
-    <Show
-      when={parsed()}
-      keyed
-      fallback={<div class={props.class}>{props.json}</div>}
-    >
-      {(value) => (
-        <div class={`json-viewer ${props.class ?? ""}`}>
-          <JsonNode value={value} depth={0} />
-        </div>
-      )}
+    <Show when={state.valid} fallback={<div class={props.class}>{props.json}</div>}>
+      <div class={`json-viewer ${props.class ?? ""}`}>
+        <JsonNode value={state.value} depth={0} />
+      </div>
     </Show>
   )
 }

--- a/packages/session-ui/src/components/json-viewer.tsx
+++ b/packages/session-ui/src/components/json-viewer.tsx
@@ -1,0 +1,103 @@
+import { createMemo, createSignal, For, Show } from "solid-js"
+import { Icon } from "@opencode-ai/ui/icon"
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue }
+
+const PRIMITIVE_CLASS: Record<string, string> = {
+  string: "json-string",
+  number: "json-number",
+  boolean: "json-boolean",
+}
+
+function escapeJsonString(value: string) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")
+}
+
+function JsonNode(props: { value: JsonValue; keyName?: string; depth: number }) {
+  const [expanded, setExpanded] = createSignal(props.depth < 2)
+
+  if (typeof props.value !== "object" || props.value === null) {
+    const className = props.value === null ? "json-null" : (PRIMITIVE_CLASS[typeof props.value] ?? "json-null")
+    const display =
+      typeof props.value === "string"
+        ? `"${escapeJsonString(props.value)}"`
+        : String(props.value)
+    return (
+      <div class="json-row" style={{ "padding-left": `${props.depth * 16}px` }}>
+        <Show when={props.keyName !== undefined}>
+          <span class="json-key">{props.keyName}: </span>
+        </Show>
+        <span class={className}>{display}</span>
+      </div>
+    )
+  }
+
+  const isArray = Array.isArray(props.value)
+  const openBracket = isArray ? "[" : "{"
+  const closeBracket = isArray ? "]" : "}"
+
+  const isEmpty = () => {
+    if (Array.isArray(props.value)) return props.value.length === 0
+    return Object.keys(props.value).length === 0
+  }
+
+  const entries = () => {
+    if (isArray) return (props.value as JsonValue[]).map((v, i) => [String(i), v] as [string, JsonValue])
+    return Object.entries(props.value as Record<string, JsonValue>)
+  }
+
+  return (
+    <div>
+      <div class="json-row" style={{ "padding-left": `${props.depth * 16}px` }}>
+        <Show when={props.keyName !== undefined}>
+          <span class="json-key">{props.keyName}: </span>
+        </Show>
+        <button
+          class="json-toggle"
+          classList={{ "json-toggle--expanded": expanded() }}
+          aria-expanded={expanded()}
+          onClick={() => setExpanded((e) => !e)}
+        >
+          <Icon name="chevron-right" size="small" />
+        </button>
+        <span class="json-bracket">{openBracket}</span>
+        <Show when={!expanded()}>
+          <span class="json-ellipsis">...</span>
+          <span class="json-bracket">{closeBracket}</span>
+        </Show>
+      </div>
+      <Show when={expanded()}>
+        <For each={entries()}>
+          {([key, val]) => <JsonNode value={val} keyName={key} depth={props.depth + 1} />}
+        </For>
+        <div class="json-row" style={{ "padding-left": `${props.depth * 16}px` }}>
+          <span class="json-bracket">{closeBracket}</span>
+        </div>
+      </Show>
+    </div>
+  )
+}
+
+export function JsonViewer(props: { json: string; class?: string }) {
+  const parsed = createMemo<JsonValue | undefined>(() => {
+    try {
+      return JSON.parse(props.json)
+    } catch {
+      return undefined
+    }
+  })
+
+  return (
+    <Show
+      when={parsed()}
+      keyed
+      fallback={<div class={props.class}>{props.json}</div>}
+    >
+      {(value) => (
+        <div class={`json-viewer ${props.class ?? ""}`}>
+          <JsonNode value={value} depth={0} />
+        </div>
+      )}
+    </Show>
+  )
+}

--- a/packages/session-ui/src/components/json-viewer.tsx
+++ b/packages/session-ui/src/components/json-viewer.tsx
@@ -11,72 +11,105 @@ const PRIMITIVE_CLASS: Record<string, string> = {
 }
 
 function escapeJsonString(value: string) {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t")
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return true
+  }
+  if (Array.isArray(value)) return value.every(isJsonValue)
+  if (typeof value !== "object") return false
+  return Object.values(value).every(isJsonValue)
+}
+
+export function parseJson(json: string): { value: JsonValue; valid: boolean } {
+  try {
+    const value: unknown = JSON.parse(json)
+    return isJsonValue(value) ? { value, valid: true } : { value: null, valid: false }
+  } catch {
+    return { value: null, valid: false }
+  }
+}
+
+export function jsonKeys(value: JsonValue): string[] {
+  if (Array.isArray(value)) return value.map((_, index) => String(index))
+  if (value !== null && typeof value === "object") return Object.keys(value)
+  return []
 }
 
 function JsonNode(props: { value: JsonValue; keyName?: string; depth: number }) {
   const [expanded, setExpanded] = createSignal(props.depth < 2)
 
-  if (typeof props.value !== "object" || props.value === null) {
-    const className = props.value === null ? "json-null" : (PRIMITIVE_CLASS[typeof props.value] ?? "json-null")
-    const display =
-      typeof props.value === "string"
-        ? `"${escapeJsonString(props.value)}"`
-        : String(props.value)
-    return (
-      <div class="json-row" style={{ "padding-left": `${props.depth * 16}px` }}>
-        <Show when={props.keyName !== undefined}>
-          <span class="json-key">{props.keyName}: </span>
-        </Show>
-        <span class={className}>{display}</span>
-      </div>
-    )
+  const isContainer = () => typeof props.value === "object" && props.value !== null
+  const isArray = () => Array.isArray(props.value)
+  const keys = () => jsonKeys(props.value)
+  const isEmpty = () => keys().length === 0
+  const valueFor = (key: string) => {
+    if (Array.isArray(props.value)) return props.value[Number(key)]
+    if (props.value !== null && typeof props.value === "object") return props.value[key]
+    return null
   }
 
-  const isArray = Array.isArray(props.value)
-  const openBracket = isArray ? "[" : "{"
-  const closeBracket = isArray ? "]" : "}"
-
-  const isEmpty = () => {
-    if (Array.isArray(props.value)) return props.value.length === 0
-    return Object.keys(props.value).length === 0
+  const primitiveClass = () => {
+    if (props.value === null) return "json-null"
+    return PRIMITIVE_CLASS[typeof props.value] ?? "json-null"
   }
-
-  const entries = () => {
-    if (isArray) return (props.value as JsonValue[]).map((v, i) => [String(i), v] as [string, JsonValue])
-    return Object.entries(props.value as Record<string, JsonValue>)
+  const primitiveDisplay = () => {
+    const value = props.value
+    if (typeof value === "string") return `"${escapeJsonString(value)}"`
+    if (typeof value === "number" || typeof value === "boolean") return String(value)
+    return "null"
   }
 
   return (
-    <div>
+    <Show
+      when={isContainer()}
+      fallback={
+        <div class="json-row" style={{ "padding-left": `${props.depth * 16}px` }}>
+          <Show when={props.keyName !== undefined}>
+            <span class="json-key">{props.keyName}: </span>
+          </Show>
+          <span class={primitiveClass()}>{primitiveDisplay()}</span>
+        </div>
+      }
+    >
       <div class="json-row" style={{ "padding-left": `${props.depth * 16}px` }}>
         <Show when={props.keyName !== undefined}>
           <span class="json-key">{props.keyName}: </span>
         </Show>
-        <button
-          class="json-toggle"
-          classList={{ "json-toggle--expanded": expanded() }}
-          aria-expanded={expanded()}
-          aria-label={props.keyName !== undefined ? `Toggle ${props.keyName}` : "Toggle"}
-          onClick={() => setExpanded((e) => !e)}
-        >
-          <Icon name="chevron-right" size="small" />
-        </button>
-        <span class="json-bracket">{openBracket}</span>
-        <Show when={!expanded()}>
+        <Show when={!isEmpty()}>
+          <button
+            class="json-toggle"
+            classList={{ "json-toggle--expanded": expanded() }}
+            aria-expanded={expanded()}
+            aria-label={props.keyName !== undefined ? `Toggle ${props.keyName}` : "Toggle"}
+            onClick={() => setExpanded((e) => !e)}
+          >
+            <Icon name="chevron-right" size="small" />
+          </button>
+        </Show>
+        <span class="json-bracket">{isArray() ? "[" : "{"}</span>
+        <Show when={isEmpty()}>
+          <span class="json-bracket">{isArray() ? "]" : "}"}</span>
+        </Show>
+        <Show when={!isEmpty() && !expanded()}>
           <span class="json-ellipsis">...</span>
-          <span class="json-bracket">{closeBracket}</span>
+          <span class="json-bracket">{isArray() ? "]" : "}"}</span>
         </Show>
       </div>
-      <Show when={expanded()}>
-        <For each={entries()}>
-          {([key, val]) => <JsonNode value={val} keyName={key} depth={props.depth + 1} />}
-        </For>
+      <Show when={!isEmpty() && expanded()}>
+        <For each={keys()}>{(key) => <JsonNode value={valueFor(key)} keyName={key} depth={props.depth + 1} />}</For>
         <div class="json-row" style={{ "padding-left": `${props.depth * 16}px` }}>
-          <span class="json-bracket">{closeBracket}</span>
+          <span class="json-bracket">{isArray() ? "]" : "}"}</span>
         </div>
       </Show>
-    </div>
+    </Show>
   )
 }
 
@@ -84,11 +117,9 @@ export function JsonViewer(props: { json: string; class?: string }) {
   const [state, setState] = createStore<{ value: JsonValue; valid: boolean }>({ value: null, valid: false })
 
   createEffect(() => {
-    try {
-      setState(reconcile({ value: JSON.parse(props.json), valid: true }))
-    } catch {
-      setState("valid", false)
-    }
+    const parsed = parseJson(props.json)
+    if (parsed.valid) setState(reconcile(parsed))
+    else setState("valid", false)
   })
 
   return (

--- a/packages/session-ui/src/styles/index.css
+++ b/packages/session-ui/src/styles/index.css
@@ -1,5 +1,6 @@
 @layer theme, base, components, utilities;
 
+@import "../components/json-viewer.css" layer(components);
 @import "../components/basic-tool.css" layer(components);
 @import "../components/file.css" layer(components);
 @import "../components/markdown.css" layer(components);


### PR DESCRIPTION
### Issue for this PR

Closes #38288

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The raw messages section in the context panel rendered each message as a flat JSON text block via the `File` component. Deeply nested structures were hard to scan.

This PR replaces that with a recursive collapsible tree viewer (`JsonViewer`). Each object/array node gets a chevron toggle; nodes at depth < 2 start expanded so `message` and `parts` fields are immediately visible. Parsing is wrapped in `createMemo` with `<Show keyed>` so the tree rebuilds reactively when parts stream in. Strings are escaped (`\n`, `\"`, etc.) and syntax-colored using the existing `--syntax-*` theme variables. Invalid JSON falls back to plain text.

No new dependencies. The old `File` + `checksum` import is removed since it is no longer needed here.

### How did you verify your code works?

Ran the app dev server (`bun dev` in `packages/app` against a local backend), opened a session, expanded the context panel → Raw messages, and confirmed:
- Tree renders with correct expand/collapse behavior
- Streaming messages update the tree reactively
- Strings with newlines/quotes display escaped
- Malformed JSON (manually tested by temporarily breaking input) falls back to raw text

### Screenshots / recordings

N/A — pure UI behavior change, no visual mockup.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR