### PR TITLE
feat(desktop): add BiDi text direction support and message metadata footer

### DIFF
--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -12,7 +12,8 @@ const C='[data-component="markdown"],[data-slot="text-part-body"],[data-slot="us
 const B='p,li,h1,h2,h3,h4,h5,h6,td,th,blockquote'
 const R='[data-slot="question-text"],[data-slot="answer-text"],[data-component="tool-output"],[data-slot="user-message-text"]'
 const I='[data-component="prompt-input"],[contenteditable]'
-const da=el=>{el.setAttribute("dir","auto")}
+const ir=c=>{const p=c.codePointAt(0);return(p>=0x0590&&p<=0x05FF)||(p>=0x0600&&p<=0x06FF)||(p>=0x0750&&p<=0x077F)||(p>=0x08A0&&p<=0x08FF)||(p>=0xFB1D&&p<=0xFDFF)||(p>=0xFE70&&p<=0xFEFF)};
+const da=el=>{const t=el.textContent;let r=0,l=0,f=null;for(const c of t){if(ir(c)){r++;if(f===null)f='r'}else if(/[A-Za-z\u00C0-\u024F]/.test(c)){l++;if(f===null)f='l'}}if(f==='r'){el.setAttribute('dir','rtl');return}if(f==='l'&&r>0&&r>=l*0.4){el.setAttribute('dir','rtl');return}el.setAttribute('dir','ltr')};
 const co=el=>{if(el.getAttribute("data-cd")==="1")return;el.setAttribute("data-cd","1");new MutationObserver(recs=>{for(const r of recs){if(r.type!=="characterData")continue;const p=r.target.parentElement;if(!p)continue;if(p.matches(B)&&p.closest(C))da(p);else if(p.matches(R))da(p)}}).observe(el,{childList:true,subtree:true,characterData:true})}
 const mc=el=>{if(el.getAttribute("data-bc")!=="1"){el.setAttribute("data-bc","1");el.querySelectorAll(B).forEach(da);el.querySelectorAll(R).forEach(da);co(el)}}
 const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))da(n);else n.querySelectorAll(I).forEach(da);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -12,7 +12,7 @@ const C='[data-component="markdown"],[data-slot="text-part-body"],[data-slot="us
 const B='p,li,h1,h2,h3,h4,h5,h6,td,th,blockquote'
 const R='[data-slot="question-text"],[data-slot="answer-text"],[data-component="tool-output"],[data-slot="user-message-text"]'
 const I='[data-component="prompt-input"],[contenteditable]'
-const da=el=>{if(!el.hasAttribute("dir"))el.setAttribute("dir","auto")}
+const da=el=>{el.setAttribute("dir","auto")}
 const co=el=>{if(el.getAttribute("data-cd")==="1")return;el.setAttribute("data-cd","1");new MutationObserver(recs=>{for(const r of recs){if(r.type!=="characterData")continue;const p=r.target.parentElement;if(!p)continue;if(p.matches(B)&&p.closest(C))da(p);else if(p.matches(R))da(p)}}).observe(el,{childList:true,subtree:true,characterData:true})}
 const mc=el=>{if(el.getAttribute("data-bc")!=="1"){el.setAttribute("data-bc","1");el.querySelectorAll(B).forEach(da);el.querySelectorAll(R).forEach(da);co(el)}}
 const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))da(n);else n.querySelectorAll(I).forEach(da);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -4,7 +4,7 @@ import type { UpdaterState } from "@opencode-ai/app/updater"
 
 // BiDi text direction support + message metadata footer
 {
-const css = `[data-component="markdown"]>*{unicode-bidi:plaintext !important}[data-slot="text-part-body"]>*{unicode-bidi:plaintext !important}[data-slot="user-message-text"]{unicode-bidi:plaintext !important}[data-component="reasoning-part"]>*{unicode-bidi:plaintext !important}[data-component="tool-output"]{unicode-bidi:plaintext !important}[data-slot="question-text"]{unicode-bidi:plaintext !important}[data-slot="answer-text"]{unicode-bidi:plaintext !important}[data-component="markdown"] code,[data-component="markdown"] pre{direction:ltr;unicode-bidi:isolate !important}[data-component="markdown"] pre code{unicode-bidi:isolate !important}`
+const css = `[data-component="markdown"]>*{unicode-bidi:plaintext !important}[data-slot="text-part-body"]>*{unicode-bidi:plaintext !important}[data-slot="user-message-text"]{unicode-bidi:plaintext !important}[data-component="reasoning-part"]>*{unicode-bidi:plaintext !important}[data-component="tool-output"]{unicode-bidi:plaintext !important}[data-slot="question-text"]{unicode-bidi:plaintext !important}[data-slot="answer-text"]{unicode-bidi:plaintext !important}[data-component="markdown"] code,[data-component="markdown"] pre{direction:ltr;unicode-bidi:isolate !important}[data-component="markdown"] pre code{unicode-bidi:isolate !important}[data-component="prompt-input"]{unicode-bidi:plaintext !important}[data-slot="question-option"]{text-align:start !important}[data-slot="option-label"]{unicode-bidi:plaintext !important}[data-slot="option-description"]{unicode-bidi:plaintext !important}`
 const s = document.createElement("style");s.textContent=css;s.id="oc-bidi-fix"
 const inj=()=>{if(document.head){document.head.appendChild(s);return true}return false}
 if(!inj())document.addEventListener("DOMContentLoaded",inj,{once:true})
@@ -12,16 +12,18 @@ const C='[data-component="markdown"],[data-slot="text-part-body"],[data-slot="us
 const B='p,li,h1,h2,h3,h4,h5,h6,td,th,blockquote'
 const R='[data-slot="question-text"],[data-slot="answer-text"],[data-component="tool-output"],[data-slot="user-message-text"]'
 const I='[data-component="prompt-input"],[contenteditable]'
+const Q='[data-slot="option-label"],[data-slot="option-description"]'
 const ir=c=>{const p=c.codePointAt(0);return(p>=0x0590&&p<=0x05FF)||(p>=0x0600&&p<=0x06FF)||(p>=0x0750&&p<=0x077F)||(p>=0x08A0&&p<=0x08FF)||(p>=0xFB1D&&p<=0xFDFF)||(p>=0xFE70&&p<=0xFEFF)};
 const da=el=>{const t=el.textContent;let r=0,l=0,f=null;for(const c of t){if(ir(c)){r++;if(f===null)f='r'}else if(/[A-Za-z\u00C0-\u024F]/.test(c)){l++;if(f===null)f='l'}}if(f==='r'){el.setAttribute('dir','rtl');return}if(f==='l'&&r>0&&r>=l*0.4){el.setAttribute('dir','rtl');return}el.setAttribute('dir','ltr')};
-const inp=el=>{da(el);if(!el.hasAttribute("data-ih")){el.setAttribute("data-ih","1");el.addEventListener("input",()=>da(el))}}
+const inp=el=>{da(el);if(!el.hasAttribute("data-ih")){el.setAttribute("data-ih","1");let t;el.addEventListener("input",()=>{clearTimeout(t);t=setTimeout(()=>da(el),300)})}}
 const co=el=>{if(el.getAttribute("data-cd")==="1")return;el.setAttribute("data-cd","1");new MutationObserver(recs=>{for(const r of recs){if(r.type!=="characterData")continue;const p=r.target.parentElement;if(!p)continue;if(p.matches(B)&&p.closest(C))da(p);else if(p.matches(R))da(p)}}).observe(el,{childList:true,subtree:true,characterData:true})}
-const mc=el=>{if(el.getAttribute("data-bc")!=="1"){el.setAttribute("data-bc","1");el.querySelectorAll(B).forEach(da);el.querySelectorAll(R).forEach(da);co(el)}}
-const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))inp(n);else n.querySelectorAll(I).forEach(inp);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})
+const mc=el=>{if(el.getAttribute("data-bc")!=="1"){el.setAttribute("data-bc","1");el.querySelectorAll(B).forEach(da);el.querySelectorAll(R).forEach(da);el.querySelectorAll(Q).forEach(da);co(el)}}
+const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))inp(n);else n.querySelectorAll(I).forEach(inp);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)});if(n.matches(Q))da(n);else n.querySelectorAll(Q).forEach(da)}}})
 if(document.documentElement)mo.observe(document.documentElement,{childList:true,subtree:true})
 else document.addEventListener("DOMContentLoaded",()=>mo.observe(document.documentElement,{childList:true,subtree:true}),{once:true})
 document.querySelectorAll(C).forEach(mc)
 document.querySelectorAll(I).forEach(inp)
+document.querySelectorAll(Q).forEach(da)
 
 const mc2=".oc-mf{font-size:11px;color:var(--text-weak);margin-top:4px;text-align:right;cursor:default;line-height:1.4}.oc-mf-ts,.oc-mf-tok{white-space:nowrap}"
 const s2=document.createElement("style");s2.textContent=mc2;s2.id="oc-meta-fix"

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -2,6 +2,42 @@ import { contextBridge, ipcRenderer, webUtils } from "electron"
 import type { ElectronAPI, WslServersEvent } from "./types"
 import type { UpdaterState } from "@opencode-ai/app/updater"
 
+// BiDi text direction support + message metadata footer
+{
+const css = `[data-component="markdown"]>*{unicode-bidi:plaintext !important}[data-slot="text-part-body"]>*{unicode-bidi:plaintext !important}[data-slot="user-message-text"]{unicode-bidi:plaintext !important}[data-component="reasoning-part"]>*{unicode-bidi:plaintext !important}[data-component="tool-output"]{unicode-bidi:plaintext !important}[data-slot="question-text"]{unicode-bidi:plaintext !important}[data-slot="answer-text"]{unicode-bidi:plaintext !important}[data-component="markdown"] code,[data-component="markdown"] pre{direction:ltr;unicode-bidi:isolate !important}[data-component="markdown"] pre code{unicode-bidi:isolate !important}[data-component="prompt-input"]{unicode-bidi:plaintext !important}`
+const s = document.createElement("style");s.textContent=css;s.id="oc-bidi-fix"
+const inj=()=>{if(document.head){document.head.appendChild(s);return true}return false}
+if(!inj())document.addEventListener("DOMContentLoaded",inj,{once:true})
+const ir=c=>{const p=c.codePointAt(0);return(p>=0x0590&&p<=0x05FF)||(p>=0x0600&&p<=0x06FF)||(p>=0x0750&&p<=0x077F)||(p>=0x08A0&&p<=0x08FF)||(p>=0xFB1D&&p<=0xFDFF)||(p>=0xFE70&&p<=0xFEFF)}
+const dd=el=>{let r=0,l=0;for(const c of el.textContent){if(ir(c))r++;else if(/[A-Za-z\u00C0-\u024F]/.test(c))l++}return(r>0&&r>=l)?'rtl':(l>0&&l>r)?'ltr':null}
+const C='[data-component="markdown"],[data-slot="text-part-body"],[data-slot="user-message-text"],[data-component="reasoning-part"],[data-component="tool-output"],[data-slot="question-text"],[data-slot="answer-text"]'
+const B='p,li,h1,h2,h3,h4,h5,h6,td,th,blockquote'
+const R='[data-slot="question-text"],[data-slot="answer-text"],[data-component="tool-output"],[data-slot="user-message-text"]'
+const I='[data-component="prompt-input"],[contenteditable]'
+const da=el=>{const d=dd(el);if(d)el.setAttribute("dir",d)}
+const dai=el=>{if(!el.hasAttribute("dir"))el.setAttribute("dir","auto")}
+const co=el=>{if(el.getAttribute("data-cd")==="1")return;el.setAttribute("data-cd","1");new MutationObserver(recs=>{for(const r of recs){if(r.type!=="characterData")continue;const p=r.target.parentElement;if(!p)continue;if(p.matches(B)&&p.closest(C))da(p);else if(p.matches(R))da(p)}}).observe(el,{childList:true,subtree:true,characterData:true})}
+const mc=el=>{if(el.getAttribute("data-bc")!=="1"){el.setAttribute("data-bc","1");el.querySelectorAll(B).forEach(da);el.querySelectorAll(R).forEach(da);co(el)}}
+const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))dai(n);else n.querySelectorAll(I).forEach(dai);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})
+if(document.documentElement)mo.observe(document.documentElement,{childList:true,subtree:true})
+else document.addEventListener("DOMContentLoaded",()=>mo.observe(document.documentElement,{childList:true,subtree:true}),{once:true})
+document.querySelectorAll(C).forEach(mc)
+document.querySelectorAll(I).forEach(dai)
+
+const mc2=".oc-mf{font-size:11px;color:var(--text-weak);margin-top:4px;text-align:right;cursor:default;line-height:1.4}.oc-mf-ts,.oc-mf-tok{white-space:nowrap}"
+const s2=document.createElement("style");s2.textContent=mc2;s2.id="oc-meta-fix"
+const inj2=()=>{if(document.head){document.head.appendChild(s2);return true}return false}
+if(!inj2())document.addEventListener("DOMContentLoaded",inj2,{once:true})
+const fm=d=>{const n=new Date();const sd=d.toDateString()===n.toDateString();const yd=new Date(n);yd.setDate(yd.getDate()-1);const iy=d.toDateString()===yd.toDateString();const ts=d.toLocaleTimeString(undefined,{hour:"numeric",minute:"2-digit"});if(sd)return"Today, "+ts;if(iy)return"Yesterday, "+ts;if(d.getFullYear()===n.getFullYear())return d.toLocaleDateString(undefined,{month:"short",day:"numeric"})+", "+ts;return d.toLocaleDateString(undefined,{month:"short",day:"numeric",year:"numeric"})+", "+ts}
+const mf=el=>{if(el.getAttribute("data-mf")==="1")return;const ia=el.matches('[data-component="text-part"]');if(!el.matches('[data-component="user-message"]')&&!ia)return;const tc=el.getAttribute("data-time-created");const tcom=el.getAttribute("data-time-completed");if(ia&&tcom===null)return;el.setAttribute("data-mf","1");const f=document.createElement("div");f.className="oc-mf";const p=[];if(tc){const d=new Date(parseInt(tc,10));const sp=document.createElement("span");sp.className="oc-mf-ts";sp.textContent=fm(d);sp.title=d.toLocaleString();p.push(sp)}if(ia){const ti=el.getAttribute("data-tokens-input");const to=el.getAttribute("data-tokens-output");const tr=el.getAttribute("data-tokens-reasoning");if(to){p.push(document.createTextNode(" \u00B7 "));const sp=document.createElement("span");sp.className="oc-mf-tok";sp.textContent="\u2191"+(ti||"0")+" \u2193"+to;const tip=[];if(ti)tip.push("Input: "+(+ti).toLocaleString()+" tok");if(to)tip.push("Output: "+(+to).toLocaleString()+" tok");if(tr)tip.push("Thinking: "+(+tr).toLocaleString()+" tok");if(tc&&tcom){const ms=parseInt(tcom,10)-parseInt(tc,10);if(ms>0){const tps=((+to)/(ms/1e3)).toFixed(1);tip.push("Speed: ~"+tps+" tok/s");tip.push("Total: "+(ms/1e3).toFixed(1)+"s")}}sp.title=tip.join(" \u00B7 ");p.push(sp)}}if(p.length===0)return;p.forEach(x=>f.appendChild(x));const cw=el.querySelector('[data-slot="user-message-copy-wrapper"],[data-slot="text-part-copy-wrapper"]');if(cw&&cw.parentNode)cw.parentNode.insertBefore(f,cw.nextSibling);else el.appendChild(f)}
+const m1=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches('[data-component="user-message"],[data-component="text-part"]'))mf(n);else n.querySelectorAll('[data-component="user-message"],[data-component="text-part"]').forEach(mf)}}})
+const m2=new MutationObserver(recs=>{for(const r of recs){if(r.type!=="attributes")continue;mf(r.target)}})
+if(document.documentElement){m1.observe(document.documentElement,{childList:true,subtree:true});m2.observe(document.documentElement,{subtree:true,attributes:true,attributeFilter:["data-time-completed"]})}else document.addEventListener("DOMContentLoaded",()=>{m1.observe(document.documentElement,{childList:true,subtree:true});m2.observe(document.documentElement,{subtree:true,attributes:true,attributeFilter:["data-time-completed"]})},{once:true})
+document.querySelectorAll('[data-component="user-message"],[data-component="text-part"]').forEach(mf)
+}
+
+
+
 const updaterCallbacks = new Set<(state: UpdaterState) => void>()
 let updaterState: UpdaterState | undefined
 let updaterSubscription: Promise<void> | undefined

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -8,21 +8,18 @@ const css = `[data-component="markdown"]>*{unicode-bidi:plaintext !important}[da
 const s = document.createElement("style");s.textContent=css;s.id="oc-bidi-fix"
 const inj=()=>{if(document.head){document.head.appendChild(s);return true}return false}
 if(!inj())document.addEventListener("DOMContentLoaded",inj,{once:true})
-const ir=c=>{const p=c.codePointAt(0);return(p>=0x0590&&p<=0x05FF)||(p>=0x0600&&p<=0x06FF)||(p>=0x0750&&p<=0x077F)||(p>=0x08A0&&p<=0x08FF)||(p>=0xFB1D&&p<=0xFDFF)||(p>=0xFE70&&p<=0xFEFF)}
-const dd=el=>{let r=0,l=0;for(const c of el.textContent){if(ir(c))r++;else if(/[A-Za-z\u00C0-\u024F]/.test(c))l++}return(r>0&&r>=l)?'rtl':(l>0&&l>r)?'ltr':null}
 const C='[data-component="markdown"],[data-slot="text-part-body"],[data-slot="user-message-text"],[data-component="reasoning-part"],[data-component="tool-output"],[data-slot="question-text"],[data-slot="answer-text"]'
 const B='p,li,h1,h2,h3,h4,h5,h6,td,th,blockquote'
 const R='[data-slot="question-text"],[data-slot="answer-text"],[data-component="tool-output"],[data-slot="user-message-text"]'
 const I='[data-component="prompt-input"],[contenteditable]'
-const da=el=>{const d=dd(el);if(d)el.setAttribute("dir",d)}
-const dai=el=>{if(!el.hasAttribute("dir"))el.setAttribute("dir","auto")}
+const da=el=>{if(!el.hasAttribute("dir"))el.setAttribute("dir","auto")}
 const co=el=>{if(el.getAttribute("data-cd")==="1")return;el.setAttribute("data-cd","1");new MutationObserver(recs=>{for(const r of recs){if(r.type!=="characterData")continue;const p=r.target.parentElement;if(!p)continue;if(p.matches(B)&&p.closest(C))da(p);else if(p.matches(R))da(p)}}).observe(el,{childList:true,subtree:true,characterData:true})}
 const mc=el=>{if(el.getAttribute("data-bc")!=="1"){el.setAttribute("data-bc","1");el.querySelectorAll(B).forEach(da);el.querySelectorAll(R).forEach(da);co(el)}}
-const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))dai(n);else n.querySelectorAll(I).forEach(dai);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})
+const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))da(n);else n.querySelectorAll(I).forEach(da);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})
 if(document.documentElement)mo.observe(document.documentElement,{childList:true,subtree:true})
 else document.addEventListener("DOMContentLoaded",()=>mo.observe(document.documentElement,{childList:true,subtree:true}),{once:true})
 document.querySelectorAll(C).forEach(mc)
-document.querySelectorAll(I).forEach(dai)
+document.querySelectorAll(I).forEach(da)
 
 const mc2=".oc-mf{font-size:11px;color:var(--text-weak);margin-top:4px;text-align:right;cursor:default;line-height:1.4}.oc-mf-ts,.oc-mf-tok{white-space:nowrap}"
 const s2=document.createElement("style");s2.textContent=mc2;s2.id="oc-meta-fix"

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -4,7 +4,7 @@ import type { UpdaterState } from "@opencode-ai/app/updater"
 
 // BiDi text direction support + message metadata footer
 {
-const css = `[data-component="markdown"]>*{unicode-bidi:plaintext !important}[data-slot="text-part-body"]>*{unicode-bidi:plaintext !important}[data-slot="user-message-text"]{unicode-bidi:plaintext !important}[data-component="reasoning-part"]>*{unicode-bidi:plaintext !important}[data-component="tool-output"]{unicode-bidi:plaintext !important}[data-slot="question-text"]{unicode-bidi:plaintext !important}[data-slot="answer-text"]{unicode-bidi:plaintext !important}[data-component="markdown"] code,[data-component="markdown"] pre{direction:ltr;unicode-bidi:isolate !important}[data-component="markdown"] pre code{unicode-bidi:isolate !important}[data-component="prompt-input"]{unicode-bidi:plaintext !important}`
+const css = `[data-component="markdown"]>*{unicode-bidi:plaintext !important}[data-slot="text-part-body"]>*{unicode-bidi:plaintext !important}[data-slot="user-message-text"]{unicode-bidi:plaintext !important}[data-component="reasoning-part"]>*{unicode-bidi:plaintext !important}[data-component="tool-output"]{unicode-bidi:plaintext !important}[data-slot="question-text"]{unicode-bidi:plaintext !important}[data-slot="answer-text"]{unicode-bidi:plaintext !important}[data-component="markdown"] code,[data-component="markdown"] pre{direction:ltr;unicode-bidi:isolate !important}[data-component="markdown"] pre code{unicode-bidi:isolate !important}`
 const s = document.createElement("style");s.textContent=css;s.id="oc-bidi-fix"
 const inj=()=>{if(document.head){document.head.appendChild(s);return true}return false}
 if(!inj())document.addEventListener("DOMContentLoaded",inj,{once:true})

--- a/packages/desktop/src/preload/index.ts
+++ b/packages/desktop/src/preload/index.ts
@@ -14,13 +14,14 @@ const R='[data-slot="question-text"],[data-slot="answer-text"],[data-component="
 const I='[data-component="prompt-input"],[contenteditable]'
 const ir=c=>{const p=c.codePointAt(0);return(p>=0x0590&&p<=0x05FF)||(p>=0x0600&&p<=0x06FF)||(p>=0x0750&&p<=0x077F)||(p>=0x08A0&&p<=0x08FF)||(p>=0xFB1D&&p<=0xFDFF)||(p>=0xFE70&&p<=0xFEFF)};
 const da=el=>{const t=el.textContent;let r=0,l=0,f=null;for(const c of t){if(ir(c)){r++;if(f===null)f='r'}else if(/[A-Za-z\u00C0-\u024F]/.test(c)){l++;if(f===null)f='l'}}if(f==='r'){el.setAttribute('dir','rtl');return}if(f==='l'&&r>0&&r>=l*0.4){el.setAttribute('dir','rtl');return}el.setAttribute('dir','ltr')};
+const inp=el=>{da(el);if(!el.hasAttribute("data-ih")){el.setAttribute("data-ih","1");el.addEventListener("input",()=>da(el))}}
 const co=el=>{if(el.getAttribute("data-cd")==="1")return;el.setAttribute("data-cd","1");new MutationObserver(recs=>{for(const r of recs){if(r.type!=="characterData")continue;const p=r.target.parentElement;if(!p)continue;if(p.matches(B)&&p.closest(C))da(p);else if(p.matches(R))da(p)}}).observe(el,{childList:true,subtree:true,characterData:true})}
 const mc=el=>{if(el.getAttribute("data-bc")!=="1"){el.setAttribute("data-bc","1");el.querySelectorAll(B).forEach(da);el.querySelectorAll(R).forEach(da);co(el)}}
-const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))da(n);else n.querySelectorAll(I).forEach(da);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})
+const mo=new MutationObserver(recs=>{for(const r of recs){for(const n of r.addedNodes){if(n.nodeType!==1)continue;if(n.matches(C))mc(n);else n.querySelectorAll(C).forEach(mc);if(n.matches(I))inp(n);else n.querySelectorAll(I).forEach(inp);if(n.matches(B)&&n.closest(C))da(n);else n.querySelectorAll(B).forEach(el=>{if(el.closest(C))da(el)});if(n.matches(R))da(n);else n.querySelectorAll(R).forEach(el=>{if(el.closest(C)||el.matches(R))da(el)})}}})
 if(document.documentElement)mo.observe(document.documentElement,{childList:true,subtree:true})
 else document.addEventListener("DOMContentLoaded",()=>mo.observe(document.documentElement,{childList:true,subtree:true}),{once:true})
 document.querySelectorAll(C).forEach(mc)
-document.querySelectorAll(I).forEach(da)
+document.querySelectorAll(I).forEach(inp)
 
 const mc2=".oc-mf{font-size:11px;color:var(--text-weak);margin-top:4px;text-align:right;cursor:default;line-height:1.4}.oc-mf-ts,.oc-mf-tok{white-space:nowrap}"
 const s2=document.createElement("style");s2.textContent=mc2;s2.id="oc-meta-fix"

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -1336,7 +1336,7 @@ export function UserMessageDisplay(props: {
   )
 
   return (
-    <div data-component="user-message" data-timeline-part-id={textPart()?.id}>
+    <div data-component="user-message" data-timeline-part-id={textPart()?.id} data-time-created={props.message.time?.created}>
       <Show when={!props.useV2Actions}>{renderAttachments()}</Show>
       <Show
         when={text()}
@@ -1739,7 +1739,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
 
   return (
     <Show when={text()}>
-      <div data-component="text-part" data-timeline-part-id={part().id}>
+      <div data-component="text-part" data-timeline-part-id={part().id} data-time-created={props.message.time?.created} data-time-completed={props.message.time?.completed} data-tokens-input={(props.message as any).tokens?.input} data-tokens-output={(props.message as any).tokens?.output} data-tokens-reasoning={(props.message as any).tokens?.reasoning} data-model-id={(props.message as any).modelID} data-provider-id={(props.message as any).providerID}>
         <div data-slot="text-part-body">
           <Show when={streaming()} fallback={<Markdown text={text()} cacheKey={part().id} streaming={false} />}>
             <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />


### PR DESCRIPTION
﻿### Issue for this PR

No related issue — discovered while testing Persian/English mixed input.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds bidirectional text (BiDi) support for mixed Persian/Arabic + English rendering in the desktop app, and a small message metadata footer (timestamp + token counts).

The BiDi part injects a `<style>` element and a `MutationObserver` in the preload script. It watches for new message DOM nodes and sets `dir` attributes using a hybrid algorithm: if the first strong character is RTL → `rtl`; if first strong is LTR but RTL content >= 40% → `rtl` (covers cases like Persian sentences starting with an English word or digit). Code blocks get `direction:ltr; unicode-bidi:isolate`. The prompt input gets `unicode-bidi:plaintext` so typed text stays correctly ordered.

The metadata footer appends time/token info below the copy-wrapper of each message. It uses MutationObservers to handle streaming output and waits for `data-time-completed` before finalizing.

### How did you verify your code works?

Tested locally with real Persian sentences containing English code snippets, inline code, numbered lists, and question tool options — both with our asar-patched build and the source PR branch. Everything renders correctly on the LTR side too (no regressions).

### Screenshots / recordings

Not applicable — this is a layout/CSS change, not a visual UI redesign. Happy to add screenshots if requested.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
