### PR TITLE
feat(app): optional vertical tab rail

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -239,7 +239,7 @@ export function SessionHeader() {
     statusLabel: language.t("status.popover.trigger"),
     reviewLabel: language.t("command.review.toggle"),
     reviewKeybind: reviewTooltipKeybind(command),
-    reviewVisible: isDesktop(),
+    reviewVisible: isDesktop() && settings.general.showReviewPanelButton(),
     reviewOpened: view().reviewPanel.opened(),
     onReviewToggle: () => view().reviewPanel.toggle(),
   }))
@@ -462,21 +462,23 @@ export function SessionHeader() {
                     </TooltipKeybind>
 
                     <div class="hidden md:flex items-center gap-1 shrink-0">
-                      <TooltipKeybind
-                        title={language.t("command.review.toggle")}
-                        keybind={command.keybind("review.toggle")}
-                      >
-                        <Button
-                          variant="ghost"
-                          class="group/review-toggle titlebar-icon w-8 h-6 p-0 box-border"
-                          onClick={() => view().reviewPanel.toggle()}
-                          aria-label={language.t("command.review.toggle")}
-                          aria-expanded={view().reviewPanel.opened()}
-                          aria-controls="review-panel"
+                      <Show when={settings.general.showReviewPanelButton()}>
+                        <TooltipKeybind
+                          title={language.t("command.review.toggle")}
+                          keybind={command.keybind("review.toggle")}
                         >
-                          <Icon size="small" name={view().reviewPanel.opened() ? "review-active" : "review"} />
-                        </Button>
-                      </TooltipKeybind>
+                          <Button
+                            variant="ghost"
+                            class="group/review-toggle titlebar-icon w-8 h-6 p-0 box-border"
+                            onClick={() => view().reviewPanel.toggle()}
+                            aria-label={language.t("command.review.toggle")}
+                            aria-expanded={view().reviewPanel.opened()}
+                            aria-controls="review-panel"
+                          >
+                            <Icon size="small" name={view().reviewPanel.opened() ? "review-active" : "review"} />
+                          </Button>
+                        </TooltipKeybind>
+                      </Show>
 
                       <TooltipKeybind
                         title={language.t("command.fileTree.toggle")}

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -382,6 +382,44 @@ export const SettingsGeneralV2: Component<{
             </div>
           </SettingsRowV2>
         </Show>
+
+        <SettingsRowV2
+          title={language.t("settings.general.row.verticalTabs.title")}
+          description={language.t("settings.general.row.verticalTabs.description")}
+        >
+          <div data-action="settings-vertical-tabs">
+            <Switch
+              checked={settings.general.tabOrientation() === "vertical"}
+              onChange={(checked) => settings.general.setTabOrientation(checked ? "vertical" : "horizontal")}
+            />
+          </div>
+        </SettingsRowV2>
+
+        <Show when={settings.general.tabOrientation() === "vertical"}>
+          <SettingsRowV2
+            title={language.t("settings.general.row.tabRailSide.title")}
+            description={language.t("settings.general.row.tabRailSide.description")}
+          >
+            <div data-action="settings-tab-rail-side">
+              <Switch
+                checked={settings.general.tabRailSide() === "right"}
+                onChange={(checked) => settings.general.setTabRailSide(checked ? "right" : "left")}
+              />
+            </div>
+          </SettingsRowV2>
+        </Show>
+
+        <SettingsRowV2
+          title={language.t("settings.general.row.showReviewPanelButton.title")}
+          description={language.t("settings.general.row.showReviewPanelButton.description")}
+        >
+          <div data-action="settings-show-review-panel-button">
+            <Switch
+              checked={settings.general.showReviewPanelButton()}
+              onChange={(checked) => settings.general.setShowReviewPanelButton(checked)}
+            />
+          </div>
+        </SettingsRowV2>
       </SettingsListV2>
     </div>
   )

--- a/packages/app/src/components/titlebar-tab-nav.css
+++ b/packages/app/src/components/titlebar-tab-nav.css
@@ -142,9 +142,134 @@
     display: none;
   }
 
+  [data-slot="tab-worktree"] {
+    display: none;
+  }
+
   [data-slot="tab-close"] {
     right: auto;
     left: 50%;
     transform: translateX(-50%);
+  }
+
+  /* In the collapsed icon strip, keep the session avatar visible on the active
+     tab and only reveal the close button on hover, so tabs stay identifiable. */
+  [data-titlebar-tab][data-active="true"]:not(:hover) [data-slot="tab-close"] {
+    opacity: 0;
+  }
+}
+
+/* Touch devices have no hover, so `hover-reveal` forces every close button
+   visible. In the collapsed strip that hides the avatars behind X buttons and
+   inverts which tab looks active. Hide all close buttons there; the rail is
+   tapped open to reveal them. */
+@media (hover: none) {
+  @container (max-width: 64px) {
+    [data-slot="tab-close"] {
+      opacity: 0;
+    }
+  }
+}
+
+/* Vertical tab rail: give stacked tabs a little more height so the grip,
+   title, and worktree badge aren't vertically clipped inside the row. */
+[data-slot="titlebar-tabs"][data-orientation="vertical"] [data-titlebar-tab] {
+  height: 2rem;
+}
+
+/* The tight leading-4 (16px) line box clips descenders (p, g, y) once the tab
+   clips overflow. Relax the line-height for vertical-rail titles so glyphs fit. */
+[data-slot="titlebar-tabs"][data-orientation="vertical"] [data-titlebar-tab-title] {
+  line-height: 1.25rem;
+}
+
+/* Right-side vertical rail: mirror each tab so the session avatar hugs the
+   right edge and the close button sits on the left. */
+[data-slot="titlebar-tabs"][data-side="right"] [data-slot="tab-link"] {
+  flex-direction: row-reverse;
+  transition: padding-left 120ms ease;
+}
+
+[data-slot="titlebar-tabs"][data-side="right"] [data-slot="tab-close"] {
+  right: auto;
+  left: 4px;
+}
+
+/* Reserve room on the sides for the close button so it doesn't cover the
+   title when the rail is narrow. The 24px badge margin already keeps the X
+   clear at any width; we only add the on-hover/active title shift when the
+   rail is narrow enough that the badge sits close enough to overlap the
+   title text after the X reveals. */
+@container (min-width: 65px) and (max-width: 180px) {
+  [data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="right"] [data-titlebar-tab]:hover [data-slot="tab-link"],
+  [data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="right"] [data-titlebar-tab][data-active="true"] [data-slot="tab-link"] {
+    padding-left: 22px;
+  }
+
+  [data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="left"] [data-titlebar-tab]:hover [data-slot="tab-link"],
+  [data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="left"] [data-titlebar-tab][data-active="true"] [data-slot="tab-link"] {
+    padding-right: 22px;
+  }
+}
+
+[data-slot="titlebar-tabs"][data-side="right"] [data-titlebar-tab] [data-slot="tab-close"]::before {
+  right: auto;
+  left: 0;
+  background: linear-gradient(to left, transparent, var(--tab-bg));
+}
+
+/* Vertical rail: push the trailing worktree/branch badge away from the corner
+   where the close button lives, so they don't overlap on touch (where the
+   close is always visible, not just on hover). 24px = the close button (20px)
+   plus its 4px offset from the rail edge. */
+[data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="left"] [data-slot="tab-worktree"] {
+  margin-right: 24px;
+}
+
+[data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="right"] [data-slot="tab-worktree"] {
+  margin-left: 24px;
+}
+
+/* Vertical rail (any width): the worktree/branch badge crowds the title on a
+   single row. Stack the badge on a second row (avatar + title on row 1, badge
+   on row 2) so the title gets the full width and the close button can't
+   overlap the badge. The markup wraps avatar+title in a single span so the
+   link only has 2 children and a column layout reliably stacks them. */
+@container (min-width: 65px) {
+  [data-slot="titlebar-tabs"][data-orientation="vertical"] [data-titlebar-tab] {
+    height: auto;
+    min-height: 3.5rem;
+  }
+
+  [data-slot="titlebar-tabs"][data-orientation="vertical"] [data-slot="tab-link"] {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    row-gap: 4px;
+    padding-block: 6px;
+  }
+
+  /* The close button is absolutely positioned at the top corner. Reserve its
+     space so the title on row 1 doesn't sit under it. 24px = 20px button +
+     4px offset. The badge's margin above already does the same for row 2. */
+  [data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="right"] [data-slot="tab-link"] {
+    padding-left: 24px;
+  }
+
+  [data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="left"] [data-slot="tab-link"] {
+    padding-right: 24px;
+  }
+
+  /* Row-1 wrapper fills the line; avatar + title sit on it. */
+  [data-slot="titlebar-tabs"][data-orientation="vertical"] [data-slot="tab-link-row"] {
+    min-width: 0;
+  }
+
+  /* Badge stays at its natural width, not stretched. */
+  [data-slot="titlebar-tabs"][data-orientation="vertical"] [data-slot="tab-worktree"] {
+    align-self: flex-start;
+  }
+  [data-slot="titlebar-tabs"][data-orientation="vertical"][data-side="right"] [data-slot="tab-worktree"] {
+    align-self: flex-end;
   }
 }

--- a/packages/app/src/components/titlebar-tab-nav.tsx
+++ b/packages/app/src/components/titlebar-tab-nav.tsx
@@ -1,14 +1,16 @@
 import { createEffect, createMemo, createSignal, onCleanup, Show, type Ref } from "solid-js"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
-import { createMutation } from "@tanstack/solid-query"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
 import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { useGlobal } from "@/context/global"
 import { useLanguage } from "@/context/language"
 import { ServerConnection, serverName } from "@/context/server"
 import { displayName, projectForSession } from "@/pages/layout/helpers"
+import { getFilename } from "@opencode-ai/core/util/path"
+import { pathKey } from "@/utils/path-key"
 import { SessionTabAvatar } from "@/pages/layout/session-tab-avatar"
+import { showToast } from "@/utils/toast"
 import type { Session } from "@opencode-ai/sdk/v2"
 import { canOpenTabRename, forwardTabRef } from "./titlebar-tab-gesture"
 import { TabPreviewPopover } from "./titlebar-tab-popover"
@@ -23,7 +25,8 @@ export function TabNavItem(props: {
   server: ServerConnection.Key
   session: () => Session | undefined
   fallbackTitle?: string
-  onRename: (title: string) => Promise<void>
+  onTitleChange?: (title: string) => void
+  onTitleChangeFailed?: (title: string) => void
   onClose: () => void
   onNavigate: () => void
   active?: boolean
@@ -33,12 +36,13 @@ export function TabNavItem(props: {
   pressed?: boolean
   hidden?: boolean
 }) {
+  const language = useLanguage()
   const [editing, setEditing] = createSignal(false)
   const [titleOverflowing, setTitleOverflowing] = createSignal(false)
   let tabRoot!: HTMLDivElement
   let titleEl!: HTMLSpanElement
+  let committing = false
   let measureFrame: number | undefined
-  const rename = createMutation(() => ({ mutationFn: props.onRename }))
 
   const closeTab = (event: MouseEvent) => {
     event.preventDefault()
@@ -67,6 +71,19 @@ export function TabNavItem(props: {
     if (!session) return
     const home = serverCtx()?.sync.data.path.home
     return home ? session.directory.replace(home, "~") : session.directory
+  })
+  // When a session runs inside a git worktree (its directory differs from the
+  // project root), surface which worktree it belongs to — the branch name if
+  // known, otherwise the worktree directory name. Sessions at the project root
+  // (no worktree) show "default" so every tab has a recognizable label.
+  const worktreeLabel = createMemo(() => {
+    const session = props.session()
+    if (!session) return
+    const root = project()?.worktree
+    if (!root || pathKey(session.directory) === pathKey(root)) return "default"
+    const ctx = serverCtx()
+    const branch = ctx ? ctx.sync.peek(session.directory, { bootstrap: false })[0].vcs?.branch : undefined
+    return branch ?? getFilename(session.directory)
   })
   // Only label the server when multiple servers are connected.
   const serverLabel = createMemo(() => {
@@ -114,20 +131,41 @@ export function TabNavItem(props: {
     selection?.addRange(range)
   }
 
+  const rename = async (title: string) => {
+    const ctx = serverCtx()
+    const session = props.session()
+    if (!ctx || !session) return
+    const client = ctx.sdk.createClient({ directory: session.directory, throwOnError: true })
+    await client.session.update({ sessionID: session.id, title })
+  }
+
   const closeRename = async (save: boolean) => {
-    if (rename.isPending || !editing()) return
+    if (committing || !editing()) return
+    committing = true
 
     const original = props.session()?.title ?? ""
     const next = (titleEl.textContent ?? "").trim()
 
     titleEl.scrollLeft = 0
+    if (save && next && next !== original) props.onTitleChange?.(next)
     setEditing(false)
 
     if (!save || !next || next === original) {
+      committing = false
       return
     }
 
-    await rename.mutateAsync(next)
+    try {
+      await rename(next)
+    } catch (err) {
+      props.onTitleChangeFailed?.(original)
+      showToast({
+        title: language.t("common.requestFailed"),
+        description: err instanceof Error ? err.message : undefined,
+      })
+    }
+
+    committing = false
   }
 
   createEffect(() => {
@@ -141,7 +179,7 @@ export function TabNavItem(props: {
   const openRename = (event: MouseEvent) => {
     event.preventDefault()
     event.stopPropagation()
-    if (!canOpenTabRename(props.dragging, editing(), rename.isPending)) return
+    if (!canOpenTabRename(props.dragging, editing(), committing)) return
     const session = props.session()
     if (!session) return
     titleEl.textContent = session.title
@@ -181,11 +219,11 @@ export function TabNavItem(props: {
       data-slot="titlebar-tab-item"
       data-title-overflow={titleOverflowing()}
       data-editing={editing()}
-      class="group relative flex h-7 w-full min-w-0 select-none flex-row items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-[6px] px-1.5 [container-type:inline-size]"
+      class="group relative flex h-7 w-full min-w-0 select-none flex-row items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-[6px] bg-[var(--tab-bg)] px-1.5 [container-type:inline-size] [--tab-bg:var(--v2-background-bg-deep)] hover:[--tab-bg:var(--v2-background-bg-layer-02)] has-[>a:focus-visible]:[--tab-bg:var(--v2-background-bg-layer-02)] data-[active='true']:[--tab-bg:var(--v2-background-bg-layer-02)] data-[dragging='true']:[--tab-bg:var(--v2-background-bg-layer-02)] data-[pressed='true']:[--tab-bg:var(--v2-background-bg-layer-02)] data-[editing='true']:[--tab-bg:var(--v2-background-bg-layer-02)]"
       classList={{ invisible: props.hidden }}
       data-active={props.active}
       data-dragging={props.dragging}
-      data-state={props.active || props.pressed ? "pressed" : undefined}
+      data-pressed={props.pressed}
       onMouseDown={(event) => {
         if (event.button !== MIDDLE_MOUSE_BUTTON) return
         event.preventDefault()
@@ -196,89 +234,104 @@ export function TabNavItem(props: {
         closeTab(event)
       }}
     >
-      <a
-        data-slot="tab-link"
-        data-titlebar-tab-link
-        href={props.href}
-        draggable={false}
-        onDragStart={(event) => {
-          event.preventDefault()
-          event.stopPropagation()
-        }}
-        onMouseDown={(event) => {
-          // Navigate on mousedown to shave the press-release delay off tab switches.
-          if (event.button !== 0) return
-          if (editing()) return
-          if (props.suppressNavigation?.()) return
-          props.onNavigate()
-        }}
-        onClick={(event) => {
-          event.preventDefault()
-          // Mouse navigation already happened on mousedown; detail 0 means keyboard activation.
-          if (event.detail > 0) return
-          if (editing()) return
-          if (props.suppressNavigation?.()) return
-          props.onNavigate()
-        }}
-        class="flex h-full min-w-0 flex-1 flex-row items-center gap-1.5 text-[13px] font-medium text-v2-text-text-faint group-data-[active='true']:text-v2-text-text-base group-data-[editing='true']:text-v2-text-text-base [-webkit-user-drag:none]"
-      >
-        <span data-slot="project-avatar-slot" class="flex size-4 shrink-0 items-center justify-center">
-          <Show
-            when={props.session()}
-            keyed
-            fallback={
-              <span class="block size-4 rounded-[3px] border border-v2-border-border-muted" aria-hidden="true" />
-            }
-          >
-            {(session) => (
-              <SessionTabAvatar
-                project={project()}
-                directory={session.directory}
-                sessionId={session.id}
-                server={props.server}
-              />
-            )}
-          </Show>
-        </span>
-        <span
-          ref={(el) => {
-            titleEl = el
-            titleEl.textContent = title() ?? ""
-          }}
-          data-slot="tab-title"
-          data-titlebar-tab-title
-          class="min-w-0 flex-1 outline-none leading-4"
-          classList={{
-            "overflow-hidden text-clip whitespace-nowrap": !editing(),
-            "select-text": editing(),
-          }}
-          contenteditable={editing() ? true : undefined}
-          onDblClick={openRename}
-          onKeyDown={(event) => {
-            event.stopPropagation()
-            if (event.key === "Enter") {
-              event.preventDefault()
-              void closeRename(true)
-              return
-            }
-            if (event.key !== "Escape") return
+      <Show when={title() !== undefined}>
+        <a
+          data-slot="tab-link"
+          data-titlebar-tab-link
+          href={props.href}
+          draggable={false}
+          onDragStart={(event) => {
             event.preventDefault()
-            titleEl.textContent = props.session()?.title ?? ""
-            void closeRename(false)
-          }}
-          onBlur={() => void closeRename(true)}
-          onPointerDown={(event) => {
-            if (!editing()) return
             event.stopPropagation()
+          }}
+          onMouseDown={(event) => {
+            // Navigate on mousedown to shave the press-release delay off tab switches.
+            if (event.button !== 0) return
+            if (editing()) return
+            if (props.suppressNavigation?.()) return
+            props.onNavigate()
           }}
           onClick={(event) => {
-            if (!editing()) return
             event.preventDefault()
+            // Mouse navigation already happened on mousedown; detail 0 means keyboard activation.
+            if (event.detail > 0) return
+            if (editing()) return
+            if (props.suppressNavigation?.()) return
+            props.onNavigate()
           }}
-        />
-      </a>
+          class="flex h-full min-w-0 flex-1 flex-row items-center gap-1.5 text-[13px] font-medium text-v2-text-text-faint group-data-[active='true']:text-v2-text-text-base group-data-[editing='true']:text-v2-text-text-base [-webkit-user-drag:none]"
+        >
+          <span data-slot="tab-link-row" class="flex min-w-0 flex-1 items-center gap-1.5">
+            <span data-slot="project-avatar-slot" class="flex size-4 shrink-0 items-center justify-center">
+              <Show
+                when={props.session()}
+                fallback={
+                  <span class="block size-4 rounded-[3px] border border-v2-border-border-muted" aria-hidden="true" />
+                }
+              >
+                {(session) => (
+                  <SessionTabAvatar
+                    project={project()}
+                    directory={session().directory}
+                    sessionId={session().id}
+                    server={props.server}
+                  />
+                )}
+              </Show>
+            </span>
+            <span
+              ref={(el) => {
+                titleEl = el
+                titleEl.textContent = title() ?? ""
+              }}
+              data-slot="tab-title"
+              data-titlebar-tab-title
+              class="min-w-0 flex-1 outline-none leading-4"
+              classList={{
+                "overflow-hidden text-clip whitespace-nowrap": !editing(),
+                "select-text": editing(),
+              }}
+              contenteditable={editing() ? true : undefined}
+              onDblClick={openRename}
+              onKeyDown={(event) => {
+                event.stopPropagation()
+                if (event.key === "Enter") {
+                  event.preventDefault()
+                  void closeRename(true)
+                  return
+                }
+                if (event.key !== "Escape") return
+                event.preventDefault()
+                titleEl.textContent = props.session()?.title ?? ""
+                void closeRename(false)
+              }}
+              onBlur={() => void closeRename(true)}
+              onPointerDown={(event) => {
+                if (!editing()) return
+                event.stopPropagation()
+              }}
+              onClick={(event) => {
+                if (!editing()) return
+                event.preventDefault()
+              }}
+            />
+          </span>
+          <Show when={!editing() && worktreeLabel()}>
+            {(label) => (
+              <span
+                data-slot="tab-worktree"
+                title={label()}
+                class="flex shrink-0 items-center gap-0.5 max-w-24 rounded-[3px] bg-v2-background-bg-layer px-1 text-[11px] leading-4 text-v2-text-text-faint"
+              >
+                <IconV2 name="branch" class="size-3 shrink-0" />
+                <span class="overflow-hidden text-clip whitespace-nowrap">{label()}</span>
+              </span>
+            )}
+          </Show>
+        </a>
+      </Show>
 
-      <div data-slot="tab-close">
+      <div data-slot="tab-close" class="group-hover:bg-[var(--tab-bg)] group-data-[active=true]:bg-[var(--tab-bg)]">
         <IconButtonV2
           size="small"
           variant="ghost-muted"
@@ -324,7 +377,6 @@ export function DraftTabItem(props: {
   pressed?: boolean
   hidden?: boolean
 }) {
-  const language = useLanguage()
   const closeTab = (event: MouseEvent) => {
     event.preventDefault()
     event.stopPropagation()
@@ -337,8 +389,8 @@ export function DraftTabItem(props: {
       data-slot="titlebar-tab-item"
       data-active={props.active}
       data-dragging={props.dragging}
-      data-state={props.active || props.pressed ? "pressed" : undefined}
-      class="group relative flex h-7 w-full min-w-0 flex-row items-center gap-1.5 overflow-hidden rounded-[6px] px-1.5 [container-type:inline-size] whitespace-nowrap"
+      data-pressed={props.pressed}
+      class="group relative flex h-7 w-full min-w-0 flex-row items-center gap-1.5 overflow-hidden rounded-[6px] bg-[var(--tab-bg)] px-1.5 [container-type:inline-size] whitespace-nowrap [--tab-bg:var(--v2-background-bg-deep)] hover:[--tab-bg:var(--v2-background-bg-layer-02)] has-[>a:focus-visible]:[--tab-bg:var(--v2-background-bg-layer-02)] data-[active='true']:[--tab-bg:var(--v2-background-bg-layer-02)] data-[dragging='true']:[--tab-bg:var(--v2-background-bg-layer-02)] data-[pressed='true']:[--tab-bg:var(--v2-background-bg-layer-02)] data-[editing='true']:[--tab-bg:var(--v2-background-bg-layer-02)]"
       classList={{ invisible: props.hidden }}
       onMouseDown={(event) => {
         if (event.button !== MIDDLE_MOUSE_BUTTON) return
@@ -384,7 +436,7 @@ export function DraftTabItem(props: {
           {props.title}
         </span>
       </a>
-      <div data-slot="tab-close">
+      <div data-slot="tab-close" class="group-hover:bg-[var(--tab-bg)] group-data-[active=true]:bg-[var(--tab-bg)]">
         <IconButtonV2
           size="small"
           variant="ghost-muted"
@@ -399,7 +451,7 @@ export function DraftTabItem(props: {
           class="hover-reveal relative z-10 group-hover:opacity-100 group-data-[active=true]:opacity-100 group-data-[editing=true]:opacity-100"
           onClick={closeTab}
           icon={<IconV2 name="xmark-small" />}
-          aria-label={language.t("common.closeTab")}
+          aria-label="Close tab"
         />
       </div>
     </div>

--- a/packages/app/src/components/titlebar-tab-rail-state.ts
+++ b/packages/app/src/components/titlebar-tab-rail-state.ts
@@ -1,0 +1,35 @@
+import { createStore } from "solid-js/store"
+import { Persist, persisted } from "@/utils/persist"
+
+export const TAB_RAIL_WIDTH_DEFAULT = 224
+export const TAB_RAIL_WIDTH_MIN = 180
+export const TAB_RAIL_WIDTH_MAX = 400
+// Dragging the resizer narrower than this collapses the rail to icons only.
+export const TAB_RAIL_COLLAPSE_THRESHOLD = 150
+// Fixed width of the collapsed (icon-only) rail. Wide enough for a large icon
+// button (36px) plus the rail's 8px padding on each side.
+export const TAB_RAIL_COLLAPSED_WIDTH = 56
+
+/**
+ * Persisted layout state for the vertical tab rail: its expanded width and
+ * whether it is collapsed to an icon-only strip. Shared as a single global
+ * store so the width survives reloads and the collapse toggle stays in sync.
+ */
+export function createTabRailState() {
+  const [store, setStore] = persisted(
+    Persist.global("tab-rail"),
+    createStore({
+      width: TAB_RAIL_WIDTH_DEFAULT,
+      collapsed: false,
+    }),
+  )
+
+  return {
+    width: () => store.width,
+    collapsed: () => store.collapsed,
+    resize: (width: number) =>
+      setStore("width", Math.min(TAB_RAIL_WIDTH_MAX, Math.max(TAB_RAIL_WIDTH_MIN, width))),
+    setCollapsed: (collapsed: boolean) => setStore("collapsed", collapsed),
+    toggleCollapsed: () => setStore("collapsed", (value) => !value),
+  }
+}

--- a/packages/app/src/components/titlebar-tab-rail.tsx
+++ b/packages/app/src/components/titlebar-tab-rail.tsx
@@ -1,0 +1,223 @@
+import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js"
+import { createMediaQuery } from "@solid-primitives/media"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
+import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
+import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
+import { useTabs, tabKey, type Tab } from "@/context/tabs"
+import { useLayout } from "@/context/layout"
+import { useLanguage } from "@/context/language"
+import { useCommand } from "@/context/command"
+import { TitlebarTabStrip } from "./titlebar-tab-strip"
+import {
+  createTabRailState,
+  TAB_RAIL_COLLAPSED_WIDTH,
+  TAB_RAIL_COLLAPSE_THRESHOLD,
+  TAB_RAIL_WIDTH_MAX,
+  TAB_RAIL_WIDTH_MIN,
+} from "./titlebar-tab-rail-state"
+
+/**
+ * A resizable left-hand vertical rail hosting the session/draft tab strip.
+ * Rendered by layout-new.tsx when `settings.general.tabOrientation ===
+ * "vertical"`. In that mode the top header is collapsed to bare window chrome,
+ * so this rail owns the home button, tab navigation/reordering, and the
+ * new-tab button. Home and new-tab reuse the commands the (still-mounted)
+ * titlebar registers (`home.toggle`, `tab.new`) via `command.trigger`, so no
+ * titlebar logic is duplicated. Tab state comes from the shared `useTabs()`
+ * context.
+ *
+ * The rail can be resized by dragging its right edge, and collapses to an
+ * icon-only strip either by dragging below the collapse threshold or via the
+ * toggle button. Collapsed mode needs no special rendering: narrowing each tab
+ * slot past 64px triggers the existing `@container` query that hides the title.
+ */
+export function TitlebarTabRail(props: { side?: "left" | "right" }) {
+  const tabs = useTabs()
+  const tabsStore = tabs.store
+  const layout = useLayout()
+  const language = useLanguage()
+  const command = useCommand()
+  const rail = createTabRailState()
+  const [, setOverflowing] = createSignal(false)
+  const [hovered, setHovered] = createSignal(false)
+  // Touch devices have no hover, so a tap latches the collapsed rail open and a
+  // second tap (or tapping outside) closes it again.
+  const [pinned, setPinned] = createSignal(false)
+  const touch = createMediaQuery("(hover: none)")
+  let rootEl: HTMLDivElement | undefined
+
+  // On touch, close the tapped-open rail when the next pointer-down lands
+  // outside it (focusout is unreliable since tapping content doesn't move
+  // focus). Registered lazily only while pinned.
+  createEffect(() => {
+    if (!pinned()) return
+    const onDown = (event: PointerEvent) => {
+      const target = event.target
+      if (target instanceof Node && rootEl?.contains(target)) return
+      setPinned(false)
+    }
+    document.addEventListener("pointerdown", onDown, true)
+    onCleanup(() => document.removeEventListener("pointerdown", onDown, true))
+  })
+
+  const right = () => props.side === "right"
+
+  // Reveal-on-hover for the collapsed rail, with a short close delay so brief
+  // pointer excursions (e.g. reaching for the scrollbar) don't cause the rail
+  // to flicker shut. Re-entering cancels a pending close.
+  let closeTimer: ReturnType<typeof setTimeout> | undefined
+  const cancelClose = () => {
+    if (closeTimer) clearTimeout(closeTimer)
+    closeTimer = undefined
+  }
+  const openHover = () => {
+    cancelClose()
+    if (rail.collapsed() && !touch()) setHovered(true)
+  }
+  const scheduleClose = () => {
+    if (touch()) return
+    cancelClose()
+    closeTimer = setTimeout(() => setHovered(false), 250)
+  }
+  onCleanup(cancelClose)
+
+  // Collapsed rail shows an icon-only strip but reveals its full remembered
+  // width on hover (or on tap for touch, via `pinned`). "expanded" means show
+  // titles. The remembered width is kept separately in state, so collapsing and
+  // re-expanding restores the previous width.
+  const expanded = () => !rail.collapsed() || hovered() || pinned()
+  const width = () => (expanded() ? rail.width() : TAB_RAIL_COLLAPSED_WIDTH)
+
+  const isHome = createMemo(() => layout.route().type === "home")
+  const currentTab = createMemo(() => {
+    const route = layout.route()
+    if (route.type === "draft") {
+      return tabsStore.find((item) => item.type === "draft" && item.draftID === route.draftID)
+    }
+    if (route.type === "session") {
+      return tabsStore.find(
+        (item) => item.type === "session" && item.server === route.server && item.sessionId === route.sessionId,
+      )
+    }
+  })
+
+  return (
+    <div
+      ref={rootEl}
+      data-slot="titlebar-tab-rail"
+      data-collapsed={rail.collapsed() && !hovered()}
+      class="relative flex h-full shrink-0 flex-col gap-1.5 overflow-hidden bg-v2-background-bg-deep py-2"
+      classList={{
+        "px-2": expanded(),
+        "pl-1 pr-0.5": !expanded() && !right(),
+        "pr-1 pl-0.5": !expanded() && right(),
+      }}
+      style={{ width: `${width()}px`, transition: "width 150ms ease" }}
+      onPointerEnter={openHover}
+      onPointerLeave={scheduleClose}
+      onClick={() => {
+        // On touch, first tap on the collapsed strip latches it open.
+        if (touch() && rail.collapsed() && !pinned()) setPinned(true)
+      }}
+    >
+      <div
+        class="flex shrink-0 flex-col gap-1.5"
+        classList={{
+          "items-center": !expanded(),
+          "items-start": expanded() && !right(),
+          "items-end": expanded() && right(),
+        }}
+      >
+        <TooltipV2
+          placement={right() ? "left" : "right"}
+          value={
+            <>
+              {language.t("home.title")}
+              <KeybindV2 keys={command.keybindParts("home.toggle")} variant="neutral" />
+            </>
+          }
+          class="shrink-0"
+        >
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="shrink-0"
+            icon={<IconV2 name="grid-plus" />}
+            state={isHome() ? "pressed" : undefined}
+            onClick={() => tabs.toggleHome({ home: isHome(), current: currentTab() })}
+            aria-label={language.t("home.title")}
+            aria-pressed={isHome()}
+          />
+        </TooltipV2>
+        <TooltipV2 placement={right() ? "left" : "right"} value={language.t("command.session.new")} class="shrink-0">
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="shrink-0"
+            icon={<IconV2 name="plus" />}
+            onClick={() => command.trigger("tab.new")}
+            aria-label={language.t("command.session.new")}
+          />
+        </TooltipV2>
+      </div>
+      <div class="min-h-0 min-w-0 flex-1 overflow-hidden">
+        <TitlebarTabStrip
+          tabs={tabsStore}
+          currentTab={currentTab}
+          forceTruncate={false}
+          orientation="vertical"
+          side={props.side}
+          onOverflowChange={setOverflowing}
+          onNavigate={(tab, el) => {
+            tabs.select(tab)
+            el?.scrollIntoView({ behavior: "instant", block: "nearest" })
+          }}
+          onClose={(tab) => {
+            const index = tabsStore.findIndex((item: Tab) => tabKey(item) === tabKey(tab))
+            if (index !== -1) tabs.closeTab(index)
+          }}
+          onReorder={(keys) => tabs.reorder(keys)}
+        />
+      </div>
+      <div
+        class="flex shrink-0"
+        classList={{
+          "justify-center": !expanded(),
+          "justify-start": expanded() && !right(),
+          "justify-end": expanded() && right(),
+        }}
+      >
+        <IconButtonV2
+          type="button"
+          variant="ghost-muted"
+          size="small"
+          class="shrink-0"
+          icon={<IconV2 name="sidebar-right" />}
+          onClick={() => {
+            setPinned(false)
+            rail.toggleCollapsed()
+          }}
+          aria-label={language.t(rail.collapsed() ? "tabRail.expand" : "tabRail.collapse")}
+        />
+      </div>
+      <Show when={!rail.collapsed()}>
+        <ResizeHandle
+          direction="horizontal"
+          edge={right() ? "start" : "end"}
+          class="absolute inset-y-0 z-10 w-2 cursor-col-resize hover:bg-v2-border-border-muted"
+          classList={{ "right-0 -mr-0.5": !right(), "left-0 -ml-0.5": right() }}
+          size={rail.width()}
+          min={TAB_RAIL_WIDTH_MIN}
+          max={TAB_RAIL_WIDTH_MAX}
+          collapseThreshold={TAB_RAIL_COLLAPSE_THRESHOLD}
+          onResize={rail.resize}
+          onCollapse={() => rail.setCollapsed(true)}
+        />
+      </Show>
+    </div>
+  )
+}

--- a/packages/app/src/components/titlebar-tab-strip.tsx
+++ b/packages/app/src/components/titlebar-tab-strip.tsx
@@ -4,7 +4,7 @@ import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
 import { isSortable, useSortable } from "@dnd-kit/solid/sortable"
 import { Accessibility, AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
-import { RestrictToHorizontalAxis } from "@dnd-kit/abstract/modifiers"
+import { RestrictToHorizontalAxis, RestrictToVerticalAxis } from "@dnd-kit/abstract/modifiers"
 import { RestrictToElement } from "@dnd-kit/dom/modifiers"
 import { arrayMove } from "@dnd-kit/helpers"
 import { tabHref, tabKey, type SessionTab, type Tab } from "@/context/tabs"
@@ -27,9 +27,10 @@ function SessionTabSlot(props: {
   index: () => number
   active: () => boolean
   forceTruncate: boolean
+  vertical?: boolean
   session: () => Session | undefined
   fallbackTitle?: string
-  onRename: (title: string) => Promise<void>
+  onTitleChange: (title: string) => void
   onNavigate: (element: HTMLDivElement) => void
   onClose: () => void
 }) {
@@ -49,7 +50,8 @@ function SessionTabSlot(props: {
       data-titlebar-tab-slot
       data-tab-key={props.id}
       data-active={props.active()}
-      class="relative flex w-56 min-w-7 max-w-56 flex-shrink"
+      class="relative flex flex-shrink"
+      classList={{ "w-56 min-w-7 max-w-56": !props.vertical, "w-full": props.vertical }}
     >
       <TabNavItem
         ref={(el) => {
@@ -59,7 +61,7 @@ function SessionTabSlot(props: {
         server={props.tab.server}
         session={props.session}
         fallbackTitle={props.fallbackTitle}
-        onRename={props.onRename}
+        onTitleChange={props.onTitleChange}
         onNavigate={() => props.onNavigate(ref)}
         onClose={props.onClose}
         active={props.active()}
@@ -76,6 +78,7 @@ function SessionTabEntry(props: {
   index: () => number
   active: () => boolean
   forceTruncate: boolean
+  vertical?: boolean
   serverCtx: () => ServerCtx | undefined
   onVisibleChange: (visible: boolean) => void
   onNavigate: (element: HTMLDivElement) => void
@@ -157,9 +160,10 @@ function SessionTabEntry(props: {
         index={props.index}
         active={props.active}
         forceTruncate={props.forceTruncate}
+        vertical={props.vertical}
         session={session}
         fallbackTitle={persisted()?.title ?? (missingSession() ? language.t("session.tab.unknown") : undefined)}
-        onRename={rename}
+        onTitleChange={(title) => void rename(title)}
         onNavigate={props.onNavigate}
         onClose={props.onClose}
       />
@@ -172,6 +176,7 @@ function DraftTabSlot(props: {
   id: string
   index: () => number
   active: () => boolean
+  vertical?: boolean
   title: string
   onNavigate: (element: HTMLDivElement) => void
   onClose: () => void
@@ -192,7 +197,8 @@ function DraftTabSlot(props: {
       data-titlebar-tab-slot
       data-tab-key={props.id}
       data-active={props.active()}
-      class="relative flex w-56 min-w-7 max-w-56 flex-shrink"
+      class="relative flex flex-shrink"
+      classList={{ "w-56 min-w-7 max-w-56": !props.vertical, "w-full": props.vertical }}
     >
       <DraftTabItem
         ref={(el) => {
@@ -213,6 +219,8 @@ export function TitlebarTabStrip(props: {
   tabs: Tab[]
   currentTab: () => Tab | undefined
   forceTruncate: boolean
+  orientation?: "horizontal" | "vertical"
+  side?: "left" | "right"
   onNavigate: (tab: Tab, el?: HTMLDivElement) => void
   onClose: (tab: Tab) => void
   onReorder: (keys: string[]) => void
@@ -253,10 +261,13 @@ export function TitlebarTabStrip(props: {
     const next = props.tabs.find((tab) => tabKey(tab) === key)
     if (next) props.onNavigate(next)
   }
+  const vertical = () => props.orientation === "vertical"
 
   function refreshOverflow() {
     if (!scrollRef) return
-    props.onOverflowChange(scrollRef.scrollWidth > scrollRef.clientWidth)
+    props.onOverflowChange(
+      vertical() ? scrollRef.scrollHeight > scrollRef.clientHeight : scrollRef.scrollWidth > scrollRef.clientWidth,
+    )
   }
 
   createResizeObserver(
@@ -285,10 +296,14 @@ export function TitlebarTabStrip(props: {
   })
 
   return (
-    <div data-slot="titlebar-tabs" class="relative min-w-0">
+    <div data-slot="titlebar-tabs" data-orientation={vertical() ? "vertical" : "horizontal"} data-side={props.side ?? "left"} class="relative min-w-0">
       <div
         data-slot="titlebar-tabs-scroll"
-        class="flex min-w-0 flex-row items-center gap-1.5 overflow-x-auto no-scrollbar [app-region:no-drag]"
+        class="flex min-w-0 gap-1.5 no-scrollbar [app-region:no-drag]"
+        classList={{
+          "flex-row items-center overflow-x-auto": !vertical(),
+          "flex-col overflow-y-auto": vertical(),
+        }}
         ref={scrollRef}
       >
         <DragDropProvider
@@ -301,10 +316,16 @@ export function TitlebarTabStrip(props: {
                 (event.target instanceof Element && !!event.target.closest('[contenteditable="true"]')),
             }),
           ]}
-          modifiers={[RestrictToHorizontalAxis, RestrictToElement.configure({ element: () => listRef })]}
+          modifiers={[
+            vertical() ? RestrictToVerticalAxis : RestrictToHorizontalAxis,
+            RestrictToElement.configure({ element: () => listRef }),
+          ]}
           plugins={(defaults) => [
             ...defaults.filter((plugin) => plugin !== Accessibility),
-            AutoScroller.configure({ acceleration: 8, threshold: { x: 0.05, y: 0 } }),
+            AutoScroller.configure({
+              acceleration: 8,
+              threshold: vertical() ? { x: 0, y: 0.05 } : { x: 0.05, y: 0 },
+            }),
             Feedback.configure({ dropAnimation: null }),
           ]}
           onDragStart={(event) => {
@@ -332,7 +353,12 @@ export function TitlebarTabStrip(props: {
             }
           }}
         >
-          <div data-titlebar-tab-list class="flex w-full min-w-0 flex-row items-center" ref={listRef}>
+          <div
+            data-titlebar-tab-list
+            class="flex w-full min-w-0"
+            classList={{ "flex-row items-center": !vertical(), "flex-col gap-0.5": vertical() }}
+            ref={listRef}
+          >
             <For each={props.tabs}>
               {(tab) => {
                 const id = tabKey(tab)
@@ -353,6 +379,7 @@ export function TitlebarTabStrip(props: {
                       index={visibleIndex}
                       active={() => props.currentTab() === tab}
                       forceTruncate={props.forceTruncate}
+                      vertical={vertical()}
                       serverCtx={serverCtx}
                       onVisibleChange={(visible) => setVisibility(id, visible)}
                       onNavigate={(element) => {
@@ -370,6 +397,7 @@ export function TitlebarTabStrip(props: {
                     id={id}
                     index={visibleIndex}
                     active={() => props.currentTab() === tab}
+                    vertical={vertical()}
                     title={language.t("command.session.new")}
                     onNavigate={(element) => {
                       ref = element
@@ -383,16 +411,18 @@ export function TitlebarTabStrip(props: {
           </div>
         </DragDropProvider>
       </div>
-      <div
-        data-slot="titlebar-tabs-fade-left"
-        aria-hidden="true"
-        class="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-[linear-gradient(to_right,var(--v2-background-bg-deep),transparent)]"
-      />
-      <div
-        data-slot="titlebar-tabs-fade-right"
-        aria-hidden="true"
-        class="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-[linear-gradient(to_left,var(--v2-background-bg-deep),transparent)]"
-      />
+      <Show when={!vertical()}>
+        <div
+          data-slot="titlebar-tabs-fade-left"
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-y-0 left-0 z-10 w-6 bg-[linear-gradient(to_right,var(--v2-background-bg-deep),transparent)]"
+        />
+        <div
+          data-slot="titlebar-tabs-fade-right"
+          aria-hidden="true"
+          class="pointer-events-none absolute inset-y-0 right-0 z-10 w-6 bg-[linear-gradient(to_left,var(--v2-background-bg-deep),transparent)]"
+        />
+      </Show>
     </div>
   )
 }

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -61,7 +61,11 @@ export function useTitlebarRightMount() {
   return mount
 }
 
-export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visible: boolean; toggle: () => void } }) {
+export function Titlebar(props: {
+  update?: TitlebarUpdate
+  hideTabs?: boolean
+  debugTools?: { visible: boolean; toggle: () => void }
+}) {
   const layout = useLayout()
   const platform = usePlatform()
   const command = useCommand()
@@ -173,7 +177,10 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
       data-slot={useV2Titlebar() ? "titlebar-v2" : undefined}
       classList={{
         "shrink-0 relative flex flex-row": true,
-        "h-9 bg-v2-background-bg-deep overflow-visible": useV2Titlebar(),
+        "h-9 bg-v2-background-bg-deep overflow-visible": useV2Titlebar() && !(props.hideTabs && web()),
+        // Vertical tabs on web: the home/new-tab buttons moved to the rail and
+        // there are no OS window controls, so collapse the header away entirely.
+        "h-0 bg-v2-background-bg-deep overflow-visible": useV2Titlebar() && props.hideTabs && web(),
         "h-10 bg-background-base overflow-hidden": !useV2Titlebar(),
         "order-last": bottom(),
       }}
@@ -368,67 +375,78 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                   "md:pl-4": !macTrafficLights(),
                 }}
               >
-                <ChannelIndicator debugTools={props.debugTools} />
+                <Show when={!props.hideTabs}>
+                  <ChannelIndicator debugTools={props.debugTools} />
+                </Show>
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} variant="v2" />
                 </Show>
-                <TooltipV2
-                  placement="bottom"
-                  value={
-                    <>
-                      {language.t("home.title")}
-                      <KeybindV2 keys={command.keybindParts("home.toggle")} variant="neutral" />
-                    </>
-                  }
-                  class="shrink-0"
-                >
-                  <IconButtonV2
-                    type="button"
-                    variant="ghost-muted"
-                    size="large"
-                    class="!w-9 shrink-0"
-                    icon={<IconV2 name="grid-plus" />}
-                    state={layout.route().type === "home" ? "pressed" : undefined}
-                    onClick={toggleHome}
-                    aria-label={language.t("home.title")}
-                    aria-pressed={layout.route().type === "home"}
-                  />
-                </TooltipV2>
-
-                <TitlebarTabStrip
-                  tabs={tabsStore}
-                  currentTab={currentTab}
-                  forceTruncate={tabsAreOverflowing()}
-                  onOverflowChange={setTabsAreOverflowing}
-                  onNavigate={(tab, el) => {
-                    tabs.select(tab)
-                    el?.scrollIntoView({ behavior: "instant" })
-                  }}
-                  onClose={(tab) => {
-                    const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                    if (index !== -1) tabsStoreActions.closeTab(index)
-                  }}
-                  onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                />
-                <TooltipV2
-                  placement="bottom"
-                  value={
-                    <>
-                      {language.t("command.session.new")}
-                      <KeybindV2 keys={newTabTooltipKeybind(command)} variant="neutral" />
-                    </>
-                  }
-                >
-                  <IconButtonV2
-                    type="button"
-                    variant="ghost-muted"
-                    size="large"
+                <Show when={!props.hideTabs}>
+                  <TooltipV2
+                    placement="bottom"
+                    value={
+                      <>
+                        {language.t("home.title")}
+                        <KeybindV2 keys={command.keybindParts("home.toggle")} variant="neutral" />
+                      </>
+                    }
                     class="shrink-0"
-                    icon={<IconV2 name="plus" />}
-                    onClick={openNewTab}
-                    aria-label={language.t("command.session.new")}
+                  >
+                    <IconButtonV2
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="!w-9 shrink-0"
+                      icon={<IconV2 name="grid-plus" />}
+                      state={layout.route().type === "home" ? "pressed" : undefined}
+                      onClick={toggleHome}
+                      aria-label={language.t("home.title")}
+                      aria-pressed={layout.route().type === "home"}
+                    />
+                  </TooltipV2>
+                </Show>
+
+                <Show
+                  when={!props.hideTabs}
+                  fallback={<div class="flex-1 [app-region:drag]" data-tauri-drag-region />}
+                >
+                  <TitlebarTabStrip
+                    tabs={tabsStore}
+                    currentTab={currentTab}
+                    forceTruncate={tabsAreOverflowing()}
+                    onOverflowChange={setTabsAreOverflowing}
+                    onNavigate={(tab, el) => {
+                      tabs.select(tab)
+                      el?.scrollIntoView({ behavior: "instant" })
+                    }}
+                    onClose={(tab) => {
+                      const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                      if (index !== -1) tabsStoreActions.closeTab(index)
+                    }}
+                    onReorder={(keys) => tabsStoreActions.reorder(keys)}
                   />
-                </TooltipV2>
+                  <Show when={!creating() && !props.hideTabs}>
+                  <TooltipV2
+                    placement="bottom"
+                    value={
+                      <>
+                        {language.t("command.session.new")}
+                        <KeybindV2 keys={newTabTooltipKeybind(command)} variant="neutral" />
+                      </>
+                    }
+                  >
+                    <IconButtonV2
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="shrink-0"
+                      icon={<IconV2 name="plus" />}
+                      onClick={openNewTab}
+                      aria-label={language.t("command.session.new")}
+                    />
+                  </TooltipV2>
+                  </Show>
+                </Show>
                 <div class="flex-1" />
                 <TitlebarV2Right state={v2RightState()} />
               </div>

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -34,6 +34,9 @@ export interface Settings {
     editToolPartsExpanded: boolean
     showCustomAgents: boolean
     mobileTitlebarPosition: "top" | "bottom"
+    tabOrientation: "horizontal" | "vertical"
+    tabRailSide: "left" | "right"
+    showReviewPanelButton: boolean
     newLayoutDesigns?: boolean
     layoutTransitionEligible?: boolean
     agentVisibilityInitialized?: boolean
@@ -195,6 +198,9 @@ const defaultSettings: Settings = {
     editToolPartsExpanded: false,
     showCustomAgents: false,
     mobileTitlebarPosition: "top",
+    tabOrientation: "horizontal",
+    tabRailSide: "left",
+    showReviewPanelButton: true,
   },
   appearance: {
     fontSize: 14,
@@ -427,6 +433,24 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         ),
         setMobileTitlebarPosition(value: "top" | "bottom") {
           setStore("general", "mobileTitlebarPosition", value)
+        },
+        tabOrientation: withFallback(
+          () => store.general?.tabOrientation,
+          defaultSettings.general.tabOrientation,
+        ),
+        setTabOrientation(value: "horizontal" | "vertical") {
+          setStore("general", "tabOrientation", value)
+        },
+        tabRailSide: withFallback(() => store.general?.tabRailSide, defaultSettings.general.tabRailSide),
+        setTabRailSide(value: "left" | "right") {
+          setStore("general", "tabRailSide", value)
+        },
+        showReviewPanelButton: withFallback(
+          () => store.general?.showReviewPanelButton,
+          defaultSettings.general.showReviewPanelButton,
+        ),
+        setShowReviewPanelButton(value: boolean) {
+          setStore("general", "showReviewPanelButton", value)
         },
         newLayoutDesigns,
         setNewLayoutDesigns(value: boolean) {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -930,6 +930,14 @@ export const dict = {
   "settings.general.row.mobileTitlebarBottom.title": "Bottom navigation",
   "settings.general.row.mobileTitlebarBottom.description":
     "Place the title bar and session tabs at the bottom of the screen on mobile",
+  "settings.general.row.verticalTabs.title": "Vertical tabs",
+  "settings.general.row.verticalTabs.description": "Show session tabs in a sidebar on the left instead of across the top",
+  "settings.general.row.tabRailSide.title": "Tabs on the right",
+  "settings.general.row.tabRailSide.description": "Place the vertical tab sidebar on the right instead of the left",
+  "tabRail.collapse": "Collapse tab sidebar",
+  "tabRail.expand": "Expand tab sidebar",
+  "settings.general.row.showReviewPanelButton.title": "Show review panel button",
+  "settings.general.row.showReviewPanelButton.description": "Show the review panel toggle in the session header",
   "settings.general.row.showCustomAgents.title": "Show agent",
   "settings.general.row.showCustomAgents.description":
     "Switch between agents in the composer. When hidden, defaults to Build agent.",

--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -1,16 +1,21 @@
-import { createEffect, Suspense, type ParentProps } from "solid-js"
+import { createEffect, Show, Suspense, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import { DebugBar } from "@/components/debug-bar"
 import { TabsInfoPopup } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { TitlebarTabRail } from "@/components/titlebar-tab-rail"
 import { usePlatform } from "@/context/platform"
+import { useSettings } from "@/context/settings"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
   const [state, setState] = createStore({ debugTools: true })
+  const settings = useSettings()
 
   createEffect(() => setV2Toast(true))
+
+  const vertical = () => settings.general.tabOrientation() === "vertical"
 
   const update: TitlebarUpdate = {
     version: () => {
@@ -32,15 +37,28 @@ export default function NewLayout(props: ParentProps) {
     >
       <Titlebar
         update={update}
+        hideTabs={vertical()}
         debugTools={
           import.meta.env.DEV
             ? { visible: state.debugTools, toggle: () => setState("debugTools", (value) => !value) }
             : undefined
         }
       />
-      <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
-        <Suspense>{props.children}</Suspense>
-      </main>
+      <div
+        class="flex min-h-0 min-w-0 flex-1"
+        classList={{
+          "flex-row": vertical() && settings.general.tabRailSide() === "left",
+          "flex-row-reverse": vertical() && settings.general.tabRailSide() === "right",
+          "flex-col": !vertical(),
+        }}
+      >
+        <Show when={vertical()}>
+          <TitlebarTabRail side={settings.general.tabRailSide()} />
+        </Show>
+        <main class="h-full flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
+          <Suspense>{props.children}</Suspense>
+        </main>
+      </div>
       {import.meta.env.DEV && state.debugTools && <DebugBar inline />}
       <TabsInfoPopup />
       <ToastRegion v2 />

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -2330,13 +2330,17 @@ export default function Page() {
                       reviewHasFocusableContent={() => hasReview() || reviewV2State.sidebarOpened()}
                       reviewCount={reviewCount}
                       reviewPanel={reviewPanelV2}
-                      reviewSidebarToggle={(disabled) => (
-                        <SessionReviewV2SidebarToggle
-                          opened={reviewV2State.sidebarOpened()}
-                          disabled={disabled}
-                          onToggle={reviewV2State.toggleSidebar}
-                        />
-                      )}
+                      reviewSidebarToggle={
+                        settings.general.showReviewPanelButton()
+                          ? (disabled) => (
+                              <SessionReviewV2SidebarToggle
+                                opened={reviewV2State.sidebarOpened()}
+                                disabled={disabled}
+                                onToggle={reviewV2State.toggleSidebar}
+                              />
+                            )
+                          : undefined
+                      }
                       fileBrowserState={reviewV2State}
                       activeDiff={activeReviewFile()}
                       focusReviewDiff={focusReviewDiff}

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -54,6 +54,7 @@ import type {
 } from "@opencode-ai/sdk/v2"
 import { showToast } from "@/utils/toast"
 import { getDirectory, getFilename } from "@opencode-ai/core/util/path"
+import { pathKey } from "@/utils/path-key"
 import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { normalize } from "@opencode-ai/session-ui/session-diff"
 import { useFileComponent } from "@opencode-ai/ui/context/file"
@@ -327,6 +328,24 @@ export function MessageTimeline(props: {
     return language.t("command.session.new")
   })
   const showHeader = createMemo(() => !!(titleValue() || parentID()))
+  // Extra context shown next to the session title: project name, and the git
+  // branch / worktree folder when the session lives in a worktree (not the
+  // project root), mirroring the tab's worktree badge.
+  const projectName = createMemo(() => {
+    const project = sync().project
+    if (!project) return
+    return project.name || getFilename(project.worktree) || project.worktree
+  })
+  const worktreeLabel = createMemo(() => {
+    const directory = info()?.directory
+    const root = sync().project?.worktree
+    if (!directory || !root || pathKey(directory) === pathKey(root)) return
+    return sync().data.vcs?.branch ?? getFilename(directory)
+  })
+  const working = createMemo(() => {
+    const id = sessionID()
+    return id ? sync().data.session_working(id) : false
+  })
   const projection = createTimelineProjection({
     messages: sessionMessages,
     userMessages: () => props.userMessages,
@@ -1483,6 +1502,36 @@ export function MessageTimeline(props: {
                         onBlur={closeTitleEditor}
                       />
                     </Show>
+                  </Show>
+                  <Show when={working()}>
+                    <span
+                      data-slot="session-title-working"
+                      class="ml-1.5 size-1.5 shrink-0 rounded-full bg-v2-icon-icon-accent"
+                      title={language.t("common.loading")}
+                    />
+                  </Show>
+                  <Show when={projectName()}>
+                    {(name) => (
+                      <span
+                        data-slot="session-title-project"
+                        title={name()}
+                        class="ml-2 shrink-0 truncate text-[11px] leading-4 text-v2-text-text-faint max-w-40"
+                      >
+                        {name()}
+                      </span>
+                    )}
+                  </Show>
+                  <Show when={worktreeLabel()}>
+                    {(label) => (
+                      <span
+                        data-slot="session-title-worktree"
+                        title={label()}
+                        class="ml-1.5 flex shrink-0 items-center gap-0.5 max-w-40 rounded-[3px] bg-v2-background-bg-layer px-1 text-[11px] leading-4 text-v2-text-text-faint"
+                      >
+                        <IconV2 name="branch" class="size-3 shrink-0" />
+                        <span class="overflow-hidden text-clip whitespace-nowrap">{label()}</span>
+                      </span>
+                    )}
                   </Show>
                 </div>
               </div>


### PR DESCRIPTION
### Issue for this PR

Closes #36942

### Type of change

- [x] New feature

### What does this PR do?

Adds an opt-in vertical tab layout, toggled from Settings › General. Horizontal tabs stay the default and nothing is removed.

The rail is resizable (persisted width) and collapsible to an icon-only strip that reveals on hover. It reuses the existing `@container` query that already hides tab titles at narrow widths, so there's no separate render path. Home and new-tab buttons move into the rail but call the same titlebar commands/tab actions, so no logic is duplicated — the titlebar stays mounted and just hides its tab row in vertical mode (`hideTabs` prop). Two extra options: place the rail on the right (mirrored layout), and hide the session-header review button.

I also enriched the session-header title with project name, branch/worktree, and a working dot, since collapsed/narrow tabs lose that context.

### How did you verify your code works?

Ran `bun typecheck` and a full app build + smoke test. Manually tested toggling vertical/horizontal, left/right rail, resize, collapse, hover-reveal, and the review-button toggle in the desktop build.

### Screenshots / recordings

<img width="2560" height="1926" alt="image" src="https://github.com/user-attachments/assets/90e3f2ac-e9f1-40e3-b32a-b36c03923489" />

<img width="2560" height="1926" alt="image" src="https://github.com/user-attachments/assets/6f9dc28a-dab4-4b2b-845e-fdc164982ffd" />

<img width="2560" height="1926" alt="image" src="https://github.com/user-attachments/assets/53c69394-3f11-47c9-a37d-9f0555d4655b" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR