### PR TITLE
feat(opencode): support external OpenAI auth broker

### DIFF
--- a/packages/opencode/src/plugin/openai/broker.ts
+++ b/packages/opencode/src/plugin/openai/broker.ts
@@ -1,0 +1,116 @@
+import { OpenAIWebSocketPool } from "./ws-pool"
+
+const REFRESH_WINDOW_MS = 5 * 60 * 1000
+
+export interface BrokerOptions {
+  url: string
+  serviceTokenFile: string
+  codexApiEndpoint: string
+  fetch: typeof fetch
+  websocketFetch?: ReturnType<typeof OpenAIWebSocketPool.createWebSocketFetch>
+}
+
+interface BrokerToken {
+  accessToken: string
+  accessTokenHash: string
+  chatgptAccountId: string
+  chatgptPlanType?: string
+  expiresAt: string
+}
+
+export function createBrokerFetch(options: BrokerOptions) {
+  let current: BrokerToken | undefined
+  let pending: Promise<BrokerToken> | undefined
+
+  const token = async (previousHash = "") => {
+    if (previousHash && current && current.accessTokenHash !== previousHash) return current
+    if (!previousHash && current && Date.parse(current.expiresAt) > Date.now() + REFRESH_WINDOW_MS) return current
+    if (pending) return pending
+
+    pending = requestToken(options, previousHash)
+      .then((result) => {
+        current = result
+        return result
+      })
+      .finally(() => {
+        pending = undefined
+      })
+    return pending
+  }
+
+  const send = async (requestInput: RequestInfo | URL, init: RequestInit | undefined, auth: BrokerToken) => {
+    const headers = new Headers(init?.headers)
+    headers.delete("authorization")
+    headers.set("authorization", `Bearer ${auth.accessToken}`)
+    headers.set("ChatGPT-Account-Id", auth.chatgptAccountId)
+
+    const parsed =
+      requestInput instanceof URL
+        ? requestInput
+        : new URL(typeof requestInput === "string" ? requestInput : requestInput.url)
+    const url =
+      parsed.pathname.includes("/v1/responses") || parsed.pathname.includes("/chat/completions")
+        ? new URL(options.codexApiEndpoint)
+        : parsed
+    const requestInit = { ...init, headers }
+    if (options.websocketFetch && parsed.pathname.endsWith("/responses")) {
+      return options.websocketFetch(url, requestInit)
+    }
+    return options.fetch(url, OpenAIWebSocketPool.withoutInternalHeaders(requestInit))
+  }
+
+  return async (requestInput: RequestInfo | URL, init?: RequestInit) => {
+    const initial = await token()
+    const response = await send(requestInput, init, initial)
+    if (response.status !== 401) return response
+
+    await response.body?.cancel()
+    return send(requestInput, init, await token(initial.accessTokenHash))
+  }
+}
+
+async function requestToken(options: BrokerOptions, previousHash: string) {
+  const serviceToken = (await Bun.file(options.serviceTokenFile).text()).trim()
+  if (!serviceToken) throw new Error("OpenAI auth broker service token is empty")
+
+  const response = await options.fetch(options.url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${serviceToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ previousAccessTokenHash: previousHash }),
+    signal: AbortSignal.timeout(15_000),
+  })
+  if (!response.ok) throw new Error(`OpenAI auth broker returned HTTP ${response.status}`)
+
+  const token: unknown = await response.json()
+  if (
+    typeof token !== "object" ||
+    token === null ||
+    !("accessToken" in token) ||
+    typeof token.accessToken !== "string" ||
+    !("accessTokenHash" in token) ||
+    typeof token.accessTokenHash !== "string" ||
+    !("chatgptAccountId" in token) ||
+    typeof token.chatgptAccountId !== "string" ||
+    !("expiresAt" in token) ||
+    typeof token.expiresAt !== "string" ||
+    !token.accessToken ||
+    !token.accessTokenHash ||
+    !token.chatgptAccountId ||
+    !token.expiresAt ||
+    !Number.isFinite(Date.parse(token.expiresAt))
+  ) {
+    throw new Error("OpenAI auth broker returned an incomplete token")
+  }
+  return {
+    accessToken: token.accessToken,
+    accessTokenHash: token.accessTokenHash,
+    chatgptAccountId: token.chatgptAccountId,
+    ...("chatgptPlanType" in token && typeof token.chatgptPlanType === "string"
+      ? { chatgptPlanType: token.chatgptPlanType }
+      : {}),
+    expiresAt: token.expiresAt,
+  }
+}

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -6,6 +6,7 @@ import { setTimeout as sleep } from "node:timers/promises"
 import { createServer } from "http"
 import { OpenAIWebSocketPool } from "./ws-pool"
 import { OauthCallbackPage } from "@opencode-ai/core/oauth/page"
+import { createBrokerFetch } from "./broker"
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 const ISSUER = "https://auth.openai.com"
@@ -102,6 +103,11 @@ interface CodexAuthPluginOptions {
   issuer?: string
   codexApiEndpoint?: string
   experimentalWebSockets?: boolean
+  fetch?: typeof fetch
+  broker?: {
+    url: string
+    serviceTokenFile: string
+  }
 }
 
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
@@ -263,6 +269,17 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
 export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPluginOptions = {}): Promise<Hooks> {
   const issuer = options.issuer ?? ISSUER
   const codexApiEndpoint = options.codexApiEndpoint ?? CODEX_API_ENDPOINT
+  const httpFetch = options.fetch ?? fetch
+  const brokerURL = options.broker?.url ?? process.env.OPENCODE_OPENAI_AUTH_BROKER_URL
+  const broker = brokerURL
+    ? {
+        url: brokerURL,
+        serviceTokenFile:
+          options.broker?.serviceTokenFile ??
+          process.env.OPENCODE_OPENAI_AUTH_BROKER_TOKEN_FILE ??
+          "/var/run/secrets/kubernetes.io/serviceaccount/token",
+      }
+    : undefined
   let websocketFetchInstalled = false
   const websocketFetches: Array<ReturnType<typeof OpenAIWebSocketPool.createWebSocketFetch>> = []
 
@@ -278,7 +295,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
     provider: {
       id: "openai",
       async models(provider, ctx) {
-        if (ctx.auth?.type !== "oauth") return provider.models
+        if (ctx.auth?.type !== "oauth" && !broker) return provider.models
 
         return Object.fromEntries(
           Object.entries(provider.models)
@@ -319,15 +336,29 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
     },
     auth: {
       provider: "openai",
+      autoload: Boolean(broker),
       async loader(getAuth) {
-        const auth = await getAuth()
         const websocketFetch = options.experimentalWebSockets
-          ? OpenAIWebSocketPool.createWebSocketFetch({ httpFetch: fetch })
+          ? OpenAIWebSocketPool.createWebSocketFetch({ httpFetch })
           : undefined
         if (websocketFetch) {
           websocketFetches.push(websocketFetch)
           websocketFetchInstalled = true
         }
+        if (broker) {
+          return {
+            apiKey: OAUTH_DUMMY_KEY,
+            openaiAuth: "broker",
+            fetch: createBrokerFetch({
+              ...broker,
+              codexApiEndpoint,
+              fetch: httpFetch,
+              websocketFetch,
+            }),
+          }
+        }
+
+        const auth = await getAuth()
         if (auth.type !== "oauth") return websocketFetch ? { fetch: websocketFetch } : {}
 
         let refreshPromise:

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1547,7 +1547,7 @@ const layer = Layer.effect(
           if (disabled.has(providerID)) continue
 
           const stored = yield* auth.get(providerID).pipe(Effect.orDie)
-          if (!stored) continue
+          if (!stored && !plugin.auth.autoload) continue
           if (!plugin.auth.loader) continue
 
           const options = yield* Effect.promise(() =>

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -18,6 +18,7 @@ import {
 } from "@opencode-ai/llm"
 import type { LLMClientShape } from "@opencode-ai/llm/route"
 import { LLMNative } from "./native-request"
+import { isOpenAIChatGPTAuth } from "./openai-auth"
 
 export type RuntimeStatus =
   | { readonly type: "supported"; readonly apiKey: string; readonly baseURL?: string }
@@ -146,7 +147,7 @@ export function stream(input: StreamInput): StreamResult {
 }
 
 function providerFetch(input: Pick<StreamInput, "provider" | "auth">): typeof globalThis.fetch | undefined {
-  if (input.provider.id !== "openai" || input.auth?.type !== "oauth") return undefined
+  if (!isOpenAIChatGPTAuth(input)) return undefined
   const value: unknown = input.provider.options.fetch
   if (typeof value !== "function") return undefined
   return value as typeof globalThis.fetch

--- a/packages/opencode/src/session/llm/openai-auth.ts
+++ b/packages/opencode/src/session/llm/openai-auth.ts
@@ -1,0 +1,8 @@
+export function isOpenAIChatGPTAuth(input: {
+  provider: { id: string; options: Record<string, unknown> }
+  auth: { type: string } | undefined
+}) {
+  return (
+    input.provider.id === "openai" && (input.auth?.type === "oauth" || input.provider.options.openaiAuth === "broker")
+  )
+}

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -14,6 +14,7 @@ import { Effect, Record } from "effect"
 import { jsonSchema, tool as aiTool, type ModelMessage, type Tool } from "ai"
 import type { Plugin } from "@/plugin"
 import { mergeDeep } from "remeda"
+import { isOpenAIChatGPTAuth } from "./openai-auth"
 
 const USER_AGENT = `opencode/${InstallationVersion}`
 
@@ -54,7 +55,7 @@ const mergeOptions = (target: Record<string, any>, source: Record<string, any> |
   mergeDeep(target, source ?? {}) as Record<string, any>
 
 export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: PrepareInput) {
-  const isOpenaiOauth = input.provider.id === "openai" && input.auth?.type === "oauth"
+  const isOpenaiOauth = isOpenAIChatGPTAuth(input)
   const system = [
     [
       ...(input.agent.prompt ? [input.agent.prompt] : SystemPrompt.provider(input.model)),

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import path from "path"
 import {
   CodexAuthPlugin,
   parseJwtClaims,
@@ -7,6 +8,7 @@ import {
   renderOAuthError,
   type IdTokenClaims,
 } from "../../src/plugin/openai/codex"
+import { tmpdir } from "../fixture/fixture"
 
 function createTestJwt(payload: object): string {
   const header = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")
@@ -286,6 +288,91 @@ describe("plugin.codex", () => {
     expect(apiRequests).toEqual([
       { authorization: "Bearer access-new", accountId: "acc-123" },
       { authorization: "Bearer access-new", accountId: "acc-123" },
+    ])
+  })
+
+  test("uses an external broker without loading or persisting OAuth credentials", async () => {
+    await using tmp = await tmpdir()
+    const serviceTokenFile = path.join(tmp.path, "service-account-token")
+    await Bun.write(serviceTokenFile, "service-account-token\n")
+
+    const brokerRequests: Array<{ authorization: string | null; previousHash: string }> = []
+    const apiRequests: Array<{ authorization: string | null; accountId: string | null }> = []
+    using server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname === "/broker") {
+          const body: unknown = await request.json()
+          const previousHash =
+            typeof body === "object" &&
+            body !== null &&
+            "previousAccessTokenHash" in body &&
+            typeof body.previousAccessTokenHash === "string"
+              ? body.previousAccessTokenHash
+              : ""
+          brokerRequests.push({
+            authorization: request.headers.get("authorization"),
+            previousHash,
+          })
+          const rotated = previousHash === "hash-1"
+          return Response.json({
+            accessToken: rotated ? "access-2" : "access-1",
+            accessTokenHash: rotated ? "hash-2" : "hash-1",
+            chatgptAccountId: "account-1",
+            chatgptPlanType: "plus",
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          })
+        }
+        if (url.pathname === "/backend-api/codex/responses") {
+          const authorization = request.headers.get("authorization")
+          apiRequests.push({
+            authorization,
+            accountId: request.headers.get("ChatGPT-Account-Id"),
+          })
+          return new Response("{}", { status: authorization === "Bearer access-1" ? 401 : 200 })
+        }
+        return new Response("unexpected request", { status: 500 })
+      },
+    })
+
+    let loadedStoredAuth = false
+    let persistedAuth = false
+    const hooks = await CodexAuthPlugin(
+      {
+        client: {
+          auth: {
+            async set() {
+              persistedAuth = true
+            },
+          },
+        } as never,
+      } as never,
+      {
+        broker: {
+          url: new URL("/broker", server.url).toString(),
+          serviceTokenFile,
+        },
+        codexApiEndpoint: new URL("/backend-api/codex/responses", server.url).toString(),
+      },
+    )
+    const loaded = await hooks.auth!.loader!(async () => {
+      loadedStoredAuth = true
+      throw new Error("broker mode must not load stored auth")
+    }, {} as never)
+
+    expect(hooks.auth?.autoload).toBe(true)
+    expect(loaded.openaiAuth).toBe("broker")
+    expect((await loaded.fetch!("https://api.openai.com/v1/responses")).status).toBe(200)
+    expect(loadedStoredAuth).toBe(false)
+    expect(persistedAuth).toBe(false)
+    expect(brokerRequests).toEqual([
+      { authorization: "Bearer service-account-token", previousHash: "" },
+      { authorization: "Bearer service-account-token", previousHash: "hash-1" },
+    ])
+    expect(apiRequests).toEqual([
+      { authorization: "Bearer access-1", accountId: "account-1" },
+      { authorization: "Bearer access-2", accountId: "account-1" },
     ])
   })
 })

--- a/packages/opencode/test/session/openai-auth.test.ts
+++ b/packages/opencode/test/session/openai-auth.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { isOpenAIChatGPTAuth } from "../../src/session/llm/openai-auth"
+
+test("recognizes OpenAI ChatGPT authentication sources", () => {
+  expect(
+    isOpenAIChatGPTAuth({
+      provider: { id: "openai", options: { openaiAuth: "broker" } },
+      auth: undefined,
+    }),
+  ).toBe(true)
+  expect(
+    isOpenAIChatGPTAuth({
+      provider: { id: "openai", options: {} },
+      auth: { type: "oauth" },
+    }),
+  ).toBe(true)
+  expect(
+    isOpenAIChatGPTAuth({
+      provider: { id: "openai", options: {} },
+      auth: { type: "api" },
+    }),
+  ).toBe(false)
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -87,6 +87,7 @@ type Rule = {
 
 export type AuthHook = {
   provider: string
+  autoload?: boolean
   loader?: (auth: () => Promise<Auth>, provider: Provider) => Promise<Record<string, any>>
   methods: (
     | {

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1698,6 +1698,44 @@ We recommend signing up for [ChatGPT Plus or Pro](https://chatgpt.com/pricing).
 
 If you already have an API key, you can select **Manually enter API Key** and paste it in your terminal.
 
+##### Using an external token broker
+
+Headless deployments can delegate ChatGPT access-token rotation to an external
+broker instead of storing an OpenAI OAuth credential in OpenCode. Configure the
+broker URL and a file containing the bearer credential used to call it:
+
+```sh
+export OPENCODE_OPENAI_AUTH_BROKER_URL="https://broker.example.com/token"
+export OPENCODE_OPENAI_AUTH_BROKER_TOKEN_FILE="/var/run/secrets/service/token"
+opencode serve --hostname 0.0.0.0 --port 4096
+```
+
+The token file is read for every broker request so platforms such as Kubernetes
+can rotate it. OpenCode sends:
+
+```json
+{
+  "previousAccessTokenHash": ""
+}
+```
+
+The broker must return a short-lived ChatGPT token and account metadata:
+
+```json
+{
+  "accessToken": "...",
+  "accessTokenHash": "...",
+  "chatgptAccountId": "...",
+  "chatgptPlanType": "plus",
+  "expiresAt": "2026-07-22T14:00:00Z"
+}
+```
+
+OpenCode refreshes before expiration. If OpenAI rejects a token with `401`, it
+sends that token's hash as `previousAccessTokenHash` and retries once with the
+broker response. Access and refresh credentials are not written to OpenCode's
+credential store in broker mode.
+
 ---
 
 ### OpenCode Zen


### PR DESCRIPTION
## Summary
- add optional external ChatGPT access-token broker support to the built-in OpenAI provider
- authenticate broker calls from a rotating token file and keep OpenAI credentials memory-only
- cache tokens, refresh before expiry, and retry once after a 401 using the previous token hash
- autoload broker-backed OpenAI without a stored OAuth credential
- support both AI SDK and native OpenAI runtime paths
- document the environment variables and broker HTTP contract

## Configuration
- `OPENCODE_OPENAI_AUTH_BROKER_URL`
- `OPENCODE_OPENAI_AUTH_BROKER_TOKEN_FILE`

## Testing
- focused broker and OpenAI runtime tests: 45 passed
- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/plugin`
- full pre-push monorepo typecheck: 30 packages passed
- changed-file oxlint and Prettier checks
- single-platform production build and binary smoke test
- full OpenCode suite: 3,183 passed, 22 skipped, 1 todo; one unrelated existing SIGINT subprocess test times out both in the suite and independently (`test/cli/run/run-process.test.ts`)

The broker response contains only a short-lived access token, token hash, account metadata, and expiry. Broker mode does not load or write OpenCode OAuth credentials.