### PR TITLE
fix(core): reject invalid UTF-8 directory paths in serve

### DIFF
--- a/packages/core/src/util/encode.ts
+++ b/packages/core/src/util/encode.ts
@@ -7,7 +7,7 @@ export function base64Encode(value: string) {
 export function base64Decode(value: string) {
   const binary = atob(value.replace(/-/g, "+").replace(/_/g, "/"))
   const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0))
-  return new TextDecoder().decode(bytes)
+  return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
 }
 
 export async function hash(content: string, algorithm = "SHA-256"): Promise<string> {

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -105,8 +105,21 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       return true
     })
 
-    const load = (input: LoadInput): Effect.Effect<InstanceContext> => {
+    const hasReplacementCharacters = (input: string): boolean => {
+      for (let i = 0; i < input.length; i++) {
+        if (input.charCodeAt(i) === 0xfffd) return true
+      }
+      return false
+    }
+
+    const loadSafe = (input: LoadInput): string => {
       const directory = FSUtil.resolve(input.directory)
+      if (hasReplacementCharacters(directory)) return FSUtil.resolve(process.cwd())
+      return directory
+    }
+
+    const load = (input: LoadInput): Effect.Effect<InstanceContext> => {
+      const directory = loadSafe(input)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const existing = cache.get(directory)
@@ -124,7 +137,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
     }
 
     const reload = (input: LoadInput): Effect.Effect<InstanceContext> => {
-      const directory = FSUtil.resolve(input.directory)
+      const directory = loadSafe(input)
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const previous = cache.get(directory)

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/instance-context.ts
@@ -12,6 +12,13 @@ export class InstanceContextMiddleware extends HttpApiMiddleware.Service<
   }
 >()("@opencode/ExperimentalHttpApiInstanceContext") {}
 
+function hasReplacementCharacters(input: string): boolean {
+  for (let i = 0; i < input.length; i++) {
+    if (input.charCodeAt(i) === 0xfffd) return true
+  }
+  return false
+}
+
 function decode(input: string): string {
   try {
     return decodeURIComponent(input)
@@ -26,7 +33,9 @@ function provideInstanceContext<E>(
 ): Effect.Effect<HttpServerResponse.HttpServerResponse, E, WorkspaceRouteContext> {
   return Effect.gen(function* () {
     const route = yield* WorkspaceRouteContext
-    const ctx = yield* store.load({ directory: decode(route.directory) })
+    const directory = decode(route.directory)
+    const clean = hasReplacementCharacters(directory) ? process.cwd() : directory
+    const ctx = yield* store.load({ directory: clean })
     return yield* effect.pipe(
       Effect.provideService(InstanceRef, ctx),
       Effect.provideService(WorkspaceRef, route.workspaceID),

--- a/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/middleware/workspace-routing.ts
@@ -83,8 +83,17 @@ function selectedV2WorkspaceID(
   return workspaceID.value
 }
 
+function hasReplacementCharacters(input: string): boolean {
+  for (let i = 0; i < input.length; i++) {
+    if (input.charCodeAt(i) === 0xfffd) return true
+  }
+  return false
+}
+
 function defaultDirectory(request: HttpServerRequest.HttpServerRequest, url: URL): string {
-  return url.searchParams.get("directory") || request.headers["x-opencode-directory"] || process.cwd()
+  const dir = url.searchParams.get("directory") || request.headers["x-opencode-directory"] || ""
+  if (dir && !hasReplacementCharacters(dir)) return dir
+  return process.cwd()
 }
 
 function shouldStayOnControlPlane(request: HttpServerRequest.HttpServerRequest, url: URL): boolean {
@@ -178,8 +187,9 @@ function planRequest(
       return yield* planWorkspaceRequest(request, url, workspace)
     }
 
+    const sessionDir = session?.directory
     return RequestPlan.Local({
-      directory: session?.directory || defaultDirectory(request, url),
+      directory: sessionDir && !hasReplacementCharacters(sessionDir) ? sessionDir : defaultDirectory(request, url),
       workspaceID: envWorkspaceID ?? workspaceID,
     })
   })

--- a/packages/server/src/location.ts
+++ b/packages/server/src/location.ts
@@ -26,12 +26,19 @@ export function response<A, E, R>(data: Effect.Effect<A, E, R>) {
   })
 }
 
+function hasReplacementCharacters(input: string): boolean {
+  for (let i = 0; i < input.length; i++) {
+    if (input.charCodeAt(i) === 0xfffd) return true
+  }
+  return false
+}
+
 function ref(request: HttpServerRequest.HttpServerRequest): Location.Ref {
   const query = new URL(request.url, "http://localhost").searchParams
   const workspaceID = query.get("location[workspace]") || request.headers["x-opencode-workspace"]
-  const directory =
-    query.get("location[directory]") ||
-    (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : process.cwd())
+  const dir = query.get("location[directory]") ||
+    (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : "")
+  const directory = dir && !hasReplacementCharacters(dir) ? dir : process.cwd()
   return Location.Ref.make({
     directory: AbsolutePath.make(directory),
     workspaceID: workspaceID ? WorkspaceV2.ID.make(workspaceID) : undefined,


### PR DESCRIPTION
### Issue for this PR

Closes #38235
Closes #37764

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

While running `opencode serve`, I got a session whose directory ended with two U+FFFD replacement characters: `.../bin/��`. The file picker rejected that path, and `prompt_async` failed because `FileSystem.realPath` tried to resolve it and got `ENOENT`.

I could reproduce the same path shape with a malformed route segment. For example, `__8` decodes to the bytes `FF FF`, and the non-fatal `TextDecoder` turns those into `��`. The app uses that as the directory, and the SDK sends it as `%EF%BF%BD%EF%BF%BD` in `x-opencode-directory`. `InstanceContextMiddleware` decodes the header, then `InstanceStore` calls `path.resolve()` on the relative `��` value and ends up with `<cwd>/��`. That matches what showed up in my log.

I do not have the original browser URL from that run, so `__8` is only a minimal reproduction of the bug, not a claim that it was the exact route segment. The database also had older session directories with literal U+FFFD characters, so values like this had already been persisted before.

The fix makes `base64Decode` use a fatal UTF-8 decoder. The app's `decode64` wrapper already handles decode errors, so malformed route segments now go through the existing invalid-route behavior. For values that already contain U+FFFD, the HTTP routing, location, decoded instance context, and `InstanceStore.load`/`reload` paths fall back to `process.cwd()` instead of initializing that directory.

### How did you verify your code works?

- `bun test test/server/httpapi-workspace-routing.test.ts test/project/instance.test.ts`: 18 passed, 0 failed
- `bun turbo typecheck`: 30 tasks passed
- `bun run script/build.ts --single --skip-embed-web-ui --skip-install`: built the Linux x64 binary and passed its `--version` smoke test
- Reproduced `__8` -> `��` -> `%EF%BF%BD%EF%BF%BD` -> `<cwd>/��` with the old decoder, then confirmed the fatal decoder rejects the same bytes
- Manually checked a valid non-ASCII base64 round trip

I reproduced the original failure with `./opencode serve --log-level DEBUG --pure --print-logs`. I have not rerun that browser flow after adding the final instance-loading guard.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
