### PR TITLE
chore(cli): upgrade acp sdk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -124,7 +124,7 @@
         "opencode2": "./bin/opencode2.cjs",
       },
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.21.0",
+        "@agentclientprotocol/sdk": "1.2.1",
         "@effect/platform-node": "catalog:",
         "@opencode-ai/client": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -1173,7 +1173,7 @@
 
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.21.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
 
     "@ai-sdk/alibaba": ["@ai-sdk/alibaba@1.0.17", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZbE+U5bWz2JBc5DERLowx5+TKbjGBE93LqKZAWvuEn7HOSQMraxFMZuc0ST335QZJAyfBOzh7m1mPQ+y7EaaoA=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "0.21.0",
+    "@agentclientprotocol/sdk": "1.2.1",
     "@effect/platform-node": "catalog:",
     "@opencode-ai/client": "workspace:*",
     "@opencode-ai/plugin": "workspace:*",

--- a/packages/cli/src/acp/agent.ts
+++ b/packages/cli/src/acp/agent.ts
@@ -13,7 +13,6 @@ import {
   type PromptRequest,
   type ResumeSessionRequest,
   type SetSessionConfigOptionRequest,
-  type SetSessionModelRequest,
   type SetSessionModeRequest,
 } from "@agentclientprotocol/sdk"
 import type { OpenCodeClient } from "@opencode-ai/client/promise"
@@ -33,7 +32,6 @@ export function create(client: OpenCodeClient, connection: AgentSideConnection) 
     unstable_forkSession: (params: ForkSessionRequest) => run(service.forkSession(params)),
     setSessionConfigOption: (params: SetSessionConfigOptionRequest) => run(service.setSessionConfigOption(params)),
     setSessionMode: (params: SetSessionModeRequest) => run(service.setSessionMode(params)),
-    unstable_setSessionModel: (params: SetSessionModelRequest) => run(service.setSessionModel(params)),
     prompt: (params: PromptRequest) => run(service.prompt(params)),
     cancel: (params: CancelNotification) => run(service.cancel(params)),
   } satisfies Agent

--- a/packages/cli/src/acp/event.ts
+++ b/packages/cli/src/acp/event.ts
@@ -47,7 +47,6 @@ export async function streamTurn(input: {
   readonly sessionID: string
   readonly cwd: string
   readonly start: TurnStart
-  readonly userMessageID?: string | null
   readonly submit: (signal: AbortSignal) => Promise<unknown>
   readonly control: TurnControl
 }): Promise<PromptResponse> {
@@ -231,7 +230,7 @@ export async function streamTurn(input: {
       if (!started) {
         streamController.abort()
         await completed.catch(() => {})
-        return response(undefined, undefined, "interrupted", true, undefined, input.userMessageID)
+        return response(undefined, undefined, "interrupted", true, undefined)
       }
     }
     const terminal = await completed
@@ -246,7 +245,6 @@ export async function streamTurn(input: {
       terminal,
       control.cancelled,
       finish,
-      input.userMessageID,
     )
   } catch (error) {
     streamController.abort()
@@ -400,7 +398,6 @@ function response(
   terminal: "succeeded" | "failed" | "interrupted",
   cancelled: boolean,
   finish: SessionMessageAssistant["finish"],
-  messageID: string | null | undefined,
 ): PromptResponse {
   const error = assistant?.error ?? executionError
   if (error?.type === "provider.auth") throw new ACPError.AuthRequiredError()
@@ -423,7 +420,7 @@ function response(
       }
     : undefined
   const stopReason = resolveStopReason({ terminal, cancelled, finish, error: error?.type })
-  return { stopReason, ...(usage ? { usage } : {}), ...(messageID ? { userMessageId: messageID } : {}), _meta: {} }
+  return { stopReason, ...(usage ? { usage } : {}), _meta: {} }
 }
 
 function resolveStopReason(input: {

--- a/packages/cli/src/acp/service.ts
+++ b/packages/cli/src/acp/service.ts
@@ -33,8 +33,6 @@ import type {
   ResumeSessionResponse,
   SetSessionConfigOptionRequest,
   SetSessionConfigOptionResponse,
-  SetSessionModelRequest,
-  SetSessionModelResponse,
   SetSessionModeRequest,
   SetSessionModeResponse,
 } from "@agentclientprotocol/sdk"
@@ -88,7 +86,6 @@ export interface Interface {
   forkSession(input: ForkSessionRequest): Promise<ForkSessionResponse>
   setSessionConfigOption(input: SetSessionConfigOptionRequest): Promise<SetSessionConfigOptionResponse>
   setSessionMode(input: SetSessionModeRequest): Promise<SetSessionModeResponse>
-  setSessionModel(input: SetSessionModelRequest): Promise<SetSessionModelResponse>
   prompt(input: PromptRequest): Promise<PromptResponse>
   cancel(input: CancelNotification): Promise<void>
 }
@@ -270,13 +267,6 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
       await selectMode(input.client, await requireSession(params.sessionId), params.modeId)
       return {}
     },
-    setSessionModel: async (params) => {
-      const state = await requireSession(params.sessionId)
-      const selected = requireModel(state.catalog, params.modelId)
-      state.model = selected
-      await input.client.session.switchModel({ sessionID: state.id, model: selected })
-      return {}
-    },
     prompt: async (params) => {
       const state = await requireSession(params.sessionId)
       if (active.has(state.id)) {
@@ -295,7 +285,6 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
         sessionID: state.id,
         cwd: state.cwd,
         start: prepared.start,
-        userMessageID: params.messageId,
         control,
         submit: (signal) => submitPrompt(input.client, state, prepared, signal),
       }).finally(() => {
@@ -479,6 +468,7 @@ async function registerMcpServers(
 
 function mcpConfig(server: McpServer) {
   if ("type" in server) {
+    if (server.type === "acp") throw new Error("MCP-over-ACP is not supported")
     return {
       type: "remote" as const,
       url: server.url,

--- a/packages/cli/test/acp/event-behavior.test.ts
+++ b/packages/cli/test/acp/event-behavior.test.ts
@@ -564,7 +564,6 @@ function turn(input: {
     sessionID: input.sessionID,
     cwd: "/workspace",
     start: { type: "input", id: input.inputID },
-    userMessageID: `client_${input.inputID}`,
     control: { cancelled: false, admission: new AbortController() },
     submit: (signal) =>
       input.fixture.client.session.prompt({ sessionID: input.sessionID, id: input.inputID, text: "hello" }, { signal }),

--- a/packages/cli/test/acp/event.test.ts
+++ b/packages/cli/test/acp/event.test.ts
@@ -85,7 +85,6 @@ test("acp prompt resolves after ordered turn updates", async () => {
 
   try {
     const id = "msg_prompt"
-    const userMessageID = "client-message"
     const response = await streamTurn({
       client,
       connection: {
@@ -97,7 +96,6 @@ test("acp prompt resolves after ordered turn updates", async () => {
       sessionID: "ses_test",
       cwd: "/workspace",
       start: { type: "input", id },
-      userMessageID,
       control: { cancelled: false, admission: new AbortController() },
       submit: () => client.session.prompt({ sessionID: "ses_test", id, text: "hi" }),
     })
@@ -112,7 +110,7 @@ test("acp prompt resolves after ordered turn updates", async () => {
         },
       },
     ])
-    expect(response).toMatchObject({ stopReason: "end_turn", userMessageId: userMessageID, usage: { totalTokens: 2 } })
+    expect(response).toMatchObject({ stopReason: "end_turn", usage: { totalTokens: 2 } })
   } finally {
     events?.close()
     await server.stop(true)

--- a/packages/cli/test/acp/service-directory.test.ts
+++ b/packages/cli/test/acp/service-directory.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { McpServer, SessionConfigOption } from "@agentclientprotocol/sdk"
-import { makeACPFixture, makeSession, secondModel, testModel } from "./service-fixture"
+import { makeACPFixture, makeSession, secondModel } from "./service-fixture"
 
 describe("acp service directory behavior", () => {
   test("creates sessions from a catalog shared by concurrent callers in the same cwd", async () => {
@@ -134,7 +134,6 @@ describe("acp service directory behavior", () => {
       configId: "mode",
       value: "plan",
     })
-    await fixture.service.setSessionModel({ sessionId: session.sessionId, modelId: "test/test-model/high" })
     await fixture.service.setSessionMode({ sessionId: session.sessionId, modeId: "build" })
 
     expect(currentValue(selectedModel, "model")).toBe("test/second-model")
@@ -148,7 +147,6 @@ describe("acp service directory behavior", () => {
     ).toEqual([
       { model: { providerID: "test", id: secondModel.id } },
       { model: { providerID: "test", id: secondModel.id, variant: "medium" } },
-      { model: { providerID: "test", id: testModel.id, variant: "high" } },
     ])
     expect(
       fixture.requests

--- a/packages/cli/test/acp/service-usage.test.ts
+++ b/packages/cli/test/acp/service-usage.test.ts
@@ -45,17 +45,14 @@ describe("acp service prompt routing and usage", () => {
 
     const commandResult = await fixture.service.prompt({
       sessionId: session.sessionId,
-      messageId: "client-command",
       prompt: [{ type: "text", text: "/review now" }],
     })
     const skillResult = await fixture.service.prompt({
       sessionId: session.sessionId,
-      messageId: "client-skill",
       prompt: [{ type: "text", text: "/verify" }],
     })
     const compactResult = await fixture.service.prompt({
       sessionId: session.sessionId,
-      messageId: "client-compact",
       prompt: [{ type: "text", text: "/compact" }],
     })
 
@@ -154,13 +151,11 @@ describe("acp service prompt routing and usage", () => {
 
     const response = await fixture.service.prompt({
       sessionId: session.sessionId,
-      messageId: "client-message",
       prompt: [{ type: "text", text: "hello" }],
     })
 
     expect(response).toEqual({
       stopReason: "end_turn",
-      userMessageId: "client-message",
       usage: {
         inputTokens: 100,
         outputTokens: 40,


### PR DESCRIPTION
## summary
- upgrade `@agentclientprotocol/sdk` from `0.21.0` to `1.2.1`, the newest stable release admitted by the repository release-age policy
- remove the retired unstable model-selector RPC in favor of stable Session Config Options
- align prompt message IDs with the stable agent-owned v1 contract
- reject the unadvertised MCP-over-ACP transport variant

## testing
- `bun test test/acp` from `packages/cli`
- `bun typecheck` from the repository root
- targeted Oxlint and Effect pattern checks