### PR TITLE
chore(opencode): upgrade acp sdk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -565,7 +565,7 @@
       "dependencies": {
         "@actions/core": "1.11.1",
         "@actions/github": "6.0.1",
-        "@agentclientprotocol/sdk": "0.21.0",
+        "@agentclientprotocol/sdk": "1.2.1",
         "@ai-sdk/alibaba": "1.0.17",
         "@ai-sdk/amazon-bedrock": "4.0.112",
         "@ai-sdk/anthropic": "3.0.82",
@@ -1167,7 +1167,7 @@
 
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
-    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.21.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw=="],
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.2.1", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA=="],
 
     "@ai-sdk/alibaba": ["@ai-sdk/alibaba@1.0.17", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ZbE+U5bWz2JBc5DERLowx5+TKbjGBE93LqKZAWvuEn7HOSQMraxFMZuc0ST335QZJAyfBOzh7m1mPQ+y7EaaoA=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@actions/core": "1.11.1",
     "@actions/github": "6.0.1",
-    "@agentclientprotocol/sdk": "0.21.0",
+    "@agentclientprotocol/sdk": "1.2.1",
     "@ai-sdk/alibaba": "1.0.17",
     "@ai-sdk/amazon-bedrock": "4.0.112",
     "@ai-sdk/anthropic": "3.0.82",

--- a/packages/opencode/src/acp/agent.ts
+++ b/packages/opencode/src/acp/agent.ts
@@ -13,7 +13,6 @@ import {
   type PromptRequest,
   type ResumeSessionRequest,
   type SetSessionConfigOptionRequest,
-  type SetSessionModelRequest,
   type SetSessionModeRequest,
 } from "@agentclientprotocol/sdk"
 import { Effect } from "effect"
@@ -70,10 +69,6 @@ export class Agent implements ACPAgent {
 
   setSessionMode(params: SetSessionModeRequest) {
     return run(this.service.setSessionMode(params))
-  }
-
-  unstable_setSessionModel(params: SetSessionModelRequest) {
-    return run(this.service.setSessionModel(params))
   }
 
   prompt(params: PromptRequest) {

--- a/packages/opencode/src/acp/service.ts
+++ b/packages/opencode/src/acp/service.ts
@@ -24,8 +24,6 @@ import {
   type SessionInfo,
   type SetSessionConfigOptionRequest,
   type SetSessionConfigOptionResponse,
-  type SetSessionModelRequest,
-  type SetSessionModelResponse,
   type SetSessionModeRequest,
   type SetSessionModeResponse,
 } from "@agentclientprotocol/sdk"
@@ -65,7 +63,6 @@ export type Interface = {
     input: SetSessionConfigOptionRequest,
   ) => Effect.Effect<SetSessionConfigOptionResponse, Error>
   readonly setSessionMode: (input: SetSessionModeRequest) => Effect.Effect<SetSessionModeResponse, Error>
-  readonly setSessionModel: (input: SetSessionModelRequest) => Effect.Effect<SetSessionModelResponse, Error>
   readonly prompt: (input: PromptRequest) => Effect.Effect<PromptResponse, Error>
   readonly cancel: (input: CancelNotification) => Effect.Effect<void, Error>
 }
@@ -462,21 +459,6 @@ export function make(input: {
     return {}
   })
 
-  const setSessionModel = Effect.fn("ACP.setSessionModel")(function* (params: SetSessionModelRequest) {
-    const current = yield* session.get(params.sessionId)
-    const snapshot = yield* configSnapshot(current)
-    const selected = yield* parseSelectedModel(snapshot, params.modelId)
-    yield* session
-      .setVariant(
-        params.sessionId,
-        Directory.variants(snapshot, selected.model)
-          ? (selected.variant ?? selectVariant(snapshot, selected.model))
-          : undefined,
-      )
-      .pipe(Effect.andThen(session.setModel(params.sessionId, selected.model)))
-    return {}
-  })
-
   return {
     initialize,
     authenticate,
@@ -488,7 +470,6 @@ export function make(input: {
     forkSession,
     setSessionConfigOption,
     setSessionMode,
-    setSessionModel,
     prompt: Effect.fn("ACP.prompt")(function* (params: PromptRequest) {
       const current = yield* session.get(params.sessionId)
       const snapshot = yield* directorySnapshot(current.cwd)
@@ -521,7 +502,7 @@ export function make(input: {
           "session",
         )
         yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-        return yield* promptResponse(response.info, params.messageId)
+        return yield* promptResponse(response.info)
       }
 
       const known = snapshot.availableCommands.find((item) => item.name === command.name)
@@ -543,7 +524,7 @@ export function make(input: {
           "session",
         )
         yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-        return yield* promptResponse(response.info, params.messageId)
+        return yield* promptResponse(response.info)
       }
 
       if (command.name === "compact") {
@@ -563,7 +544,7 @@ export function make(input: {
       }
 
       yield* sendUsageUpdate(input.usage, input.sdk, input.connection, current.id, current.cwd)
-      return yield* promptResponse(undefined, params.messageId)
+      return yield* promptResponse(undefined)
     }),
     cancel,
   }
@@ -813,22 +794,17 @@ function detectSlashCommand(parts: ReturnType<typeof promptContentToParts>) {
   return { name, args: rest.join(" ").trim() }
 }
 
-const promptResponse = Effect.fn("ACP.promptResponse")(function* (
-  info: AssistantInfo,
-  messageId: string | null | undefined,
-) {
+const promptResponse = Effect.fn("ACP.promptResponse")(function* (info: AssistantInfo) {
   if (!info?.error) {
     return {
       stopReason: "end_turn" as const,
       ...(info ? { usage: UsageService.buildUsage(info) } : {}),
-      ...(messageId ? { userMessageId: messageId } : {}),
       _meta: {},
     }
   }
 
   const base = {
     usage: UsageService.buildUsage(info),
-    ...(messageId ? { userMessageId: messageId } : {}),
     _meta: {},
   }
 
@@ -1004,6 +980,7 @@ function mcpRegistrationKey(name: string, config: ReturnType<typeof mcpConfig>) 
 
 function mcpConfig(server: McpServer) {
   if ("type" in server) {
+    if (server.type === "acp") throw new Error("MCP-over-ACP is not supported")
     return {
       type: "remote" as const,
       url: server.url,

--- a/packages/opencode/test/acp/service-session.test.ts
+++ b/packages/opencode/test/acp/service-session.test.ts
@@ -987,7 +987,6 @@ describe("ACP service sessions", () => {
     const result = await Effect.runPromise(
       service.prompt({
         sessionId: session.sessionId,
-        messageId: "00000000-0000-4000-8000-000000000001",
         prompt: [{ type: "text", text: "hello" }],
       }),
     )
@@ -1012,7 +1011,6 @@ describe("ACP service sessions", () => {
         cachedWriteTokens: 13,
         totalTokens: 171,
       },
-      userMessageId: "00000000-0000-4000-8000-000000000001",
       _meta: {},
     })
     expect(usageUpdates).toEqual([session.sessionId])


### PR DESCRIPTION
## summary
- upgrade `@agentclientprotocol/sdk` from `0.21.0` to `1.2.1`, the newest stable release admitted by the repository release-age policy
- remove the retired unstable model-selector RPC in favor of stable Session Config Options
- align prompt message IDs with the stable agent-owned v1 contract
- reject the unadvertised MCP-over-ACP transport variant

## testing
- `bun test test/acp test/cli/acp` from `packages/opencode`
- `bun typecheck` from the repository root
- targeted Oxlint