### PR TITLE
fix(provider): correct MiniMax M3 thinking variants

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -693,6 +693,12 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     model.api.id.toLowerCase().includes("minimax-m3") &&
     ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)
   ) {
+    if (["nvidia", "lilac"].includes(model.providerID)) {
+      return {
+        none: { chat_template_kwargs: { thinking_mode: "disabled" } },
+        thinking: { chat_template_kwargs: { thinking_mode: "enabled" } },
+      }
+    }
     return {
       none: { thinking: { type: "disabled" } },
       thinking: { thinking: { type: "adaptive" } },

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3468,6 +3468,22 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
+  test.each(["nvidia", "lilac"])("%s minimax m3 returns chat template thinking toggles", (providerID) => {
+    const model = createMockModel({
+      id: `${providerID}/minimaxai/minimax-m3`,
+      providerID,
+      api: {
+        id: "minimaxai/minimax-m3",
+        url: "https://api.example.com/v1",
+        npm: "@ai-sdk/openai-compatible",
+      },
+    })
+    expect(ProviderTransform.variants(model)).toEqual({
+      none: { chat_template_kwargs: { thinking_mode: "disabled" } },
+      thinking: { chat_template_kwargs: { thinking_mode: "enabled" } },
+    })
+  })
+
   test("glm returns empty object", () => {
     const model = createMockModel({
       id: "glm/glm-4",


### PR DESCRIPTION
## Summary

- use `chat_template_kwargs.thinking_mode` for MiniMax M3 variants on NVIDIA and Lilac
- preserve the existing adaptive/disabled variants for direct MiniMax and every other route
- add focused regression coverage for both affected providers

No request translation or provider-option cleanup is added; these are ordinary model variant bodies returned by the existing variant generator.

Fixes #35027

## Testing

- `bun test test/provider/transform.test.ts` (358 pass)
- `bun typecheck`
- `bunx prettier --check src/provider/transform.ts test/provider/transform.test.ts`
- `git diff --check`