### PR TITLE
feat(desktop): Improve keyboard navigation and add accept button in open project dialog

### DIFF
--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -1,5 +1,6 @@
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Dialog } from "@opencode-ai/ui/dialog"
+import { Button } from "@opencode-ai/ui/button"
 import { FileIcon } from "@opencode-ai/ui/file-icon"
 import { List } from "@opencode-ai/ui/list"
 import type { ListRef } from "@opencode-ai/ui/list"
@@ -8,7 +9,7 @@ import { createMemo, createResource, createSignal } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { ServerConnection } from "@/context/server"
 import { useGlobal } from "@/context/global"
-import { cleanPickerInput, createDirectorySearch, displayPickerPath } from "./directory-picker-domain"
+import { cleanPickerInput, createDirectorySearch, displayPickerPath, pickerAbsoluteInput, pickerRoot } from "./directory-picker-domain"
 
 interface DialogSelectDirectoryProps {
   title?: string
@@ -122,6 +123,25 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
     dialog.close()
   }
 
+  // Navigate into the highlighted item (append "/" and refetch suggestions)
+  function navigateInto(item: Row) {
+    const value = displayPickerPath(item.absolute, filter(), home())
+    list?.setFilter(value.endsWith("/") ? value : value + "/")
+  }
+
+  // Resolve the current filter path as the selection
+  const resolvedPath = createMemo(() => {
+    const base = start() ?? home()
+    const absolute = filter() ? pickerAbsoluteInput(filter(), home(), base) : base
+    return absolute && pickerRoot(absolute) ? absolute : undefined
+  })
+
+  function confirmFilter() {
+    const absolute = resolvedPath()
+    if (!absolute) return
+    resolve(absolute)
+  }
+
   return (
     <Dialog title={props.title ?? language.t("command.project.open")}>
       <List
@@ -143,19 +163,27 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
         ref={(r) => (list = r)}
         onFilter={(value) => setFilter(cleanPickerInput(value))}
         onKeyEvent={(e, item) => {
-          if (e.key !== "Tab") return
-          if (e.shiftKey) return
-          if (!item) return
-
-          e.preventDefault()
-          e.stopPropagation()
-
-          const value = displayPickerPath(item.absolute, filter(), home())
-          list?.setFilter(value.endsWith("/") ? value : value + "/")
+          // Ctrl+Enter or Meta+Enter: confirm the current filter path
+          if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault()
+            e.stopPropagation()
+            confirmFilter()
+            return
+          }
+          // Tab or Enter: navigate into highlighted directory, or confirm filter if nothing highlighted
+          if (e.key === "Tab" || e.key === "Enter") {
+            if (e.shiftKey) return
+            e.preventDefault()
+            e.stopPropagation()
+            if (item) navigateInto(item)
+            else confirmFilter()
+            return
+          }
         }}
         onSelect={(path) => {
+          // Clicking an item navigates into it; use the Open button to confirm
           if (!path) return
-          resolve(path.absolute)
+          navigateInto(path)
         }}
       >
         {(item) => {
@@ -189,6 +217,14 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           )
         }}
       </List>
+      <div class="px-3 pb-3 pt-2 flex justify-end gap-2">
+        <Button variant="ghost" onClick={() => dialog.close()}>
+          {language.t("common.cancel")}
+        </Button>
+        <Button variant="primary" disabled={!resolvedPath()} onClick={confirmFilter}>
+          {language.t("dialog.directory.action.selectFolder")}
+        </Button>
+      </div>
     </Dialog>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #38338

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Open Project dialog immediately resolved and closed when clicking a suggestion or pressing Enter, making it impossible to navigate into a subdirectory and continue. There was also no explicit confirm action.

- Tab and Enter now navigate into the highlighted directory (appends `/` and refetches) instead of confirming
- Clicking an item also navigates in rather than immediately opening the project
- Added Cancel and Select Folder buttons the footer
- Ctrl/Option+Enter or the button confirms the current path
- Enter with no item highlighted confirms the current filter path directly

### How did you verify your code works?

Tested locally: typed a partial path, navigated into suggestions with Enter and Tab, confirmed with the button and Ctrl+Enter. Verified backspace works normally in the input.

### Screenshots / recordings

https://github.com/user-attachments/assets/44d73255-19ec-42f4-afc3-0e0e600e5a3f

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR