### PR TITLE
feat(app): show theme preview during selection

### DIFF
--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -460,6 +460,72 @@ export const SettingsGeneralV2: Component<{
           />
         </SettingsRowV2>
 
+        <div data-component="settings-v2-theme-preview">
+          <div data-slot="settings-v2-theme-preview-label">
+            {language.t("settings.general.row.theme.preview.before")}{" "}
+            <span data-slot="settings-v2-theme-preview-inline">code</span>{" "}
+            {language.t("settings.general.row.theme.preview.after")}
+          </div>
+          <pre
+            data-slot="settings-v2-theme-preview-code"
+            style={{ "font-family": monoFontFamily(settings.appearance.font()) }}
+          >
+            <code>
+              <span class="text-syntax-comment">{"// Theme preview"}</span>
+              {"\n"}
+              <span class="text-syntax-keyword">type</span>{" "}
+              <span class="text-syntax-type">User</span>{" "}
+              <span class="text-syntax-operator">=</span>{" "}
+              <span class="text-syntax-punctuation">{"{"}</span>{" "}
+              <span class="text-syntax-property">id</span>
+              <span class="text-syntax-punctuation">:</span>{" "}
+              <span class="text-syntax-type">number</span>
+              <span class="text-syntax-punctuation">;</span>{" "}
+              <span class="text-syntax-property">name</span>
+              <span class="text-syntax-punctuation">:</span>{" "}
+              <span class="text-syntax-type">string</span>{" "}
+              <span class="text-syntax-punctuation">{"}"}</span>
+              {"\n"}
+              <span class="text-syntax-keyword">const</span>{" "}
+              <span class="text-syntax-variable">find</span>{" "}
+              <span class="text-syntax-operator">=</span>{" "}
+              <span class="text-syntax-punctuation">(</span>
+              <span class="text-syntax-variable">id</span>
+              <span class="text-syntax-punctuation">:</span>{" "}
+              <span class="text-syntax-type">number</span>
+              <span class="text-syntax-punctuation">)</span>
+              <span class="text-syntax-punctuation">:</span>{" "}
+              <span class="text-syntax-type">User</span>{" "}
+              <span class="text-syntax-operator">|</span>{" "}
+              <span class="text-syntax-primitive">null</span>{" "}
+              <span class="text-syntax-operator">{"=>"}</span>{" "}
+              <span class="text-syntax-punctuation">{"{"}</span>
+              {"\n"}
+              {"  "}
+              <span class="text-syntax-keyword">if</span>{" "}
+              <span class="text-syntax-punctuation">(</span>
+              <span class="text-syntax-variable">id</span>{" "}
+              <span class="text-syntax-operator">{"<"}</span>{" "}
+              <span class="text-syntax-primitive">1</span>
+              <span class="text-syntax-punctuation">)</span>{" "}
+              <span class="text-syntax-keyword">return</span>{" "}
+              <span class="text-syntax-primitive">null</span>
+              {"\n"}
+              {"  "}
+              <span class="text-syntax-keyword">return</span>{" "}
+              <span class="text-syntax-punctuation">{"{"}</span>{" "}
+              <span class="text-syntax-property">id</span>
+              <span class="text-syntax-punctuation">,</span>{" "}
+              <span class="text-syntax-property">name</span>
+              <span class="text-syntax-punctuation">:</span>{" "}
+              <span class="text-syntax-string">'"MJ"'</span>{" "}
+              <span class="text-syntax-punctuation">{"}"}</span>
+              {"\n"}
+              <span class="text-syntax-punctuation">{"}"}</span>
+            </code>
+          </pre>
+        </div>
+
         <SettingsRowV2
           title={language.t("settings.general.row.uiFont.title")}
           description={language.t("settings.general.row.uiFont.description")}

--- a/packages/app/src/components/settings-v2/settings-v2.css
+++ b/packages/app/src/components/settings-v2/settings-v2.css
@@ -164,6 +164,55 @@
   width: 100%;
 }
 
+[data-component="settings-v2-row"]:has(+ [data-component="settings-v2-theme-preview"]) {
+  border-bottom: none;
+  padding-bottom: 12px;
+}
+
+[data-component="settings-v2-theme-preview"] {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-bottom: 20px;
+  border-bottom: 0.5px solid var(--v2-border-border-base);
+}
+
+[data-slot="settings-v2-theme-preview-label"] {
+  font-size: 13px;
+  font-weight: 440;
+  line-height: 20px;
+  color: var(--v2-text-text-muted);
+}
+
+[data-slot="settings-v2-theme-preview-inline"] {
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--v2-background-bg-base);
+  box-shadow: inset 0 0 0 0.5px var(--v2-border-border-muted);
+  font-family: var(--font-family-mono);
+  font-size: 12px;
+  font-weight: 530;
+  color: var(--syntax-string);
+}
+
+[data-slot="settings-v2-theme-preview-code"] {
+  margin: 0;
+  padding: 12px 14px;
+  overflow-x: auto;
+  border-radius: 6px;
+  background: var(--v2-background-bg-base);
+  box-shadow: inset 0 0 0 0.5px var(--v2-border-border-muted);
+  font-size: 12px;
+  font-weight: 440;
+  line-height: 1.55;
+  color: var(--v2-text-text-base);
+  user-select: text;
+}
+
+[data-slot="settings-v2-theme-preview-code"] code {
+  font-family: inherit;
+}
+
 [data-component="dialog-v2"][data-variant="settings"] [data-component="select-v2-root"] {
   width: fit-content;
   max-width: 100%;

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -869,6 +869,8 @@ export const dict = {
   "settings.general.row.colorScheme.description": "Choose whether OpenCode follows the system, light, or dark theme",
   "settings.general.row.theme.title": "Theme",
   "settings.general.row.theme.description": "Customise how OpenCode is themed.",
+  "settings.general.row.theme.preview.before": "This is how your",
+  "settings.general.row.theme.preview.after": "will look like:",
   "settings.general.row.font.title": "Code Font",
   "settings.general.row.font.description": "Customise the font used in code blocks",
   "settings.general.row.terminalFont.title": "Terminal Font",


### PR DESCRIPTION
### Issue for this PR

Closes #38347

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Added a live theme preview to show how code will look like.

### How did you verify your code works?

Build and run the desktop app to verify the change. 

### Screenshots / recordings
Before vs After:
<img width="1496" height="967" alt="Screenshot 2026-07-22 at 9 16 40 PM" src="https://github.com/user-attachments/assets/58f0bf57-20f4-4f0b-908e-172178a47476" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR