### PR TITLE
fix(plugin): bridge live tool metadata

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -143,6 +143,9 @@ const layer = Layer.effect(
                 const pluginCtx: PluginToolContext = {
                   ...toolCtx,
                   ask: (req) => bridge.promise(toolCtx.ask(req)),
+                  metadata: (input) => {
+                    bridge.fork(toolCtx.metadata(input))
+                  },
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -462,6 +462,51 @@ describe("tool.registry", () => {
     }),
   )
 
+  it.instance("publishes live metadata from custom tools", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const customTools = path.join(test.directory, ".opencode", "tools")
+      const pluginTool = pathToFileURL(path.resolve(import.meta.dir, "../../../plugin/src/tool.ts")).href
+      yield* Effect.promise(() => fs.mkdir(customTools, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(customTools, "live-metadata.ts"),
+          [
+            `import { tool } from ${JSON.stringify(pluginTool)}`,
+            "export default tool({",
+            "  description: 'publishes metadata while running',",
+            "  args: {},",
+            "  execute: async (_args, context) => {",
+            "    context.metadata({ title: 'Running', metadata: { phase: 'running' } })",
+            "    return 'done'",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const loaded = (yield* registry.all()).find((tool) => tool.id === "live-metadata")
+      if (!loaded) throw new Error("custom live-metadata tool was not loaded")
+      const agents = yield* Agent.Service
+      const metadata: unknown[] = []
+      const result = yield* loaded.execute({}, {
+        sessionID: SessionID.make("ses_test"),
+        messageID: MessageID.make("msg_test"),
+        agent: (yield* agents.defaultInfo()).name,
+        abort: new AbortController().signal,
+        messages: [],
+        metadata: (input) => Effect.sync(() => metadata.push(input)),
+        ask: () => Effect.void,
+      } satisfies Tool.Context)
+      yield* Effect.sleep("10 millis")
+
+      expect(result.output).toBe("done")
+      expect(metadata).toEqual([{ title: "Running", metadata: { phase: "running" } }])
+    }),
+  )
+
   it.instance("loads legacy JSON-schema-shaped custom tools with wire schema", () =>
     Effect.gen(function* () {
       const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #37877

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Tool.Context.metadata()` is Effect-backed internally, but the Promise plugin adapter only converted `ask()`. A plugin call to `context.metadata()` therefore constructed and discarded an Effect. This bridges metadata with the existing `EffectBridge`, matching the `ask()` adapter and executing the update while the custom tool is still running.

### How did you verify your code works?

Added a regression test that loads a custom plugin tool, calls `context.metadata()`, and asserts that the host metadata callback receives the running update. `git diff --check` passes. I could not run the Bun suite because the isolated worktree has neither Bun nor node_modules.

### Screenshots / recordings

Not applicable; this is a server-side plugin bridge.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR