### PR TITLE
fix(app): apply agent model to new sessions

### DIFF
--- a/packages/app/src/pages/session/composer/session-composer-controls.test.ts
+++ b/packages/app/src/pages/session/composer/session-composer-controls.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test"
+import { createNewSessionAgentSelect } from "./session-composer-controls"
+
+describe("createNewSessionAgentSelect", () => {
+  test("uses the selected agent model for a new session", () => {
+    let agent: { model?: { providerID: string; modelID: string } } | undefined
+    const models: Array<{ providerID: string; modelID: string } | undefined> = []
+    const select = createNewSessionAgentSelect({
+      selectAgent: (name) => {
+        agent = name === "plan" ? { model: { providerID: "openai", modelID: "gpt-5.4" } } : undefined
+      },
+      currentAgent: () => agent,
+      selectModel: (model) => models.push(model),
+    })
+
+    select("plan")
+
+    expect(models).toEqual([{ providerID: "openai", modelID: "gpt-5.4" }])
+  })
+
+  test("clears the previous prompt model when the selected agent has no model", () => {
+    let agent: { model?: { providerID: string; modelID: string } } | undefined = {
+      model: { providerID: "openai", modelID: "gpt-5.4" },
+    }
+    const models: Array<{ providerID: string; modelID: string } | undefined> = []
+    const select = createNewSessionAgentSelect({
+      selectAgent: () => {
+        agent = {}
+      },
+      currentAgent: () => agent,
+      selectModel: (model) => models.push(model),
+    })
+
+    select("build")
+
+    expect(models).toEqual([undefined])
+  })
+})

--- a/packages/app/src/pages/session/composer/session-composer-controls.ts
+++ b/packages/app/src/pages/session/composer/session-composer-controls.ts
@@ -7,7 +7,7 @@ import type { PromptProjectControls } from "@/components/prompt-project-selector
 import { useDirectoryPicker } from "@/components/directory-picker"
 import { useGlobal } from "@/context/global"
 import { useLayout } from "@/context/layout"
-import { useLocal, type ModelSelection } from "@/context/local"
+import { useLocal, type ModelKey, type ModelSelection } from "@/context/local"
 import type { QueryOptionsApi } from "@/context/server-sync"
 import { useServerSDK } from "@/context/server-sdk"
 import { serverName, ServerConnection, useServer } from "@/context/server"
@@ -16,6 +16,17 @@ import { useSync } from "@/context/sync"
 import { useTabs } from "@/context/tabs"
 import { useProviders } from "@/hooks/use-providers"
 import { pathKey } from "@/utils/path-key"
+
+export function createNewSessionAgentSelect(input: {
+  selectAgent: (name: string | undefined) => void
+  currentAgent: () => { model?: ModelKey } | undefined
+  selectModel: (model: ModelKey | undefined) => void
+}) {
+  return (name: string | undefined) => {
+    input.selectAgent(name)
+    input.selectModel(input.currentAgent()?.model)
+  }
+}
 
 export function createPromptInputController(input: {
   sessionKey: Accessor<string>
@@ -32,6 +43,13 @@ export function createPromptInputController(input: {
   const agentsQuery = createQuery(() => input.queryOptions.agents(pathKey(sdk().directory)))
   const globalProvidersQuery = createQuery(() => input.queryOptions.providers(null))
   const providersQuery = createQuery(() => input.queryOptions.providers(pathKey(sdk().directory)))
+  const selectAgent = input.model
+    ? createNewSessionAgentSelect({
+        selectAgent: local.agent.set,
+        currentAgent: local.agent.current,
+        selectModel: input.model.set,
+      })
+    : local.agent.set
 
   return createMemo<PromptInputControls>(() => ({
     agents: {
@@ -40,7 +58,7 @@ export function createPromptInputController(input: {
       current: local.agent.current()?.name ?? "",
       loading: agentsQuery.isLoading,
       visible: local.agent.visible(),
-      select: local.agent.set,
+      select: selectAgent,
     },
     model: {
       selection: input.model ?? local.model,


### PR DESCRIPTION
### Issue for this PR

Closes #38333

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Selecting an agent in a new session updated the Local draft model, but left the prompt composer's previously selected model unchanged. The prompt model has higher resolution priority, so the first submitted message could use the stale model rather than the selected agent's configured model.

This change synchronizes the prompt model after selecting an agent in a new session. If the selected agent has no configured model, it clears the stale prompt model so the normal fallback selection applies. A later explicit model selection still updates the prompt model normally.

### How did you verify your code works?

- Added regression tests for selecting an agent with a configured model and selecting one without a configured model.
- Ran `bun test --conditions=browser --preload ./happydom.ts src/pages/session/composer/session-composer-controls.test.ts`.
- Ran `bun typecheck`; the push hook also completed the workspace typecheck successfully.
- Ran `bun run test:unit`: 627 tests passed; one existing Arabic i18n parity failure is unrelated to this change.

### Screenshots / recordings

No visual layout change; this fixes the model selected for a new session.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR