### PR TITLE
docs: document web search providers

### DIFF
--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -257,12 +257,13 @@ Allows the LLM to fetch and read web pages. Useful for looking up documentation 
 Search the web for information.
 
 :::note
-This tool is only available when using the OpenCode provider or when the `OPENCODE_ENABLE_EXA` environment variable is set to any truthy value (e.g., `true` or `1`).
+This tool is available when using the OpenCode provider. For other providers, set `OPENCODE_ENABLE_EXA` or `OPENCODE_ENABLE_PARALLEL` to a truthy value (e.g., `true` or `1`).
 
-To enable when launching OpenCode:
+To enable a specific web search backend when launching OpenCode:
 
 ```bash
 OPENCODE_ENABLE_EXA=1 opencode
+OPENCODE_ENABLE_PARALLEL=1 opencode
 ```
 
 :::
@@ -276,9 +277,9 @@ OPENCODE_ENABLE_EXA=1 opencode
 }
 ```
 
-Performs web searches using Exa AI to find relevant information online. Useful for researching topics, finding current events, or gathering information beyond the training data cutoff.
+Performs web searches using Exa or Parallel to find relevant information online. Useful for researching topics, finding current events, or gathering information beyond the training data cutoff.
 
-No API key is required — the tool connects directly to Exa AI's hosted MCP service without authentication.
+No API key is required — the tool connects directly to the selected provider's hosted MCP service without authentication.
 
 :::tip
 Use `websearch` when you need to find information (discovery), and `webfetch` when you need to retrieve content from a specific URL (retrieval).


### PR DESCRIPTION
### Issue for this PR

Closes #38371

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Updates the `websearch` docs to name Exa and Parallel as supported backends and show the enable flag for each.

### How did you verify your code works?

- `bunx prettier --check src/content/docs/tools.mdx`
- `git diff --check`

### Screenshots / recordings

Not applicable; documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR