### PR TITLE
fix(core): omit undefined search metadata

### DIFF
--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -65,8 +65,8 @@ const layer = Layer.effectDiscard(
                 save: ["*"],
                 metadata: {
                   root: input.path ?? ".",
-                  path: input.path,
-                  limit: input.limit,
+                  ...(input.path === undefined ? {} : { path: input.path }),
+                  ...(input.limit === undefined ? {} : { limit: input.limit }),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -84,9 +84,9 @@ const layer = Layer.effectDiscard(
                 save: ["*"],
                 metadata: {
                   root: ".",
-                  path: input.path,
-                  include: input.include,
-                  limit: input.limit,
+                  ...(input.path === undefined ? {} : { path: input.path }),
+                  ...(input.include === undefined ? {} : { include: input.include }),
+                  ...(input.limit === undefined ? {} : { limit: input.limit }),
                 },
                 sessionID: context.sessionID,
                 agent: context.agent,


### PR DESCRIPTION
Fixes #37650

Only include provided optional search inputs in pending permission metadata, so the response remains JSON-encodable.

Validation: `git diff --check`

Not run: Bun is unavailable in this environment.