### PR TITLE
fix(opencode): refresh projects after git init

### DIFF
--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -106,9 +106,16 @@ const layer = Layer.effect(
     const config = (yield* (yield* Config.Service).entries())
       .filter((entry): entry is Config.Document => entry.type === "document")
       .flatMap((item) => item.info.watcher?.ignore ?? [])
-    if (location.vcs && (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER)) {
+    if (yield* Flag.OPENCODE_EXPERIMENTAL_FILEWATCHER) {
       yield* Effect.forkScoped(
-        subscribe(location.directory, [...Ignore.PATTERNS, ...config, ...protecteds(location.directory)]),
+        subscribe(
+          location.directory,
+          [
+            ...(location.vcs ? Ignore.PATTERNS : Ignore.PATTERNS.filter((pattern) => pattern !== ".git")),
+            ...config,
+            ...protecteds(location.directory),
+          ],
+        ),
       )
     }
 

--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -6,7 +6,10 @@ import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance as runDisposers } from "@/effect/instance-registry"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
+import path from "path"
+import { EventV2Bridge } from "@/event-v2-bridge"
 import { type InstanceContext } from "./instance-context"
 import { InstanceBootstrap } from "./bootstrap-service"
 import * as Project from "./project"
@@ -34,11 +37,12 @@ interface Entry {
   readonly deferred: Deferred.Deferred<InstanceContext>
 }
 
-const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Service> = Layer.effect(
+const layer: Layer.Layer<Service, never, Project.Service | EventV2Bridge.Service | InstanceBootstrap.Service> = Layer.effect(
   Service,
   Effect.gen(function* () {
     const project = yield* Project.Service
     const bootstrap = yield* InstanceBootstrap.Service
+    const events = yield* EventV2Bridge.Service
     const scope = yield* Scope.Scope
     const cache = new Map<string, Entry>()
 
@@ -144,6 +148,20 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       ).pipe(Effect.withSpan("InstanceStore.reload"))
     }
 
+    const unsubscribe = yield* events.listen((event) => {
+      if (event.type !== Watcher.Event.Updated.type) return Effect.void
+      const data = event.data as typeof Watcher.Event.Updated.data.Type
+      if (data.event !== "add") return Effect.void
+      if (!event.location) return Effect.void
+      if (path.relative(event.location.directory, data.file) !== ".git") return Effect.void
+      const entry = cache.get(FSUtil.resolve(event.location.directory))
+      if (!entry) return Effect.void
+      return Deferred.await(entry.deferred).pipe(
+        Effect.flatMap((ctx) => (ctx.project.vcs === "git" ? Effect.void : reload({ directory: ctx.directory }).pipe(Effect.asVoid))),
+        Effect.catch(() => Effect.void),
+      )
+    })
+
     const dispose = Effect.fn("InstanceStore.dispose")(function* (ctx: InstanceContext) {
       const entry = cache.get(ctx.directory)
       if (!entry) return yield* disposeContext(ctx)
@@ -189,6 +207,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
     const provide = <A, E, R>(input: LoadInput, effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
       load(input).pipe(Effect.flatMap((ctx) => effect.pipe(Effect.provideService(InstanceRef, ctx))))
 
+    yield* Effect.addFinalizer(() => unsubscribe)
     yield* Effect.addFinalizer(() => disposeAll().pipe(Effect.ignore))
 
     return Service.of({
@@ -207,7 +226,7 @@ export const bootstrapNode = LayerNode.unbound(InstanceBootstrap.Service, Node.t
 export const node = makeGlobalNode({
   service: Service,
   layer: layer,
-  deps: [Project.node, bootstrapNode],
+  deps: [Project.node, EventV2Bridge.node, bootstrapNode],
 })
 
 export * as InstanceStore from "./instance-store"

--- a/packages/opencode/test/server/project-init-git.test.ts
+++ b/packages/opencode/test/server/project-init-git.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect } from "bun:test"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { Effect, Layer } from "effect"
 import { HttpClientResponse } from "effect/unstable/http"
 import path from "path"
@@ -9,6 +10,7 @@ import { InstanceRef } from "../../src/effect/instance-ref"
 import { InstanceBootstrap } from "../../src/project/bootstrap"
 import { InstanceStore } from "../../src/project/instance-store"
 import { GlobalBus, type GlobalEvent } from "../../src/bus/global"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
 import { Snapshot } from "../../src/snapshot"
 import { resetDatabase } from "../fixture/db"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
@@ -24,7 +26,11 @@ const noopBootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap
 const testInstanceStore = AppNodeBuilder.build(InstanceStore.node, [[InstanceStore.bootstrapNode, noopBootstrap]])
 
 const it = testEffect(
-  Layer.mergeAll(AppNodeBuilder.build(LayerNode.group([FSUtil.node, Snapshot.node])), testInstanceStore, httpApiLayer),
+  Layer.mergeAll(
+    AppNodeBuilder.build(LayerNode.group([FSUtil.node, Snapshot.node, EventV2Bridge.node])),
+    testInstanceStore,
+    httpApiLayer,
+  ),
 )
 
 function request(directory: string, url: string, init: RequestInit = {}) {
@@ -53,6 +59,26 @@ const disposedEvents = (seen: GlobalEvent[], dir: string) =>
   seen.filter((evt) => evt.directory === dir && evt.payload.type === "server.instance.disposed").length
 
 describe("project.initGit endpoint", () => {
+  it.instance("reloads after a watched git initialization", () =>
+    Effect.gen(function* () {
+      const tmp = yield* TestInstance
+      const events = yield* collectGlobalEvents()
+      const bridge = yield* EventV2Bridge.Service
+      const store = yield* InstanceStore.Service
+
+      const before = yield* store.load({ directory: tmp.directory })
+      expect(before.project.vcs).toBeUndefined()
+
+      const process = Bun.spawn(["git", "init", "--quiet"], { cwd: tmp.directory })
+      expect(yield* Effect.promise(() => process.exited)).toBe(0)
+      yield* bridge.publish(Watcher.Event.Updated, { file: path.join(tmp.directory, ".git"), event: "add" })
+
+      expect(disposedEvents(events.seen, tmp.directory)).toBe(1)
+      const current = yield* store.load({ directory: tmp.directory })
+      expect(current.project).toMatchObject({ vcs: "git", worktree: tmp.directory })
+    }),
+  )
+
   it.instance("initializes git and reloads immediately", () =>
     Effect.gen(function* () {
       const tmp = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #28977

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A project opened before `git init` kept a non-Git instance context, so the workspace toggle stayed disabled until restart. The file watcher now observes creation of `.git` for non-Git locations. InstanceStore reloads that active location on the creation event, which rediscoveres the project as Git and publishes the updated context.

### How did you verify your code works?

Ran `bun test test/server/project-init-git.test.ts` from `packages/opencode` (3 passing). The new regression test loads a non-Git instance, initializes Git, publishes the watched `.git` creation, and asserts that the reloaded instance is Git-backed. Ran `bun typecheck` from `packages/opencode`.

### Screenshots / recordings

N/A — non-UI server lifecycle change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR