### PR TITLE
fix(session): end the turn loop by reply parent, not message ID order

### DIFF
--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -38,18 +38,6 @@ function generateID(prefix: keyof typeof prefixes, direction: "descending" | "as
   return given
 }
 
-const ASCENDING = /^[0-9a-f]{12}[0-9A-Za-z]{14}$/
-
-/**
- * Whether an ID has the shape `ascending()` produces, and so sorts by creation
- * time against other IDs of the same prefix. Callers that accept an ID from a
- * client should check this before storing it anywhere ordering is load-bearing.
- */
-export function isAscending(prefix: keyof typeof prefixes, id: string): boolean {
-  const start = prefixes[prefix] + "_"
-  return id.startsWith(start) && ASCENDING.test(id.slice(start.length))
-}
-
 function randomBase62(length: number): string {
   const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
   let result = ""

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -38,6 +38,18 @@ function generateID(prefix: keyof typeof prefixes, direction: "descending" | "as
   return given
 }
 
+const ASCENDING = /^[0-9a-f]{12}[0-9A-Za-z]{14}$/
+
+/**
+ * Whether an ID has the shape `ascending()` produces, and so sorts by creation
+ * time against other IDs of the same prefix. Callers that accept an ID from a
+ * client should check this before storing it anywhere ordering is load-bearing.
+ */
+export function isAscending(prefix: keyof typeof prefixes, id: string): boolean {
+  const start = prefixes[prefix] + "_"
+  return id.startsWith(start) && ASCENDING.test(id.slice(start.length))
+}
+
 function randomBase62(length: number): string {
   const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
   let result = ""

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -588,21 +588,21 @@ export function latest(msgs: WithParts[]) {
   let finished: Assistant | undefined
   for (const msg of msgs) {
     const info = msg.info
-    if (info.role === "user" && (!user || isAfter(info, user))) user = info
-    if (info.role === "assistant" && (!assistant || isAfter(info, assistant))) assistant = info
-    if (info.role === "assistant" && info.finish && (!finished || isAfter(info, finished))) finished = info
+    if (info.role === "user" && (!user || isNewerMessage(info, user))) user = info
+    if (info.role === "assistant" && (!assistant || isNewerMessage(info, assistant))) assistant = info
+    if (info.role === "assistant" && info.finish && (!finished || isNewerMessage(info, finished))) finished = info
   }
   const tasks = msgs.flatMap((m) =>
-    finished && !isAfter(m.info, finished)
+    finished && !isNewerMessage(m.info, finished)
       ? []
       : m.parts.filter((p): p is CompactionPart | SubtaskPart => p.type === "compaction" || p.type === "subtask"),
   )
   return { user, assistant, finished, tasks }
 }
 
-function isAfter(a: Info, b: Info) {
-  if (a.time.created !== b.time.created) return a.time.created > b.time.created
-  return a.id > b.id
+function isNewerMessage(candidate: Info, current: Info) {
+  if (candidate.time.created !== current.time.created) return candidate.time.created > current.time.created
+  return candidate.id > current.id
 }
 
 export function fromError(

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -577,27 +577,32 @@ export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: Ses
 
 // filterCompacted reorders messages for model consumption
 // ([compaction-user, summary, ...retained tail..., continue-user]), so array
-// position is not chronological. Derive each binding by max id (MessageID
-// is monotonic via MessageID.ascending) so a pre-compaction overflowing tail
-// assistant doesn't get mistaken for the most recent turn. tasks are
-// compaction/subtask parts attached to user messages newer than the latest
-// finished assistant — i.e. unprocessed work.
+// position is not chronological. Derive each binding by creation time so a
+// client-supplied message ID cannot change turn ordering. IDs break ties for
+// messages created in the same millisecond. tasks are compaction/subtask parts
+// attached to user messages newer than the latest finished assistant — i.e.
+// unprocessed work.
 export function latest(msgs: WithParts[]) {
   let user: User | undefined
   let assistant: Assistant | undefined
   let finished: Assistant | undefined
   for (const msg of msgs) {
     const info = msg.info
-    if (info.role === "user" && (!user || info.id > user.id)) user = info
-    if (info.role === "assistant" && (!assistant || info.id > assistant.id)) assistant = info
-    if (info.role === "assistant" && info.finish && (!finished || info.id > finished.id)) finished = info
+    if (info.role === "user" && (!user || isAfter(info, user))) user = info
+    if (info.role === "assistant" && (!assistant || isAfter(info, assistant))) assistant = info
+    if (info.role === "assistant" && info.finish && (!finished || isAfter(info, finished))) finished = info
   }
   const tasks = msgs.flatMap((m) =>
-    finished && m.info.id <= finished.id
+    finished && !isAfter(m.info, finished)
       ? []
       : m.parts.filter((p): p is CompactionPart | SubtaskPart => p.type === "compaction" || p.type === "subtask"),
   )
   return { user, assistant, finished, tasks }
+}
+
+function isAfter(a: Info, b: Info) {
+  if (a.time.created !== b.time.created) return a.time.created > b.time.created
+  return a.id > b.id
 }
 
 export function fromError(

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1108,11 +1108,16 @@ const layer = Layer.effect(
               (part) => part.type === "tool" && !part.metadata?.providerExecuted && !isOrphanedInterruptedTool(part),
             ) ?? false
 
+          // The turn is over once the newest assistant message is the reply to the
+          // newest user message. Compare parentID rather than ordering the two IDs:
+          // parentID is assigned by this loop, whereas a message ID can be supplied
+          // by the client, and one that does not sort below the IDs minted later
+          // pins `lastUser` forever and the loop never exits.
           if (
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            lastAssistant.parentID === lastUser.id
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3,7 +3,6 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import os from "os"
-import { Identifier } from "@/id/id"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import { SessionRevert } from "./revert"
@@ -98,16 +97,6 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   // cleanup() marks abandoned tool_use blocks this way after retries/aborts.
   // They are not pending work and must not trigger an assistant-prefill request.
   return part.state.status === "error" && part.state.metadata?.interrupted === true
-}
-
-function requireAscendingMessageID(messageID: string | undefined) {
-  // A caller-supplied ID is stored as-is and ordered against the IDs minted for
-  // the rest of the session, so it has to sort the same way. Rejecting it here
-  // beats accepting one that silently breaks `MessageV2.latest`.
-  if (messageID === undefined || Identifier.isAscending("message", messageID)) return
-  throw new NamedError.Unknown({
-    message: `Message ID "${messageID}" is not an ascending ID. Generate it with Identifier.ascending("message") so it sorts after the messages already in the session.`,
-  })
 }
 
 export interface Interface {
@@ -477,7 +466,6 @@ const layer = Layer.effect(
               yield* events.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
               throw error
             }
-            requireAscendingMessageID(input.messageID)
             const model = input.model ?? agent.model ?? (yield* currentModel(input.sessionID))
             const userMsg: SessionV1.User = {
               id: input.messageID ?? MessageID.ascending(),
@@ -665,7 +653,6 @@ const layer = Layer.effect(
           : undefined
       const variant = input.variant ?? (ag.variant && full?.variants?.[ag.variant] ? ag.variant : undefined)
 
-      requireAscendingMessageID(input.messageID)
       const info: SessionV1.User = {
         id: input.messageID ?? MessageID.ascending(),
         role: "user",
@@ -1122,10 +1109,8 @@ const layer = Layer.effect(
             ) ?? false
 
           // The turn is over once the newest assistant message is the reply to the
-          // newest user message. Compare parentID rather than ordering the two IDs:
-          // parentID is assigned by this loop, whereas a message ID can be supplied
-          // by the client, and one that does not sort below the IDs minted later
-          // pins `lastUser` forever and the loop never exits.
+          // newest user message. parentID records that relationship directly and
+          // remains valid when the client supplies the message ID.
           if (
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -3,6 +3,7 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import os from "os"
+import { Identifier } from "@/id/id"
 import { SessionID, MessageID, PartID } from "./schema"
 import { MessageV2 } from "./message-v2"
 import { SessionRevert } from "./revert"
@@ -97,6 +98,16 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
   // cleanup() marks abandoned tool_use blocks this way after retries/aborts.
   // They are not pending work and must not trigger an assistant-prefill request.
   return part.state.status === "error" && part.state.metadata?.interrupted === true
+}
+
+function requireAscendingMessageID(messageID: string | undefined) {
+  // A caller-supplied ID is stored as-is and ordered against the IDs minted for
+  // the rest of the session, so it has to sort the same way. Rejecting it here
+  // beats accepting one that silently breaks `MessageV2.latest`.
+  if (messageID === undefined || Identifier.isAscending("message", messageID)) return
+  throw new NamedError.Unknown({
+    message: `Message ID "${messageID}" is not an ascending ID. Generate it with Identifier.ascending("message") so it sorts after the messages already in the session.`,
+  })
 }
 
 export interface Interface {
@@ -466,6 +477,7 @@ const layer = Layer.effect(
               yield* events.publish(Session.Event.Error, { sessionID: input.sessionID, error: error.toObject() })
               throw error
             }
+            requireAscendingMessageID(input.messageID)
             const model = input.model ?? agent.model ?? (yield* currentModel(input.sessionID))
             const userMsg: SessionV1.User = {
               id: input.messageID ?? MessageID.ascending(),
@@ -653,6 +665,7 @@ const layer = Layer.effect(
           : undefined
       const variant = input.variant ?? (ag.variant && full?.variants?.[ag.variant] ? ag.variant : undefined)
 
+      requireAscendingMessageID(input.messageID)
       const info: SessionV1.User = {
         id: input.messageID ?? MessageID.ascending(),
         role: "user",

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1659,4 +1659,40 @@ describe("session.message-v2.latest", () => {
     expect(state.tasks).toHaveLength(1)
     expect(state.tasks[0]).toMatchObject({ type: "compaction", auto: true })
   })
+
+  test("client-supplied IDs do not control message or task ordering", () => {
+    const oldUser = MessageID.make("msg_fcfbda4a-03c9-4e6b-82cf-2febde1b46a6")
+    const oldAssistant = MessageID.make("msg_f86f0407d0016iNuRJc2PUqfPV")
+    const newUser = MessageID.make("msg_00000000000000000000000000")
+    const state = MessageV2.latest([
+      {
+        info: { ...userInfo(oldUser), time: { created: 1 } },
+        parts: [],
+      },
+      {
+        info: {
+          ...assistantInfo(oldAssistant, oldUser),
+          finish: "stop",
+          time: { created: 2 },
+        },
+        parts: [],
+      },
+      {
+        info: { ...userInfo(newUser), time: { created: 3 } },
+        parts: [
+          {
+            ...basePart(newUser, "new-task"),
+            type: "compaction",
+            auto: true,
+          },
+        ] as SessionV1.Part[],
+      },
+    ])
+
+    expect(state.user?.id).toBe(newUser)
+    expect(state.assistant?.id).toBe(oldAssistant)
+    expect(state.finished?.id).toBe(oldAssistant)
+    expect(state.tasks).toHaveLength(1)
+    expect(state.tasks[0]).toMatchObject({ type: "compaction", auto: true })
+  })
 })

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -460,6 +460,46 @@ noLLMServer.instance(
   { config: cfg },
 )
 
+it.instance("client-supplied message IDs do not control consecutive turns", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const messageID = MessageID.make("msg_fcfbda4a-03c9-4e6b-82cf-2febde1b46a6")
+
+    yield* llm.text("first reply")
+    const first = yield* prompt.prompt({
+      sessionID: chat.id,
+      messageID,
+      agent: "build",
+      model: ref,
+      parts: [{ type: "text", text: "first prompt" }],
+    })
+
+    expect(first.info.role).toBe("assistant")
+    if (first.info.role === "assistant") expect(first.info.parentID).toBe(messageID)
+
+    yield* llm.text("second reply")
+    const second = yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      model: ref,
+      parts: [{ type: "text", text: "second prompt" }],
+    })
+
+    expect(second.info.role).toBe("assistant")
+    if (second.info.role !== "assistant") return
+    const messages = yield* sessions.messages({ sessionID: chat.id })
+    const secondUser = messages.findLast((message) => message.info.role === "user")
+    if (!secondUser || secondUser.info.role !== "user") throw new Error("expected second user message")
+    expect(secondUser.info.id).not.toBe(messageID)
+    expect(second.info.parentID).toBe(secondUser.info.id)
+    expect(second.parts).toContainEqual(expect.objectContaining({ type: "text", text: "second reply" }))
+    expect(yield* llm.calls).toBe(2)
+  }),
+)
+
 it.instance("loop exits without an LLM request for interrupted orphan tool calls", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #35741

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a session turn loop caused by treating message IDs as timestamps.

Clients may supply `messageID`, and the public schema only requires the `msg` prefix. If that ID sorts after IDs created by the server, `MessageV2.latest` can keep selecting an older user message. A completed assistant reply then fails the loop's ID-order exit check, so the model is prompted again.

This change:

- selects the latest user, assistant, finished assistant, and pending task boundary by `time.created`, with ID as the same-millisecond tie-breaker
- ends a completed turn when the assistant's `parentID` matches the latest user message
- keeps existing client-supplied ID formats working and recovers sessions that already contain a non-monotonic ID
- adds unit coverage for message and task ordering plus a two-turn regression using the UUID observed in the affected session

### How did you verify your code works?

- `bun test test/session --timeout 30000 --only-failures`: 370 passed, 7 skipped, 1 todo
- `bun test test/session/message-v2.test.ts test/session/prompt.test.ts --timeout 30000 --only-failures`: 94 passed, 1 skipped
- `bun typecheck` from `packages/opencode`
- repository pre-push `bun turbo typecheck`: 30 successful targets
- Prettier check and `git diff --check`

### Screenshots / recordings

Not applicable. This changes session ordering and loop behavior without changing UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
