### PR TITLE
fix(a11y): expose streaming assistant content to screen readers

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -1147,7 +1147,7 @@ export function MessageTimeline(props: {
             <Show when={message()}>
               {(message) => (
                 <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
-                  <div data-slot="session-turn-message-content" aria-live="off">
+                  <div data-slot="session-turn-message-content" aria-live="polite">
                     <Message
                       message={message()}
                       parts={getMsgParts(userMessageRow().userMessageID)}
@@ -1185,7 +1185,7 @@ export function MessageTimeline(props: {
             <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
               <div
                 data-slot="session-turn-assistant-content"
-                aria-hidden={workingTurn(assistantPartRow().userMessageID)}
+                aria-busy={workingTurn(assistantPartRow().userMessageID)}
               >
                 {renderAssistantPartGroup(assistantPartRow, onSizeChange)}
               </div>

--- a/packages/session-ui/src/components/session-turn.tsx
+++ b/packages/session-ui/src/components/session-turn.tsx
@@ -397,7 +397,7 @@ export function SessionTurn(
               data-slot="session-turn-message-container"
               class={props.classes?.container}
             >
-              <div data-slot="session-turn-message-content" aria-live="off">
+              <div data-slot="session-turn-message-content" aria-live="polite">
                 <Message message={message()!} parts={parts()} actions={props.actions} />
               </div>
               <Show when={divider()}>
@@ -406,7 +406,7 @@ export function SessionTurn(
                 </div>
               </Show>
               <Show when={assistantMessages().length > 0}>
-                <div data-slot="session-turn-assistant-content" aria-hidden={working()}>
+                <div data-slot="session-turn-assistant-content" aria-busy={working()}>
                   <AssistantParts
                     messages={assistantMessages()}
                     showAssistantCopyPartID={assistantCopyPartID()}


### PR DESCRIPTION
### Issue for this PR

Closes #33137

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes an accessibility issue where streamed assistant content was hidden from screen readers during generation.

The actual file Desktop renders is `packages/app/src/pages/session/timeline/message-timeline.tsx` (not `packages/session-ui/src/components/session-turn.tsx` that PR #33139 targeted — that file is only used in the enterprise share page).

`message-timeline.tsx` has the same two patterns:
- Line 1150: `aria-live="off"` on `session-turn-message-content`
- Line 1188: `aria-hidden={workingTurn(assistantPartRow().userMessageID)}` on `session-turn-assistant-content`

**Changes:**
1. `aria-live="off"` → `aria-live="polite"` on `session-turn-message-content` (line 1150): allows screen readers to announce streamed updates incrementally without interrupting the user.
2. `aria-hidden={workingTurn(...)}` → `aria-busy={workingTurn(...)}` on `session-turn-assistant-content` (line 1188): tells the screen reader the region is busy updating rather than hiding it entirely from the accessibility tree.

This is a strictly better fix than removing `aria-hidden` entirely (as #33139 did): `aria-busy` preserves the "busy" signal so screen readers can choose how to handle frequent updates, instead of flooding the user with every token.

### How did you verify your code works?

Tested locally with NVDA on Windows 10:
- **Before:** NVDA only read "Thinking..." during generation; streamed assistant content was unavailable.
- **After:** Streamed content appears in the accessibility tree during generation and is readable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
