### PR TITLE
docs: mention Exa and Parallel as web search backends

### DIFF
--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -701,6 +701,7 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
 | `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
 | `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
+| `OPENCODE_ENABLE_PARALLEL`            | boolean | Enable Parallel web search tools                  |
 | `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
 | `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
 | `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -257,12 +257,14 @@ Allows the LLM to fetch and read web pages. Useful for looking up documentation 
 Search the web for information.
 
 :::note
-This tool is only available when using the OpenCode provider or when the `OPENCODE_ENABLE_EXA` environment variable is set to any truthy value (e.g., `true` or `1`).
+This tool is only available when using the OpenCode provider or when either the `OPENCODE_ENABLE_EXA` or `OPENCODE_ENABLE_PARALLEL` environment variable is set to any truthy value (e.g., `true` or `1`).
 
 To enable when launching OpenCode:
 
 ```bash
 OPENCODE_ENABLE_EXA=1 opencode
+# or
+OPENCODE_ENABLE_PARALLEL=1 opencode
 ```
 
 :::
@@ -276,9 +278,9 @@ OPENCODE_ENABLE_EXA=1 opencode
 }
 ```
 
-Performs web searches using Exa AI to find relevant information online. Useful for researching topics, finding current events, or gathering information beyond the training data cutoff.
+Performs web searches using Exa or Parallel to find relevant information online. Useful for researching topics, finding current events, or gathering information beyond the training data cutoff. Setting only one of the enable flags pins the search to that backend; otherwise a backend is chosen automatically per session.
 
-No API key is required — the tool connects directly to Exa AI's hosted MCP service without authentication.
+No API key is required — the tool connects directly to the backend's hosted MCP service without authentication.
 
 :::tip
 Use `websearch` when you need to find information (discovery), and `webfetch` when you need to retrieve content from a specific URL (retrieval).


### PR DESCRIPTION
### Issue for this PR

Closes #38371

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The websearch docs only mentioned Exa, but the tool supports Exa or Parallel. Updated the websearch section in tools.mdx to cover both backends and their enable flags, and added the missing `OPENCODE_ENABLE_PARALLEL` row to the env var table in cli.mdx.

### How did you verify your code works?

Checked the wording against the implementation: `selectWebSearchProvider` in `packages/opencode/src/tool/websearch.ts` (single flag pins that backend, otherwise picked automatically per session) and the flag wiring in `packages/core/src/tool/websearch.ts`.

### Screenshots / recordings

_Docs-only change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
