### PR TITLE
fix: pr-standards falsely flags v2-based PRs as missing a linked issue

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -135,7 +135,14 @@ jobs:
 
             const linkedIssues = result.repository.pullRequest.closingIssuesReferences.totalCount;
 
-            if (linkedIssues === 0) {
+            // closingIssuesReferences is only populated for PRs that target the
+            // default branch, so PRs based on other branches (e.g. v2) would
+            // always be flagged. Fall back to matching closing keywords in the
+            // PR body before flagging.
+            const closingKeyword = /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b:?\s+#\d+/i;
+            const bodyReferencesIssue = closingKeyword.test(pr.body ?? '');
+
+            if (linkedIssues === 0 && !bodyReferencesIssue) {
               await addLabel('needs:issue');
               await comment('issue', `Thanks for your contribution!
 


### PR DESCRIPTION
### Issue for this PR

Closes #38407

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The pr-standards issue check relies on `closingIssuesReferences`, which GitHub only populates for PRs targeting the default branch. Every PR based on `v2` with a valid `Closes #N` line gets falsely labeled `needs:issue` (recent examples: #38406, #37088, #36242, #36403).

This adds a fallback: when the GraphQL count is 0, match the PR body against GitHub's closing keywords before flagging.

Known limitation: the fallback does not verify the referenced issue exists (GitHub provides no linkage data for non-default-branch PRs to check against). The bot is an advisory nudge, so keyword presence seemed like the right bar; happy to add a lookup if you want it stricter.

### How did you verify your code works?

Ran the new regex against a small case table (closes/fixes/resolves variants, keyword without number, bare number without keyword, null body). Cannot run the workflow itself from a fork; the logic change is the two-line condition plus the regex.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
