### PR TITLE
fix(core): migrate named agent colors

### DIFF
--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -4,7 +4,10 @@ import { Schema, SchemaGetter } from "effect"
 import { PositiveInt } from "../../schema"
 import { ConfigPermissionV1 } from "./permission"
 
-const Color = Schema.String.check(Schema.isPattern(/^#[0-9a-fA-F]{6}$/))
+const Color = Schema.Union([
+  Schema.String.check(Schema.isPattern(/^#[0-9a-fA-F]{6}$/)),
+  Schema.Literals(["primary", "secondary", "accent", "success", "warning", "error", "info"]),
+])
 
 const AgentSchema = Schema.StructWithRest(
   Schema.Struct({
@@ -26,7 +29,7 @@ const AgentSchema = Schema.StructWithRest(
     }),
     options: Schema.optional(Schema.Record(Schema.String, Schema.Any)),
     color: Schema.optional(Color).annotate({
-      description: "Hex color code (e.g., #FF5733)",
+      description: "Hex color code (e.g., #FF5733) or theme color (e.g., primary)",
     }),
     steps: Schema.optional(PositiveInt).annotate({
       description: "Maximum number of agentic iterations before forcing text-only response",

--- a/packages/core/src/v1/config/migrate.ts
+++ b/packages/core/src/v1/config/migrate.ts
@@ -161,7 +161,7 @@ export function migrateAgent(info: ConfigAgentV1.Info) {
     description: info.description,
     mode: info.mode,
     hidden: info.hidden,
-    color: info.color,
+    color: info.color === undefined ? undefined : info.color.startsWith("#") ? info.color : "#aaaaaa",
     steps: info.steps,
     disabled: info.disable,
     permissions: permissions(info.permission),

--- a/packages/core/test/config/agent.test.ts
+++ b/packages/core/test/config/agent.test.ts
@@ -27,13 +27,6 @@ test("rejects named agent color tokens", () => {
   expect(() => decode({ agents: { reviewer: { color: "warning" } } })).toThrow()
 })
 
-test("migrates v1 named agent colors to hex", () => {
-  for (const color of ["primary", "secondary", "accent", "success", "warning", "error", "info"] as const) {
-    expect(ConfigMigrateV1.migrateAgent({ color }).color).toBe("#aaaaaa")
-  }
-  expect(ConfigMigrateV1.migrateAgent({ color: "#ff6b6b" }).color).toBe("#ff6b6b")
-})
-
 describe("ConfigAgentPlugin.Plugin", () => {
   it.effect("matches POSIX paths against home-relative permissions", () =>
     Effect.gen(function* () {
@@ -260,7 +253,6 @@ describe("ConfigAgentPlugin.Plugin", () => {
 model: openrouter/openai/gpt-5
 description: Markdown description
 temperature: 0.5
-color: warning
 tools:
   write: false
 ---
@@ -305,7 +297,6 @@ Use native v2 fields.`,
             model: { providerID: "openrouter", id: "openai/gpt-5" },
             system: "Review carefully.",
             description: "Markdown description",
-            color: "#aaaaaa",
             request: { body: { temperature: 0.5 } },
             permissions: [...defaultPermissions, { action: "edit", resource: "*", effect: "deny" }],
           })

--- a/packages/core/test/config/agent.test.ts
+++ b/packages/core/test/config/agent.test.ts
@@ -27,6 +27,13 @@ test("rejects named agent color tokens", () => {
   expect(() => decode({ agents: { reviewer: { color: "warning" } } })).toThrow()
 })
 
+test("migrates v1 named agent colors to hex", () => {
+  for (const color of ["primary", "secondary", "accent", "success", "warning", "error", "info"] as const) {
+    expect(ConfigMigrateV1.migrateAgent({ color }).color).toBe("#aaaaaa")
+  }
+  expect(ConfigMigrateV1.migrateAgent({ color: "#ff6b6b" }).color).toBe("#ff6b6b")
+})
+
 describe("ConfigAgentPlugin.Plugin", () => {
   it.effect("matches POSIX paths against home-relative permissions", () =>
     Effect.gen(function* () {
@@ -253,6 +260,7 @@ describe("ConfigAgentPlugin.Plugin", () => {
 model: openrouter/openai/gpt-5
 description: Markdown description
 temperature: 0.5
+color: warning
 tools:
   write: false
 ---
@@ -297,6 +305,7 @@ Use native v2 fields.`,
             model: { providerID: "openrouter", id: "openai/gpt-5" },
             system: "Review carefully.",
             description: "Markdown description",
+            color: "#aaaaaa",
             request: { body: { temperature: 0.5 } },
             permissions: [...defaultPermissions, { action: "edit", resource: "*", effect: "deny" }],
           })


### PR DESCRIPTION
## Summary

- preserve named agent colors in the V1 config schema
- migrate legacy named colors to `#aaaaaa` before V2 validation
- retain existing six-digit hex colors unchanged