### PR TITLE
fix:(web) 修复web模式下本地客户端时间早于服务端时间导致的大模型不回复bug

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -577,23 +577,30 @@ export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: Ses
 
 // filterCompacted reorders messages for model consumption
 // ([compaction-user, summary, ...retained tail..., continue-user]), so array
-// position is not chronological. Derive each binding by max id (MessageID
-// is monotonic via MessageID.ascending) so a pre-compaction overflowing tail
-// assistant doesn't get mistaken for the most recent turn. tasks are
-// compaction/subtask parts attached to user messages newer than the latest
-// finished assistant — i.e. unprocessed work.
+// position is not chronological. Derive each binding by service timestamp
+// (MessageID.ascending monotonicity is guaranteed only for server-generated
+// IDs; client-provided IDs may use a different clock) so a pre-compaction
+// overflowing tail assistant doesn't get mistaken for the most recent turn.
+// tasks are compaction/subtask parts attached to user messages newer than the
+// latest finished assistant — i.e. unprocessed work.
+export function after(a: Pick<Info, "time" | "id">, b: Pick<Info, "time" | "id">) {
+  return a.time.created !== b.time.created
+    ? a.time.created > b.time.created
+    : a.id > b.id
+}
+
 export function latest(msgs: WithParts[]) {
   let user: User | undefined
   let assistant: Assistant | undefined
   let finished: Assistant | undefined
   for (const msg of msgs) {
     const info = msg.info
-    if (info.role === "user" && (!user || info.id > user.id)) user = info
-    if (info.role === "assistant" && (!assistant || info.id > assistant.id)) assistant = info
-    if (info.role === "assistant" && info.finish && (!finished || info.id > finished.id)) finished = info
+    if (info.role === "user" && (!user || after(info, user))) user = info
+    if (info.role === "assistant" && (!assistant || after(info, assistant))) assistant = info
+    if (info.role === "assistant" && info.finish && (!finished || after(info, finished))) finished = info
   }
   const tasks = msgs.flatMap((m) =>
-    finished && m.info.id <= finished.id
+    finished && !after(m.info, finished)
       ? []
       : m.parts.filter((p): p is CompactionPart | SubtaskPart => p.type === "compaction" || p.type === "subtask"),
   )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4,7 +4,7 @@ import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import os from "os"
 import { SessionID, MessageID, PartID } from "./schema"
-import { MessageV2 } from "./message-v2"
+import { MessageV2, after } from "./message-v2"
 import { SessionRevert } from "./revert"
 import { Session } from "./session"
 import { Agent } from "../agent/agent"
@@ -1112,7 +1112,7 @@ const layer = Layer.effect(
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            after(lastAssistant, lastUser)
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),


### PR DESCRIPTION
### Issue for this PR
Fixes #38268 
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

具体bug描述见我的issue。经过测试，在我故意将客户端时间调慢1分钟后，修复过的web端可以正常与大模型对话。此次提交，主要修改了大模型对对话条目的id时间戳先后顺序判断准则，改为统一用created字段判断。

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works? 
我打包了opencode.exe文件后，重新在远程服务器部署，本地访问。在有时差的情况下，现在可以正常对话了。
### Screenshots / recordings
<img width="793" height="303" alt="image" src="https://github.com/user-attachments/assets/b0aa485c-cb27-4933-a491-42f87b623965" />

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
