### PR TITLE
fix(provider): select prompt cache keys by SDK

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1141,7 +1141,7 @@ export function options(input: {
   sessionID: string
   providerOptions?: Record<string, any>
 }): Record<string, any> {
-  const result: Record<string, any> = cachingOptions(input)
+  const result: Record<string, any> = {}
 
   if (
     input.model.api.npm === "@ai-sdk/google-vertex/anthropic" ||
@@ -1278,49 +1278,37 @@ export function options(input: {
     }
   }
 
+  if (input.providerOptions?.setCacheKey !== false) {
+    if (input.model.api.npm === "@ai-sdk/deepinfra" || input.model.api.npm === "@ai-sdk/cerebras") {
+      result["prompt_cache_key"] = input.sessionID
+    } else if (
+      input.model.api.npm === "@ai-sdk/openai" ||
+      input.model.api.npm === "@ai-sdk/azure" ||
+      input.model.api.npm === "@ai-sdk/xai" ||
+      input.model.api.npm === "@ai-sdk/mistral" ||
+      input.model.api.npm === "venice-ai-sdk-provider" ||
+      input.providerOptions?.setCacheKey === true
+    ) {
+      result["promptCacheKey"] = input.sessionID
+    }
+  }
+
+  if (input.model.api.npm === "@ai-sdk/gateway") {
+    result["gateway"] = { caching: "auto" }
+  }
+
   return result
 }
 
-function cachingOptions(input: {
-  model: Provider.Model
-  sessionID: string
-  providerOptions?: Record<string, any>
-}): Record<string, any> {
-  if (input.providerOptions?.setCacheKey === false) {
-    if (input.model.api.npm === "@ai-sdk/gateway") return { gateway: { caching: "auto" } }
-    return {}
-  }
-
-  if (input.model.api.npm === "@ai-sdk/deepinfra" || input.model.api.npm === "@ai-sdk/cerebras") {
-    return { prompt_cache_key: input.sessionID }
-  }
-
-  if (
-    input.model.api.npm === "@ai-sdk/openai" ||
-    (input.model.providerID === "openai" && input.model.api.npm !== "@ai-sdk/openai-compatible") ||
-    input.model.api.npm === "@ai-sdk/azure" ||
-    input.model.api.npm === "@ai-sdk/xai" ||
-    input.model.api.npm === "@ai-sdk/mistral" ||
-    input.model.api.npm === "venice-ai-sdk-provider" ||
-    input.providerOptions?.setCacheKey === true
-  ) {
-    return { promptCacheKey: input.sessionID }
-  }
-
-  if (input.model.api.npm === "@ai-sdk/gateway") return { gateway: { caching: "auto" } }
-  return {}
-}
-
-export function smallOptions(model: Provider.Model, sessionID?: string, providerOptions?: Record<string, any>) {
+export function smallOptions(model: Provider.Model) {
   const small = Object.values(model.variants ?? {})[0] ?? {}
-  const caching = sessionID ? cachingOptions({ model, sessionID, providerOptions }) : {}
   if (
     model.providerID === "openai" ||
     model.api.npm === "@ai-sdk/openai" ||
     model.api.npm === "@ai-sdk/github-copilot" ||
     model.api.npm === "@ai-sdk/xai"
   ) {
-    const base = { ...caching, store: false }
+    const base = { store: false }
     return mergeDeep(base, small)
   }
   if (model.providerID === "openrouter" || model.providerID === "llmgateway") {
@@ -1330,11 +1318,11 @@ export function smallOptions(model: Provider.Model, sessionID?: string, provider
   }
 
   if (model.providerID === "venice") {
-    if (Object.keys(small).length > 0) return mergeDeep(caching, small)
-    return mergeDeep(caching, { veniceParameters: { disableThinking: true } })
+    if (Object.keys(small).length > 0) return small
+    return { veniceParameters: { disableThinking: true } }
   }
 
-  return mergeDeep(caching, small)
+  return small
 }
 
 // Maps model ID prefix to provider slug used in providerOptions.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -58,6 +58,28 @@ function sdkKey(npm: string): string | undefined {
       return "vertex"
     case "@ai-sdk/google":
       return "google"
+    case "@ai-sdk/alibaba":
+      return "alibaba"
+    case "@ai-sdk/cerebras":
+      return "cerebras"
+    case "@ai-sdk/cohere":
+      return "cohere"
+    case "@ai-sdk/deepinfra":
+      return "deepinfra"
+    case "@ai-sdk/groq":
+      return "groq"
+    case "@ai-sdk/mistral":
+      return "mistral"
+    case "@ai-sdk/perplexity":
+      return "perplexity"
+    case "@ai-sdk/togetherai":
+      return "togetherai"
+    case "@ai-sdk/vercel":
+      return "vercel"
+    case "@ai-sdk/xai":
+      return "xai"
+    case "venice-ai-sdk-provider":
+      return "venice"
     case "@ai-sdk/gateway":
       return "gateway"
     case "@openrouter/ai-sdk-provider":
@@ -442,6 +464,9 @@ function mapProviderOptions(
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
   msgs = unsupportedParts(msgs, model)
   msgs = normalizeMessages(msgs, model, options)
+  const usesAnthropicAutomaticCaching =
+    options.cacheControl !== undefined &&
+    (model.api.npm === "@ai-sdk/anthropic" || model.api.npm === "@ai-sdk/google-vertex/anthropic")
   if (
     (model.providerID === "anthropic" ||
       model.providerID === "google-vertex-anthropic" ||
@@ -451,7 +476,8 @@ export function message(msgs: ModelMessage[], model: Provider.Model, options: Re
       model.id.includes("claude") ||
       model.api.npm === "@ai-sdk/anthropic" ||
       model.api.npm === "@ai-sdk/alibaba") &&
-    model.api.npm !== "@ai-sdk/gateway"
+    model.api.npm !== "@ai-sdk/gateway" &&
+    !usesAnthropicAutomaticCaching
   ) {
     msgs = applyCaching(msgs, model)
   }
@@ -1115,7 +1141,7 @@ export function options(input: {
   sessionID: string
   providerOptions?: Record<string, any>
 }): Record<string, any> {
-  const result: Record<string, any> = {}
+  const result: Record<string, any> = cachingOptions(input)
 
   if (
     input.model.api.npm === "@ai-sdk/google-vertex/anthropic" ||
@@ -1137,7 +1163,6 @@ export function options(input: {
 
   if (input.model.api.npm === "@ai-sdk/azure") {
     result["store"] = false
-    result["promptCacheKey"] = input.sessionID
   }
 
   if (input.model.api.npm === "@openrouter/ai-sdk-provider" || input.model.api.npm === "@llmgateway/ai-sdk-provider") {
@@ -1164,16 +1189,6 @@ export function options(input: {
       type: "enabled",
       clear_thinking: false,
     }
-  }
-
-  if (
-    input.providerOptions?.setCacheKey !== false &&
-    (input.model.providerID === "openai" ||
-      input.model.api.npm === "@ai-sdk/openai" ||
-      input.model.api.npm === "@ai-sdk/xai" ||
-      input.providerOptions?.setCacheKey)
-  ) {
-    result["promptCacheKey"] = input.sessionID
   }
 
   if (input.model.providerID === "meta" && input.model.api.npm === "@ai-sdk/openai") {
@@ -1256,38 +1271,56 @@ export function options(input: {
       result["textVerbosity"] = "low"
     }
 
-    if (input.model.providerID.startsWith("opencode")) {
+    if (input.model.providerID.startsWith("opencode") && input.providerOptions?.setCacheKey !== false) {
       result["promptCacheKey"] = input.sessionID
       result["include"] = INCLUDE_ENCRYPTED_REASONING
       result["reasoningSummary"] = "auto"
     }
   }
 
-  if (input.model.providerID === "venice") {
-    result["promptCacheKey"] = input.sessionID
-  }
-
-  if (input.model.providerID === "openrouter") {
-    result["prompt_cache_key"] = input.sessionID
-  }
-  if (input.model.api.npm === "@ai-sdk/gateway") {
-    result["gateway"] = {
-      caching: "auto",
-    }
-  }
-
   return result
 }
 
-export function smallOptions(model: Provider.Model) {
+function cachingOptions(input: {
+  model: Provider.Model
+  sessionID: string
+  providerOptions?: Record<string, any>
+}): Record<string, any> {
+  if (input.providerOptions?.setCacheKey === false) {
+    if (input.model.api.npm === "@ai-sdk/gateway") return { gateway: { caching: "auto" } }
+    return {}
+  }
+
+  if (input.model.api.npm === "@ai-sdk/deepinfra" || input.model.api.npm === "@ai-sdk/cerebras") {
+    return { prompt_cache_key: input.sessionID }
+  }
+
+  if (
+    input.model.api.npm === "@ai-sdk/openai" ||
+    (input.model.providerID === "openai" && input.model.api.npm !== "@ai-sdk/openai-compatible") ||
+    input.model.api.npm === "@ai-sdk/azure" ||
+    input.model.api.npm === "@ai-sdk/xai" ||
+    input.model.api.npm === "@ai-sdk/mistral" ||
+    input.model.api.npm === "venice-ai-sdk-provider" ||
+    input.providerOptions?.setCacheKey === true
+  ) {
+    return { promptCacheKey: input.sessionID }
+  }
+
+  if (input.model.api.npm === "@ai-sdk/gateway") return { gateway: { caching: "auto" } }
+  return {}
+}
+
+export function smallOptions(model: Provider.Model, sessionID?: string, providerOptions?: Record<string, any>) {
   const small = Object.values(model.variants ?? {})[0] ?? {}
+  const caching = sessionID ? cachingOptions({ model, sessionID, providerOptions }) : {}
   if (
     model.providerID === "openai" ||
     model.api.npm === "@ai-sdk/openai" ||
     model.api.npm === "@ai-sdk/github-copilot" ||
     model.api.npm === "@ai-sdk/xai"
   ) {
-    const base = { store: false }
+    const base = { ...caching, store: false }
     return mergeDeep(base, small)
   }
   if (model.providerID === "openrouter" || model.providerID === "llmgateway") {
@@ -1297,11 +1330,11 @@ export function smallOptions(model: Provider.Model) {
   }
 
   if (model.providerID === "venice") {
-    if (Object.keys(small).length > 0) return small
-    return { veniceParameters: { disableThinking: true } }
+    if (Object.keys(small).length > 0) return mergeDeep(caching, small)
+    return mergeDeep(caching, { veniceParameters: { disableThinking: true } })
   }
 
-  return small
+  return mergeDeep(caching, small)
 }
 
 // Maps model ID prefix to provider slug used in providerOptions.

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1239,6 +1239,25 @@ export function options(input: {
     result["enable_thinking"] = true
   }
 
+  if (input.providerOptions?.setCacheKey !== false) {
+    if (input.model.api.npm === "@ai-sdk/deepinfra" || input.model.api.npm === "@ai-sdk/cerebras") {
+      result["prompt_cache_key"] = input.sessionID
+    } else if (
+      input.model.api.npm === "@ai-sdk/openai" ||
+      input.model.api.npm === "@ai-sdk/azure" ||
+      input.model.api.npm === "@ai-sdk/xai" ||
+      input.model.api.npm === "@ai-sdk/mistral" ||
+      input.model.api.npm === "venice-ai-sdk-provider" ||
+      input.providerOptions?.setCacheKey === true
+    ) {
+      result["promptCacheKey"] = input.sessionID
+    }
+  }
+
+  if (input.model.api.npm === "@ai-sdk/gateway") {
+    result["gateway"] = { caching: "auto" }
+  }
+
   if (input.model.api.npm === "@ai-sdk/azure" && input.model.api.id.includes("gpt-5.5")) {
     result["reasoningSummary"] = "auto"
     return result
@@ -1276,25 +1295,6 @@ export function options(input: {
       result["include"] = INCLUDE_ENCRYPTED_REASONING
       result["reasoningSummary"] = "auto"
     }
-  }
-
-  if (input.providerOptions?.setCacheKey !== false) {
-    if (input.model.api.npm === "@ai-sdk/deepinfra" || input.model.api.npm === "@ai-sdk/cerebras") {
-      result["prompt_cache_key"] = input.sessionID
-    } else if (
-      input.model.api.npm === "@ai-sdk/openai" ||
-      input.model.api.npm === "@ai-sdk/azure" ||
-      input.model.api.npm === "@ai-sdk/xai" ||
-      input.model.api.npm === "@ai-sdk/mistral" ||
-      input.model.api.npm === "venice-ai-sdk-provider" ||
-      input.providerOptions?.setCacheKey === true
-    ) {
-      result["promptCacheKey"] = input.sessionID
-    }
-  }
-
-  if (input.model.api.npm === "@ai-sdk/gateway") {
-    result["gateway"] = { caching: "auto" }
   }
 
   return result

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -82,7 +82,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
       ? input.model.variants[input.user.model.variant]
       : {}
   const base = input.small
-    ? ProviderTransform.smallOptions(input.model)
+    ? ProviderTransform.smallOptions(input.model, input.sessionID, input.provider.options)
     : ProviderTransform.options({
         model: input.model,
         sessionID: input.sessionID,

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -82,7 +82,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
       ? input.model.variants[input.user.model.variant]
       : {}
   const base = input.small
-    ? ProviderTransform.smallOptions(input.model, input.sessionID, input.provider.options)
+    ? ProviderTransform.smallOptions(input.model)
     : ProviderTransform.options({
         model: input.model,
         sessionID: input.sessionID,

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -88,6 +88,32 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBe(sessionID)
   })
 
+  test("should set promptCacheKey for the OpenAI SDK regardless of provider ID", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        providerID: "custom-openai",
+        api: { id: "gpt-5", url: "https://example.com", npm: "@ai-sdk/openai" },
+      },
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
+  test("should not set promptCacheKey for the OpenAI-compatible SDK by provider name", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        providerID: "openai",
+        api: { id: "gpt-5", url: "https://example.com", npm: "@ai-sdk/openai-compatible" },
+      },
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.promptCacheKey).toBeUndefined()
+  })
+
   test("should not set promptCacheKey for openai when explicitly disabled", () => {
     const openaiModel = {
       ...mockModel,
@@ -209,6 +235,55 @@ describe("ProviderTransform.options - setCacheKey", () => {
       providerOptions: {},
     })
     expect(result.store).toBe(false)
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
+  test("should disable the Azure cache key without disabling store=false", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        providerID: "azure",
+        api: { id: "gpt-5", url: "https://azure.com", npm: "@ai-sdk/azure" },
+      },
+      sessionID,
+      providerOptions: { setCacheKey: false },
+    })
+    expect(result.store).toBe(false)
+    expect(result.promptCacheKey).toBeUndefined()
+  })
+
+  for (const npm of ["@ai-sdk/deepinfra", "@ai-sdk/cerebras"]) {
+    test(`should set the snake-case cache key for ${npm}`, () => {
+      const result = ProviderTransform.options({
+        model: { ...mockModel, providerID: "custom", api: { ...mockModel.api, npm } },
+        sessionID,
+        providerOptions: {},
+      })
+      expect(result.prompt_cache_key).toBe(sessionID)
+      expect(result.promptCacheKey).toBeUndefined()
+    })
+  }
+
+  test("should set promptCacheKey for the Mistral SDK", () => {
+    const result = ProviderTransform.options({
+      model: { ...mockModel, providerID: "custom", api: { ...mockModel.api, npm: "@ai-sdk/mistral" } },
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
+  test("should not send an undocumented OpenRouter prompt_cache_key", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        providerID: "openrouter",
+        api: { ...mockModel.api, npm: "@openrouter/ai-sdk-provider" },
+      },
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.prompt_cache_key).toBeUndefined()
   })
 })
 
@@ -719,6 +794,17 @@ describe("ProviderTransform.providerOptions", () => {
   test("forces reasoning for OpenAI package models marked reasoning-capable", () => {
     expect(ProviderTransform.providerOptions(createModel(), { store: false })).toEqual({
       openai: { forceReasoning: true, store: false },
+    })
+  })
+
+  test("uses canonical sdk key for custom xAI models", () => {
+    const model = createModel({
+      providerID: "my-xai",
+      api: { id: "grok-4", url: "https://api.x.ai", npm: "@ai-sdk/xai" },
+    })
+
+    expect(ProviderTransform.providerOptions(model, { promptCacheKey: "session" })).toEqual({
+      xai: { promptCacheKey: "session" },
     })
   })
 
@@ -3011,6 +3097,20 @@ describe("ProviderTransform.message - cache control on gateway", () => {
     })
   })
 
+  test("does not add explicit breakpoints when Anthropic automatic caching is enabled", () => {
+    const model = createModel({
+      providerID: "anthropic",
+      api: { id: "claude-sonnet-4", url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" },
+    })
+    const msgs = [
+      { role: "system", content: "You are a helpful assistant" },
+      { role: "user", content: "Hello" },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, model, { cacheControl: { type: "ephemeral" } }) as any[]
+    expect(result.every((message) => message.providerOptions === undefined)).toBe(true)
+  })
+
   test("google-vertex-anthropic applies cache control", () => {
     const model = createModel({
       providerID: "google-vertex-anthropic",
@@ -5116,6 +5216,13 @@ describe("ProviderTransform.smallOptions - gpt-5 chat/search", () => {
       expect(ProviderTransform.smallOptions(createModel(testCase.id))).toEqual(testCase.options)
     })
   }
+
+  test("includes the OpenAI cache key in small requests", () => {
+    expect(ProviderTransform.smallOptions(createModel("gpt-5-chat-latest"), "session-123")).toEqual({
+      store: false,
+      promptCacheKey: "session-123",
+    })
+  })
 })
 
 test("ProviderTransform.smallOptions preserves the weakest OpenRouter reasoning effort", () => {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -252,6 +252,21 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBeUndefined()
   })
 
+  test("should keep the Azure cache key for gpt-5.5 early return", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        providerID: "azure",
+        api: { id: "gpt-5.5", url: "https://azure.com", npm: "@ai-sdk/azure" },
+      },
+      sessionID,
+      providerOptions: {},
+    })
+    expect(result.store).toBe(false)
+    expect(result.reasoningSummary).toBe("auto")
+    expect(result.promptCacheKey).toBe(sessionID)
+  })
+
   for (const npm of ["@ai-sdk/deepinfra", "@ai-sdk/cerebras"]) {
     test(`should set the snake-case cache key for ${npm}`, () => {
       const result = ProviderTransform.options({

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -5216,13 +5216,6 @@ describe("ProviderTransform.smallOptions - gpt-5 chat/search", () => {
       expect(ProviderTransform.smallOptions(createModel(testCase.id))).toEqual(testCase.options)
     })
   }
-
-  test("includes the OpenAI cache key in small requests", () => {
-    expect(ProviderTransform.smallOptions(createModel("gpt-5-chat-latest"), "session-123")).toEqual({
-      store: false,
-      promptCacheKey: "session-123",
-    })
-  })
 })
 
 test("ProviderTransform.smallOptions preserves the weakest OpenRouter reasoning effort", () => {


### PR DESCRIPTION
## Summary

- Select prompt cache keys by AI SDK npm package instead of logical provider ID
- OpenAI / Azure / xAI / Venice / Mistral → `promptCacheKey`; DeepInfra / Cerebras → `prompt_cache_key`
- Do not send cache keys for generic openai-compatible or OpenRouter Chat Completions
- Keep gateway `caching: "auto"`; skip Anthropic explicit breakpoints when automatic `cacheControl` is set
- Map custom provider IDs to canonical SDK option namespaces

Split from #35982 (cache-key request shaping only; usage accounting and package patches deferred).
Mistral defaults may not hit the wire until the deferred SDK patch lands.

## Test plan

- [x] `bun test test/provider/transform.test.ts --test-name-pattern "setCacheKey|promptCache|prompt_cache|automatic caching|canonical sdk|azure"` in `packages/opencode`
- [x] `bun typecheck` in `packages/opencode`