### PR TITLE
fix(session): recover orphan assistant scaffolds

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1078,6 +1078,31 @@ const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
+    const finalizeAssistant = Effect.fnUntraced(function* (input: {
+      message: SessionV1.Assistant
+      error: unknown
+      aborted?: boolean
+      requireEmpty?: boolean
+    }) {
+      const stored = yield* MessageV2.get({ sessionID: input.message.sessionID, messageID: input.message.id }).pipe(
+        Effect.provideService(Database.Service, database),
+        Effect.option,
+      )
+      if (Option.isNone(stored)) return false
+      if (stored.value.info.role !== "assistant") return false
+      if (stored.value.info.time.completed) return false
+      if (input.requireEmpty && (stored.value.parts.length > 0 || stored.value.info.finish || stored.value.info.error))
+        return false
+      // finish is provider-owned; leaving it unset lets a later loop produce the missing response.
+      stored.value.info.error ??= MessageV2.fromError(input.error, {
+        providerID: stored.value.info.providerID,
+        aborted: input.aborted,
+      })
+      stored.value.info.time.completed = Date.now()
+      yield* sessions.updateMessage(stored.value.info)
+      return true
+    })
+
     const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
@@ -1092,6 +1117,29 @@ const layer = Layer.effect(
           let msgs = yield* MessageV2.filterCompactedEffect(sessionID).pipe(
             Effect.provideService(Database.Service, database),
           )
+
+          const repaired = yield* Effect.forEach(
+            msgs.filter(
+              (message): message is SessionV1.WithParts & { info: SessionV1.Assistant } =>
+                message.info.role === "assistant" &&
+                message.parts.length === 0 &&
+                !message.info.finish &&
+                !message.info.error &&
+                !message.info.time.completed,
+            ),
+            (message) =>
+              finalizeAssistant({
+                message: message.info,
+                error: new DOMException("Assistant turn was interrupted before producing output.", "AbortError"),
+                aborted: true,
+                requireEmpty: true,
+              }),
+          )
+          if (repaired.some(Boolean)) {
+            msgs = yield* MessageV2.filterCompactedEffect(sessionID).pipe(
+              Effect.provideService(Database.Service, database),
+            )
+          }
 
           const { user: lastUser, assistant: lastAssistant, finished: lastFinished, tasks } = MessageV2.latest(msgs)
 
@@ -1198,25 +1246,33 @@ const layer = Layer.effect(
             time: { created: Date.now() },
             sessionID,
           }
-          yield* sessions.updateMessage(msg)
 
-          const finalizeInterruptedAssistant = Effect.gen(function* () {
-            if (msg.time.completed) return
-            msg.error ??= MessageV2.fromError(new DOMException("Aborted", "AbortError"), {
-              providerID: msg.providerID,
-              aborted: true,
-            })
-            msg.time.completed = Date.now()
+          const finalizeFailedAssistant = (cause: Cause.Cause<never>) => {
+            const aborted = Cause.hasInterruptsOnly(cause)
+            return finalizeAssistant({
+              message: msg,
+              error: aborted ? new DOMException("Aborted", "AbortError") : Cause.squash(cause),
+              aborted,
+            }).pipe(
+              Effect.catchCause((finalizeCause) =>
+                Effect.logError("failed to finalize assistant message", {
+                  "session.id": sessionID,
+                  messageID: msg.id,
+                  error: Cause.squash(finalizeCause),
+                }),
+              ),
+              Effect.asVoid,
+            )
+          }
+
+          const handle = yield* Effect.gen(function* () {
             yield* sessions.updateMessage(msg)
-          })
-
-          const handle = yield* processor
-            .create({
+            return yield* processor.create({
               assistantMessage: msg,
               sessionID,
               model,
             })
-            .pipe(Effect.onInterrupt(() => finalizeInterruptedAssistant))
+          }).pipe(Effect.onError(finalizeFailedAssistant))
 
           const outcome: "break" | "continue" = yield* Effect.gen(function* () {
             const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
@@ -1327,10 +1383,7 @@ const layer = Layer.effect(
               })
             }
             return "continue" as const
-          }).pipe(
-            Effect.ensuring(instruction.clear(handle.message.id)),
-            Effect.onInterrupt(() => finalizeInterruptedAssistant),
-          )
+          }).pipe(Effect.ensuring(instruction.clear(handle.message.id)), Effect.onError(finalizeFailedAssistant))
           if (outcome === "break") break
           continue
         }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -163,6 +163,18 @@ const blockingProcessor = Layer.succeed(
     create: () => Effect.sync(() => processorCreateStarted.shift()?.()).pipe(Effect.andThen(Effect.never)),
   }),
 )
+const failingCreateProcessor = Layer.mock(SessionProcessor.Service, {
+  create: () => Effect.die(new Error("processor creation failed")),
+})
+const failingProcessProcessor = Layer.mock(SessionProcessor.Service, {
+  create: (input) =>
+    Effect.succeed({
+      message: input.assistantMessage,
+      updateToolCall: () => Effect.succeed(undefined),
+      completeToolCall: () => Effect.void,
+      process: () => Effect.die(new Error("processor execution failed")),
+    } satisfies SessionProcessor.Handle),
+})
 
 const runtimeFlags = RuntimeFlags.layer({ experimentalEventSystem: true })
 
@@ -208,7 +220,10 @@ const promptRoot = LayerNode.group([
   RuntimeFlags.node,
 ])
 
-function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makePrompt(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking" | "failing-create" | "failing-process"
+}) {
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
@@ -217,6 +232,12 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
   ] as const
   if (input?.processor === "blocking") {
     return LayerNode.compile(promptRoot, [...replacements, [SessionProcessor.node, blockingProcessor]])
+  }
+  if (input?.processor === "failing-create") {
+    return LayerNode.compile(promptRoot, [...replacements, [SessionProcessor.node, failingCreateProcessor]])
+  }
+  if (input?.processor === "failing-process") {
+    return LayerNode.compile(promptRoot, [...replacements, [SessionProcessor.node, failingProcessProcessor]])
   }
   return LayerNode.compile(promptRoot, replacements)
 }
@@ -235,13 +256,18 @@ function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processo
   return LayerNode.compile(root, replacements)
 }
 
-function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttpNoLLMServer(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking" | "failing-create" | "failing-process"
+}) {
   return makePrompt(input)
 }
 
 const it = testEffect(makeHttp())
 const noLLMServer = testEffect(makeHttpNoLLMServer())
 const raceNoLLMServer = testEffect(makeHttpNoLLMServer({ processor: "blocking" }))
+const failingCreateNoLLMServer = testEffect(makeHttpNoLLMServer({ processor: "failing-create" }))
+const failingProcessNoLLMServer = testEffect(makeHttpNoLLMServer({ processor: "failing-process" }))
 const withMcpInstructions = testEffect(
   makeHttp({
     mcpInstructions: [
@@ -511,6 +537,49 @@ it.instance("loop calls LLM and returns assistant message", () =>
     const parts = result.parts.filter((p) => p.type === "text")
     expect(parts.some((p) => p.type === "text" && p.text === "world")).toBe(true)
     expect(yield* llm.hits).toHaveLength(1)
+  }),
+)
+
+it.instance("loop repairs orphan assistant shell and returns a new response", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const abandoned = yield* user(chat.id, "abandoned")
+    const orphan: SessionV1.Assistant = {
+      id: MessageID.ascending(),
+      role: "assistant",
+      parentID: abandoned.id,
+      sessionID: chat.id,
+      mode: "build",
+      agent: "build",
+      cost: 0,
+      path: { cwd: "/tmp", root: "/tmp" },
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: ref.modelID,
+      providerID: ref.providerID,
+      time: { created: Date.now() },
+    }
+    yield* sessions.updateMessage(orphan)
+    const latest = yield* user(chat.id, "please continue")
+    yield* llm.text("recovered")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    const stored = yield* MessageV2.get({ sessionID: chat.id, messageID: orphan.id })
+
+    expect(yield* llm.hits).toHaveLength(1)
+    expect(result.info.id).not.toBe(orphan.id)
+    expect(result.info.role).toBe("assistant")
+    if (result.info.role === "assistant") expect(result.info.parentID).toBe(latest.id)
+    expect(result.parts).toEqual(expect.arrayContaining([expect.objectContaining({ type: "text", text: "recovered" })]))
+    expect(stored.parts).toHaveLength(0)
+    expect(stored.info.role).toBe("assistant")
+    if (stored.info.role === "assistant") {
+      expect(stored.info.finish).toBeUndefined()
+      expect(stored.info.error?.name).toBe("MessageAbortedError")
+      expect(stored.info.time.completed).toBeNumber()
+    }
   }),
 )
 
@@ -1215,6 +1284,74 @@ raceNoLLMServer.instance(
     }),
   { config: cfg },
   3_000,
+)
+
+failingCreateNoLLMServer.instance(
+  "finalizes assistant when processor creation defects",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Processor creation defect" })
+      const parent = yield* user(chat.id, "hello")
+
+      const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasDies(exit.cause)).toBe(true)
+        expect(Cause.squash(exit.cause)).toMatchObject({ message: "processor creation failed" })
+      }
+
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const assistant = messages.find(
+        (message) => message.info.role === "assistant" && message.info.parentID === parent.id,
+      )
+      expect(assistant?.parts).toHaveLength(0)
+      expect(assistant?.info.role).toBe("assistant")
+      if (assistant?.info.role === "assistant") {
+        expect(assistant.info.finish).toBeUndefined()
+        expect(assistant.info.error).toMatchObject({
+          name: "UnknownError",
+          data: { message: "processor creation failed" },
+        })
+        expect(assistant.info.time.completed).toBeNumber()
+      }
+    }),
+  { config: cfg },
+)
+
+failingProcessNoLLMServer.instance(
+  "finalizes assistant when processor execution defects",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Processor execution defect" })
+      const parent = yield* user(chat.id, "hello")
+
+      const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasDies(exit.cause)).toBe(true)
+        expect(Cause.squash(exit.cause)).toMatchObject({ message: "processor execution failed" })
+      }
+
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const assistant = messages.find(
+        (message) => message.info.role === "assistant" && message.info.parentID === parent.id,
+      )
+      expect(assistant?.parts).toHaveLength(0)
+      expect(assistant?.info.role).toBe("assistant")
+      if (assistant?.info.role === "assistant") {
+        expect(assistant.info.finish).toBeUndefined()
+        expect(assistant.info.error).toMatchObject({
+          name: "UnknownError",
+          data: { message: "processor execution failed" },
+        })
+        expect(assistant.info.time.completed).toBeNumber()
+      }
+    }),
+  { config: cfg },
 )
 
 noLLMServer.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #38425

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The prompt loop persists an assistant scaffold before processor setup. A prior interruption or a later setup defect can leave that row with no parts, error, finish, or completion timestamp.

This change marks exact historical empty scaffolds as interrupted before selecting the latest turn, then continues normally so the latest user still receives a response. It also finalizes newly persisted scaffolds on any failed Effect exit during message persistence, processor creation, or turn execution while preserving the original failure.

`finish` remains unset because it is provider-owned; this keeps interrupted scaffolds from terminating the replacement turn.

### How did you verify your code works?

- `bun test --timeout 30000 test/session/prompt.test.ts` (59 pass, 1 skip)
- `bun typecheck` from `packages/opencode`
- `bun turbo typecheck` (30 packages passed)
- `bunx prettier --check packages/opencode/src/session/prompt.ts packages/opencode/test/session/prompt.test.ts`
- `git diff --check origin/dev...HEAD`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
