### PR TITLE
feat(command): identify command sources

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -551,6 +551,7 @@ export type CommandInfo = {
   agent?: string
   model?: ModelRef
   subtask?: boolean
+  source?: "command" | "mcp"
 }
 
 export type ProviderRequest = {

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -85,6 +85,7 @@ export const layer = (options?: ShellSelect.Options) => Layer.effect(
           name: mcpCommandName(prompt.server, prompt.name),
           template: "",
           description: prompt.description,
+          source: "mcp",
         }),
       )
     })
@@ -98,7 +99,10 @@ export const layer = (options?: ShellSelect.Options) => Layer.effect(
         return (yield* mcpCommands()).find((command) => command.name === name)
       }),
       list: Effect.fn("CommandV2.list")(function* () {
-        const commands = Array.from(state.get().commands.values()) as Info[]
+        const commands = Array.from(state.get().commands.values()).map((command) => ({
+          ...command,
+          source: command.source ?? "command" as const,
+        }))
         const names = new Set(commands.map((command) => command.name))
         return [
           ...commands,

--- a/packages/core/test/command.test.ts
+++ b/packages/core/test/command.test.ts
@@ -59,6 +59,7 @@ describe("CommandV2", () => {
             providerID: ProviderV2.ID.make("anthropic"),
             variant: ModelV2.VariantID.make("high"),
           },
+          source: "command",
         }),
       ])
     }),

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -95,9 +95,10 @@ Review files`,
                 variant: ModelV2.VariantID.make("high"),
               },
               subtask: true,
+              source: "command",
             }),
-            CommandV2.Info.make({ name: "empty", template: "" }),
-            CommandV2.Info.make({ name: "nested/docs", template: "Write docs" }),
+            CommandV2.Info.make({ name: "empty", template: "", source: "command" }),
+            CommandV2.Info.make({ name: "nested/docs", template: "Write docs", source: "command" }),
           ])
 
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "commands", "review.md"), "Review again"))

--- a/packages/schema/src/command.ts
+++ b/packages/schema/src/command.ts
@@ -16,6 +16,7 @@ export const Info = Schema.Struct({
   agent: Agent.ID.pipe(optional),
   model: Model.Ref.pipe(optional),
   subtask: Schema.Boolean.pipe(optional),
+  source: Schema.Literals(["command", "mcp"]).pipe(optional),
 }).annotate({ identifier: "Command.Info" })
 
 export const Event = {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds source metadata to current command definitions so clients can distinguish commands loaded from configuration, plugins, and MCP servers. The command projection now preserves that source through overrides.

### How did you verify your code works?

- Ran the repository pre-push typecheck across all 33 configured packages.
- Ran the focused command and command-config tests: 3 passed.
- Ran the core and schema package typechecks.

### Screenshots / recordings

Not applicable; this is an API/schema change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR