### PR TITLE
feat(pty): expose shells and connect tokens

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -820,55 +820,71 @@ export interface EventApi<E = never> {
   readonly subscribe: EventSubscribeOperation<E>
 }
 
-type Endpoint20_0Request = Parameters<RawClient["server.pty"]["pty.list"]>[0]
+type Endpoint20_0Request = Parameters<RawClient["server.pty"]["pty.shells"]>[0]
 export type Endpoint20_0Input = { readonly location?: Endpoint20_0Request["query"]["location"] }
-export type Endpoint20_0Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.list"]>>
-export type PtyListOperation<E = never> = (input?: Endpoint20_0Input) => Effect.Effect<Endpoint20_0Output, E>
+export type Endpoint20_0Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.shells"]>>
+export type PtyShellsOperation<E = never> = (input?: Endpoint20_0Input) => Effect.Effect<Endpoint20_0Output, E>
 
-type Endpoint20_1Request = Parameters<RawClient["server.pty"]["pty.create"]>[0]
-export type Endpoint20_1Input = {
-  readonly location?: Endpoint20_1Request["query"]["location"]
-  readonly command?: Endpoint20_1Request["payload"]["command"]
-  readonly args?: Endpoint20_1Request["payload"]["args"]
-  readonly cwd?: Endpoint20_1Request["payload"]["cwd"]
-  readonly title?: Endpoint20_1Request["payload"]["title"]
-  readonly env?: Endpoint20_1Request["payload"]["env"]
-}
-export type Endpoint20_1Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.create"]>>
-export type PtyCreateOperation<E = never> = (input?: Endpoint20_1Input) => Effect.Effect<Endpoint20_1Output, E>
+type Endpoint20_1Request = Parameters<RawClient["server.pty"]["pty.list"]>[0]
+export type Endpoint20_1Input = { readonly location?: Endpoint20_1Request["query"]["location"] }
+export type Endpoint20_1Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.list"]>>
+export type PtyListOperation<E = never> = (input?: Endpoint20_1Input) => Effect.Effect<Endpoint20_1Output, E>
 
-type Endpoint20_2Request = Parameters<RawClient["server.pty"]["pty.get"]>[0]
+type Endpoint20_2Request = Parameters<RawClient["server.pty"]["pty.create"]>[0]
 export type Endpoint20_2Input = {
-  readonly ptyID: Endpoint20_2Request["params"]["ptyID"]
   readonly location?: Endpoint20_2Request["query"]["location"]
+  readonly command?: Endpoint20_2Request["payload"]["command"]
+  readonly args?: Endpoint20_2Request["payload"]["args"]
+  readonly cwd?: Endpoint20_2Request["payload"]["cwd"]
+  readonly title?: Endpoint20_2Request["payload"]["title"]
+  readonly env?: Endpoint20_2Request["payload"]["env"]
 }
-export type Endpoint20_2Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.get"]>>
-export type PtyGetOperation<E = never> = (input: Endpoint20_2Input) => Effect.Effect<Endpoint20_2Output, E>
+export type Endpoint20_2Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.create"]>>
+export type PtyCreateOperation<E = never> = (input?: Endpoint20_2Input) => Effect.Effect<Endpoint20_2Output, E>
 
-type Endpoint20_3Request = Parameters<RawClient["server.pty"]["pty.update"]>[0]
+type Endpoint20_3Request = Parameters<RawClient["server.pty"]["pty.get"]>[0]
 export type Endpoint20_3Input = {
   readonly ptyID: Endpoint20_3Request["params"]["ptyID"]
   readonly location?: Endpoint20_3Request["query"]["location"]
-  readonly title?: Endpoint20_3Request["payload"]["title"]
-  readonly size?: Endpoint20_3Request["payload"]["size"]
 }
-export type Endpoint20_3Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.update"]>>
-export type PtyUpdateOperation<E = never> = (input: Endpoint20_3Input) => Effect.Effect<Endpoint20_3Output, E>
+export type Endpoint20_3Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.get"]>>
+export type PtyGetOperation<E = never> = (input: Endpoint20_3Input) => Effect.Effect<Endpoint20_3Output, E>
 
-type Endpoint20_4Request = Parameters<RawClient["server.pty"]["pty.remove"]>[0]
+type Endpoint20_4Request = Parameters<RawClient["server.pty"]["pty.update"]>[0]
 export type Endpoint20_4Input = {
   readonly ptyID: Endpoint20_4Request["params"]["ptyID"]
   readonly location?: Endpoint20_4Request["query"]["location"]
+  readonly title?: Endpoint20_4Request["payload"]["title"]
+  readonly size?: Endpoint20_4Request["payload"]["size"]
 }
-export type Endpoint20_4Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.remove"]>>
-export type PtyRemoveOperation<E = never> = (input: Endpoint20_4Input) => Effect.Effect<Endpoint20_4Output, E>
+export type Endpoint20_4Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.update"]>>
+export type PtyUpdateOperation<E = never> = (input: Endpoint20_4Input) => Effect.Effect<Endpoint20_4Output, E>
+
+type Endpoint20_5Request = Parameters<RawClient["server.pty"]["pty.remove"]>[0]
+export type Endpoint20_5Input = {
+  readonly ptyID: Endpoint20_5Request["params"]["ptyID"]
+  readonly location?: Endpoint20_5Request["query"]["location"]
+}
+export type Endpoint20_5Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.remove"]>>
+export type PtyRemoveOperation<E = never> = (input: Endpoint20_5Input) => Effect.Effect<Endpoint20_5Output, E>
+
+type Endpoint20_6Request = Parameters<RawClient["server.pty"]["pty.connectToken"]>[0]
+export type Endpoint20_6Input = {
+  readonly ptyID: Endpoint20_6Request["params"]["ptyID"]
+  readonly location?: Endpoint20_6Request["query"]["location"]
+  readonly "x-opencode-ticket"?: Endpoint20_6Request["headers"]["x-opencode-ticket"]
+}
+export type Endpoint20_6Output = EffectValue<ReturnType<RawClient["server.pty"]["pty.connectToken"]>>
+export type PtyConnectTokenOperation<E = never> = (input: Endpoint20_6Input) => Effect.Effect<Endpoint20_6Output, E>
 
 export interface PtyApi<E = never> {
+  readonly shells: PtyShellsOperation<E>
   readonly list: PtyListOperation<E>
   readonly create: PtyCreateOperation<E>
   readonly get: PtyGetOperation<E>
   readonly update: PtyUpdateOperation<E>
   readonly remove: PtyRemoveOperation<E>
+  readonly connectToken: PtyConnectTokenOperation<E>
 }
 
 type Endpoint21_0Request = Parameters<RawClient["server.shell"]["shell.list"]>[0]

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -977,21 +977,26 @@ const Endpoint19_0 = (raw: RawClient["server.event"]) => () =>
 
 const adaptGroup19 = (raw: RawClient["server.event"]) => ({ subscribe: Endpoint19_0(raw) })
 
-type Endpoint20_0Request = Parameters<RawClient["server.pty"]["pty.list"]>[0]
+type Endpoint20_0Request = Parameters<RawClient["server.pty"]["pty.shells"]>[0]
 type Endpoint20_0Input = { readonly location?: Endpoint20_0Request["query"]["location"] }
 const Endpoint20_0 = (raw: RawClient["server.pty"]) => (input?: Endpoint20_0Input) =>
+  raw["pty.shells"]({ query: { location: input?.["location"] } }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint20_1Request = Parameters<RawClient["server.pty"]["pty.list"]>[0]
+type Endpoint20_1Input = { readonly location?: Endpoint20_1Request["query"]["location"] }
+const Endpoint20_1 = (raw: RawClient["server.pty"]) => (input?: Endpoint20_1Input) =>
   raw["pty.list"]({ query: { location: input?.["location"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint20_1Request = Parameters<RawClient["server.pty"]["pty.create"]>[0]
-type Endpoint20_1Input = {
-  readonly location?: Endpoint20_1Request["query"]["location"]
-  readonly command?: Endpoint20_1Request["payload"]["command"]
-  readonly args?: Endpoint20_1Request["payload"]["args"]
-  readonly cwd?: Endpoint20_1Request["payload"]["cwd"]
-  readonly title?: Endpoint20_1Request["payload"]["title"]
-  readonly env?: Endpoint20_1Request["payload"]["env"]
+type Endpoint20_2Request = Parameters<RawClient["server.pty"]["pty.create"]>[0]
+type Endpoint20_2Input = {
+  readonly location?: Endpoint20_2Request["query"]["location"]
+  readonly command?: Endpoint20_2Request["payload"]["command"]
+  readonly args?: Endpoint20_2Request["payload"]["args"]
+  readonly cwd?: Endpoint20_2Request["payload"]["cwd"]
+  readonly title?: Endpoint20_2Request["payload"]["title"]
+  readonly env?: Endpoint20_2Request["payload"]["env"]
 }
-const Endpoint20_1 = (raw: RawClient["server.pty"]) => (input?: Endpoint20_1Input) =>
+const Endpoint20_2 = (raw: RawClient["server.pty"]) => (input?: Endpoint20_2Input) =>
   raw["pty.create"]({
     query: { location: input?.["location"] },
     payload: {
@@ -1003,46 +1008,61 @@ const Endpoint20_1 = (raw: RawClient["server.pty"]) => (input?: Endpoint20_1Inpu
     },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint20_2Request = Parameters<RawClient["server.pty"]["pty.get"]>[0]
-type Endpoint20_2Input = {
-  readonly ptyID: Endpoint20_2Request["params"]["ptyID"]
-  readonly location?: Endpoint20_2Request["query"]["location"]
+type Endpoint20_3Request = Parameters<RawClient["server.pty"]["pty.get"]>[0]
+type Endpoint20_3Input = {
+  readonly ptyID: Endpoint20_3Request["params"]["ptyID"]
+  readonly location?: Endpoint20_3Request["query"]["location"]
 }
-const Endpoint20_2 = (raw: RawClient["server.pty"]) => (input: Endpoint20_2Input) =>
+const Endpoint20_3 = (raw: RawClient["server.pty"]) => (input: Endpoint20_3Input) =>
   raw["pty.get"]({ params: { ptyID: input["ptyID"] }, query: { location: input["location"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
-type Endpoint20_3Request = Parameters<RawClient["server.pty"]["pty.update"]>[0]
-type Endpoint20_3Input = {
-  readonly ptyID: Endpoint20_3Request["params"]["ptyID"]
-  readonly location?: Endpoint20_3Request["query"]["location"]
-  readonly title?: Endpoint20_3Request["payload"]["title"]
-  readonly size?: Endpoint20_3Request["payload"]["size"]
+type Endpoint20_4Request = Parameters<RawClient["server.pty"]["pty.update"]>[0]
+type Endpoint20_4Input = {
+  readonly ptyID: Endpoint20_4Request["params"]["ptyID"]
+  readonly location?: Endpoint20_4Request["query"]["location"]
+  readonly title?: Endpoint20_4Request["payload"]["title"]
+  readonly size?: Endpoint20_4Request["payload"]["size"]
 }
-const Endpoint20_3 = (raw: RawClient["server.pty"]) => (input: Endpoint20_3Input) =>
+const Endpoint20_4 = (raw: RawClient["server.pty"]) => (input: Endpoint20_4Input) =>
   raw["pty.update"]({
     params: { ptyID: input["ptyID"] },
     query: { location: input["location"] },
     payload: { title: input["title"], size: input["size"] },
   }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint20_4Request = Parameters<RawClient["server.pty"]["pty.remove"]>[0]
-type Endpoint20_4Input = {
-  readonly ptyID: Endpoint20_4Request["params"]["ptyID"]
-  readonly location?: Endpoint20_4Request["query"]["location"]
+type Endpoint20_5Request = Parameters<RawClient["server.pty"]["pty.remove"]>[0]
+type Endpoint20_5Input = {
+  readonly ptyID: Endpoint20_5Request["params"]["ptyID"]
+  readonly location?: Endpoint20_5Request["query"]["location"]
 }
-const Endpoint20_4 = (raw: RawClient["server.pty"]) => (input: Endpoint20_4Input) =>
+const Endpoint20_5 = (raw: RawClient["server.pty"]) => (input: Endpoint20_5Input) =>
   raw["pty.remove"]({ params: { ptyID: input["ptyID"] }, query: { location: input["location"] } }).pipe(
     Effect.mapError(mapClientError),
   )
 
+type Endpoint20_6Request = Parameters<RawClient["server.pty"]["pty.connectToken"]>[0]
+type Endpoint20_6Input = {
+  readonly ptyID: Endpoint20_6Request["params"]["ptyID"]
+  readonly location?: Endpoint20_6Request["query"]["location"]
+  readonly "x-opencode-ticket"?: Endpoint20_6Request["headers"]["x-opencode-ticket"]
+}
+const Endpoint20_6 = (raw: RawClient["server.pty"]) => (input: Endpoint20_6Input) =>
+  raw["pty.connectToken"]({
+    params: { ptyID: input["ptyID"] },
+    query: { location: input["location"] },
+    headers: { "x-opencode-ticket": input["x-opencode-ticket"] },
+  }).pipe(Effect.mapError(mapClientError))
+
 const adaptGroup20 = (raw: RawClient["server.pty"]) => ({
-  list: Endpoint20_0(raw),
-  create: Endpoint20_1(raw),
-  get: Endpoint20_2(raw),
-  update: Endpoint20_3(raw),
-  remove: Endpoint20_4(raw),
+  shells: Endpoint20_0(raw),
+  list: Endpoint20_1(raw),
+  create: Endpoint20_2(raw),
+  get: Endpoint20_3(raw),
+  update: Endpoint20_4(raw),
+  remove: Endpoint20_5(raw),
+  connectToken: Endpoint20_6(raw),
 })
 
 type Endpoint21_0Request = Parameters<RawClient["server.shell"]["shell.list"]>[0]

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -162,6 +162,8 @@ import type {
   SkillListInput,
   SkillListOutput,
   EventSubscribeOutput,
+  PtyShellsInput,
+  PtyShellsOutput,
   PtyListInput,
   PtyListOutput,
   PtyCreateInput,
@@ -172,6 +174,8 @@ import type {
   PtyUpdateOutput,
   PtyRemoveInput,
   PtyRemoveOutput,
+  PtyConnectTokenInput,
+  PtyConnectTokenOutput,
   ShellListInput,
   ShellListOutput,
   ShellCreateInput,
@@ -1430,6 +1434,18 @@ export function make(options: ClientOptions) {
         ),
     },
     pty: {
+      shells: (input?: PtyShellsInput, requestOptions?: RequestOptions) =>
+        request<PtyShellsOutput>(
+          {
+            method: "GET",
+            path: `/api/pty/shells`,
+            query: { location: input?.["location"] },
+            successStatus: 200,
+            declaredStatuses: [401, 400],
+            empty: false,
+          },
+          requestOptions,
+        ),
       list: (input?: PtyListInput, requestOptions?: RequestOptions) =>
         request<PtyListOutput>(
           {
@@ -1495,6 +1511,19 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [404, 401, 400],
             empty: true,
+          },
+          requestOptions,
+        ),
+      connectToken: (input: PtyConnectTokenInput, requestOptions?: RequestOptions) =>
+        request<PtyConnectTokenOutput>(
+          {
+            method: "POST",
+            path: `/api/pty/${encodeURIComponent(input.ptyID)}/connect-token`,
+            query: { location: input["location"] },
+            headers: { "x-opencode-ticket": input["x-opencode-ticket"] },
+            successStatus: 200,
+            declaredStatuses: [403, 404, 401, 400],
+            empty: false,
           },
           requestOptions,
         ),

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -501,6 +501,10 @@ export type QuestionTool = { messageID: string; callID: string }
 
 export type QuestionAnswer = Array<string>
 
+export type PtyShell = { path: string; name: string; acceptable: boolean }
+
+export type PtyTicketConnectToken = { ticket: string; expires_in: number }
+
 export type ShellInfo1 = {
   id: string
   status: "running" | "exited" | "timeout" | "killed"
@@ -2529,6 +2533,10 @@ export const isPermissionNotFoundError = (value: unknown): value is PermissionNo
 export type PtyNotFoundError = { readonly _tag: "PtyNotFoundError"; readonly ptyID: string; readonly message: string }
 export const isPtyNotFoundError = (value: unknown): value is PtyNotFoundError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "PtyNotFoundError"
+
+export type ForbiddenError = { readonly _tag: "ForbiddenError"; readonly message: string }
+export const isForbiddenError = (value: unknown): value is ForbiddenError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "ForbiddenError"
 
 export type ShellNotFoundError = { readonly _tag: "ShellNotFoundError"; readonly id: string; readonly message: string }
 export const isShellNotFoundError = (value: unknown): value is ShellNotFoundError =>
@@ -4649,6 +4657,17 @@ export type SkillListOutput = {
 
 export type EventSubscribeOutput = V2Event
 
+export type PtyShellsInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+}
+
+export type PtyShellsOutput = {
+  location: { directory: string; workspaceID?: string; project: { id: string; directory: string } }
+  data: Array<PtyShell>
+}
+
 export type PtyListInput = {
   readonly location?: {
     readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
@@ -4743,6 +4762,19 @@ export type PtyRemoveInput = {
 }
 
 export type PtyRemoveOutput = void
+
+export type PtyConnectTokenInput = {
+  readonly ptyID: { readonly ptyID: string }["ptyID"]
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly "x-opencode-ticket"?: { readonly "x-opencode-ticket"?: string | undefined }["x-opencode-ticket"]
+}
+
+export type PtyConnectTokenOutput = {
+  location: { directory: string; workspaceID?: string; project: { id: string; directory: string } }
+  data: PtyTicketConnectToken
+}
 
 export type ShellListInput = {
   readonly location?: {

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -44,9 +44,36 @@ test("exposes every standard HTTP API group", () => {
   expect(Object.keys(client.integration.command)).toEqual(["connect", "status", "cancel"])
   expect(Object.keys(client.file)).toEqual(["read", "list", "find"])
   expect(Object.keys(client.vcs)).toEqual(["status", "diff"])
-  expect(Object.keys(client.pty)).toEqual(["list", "create", "get", "update", "remove"])
+  expect(Object.keys(client.pty)).toEqual(["shells", "list", "create", "get", "update", "remove", "connectToken"])
   expect(Object.keys(client.shell)).toEqual(["list", "create", "get", "timeout", "output", "remove"])
   expect(Object.keys(client.project)).toEqual(["list", "current", "directories"])
+})
+
+test("PTY connect token sends the required browser header", async () => {
+  let request: Request | undefined
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: async (input, init) => {
+      request = input instanceof Request ? input : new Request(input, init)
+      return Response.json({
+        location: { directory: "/tmp/project", project: { id: "proj_test", directory: "/tmp/project" } },
+        data: { ticket: "ticket", expires_in: 60 },
+      })
+    },
+  })
+
+  const result = await client.pty.connectToken({
+    ptyID: "pty_test",
+    location: { directory: "/tmp/project" },
+    "x-opencode-ticket": "1",
+  })
+
+  expect(result.data.ticket).toBe("ticket")
+  expect(request?.method).toBe("POST")
+  expect(request?.headers.get("x-opencode-ticket")).toBe("1")
+  expect(request?.url).toBe(
+    "http://localhost:3000/api/pty/pty_test/connect-token?location%5Bdirectory%5D=%2Ftmp%2Fproject",
+  )
 })
 
 test("server.get uses the public HTTP contract", async () => {

--- a/packages/core/src/pty.ts
+++ b/packages/core/src/pty.ts
@@ -78,6 +78,7 @@ export class ExitedError extends Schema.TaggedErrorClass<ExitedError>()("Pty.Exi
 }) {}
 
 export interface Interface {
+  readonly shells: () => Effect.Effect<ReadonlyArray<Pty.Shell>>
   readonly list: () => Effect.Effect<Info[]>
   readonly get: (id: PtyID) => Effect.Effect<Info, NotFoundError>
   readonly create: (input: CreateInput) => Effect.Effect<Info>
@@ -156,6 +157,10 @@ export const layer = (options?: ShellSelect.Options) => Layer.effect(
 
     const list = Effect.fn("Pty.list")(function* () {
       return Array.from(sessions.values()).map((session) => session.info)
+    })
+
+    const shells = Effect.fn("Pty.shells")(function* () {
+      return yield* Effect.promise(() => ShellSelect.list(options))
     })
 
     const get = Effect.fn("Pty.get")(function* (id: PtyID) {
@@ -309,7 +314,7 @@ export const layer = (options?: ShellSelect.Options) => Layer.effect(
       }
     })
 
-    return Service.of({ list, get, create, update, remove, write, attach })
+    return Service.of({ shells, list, get, create, update, remove, write, attach })
   }),
 )
 

--- a/packages/core/test/pty/pty-session.test.ts
+++ b/packages/core/test/pty/pty-session.test.ts
@@ -90,6 +90,18 @@ const waitForOutput = (output: Queue.Queue<string>, text: string) =>
     }),
   )
 
+describe("Pty.shells", () => {
+  it.live("lists available shells", () =>
+    Effect.gen(function* () {
+      const pty = yield* Pty.Service
+      const shells = yield* pty.shells()
+
+      expect(shells.length).toBeGreaterThan(0)
+      expect(shells.every((shell) => shell.path && shell.name && typeof shell.acceptable === "boolean")).toBe(true)
+    }),
+  )
+})
+
 describe("pty", () => {
   it.live("returns typed not found errors for missing sessions", () =>
     Effect.gen(function* () {

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -63,5 +63,5 @@ export const groupNames = {
   "server.path": "path",
 } as const
 
-export const promiseOmitEndpoints = new Set(["pty.connect", "pty.connectToken"])
-export const effectOmitEndpoints = new Set(["fs.read", "pty.connect", "pty.connectToken"])
+export const promiseOmitEndpoints = new Set(["pty.connect"])
+export const effectOmitEndpoints = new Set(["fs.read", "pty.connect"])

--- a/packages/protocol/src/groups/pty.ts
+++ b/packages/protocol/src/groups/pty.ts
@@ -20,6 +20,20 @@ export function hasPtyConnectTicketURL(url: URL) {
 
 export const PtyGroup = HttpApiGroup.make("server.pty")
   .add(
+    HttpApiEndpoint.get("pty.shells", "/api/pty/shells", {
+      query: LocationQuery,
+      success: Location.response(Schema.Array(Pty.Shell)),
+    })
+      .annotateMerge(locationQueryOpenApi)
+      .annotateMerge(
+        OpenApi.annotations({
+          identifier: "v2.pty.shells",
+          summary: "List available shells",
+          description: "List shells available for interactive terminal sessions.",
+        }),
+      ),
+  )
+  .add(
     HttpApiEndpoint.get("pty.list", "/api/pty", {
       query: LocationQuery,
       success: Location.response(Schema.Array(Pty.Info)),
@@ -101,13 +115,14 @@ export const PtyGroup = HttpApiGroup.make("server.pty")
     HttpApiEndpoint.post("pty.connectToken", "/api/pty/:ptyID/connect-token", {
       params: { ptyID: Pty.ID },
       query: LocationQuery,
+      headers: Schema.Struct({ [PTY_CONNECT_TOKEN_HEADER]: Schema.optional(Schema.String) }),
       success: Location.response(PtyTicket.ConnectToken),
       error: [ForbiddenError, PtyNotFoundError],
     })
       .annotateMerge(locationQueryOpenApi)
       .annotateMerge(
         OpenApi.annotations({
-          identifier: "v2.pty.connect.token",
+          identifier: "v2.pty.connectToken",
           summary: "Create PTY WebSocket token",
           description: "Create a short-lived single-use ticket for opening a PTY WebSocket connection.",
         }),

--- a/packages/schema/src/pty.ts
+++ b/packages/schema/src/pty.ts
@@ -56,3 +56,10 @@ export const UpdateInput = Schema.Struct({
   ),
 })
 export interface UpdateInput extends Schema.Schema.Type<typeof UpdateInput> {}
+
+export const Shell = Schema.Struct({
+  path: Schema.String,
+  name: Schema.String,
+  acceptable: Schema.Boolean,
+}).annotate({ identifier: "Pty.Shell" })
+export interface Shell extends Schema.Schema.Type<typeof Shell> {}

--- a/packages/server/src/handlers/pty.ts
+++ b/packages/server/src/handlers/pty.ts
@@ -30,6 +30,13 @@ export const PtyHandler = HttpApiBuilder.group(Api, "server.pty", (handlers) =>
 
     return handlers
       .handle(
+        "pty.shells",
+        Effect.fn(function* () {
+          const pty = yield* Pty.Service
+          return yield* response(pty.shells())
+        }),
+      )
+      .handle(
         "pty.list",
         Effect.fn(function* () {
           const pty = yield* Pty.Service


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds current API support for listing available shells and issuing short-lived PTY connection tokens. This lets clients establish authenticated terminal WebSocket connections without relying on legacy PTY routes.

### How did you verify your code works?

- Ran the repository pre-push typecheck across all 33 configured tasks.
- Ran focused typechecks for core, schema, protocol, server, and client.

### Screenshots / recordings

Not applicable; this is an API change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR