### PR TITLE
feat(project): support project metadata updates

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -620,21 +620,32 @@ export interface CredentialApi<E = never> {
 export type Endpoint13_0Output = EffectValue<ReturnType<RawClient["server.project"]["project.list"]>>
 export type ProjectListOperation<E = never> = () => Effect.Effect<Endpoint13_0Output, E>
 
-type Endpoint13_1Request = Parameters<RawClient["server.project"]["project.current"]>[0]
-export type Endpoint13_1Input = { readonly location?: Endpoint13_1Request["query"]["location"] }
-export type Endpoint13_1Output = EffectValue<ReturnType<RawClient["server.project"]["project.current"]>>
-export type ProjectCurrentOperation<E = never> = (input?: Endpoint13_1Input) => Effect.Effect<Endpoint13_1Output, E>
-
-type Endpoint13_2Request = Parameters<RawClient["server.project"]["project.directories"]>[0]
-export type Endpoint13_2Input = {
-  readonly projectID: Endpoint13_2Request["params"]["projectID"]
-  readonly location?: Endpoint13_2Request["query"]["location"]
+type Endpoint13_1Request = Parameters<RawClient["server.project"]["project.update"]>[0]
+export type Endpoint13_1Input = {
+  readonly projectID: Endpoint13_1Request["params"]["projectID"]
+  readonly name?: Endpoint13_1Request["payload"]["name"]
+  readonly icon?: Endpoint13_1Request["payload"]["icon"]
+  readonly commands?: Endpoint13_1Request["payload"]["commands"]
 }
-export type Endpoint13_2Output = EffectValue<ReturnType<RawClient["server.project"]["project.directories"]>>
-export type ProjectDirectoriesOperation<E = never> = (input: Endpoint13_2Input) => Effect.Effect<Endpoint13_2Output, E>
+export type Endpoint13_1Output = EffectValue<ReturnType<RawClient["server.project"]["project.update"]>>
+export type ProjectUpdateOperation<E = never> = (input: Endpoint13_1Input) => Effect.Effect<Endpoint13_1Output, E>
+
+type Endpoint13_2Request = Parameters<RawClient["server.project"]["project.current"]>[0]
+export type Endpoint13_2Input = { readonly location?: Endpoint13_2Request["query"]["location"] }
+export type Endpoint13_2Output = EffectValue<ReturnType<RawClient["server.project"]["project.current"]>>
+export type ProjectCurrentOperation<E = never> = (input?: Endpoint13_2Input) => Effect.Effect<Endpoint13_2Output, E>
+
+type Endpoint13_3Request = Parameters<RawClient["server.project"]["project.directories"]>[0]
+export type Endpoint13_3Input = {
+  readonly projectID: Endpoint13_3Request["params"]["projectID"]
+  readonly location?: Endpoint13_3Request["query"]["location"]
+}
+export type Endpoint13_3Output = EffectValue<ReturnType<RawClient["server.project"]["project.directories"]>>
+export type ProjectDirectoriesOperation<E = never> = (input: Endpoint13_3Input) => Effect.Effect<Endpoint13_3Output, E>
 
 export interface ProjectApi<E = never> {
   readonly list: ProjectListOperation<E>
+  readonly update: ProjectUpdateOperation<E>
   readonly current: ProjectCurrentOperation<E>
   readonly directories: ProjectDirectoriesOperation<E>
 }

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -742,17 +742,30 @@ const adaptGroup12 = (raw: RawClient["server.credential"]) => ({ update: Endpoin
 const Endpoint13_0 = (raw: RawClient["server.project"]) => () =>
   raw["project.list"]({}).pipe(Effect.mapError(mapClientError))
 
-type Endpoint13_1Request = Parameters<RawClient["server.project"]["project.current"]>[0]
-type Endpoint13_1Input = { readonly location?: Endpoint13_1Request["query"]["location"] }
-const Endpoint13_1 = (raw: RawClient["server.project"]) => (input?: Endpoint13_1Input) =>
+type Endpoint13_1Request = Parameters<RawClient["server.project"]["project.update"]>[0]
+type Endpoint13_1Input = {
+  readonly projectID: Endpoint13_1Request["params"]["projectID"]
+  readonly name?: Endpoint13_1Request["payload"]["name"]
+  readonly icon?: Endpoint13_1Request["payload"]["icon"]
+  readonly commands?: Endpoint13_1Request["payload"]["commands"]
+}
+const Endpoint13_1 = (raw: RawClient["server.project"]) => (input: Endpoint13_1Input) =>
+  raw["project.update"]({
+    params: { projectID: input["projectID"] },
+    payload: { name: input["name"], icon: input["icon"], commands: input["commands"] },
+  }).pipe(Effect.mapError(mapClientError))
+
+type Endpoint13_2Request = Parameters<RawClient["server.project"]["project.current"]>[0]
+type Endpoint13_2Input = { readonly location?: Endpoint13_2Request["query"]["location"] }
+const Endpoint13_2 = (raw: RawClient["server.project"]) => (input?: Endpoint13_2Input) =>
   raw["project.current"]({ query: { location: input?.["location"] } }).pipe(Effect.mapError(mapClientError))
 
-type Endpoint13_2Request = Parameters<RawClient["server.project"]["project.directories"]>[0]
-type Endpoint13_2Input = {
-  readonly projectID: Endpoint13_2Request["params"]["projectID"]
-  readonly location?: Endpoint13_2Request["query"]["location"]
+type Endpoint13_3Request = Parameters<RawClient["server.project"]["project.directories"]>[0]
+type Endpoint13_3Input = {
+  readonly projectID: Endpoint13_3Request["params"]["projectID"]
+  readonly location?: Endpoint13_3Request["query"]["location"]
 }
-const Endpoint13_2 = (raw: RawClient["server.project"]) => (input: Endpoint13_2Input) =>
+const Endpoint13_3 = (raw: RawClient["server.project"]) => (input: Endpoint13_3Input) =>
   raw["project.directories"]({
     params: { projectID: input["projectID"] },
     query: { location: input["location"] },
@@ -760,8 +773,9 @@ const Endpoint13_2 = (raw: RawClient["server.project"]) => (input: Endpoint13_2I
 
 const adaptGroup13 = (raw: RawClient["server.project"]) => ({
   list: Endpoint13_0(raw),
-  current: Endpoint13_1(raw),
-  directories: Endpoint13_2(raw),
+  update: Endpoint13_1(raw),
+  current: Endpoint13_2(raw),
+  directories: Endpoint13_3(raw),
 })
 
 type Endpoint14_0Request = Parameters<RawClient["server.form"]["form.request.list"]>[0]

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -121,6 +121,8 @@ import type {
   CredentialRemoveInput,
   CredentialRemoveOutput,
   ProjectListOutput,
+  ProjectUpdateInput,
+  ProjectUpdateOutput,
   ProjectCurrentInput,
   ProjectCurrentOutput,
   ProjectDirectoriesInput,
@@ -1168,6 +1170,18 @@ export function make(options: ClientOptions) {
       list: (requestOptions?: RequestOptions) =>
         request<ProjectListOutput>(
           { method: "GET", path: `/api/project`, successStatus: 200, declaredStatuses: [401, 400], empty: false },
+          requestOptions,
+        ),
+      update: (input: ProjectUpdateInput, requestOptions?: RequestOptions) =>
+        request<ProjectUpdateOutput>(
+          {
+            method: "PATCH",
+            path: `/api/project/${encodeURIComponent(input.projectID)}`,
+            body: { name: input["name"], icon: input["icon"], commands: input["commands"] },
+            successStatus: 200,
+            declaredStatuses: [404, 401, 400],
+            empty: false,
+          },
           requestOptions,
         ),
       current: (input?: ProjectCurrentInput, requestOptions?: RequestOptions) =>

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -2516,6 +2516,14 @@ export type McpServerNotFoundError = {
 export const isMcpServerNotFoundError = (value: unknown): value is McpServerNotFoundError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "McpServerNotFoundError"
 
+export type ProjectNotFoundError = {
+  readonly _tag: "ProjectNotFoundError"
+  readonly projectID: string
+  readonly message: string
+}
+export const isProjectNotFoundError = (value: unknown): value is ProjectNotFoundError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "ProjectNotFoundError"
+
 export type FormNotFoundError = { readonly _tag: "FormNotFoundError"; readonly id: string; readonly message: string }
 export const isFormNotFoundError = (value: unknown): value is FormNotFoundError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "FormNotFoundError"
@@ -3612,6 +3620,27 @@ export type CredentialRemoveInput = {
 export type CredentialRemoveOutput = void
 
 export type ProjectListOutput = Array<Project>
+
+export type ProjectUpdateInput = {
+  readonly projectID: { readonly projectID: string }["projectID"]
+  readonly name?: {
+    readonly name?: string
+    readonly icon?: { readonly url?: string; readonly override?: string; readonly color?: string }
+    readonly commands?: { readonly start?: string }
+  }["name"]
+  readonly icon?: {
+    readonly name?: string
+    readonly icon?: { readonly url?: string; readonly override?: string; readonly color?: string }
+    readonly commands?: { readonly start?: string }
+  }["icon"]
+  readonly commands?: {
+    readonly name?: string
+    readonly icon?: { readonly url?: string; readonly override?: string; readonly color?: string }
+    readonly commands?: { readonly start?: string }
+  }["commands"]
+}
+
+export type ProjectUpdateOutput = Project
 
 export type ProjectCurrentInput = {
   readonly location?: {

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -46,7 +46,7 @@ test("exposes every standard HTTP API group", () => {
   expect(Object.keys(client.vcs)).toEqual(["get", "status", "diff"])
   expect(Object.keys(client.pty)).toEqual(["shells", "list", "create", "get", "update", "remove", "connectToken"])
   expect(Object.keys(client.shell)).toEqual(["list", "create", "get", "timeout", "output", "remove"])
-  expect(Object.keys(client.project)).toEqual(["list", "current", "directories"])
+  expect(Object.keys(client.project)).toEqual(["list", "update", "current", "directories"])
 })
 
 test("PTY connect token sends the required browser header", async () => {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -3,7 +3,7 @@ export * as Project from "./project"
 
 import { Context, Effect, Layer, Schema } from "effect"
 import { ChildProcess } from "effect/unstable/process"
-import { asc, desc } from "drizzle-orm"
+import { asc, desc, eq } from "drizzle-orm"
 import path from "path"
 import { AbsolutePath } from "./schema"
 import { Database } from "./database/database"
@@ -37,6 +37,13 @@ export type DirectoriesInput = typeof DirectoriesInput.Type
 export const Directories = ProjectSchema.Directories
 export type Directories = typeof Directories.Type
 
+export const UpdateInput = ProjectSchema.UpdateInput
+export type UpdateInput = typeof UpdateInput.Type
+
+export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("Project.NotFoundError", {
+  projectID: ID,
+}) {}
+
 export interface Resolved {
   readonly previous?: ID
   readonly id: ID
@@ -58,6 +65,7 @@ export const root = Effect.fn("Project.root")(function* (
 export interface Interface {
   readonly list: () => Effect.Effect<ReadonlyArray<Info>>
   readonly directories: (input: DirectoriesInput) => Effect.Effect<Directories>
+  readonly update: (projectID: ID, input: UpdateInput) => Effect.Effect<Info, NotFoundError>
   readonly resolve: (input: AbsolutePath) => Effect.Effect<Resolved>
   /**
    * Temporary bridge method for writing the resolved project ID to the repo-local cache.
@@ -119,6 +127,25 @@ const layer = Layer.effect(
 
     const directories = Effect.fn("Project.directories")(function* (input: DirectoriesInput) {
       return yield* projectDirectories.list(input.projectID)
+    })
+
+    const update = Effect.fn("Project.update")(function* (projectID: ID, input: UpdateInput) {
+      const row = yield* db
+        .update(ProjectTable)
+        .set({
+          name: input.name,
+          icon_url: input.icon?.url,
+          icon_url_override: input.icon?.override,
+          icon_color: input.icon?.color,
+          commands: input.commands,
+          time_updated: Date.now(),
+        })
+        .where(eq(ProjectTable.id, projectID))
+        .returning()
+        .get()
+        .pipe(Effect.orDie)
+      if (!row) return yield* new NotFoundError({ projectID })
+      return fromRow(row)
     })
 
     const cached = Effect.fnUntraced(function* (dir: string) {
@@ -229,7 +256,7 @@ const layer = Layer.effect(
       yield* fs.writeFileString(path.join(input.store, "opencode"), input.id).pipe(Effect.ignore)
     })
 
-    return Service.of({ list, directories, resolve, commit })
+    return Service.of({ list, directories, update, resolve, commit })
   }),
 )
 

--- a/packages/core/src/project/schema.ts
+++ b/packages/core/src/project/schema.ts
@@ -22,6 +22,9 @@ export type DirectoriesInput = typeof DirectoriesInput.Type
 export const Directories = Project.Directories
 export type Directories = typeof Directories.Type
 
+export const UpdateInput = Project.UpdateInput
+export type UpdateInput = typeof UpdateInput.Type
+
 export const Vcs = Schema.Union([
   Schema.Struct({
     type: Schema.Literal("git"),

--- a/packages/core/test/effect/layer-node/node-build.test.ts
+++ b/packages/core/test/effect/layer-node/node-build.test.ts
@@ -79,6 +79,7 @@ describe("node build", () => {
         return Project.Service.of({
           list: () => Effect.succeed([]),
           directories: () => Effect.succeed([]),
+          update: () => Effect.die("unused"),
           resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory }),
           commit: () => Effect.void,
         })

--- a/packages/core/test/location.test.ts
+++ b/packages/core/test/location.test.ts
@@ -14,6 +14,7 @@ const projectLayer = Layer.succeed(
   Project.Service.of({
     list: () => Effect.succeed([]),
     directories: () => Effect.succeed([]),
+    update: () => Effect.die("unused"),
     resolve: () =>
       Effect.succeed({
         id: Project.ID.make("project"),

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -66,6 +66,31 @@ describe("ProjectV2.list", () => {
   )
 })
 
+describe("ProjectV2.update", () => {
+  it.effect("updates project metadata", () =>
+    Effect.gen(function* () {
+      const db = (yield* Database.Service).db
+      const project = yield* ProjectV2.Service
+      const id = ProjectV2.ID.make("updated")
+      yield* db
+        .insert(ProjectTable)
+        .values({ id, worktree: abs("/updated"), sandboxes: [], time_created: 1, time_updated: 1 })
+        .run()
+
+      const result = yield* project.update(id, {
+        name: "Updated",
+        icon: { color: "#ffffff" },
+        commands: { start: "bun dev" },
+      })
+
+      expect(result.name).toBe("Updated")
+      expect(result.icon).toEqual({ color: "#ffffff" })
+      expect(result.commands).toEqual({ start: "bun dev" })
+      expect(result.time.updated).toBeGreaterThan(1)
+    }),
+  )
+})
+
 function remoteID(remote: string) {
   return ProjectV2.ID.make(Hash.fast(`git-remote:${remote}`))
 }

--- a/packages/core/test/session-compact.test.ts
+++ b/packages/core/test/session-compact.test.ts
@@ -36,6 +36,7 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: ProjectV2.ID.global, directory }),
     directories: () => Effect.succeed([]),
+    update: () => Effect.die("unused"),
     commit: () => Effect.void,
   }),
 )

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -34,6 +34,7 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: ProjectV2.ID.global, directory }),
     directories: () => Effect.succeed([]),
+    update: () => Effect.die("unused"),
     commit: () => Effect.void,
   }),
 )

--- a/packages/core/test/session-instructions.test.ts
+++ b/packages/core/test/session-instructions.test.ts
@@ -57,6 +57,7 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: ProjectV2.ID.global, directory }),
     directories: () => Effect.succeed([]),
+    update: () => Effect.die("unused"),
     commit: () => Effect.void,
   }),
 )

--- a/packages/core/test/session-log.test.ts
+++ b/packages/core/test/session-log.test.ts
@@ -22,6 +22,7 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: ProjectV2.ID.global, directory }),
     directories: () => Effect.succeed([]),
+    update: () => Effect.die("unused"),
     commit: () => Effect.void,
   }),
 )

--- a/packages/core/test/session-remove.test.ts
+++ b/packages/core/test/session-remove.test.ts
@@ -19,6 +19,7 @@ const projects = Layer.succeed(
     list: () => Effect.succeed([]),
     resolve: (directory) => Effect.succeed({ id: ProjectV2.ID.global, directory }),
     directories: () => Effect.succeed([]),
+    update: () => Effect.die("unused"),
     commit: () => Effect.void,
   }),
 )

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect"
 import { Skill } from "@opencode-ai/schema/skill"
+import { Project } from "@opencode-ai/schema/project"
 
 export class InvalidRequestError extends Schema.TaggedErrorClass<InvalidRequestError>()(
   "InvalidRequestError",
@@ -57,6 +58,15 @@ export class ProviderNotFoundError extends Schema.TaggedErrorClass<ProviderNotFo
   "ProviderNotFoundError",
   {
     providerID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
+export class ProjectNotFoundError extends Schema.TaggedErrorClass<ProjectNotFoundError>()(
+  "ProjectNotFoundError",
+  {
+    projectID: Project.ID,
     message: Schema.String,
   },
   { httpApiStatus: 404 },

--- a/packages/protocol/src/groups/project.ts
+++ b/packages/protocol/src/groups/project.ts
@@ -2,6 +2,7 @@ import { Project } from "@opencode-ai/schema/project"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { LocationQuery, locationQueryOpenApi } from "./location.js"
+import { ProjectNotFoundError } from "../errors.js"
 
 const root = "/api/project"
 
@@ -14,6 +15,20 @@ export const ProjectGroup = HttpApiGroup.make("server.project")
         identifier: "v2.project.list",
         summary: "List projects",
         description: "List known projects.",
+      }),
+    ),
+  )
+  .add(
+    HttpApiEndpoint.patch("project.update", `${root}/:projectID`, {
+      params: { projectID: Project.ID },
+      payload: Project.UpdateInput,
+      success: Project.Info,
+      error: ProjectNotFoundError,
+    }).annotateMerge(
+      OpenApi.annotations({
+        identifier: "v2.project.update",
+        summary: "Update project",
+        description: "Update project metadata.",
       }),
     ),
   )

--- a/packages/schema/src/project.ts
+++ b/packages/schema/src/project.ts
@@ -56,5 +56,12 @@ export const Info = Schema.Struct({
 }).annotate({ identifier: "Project" })
 export interface Info extends Schema.Schema.Type<typeof Info> {}
 
+export const UpdateInput = Schema.Struct({
+  name: optional(Schema.String),
+  icon: optional(Icon),
+  commands: optional(Commands),
+}).annotate({ identifier: "Project.UpdateInput" })
+export interface UpdateInput extends Schema.Schema.Type<typeof UpdateInput> {}
+
 const Updated = ephemeral({ type: "project.updated", schema: Info.fields })
 export const Event = { Updated, Definitions: inventory(Updated) }

--- a/packages/server/src/handlers/project.ts
+++ b/packages/server/src/handlers/project.ts
@@ -3,10 +3,26 @@ import { Project } from "@opencode-ai/core/project"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
+import { ProjectNotFoundError } from "@opencode-ai/protocol/errors"
 
 export const ProjectHandler = HttpApiBuilder.group(Api, "server.project", (handlers) =>
   handlers
     .handle("project.list", () => Project.Service.use((project) => project.list()))
+    .handle("project.update", (ctx) =>
+      Effect.gen(function* () {
+        const project = yield* Project.Service
+        return yield* project.update(ctx.params.projectID, ctx.payload).pipe(
+          Effect.catchTag(
+            "Project.NotFoundError",
+            () =>
+              new ProjectNotFoundError({
+                projectID: ctx.params.projectID,
+                message: `Project not found: ${ctx.params.projectID}`,
+              }),
+          ),
+        )
+      }),
+    )
     .handle("project.current", () =>
       Location.Service.use((location) =>
         Effect.succeed({ id: location.project.id, directory: location.project.directory }),


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds current API support for updating project metadata, including project names and icons. Updates are persisted through the project store and return a not-found error for unknown projects.

### How did you verify your code works?

- Ran the repository pre-push typecheck across all 33 configured tasks.
- Ran focused typechecks for core, schema, protocol, server, and client.

### Screenshots / recordings

Not applicable; this is an API and persistence change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR