### PR TITLE
fix(opencode): remove explicit bun instruction from LLM system prompt

### DIFF
--- a/packages/opencode/src/session/prompt/codex.txt
+++ b/packages/opencode/src/session/prompt/codex.txt
@@ -11,7 +11,7 @@ You are an interactive CLI tool that helps users with software engineering tasks
 - Prefer specialized tools over shell for file operations:
   - Use Read to view files, Edit to modify files, and Write only when needed.
   - Use Glob to find files by name and Grep to search file contents.
-- Use Bash for terminal operations (git, bun, builds, tests, running scripts).
+- Use Bash for terminal operations (git, builds, tests, running scripts).
 - Run tool calls in parallel when neither call needs the other’s output; otherwise run sequentially.
 
 ## Git and workspace hygiene


### PR DESCRIPTION
## Problem

The LLM system prompt instructs the model to use Bash for \un\ operations:

\\\
Use Bash for terminal operations (git, bun, builds, tests, running scripts).
\\\

When bun is not installed in PATH, the LLM generates \un test\, \un install\, etc. which fail with \un: command not found\. This affects users who use npm/pnpm/yarn projects but don't have bun installed.

Reported in ECC issue: https://github.com/affaan-m/ECC/issues/2074

## Fix

Remove \un\ from the parenthetical examples. The LLM already detects the correct package manager from lock files (bun.lockb, pnpm-lock.yaml, etc.) and the \package.json\ \packageManager\ field. This change prevents unnecessary bun-biased command generation without affecting projects that actually use bun.

## Impact

- Users without bun: no more spurious \un: command not found\ errors
- Users with bun in bun projects: unaffected (detected via bun.lockb)
- Users with bun in non-bun projects: unaffected