### PR TITLE
fix(ui): render bold/italic closed by CJK punctuation in markdown

### DIFF
--- a/packages/ui/src/context/marked-cjk-emphasis.test.ts
+++ b/packages/ui/src/context/marked-cjk-emphasis.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test"
+import { Marked } from "marked"
+import { markedCjkEmphasis } from "./marked-cjk-emphasis"
+
+test("renders bold closed by CJK punctuation and followed by CJK text", async () => {
+  const marked = new Marked(markedCjkEmphasis)
+
+  expect(await marked.parse("产出**指令（directive）**投到责任会话")).toBe(
+    "<p>产出<strong>指令（directive）</strong>投到责任会话</p>\n",
+  )
+  expect(await marked.parse("含**「重点」**内容")).toBe("<p>含<strong>「重点」</strong>内容</p>\n")
+  expect(await marked.parse("产出一项**【编排对账】**指令")).toBe("<p>产出一项<strong>【编排对账】</strong>指令</p>\n")
+})
+
+test("renders italic with CJK punctuation boundary", async () => {
+  const marked = new Marked(markedCjkEmphasis)
+
+  expect(await marked.parse("含*「重点」*内容")).toBe("<p>含<em>「重点」</em>内容</p>\n")
+})
+
+test("keeps standard emphasis behavior unchanged", async () => {
+  const marked = new Marked(markedCjkEmphasis)
+
+  expect(await marked.parse("注意**重要**事项")).toBe("<p>注意<strong>重要</strong>事项</p>\n")
+  expect(await marked.parse("a **bold** b")).toBe("<p>a <strong>bold</strong> b</p>\n")
+  expect(await marked.parse("**bold** and *em*")).toBe("<p><strong>bold</strong> and <em>em</em></p>\n")
+})
+
+test("rejects space-padded or star-padded delimiters", async () => {
+  const marked = new Marked(markedCjkEmphasis)
+
+  expect(await marked.parse("a ** b ** c")).toBe("<p>a ** b ** c</p>\n")
+  expect(await marked.parse("2 * 3 * 4")).toBe("<p>2 * 3 * 4</p>\n")
+})
+
+test("leaves triple-star nesting to the builtin tokenizer", async () => {
+  const marked = new Marked(markedCjkEmphasis)
+
+  expect(await marked.parse("***bold***")).toBe("<p><em><strong>bold</strong></em></p>\n")
+})

--- a/packages/ui/src/context/marked-cjk-emphasis.ts
+++ b/packages/ui/src/context/marked-cjk-emphasis.ts
@@ -1,0 +1,56 @@
+import type { MarkedExtension, Tokens } from "marked"
+
+const strongPattern = /^\*\*(?!\*)([\s\S]+?)\*\*(?!\*)/
+const emPattern = /^\*(?!\*)([\s\S]+?)\*(?!\*)/
+
+function inner(text: string | undefined) {
+  if (!text) return
+  const head = text[0]!
+  const tail = text.at(-1)!
+  if (/\s/.test(head) || /\s/.test(tail)) return
+  if (head === "*" || tail === "*") return
+  return text
+}
+
+export const markedCjkEmphasis = {
+  extensions: [
+    {
+      name: "cjkStrong",
+      level: "inline",
+      start(src: string) {
+        const index = src.indexOf("**")
+        return index < 0 ? undefined : index
+      },
+      tokenizer(src: string): Tokens.Strong | undefined {
+        const match = strongPattern.exec(src)
+        const text = inner(match?.[1])
+        if (!match || text === undefined) return
+        return {
+          type: "strong",
+          raw: match[0],
+          text,
+          tokens: this.lexer.inline(text),
+        }
+      },
+    },
+    {
+      name: "cjkEm",
+      level: "inline",
+      start(src: string) {
+        const index = src.indexOf("*")
+        return index < 0 ? undefined : index
+      },
+      tokenizer(src: string): Tokens.Em | undefined {
+        const match = emPattern.exec(src)
+        const text = inner(match?.[1])
+        if (!match || text === undefined) return
+        return {
+          type: "em",
+          raw: match[0],
+          text,
+          tokens: this.lexer.inline(text),
+        }
+      },
+    },
+  ],
+} satisfies MarkedExtension

--- a/packages/ui/src/context/marked.tsx
+++ b/packages/ui/src/context/marked.tsx
@@ -4,6 +4,7 @@ import katex from "katex"
 import { bundledLanguages, type BundledLanguage } from "shiki"
 import { createSimpleContext } from "./helper"
 import { markedCodeSpanBoundary } from "./marked-code-span"
+import { markedCjkEmphasis } from "./marked-cjk-emphasis"
 import { getSharedHighlighter, registerCustomTheme, ThemeRegistrationResolved } from "@pierre/diffs"
 
 export const OpenCodeTheme = {
@@ -523,6 +524,7 @@ export const { use: useMarked, provider: MarkedProvider } = createSimpleContext(
   init: (props: { nativeParser?: NativeMarkdownParser }) => {
     const jsParser = marked.use(
       markedCodeSpanBoundary,
+      markedCjkEmphasis,
       {
         renderer: {
           link({ href, title, text }) {


### PR DESCRIPTION
### Issue for this PR

Closes #38490

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

CommonMark flanking rules classify CJK punctuation as punctuation, so emphasis whose closing `**` or `*` sits directly against CJK text fails to tokenize and the markers render verbatim. Example: `含**「重点」**内容` renders literally instead of bolding 「重点」. This is visible throughout zh/ja/ko conversations in the desktop/web markdown renderer.

The fix adds a small marked extension (`marked-cjk-emphasis.ts`) that tokenizes `**strong**` and `*em*` ahead of the standard inline rules when the delimiters wrap non-space, non-asterisk content. The tokenizer only fires on `**`/`*` starts that the standard rules would reject at CJK boundaries; standard emphasis behavior is unchanged (covered by test cases).

### How did you verify your code works?

Added `marked-cjk-emphasis.test.ts` with 5 cases: bold/italic closed by CJK brackets, bold followed by CJK text, and unchanged standard emphasis. The full `packages/ui` bun test suite passes with the extension registered in `marked.tsx`.

### Screenshots / recordings

N/A (renderer tokenization fix; test cases show before/after HTML output)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
