### PR TITLE
mini: add replay settings to cli config

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -140,11 +140,11 @@ export const Commands = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCO
           Flag.withDefault(false),
         ),
         replay: Flag.boolean("replay").pipe(
-          Flag.withDescription("Replay session history on resume and after resize"),
-          Flag.withDefault(true),
+          Flag.withDescription("Restore session history on resume and resize (disable with --no-replay)"),
+          Flag.optional,
         ),
         replayLimit: Flag.integer("replay-limit").pipe(
-          Flag.withDescription("Cap visible replay to the newest N messages"),
+          Flag.withDescription("Limit replay to the newest N messages (default: 200)"),
           Flag.optional,
         ),
         model: Flag.string("model").pipe(

--- a/packages/cli/src/commands/handlers/mini.ts
+++ b/packages/cli/src/commands/handlers/mini.ts
@@ -28,8 +28,8 @@ export default Runtime.handler(Commands.commands.mini, (input) =>
         model: Option.getOrUndefined(input.model),
         agent: Option.getOrUndefined(input.agent),
         prompt: Option.getOrUndefined(input.prompt),
-        replay: input.replay,
-        replayLimit: Option.getOrUndefined(input.replayLimit),
+        replay: Option.getOrUndefined(input.replay) ?? resolved.mini?.replay ?? true,
+        replayLimit: Option.getOrUndefined(input.replayLimit) ?? resolved.mini?.replay_limit,
         demo: input.demo,
         tuiConfig: resolved,
         config: {

--- a/packages/cli/test/mini.test.ts
+++ b/packages/cli/test/mini.test.ts
@@ -214,11 +214,15 @@ describe("mini command", () => {
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain("--server string")
     expect(result.stdout).toContain("--prompt string")
+    expect(result.stdout).toContain("--replay")
+    expect(result.stdout).toContain("disable with --no-replay")
+    expect(result.stdout).toContain("--replay-limit integer")
+    expect(result.stdout).toContain("Limit replay to the newest N messages (default: 200)")
     expect(result.stdout).not.toContain("SUBCOMMANDS")
   })
 
   test("routes local and explicit-server invocations into mini", async () => {
-    for (const args of [["mini"], ["mini", "--server", "http://127.0.0.1:1"]]) {
+    for (const args of [["mini"], ["mini", "--no-replay"], ["mini", "--server", "http://127.0.0.1:1"]]) {
       const result = await cli(args)
 
       expect(result.exitCode).toBe(1)

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -142,6 +142,12 @@ export const Info = Schema.Struct({
       mono: Schema.optional(Schema.Boolean).annotate({
         description: "Use monochrome ASCII output",
       }),
+      replay: Schema.optional(Schema.Boolean).annotate({
+        description: "Restore session history on resume and terminal resize",
+      }),
+      replay_limit: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))).annotate({
+        description: "Maximum number of newest messages restored during replay",
+      }),
     }),
   ).annotate({ description: "Mini transcript presentation settings" }),
   hints: Schema.optional(

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -1,12 +1,24 @@
 /** @jsxImportSource @opentui/solid */
 import { testRender } from "@opentui/solid"
 import { expect, test } from "bun:test"
+import { Schema } from "effect"
 import {
   resolve,
   ConfigProvider,
+  Info,
   useConfig,
   type Interface,
 } from "../src/config"
+
+test("validates mini replay settings", () => {
+  const decode = Schema.decodeUnknownSync(Info)
+
+  expect(decode({ mini: { replay: false, replay_limit: 50 } })).toEqual({
+    mini: { replay: false, replay_limit: 50 },
+  })
+  expect(() => decode({ mini: { replay_limit: 0 } })).toThrow()
+  expect(() => decode({ mini: { replay_limit: 1.5 } })).toThrow()
+})
 
 test("resolves nested config and keybind defaults", () => {
   const config = resolve(


### PR DESCRIPTION
Allow disabling history replay and capping its window from
cli.json so defaults match user preference without flags on
every launch. Flags still win when set.
