### PR TITLE
fix(opencode): expand tilde in glob tool path

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -1,3 +1,4 @@
+import os from "os"
 import path from "path"
 import { Effect, Schema } from "effect"
 import { InstanceState } from "@/effect/instance-state"
@@ -36,6 +37,8 @@ export const GlobTool = Tool.define(
           })
 
           let search = params.path ?? ins.directory
+          if (search === "~") search = os.homedir()
+          if (search.startsWith("~/")) search = path.join(os.homedir(), search.slice(2))
           search = path.isAbsolute(search) ? search : path.resolve(ins.directory, search)
           const info = yield* fs.stat(search).pipe(Effect.catch(() => Effect.succeed(undefined)))
           if (info?.type === "File") {


### PR DESCRIPTION
Closes #38497

**Type of change:** Bug fix

**What does this PR do?**
The glob tool does not expand tilde in the path parameter. path.isAbsolute() returns false for paths starting with ~, causing them to be resolved relative to the instance directory instead of the user home directory. This results in ripgrep execution failed errors.

Added tilde expansion before the path.isAbsolute check, following the same pattern already used in shell.ts and permission/index.ts.

**How did you verify your code works?**
Compared against existing tilde expansion patterns in shell.ts and permission/index.ts within the same codebase. The fix mirrors those implementations exactly. The expanded path then passes through the existing path.isAbsolute check which correctly identifies the resolved home directory as absolute.

**Checklist:**
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR