### PR TITLE
feat(cli): stream incremental reasoning/text deltas in run --format json

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -696,6 +696,10 @@ export const RunCommand = effectCmd({
         // created, and replies issued from inside the loop must use that client.
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
+          // Track partID -> part.type so `message.part.delta` events (which only
+          // carry a partID) can be attributed to the reasoning/text part they
+          // belong to when streamed in --format json.
+          const partTypes = new Map<string, string>()
           let error: string | undefined
 
           for await (const event of events.stream) {
@@ -715,6 +719,7 @@ export const RunCommand = effectCmd({
             if (event.type === "message.part.updated") {
               const part = event.properties.part
               if (part.sessionID !== sessionID) continue
+              partTypes.set(part.id, part.type)
 
               if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
                 if (emit("tool_use", { part })) continue
@@ -771,6 +776,16 @@ export const RunCommand = effectCmd({
                 }
                 process.stdout.write(line + EOL)
               }
+            }
+
+            // Stream incremental reasoning/text tokens in --format json. The
+            // formatted (non-json) renderer intentionally waits for the whole
+            // part (see the `part.time?.end` gates above), so `emit` is a no-op
+            // there and this only affects the raw JSON event stream.
+            if (event.type === "message.part.delta") {
+              const props = event.properties
+              if (props.sessionID !== sessionID) continue
+              if (emit("part_delta", { ...props, partType: partTypes.get(props.partID) })) continue
             }
 
             if (event.type === "session.error") {


### PR DESCRIPTION
### Issue for this PR

N/A — no existing issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --format json --thinking` never streams reasoning. During a long thinking phase the JSON stream is silent, then the whole reasoning block appears at once when it ends.

The loop in `run.ts` only handles `message.part.updated`, and gates `reasoning`/`text` on `part.time?.end`, which is only set once the part finishes (`SessionProcessor.finishReasoning`). The incremental tokens are published as `message.part.delta` (`session.updatePartDelta`), but `run` never listens for them, so they're dropped.

This adds one branch that emits `message.part.delta` as `part_delta` events when `--format json`. A `partID -> part.type` map (filled from `message.part.updated`) tags each delta so consumers know whether it's reasoning or text:

`{"type":"part_delta","partID":"prt_...","field":"text","delta":"...","partType":"reasoning"}`

`emit()` is a no-op unless `--format json`, so the formatted/TTY output is untouched (it still waits for the whole part on purpose). It's a new event type, so existing JSON consumers ignore it; the final `reasoning`/`text` events are still emitted at `time.end`.

### How did you verify your code works?

Ran the patched build from source against a real model:

```
bun dev run --thinking --variant high --format json --model anthropic/claude-opus-4-8 "..."
```

The JSON stream now includes `part_delta` events (it didn't before): `4 part_delta / 2 reasoning / 2 text / 1 step_start / 1 step_finish`. Reasoning tokens arrive incrementally instead of only at block end, e.g.:

```
{"type":"part_delta","partID":"prt_f8f0...","field":"text","delta":"I","partType":"reasoning"}
{"type":"part_delta","partID":"prt_f8f0...","field":"text","delta":"'m calculating that 17 times 23...","partType":"reasoning"}
```

`bun run typecheck` (tsgo --noEmit) passes and `oxlint` reports 0 errors on the file.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
