### PR TITLE
docs: add opencode-episodic-memory to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-episodic-memory](https://github.com/robertn702/opencode-episodic-memory)                 | Semantic search over past conversations with fully local embeddings — recall decisions and discussions across sessions |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the community Plugins table on the Ecosystem docs page (`packages/web/src/content/docs/ecosystem.mdx`) for **opencode-episodic-memory**: semantic search over past conversations with fully local embeddings — recall decisions and discussions across sessions.

- Plugin repo: https://github.com/robertn702/opencode-episodic-memory
- It is an npm-published OpenCode plugin (installable via the plugins mechanism), providing `episodic_search`/`episodic_read` tools plus a `session.idle` reindex, all running locally against the OpenCode session DB.

The Ecosystem page explicitly invites these additions ("You can contribute to this page..."), and the row is appended to the end of the table to match the existing convention that recent additions go last.

### How did you verify your code works?

Single-line addition to the Markdown table. Verified the new row uses the same `| Name | Description |` pipe structure as neighboring rows and that the first-column boundary stays aligned with the rest of the table. No code or build changes.

### Screenshots / recordings

_N/A — text-only docs change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
