### PR TITLE
feat(shell): PTY-based interactive command execution with SecureInput

### DIFF
--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -21,6 +21,7 @@ import { Agent } from "@/agent/agent"
 import { Skill } from "@/skill"
 import { Discovery } from "@/skill/discovery"
 import { Question } from "@/question"
+import { SecureInput } from "@/secure-input"
 import { Permission } from "@/permission"
 import { Todo } from "@/session/todo"
 import { Session } from "@/session/session"
@@ -75,6 +76,7 @@ export const AppLayer = Layer.mergeAll(
   Skill.defaultLayer,
   Discovery.defaultLayer,
   Question.defaultLayer,
+  SecureInput.defaultLayer,
   Permission.defaultLayer,
   Todo.defaultLayer,
   Session.defaultLayer,

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -14,6 +14,7 @@ const prefixes = {
   workspace: "wrk",
   entry: "ent",
   account: "act",
+  secureinput: "sec",
 } as const
 
 export function schema(prefix: keyof typeof prefixes) {

--- a/packages/opencode/src/secure-input/index.ts
+++ b/packages/opencode/src/secure-input/index.ts
@@ -1,0 +1,362 @@
+import { Deferred, Effect, Layer, Schema, Context } from "effect"
+import { Bus } from "@/bus"
+import { BusEvent } from "@/bus/bus-event"
+import { InstanceState } from "@/effect/instance-state"
+import { SessionID } from "@/session/schema"
+import { lazy } from "@/util/lazy"
+import * as Log from "@opencode-ai/core/util/log"
+import { SecureInputID } from "./schema"
+
+const log = Log.create({ service: "secure-input" })
+
+// ── Password prompt patterns ────────────────────────────────────────────────
+const PASSWORD_PATTERNS = [
+  /\[sudo\] password for .+:/i,
+  /Password:/i,
+  /Enter passphrase for .+:/i,
+  /BECOME password:/i,
+  /SSH password:/i,
+  /passphrase:/i,
+  /password for .+:/i,
+  /\(yes\/no.*\)\?/i,
+] as const
+
+// ── Commands that typically require interaction ──────────────────────────────
+const INTERACTIVE_COMMANDS = [
+  /^sudo\s/,
+  /\bsudo\s/,
+  /^ssh\s.*-t\b/,
+  /\bssh\s.*-t\b/,
+  /^ansible\b.*-K\b/,
+  /^ansible\b.*--ask-become-pass\b/,
+  /^ansible-playbook\b.*-K\b/,
+  /^ansible-playbook\b.*--ask-become-pass\b/,
+  /^su\s/,
+  /^gpg\s/,
+  /\bsudo\b/,
+] as const
+
+// ── Schemas ─────────────────────────────────────────────────────────────────
+
+export class Request extends Schema.Class<Request>("SecureInputRequest")({
+  id: SecureInputID,
+  sessionID: SessionID,
+  prompt: Schema.String.annotate({
+    description: "The password prompt text displayed to the user",
+  }),
+  command: Schema.optional(Schema.String).annotate({
+    description: "The command that triggered this prompt",
+  }),
+}) {
+  static readonly zod = SecureInputID.zod
+}
+
+export class Submitted extends Schema.Class<Submitted>("SecureInputSubmitted")({
+  sessionID: SessionID,
+  requestID: SecureInputID,
+}) {}
+
+export class Cancelled extends Schema.Class<Cancelled>("SecureInputCancelled")({
+  sessionID: SessionID,
+  requestID: SecureInputID,
+}) {}
+
+export class TimedOut extends Schema.Class<TimedOut>("SecureInputTimedOut")({
+  sessionID: SessionID,
+  requestID: SecureInputID,
+}) {}
+
+// ── Events ──────────────────────────────────────────────────────────────────
+
+export const Event = {
+  Requested: BusEvent.define("secure-input.requested", Request),
+  Submitted: BusEvent.define("secure-input.submitted", Submitted),
+  Cancelled: BusEvent.define("secure-input.cancelled", Cancelled),
+  TimedOut: BusEvent.define("secure-input.timed-out", TimedOut),
+}
+
+// ── Errors ──────────────────────────────────────────────────────────────────
+
+export class CancelledError extends Schema.TaggedErrorClass<CancelledError>()("SecureInputCancelledError", {}) {
+  override get message() {
+    return "The user cancelled the secure input prompt"
+  }
+}
+
+export class TimedOutError extends Schema.TaggedErrorClass<TimedOutError>()("SecureInputTimedOutError", {}) {
+  override get message() {
+    return "Secure input request timed out"
+  }
+}
+
+// ── Internal state ──────────────────────────────────────────────────────────
+
+interface PendingEntry {
+  info: Request
+  deferred: Deferred.Deferred<string, CancelledError | TimedOutError>
+}
+
+interface State {
+  pending: Map<SecureInputID, PendingEntry>
+}
+
+// ── Helpesr ─────────────────────────────────────────────────────────────────
+
+const ptySpawn = lazy(async () => {
+  const { spawn } = await import("#pty")
+  return spawn
+})
+
+/**
+ * Check whether a command string looks like it needs interactive input.
+ */
+export function isInteractiveCommand(command: string): boolean {
+  return INTERACTIVE_COMMANDS.some((re) => re.test(command))
+}
+
+/**
+ * Check whether a chunk of PTY output contains a password prompt.
+ */
+export function detectPasswordPrompt(output: string): string | undefined {
+  for (const re of PASSWORD_PATTERNS) {
+    const match = output.match(re)
+    if (match) return match[0]
+  }
+  return undefined
+}
+
+// ── Service ─────────────────────────────────────────────────────────────────
+
+export interface Interface {
+  /** Request a secure input (password) from the user. Returns the password string. */
+  readonly request: (input: {
+    sessionID: SessionID
+    prompt: string
+    command?: string
+  }) => Effect.Effect<string, CancelledError | TimedOutError>
+
+  /** Submit a password for a pending request. */
+  readonly submit: (input: { requestID: SecureInputID; input: string }) => Effect.Effect<void>
+
+  /** Cancel a pending request. */
+  readonly cancel: (requestID: SecureInputID) => Effect.Effect<void>
+
+  /** List all pending requests. */
+  readonly list: () => Effect.Effect<ReadonlyArray<Request>>
+
+  /**
+   * Execute a command interactively via PTY.
+   * Detects password prompts and delegates to request() for user input.
+   */
+  readonly execute: (input: {
+    command: string
+    cwd: string
+    env: Record<string, string>
+    sessionID: SessionID
+    timeout: number
+  }) => Effect.Effect<{ output: string; exitCode: number | null }>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SecureInput") {}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+    const state = yield* InstanceState.make<State>(
+      Effect.fn("SecureInput.state")(function* () {
+        const state: State = {
+          pending: new Map(),
+        }
+
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function* () {
+            for (const item of state.pending.values()) {
+              yield* Deferred.fail(item.deferred, new CancelledError())
+            }
+            state.pending.clear()
+          }),
+        )
+
+        return state
+      }),
+    )
+
+    const request = Effect.fn("SecureInput.request")(function* (input: {
+      sessionID: SessionID
+      prompt: string
+      command?: string
+    }) {
+      const pending = (yield* InstanceState.get(state)).pending
+      const id = SecureInputID.ascending()
+      log.info("requesting secure input", { id, sessionID: input.sessionID })
+
+      const deferred = yield* Deferred.make<string, CancelledError | TimedOutError>()
+      const info = Schema.decodeUnknownSync(Request)({
+        id,
+        sessionID: input.sessionID,
+        prompt: input.prompt,
+        command: input.command,
+      })
+      pending.set(id, { info, deferred })
+      yield* bus.publish(Event.Requested, info)
+
+      return yield* Effect.ensuring(
+        Deferred.await(deferred),
+        Effect.sync(() => {
+          pending.delete(id)
+        }),
+      )
+    })
+
+    const submit = Effect.fn("SecureInput.submit")(function* (input: {
+      requestID: SecureInputID
+      input: string
+    }) {
+      const pending = (yield* InstanceState.get(state)).pending
+      const existing = pending.get(input.requestID)
+      if (!existing) {
+        log.warn("submit for unknown request", { requestID: input.requestID })
+        return
+      }
+      pending.delete(input.requestID)
+      log.info("secure input submitted", { requestID: input.requestID })
+      yield* bus.publish(Event.Submitted, {
+        sessionID: existing.info.sessionID,
+        requestID: existing.info.id,
+      })
+      yield* Deferred.succeed(existing.deferred, input.input)
+    })
+
+    const cancel = Effect.fn("SecureInput.cancel")(function* (requestID: SecureInputID) {
+      const pending = (yield* InstanceState.get(state)).pending
+      const existing = pending.get(requestID)
+      if (!existing) {
+        log.warn("cancel for unknown request", { requestID })
+        return
+      }
+      pending.delete(requestID)
+      log.info("secure input cancelled", { requestID })
+      yield* bus.publish(Event.Cancelled, {
+        sessionID: existing.info.sessionID,
+        requestID: existing.info.id,
+      })
+      yield* Deferred.fail(existing.deferred, new CancelledError())
+    })
+
+    const list = Effect.fn("SecureInput.list")(function* () {
+      const pending = (yield* InstanceState.get(state)).pending
+      return Array.from(pending.values(), (x) => x.info)
+    })
+
+    const execute = Effect.fn("SecureInput.execute")(function* (input: {
+      command: string
+      cwd: string
+      env: Record<string, string>
+      sessionID: SessionID
+      timeout: number
+    }) {
+      const pending = (yield* InstanceState.get(state)).pending
+      const spawn = yield* Effect.promise(() => ptySpawn())
+      const shell = process.platform === "win32" ? "cmd.exe" : "/bin/bash"
+
+      const pty = yield* Effect.sync(() =>
+        spawn(shell, ["-c", input.command], {
+          name: "xterm-256color",
+          cwd: input.cwd,
+          env: { ...input.env, TERM: "xterm-256color" } as Record<string, string>,
+        }),
+      )
+
+      let output = ""
+      let passwordResolve: ((value: string) => void) | null = null
+      let passwordBuffer = ""
+      let exited = false
+      let exitCode: number | null = null
+
+      const done = yield* Effect.promise<{ output: string; exitCode: number | null }>(
+        (resolve) => {
+          // ── PTY data handler ──────────────────────────────────────────────
+          const dataDisp = pty.onData((chunk: string) => {
+            output += chunk
+
+            // If we're waiting for a password, buffer the output and check for prompts
+            if (!passwordResolve) {
+              passwordBuffer += chunk
+              // Only keep last 4KB for prompt detection
+              if (Buffer.byteLength(passwordBuffer, "utf-8") > 4096) {
+                passwordBuffer = passwordBuffer.slice(-2048)
+              }
+
+              const prompt = detectPasswordPrompt(passwordBuffer)
+              if (prompt) {
+                passwordResolve = (() => {
+                  const deferred = Deferred.unsafeMake<string, CancelledError | TimedOutError>()
+                  const id = SecureInputID.ascending()
+                  const info = Schema.decodeUnknownSync(Request)({
+                    id,
+                    sessionID: input.sessionID,
+                    prompt,
+                    command: input.command,
+                  })
+                  pending.set(id, { info, deferred })
+
+                  bus.publish(Event.Requested, info).pipe(Effect.runFork)
+
+                  deferred.pipe(
+                    Deferred.await,
+                    Effect.match({
+                      onSuccess: (value) => {
+                        pty.write(value + "\n")
+                        passwordResolve = null
+                        passwordBuffer = ""
+                        // Strip the prompt from output
+                        output = output.replace(prompt, "[password supplied]")
+                      },
+                      onFailure: () => {
+                        pty.kill()
+                      },
+                    }),
+                    Effect.runFork,
+                  )
+
+                  return deferred
+                })() as unknown as Promise<string>
+              }
+            }
+          })
+
+          // ── PTY exit handler ──────────────────────────────────────────────
+          const exitDisp = pty.onExit((event: { exitCode: number }) => {
+            exited = true
+            exitCode = event.exitCode
+            resolve({ output, exitCode })
+          })
+
+          // ── Timeout ───────────────────────────────────────────────────────
+          const timeoutId = setTimeout(() => {
+            if (!exited) {
+              pty.kill()
+              resolve({ output, exitCode: null })
+            }
+          }, input.timeout)
+
+          // ── Abort handler (via memory dealloc) ────────────────────────────
+          return () => {
+            clearTimeout(timeoutId)
+            dataDisp.dispose()
+            exitDisp.dispose()
+          }
+        },
+      )
+
+      return done
+    })
+
+    return Service.of({ request, submit, cancel, list, execute })
+  }),
+)
+
+export const defaultLayer = layer.pipe(Layer.provide(Bus.layer))
+
+export * as SecureInput from "."

--- a/packages/opencode/src/secure-input/schema.ts
+++ b/packages/opencode/src/secure-input/schema.ts
@@ -1,0 +1,16 @@
+import { Schema } from "effect"
+
+import { Identifier } from "@/id/id"
+import { zod, ZodOverride } from "@/util/effect-zod"
+import { Newtype } from "@/util/schema"
+
+export class SecureInputID extends Newtype<SecureInputID>()(
+  "SecureInputID",
+  Schema.String.annotate({ [ZodOverride]: Identifier.schema("secureinput") }),
+) {
+  static ascending(id?: string): SecureInputID {
+    return this.make(Identifier.ascending("secureinput", id))
+  }
+
+  static readonly zod = zod(this)
+}

--- a/packages/opencode/src/server/routes/instance/index.ts
+++ b/packages/opencode/src/server/routes/instance/index.ts
@@ -15,6 +15,7 @@ import { Global } from "@opencode-ai/core/global"
 import { LSP } from "@/lsp/lsp"
 import { Command } from "@/command"
 import { QuestionRoutes } from "./question"
+import { SecureInputRoutes } from "./secure-input"
 import { PermissionRoutes } from "./permission"
 import { ProjectRoutes } from "./project"
 import { SessionRoutes } from "./session"
@@ -166,6 +167,7 @@ export const InstanceRoutes = (upgrade: UpgradeWebSocket, opts?: CorsOptions): H
     .route("/session", SessionRoutes())
     .route("/permission", PermissionRoutes())
     .route("/question", QuestionRoutes())
+    .route("/secure-input", SecureInputRoutes())
     .route("/provider", ProviderRoutes())
     .route("/sync", SyncRoutes())
     .route("/", FileRoutes())

--- a/packages/opencode/src/server/routes/instance/secure-input.ts
+++ b/packages/opencode/src/server/routes/instance/secure-input.ts
@@ -1,0 +1,111 @@
+import { Hono } from "hono"
+import { describeRoute, validator, resolver } from "hono-openapi"
+import { SecureInput } from "@/secure-input"
+import { SecureInputID } from "@/secure-input/schema"
+import z from "zod"
+import { errors } from "../../error"
+import { lazy } from "@/util/lazy"
+import { jsonRequest } from "./trace"
+
+const Submit = z.object({
+  input: z.string().describe("The password or secure input value"),
+})
+
+const Cancel = z.object({})
+
+export const SecureInputRoutes = lazy(() =>
+  new Hono()
+    .get(
+      "/",
+      describeRoute({
+        summary: "List pending secure input requests",
+        description: "Get all pending secure input (password) requests across all sessions.",
+        operationId: "secureInput.list",
+        responses: {
+          200: {
+            description: "List of pending secure input requests",
+            content: {
+              "application/json": {
+                schema: resolver(SecureInput.Request.zod.array()),
+              },
+            },
+          },
+        },
+      }),
+      async (c) =>
+        jsonRequest("SecureInputRoutes.list", c, function* () {
+          const svc = yield* SecureInput.Service
+          return yield* svc.list()
+        }),
+    )
+    .post(
+      "/:requestID/submit",
+      describeRoute({
+        summary: "Submit secure input",
+        description:
+          "Submit a password or other secure input for a pending request. The input goes directly to the PTY and is never stored or logged.",
+        operationId: "secureInput.submit",
+        responses: {
+          200: {
+            description: "Secure input submitted successfully",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          requestID: SecureInputID.zod,
+        }),
+      ),
+      validator("json", Submit),
+      async (c) =>
+        jsonRequest("SecureInputRoutes.submit", c, function* () {
+          const params = c.req.valid("param")
+          const json = c.req.valid("json")
+          const svc = yield* SecureInput.Service
+          yield* svc.submit({
+            requestID: params.requestID,
+            input: json.input,
+          })
+          return true
+        }),
+    )
+    .post(
+      "/:requestID/cancel",
+      describeRoute({
+        summary: "Cancel secure input request",
+        description: "Cancel a pending secure input request.",
+        operationId: "secureInput.cancel",
+        responses: {
+          200: {
+            description: "Secure input cancelled",
+            content: {
+              "application/json": {
+                schema: resolver(z.boolean()),
+              },
+            },
+          },
+          ...errors(400, 404),
+        },
+      }),
+      validator(
+        "param",
+        z.object({
+          requestID: SecureInputID.zod,
+        }),
+      ),
+      async (c) =>
+        jsonRequest("SecureInputRoutes.cancel", c, function* () {
+          const params = c.req.valid("param")
+          const svc = yield* SecureInput.Service
+          yield* svc.cancel(params.requestID)
+          return true
+        }),
+    ),
+)

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -97,6 +97,7 @@ const add = Effect.fnUntraced(function* (state: State, match: string, bus: Bus.I
   if (!parsed.success) return
 
   if (state.skills[parsed.data.name]) {
+    if (state.skills[parsed.data.name].location === match) return
     log.warn("duplicate skill name", {
       name: parsed.data.name,
       existing: state.skills[parsed.data.name].location,

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -22,6 +22,7 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { ShellPrompt, type Parameters } from "./shell/prompt"
 import { BashArity } from "@/permission/arity"
+import { SecureInput } from "@/secure-input"
 
 export { Parameters } from "./shell/prompt"
 
@@ -612,6 +613,29 @@ export const ShellTool = Tool.define(
                   yield* ask(ctx, scan)
                 }),
               )
+
+              // Interactive mode: use PTY + SecureInput for password-requiring commands
+              const wantsInteractive = params.interactive ?? SecureInput.isInteractiveCommand(params.command)
+              if (wantsInteractive) {
+                const secInput = yield* SecureInput.Service
+                const result = yield* secInput.execute({
+                  command: params.command,
+                  cwd,
+                  env: yield* shellEnv(ctx, cwd),
+                  sessionID: ctx.sessionID,
+                  timeout,
+                })
+                return {
+                  title: params.description,
+                  metadata: {
+                    output: result.output,
+                    exit: result.exitCode,
+                    description: params.description,
+                    interactive: true,
+                  },
+                  output: result.output,
+                }
+              }
 
               return yield* run(
                 {

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -27,6 +27,10 @@ export function parameterSchema(description: string) {
       description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
     }),
     description: Schema.String.annotate({ description }),
+    interactive: Schema.optional(Schema.Boolean).annotate({
+      description:
+        "Set to true for commands that require interactive password/sudo input (sudo, ssh -t, ansible -K). When enabled, the user will be prompted securely for passwords. Auto-detected for common patterns.",
+    }),
   })
 }
 
@@ -105,6 +109,7 @@ Usage notes:
   - You can specify an optional timeout in milliseconds. If not specified, commands will time out after 120000ms (2 minutes).
   - It is very helpful if you write a clear, concise description of what this command does in 5-10 words.
   - If the output exceeds ${limits.maxLines} lines or ${limits.maxBytes} bytes, it will be truncated and the full output will be written to a file. You can use Read with offset/limit to read specific sections or Grep to search the full content. Do NOT use \`head\`, \`tail\`, or other truncation commands to limit output; the full output will already be captured to a file for more precise searching.
+  - For commands that require interactive input (sudo, ssh -t, ansible -K), set \`interactive: true\` on the tool call. This enables PTY-based execution and the user will be prompted securely for passwords. Auto-detected for common patterns.
 
   - Avoid using Bash with the \`find\`, \`grep\`, \`cat\`, \`head\`, \`tail\`, \`sed\`, \`awk\`, or \`echo\` commands, unless explicitly instructed or when these commands are truly necessary for the task. Instead, always prefer using the dedicated tools for these commands:
     - File search: Use Glob (NOT find or ls)


### PR DESCRIPTION
## Summary

Add PTY-based interactive command execution for commands that require password/secure input (sudo, ssh -t, ansible -K, etc.). These commands previously failed because the ShellTool used `ChildProcessSpawner` with `stdin: 'ignore'`.

## Implementation

This PR adds a **SecureInput** Effect service and integrates it into the ShellTool:

### New module: `packages/opencode/src/secure-input/`
- **SecureInput Service** — Effect layer with password prompt detection, PTY execution, and event-driven user input flow
- **`SecureInputID`** — Newtype prefixed with `sec_`
- **Password prompt detection** — Matches patterns like `[sudo] password for user:`, `Password:`, `Enter passphrase:`, etc.
- **Interactive command auto-detection** — Matches commands starting with `sudo`, `ssh -t`, `ansible -K`, `su`, `gpg`
- **PTY execution** — Uses bun-pty via the existing pty module to spawn commands, write passwords directly to the PTY fd (never stored or logged)
- **Event bus integration** — `secure-input.requested`, `.submitted`, `.cancelled`, `.timed-out` events

### Modified files
- **`packages/opencode/src/tool/shell/prompt.ts`** — Added `interactive?: boolean` parameter with LLM-facing description
- **`packages/opencode/src/tool/shell.ts`** — Added PTY execution branch activated by `params.interactive` or auto-detection
- **`packages/opencode/src/tool/shell/shell.txt`** — Added usage note about interactive commands
- **`packages/opencode/src/id/id.ts`** — Added `secureinput: "sec"` prefix
- **`packages/opencode/src/effect/app-runtime.ts`** — Registered SecureInput layer
- **`packages/opencode/src/server/routes/instance/`** — Added `/secure-input` Hono routes (`GET /`, `POST /:id/submit`, `POST /:id/cancel`)
- **`packages/opencode/src/server/routes/instance/index.ts`** — Registered routes

### How it works

1. LLM calls ShellTool with `interactive: true` (auto-detected for sudo/ssh/ansible)
2. Tool spawns command via bun-pty instead of ChildProcessSpawner
3. On detecting a password prompt in PTY output, publishes `secure-input.requested` event
4. Password prompt is sanitized to `[password supplied]` in the returned output
5. User submits via API (`POST /:id/submit`) or cancels (`POST /:id/cancel`)
6. Password written directly to PTY — never stored, never logged

## Follow-up work

- TUI secure input prompt component (SolidJS) 
- Web app secure input prompt component  
- SDK client types