### PR TITLE
fix(session): retry flattened overload errors

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -700,7 +700,6 @@ export function fromError(
         { cause: e },
       ).toObject()
     case e instanceof Error:
-      return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
     default:
       try {
         const parsed = ProviderError.parseStreamError(e)
@@ -726,7 +725,10 @@ export function fromError(
           ).toObject()
         }
       } catch {}
-      return new NamedError.Unknown({ message: JSON.stringify(e) }, { cause: e }).toObject()
+      return new NamedError.Unknown(
+        { message: e instanceof Error ? errorMessage(e) : JSON.stringify(e) },
+        { cause: e },
+      ).toObject()
   }
 }
 

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -122,14 +122,15 @@ export function retryable(error: Err, provider: string) {
     return { message: error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message }
   }
 
-  // Check for rate limit patterns in plain text error messages
+  // Check for retryable patterns in plain text error messages
   const msg = isRecord(error.data) ? error.data.message : undefined
   if (typeof msg === "string") {
     const lower = msg.toLowerCase()
     if (
       lower.includes("rate increased too quickly") ||
       lower.includes("rate limit") ||
-      lower.includes("too many requests")
+      lower.includes("too many requests") ||
+      lower.includes("our servers are currently overloaded")
     ) {
       return { message: msg }
     }

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -437,4 +437,44 @@ describe("session.message-v2.fromError", () => {
       message: "An error occurred while processing your request.",
     })
   })
+
+  test("converts overloaded stream errors wrapped in Error to retryable APIError", () => {
+    const error = new Error(
+      JSON.stringify({
+        type: "error",
+        error: {
+          type: "service_unavailable_error",
+          code: "server_is_overloaded",
+          message: "The server is overloaded. Please try again later.",
+        },
+      }),
+    )
+    const result = MessageV2.fromError(error, { providerID: ProviderV2.ID.make("openai") })
+
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.isRetryable).toBe(true)
+    expect(SessionRetry.retryable(result, retryProvider)).toEqual({
+      message: "The server is overloaded. Please try again later.",
+    })
+  })
+
+  test("preserves unknown Error messages as UnknownError", () => {
+    const result = MessageV2.fromError(new Error("Unknown error"), { providerID })
+
+    expect(result).toStrictEqual({
+      name: "UnknownError",
+      data: {
+        message: "Unknown error",
+      },
+    })
+  })
+
+  test("retries flattened OpenAI-compatible overload Errors", () => {
+    const error = new Error("Our servers are currently overloaded. Please try again later.")
+    const result = MessageV2.fromError(error, { providerID: ProviderV2.ID.make("openai") })
+
+    expect(result.name).toBe("UnknownError")
+    expect(SessionRetry.retryable(result, retryProvider)).toEqual({ message: error.message })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #25884

Supersedes #25886 on current `dev`: its structured overload case is already handled upstream; this PR covers the remaining `Error`-wrapped and SDK-flattened paths.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenAI-compatible overload events can reach session handling in two forms: a JSON payload wrapped in `Error`, or the SDK-flattened message `Our servers are currently overloaded...`.

This lets generic `Error` values pass through the existing stream parser before the `UnknownError` fallback, and recognizes the specific flattened overload phrase in retry classification. Unrelated errors keep their existing behavior. This covers the remaining current-`dev` gap not handled by the older #25886 patch.

### How did you verify your code works?

- `bun test test/session/message-v2.test.ts test/session/retry.test.ts` (72 passed)
- `bun typecheck` from `packages/opencode`
- pre-push `bun turbo typecheck`
- Prettier and `git diff --check`

### Screenshots / recordings

N/A. This is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR