### PR TITLE
fix(session): scope default lists by directory

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -13,6 +13,7 @@ import { NotFoundError } from "@/storage/storage"
 import { EOL } from "os"
 import path from "path"
 import { which } from "@opencode-ai/core/util/which"
+import { InstanceRef } from "@/effect/instance-ref"
 
 function pagerCmd(): string[] {
   const lessOptions = ["-R", "-S"]
@@ -84,7 +85,11 @@ export const SessionListCommand = effectCmd({
         default: "table",
       }),
   handler: Effect.fn("Cli.session.list")(function* (args) {
-    const sessions = yield* Session.Service.use((svc) => svc.list({ roots: true, limit: args.maxCount }))
+    const ctx = yield* InstanceRef
+    if (!ctx) return yield* Effect.die("InstanceRef not provided")
+    const sessions = yield* Session.Service.use((svc) =>
+      svc.list(createSessionListQuery({ directory: ctx.directory, maxCount: args.maxCount })),
+    )
 
     if (sessions.length === 0) return
 
@@ -114,6 +119,14 @@ export const SessionListCommand = effectCmd({
     }
   }),
 })
+
+export function createSessionListQuery(input: { directory: string; maxCount?: number }) {
+  return {
+    directory: input.directory,
+    roots: true,
+    limit: input.maxCount,
+  }
+}
 
 function formatSessionTable(sessions: Session.Info[]): string {
   const lines: string[] = []

--- a/packages/opencode/test/cli/session.test.ts
+++ b/packages/opencode/test/cli/session.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test"
+import { createSessionListQuery } from "../../src/cli/cmd/session"
+
+describe("session list", () => {
+  test("scopes the query to the current exact directory", () => {
+    expect(createSessionListQuery({ directory: "/workspace/packages/opencode", maxCount: 12 })).toEqual({
+      directory: "/workspace/packages/opencode",
+      roots: true,
+      limit: 12,
+    })
+  })
+})

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -19,7 +19,7 @@ import { DialogSessionDeleteFailed } from "./dialog-session-delete-failed"
 import { useCommandShortcut } from "../keymap"
 import { useEvent } from "../context/event"
 
-type SessionListFilter = { scope?: "project"; path?: string }
+type SessionListFilter = { scope?: "project"; directory?: string }
 
 export function createDialogSessionListQuery(input: { search?: string; filter: SessionListFilter }) {
   const search = input.search?.trim()

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -29,7 +29,6 @@ import { createSimpleContext } from "./helper"
 import { useExit } from "./exit"
 import { useArgs } from "./args"
 import { batch, onMount } from "solid-js"
-import path from "path"
 import { useKV } from "./kv"
 import { usePermission } from "./permission"
 
@@ -49,6 +48,14 @@ function search<T>(items: T[], target: string, key: (item: T) => string) {
     else right = middle - 1
   }
   return { found: false, index: left }
+}
+
+export function createSessionListFilter(input: { directoryFilterEnabled: boolean; directory?: string }): {
+  scope?: "project"
+  directory?: string
+} {
+  if (!input.directoryFilterEnabled || !input.directory) return { scope: "project" }
+  return { directory: input.directory }
 }
 
 export const {
@@ -151,14 +158,11 @@ export const {
       hydratingSessions.get(sessionID)?.parts.add(partID)
     }
 
-    function sessionListQuery(): { scope?: "project"; path?: string } {
-      if (!kv.get("session_directory_filter_enabled", true)) return { scope: "project" }
-      if (!project.data.instance.path.worktree || !project.data.instance.path.directory) return { scope: "project" }
-      return {
-        path: path
-          .relative(path.resolve(project.data.instance.path.worktree), project.data.instance.path.directory)
-          .replaceAll("\\", "/"),
-      }
+    function sessionListQuery() {
+      return createSessionListFilter({
+        directoryFilterEnabled: kv.get("session_directory_filter_enabled", true),
+        directory: project.data.instance.path.directory,
+      })
     }
 
     function listSessions() {

--- a/packages/tui/test/component/dialog-session-list.test.ts
+++ b/packages/tui/test/component/dialog-session-list.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "bun:test"
 import { createDialogSessionListQuery, loadDialogSessionList } from "../../src/component/dialog-session-list"
 
 describe("dialog session list", () => {
-  test("requests root sessions for the default browse list", () => {
-    expect(createDialogSessionListQuery({ filter: { path: "packages/tui" } })).toEqual({
+  test("requests root sessions in the exact directory for the default browse list", () => {
+    expect(createDialogSessionListQuery({ filter: { directory: "/workspace/packages/tui" } })).toEqual({
       roots: true,
       limit: 100,
-      path: "packages/tui",
+      directory: "/workspace/packages/tui",
     })
   })
 

--- a/packages/tui/test/context/session-list-filter.test.ts
+++ b/packages/tui/test/context/session-list-filter.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+import { createSessionListFilter } from "../../src/context/sync"
+
+describe("session list filter", () => {
+  test("uses the current exact directory when filtering is enabled", () => {
+    expect(createSessionListFilter({ directoryFilterEnabled: true, directory: "/workspace/packages/tui" })).toEqual({
+      directory: "/workspace/packages/tui",
+    })
+  })
+
+  test("uses the project scope when directory filtering is disabled", () => {
+    expect(createSessionListFilter({ directoryFilterEnabled: false, directory: "/workspace/packages/tui" })).toEqual({
+      scope: "project",
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #38529
Replaces the implementation scope from #28972 and #18890.

Related to #31210. This is the current-`dev` implementation for #38529; unlike #31210, it intentionally makes exact-directory filtering the default in both Git and non-Git contexts while retaining project scope when directory filtering is disabled.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Non-git directories share the global project, so project-only session queries can mix unrelated directories.

The CLI now sends its exact instance directory when listing sessions. The TUI uses the same exact-directory filter by default and keeps project scope when directory filtering is disabled. Explicit recursive `path` behavior is unchanged, and directory queries retain the legacy `path IS NULL` fallback. Resume-time cwd handling is intentionally out of scope.

### How did you verify your code works?

- Focused CLI, TUI, and server session-list tests
- `bun typecheck` in `packages/opencode` and `packages/tui`
- pre-push `bun turbo typecheck`
- Prettier and `git diff --check`

### Screenshots / recordings

N/A. Query behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR