### PR TITLE
fix(app): handle undefined selection.directory in new tab from home page

### DIFF
--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -345,15 +345,15 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
               if (route.type === "home") {
                 const selection = layout.home.selection()
                 const conn = global.servers.list().find((item) => ServerConnection.key(item) === selection.server)
-                const project = conn
-                  ? global
-                      .ensureServerCtx(conn)
-                      .projects.list()
-                      .find((item) => item.worktree === selection.directory)
-                  : undefined
-                if (conn && project) {
-                  tabs.newDraft({ server: ServerConnection.key(conn), directory: project.worktree }, "")
-                  return
+                if (conn) {
+                  const projects = global.ensureServerCtx(conn).projects.list()
+                  const project = selection.directory
+                    ? projects.find((item) => item.worktree === selection.directory)
+                    : projects[0]
+                  if (project) {
+                    tabs.newDraft({ server: ServerConnection.key(conn), directory: project.worktree }, "")
+                    return
+                  }
                 }
               }
 


### PR DESCRIPTION
### Bug
When clicking the "+" button on the home page, `selection.directory` is `undefined` by default (set in `layout.tsx` as `{ server: server.key }` without a directory). The project lookup `projects.find((item) => item.worktree === selection.directory)` never matches `undefined`, so the new draft creation silently fails.

### Fix
When `selection.directory` is not set, fall back to `projects[0]` (the first project from the server connection) instead of attempting to match against `undefined`.

### Before
```ts
const project = conn
  ? global.ensureServerCtx(conn).projects.list()
      .find((item) => item.worktree === selection.directory)
  : undefined
if (conn && project) { ... }
```

### After
```ts
if (conn) {
  const projects = global.ensureServerCtx(conn).projects.list()
  const project = selection.directory
    ? projects.find((item) => item.worktree === selection.directory)
    : projects[0]
  if (project) {
    tabs.newDraft(...)
    return
  }
}
```