### PR TITLE
feat(tui): expose native OpenCode theme

### DIFF
--- a/packages/tui/src/theme/index.ts
+++ b/packages/tui/src/theme/index.ts
@@ -1,11 +1,13 @@
 import { Schema } from "effect"
 import { resolveThemeColors } from "./resolve"
-import { DEFAULT_THEMES, type Theme, type ThemeV1Json } from "./v1"
+import { DEFAULT_THEMES_V1, type Theme, type ThemeV1Json } from "./v1"
+import { DEFAULT_THEMES_V2 } from "./v2/defaults"
 import { resolveThemeDocument, themeDecodeError } from "./v2/resolve"
 import { ThemeDocument } from "./v2/schema"
 import { migrateV1 } from "./v2/v1-migrate"
 
-export { DEFAULT_THEMES, generateSyntax, selectedForeground, type Theme, type ThemeV1Json } from "./v1"
+export { DEFAULT_THEMES, DEFAULT_THEMES_V1, generateSyntax, selectedForeground, type Theme, type ThemeV1Json } from "./v1"
+export { DEFAULT_THEMES_V2 } from "./v2/defaults"
 export { resolveThemeDocument, type ThemeDocument }
 
 export type ThemeDocumentSource = Record<string, unknown>
@@ -20,7 +22,8 @@ const decodeThemeDocument = Schema.decodeUnknownSync(ThemeDocument)
 function listThemes() {
   // Priority: defaults < plugin installs < custom files < generated system.
   const themes: Record<string, ThemeDocumentSource> = {
-    ...DEFAULT_THEMES,
+    ...DEFAULT_THEMES_V1,
+    ...DEFAULT_THEMES_V2,
     ...pluginThemes,
     ...customThemes,
   }

--- a/packages/tui/src/theme/v1.ts
+++ b/packages/tui/src/theme/v1.ts
@@ -108,7 +108,7 @@ export type ThemeV1Json = {
   }
 }
 
-export const DEFAULT_THEMES: Record<string, ThemeV1Json> = {
+export const DEFAULT_THEMES_V1: Record<string, ThemeV1Json> = {
   aura,
   ayu,
   catppuccin,
@@ -143,6 +143,8 @@ export const DEFAULT_THEMES: Record<string, ThemeV1Json> = {
   zenburn,
   carbonfox,
 }
+
+export const DEFAULT_THEMES = DEFAULT_THEMES_V1
 
 export function selectedForeground(theme: Theme, bg?: RGBA): RGBA {
   if (theme._hasSelectedListItemText) return theme.selectedListItemText

--- a/packages/tui/src/theme/v2/defaults.ts
+++ b/packages/tui/src/theme/v2/defaults.ts
@@ -438,3 +438,7 @@ export const DEFAULT_THEME = {
     },
   },
 } satisfies ThemeDocument
+
+export const DEFAULT_THEMES_V2 = {
+  "opencode-v2": DEFAULT_THEME,
+} as const satisfies Record<string, ThemeDocument>

--- a/packages/tui/src/theme/v2/index.ts
+++ b/packages/tui/src/theme/v2/index.ts
@@ -43,6 +43,6 @@ export type {
   ResolvedThemeView,
   StatefulColor,
 } from "./types"
-export { DEFAULT_CATEGORICAL } from "./defaults"
+export { DEFAULT_CATEGORICAL, DEFAULT_THEME, DEFAULT_THEMES_V2 } from "./defaults"
 export { migrateV1 } from "./v1-migrate"
 export { selectTheme, selectThemeMode, supportsThemeMode, themeModes } from "./select"


### PR DESCRIPTION
## Summary

- rename the bundled legacy registry to `DEFAULT_THEMES_V1`
- add `DEFAULT_THEMES_V2` with the canonical native theme exposed as `opencode-v2`
- combine both bundled registries before plugin and custom overrides
- retain `DEFAULT_THEMES` as a compatibility alias for existing imports

## Verification

- `bun typecheck`
- focused existing theme tests: 23 passed
- confirmed `allThemes()["opencode-v2"]` parses as a version 2 document
- `git diff --check`

No tests were modified.