### PR TITLE
fix(llm): prevent infinite loop when finish_reason missing in stream

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -462,7 +462,10 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
 const finishEvents = (state: ParserState): ReadonlyArray<LLMEvent> => {
   const events: LLMEvent[] = []
   const hasToolCalls = state.toolCallEvents.length > 0
-  const reason = state.finishReason === "stop" && hasToolCalls ? "tool-calls" : state.finishReason
+  const hasPendingTools = Object.keys(state.tools).length > 0
+  const reason = state.finishReason === "stop" && hasToolCalls
+    ? "tool-calls"
+    : state.finishReason ?? (!hasPendingTools ? "stop" : undefined)
   const lifecycle = state.toolCallEvents.length ? Lifecycle.stepStart(state.lifecycle, events) : state.lifecycle
   events.push(...state.toolCallEvents)
   if (reason) Lifecycle.finish(lifecycle, events, { reason, usage: state.usage })

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -654,6 +654,21 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("emits step-finish with stop even without finish_reason in stream", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        deltaChunk({ role: "assistant", content: "Hello" }),
+        deltaChunk({ content: "!" }),
+      )
+      const events = Array.from(
+        yield* LLMClient.stream(request).pipe(Stream.runCollect, Effect.provide(fixedResponse(body))),
+      )
+      expect(events.filter((e) => e.type === "step-finish")).toEqual([
+        { type: "step-finish", index: 0, reason: "stop", usage: undefined, providerMetadata: undefined },
+      ])
+    }),
+  )
+
   it.effect("short-circuits the upstream stream when the consumer takes a prefix", () =>
     Effect.gen(function* () {
       // The body has more chunks than we'll consume. If `Stream.take(1)` did


### PR DESCRIPTION
### Issue for this PR

  Closes #37855

### Type of change

    - [x] Bug fix
    - [ ] New feature
    - [ ] Refactor / code improvement
    - [ ] Documentation

 ### What does this PR do?

    In web mode, some providers omit `finish_reason` on the final SSE chunk. `finishEvents()` left
  `reason` undefined in that case, the `step-finish` event was never emitted, and `processor.ts` returned
  `"continue"` indefinitely.

    When `finishReason` is undefined and no pending tools exist, this PR defaults to `"stop"`. Pending
  (unfinished) tool calls still keep the previous behavior to avoid emitting a false `"stop"` for
  interrupted streams.

### How did you verify your code works?

    - Added a unit test in `openai-chat.test.ts` to ensure `step-finish` is properly emitted with
  `reason: "stop"` even when `finish_reason` is completely missing from the stream.
    - Verified the infinite loop no longer occurs.

### Screenshots / recordings

    _If this is a UI change, please include a screenshot or recording._

### Checklist

    - [x] I have tested my changes locally
    - [x] I have not included unrelated changes in this PR