### PR TITLE
fix(core): stop forcing toolChoice none on session.generate

### DIFF
--- a/packages/core/src/session/generate-node.ts
+++ b/packages/core/src/session/generate-node.ts
@@ -74,7 +74,6 @@ export const layer = Layer.effect(
             system: contextEvent.system,
             messages: contextEvent.messages,
             tools: hookedTools,
-            toolChoice: "none",
           }),
         )
         yield* Effect.logInfo("session generation usage diagnostic", { usage: response.usage })

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -301,7 +301,7 @@ it.effect("generates from fresh settled Session context without durable mutation
       ),
     ).toEqual(["Settled partial answer"])
     expect(requests[0]?.tools).toMatchObject([{ name: "lookup", description: "Hooked lookup" }])
-    expect(requests[0]?.toolChoice).toMatchObject({ type: "none" })
+    expect(requests[0]?.toolChoice).toBeUndefined()
     expect(yield* durableState(db, sessionID)).toEqual(before)
   }),
 )


### PR DESCRIPTION
## Summary
- `session.generate` no longer sets `toolChoice: \"none\"`.
- Keeps tool definitions so Anthropic/Gemini request prefixes match durable agent turns (better prompt-cache hits for warming/generate).
- Still one physical attempt via `llm.generate`; returns `response.text` only and does not execute tools.

## Behavior if the model calls a tool
- **OpenCode `session.generate`:** tool calls are collected on the response and ignored; no tool execution, no session mutation; returned text may be empty.
- **AI SDK `generateText` (default `stopWhen: stepCountIs(1)`):** parses tool calls and **runs** tool `execute` handlers for that step, then stops without another model round. Different product default than our generate.

## Test plan
- [x] `bun test test/session-generate.test.ts` in `packages/core`
- [x] `bun typecheck` in `packages/core`