### PR TITLE
fix(core): soft-fail realPath in bash advisory arg scan

### DIFF
--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -78,6 +78,12 @@ const isTimeout = (error: AppProcess.AppProcessError) =>
 
 const shellTokens = (command: string) => command.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g) ?? []
 const unquote = (value: string) => value.replace(/^(['"])(.*)\1$/, "$2")
+// Advisory-only path scan: soft-fail realPath so live Unix sockets (EOPNOTSUPP) and similar
+// non-NotFound failures do not abort the bash tool. Workdir auth still uses strict resolve.
+const softResolve = (fs: FSUtil.Interface, target: string) => {
+  const lexical = path.resolve(FSUtil.windowsPath(target))
+  return fs.realPath(lexical).pipe(Effect.catch(() => Effect.succeed(lexical)))
+}
 const externalCommandDirectories = Effect.fn("BashTool.externalCommandDirectories")(function* (
   fs: FSUtil.Interface,
   command: string,
@@ -87,9 +93,9 @@ const externalCommandDirectories = Effect.fn("BashTool.externalCommandDirectorie
   for (const token of shellTokens(command)) {
     const value = unquote(token).replace(/[;,|&]+$/, "")
     if (!path.isAbsolute(value)) continue
-    const resolved = yield* fs.resolve(value)
+    const resolved = yield* softResolve(fs, value)
     if (FSUtil.contains(cwd, resolved)) continue
-    directories.add(yield* fs.resolve(path.dirname(resolved)))
+    directories.add(yield* softResolve(fs, path.dirname(resolved)))
   }
   return [...directories]
 })

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises"
 import { realpathSync } from "node:fs"
+import { createServer } from "node:net"
 import path from "path"
 import { describe, expect, test } from "bun:test"
 import { Effect, Layer } from "effect"
@@ -131,6 +132,7 @@ const call = (input: typeof BashTool.Input.Type, id = "call-bash") => ({
 })
 
 const it = testEffect(Layer.empty)
+const unixSocketTest = process.platform === "win32" ? it.live.skip : it.live
 
 describe("BashTool", () => {
   it.live("registers and returns structured successful output from the active Location", () =>
@@ -340,6 +342,48 @@ describe("BashTool", () => {
         Effect.promise(() =>
           Promise.all([active[Symbol.asyncDispose](), outside[Symbol.asyncDispose]()]).then(() => undefined),
         ),
+    ),
+  )
+
+  unixSocketTest("soft-fails advisory realPath for live Unix socket arguments", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(async () => {
+        const [active, outside] = await Promise.all([tmpdir(), tmpdir()])
+        const socketPath = path.join(outside.path, "live.sock")
+        const server = createServer()
+        await new Promise<void>((resolve, reject) => {
+          server.once("error", reject)
+          server.listen(socketPath, () => resolve())
+        })
+        return { active, outside, socketPath, server }
+      }),
+      (ctx) => {
+        reset()
+        denyAction = "external_directory"
+        return withTool(ctx.active.path, (registry) =>
+          settleTool(registry, call({ command: `printf '%s\\n' ${ctx.socketPath}` })),
+        ).pipe(
+          Effect.andThen((settled) =>
+            Effect.sync(() => {
+              expect(assertions.map((item) => item.action)).toEqual(["bash"])
+              expect(runs).toHaveLength(1)
+              expect(settled.output?.structured).toMatchObject({
+                truncated: false,
+              })
+              expect(settled.output?.structured).not.toHaveProperty("warnings")
+              expect(settled.output?.content[1]).toMatchObject({
+                type: "text",
+                text: expect.stringContaining("Warnings:"),
+              })
+            }),
+          ),
+        )
+      },
+      (ctx) =>
+        Effect.promise(async () => {
+          await new Promise<void>((resolve) => ctx.server.close(() => resolve()))
+          await Promise.all([ctx.active[Symbol.asyncDispose](), ctx.outside[Symbol.asyncDispose]()])
+        }),
     ),
   )
 


### PR DESCRIPTION
### Issue for this PR

Fixes #38544

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V2 bash runs an advisory scan over absolute command arguments via `externalCommandDirectories` → `FSUtil.resolve` → `FileSystem.realPath`. On Darwin (and similar platforms), `realpath` on a **live Unix-domain socket** fails with `EOPNOTSUPP`. `FSUtil.resolve` only soft-fails `NotFound` and `orDie`s everything else, so the advisory scan aborted the whole bash tool with a fatal error before the command ran.

This change soft-fails `realPath` **only** inside that advisory scanner (lexical path fallback), matching the existing best-effort pattern used elsewhere (e.g. filesystem watcher). Workdir / `external_directory` authorization still uses strict `FSUtil.resolve` / `LocationMutation` — authorization behavior is unchanged.

### How did you verify your code works?

```bash
cd packages/core && bun test test/tool-bash.test.ts
```

Result: 12 pass, 0 fail (including new `soft-fails advisory realPath for live Unix socket arguments`).

Also ran `bun typecheck` from the repo root: 30/30 tasks successful.

### Screenshots / recordings

_N/A — non-UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR