### PR TITLE
fix(core): isolate tool hook outcomes

### DIFF
--- a/packages/codemode/src/tool.ts
+++ b/packages/codemode/src/tool.ts
@@ -29,7 +29,7 @@ export type JsonSchema = {
 /** Either a validating Effect Schema or a render-only JSON Schema document. */
 export type SchemaType = Schema.Decoder<unknown> | JsonSchema
 
-/** Executable tool tool exposed through CodeMode's `tools` object. */
+/** Executable tool exposed through CodeMode's `tools` object. */
 export type Tool<R = never> = {
   readonly _tag: "CodeModeTool"
   readonly description: string

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -394,19 +394,15 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: PluginV2.Int
           })
         }
         return toolHooks.hook.after((event) => {
-          // JS plugin boundary: marshal the canonical outcome out, copy mutations back.
-          const output: Record<string, unknown> = {
+          // Decode first so plugin mutations cannot alias the canonical outcome.
+          const output = {
             tool: event.tool,
             sessionID: event.sessionID,
             agent: event.agent,
             messageID: event.messageID,
             callID: event.callID,
             input: event.input,
-            status: event.status,
-            content: event.content,
-            metadata: event.metadata,
-            outputPaths: event.outputPaths,
-            ...(event.status === "error" ? { error: event.error } : {}),
+            ...Schema.decodeUnknownSync(Tool.ExecuteAfterOutcome)(event),
           }
           return Reflect.apply(callback, undefined, [output]).pipe(
             Effect.tap(() => {
@@ -417,16 +413,16 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: PluginV2.Int
                 return Effect.logWarning("ignoring execute.after tool status change", { tool: event.tool })
               return Effect.sync(() => {
                 if (event.status === "completed" && decoded.value.status === "completed") {
-                  if (output.content !== event.content) event.content = decoded.value.content
-                  if (output.metadata !== event.metadata) event.metadata = decoded.value.metadata
-                  if (output.outputPaths !== event.outputPaths) event.outputPaths = decoded.value.outputPaths
+                  event.content = decoded.value.content
+                  event.metadata = decoded.value.metadata
+                  event.outputPaths = decoded.value.outputPaths
                   return
                 }
                 if (event.status === "error" && decoded.value.status === "error") {
-                  if (output.error !== event.error) event.error = decoded.value.error
-                  if (output.content !== event.content) event.content = decoded.value.content
-                  if (output.metadata !== event.metadata) event.metadata = decoded.value.metadata
-                  if (output.outputPaths !== event.outputPaths) event.outputPaths = decoded.value.outputPaths
+                  event.error = decoded.value.error
+                  event.content = decoded.value.content
+                  event.metadata = decoded.value.metadata
+                  event.outputPaths = decoded.value.outputPaths
                 }
               })
             }),

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -130,7 +130,7 @@ const layer = Layer.effect(
       // Durable publishes are serialized so tool fibers and step settlement never interleave
       // mid-event.
       const serialized = <A, E, R>(effect: Effect.Effect<A, E, R>) => publication.withPermit(effect)
-      const publish = (event: LLMEvent, error?: SessionError.Error) => serialized(publisher.publish(event, error))
+      const publish = (event: LLMEvent) => serialized(publisher.publish(event))
       let overflowFailure: ProviderErrorEvent | undefined
       const providerStream = llm.stream(prepared.request).pipe(
         Stream.runForEach((event) =>

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -1,5 +1,5 @@
-import { type LLMEvent, type ProviderMetadata, type ToolContent, type ToolResultValue } from "@opencode-ai/ai"
-import { Effect, Schema } from "effect"
+import { type LLMEvent, type ProviderMetadata, type ToolResultValue } from "@opencode-ai/ai"
+import { Effect } from "effect"
 import { EventV2 } from "../../event"
 import { ModelV2 } from "../../model"
 import { SessionEvent } from "../event"
@@ -12,7 +12,6 @@ import { Snapshot } from "../../snapshot"
 import { RelativePath } from "../../schema"
 import { SessionUsage } from "../usage"
 import { Tool } from "../../tool/tool"
-import { MAX_BYTES } from "../../tool-output-store"
 import type { ToolRegistry } from "../../tool/registry"
 
 type Input = {
@@ -28,9 +27,11 @@ const record = (value: unknown): Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : { value }
 
 /** Derives canonical model content from a provider-hosted tool result. */
-const hostedContent = (result: ToolResultValue): readonly [ToolContent, ...ToolContent[]] => {
-  if (result.type === "content" && result.value.length > 0)
-    return result.value as unknown as readonly [ToolContent, ...ToolContent[]]
+const hostedContent = (result: ToolResultValue): Tool.NonEmptyContent => {
+  if (result.type === "content") {
+    const content = Tool.nonEmpty(result.value)
+    if (content !== undefined) return content
+  }
   return [{ type: "text", text: Tool.stringify(result.value) }]
 }
 
@@ -47,11 +48,8 @@ export const createLLMEventPublisher = (events: Pick<EventV2.Interface, "publish
       progress?: ToolRegistry.Progress
     }
   >()
-  const failureSnapshot = (tool: { readonly progress?: ToolRegistry.Progress }) => {
-    if (!tool.progress) return {}
-    const metadata = Tool.jsonMetadata(tool.progress, MAX_BYTES)
-    return metadata === undefined ? {} : { metadata }
-  }
+  const failureSnapshot = (tool: { readonly progress?: ToolRegistry.Progress }) =>
+    tool.progress === undefined ? {} : { metadata: tool.progress }
   let assistantMessageID = input.assistantMessageID
   let stepStarted = false
   let stepFailed = false
@@ -292,7 +290,7 @@ export const createLLMEventPublisher = (events: Pick<EventV2.Interface, "publish
     return tool ? Effect.succeed(tool.assistantMessageID) : Effect.die(new Error(`Unknown tool call: ${callID}`))
   }
 
-  const publish = Effect.fn("SessionRunner.publishLLMEvent")(function* (event: LLMEvent, error?: SessionError.Error) {
+  const publish = Effect.fn("SessionRunner.publishLLMEvent")(function* (event: LLMEvent) {
     switch (event.type) {
       case "step-start":
         yield* startAssistant()
@@ -405,12 +403,12 @@ export const createLLMEventPublisher = (events: Pick<EventV2.Interface, "publish
         tool.settled = true
         const executed = event.providerExecuted === true || tool.providerExecuted
         const resultState = providerState(event.providerMetadata)
-        if (error !== undefined || event.result.type === "error") {
+        if (event.result.type === "error") {
           yield* events.publish(SessionEvent.Tool.Failed, {
             sessionID: input.sessionID,
             assistantMessageID: tool.assistantMessageID,
             callID: event.id,
-            error: error ?? { type: "tool.execution", message: Tool.stringify(event.result.value) },
+            error: { type: "tool.execution", message: Tool.stringify(event.result.value) },
             ...failureSnapshot(tool),
             executed,
             resultState,
@@ -471,13 +469,12 @@ export const createLLMEventPublisher = (events: Pick<EventV2.Interface, "publish
     const tool = tools.get(callID)
     if (!tool?.called || tool.settled)
       return yield* Effect.die(new Error(`Tool progress outside running call: ${callID}`))
-    const current = { ...update }
-    tool.progress = current
+    tool.progress = update
     yield* events.publish(SessionEvent.Tool.Progress, {
       sessionID: input.sessionID,
       assistantMessageID: tool.assistantMessageID,
       callID,
-      metadata: current,
+      metadata: update,
     })
   })
 

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -365,7 +365,7 @@ describe("PluginV2", () => {
             yield* ctx.tool
               .hook("execute.after", (event) =>
                 Effect.sync(() => {
-                  if (event.status === "completed") event.content = [] as never
+                  if (event.status === "completed") (event.content as unknown as unknown[]).splice(0)
                 }),
               )
               .pipe(Effect.asVoid)

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -118,14 +118,24 @@ test("provider-executed success derives content and retains provider result stat
 test("interrupted progress metadata remains in the terminal failure snapshot", async () => {
   const { published, publisher } = capture("anthropic", { interruptProgress: true })
   await Effect.runPromise(publisher.publish(call))
-  const exit = await Effect.runPromiseExit(
-    publisher.progress(call.id, { phase: "visible" }),
-  )
+  const exit = await Effect.runPromiseExit(publisher.progress(call.id, { phase: "visible" }))
   expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true)
   await Effect.runPromise(publisher.failUnsettledTools({ type: "aborted", message: "interrupted" }))
 
   expect(published.find((event) => event.type === "session.tool.failed.2")?.data).toMatchObject({
     metadata: { phase: "visible" },
+  })
+})
+
+test("failure snapshot retains canonical progress above the default byte limit", async () => {
+  const { published, publisher } = capture("anthropic", { interruptProgress: true })
+  await Effect.runPromise(publisher.publish(call))
+  const detail = "x".repeat(60 * 1024)
+  await Effect.runPromiseExit(publisher.progress(call.id, { detail }))
+  await Effect.runPromise(publisher.failUnsettledTools({ type: "aborted", message: "interrupted" }))
+
+  expect(published.find((event) => event.type === "session.tool.failed.2")?.data).toMatchObject({
+    metadata: { detail },
   })
 })
 


### PR DESCRIPTION
## What

Hardens and simplifies the canonical tool-outcome path introduced by #38367.

- Isolates `execute.after` plugin mutations from Core-owned outcome state.
- Trusts already-validated progress metadata instead of validating it again with a conflicting fixed limit.
- Removes the obsolete publisher error bridge and an unsafe hosted-content cast.
- Fixes the accidental “tool tool” Code Mode comment.

## Before / After

**Before:** The plugin host shallow-copied an `execute.after` event. A plugin could mutate `content`, `metadata`, `error`, or `outputPaths` in place, changing Core's canonical outcome before validation ran. An invalid mutation could therefore be logged as ignored while still leaking into publication. Retained progress was also validated once against the configured limit and again against a fixed 50 KiB limit, so accepted live progress could disappear from a terminal failure snapshot.

**After:** Plugins receive a schema-decoded, detached outcome. Core applies the mutation only after the complete result decodes successfully and retains the original outcome otherwise. The publisher treats `ToolRegistry.Progress` as the already-canonical contract it is, so live progress and terminal failure snapshots use the same configured policy.

## How

- `packages/core/src/plugin/host.ts` decodes a detached hook draft before invoking JavaScript and atomically copies back a valid same-status outcome.
- `packages/core/src/session/runner/publish-llm-event.ts` removes duplicate progress validation, drops the dead optional error parameter, and uses `Tool.nonEmpty` for hosted content.
- Focused regressions cover invalid in-place array mutation and retained progress above the default byte limit.

## Scope

This PR does not redesign the tool hook API, remove existing hook fields, optimize Code Mode catalog materialization, or consolidate every terminal publisher branch. It is limited to confirmed correctness issues and direct cleanup from #38367.

## Testing

- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/codemode`
- `bun run test test/plugin.test.ts test/session-runner-tool-events.test.ts` in `packages/core` (24 passed)
- Push-hook monorepo typecheck (33 packages passed)
- Prettier check on all changed files
- `git diff --check`

## Flow

```mermaid
flowchart LR
  A[Canonical outcome] --> B[Schema-decoded detached draft]
  B --> C[execute.after plugin]
  C --> D{Valid and same status?}
  D -->|yes| E[Apply decoded outcome]
  D -->|no| F[Keep canonical outcome]
  E --> G[Bound and publish]
  F --> G
```
