### PR TITLE
fix(opencode): preserve grep symlink paths

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -69,7 +69,10 @@ export const GrepTool = Tool.define(
           if (result.length === 0) return empty
 
           const rows = result.map((item) => ({
-            path: path.resolve(cwd, item.entry.path),
+            path: path.resolve(
+              requestedInfo?.type === "Directory" ? requested : path.dirname(requested),
+              item.entry.path,
+            ),
             line: item.line,
             text: item.text,
           }))

--- a/packages/opencode/test/tool/grep.test.ts
+++ b/packages/opencode/test/tool/grep.test.ts
@@ -215,6 +215,8 @@ describe("tool.grep", () => {
       )
 
       expect(result.metadata.matches).toBe(1)
+      expect(result.output).toContain(path.join(alias, "test.txt"))
+      expect(result.output).not.toContain(path.join(real, "test.txt"))
       expect(requests.find((req) => req.permission === "external_directory")).toBeUndefined()
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #38582 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Grep canonicalized symlinked search paths and returned the real target path in its output. Subsequent tool calls could then fail external-directory permission checks configured for the original symlink path.

This keeps the canonical path for running ripgrep, but formats results relative to the path requested by the user.

### How did you verify your code works?

Added regression coverage for searching through a directory symlink and verified that results contain the symlink path rather than the real path.

Ran `bun test test/tool/grep.test.ts` and verified with `bun dev` on a local build that the grep tool did indeed return the resolved path instead of real path.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR