### PR TITLE
fix(opencode): recover projects moved to a new path

### DIFF
--- a/packages/opencode/src/project/instance-store.ts
+++ b/packages/opencode/src/project/instance-store.ts
@@ -5,7 +5,6 @@ import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { WorkspaceContext } from "@/control-plane/workspace-context"
 import { InstanceRef } from "@/effect/instance-ref"
 import { disposeInstance as runDisposers } from "@/effect/instance-registry"
-import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Context, Deferred, Duration, Effect, Exit, Layer, Scope } from "effect"
 import { type InstanceContext } from "./instance-context"
 import { InstanceBootstrap } from "./bootstrap-service"
@@ -105,8 +104,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       return true
     })
 
-    const load = (input: LoadInput): Effect.Effect<InstanceContext> => {
-      const directory = FSUtil.resolve(input.directory)
+    const loadResolved = (input: LoadInput, directory: string): Effect.Effect<InstanceContext> => {
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const existing = cache.get(directory)
@@ -123,8 +121,12 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       ).pipe(Effect.withSpan("InstanceStore.load"))
     }
 
-    const reload = (input: LoadInput): Effect.Effect<InstanceContext> => {
-      const directory = FSUtil.resolve(input.directory)
+    const load = (input: LoadInput): Effect.Effect<InstanceContext> =>
+      project
+        .resolveDirectory(input.directory)
+        .pipe(Effect.flatMap((directory) => loadResolved({ ...input, directory }, directory)))
+
+    const reloadResolved = (input: LoadInput, directory: string): Effect.Effect<InstanceContext> => {
       return Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
           const previous = cache.get(directory)
@@ -144,6 +146,11 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
       ).pipe(Effect.withSpan("InstanceStore.reload"))
     }
 
+    const reload = (input: LoadInput): Effect.Effect<InstanceContext> =>
+      project
+        .resolveDirectory(input.directory)
+        .pipe(Effect.flatMap((directory) => reloadResolved({ ...input, directory }, directory)))
+
     const dispose = Effect.fn("InstanceStore.dispose")(function* (ctx: InstanceContext) {
       const entry = cache.get(ctx.directory)
       if (!entry) return yield* disposeContext(ctx)
@@ -155,7 +162,7 @@ const layer: Layer.Layer<Service, never, Project.Service | InstanceBootstrap.Ser
     })
 
     const disposeDirectory = Effect.fn("InstanceStore.disposeDirectory")(function* (input: string) {
-      const directory = FSUtil.resolve(input)
+      const directory = yield* project.resolveDirectory(input)
       const entry = cache.get(directory)
       if (!entry) return
       const exit = yield* Deferred.await(entry.deferred).pipe(Effect.exit)

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,5 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, or, sql } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
 import { ProjectDirectoryTable, ProjectTable } from "@opencode-ai/core/project/sql"
 import { ProjectDirectories } from "@opencode-ai/core/project/directories"
@@ -229,12 +229,14 @@ const layer = Layer.effect(
             sandboxes: [] as string[],
             time: { created: Date.now(), updated: Date.now() },
           }
+      const replaceWorktree =
+        projectID !== ProjectV2.ID.global && row !== undefined && !(yield* fs.isDir(existing.worktree))
 
       if (flags.experimentalIconDiscovery) yield* discover(existing).pipe(Effect.ignore, Effect.forkIn(scope))
 
       const result: Info = {
         ...existing,
-        worktree: projectID === ProjectV2.ID.global ? worktree : existing.worktree,
+        worktree: projectID === ProjectV2.ID.global || replaceWorktree ? worktree : existing.worktree,
         vcs: data.vcs?.type ?? fakeVcs,
         time: { ...existing.time, updated: Date.now() },
       }
@@ -249,7 +251,7 @@ const layer = Layer.effect(
         (s) =>
           fs.exists(s).pipe(
             Effect.orDie,
-            Effect.map((exists) => (exists ? s : undefined)),
+            Effect.map((exists) => (exists && s !== result.worktree ? s : undefined)),
           ),
         { concurrency: "unbounded" },
       ).pipe(Effect.map((arr) => arr.filter((x): x is string => x !== undefined)))
@@ -287,6 +289,30 @@ const layer = Layer.effect(
         })
         .run()
         .pipe(Effect.orDie)
+
+      if (replaceWorktree) {
+        yield* db
+          .update(SessionTable)
+          .set({
+            project_id: projectID,
+            directory: data.directory,
+            time_updated: sql`${SessionTable.time_updated}`,
+          })
+          .where(
+            and(
+              or(eq(SessionTable.project_id, ProjectV2.ID.global), eq(SessionTable.project_id, projectID)),
+              eq(SessionTable.directory, existing.worktree),
+            ),
+          )
+          .run()
+          .pipe(Effect.orDie)
+        yield* db
+          .update(WorkspaceTable)
+          .set({ directory: data.directory })
+          .where(and(eq(WorkspaceTable.project_id, projectID), eq(WorkspaceTable.directory, existing.worktree)))
+          .run()
+          .pipe(Effect.orDie)
+      }
 
       if (projectID !== ProjectV2.ID.global) {
         yield* db

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -87,6 +87,7 @@ export interface Interface {
    * fires. Subscription lifetime is tied to the per-instance state scope.
    */
   readonly init: () => Effect.Effect<void>
+  readonly resolveDirectory: (directory: string) => Effect.Effect<string>
   readonly fromDirectory: (directory: string) => Effect.Effect<{ project: Info; sandbox: string }>
   readonly discover: (input: Info) => Effect.Effect<void>
   readonly list: () => Effect.Effect<Info[]>
@@ -113,6 +114,7 @@ const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
     const { db } = yield* Database.Service
+    const directoryAliases = new Map<string, AbsolutePath>()
 
     const git = Effect.fnUntraced(
       function* (args: string[], opts?: { cwd?: string }) {
@@ -210,10 +212,41 @@ const layer = Layer.effect(
         )
     })
 
+    const resolveDirectory = Effect.fn("Project.resolveDirectory")(function* (directory: string) {
+      const requested = AbsolutePath.make(FSUtil.resolve(directory))
+      if (yield* fs.isDir(requested)) return requested
+      const alias = directoryAliases.get(requested)
+      if (alias && (yield* fs.isDir(alias))) return alias
+      directoryAliases.delete(requested)
+
+      const row = yield* db
+        .select()
+        .from(ProjectTable)
+        .where(eq(ProjectTable.worktree, requested))
+        .get()
+        .pipe(Effect.orDie)
+      if (!row) return requested
+
+      const candidates = yield* Effect.forEach(
+        row.sandboxes,
+        (sandbox) => fs.isDir(sandbox).pipe(Effect.map((exists) => (exists ? sandbox : undefined))),
+        { concurrency: "unbounded" },
+      ).pipe(Effect.map((items) => items.filter((item): item is AbsolutePath => item !== undefined)))
+      if (candidates.length !== 1) return requested
+
+      yield* Effect.logInfo("recovering moved project directory", {
+        projectID: row.id,
+        previous: requested,
+        directory: candidates[0],
+      })
+      directoryAliases.set(requested, candidates[0])
+      return candidates[0]
+    })
+
     const fromDirectory = Effect.fn("Project.fromDirectory")(function* (directory: string) {
       yield* Effect.logInfo("fromDirectory", { directory })
 
-      const data = yield* projectV2.resolve(AbsolutePath.make(directory))
+      const data = yield* projectV2.resolve(yield* resolveDirectory(directory))
       const worktree = data.id === ProjectV2.ID.make("global") && !data.vcs ? "/" : data.directory
 
       // Phase 2: upsert
@@ -296,6 +329,7 @@ const layer = Layer.effect(
           .set({
             project_id: projectID,
             directory: data.directory,
+            path: "",
             time_updated: sql`${SessionTable.time_updated}`,
           })
           .where(
@@ -475,6 +509,7 @@ const layer = Layer.effect(
 
     return Service.of({
       init,
+      resolveDirectory,
       fromDirectory,
       discover,
       list,

--- a/packages/opencode/test/project/instance.test.ts
+++ b/packages/opencode/test/project/instance.test.ts
@@ -6,8 +6,14 @@ import { InstanceRef } from "../../src/effect/instance-ref"
 import { registerDisposer } from "../../src/effect/instance-registry"
 import { InstanceBootstrap } from "../../src/project/bootstrap"
 import { InstanceStore } from "../../src/project/instance-store"
+import { Project } from "../../src/project/project"
 import { tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
+import { Database } from "@opencode-ai/core/database/database"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { eq } from "drizzle-orm"
+import { rename, rm } from "fs/promises"
 
 let bootstrapRun: Effect.Effect<void> = Effect.void
 const noopBootstrap = Layer.succeed(
@@ -16,7 +22,7 @@ const noopBootstrap = Layer.succeed(
 )
 
 const it = testEffect(
-  LayerNode.compile(LayerNode.group([InstanceStore.node, CrossSpawnSpawner.node]), [
+  LayerNode.compile(LayerNode.group([InstanceStore.node, CrossSpawnSpawner.node, Project.node, Database.node]), [
     [InstanceStore.bootstrapNode, noopBootstrap],
   ]),
 )
@@ -47,6 +53,31 @@ describe("InstanceStore", () => {
 
       expect(ctx.directory).toBe(dir)
       expect(ctx.worktree).toBe(dir)
+    }),
+  )
+
+  it.live("loads a moved project through its stale directory", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped({ git: true })
+      const store = yield* InstanceStore.Service
+      const project = yield* Project.Service
+      const { db } = yield* Database.Service
+      const initial = yield* project.fromDirectory(dir)
+      const moved = dir + "-moved"
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(moved, { recursive: true, force: true })))
+      yield* Effect.promise(() => rename(dir, moved))
+      yield* db
+        .update(ProjectTable)
+        .set({ sandboxes: [AbsolutePath.make(moved)] })
+        .where(eq(ProjectTable.id, initial.project.id))
+        .run()
+        .pipe(Effect.orDie)
+
+      const ctx = yield* store.load({ directory: dir })
+
+      expect(ctx.directory).toBe(moved)
+      expect(ctx.worktree).toBe(moved)
+      expect(yield* store.load({ directory: moved })).toBe(ctx)
     }),
   )
 

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -460,18 +460,27 @@ describe("Project.fromDirectory with worktrees", () => {
       const moved = tmp + "-moved"
       yield* Effect.addFinalizer(() => Effect.promise(() => rm(moved, { recursive: true, force: true })))
       yield* Effect.promise(() => rename(tmp, moved))
+      yield* db
+        .update(ProjectTable)
+        .set({ sandboxes: [AbsolutePath.make(moved)] })
+        .where(eq(ProjectTable.id, initial.project.id))
+        .run()
+        .pipe(Effect.orDie)
 
-      const result = yield* project.fromDirectory(moved)
+      expect(yield* project.resolveDirectory(tmp)).toBe(moved)
+      const result = yield* project.fromDirectory(tmp)
 
       expect(result.project.id).toBe(initial.project.id)
       expect(result.project.worktree).toBe(moved)
       expect(result.project.sandboxes).not.toContain(tmp)
       expect(result.project.sandboxes).not.toContain(moved)
+      expect(yield* project.resolveDirectory(tmp)).toBe(moved)
       expect((yield* project.get(result.project.id))?.worktree).toBe(moved)
       for (const id of [projectSessionID, globalSessionID]) {
         const session = yield* db.select().from(SessionTable).where(eq(SessionTable.id, id)).get().pipe(Effect.orDie)
         expect(session?.project_id).toBe(result.project.id)
         expect(session?.directory).toBe(moved)
+        expect(session?.path).toBe("")
         expect(session?.time_updated).toBe(now)
       }
       expect(

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -20,6 +20,8 @@ import { testEffect } from "../lib/effect"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { rename, rm } from "fs/promises"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 
 const encoder = new TextEncoder()
 
@@ -394,6 +396,88 @@ describe("Project.fromDirectory with worktrees", () => {
       expect(result.project.worktree).toBe(worktree1)
       expect(result.project.sandboxes).toContain(worktree2)
       expect(result.project.sandboxes).not.toContain(tmp)
+    }),
+  )
+
+  it.live("promotes a moved repository when the stored worktree is missing", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const { db } = yield* Database.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      const initial = yield* project.fromDirectory(tmp)
+      const projectSessionID = crypto.randomUUID() as SessionID
+      const globalSessionID = crypto.randomUUID() as SessionID
+      const workspaceID = WorkspaceV2.ID.ascending()
+      const now = Date.now()
+      yield* db
+        .insert(ProjectTable)
+        .values({
+          id: ProjectV2.ID.global,
+          worktree: AbsolutePath.make("/"),
+          time_created: now,
+          time_updated: now,
+          sandboxes: [],
+        })
+        .onConflictDoNothing()
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(SessionTable)
+        .values([
+          {
+            id: projectSessionID,
+            project_id: initial.project.id,
+            slug: projectSessionID,
+            directory: tmp,
+            title: "project session",
+            version: "0.0.0-test",
+            time_created: now,
+            time_updated: now,
+          },
+          {
+            id: globalSessionID,
+            project_id: ProjectV2.ID.global,
+            slug: globalSessionID,
+            directory: tmp,
+            title: "global session",
+            version: "0.0.0-test",
+            time_created: now,
+            time_updated: now,
+          },
+        ])
+        .run()
+        .pipe(Effect.orDie)
+      yield* db
+        .insert(WorkspaceTable)
+        .values({
+          id: workspaceID,
+          type: "local",
+          project_id: initial.project.id,
+          directory: tmp,
+        })
+        .run()
+        .pipe(Effect.orDie)
+      const moved = tmp + "-moved"
+      yield* Effect.addFinalizer(() => Effect.promise(() => rm(moved, { recursive: true, force: true })))
+      yield* Effect.promise(() => rename(tmp, moved))
+
+      const result = yield* project.fromDirectory(moved)
+
+      expect(result.project.id).toBe(initial.project.id)
+      expect(result.project.worktree).toBe(moved)
+      expect(result.project.sandboxes).not.toContain(tmp)
+      expect(result.project.sandboxes).not.toContain(moved)
+      expect((yield* project.get(result.project.id))?.worktree).toBe(moved)
+      for (const id of [projectSessionID, globalSessionID]) {
+        const session = yield* db.select().from(SessionTable).where(eq(SessionTable.id, id)).get().pipe(Effect.orDie)
+        expect(session?.project_id).toBe(result.project.id)
+        expect(session?.directory).toBe(moved)
+        expect(session?.time_updated).toBe(now)
+      }
+      expect(
+        (yield* db.select().from(WorkspaceTable).where(eq(WorkspaceTable.id, workspaceID)).get().pipe(Effect.orDie))
+          ?.directory,
+      ).toBe(moved)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #38578

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a Git repository moved, the stored project kept the missing original path
as its primary worktree and tracked the live path as a sandbox. Desktop startup
could therefore request the deleted path first, causing Git discovery to fail
in `FileSystem.realPath` before the existing project record could be repaired.

This change recovers the project at both boundaries:

- before instance creation, a missing stored worktree resolves to its single
  surviving sandbox;
- the recovered directory is used as the instance cache key and runtime
  context, so the stale and current requests share one valid instance;
- the in-process alias remains available for repeated stale requests after the
  database migration;
- the live worktree is promoted to the project's primary worktree;
- missing and duplicate sandbox paths are removed;
- matching project and legacy-global sessions move to the recovered project
  directory, including their relative `path`, without changing
  `time_updated`; and
- matching workspace directories are updated.

Recovery is intentionally conservative: it only redirects a missing primary
worktree when exactly one recorded sandbox still exists. Existing behavior is
unchanged when the primary worktree exists or multiple live sandboxes make the
replacement ambiguous.

### How did you verify your code works?

The regression tests create a Git repository, seed project and legacy-global
sessions plus a workspace, move the repository, and then request the deleted
path. They verify:

- the stale directory resolves to the moved repository before Git discovery;
- instance context and caching use the live path;
- the project ID remains stable;
- the live worktree is promoted and sandbox state is cleaned;
- sessions, relative paths, and workspace records are migrated; and
- session timestamps are preserved.

Executed:

```text
bun test test/project/project.test.ts test/project/instance.test.ts
# 47 pass, 0 fail

bun typecheck

# Required pre-push monorepo hook
bun turbo typecheck
# 30 successful, 30 total

oxlint packages/opencode/src/project/project.ts \
  packages/opencode/src/project/instance-store.ts \
  packages/opencode/test/project/project.test.ts \
  packages/opencode/test/project/instance.test.ts
# 0 errors

git diff --check
```

### Screenshots / recordings

Not applicable; this is a project/session persistence and instance-routing fix
with no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
