### PR TITLE
fix(core): stabilize tool definition ordering

### DIFF
--- a/packages/core/src/tool/registry.ts
+++ b/packages/core/src/tool/registry.ts
@@ -323,7 +323,10 @@ const registryLayer = Layer.effect(
             const codemodeTool = (yield* codeMode.materialize(permissions)).tool
             return {
               definitions: [
-                ...Array.from(direct, ([name, registration]) => toLLMDefinition(name, registration.tool)),
+                // Definitions are prompt-cache prefix bytes, so order only after effective registrations settle.
+                ...Array.from(direct)
+                  .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+                  .map(([name, registration]) => toLLMDefinition(name, registration.tool)),
                 ...(codemodeTool ? [toLLMDefinition("execute", codemodeTool)] : []),
               ],
               execute: (input: ExecuteInput) => {

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -300,8 +300,8 @@ describe("PluginV2", () => {
       yield* plugins.activate([versioned(plugin)])
 
       expect((yield* registry.snapshot()).definitions.map((tool) => tool.name)).toEqual([
-        "plain",
         "context7_look_up",
+        "plain",
         "execute",
       ])
     }),

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -121,6 +121,33 @@ describe("ToolRegistry", () => {
     }),
   )
 
+  it.effect("canonicalizes effective definitions and keeps Code Mode last", () =>
+    Effect.gen(function* () {
+      const service = yield* ToolRegistry.Service
+      const tool = make()
+      const capture = (registrations: Parameters<typeof service.registerBatch>[0]) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            yield* service.registerBatch(registrations)
+            return (yield* service.snapshot()).definitions
+          }),
+        )
+      const first = yield* capture([
+        { tools: { zeta: tool, alpha: tool }, options: { codemode: false } },
+        { tools: { beta: tool }, options: { namespace: "alpha", codemode: false } },
+        { tools: { echo: tool } },
+      ])
+      const second = yield* capture([
+        { tools: { echo: tool } },
+        { tools: { beta: tool }, options: { namespace: "alpha", codemode: false } },
+        { tools: { alpha: tool, zeta: tool }, options: { codemode: false } },
+      ])
+
+      expect(first).toEqual(second)
+      expect(first.map((definition) => definition.name)).toEqual(["alpha", "alpha_beta", "zeta", "execute"])
+    }),
+  )
+
   it.effect("filters disabled tools with edit aliases and ordered wildcard precedence", () =>
     Effect.gen(function* () {
       const service = yield* ToolRegistry.Service
@@ -142,7 +169,7 @@ describe("ToolRegistry", () => {
           { action: "*", resource: "*", effect: "deny" },
         ]),
       ).toEqual([])
-      expect(yield* names([{ action: "edit", resource: "*", effect: "deny" }])).toEqual(["question", "bash"])
+      expect(yield* names([{ action: "edit", resource: "*", effect: "deny" }])).toEqual(["bash", "question"])
     }),
   )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1099,7 +1099,7 @@ describe("SessionRunnerLLM", () => {
 
       expect(requests).toHaveLength(1)
       expect(requests[0]?.model).toBe(model)
-      expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(["echo", "defect", "storefail"])
+      expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(["defect", "echo", "storefail"])
       expect(requests[0]?.messages.map((message) => ({ role: message.role, content: message.content }))).toEqual([
         { role: "user", content: [{ type: "text", text: "First" }] },
         { role: "user", content: [{ type: "text", text: "Second" }] },
@@ -2392,7 +2392,7 @@ describe("SessionRunnerLLM", () => {
       yield* session.resume(sessionID)
 
       expect(requests).toHaveLength(1)
-      expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(["echo", "defect", "storefail"])
+      expect(requests[0]?.tools.map((tool) => tool.name)).toEqual(["defect", "echo", "storefail"])
       expect(yield* session.context(sessionID)).toMatchObject([
         { type: "user", text: "Use tools" },
         {


### PR DESCRIPTION
## What

Emit effective native tool definitions in canonical provider-visible name order so semantically equivalent registration sets produce byte-identical tool arrays regardless of plugin or registration order.

This stabilizes the first and usually largest provider prompt-cache prefix component.

## Before / After

**Before**

1. Register native tools in one plugin or reload order.
2. `ToolRegistry.snapshot()` preserves the registry `Map` insertion order in `LLM.ToolDefinition[]`.
3. Reload the same effective tools in another order.
4. The provider tool array changes even though names, descriptions, schemas, permissions, and execution behavior are identical.
5. Provider prompt caches may miss unnecessarily.

**After**

1. Latest-active registration selection and permission filtering settle exactly as before.
2. The newly allocated effective direct-entry array is sorted by final provider-visible name.
3. Definitions are projected from that canonical order.
4. Code Mode’s `execute` definition remains appended last.
5. The captured execution `Map` remains unchanged.

## How

- `packages/core/src/tool/registry.ts` sorts effective direct entries immediately before `LLM.ToolDefinition` projection.
- `packages/core/test/session-runner-tool-registry.test.ts` compares opposite batch, object, and namespaced registration orders and verifies `execute` remains last.
- `packages/core/test/session-runner.test.ts` pins the canonical order on real prepared model requests.

```mermaid
flowchart LR
  A[Scoped registrations] --> B[Latest-active winners]
  B --> C[Permission filtering]
  C --> D[Sort direct entries by final name]
  D --> E[Native LLM definitions]
  E --> F[Append Code Mode execute]
```

## Scope

- Does not change registration precedence, permission filtering, execution lookup, or context-hook semantics.
- Does not reorder Code Mode’s `execute` definition relative to native tools.
- Does not combine Code Mode instruction and execution materialization into one snapshot.
- No Changeset: `@opencode-ai/core` is private.

## Testing

- `bun run test test/session-runner-tool-registry.test.ts` in `packages/core`: 19 passed.
- `bun run test test/session-runner.test.ts` in `packages/core`: 137 passed.
- `bun typecheck` in `packages/core`.
- Pre-push `bun turbo typecheck --concurrency=3`: 33 packages passed.
- Prettier check for the registry implementation and focused registry test.
- `git diff --check`.