### PR TITLE
fix: session changes panel always empty — Session.diff() stub + SessionSummary.diff() fallback

### DIFF
--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -488,7 +488,7 @@ export type Patch = Omit<Partial<Info>, "time" | "share" | "summary" | "revert" 
 const layer: Layer.Layer<
   Service,
   never,
-  BackgroundJob.Service | RuntimeFlags.Service | Database.Service | EventV2Bridge.Service
+  BackgroundJob.Service | RuntimeFlags.Service | Database.Service | EventV2Bridge.Service | Snapshot.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -497,6 +497,7 @@ const layer: Layer.Layer<
     const background = yield* BackgroundJob.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
+    const shot = yield* Snapshot.Service
 
     const createNext = Effect.fn("Session.createNext")(function* (input: {
       id?: SessionID
@@ -823,8 +824,24 @@ const layer: Layer.Layer<
     })
 
     const diff = Effect.fn("Session.diff")(function* (sessionID: SessionID) {
-      void sessionID
-      return [] as Snapshot.FileDiff[]
+      const msgs = yield* messages({ sessionID }).pipe(Effect.orDie)
+      let from: string | undefined
+      let to : string | undefined
+      for (const item of msgs) {
+        if (!from) {
+          for (const part of item.parts) {
+            if (part.type === "step-start" && part.snapshot) {
+              from = part.snapshot
+              break
+            }
+          }
+        }
+        for (const part of item.parts) {
+          if (part.type === "step-finish" && part.snapshot) to = part.snapshot
+        }
+      }
+      if (from && to) return yield* shot.diffFull(from, to)
+      return []
     })
 
     const messages: Interface["messages"] = Effect.fn("Session.messages")(function* (input) {
@@ -1012,7 +1029,7 @@ function listByProject(
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [BackgroundJob.node, RuntimeFlags.node, Database.node, EventV2Bridge.node],
+  deps: [BackgroundJob.node, RuntimeFlags.node, Database.node, EventV2Bridge.node, Snapshot.node],
 })
 
 export * as Session from "./session"

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -127,12 +127,16 @@ const layer = Layer.effect(
     })
 
     const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {
-      if (!input.messageID) return []
-      const message = (yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)).find(
-        (item) => item.info.id === input.messageID,
-      )
+      if (!input.messageID) {
+        const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
+        if (!all.length) return []
+        return yield* computeDiff({ messages: all })
+      }
+      const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
+      const message = all.find((item) => item.info.id === input.messageID)
       if (!message || message.info.role !== "user") return []
       const diffs = message.info.summary?.diffs ?? []
+      if (diffs.length === 0) return yield* computeDiff({ messages: all })
       return diffs.map((item) => {
         if (item.file === undefined) return item
         const file = unquoteGitPath(item.file)


### PR DESCRIPTION
Fixes #32852

## Problem

The TUI right-panel "Session Changes" tab and Desktop review panel never show modified files. Users see "No changes in this session yet" even after agents modify dozens of files.

## Root cause

Two bugs introduced in a refactor from an older working version (e.g. `51e310c9`):

### 1. `session.ts` — `Session.diff()` is a hardcoded stub

```ts
const diff = Effect.fn("Session.diff")(function* (sessionID) {
  void sessionID        // discards parameter
  return []             // always empty
})
```

### 2. `summary.ts` — `SessionSummary.diff()` only reads per-message cached diffs

```ts
const diff = Effect.fn("SessionSummary.diff")(function* (input) {
  if (!input.messageID) return []   // dead end for full session view
  return message.summary?.diffs ?? []  // per-turn cache, usually empty
})
```

`summarize()` stores diffs per user-turn in `message.summary.diffs`. But file changes span multiple turns, so each turn"s cached diffs are consistently `[]`. The full session diff is never computed or exposed.

## Fix

**`session.ts`**: Replace stub with full implementation — fetch all session messages, scan for `step-start`/`step-finish` snapshot hashes, call `Snapshot.diffFull(from, to)`. Adds `Snapshot.Service` as layer dependency (already in runtime at `app-runtime.ts:68` before `Session.node` at line 79).

**`summary.ts`**: When cached diffs are empty or no `messageID` given, fall back to computing the full session diff from all messages via `computeDiff()`.

## Related

- Also closes #13981 (closed as COMPLETED but bug persisted — root cause analysis provided in this PR)
- Related: #30877, #13065, #11856, #10920, #10716, #7555
- Complementary PRs: #37542 (fixes `summarize()` write path), #37613 (broader refactor)

## Testing

- [x] Existing tests pass: `session.test.ts` (7), `snapshot.test.ts` (57), `session-diff-missing-patch.test.ts`
- [x] Typecheck passes (`bun turbo typecheck`: 30/30 packages)
- [x] Verified end-to-end on macOS with patched binary: Changes panel shows file diffs for previously-empty sessions
- [x] Backward compatible — all existing test expectations preserved