### PR TITLE
fix(core): preserve global instructions across read races

### DIFF
--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -66,7 +66,10 @@ export const layer = (options?: Options) => Layer.effect(
           fs.resolve,
         ),
       )
-      const paths = Array.dedupe([yield* fs.resolve(join(global.config, "AGENTS.md")), ...discovered])
+      const globalPath = yield* fs.resolve(join(global.config, "AGENTS.md"))
+      const observed = new Set(discovered)
+      if (yield* fs.exists(globalPath)) observed.add(globalPath)
+      const paths = Array.dedupe([globalPath, ...discovered])
       const files = yield* Effect.forEach(
         paths,
         (path) =>
@@ -79,7 +82,7 @@ export const layer = (options?: Options) => Layer.effect(
             ),
         { concurrency: "unbounded" },
       )
-      if (files.some((file, index) => file === undefined && discovered.has(paths[index])))
+      if (files.some((file, index) => file === undefined && observed.has(paths[index])))
         return Instructions.unavailable
       return files.filter((file): file is File => file !== undefined)
     })

--- a/packages/core/test/instruction-discovery.test.ts
+++ b/packages/core/test/instruction-discovery.test.ts
@@ -199,6 +199,42 @@ describe("InstructionDiscovery", () => {
     }),
   )
 
+  it.effect("preserves admitted instructions when the global file disappears before read", () =>
+    Effect.gen(function* () {
+      const file = AbsolutePath.make("/global/AGENTS.md")
+      const racingFS = Layer.effect(
+        FSUtil.Service,
+        FSUtil.Service.pipe(
+          Effect.map((fs) =>
+            FSUtil.Service.of({
+              ...fs,
+              exists: () => Effect.succeed(true),
+              up: () => Effect.succeed([]),
+              readFileStringSafe: () => Effect.succeed(undefined),
+            }),
+          ),
+        ),
+      ).pipe(Layer.provide(LayerNode.compile(FSUtil.node)))
+      const context = yield* InstructionDiscovery.Service.pipe(
+        Effect.flatMap((service) => service.load()),
+        Effect.provide(
+          instructionLayer({
+            config: "/global",
+            filesystemLayer: racingFS,
+            locationServiceLayer: Layer.succeed(
+              Location.Service,
+              Location.Service.of(location({ directory: AbsolutePath.make("/repo") })),
+            ),
+          }),
+        ),
+      )
+
+      expect(
+        (yield* readUpdate(context, state({ "core/instructions": [{ path: file, content: "old" }] }))).changed,
+      ).toBe(false)
+    }),
+  )
+
   it.effect("canonicalizes upward discovery boundaries", () =>
     Effect.gen(function* () {
       let observed: { targets: string[]; start: string; stop?: string } | undefined


### PR DESCRIPTION
## What

Preserve the last admitted global `AGENTS.md` instructions when the file disappears between filesystem observation and content read.

## Before / After

**Before**

1. Instruction discovery always included the global `AGENTS.md` path but did not record whether the file existed.
2. The file could exist during discovery and disappear before `readFileStringSafe`, for example during an atomic editor replacement.
3. The missing read was filtered out as though the file had been deliberately removed.
4. Session instruction state durably admitted a removal update, temporarily telling the model that the previous global instructions no longer applied.

**After**

1. Discovery records whether the global file exists before reading it.
2. If an observed global file disappears before the read, the aggregate observation is `Unavailable`.
3. `InstructionState` retains the previously admitted instruction value and emits no update.
4. A global file that is already absent during observation still produces normal removal semantics.

## How

- `packages/core/src/instruction-discovery.ts` adds the global file to the same observed-path set already used for upward project instruction files.
- `packages/core/test/instruction-discovery.test.ts` deterministically models `exists === true` followed by a missing safe read and verifies that admitted instructions remain unchanged.

## Scope

- Does not retry filesystem reads.
- Does not change project `AGENTS.md` discovery; it already handled this race.
- Does not retain instructions after a global file is observed as absent.

## Testing

- `bun run test test/instruction-discovery.test.ts`: 8 passed.
- `bun run test test/instruction-state.test.ts test/session-instructions.test.ts`: 15 passed.
- The new regression test failed before the fix with `changed: true` and passes after it with `changed: false`.
- `bun typecheck` from `packages/core` passed.
- Repository-wide `bun typecheck`: 33 package tasks passed.
- Changed-file lint passed with no warnings or errors.
- Full Core run: 1,421 passed, 6 skipped; the only failure was the unrelated `LocationServiceMap > keeps flush pending while startup updates continue` timeout.
