### PR TITLE
fix(app): hydrate v1 session progress

### DIFF
--- a/packages/app/src/context/server-sync.test.ts
+++ b/packages/app/src/context/server-sync.test.ts
@@ -64,7 +64,7 @@ describe("MCP queries", () => {
 })
 
 describe("active session query", () => {
-  test("loads active sessions once per server cache", async () => {
+  test("loads active sessions immediately and once per server cache", async () => {
     let calls = 0
     const queryClient = new QueryClient()
     const options = loadActiveSessionsQuery(ServerScope.local, {
@@ -77,6 +77,7 @@ describe("active session query", () => {
     expect(await queryClient.fetchQuery(options)).toEqual({ ses_running: { type: "running" } })
     expect(await queryClient.fetchQuery(options)).toEqual({ ses_running: { type: "running" } })
     expect(calls).toBe(1)
+    expect(options.enabled).toBe(true)
     expect([...options.queryKey]).toEqual([ServerScope.local, "activeSessions"])
   })
 

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -157,7 +157,7 @@ export const loadActiveSessionsQuery = (
   queryOptions<SessionActiveOutput, Error, SessionActiveOutput, readonly [ServerScope, "activeSessions"]>({
     queryKey: [scope, "activeSessions"] as const,
     queryFn: () => api.active(),
-    enabled: false,
+    enabled: true,
     staleTime: Number.POSITIVE_INFINITY,
     gcTime: Number.POSITIVE_INFINITY,
     refetchOnMount: false,
@@ -242,8 +242,8 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
       active: async () => {
         if ((await serverSDK.protocol) === "v1") {
           const statuses = (await serverSDK.client.session.status()).data ?? {}
-          for (const [sessionID, status] of Object.entries(statuses)) {
-            session.set("session_status", sessionID, reconcile(status))
+          seedActiveSessionStatuses(session, statuses)
+          for (const sessionID of Object.keys(statuses)) {
             void session.resolve(sessionID).catch(() => undefined)
           }
           return Object.fromEntries(


### PR DESCRIPTION
## Summary

- fetch active sessions during initial server sync instead of waiting for a `server.connected` event
- preserve newer event-written v1 statuses when initial hydration races the event stream
- cover immediate active-session query hydration

## Validation

- `bun test --preload ./happydom.ts ./src/context/server-sync.test.ts`
- `bun typecheck`
- `bun test ./e2e/performance/unit`
- Playwright v1 remote-tab fixture with `server.connected` suppressed: fails on `dev`, passes on this branch