### PR TITLE
fix: slash command message ordering in timeline

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -283,6 +283,12 @@ export function MessageTimeline(props: {
     return sync().data.session_status[id] ?? idle
   })
   const sessionMessages = createMemo(() => (sessionID() ? (sync().data.message[sessionID()!] ?? []) : []))
+  const orderedMessages = createMemo(() => {
+    const msgs = sessionMessages()
+    return [...msgs].sort(
+      (a, b) => (a.time?.created ?? 0) - (b.time?.created ?? 0) || String(a.id ?? "").localeCompare(String(b.id ?? "")),
+    )
+  })
   const projectedMessages = createMemo(() => {
     const id = sessionID()
     if (!id) return []
@@ -331,7 +337,7 @@ export function MessageTimeline(props: {
   })
   const showHeader = createMemo(() => !!(titleValue() || parentID()))
   const projection = createTimelineProjection({
-    messages: sessionMessages,
+    messages: orderedMessages,
     sessionMessages: projectedMessages,
     parts: getMsgParts,
     status: sessionStatus,

--- a/packages/app/src/pages/session/timeline/model.ts
+++ b/packages/app/src/pages/session/timeline/model.ts
@@ -41,7 +41,9 @@ export function createTimelineModel(input: {
   )
   const messages = createMemo(() => {
     const id = input.sessionID()
-    return id ? (sync().data.message[id] ?? []) : []
+    if (!id) return []
+    const msgs = sync().data.message[id] ?? []
+    return [...msgs].sort((a, b) => (a.time?.created ?? 0) - (b.time?.created ?? 0) || String(a.id ?? "").localeCompare(String(b.id ?? "")))
   })
   const ready = createMemo(() => {
     const id = input.sessionID()


### PR DESCRIPTION
### Issue for this PR

Fixes #38613

### Type of change

- [x] Bug fix

### What does this PR do?

Fix the WebChat slash command message ordering bug where command output appears at the wrong position in the timeline.

Root cause: event-stream race condition — when slash command output messages arrive before the previous turn's final flush events, the sync data array contains messages in the wrong order. Both `model.ts` and `message-timeline.tsx` use the unsorted sync array directly.

Fix:
- **model.ts**: sort messages by `time.created` in the `messages` memo (id as tiebreaker), fixing ordering at the data source
- **message-timeline.tsx**: add `orderedMessages` memo as defensive layer, passing sorted messages to `createTimelineProjection` instead of raw `sessionMessages`

> Note: the submission-side race (setBusy/setIdle) has been independently addressed upstream via the `serverSync()` API refactor.

### How did you verify your code works?

1. Rebuilt binary with WebChat frontend embedded
2. Tested on WebChat over multiple days:
   - Slash command output appears in correct chronological order
   - No visible side effects on normal message flow
3. Smoke test: binary launches and responds normally

### Screenshots / recordings

Not applicable — behavioral fix, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR