### PR TITLE
feat(tui): add Missed column to v2 turn token usage diagnostics

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1080,6 +1080,7 @@ function SessionRowView(props: SessionRowViewProps) {
             <TurnTokenUsage
               messageIDs={row().messageIDs}
               previousCacheRead={row().previousCacheRead}
+              previousTotal={row().previousTotal}
               message={props.message}
             />
           )}
@@ -1092,12 +1093,14 @@ function SessionRowView(props: SessionRowViewProps) {
 function TurnTokenUsage(props: {
   messageIDs: string[]
   previousCacheRead?: number
+  previousTotal?: number
   message: (messageID: string) => SessionMessageInfo | undefined
 }) {
   const config = useConfig()
   const { themeV2 } = useTheme()
   const steps = createMemo(() => {
     let previousCacheRead = props.previousCacheRead
+    let previousTotal: number | undefined = props.previousTotal
     return props.messageIDs.flatMap((messageID) => {
       const message = props.message(messageID)
       if (message?.type !== "assistant" || !message.tokens) return []
@@ -1113,7 +1116,9 @@ function TurnTokenUsage(props: {
         previousCacheRead !== undefined && message.tokens.cache.read < previousCacheRead
           ? previousCacheRead - message.tokens.cache.read
           : undefined
+      const missed = previousTotal !== undefined ? previousTotal - message.tokens.cache.read : undefined
       previousCacheRead = message.tokens.cache.read
+      previousTotal = total
       return [
         {
           finish: message.finish === "tool-calls" ? "tool-call" : (message.finish ?? "unknown"),
@@ -1121,6 +1126,7 @@ function TurnTokenUsage(props: {
           cached: message.tokens.cache.read,
           total,
           cacheBust,
+          missed,
         },
       ]
     })
@@ -1129,6 +1135,10 @@ function TurnTokenUsage(props: {
     step: Math.max("Step".length, ...steps().map((item) => item.finish.length)),
     newTokens: Math.max("New".length, ...steps().map((item) => item.newTokens.toLocaleString().length)),
     cached: Math.max("Cached".length, ...steps().map((item) => item.cached.toLocaleString().length)),
+    missed: Math.max(
+      "Missed".length,
+      ...steps().map((item) => (item.missed !== undefined ? item.missed.toLocaleString().length : 1)),
+    ),
     total: Math.max("Total".length, ...steps().map((item) => item.total.toLocaleString().length)),
   }))
   return (
@@ -1149,6 +1159,8 @@ function TurnTokenUsage(props: {
             {"  "}
             {"Cached".padStart(columns().cached)}
             {"  "}
+            {"Missed".padStart(columns().missed)}
+            {"  "}
             {"Total".padStart(columns().total)}
           </text>
         </box>
@@ -1162,6 +1174,8 @@ function TurnTokenUsage(props: {
                 </span>
                 {"  "}
                 {item.cached.toLocaleString().padStart(columns().cached)}
+                {"  "}
+                {item.missed !== undefined ? item.missed.toLocaleString().padStart(columns().missed) : "-".padStart(columns().missed)}
                 {"  "}
                 {item.total.toLocaleString().padStart(columns().total)}
               </text>

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -28,7 +28,7 @@ export type SessionRow =
       completed: boolean
     }
   | { type: "assistant-footer"; messageID: string }
-  | { type: "turn-usage"; messageIDs: string[]; previousCacheRead?: number }
+  | { type: "turn-usage"; messageIDs: string[]; previousCacheRead?: number; previousTotal?: number }
 
 export function createSessionRows(sessionID: Accessor<string>) {
   const data = useData()
@@ -280,7 +280,11 @@ export function reduceSessionRows(
   const pendingCompactions = messages.filter((message) => message.type === "compaction" && message.status === "running")
   const pending = new Set([...pendingCompactions.map((message) => message.id), ...inputs])
   const usage = turnTokens
-    ? { steps: [] as SessionMessageAssistant[], previousTurnCacheRead: undefined as number | undefined }
+    ? {
+        steps: [] as SessionMessageAssistant[],
+        previousTurnCacheRead: undefined as number | undefined,
+        previousTurnTotal: undefined as number | undefined,
+      }
     : undefined
   return [
     ...messages.filter((message) => !pending.has(message.id)),
@@ -315,8 +319,10 @@ export function reduceSessionRows(
           ...(usage.previousTurnCacheRead === undefined
             ? {}
             : { previousCacheRead: usage.previousTurnCacheRead }),
+          ...(usage.previousTurnTotal === undefined ? {} : { previousTotal: usage.previousTurnTotal }),
         })
         usage.previousTurnCacheRead = last.tokens.cache.read
+        usage.previousTurnTotal = tokenTotal(last.tokens)
       }
       usage.steps.length = 0
     }


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] New feature

### What does this PR do?

Adds a `Missed` column to the v2 turn token usage diagnostics panel, showing how many tokens from the previous step's total were not served from cache in the current step.

Formula: `Missed = previous step Total - current step Cached`

- The first step (including the first step of a cross-turn continuation) shows `-`
- `Missed` tracks across turn boundaries so values carry over between turns

Example output:

```
◈Tokens
Step       New  Cached  Missed   Total
tool-call  184  34,304      58  34,488
tool-call  263  34,432      56  34,695
stop       143  34,688       7  34,831
```

- Step 2 Missed=58: 58 of step 1's 34,488 tokens were not in cache
- Step 3 Missed=56: 56 of step 2's 34,695 tokens missed cache
- Step 4 Missed=7: nearly all of step 3's tokens hit cache

### Why Missed matters

Some models cache the `New` tokens from the previous step and serve them as `Cached` in the next — you pay once. Others never do. If `Missed` is consistently larger than the previous step's `New`, you are paying for the same output twice, a signal worth raising with your provider. (DeepSeek gets this right and does cache outputs. Many others do not.)

### How did you verify your code works?

- `bun typecheck` passes
- Verified values locally in the TUI with turn_tokens debug enabled

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
