### PR TITLE
fix(app): gate config permission auto-accept

### DIFF
--- a/packages/app/src/context/permission.tsx
+++ b/packages/app/src/context/permission.tsx
@@ -212,6 +212,7 @@ function createServerPermissionState(input: { sdk: ServerSDK; sync: ServerSync }
   )
 
   function enableConfiguredDirectory(directory: string) {
+    if (input.sdk.protocolKind() !== "v1") return
     if (meta.disposed || !ready()) return
     const [childStore] = input.sync.child(directory)
     if (childStore.config.permission !== "allow") return


### PR DESCRIPTION
## Summary
- keep config-derived permission auto-accept v1-only while preserving manual permission controls

## Stack
- depends on #38649

## Testing
- `bun typecheck` in `packages/app`