### PR TITLE
fix(cli): emit text_delta events in run --format json

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -696,6 +696,10 @@ export const RunCommand = effectCmd({
         // created, and replies issued from inside the loop must use that client.
         async function loop(client: OpencodeClient, events: Awaited<ReturnType<typeof sdk.event.subscribe>>) {
           const toggles = new Map<string, boolean>()
+          // Track each part's type so message.part.delta (which carries field
+          // but not part type) can be limited to text parts. Reasoning parts
+          // update the same "text" field but must not surface as text_delta.
+          const partTypes = new Map<string, string>()
           let error: string | undefined
 
           for await (const event of events.stream) {
@@ -715,6 +719,7 @@ export const RunCommand = effectCmd({
             if (event.type === "message.part.updated") {
               const part = event.properties.part
               if (part.sessionID !== sessionID) continue
+              partTypes.set(part.id, part.type)
 
               if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
                 if (emit("tool_use", { part })) continue
@@ -771,6 +776,29 @@ export const RunCommand = effectCmd({
                 }
                 process.stdout.write(line + EOL)
               }
+            }
+
+            // message.part.delta carries each streaming text chunk as it is
+            // produced. Under --format json, mirror it as a text_delta event so
+            // consumers can render incremental progress instead of waiting for the
+            // final complete text event (still emitted above for backward
+            // compatibility). Non-json mode ignores deltas; its text rendering is
+            // driven by the complete part in message.part.updated.
+            if (event.type === "message.part.delta") {
+              const props = event.properties
+              if (
+                props.sessionID === sessionID &&
+                props.field === "text" &&
+                typeof props.delta === "string" &&
+                partTypes.get(props.partID) === "text"
+              ) {
+                emit("text_delta", {
+                  messageID: props.messageID,
+                  partID: props.partID,
+                  delta: props.delta,
+                })
+              }
+              continue
             }
 
             if (event.type === "session.error") {

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -120,9 +120,20 @@ describe("opencode run (non-interactive subprocess)", () => {
           expect(typeof evt.type).toBe("string")
           expect(typeof evt.sessionID).toBe("string")
         }
-        expect(events.map((event) => event.type)).toEqual(["step_start", "text", "step_finish"])
+        expect(events.map((event) => event.type)).toEqual([
+          "step_start",
+          "text_delta",
+          "text",
+          "step_finish",
+        ])
         expect(events.map(({ timestamp: _, sessionID: __, ...event }) => event)).toEqual([
           { type: "step_start", part: expect.objectContaining({ type: "step-start" }) },
+          {
+            type: "text_delta",
+            messageID: expect.any(String),
+            partID: expect.any(String),
+            delta: "structured output",
+          },
           {
             type: "text",
             part: expect.objectContaining({ type: "text", text: "structured output" }),
@@ -136,6 +147,40 @@ describe("opencode run (non-interactive subprocess)", () => {
             .slice(0, -1)
             .every((line) => line.length > 0),
         ).toBe(true)
+      }),
+    60_000,
+  )
+
+  // Regression for #38638: message.part.delta was dropped, so --format json
+  // only ever emitted the complete text after generation finished. Now each
+  // streaming chunk surfaces as a text_delta ahead of the final text event.
+  cliIt.concurrent(
+    "--format json emits text_delta events that stream text as it arrives (regression for #38638)",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        // Two text chunks on one reply become two message.part.delta events;
+        // their deltas must concatenate to the full text, ahead of the final
+        // complete text event which is retained for backward compatibility.
+        yield* llm.push(reply().text("Hello ").text("world").stop().item())
+        const result = yield* opencode.run("stream me", { format: "json" })
+        opencode.expectExit(result, 0)
+
+        const events = opencode.parseJsonEvents(result.stdout)
+        const types = events.map((event) => event.type)
+        const deltas = events.filter((event) => event.type === "text_delta")
+
+        expect(deltas.length).toBe(2)
+        expect(deltas.map((event) => event.delta).join("")).toBe("Hello world")
+        for (const event of deltas) {
+          expect(typeof event.messageID).toBe("string")
+          expect(typeof event.partID).toBe("string")
+        }
+        // text_delta events precede the final complete text event.
+        expect(types.lastIndexOf("text_delta")).toBeLessThan(types.indexOf("text"))
+        // The complete text event is retained for backward compatibility.
+        expect(events.find((event) => event.type === "text")?.part).toEqual(
+          expect.objectContaining({ type: "text", text: "Hello world" }),
+        )
       }),
     60_000,
   )
@@ -185,10 +230,12 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(events.map((event) => event.type)).toEqual([
           "step_start",
           "reasoning",
+          "text_delta",
           "text",
           "tool_use",
           "step_finish",
           "step_start",
+          "text_delta",
           "text",
           "step_finish",
         ])
@@ -229,6 +276,7 @@ describe("opencode run (non-interactive subprocess)", () => {
         expect(result.exitCode).toBe(0)
         expect(events.map((event) => event.type)).toEqual([
           "step_start",
+          "text_delta",
           "text",
           "tool_use",
           "step_finish",


### PR DESCRIPTION
### Issue for this PR

Closes #38638

### Type of change

- [x] Bug fix

### What does this PR do?

`opencode run --format json` only emitted the complete `text` event after generation finished, and silently dropped every `message.part.delta` event the server already produces in real time. Consumers parsing the JSON stream could not show streaming/progress output — for a long-running prompt they'd see `step_start`, then nothing for tens of seconds, then the whole response and `step_finish` at once (#38638).

The `run` event loop in `packages/opencode/src/cli/cmd/run.ts` handled `message.part.updated` but had no case for `message.part.delta`. This adds one: under `--format json`, each streaming text chunk is mirrored as a `text_delta` event (`{ messageID, partID, delta }`) ahead of the final complete `text` event, which is still emitted for backward compatibility. Non-json mode is unchanged — its text rendering is driven by the complete part.

Worth flagging: a `message.part.delta` event carries `field` but **not** the part type, and reasoning deltas also use `field: "text"` — `processor.ts` updates the reasoning part's text via the same `updatePartDelta({ field: "text", ... })` call. Filtering on `field === "text"` alone would therefore leak reasoning content into `text_delta`. The fix tracks each part's type from `message.part.updated` in a `partTypes` map and only emits `text_delta` for parts whose type is `text`, mirroring how `run/session-data.ts` resolves a delta's kind before rendering it.

### How did you verify your code works?

- `bun run typecheck` (`tsgo --noEmit`) on the `opencode` package: 0 errors.
- Extended the existing subprocess integration tests in `test/cli/run/run-process.test.ts` (real CLI binary against an in-process `TestLLMServer`): updated the three existing `--format json` cases to assert `text_delta` now precedes `text`, and added a regression case for #38638 that sends two text chunks on one reply and asserts the `text_delta` events concatenate to the full text, carry `messageID`/`partID`, precede the final `text`, and that the complete `text` event is still emitted.
- `bun test test/cli/run/run-process.test.ts --test-name-pattern "format json"`: 4/5 of the affected cases pass locally. The remaining case (`records partial output for an unknown stream finish`) fails on Windows **before this PR as well** — confirmed by `git stash`-ing the changes and re-running on unmodified `dev`, where it fails the same way (the second `step_start`/`step_finish` is not emitted). It is a Windows `cross-spawn` exit-timing issue with the mid-stream `llm.fail`, not a regression; the Linux CI run is the source of truth.

### Screenshots / recordings

N/A — pure CLI/JSON output change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
