### PR TITLE
fix(opencode): collapse plugin-pushed system messages into one

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -71,7 +71,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
     { sessionID: input.sessionID, model: input.model },
     { system },
   )
-  if (system.length > 2 && system[0] === header) {
+  if (system.length > 1 && system[0] === header) {
     const rest = system.slice(1)
     system.length = 0
     system.push(header, rest.join("\n"))

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -109,7 +109,16 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
             }),
           ),
           ...input.messages,
-        ]
+        ].reduce((acc, m) => {
+          if (m.role !== "system") { acc.push(m); return acc; }
+          const last = acc[acc.length - 1] as ModelMessage | undefined;
+          if (last && last.role === "system") {
+            last.content = (last.content as string) + "\n" + (m.content as string);
+          } else {
+            acc.push(m);
+          }
+          return acc;
+        }, [] as ModelMessage[])
 
   const params = yield* input.plugin.trigger(
     "chat.params",

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -408,6 +408,43 @@ describe("ProviderTransform.options - gpt-5 textVerbosity", () => {
     expect(result.tools.lookup.strict).toBe(false)
   })
 
+  test("collapses multiple system entries into one message", async () => {
+    const model = createGpt5Model("gpt-5.4")
+    const result = await Effect.runPromise(
+      LLMRequestPrep.prepare({
+        user: {
+          id: "msg_user-test",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID: "azure", modelID: "gpt-5.4" },
+        } as any,
+        sessionID,
+        model,
+        agent: { name: "test", mode: "primary", options: {}, permission: [] } as any,
+        system: [],
+        messages: [{ role: "user", content: "Hello" }],
+        tools: {},
+        provider: { id: "azure", options: {} } as any,
+        auth: undefined,
+        plugin: {
+          trigger: (_name, _input, output: any) => {
+            output.system.push("extra instructions")
+            return Effect.succeed(output)
+          },
+          list: () => Effect.succeed([]),
+          init: () => Effect.void,
+        } as any,
+        flags: { outputTokenMax: 32_000, client: "test" } as any,
+        isWorkflow: false,
+      }),
+    )
+    const systemMessages = result.messages.filter((m: any) => m.role === "system")
+    expect(systemMessages).toHaveLength(1)
+    expect(systemMessages[0].content).toContain("extra instructions")
+  })
+
   test("gpt-5.1 should have textVerbosity set to low", () => {
     const model = createGpt5Model("gpt-5.1")
     const result = ProviderTransform.options({ model, sessionID, providerOptions: {} })


### PR DESCRIPTION
### Issue for this PR

Closes #34321
This supersedes #34322 by @MADEVAL because some further fix was missing (collapse again in the messages)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a plugin uses experimental.chat.system.transform to push additional system instructions, the collapse guard `system.length > 2` was one too high. The initial array has 1 element and a plugin that pushes 1 entry makes it 2, so `2 > 2` never fired. The result was multiple {role: "system"} messages, which OpenAI-compatible providers reject.

The fix changes the guard from `> 2` to `> 1`. The `system[0] === header` check still protects against intentional header replacement by plugins.

### How did you verify your code works?

Added a test in transform.test.ts that simulates a plugin pushing to system and verifies the prepared messages array has exactly one system message containing the extra instructions. Traced the full code path: system array construction, plugin trigger, collapse guard, and message construction.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR