### PR TITLE
feat: add elapsed timer display for tools and turns

### DIFF
--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -6,7 +6,7 @@ import { Icon } from "@opencode-ai/ui/v2/icon"
 import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import type { Prompt, ReferenceInfo } from "@opencode-ai/sdk/v2/client"
-import { createEffect, createMemo, on, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, on, onCleanup, Show, type Accessor } from "solid-js"
 import { ModelSelectorPopoverV2 } from "@/components/dialog-select-model"
 import { DialogSelectModelUnpaidV2 } from "@/components/dialog-select-model-unpaid-v2"
 import type { PromptInputProps } from "@/components/prompt-input/contracts"
@@ -44,6 +44,7 @@ export type PromptInputV2ComposerProps = {
 export type PromptInputV2ControllerProps = Omit<PromptInputProps, "class" | "edit" | "onEditLoaded" | "submission">
 export type PromptInputV2ComposerController = PromptInputV2Interaction & {
   readonly model: PromptInputProps["controls"]["model"]
+  readonly elapsed: Accessor<string>
 }
 
 export function PromptInputV2Composer(props: PromptInputV2ComposerProps) {
@@ -62,6 +63,13 @@ export function PromptInputV2Composer(props: PromptInputV2ComposerProps) {
         class={props.class}
         attachKeybind={command.keybindParts("file.attach")}
         attachShortcut={command.keybind("file.attach")}
+        submitTrailing={
+          <Show when={props.controller.elapsed()}>
+            <span class="shrink-0 select-none whitespace-nowrap px-1 text-[12px] leading-5 text-v2-text-text-faint">
+              {props.controller.elapsed()}
+            </span>
+          </Show>
+        }
         modelControl={
           <PromptInputV2ModelControl
             loading={props.controller.model.loading}
@@ -196,6 +204,24 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
     return text.trim().length === 0 && attachments().length === 0 && commentCount() === 0
   })
   const stopping = createMemo(() => working() && blank())
+
+  const [now, setNow] = createSignal(Date.now())
+  createEffect(() => {
+    if (!working()) return
+    setNow(Date.now())
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    onCleanup(() => clearInterval(timer))
+  })
+  const elapsed = createMemo(() => {
+    if (!working()) return ""
+    const messages = sync().data.message[props.controls.session.id ?? ""]
+    const start = messages?.findLast((m) => m.role === "user")?.time.created
+    if (typeof start !== "number") return ""
+    const total = Math.max(0, Math.round((now() - start) / 1000))
+    if (total < 60) return language.t("ui.message.duration.seconds", { count: total })
+    return language.t("ui.message.duration.minutesSeconds", { minutes: Math.floor(total / 60), seconds: total % 60 })
+  })
+
   const placeholder = createMemo(() =>
     promptPlaceholder({
       mode: mode(),
@@ -472,6 +498,7 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
     },
   })
   Object.defineProperty(controller, "model", { get: () => props.controls.model })
+  Object.defineProperty(controller, "elapsed", { get: () => elapsed })
   return controller as PromptInputV2ComposerController
 }
 

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -284,6 +284,24 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return text.trim().length === 0 && imageAttachments().length === 0 && commentCount() === 0
   })
   const stopping = createMemo(() => working() && blank())
+
+  const [now, setNow] = createSignal(Date.now())
+  createEffect(() => {
+    if (!working()) return
+    setNow(Date.now())
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    onCleanup(() => clearInterval(timer))
+  })
+  const elapsed = createMemo(() => {
+    if (!working()) return ""
+    const messages = sync().data.message[props.controls.session.id ?? ""]
+    const start = messages?.findLast((m) => m.role === "user")?.time.created
+    if (typeof start !== "number") return ""
+    const total = Math.max(0, Math.round((now() - start) / 1000))
+    if (total < 60) return language.t("ui.message.duration.seconds", { count: total })
+    return language.t("ui.message.duration.minutesSeconds", { minutes: Math.floor(total / 60), seconds: total % 60 })
+  })
+
   const tip = () => {
     if (stopping()) {
       return (
@@ -1574,6 +1592,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
             />
 
             <div class="flex items-center gap-1 pointer-events-auto">
+              <Show when={elapsed()}>
+                <span class="text-12-regular text-text-weak cursor-default select-none whitespace-nowrap px-1">
+                  {elapsed()}
+                </span>
+              </Show>
               <Tooltip placement="top" inactive={!working() && blank()} value={tip()}>
                 <IconButton
                   data-action="prompt-submit"

--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,17 @@
-../../ui/src/custom-elements.d.ts
+import { DIFFS_TAG_NAME } from "@pierre/diffs"
+
+/**
+ * TypeScript declaration for the <diffs-container> custom element.
+ * This tells TypeScript that <diffs-container> is a valid JSX element in SolidJS.
+ * Required for using the @pierre/diffs web component in .tsx files.
+ */
+
+declare module "solid-js" {
+  namespace JSX {
+    interface IntrinsicElements {
+      [DIFFS_TAG_NAME]: HTMLAttributes<HTMLElement>
+    }
+  }
+}
+
+export {}

--- a/packages/session-ui/src/components/basic-tool.css
+++ b/packages/session-ui/src/components/basic-tool.css
@@ -62,6 +62,15 @@
     font-size: 14px;
   }
 
+  [data-slot="basic-tool-tool-duration"] {
+    flex-shrink: 0;
+    font-size: 12px;
+    line-height: var(--line-height-large);
+    color: var(--text-weak, var(--v2-text-text-faint));
+    white-space: nowrap;
+    user-select: none;
+  }
+
   [data-slot="basic-tool-tool-info-structured"] {
     flex: 0 1 auto;
     width: auto;

--- a/packages/session-ui/src/components/basic-tool.tsx
+++ b/packages/session-ui/src/components/basic-tool.tsx
@@ -1,10 +1,24 @@
-import { createEffect, For, Match, on, onCleanup, onMount, Show, Switch, type Accessor, type JSX } from "solid-js"
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  Match,
+  on,
+  onCleanup,
+  onMount,
+  Show,
+  Switch,
+  type Accessor,
+  type JSX,
+} from "solid-js"
 import { animate, type AnimationPlaybackControls } from "motion"
 import { useI18n } from "@opencode-ai/ui/context/i18n"
 import { createStore } from "solid-js/store"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
 import type { IconProps } from "@opencode-ai/ui/icon"
 import { TextShimmer } from "@opencode-ai/ui/text-shimmer"
+import { formatDuration } from "./duration"
 
 export type TriggerTitle = {
   title: string
@@ -27,6 +41,7 @@ export interface BasicToolProps {
   trigger: TriggerTitle | JSX.Element | ((open: Accessor<boolean>) => JSX.Element)
   children?: JSX.Element
   status?: string
+  time?: { start: number; end?: number }
   hideDetails?: boolean
   defaultOpen?: boolean
   open?: boolean
@@ -91,6 +106,23 @@ export function BasicTool(props: BasicToolProps) {
   const open = () => props.open ?? state.open
   const ready = () => state.ready
   const pending = () => props.status === "pending" || props.status === "running"
+
+  const [now, setNow] = createSignal(Date.now())
+  createEffect(() => {
+    if (!props.time) return
+    if (typeof props.time.end === "number") return
+    if (!pending()) return
+    setNow(Date.now())
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    onCleanup(() => clearInterval(timer))
+  })
+  const duration = createMemo(() => {
+    const time = props.time
+    if (!time) return ""
+    const end = typeof time.end === "number" ? time.end : pending() ? now() : undefined
+    if (typeof end !== "number") return ""
+    return formatDuration(Math.max(0, end - time.start))
+  })
   const hasChildren = () => (props.defer ? "children" in props : props.children)
   const dynamicTrigger = typeof props.trigger === "function" ? props.trigger(open) : undefined
 
@@ -248,6 +280,9 @@ export function BasicTool(props: BasicToolProps) {
           </Switch>
         </div>
       </div>
+      <Show when={duration()}>
+        <span data-slot="basic-tool-tool-duration">{duration()}</span>
+      </Show>
       <Show when={hasChildren() && !props.hideDetails && !props.locked && (!pending() || props.allowOpenWhilePending)}>
         <Collapsible.Arrow />
       </Show>
@@ -323,6 +358,7 @@ function args(input: Record<string, unknown> | undefined) {
 export function GenericTool(props: {
   tool: string
   status?: string
+  time?: { start: number; end?: number }
   hideDetails?: boolean
   input?: Record<string, unknown>
 }) {
@@ -332,6 +368,7 @@ export function GenericTool(props: {
     <BasicTool
       icon="mcp"
       status={props.status}
+      time={props.time}
       trigger={{
         title: i18n.t("ui.basicTool.called", { tool: props.tool }),
         subtitle: label(props.input),

--- a/packages/session-ui/src/components/duration.ts
+++ b/packages/session-ui/src/components/duration.ts
@@ -1,0 +1,7 @@
+export function formatDuration(ms: number) {
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+  const minutes = Math.floor(ms / 60000)
+  const seconds = Math.floor((ms % 60000) / 1000)
+  return `${minutes}m ${seconds}s`
+}

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -223,17 +223,13 @@
     margin-top: 0;
   }
 
-  [data-slot="text-part-copy-wrapper"] {
+  [data-slot="text-part-footer"] {
     min-height: 24px;
     margin-top: 4px;
     display: flex;
     align-items: center;
     justify-content: flex-start;
     gap: 10px;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity 0.15s ease;
-    will-change: opacity;
 
     [data-component="tooltip-trigger"] {
       display: inline-flex;
@@ -245,10 +241,19 @@
     user-select: none;
   }
 
-  [data-slot="text-part-copy-wrapper"][data-interrupted] {
+  [data-slot="text-part-footer"][data-interrupted] {
     width: 100%;
     justify-content: flex-end;
     gap: 12px;
+  }
+
+  [data-slot="text-part-copy-wrapper"] {
+    display: flex;
+    align-items: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease;
+    will-change: opacity;
   }
 
   &:hover [data-slot="text-part-copy-wrapper"],

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -36,6 +36,7 @@ import { useFileComponent } from "@opencode-ai/ui/context/file"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { type UiI18n, useI18n } from "@opencode-ai/ui/context/i18n"
 import { BasicTool, GenericTool } from "./basic-tool"
+import { formatDuration } from "./duration"
 import { Accordion } from "@opencode-ai/ui/accordion"
 import { StickyAccordionHeader } from "@opencode-ai/ui/sticky-accordion-header"
 import { Collapsible } from "@opencode-ai/ui/collapsible"
@@ -1481,6 +1482,7 @@ export interface ToolProps {
   sessionID?: string
   output?: string
   status?: string
+  time?: { start: number; end?: number }
   hideDetails?: boolean
   defaultOpen?: boolean
   open?: boolean
@@ -1584,6 +1586,11 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
     return taskId()
   })
 
+  const stateTime = () => {
+    const state = part().state
+    if (state.status === "pending") return undefined
+    return state.time
+  }
   const render = createMemo(() => ToolRegistry.render(part().tool) ?? GenericTool)
   const controlledOpen = () => (props.onToolOpenChange ? (props.toolOpen ?? props.defaultOpen) : undefined)
   const handleToolOpenChange = (open: boolean) => props.onToolOpenChange?.(open)
@@ -1628,6 +1635,7 @@ PART_MAPPING["tool"] = function ToolPartDisplay(props) {
               // @ts-expect-error
               output={part().state.output}
               status={part().state.status}
+              time={stateTime()}
               hideDetails={props.hideDetails}
               defaultOpen={props.defaultOpen}
               open={controlledOpen()}
@@ -1665,7 +1673,6 @@ PART_MAPPING["compaction"] = function CompactionPartDisplay() {
 PART_MAPPING["text"] = function TextPartDisplay(props) {
   const data = useData()
   const i18n = useI18n()
-  const numfmt = createMemo(() => new Intl.NumberFormat(i18n.locale()))
   const part = () => props.part as TextPart
   const interrupted = createMemo(
     () =>
@@ -1690,14 +1697,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
           ? completed - message.time.created
           : -1
     if (!(ms >= 0)) return ""
-    const total = Math.round(ms / 1000)
-    if (total < 60) return i18n.t("ui.message.duration.seconds", { count: numfmt().format(total) })
-    const minutes = Math.floor(total / 60)
-    const seconds = total % 60
-    return i18n.t("ui.message.duration.minutesSeconds", {
-      minutes: numfmt().format(minutes),
-      seconds: numfmt().format(seconds),
-    })
+    return formatDuration(ms)
   })
 
   const meta = createMemo(() => {
@@ -1748,15 +1748,17 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
           </Show>
         </div>
         <Show when={showCopy()}>
-          <div data-slot="text-part-copy-wrapper" data-interrupted={interrupted() ? "" : undefined}>
-            <MessageActionButton
-              icon={copied() ? "check" : "copy"}
-              label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-              useV2={props.useV2Actions}
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={handleCopy}
-              aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
-            />
+          <div data-slot="text-part-footer" data-interrupted={interrupted() ? "" : undefined}>
+            <div data-slot="text-part-copy-wrapper">
+              <MessageActionButton
+                icon={copied() ? "check" : "copy"}
+                label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+                useV2={props.useV2Actions}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={handleCopy}
+                aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copyResponse")}
+              />
+            </div>
             <Show when={meta()}>
               <span data-slot="text-part-meta" class="text-12-regular text-text-weak cursor-default">
                 {meta()}
@@ -2090,6 +2092,7 @@ ToolRegistry.register({
       <BasicTool
         icon="task"
         status={props.status}
+        time={props.time}
         trigger={trigger()}
         hideDetails
         triggerAsLink
@@ -2657,6 +2660,6 @@ ToolRegistry.register({
       </div>
     )
 
-    return <BasicTool icon="brain" status={props.status} trigger={trigger()} hideDetails />
+    return <BasicTool icon="brain" status={props.status} time={props.time} trigger={trigger()} hideDetails />
   },
 })

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -39,6 +39,7 @@ export type PromptInputV2Props = {
   borderUnderlay?: boolean
   class?: string
   modelControl?: JSX.Element
+  submitTrailing?: JSX.Element
   attachKeybind?: string[]
   attachShortcut?: string
 }
@@ -244,6 +245,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
               )}
             </Show>
           </div>
+          {props.submitTrailing}
           <PromptInputV2SubmitButton
             mode={state.mode}
             stopping={view.submit.stopping()}

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1524,6 +1524,27 @@ export function Prompt(props: PromptProps) {
                   </box>
                   <box flexDirection="row" gap={1} flexShrink={0}>
                     {(() => {
+                      const started = createMemo(() => {
+                        const messages = sync.data.message[props.sessionID ?? ""]
+                        if (!messages) return
+                        return messages.findLast((x) => x.role === "user")?.time.created
+                      })
+                      const [now, setNow] = createSignal(Date.now())
+                      onMount(() => {
+                        const timer = setInterval(() => setNow(Date.now()), 500)
+                        onCleanup(() => clearInterval(timer))
+                      })
+                      return (
+                        <Show when={started()}>
+                          {(start) => (
+                            <text flexShrink={0} fg={theme.textMuted}>
+                              {Locale.duration(Math.max(0, now() - start()))}
+                            </text>
+                          )}
+                        </Show>
+                      )
+                    })()}
+                    {(() => {
                       const retry = createMemo(() => {
                         const s = status()
                         if (s.type !== "retry") return

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1873,6 +1873,19 @@ function InlineTool(props: {
     return theme.text
   })
 
+  const [now, setNow] = createSignal(Date.now())
+  createEffect(() => {
+    if (props.part.state.status !== "running") return
+    const timer = setInterval(() => setNow(Date.now()), 500)
+    onCleanup(() => clearInterval(timer))
+  })
+  const duration = createMemo(() => {
+    const state = props.part.state
+    if (state.status === "completed" || state.status === "error") return state.time.end - state.time.start
+    if (state.status === "running") return now() - state.time.start
+    return 0
+  })
+
   return (
     <InlineToolRow
       icon={props.icon}
@@ -1888,6 +1901,7 @@ function InlineTool(props: {
       failure={props.failure}
       spinner={props.spinner}
       separate={props.separate}
+      duration={duration() ? Locale.duration(duration()) : undefined}
       onMouseOver={() => clickable() && setHover(true)}
       onMouseOut={() => setHover(false)}
       onMouseUp={() => {
@@ -1918,11 +1932,13 @@ export function InlineToolRow(props: {
   failure?: string
   spinner?: boolean
   separate?: boolean
+  duration?: string
   children: JSX.Element
   onMouseOver?: () => void
   onMouseOut?: () => void
   onMouseUp?: () => void
 }) {
+  const { theme } = useTheme()
   return (
     <box
       paddingLeft={3}
@@ -1941,7 +1957,12 @@ export function InlineToolRow(props: {
     >
       <Switch>
         <Match when={props.spinner}>
-          <Spinner color={props.color} children={props.children} />
+          <Spinner color={props.color}>
+            {props.children}
+            <Show when={props.duration}>
+              <span style={{ fg: theme.textMuted }}> · {props.duration}</span>
+            </Show>
+          </Spinner>
         </Match>
         <Match when={true}>
           <Show
@@ -1970,6 +1991,9 @@ export function InlineToolRow(props: {
                 attributes={props.denied ? TextAttributes.STRIKETHROUGH : undefined}
               >
                 {props.failed && !props.complete ? (props.failure ?? props.children) : props.children}
+                <Show when={props.duration}>
+                  <span style={{ fg: theme.textMuted }}> · {props.duration}</span>
+                </Show>
               </text>
             </box>
           </Show>


### PR DESCRIPTION
### Issue for this PR

Closes #38666

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shows how long each tool call takes, plus the elapsed time of the current turn:

- **TUI**: duration next to each inline tool row (live while running), and a live elapsed counter in the prompt area
- **Web/Desktop (session-ui)**: duration in the tool row header via `BasicTool` (running tools tick every second), and the turn duration in the assistant text part footer
- Durations render as `350ms` / `3.2s` / `1m 5s` via a small shared `formatDuration` helper (same style as the existing TUI `Locale.duration`)

All timing data (`state.time.start/end` on tool parts, `time.created/completed` on messages) is already synced to clients - no server, schema, or protocol changes. Rendering only.

### How did you verify your code works?

- `bun typecheck` passes in `packages/session-ui`, `packages/app`, and `packages/tui`
- Ran the TUI from source and the web app dev server; confirmed durations appear on tool rows, tick live while running, and that the turn total shows in the footer

### Screenshots / recordings

Screenshots of the TUI and web UI will be attached in a comment below.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Related: #36099