### PR TITLE
fix(cli): await event loop in run --attach mode

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -832,7 +832,6 @@ export const RunCommand = effectCmd({
             process.exitCode = 1
           })
           async function finish() {
-            if (args.attach) return
             const error = await completed
             if (error) process.exitCode = 1
           }


### PR DESCRIPTION
### Issue for this PR

Closes #38661

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode run --attach <url>` in non-interactive mode outputs only the first event (typically `step-start`) then exits with code 0, dropping the model's text response, reasoning, and final step events. The server completes the full agentic loop, but the CLI exits before consuming the remaining SSE events.

The actual sequence is:

1. `client.session.prompt()` is a blocking HTTP call (`POST /session/:id/message`) whose server-side handler runs the full `yield* loop(...)` agentic loop, only returning once the session goes idle.
2. By the time the prompt response arrives, SSE events for the completed turn are already buffered in the client's stream — but the `for await` loop has not yet iterated to consume them.
3. `finish()` hits the `if (args.attach) return` guard and returns immediately, without awaiting `completed`.
4. `index.ts` runs `finally { process.exit() }` synchronously after the handler returns.
5. The process dies, killing the active SSE connection. Buffered-but-unconsumed events are lost.

The `if (args.attach) return` guard was introduced in #31389, which fixed local mode by adding `await completed`. Attach mode was accidentally skipped with no design rationale: `question`, `plan_enter`, and `plan_exit` permissions are already denied at session creation, and `permission.asked` events are auto-replied (approve with `--auto`, reject otherwise). Local mode has worked correctly with `await completed` since that PR landed.

The fix removes the guard so attach mode also awaits the event loop before returning. The loop breaks on `session.status idle`, `completed` resolves, and `process.exit()` fires cleanly with all events consumed.

### How did you verify your code works?

Reproduced against a latest dev server with `opencode-go/deepseek-v4-flash`:

**Before fix** — only `step_start` emitted, then exit 0:
```
{"type":"step_start",...}
EXIT=0
```

**After fix** — full event stream:
```
{"type":"step_start",...}
{"type":"reasoning",...}
{"type":"text","part":{"text":"hello world",...}}
{"type":"step_finish",...}
```

Server-side session data confirmed the model response was always stored; the client was just exiting before consuming it.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR