### PR TITLE
fix(session): retry transient transport failures

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -603,17 +603,101 @@ function isAfter(info: Info, other?: Info) {
   return info.id > other.id
 }
 
+// Transport failures that can recover without changing the request. Every code
+// here is still bounded by the global retry limit (~60s of backoff) and then
+// surfaces, so a genuinely broken endpoint still reports within a minute.
+//
+// Bun's native fetch collapses DNS failure, refused connection, TLS mismatch,
+// and unroutable network into a single ConnectionRefused with one shared
+// message, so it cannot be treated as permanent without also giving up retries
+// for wifi flaps, VPN reconnects, and sleep/wake. Bounded retry is the only
+// classification that serves both.
+const TRANSIENT_SYS_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_SOCKET",
+  "ConnectionClosed",
+  "ConnectionRefused",
+  "FailedToOpenSocket",
+  "Timeout",
+])
+// Node and undici report these only for a genuinely unresolvable or refused
+// endpoint, so they stay permanent and surface immediately. They are reachable
+// through a custom fetch implementation rather than Bun's own.
+const PERMANENT_SYS_CODES = new Set(["ENOTFOUND", "ECONNREFUSED", "DNSResolveFailed", "DNSResolutionFailed"])
+const TRANSIENT_ERROR_CODES = new Set([
+  "TimeoutError",
+  "NETWORK_ERROR",
+  "ZlibError",
+  "ProviderHeaderTimeoutError",
+  "ProviderResponseStreamError",
+])
+const CAUSE_MAX_DEPTH = 8
+
+export function isPermanentTransportCode(code: unknown) {
+  return typeof code === "string" && PERMANENT_SYS_CODES.has(code)
+}
+
+export function isTransientTransportCode(code: unknown) {
+  return typeof code === "string" && (TRANSIENT_SYS_CODES.has(code) || TRANSIENT_ERROR_CODES.has(code))
+}
+
+// Exact messages emitted for a prematurely closed transport. Generic text
+// such as "network error" or "fetch failed" cannot distinguish a transient
+// disconnect from a permanent DNS, TLS, authentication, or endpoint failure.
+const TRANSIENT_MESSAGES = new Set(["socket hang up", "sse read timed out", "other side closed", "terminated"])
+
+// Walks the cause chain, which is where a transport fault ends up once the
+// provider SDK wraps it. CAUSE_MAX_DEPTH bounds the walk, so a self-referential
+// cause cannot spin.
+function classifyTransportError(error: unknown) {
+  let current = error
+  let transient: SystemError | undefined
+  for (let depth = 0; depth < CAUSE_MAX_DEPTH; depth++) {
+    if (!(current instanceof Error)) break
+    const code = "code" in current && typeof current.code === "string" ? current.code : undefined
+    if (isPermanentTransportCode(code)) return { type: "permanent" as const, error: current as SystemError }
+    if (!transient && code && TRANSIENT_SYS_CODES.has(code)) transient = current as SystemError
+    current = current.cause
+  }
+  if (transient) return { type: "transient" as const, error: transient }
+  return undefined
+}
+
 export function fromError(
   e: unknown,
   ctx: { providerID: ProviderV2.ID; aborted?: boolean },
 ): NonNullable<Assistant["error"]> {
+  const error = classify(e, ctx)
+  // A cancelled request must never be retried. Abort can surface as a
+  // transport-shaped failure instead of an interrupt when it races the read, so
+  // rather than guarding each transport branch, refuse every retryable
+  // classification once the turn is known to be aborted.
+  if (ctx.aborted && APIError.isInstance(error) && error.data.isRetryable)
+    return new AbortedError({ message: error.data.message }, { cause: e }).toObject()
+  return error
+}
+
+function classify(e: unknown, ctx: { providerID: ProviderV2.ID; aborted?: boolean }): NonNullable<Assistant["error"]> {
+  const transport = classifyTransportError(e)
+  const transient = transport?.type === "transient" ? transport.error : undefined
+  const permanent = transport?.type === "permanent" ? transport.error : undefined
+  const sysCode = transient?.code
   switch (true) {
     case e instanceof DOMException && e.name === "AbortError":
-      return new AbortedError(
-        { message: e.message },
-        {
-          cause: e,
-        },
+      // Controlled timeouts carry their own error types. A bare AbortError is a cancellation.
+      return new AbortedError({ message: e.message }, { cause: e }).toObject()
+    case e instanceof DOMException && e.name === "TimeoutError":
+      return new APIError(
+        { message: e.message || "Request timed out", isRetryable: true, metadata: { code: "TimeoutError" } },
+        { cause: e },
       ).toObject()
     case OutputLengthError.isInstance(e):
       return e
@@ -625,23 +709,23 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
-    case (e as SystemError)?.code === "ECONNRESET":
+    // An APICallError carrying a transport fault is handled in its own branch
+    // below so the response envelope survives; this branch is for a bare
+    // transport error with no response.
+    case sysCode !== undefined && !APICallError.isInstance(e):
       return new APIError(
         {
-          message: "Connection reset by server",
+          message: sysCode === "ECONNRESET" ? "Connection reset by server" : `Network error (${sysCode})`,
           isRetryable: true,
           metadata: {
-            code: (e as SystemError).code ?? "",
-            syscall: (e as SystemError).syscall ?? "",
-            message: (e as SystemError).message ?? "",
+            code: sysCode,
+            syscall: transient?.syscall ?? "",
+            message: transient?.message ?? "",
           },
         },
         { cause: e },
       ).toObject()
     case e instanceof Error && (e as FetchDecompressionError).code === "ZlibError":
-      if (ctx.aborted) {
-        return new AbortedError({ message: e.message }, { cause: e }).toObject()
-      }
       return new APIError(
         {
           message: "Response decompression failed",
@@ -691,15 +775,31 @@ export function fromError(
         ).toObject()
       }
 
+      // Keep the response envelope even when a transport fault is the root
+      // cause: retry-after headers and the body are the useful diagnostics, and
+      // replacing them with a bare network error loses both.
+      const transportError = permanent ?? transient
       return new APIError(
         {
           message: parsed.message,
           statusCode: parsed.statusCode,
-          isRetryable: parsed.isRetryable,
+          isRetryable: permanent ? false : transient !== undefined || parsed.isRetryable,
           responseHeaders: parsed.responseHeaders,
           responseBody: parsed.responseBody,
-          metadata: parsed.metadata,
+          metadata: transportError
+            ? {
+                ...parsed.metadata,
+                code: transportError.code ?? "",
+                syscall: transportError.syscall ?? "",
+                message: transportError.message ?? "",
+              }
+            : parsed.metadata,
         },
+        { cause: e },
+      ).toObject()
+    case e instanceof Error && TRANSIENT_MESSAGES.has(e.message.toLowerCase()):
+      return new APIError(
+        { message: e.message, isRetryable: true, metadata: { code: "NETWORK_ERROR", message: e.message } },
         { cause: e },
       ).toObject()
     case e instanceof Error:

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -72,6 +72,15 @@ interface ProcessorContext extends Input {
   needsCompaction: boolean
   currentText: SessionV1.TextPart | undefined
   reasoningMap: Record<string, SessionV1.ReasoningPart>
+  // Sticky once a tool has started executing. A retry replays the same request,
+  // so the model re-emits the same call and a side-effecting tool would run a
+  // second time. Deleting the part cannot undo what already touched the disk,
+  // so this is the one failure the turn must not replay.
+  executed: boolean
+  // Parts written by the attempt currently in flight. A retry removes them
+  // first, otherwise the truncated output from the failed attempt stays in the
+  // transcript alongside its replacement.
+  attemptParts: SessionV1.Part["id"][]
 }
 
 type StreamEvent = LLMEvent
@@ -111,6 +120,8 @@ const layer = Layer.effect(
         needsCompaction: false,
         currentText: undefined,
         reasoningMap: {},
+        executed: false,
+        attemptParts: [],
       }
       let aborted = false
 
@@ -243,6 +254,7 @@ const layer = Layer.effect(
           state: { status: "pending", input: {}, raw: "" },
           metadata: input.providerExecuted ? { providerExecuted: true } : undefined,
         } satisfies SessionV1.ToolPart)
+        ctx.attemptParts.push(part.id)
         ctx.toolcalls[input.id] = {
           done: yield* Deferred.make<void>(),
           partID: part.id,
@@ -288,6 +300,7 @@ const layer = Layer.effect(
               time: { start: Date.now() },
               metadata: value.providerMetadata,
             }
+            ctx.attemptParts.push(ctx.reasoningMap[value.id].id)
             yield* session.updatePart(ctx.reasoningMap[value.id])
             return
 
@@ -334,6 +347,8 @@ const layer = Layer.effect(
             }
             yield* ensureToolCall(value)
             const input = isRecord(value.input) ? value.input : { value: value.input }
+            // The call is about to execute, so the turn can no longer be replayed.
+            ctx.executed = true
             yield* updateToolCall(value.id, (match) => ({
               ...match,
               tool: value.name,
@@ -493,6 +508,7 @@ const layer = Layer.effect(
               time: { start: Date.now() },
               metadata: value.providerMetadata,
             }
+            ctx.attemptParts.push(ctx.currentText.id)
             yield* session.updatePart(ctx.currentText)
             return
 
@@ -634,6 +650,17 @@ const layer = Layer.effect(
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
+            // Drop whatever the previous attempt managed to write. The request is
+            // replayed unchanged, so leaving those parts behind would show the
+            // truncated output followed by the full replacement.
+            yield* Effect.forEach(ctx.attemptParts, (partID) =>
+              session.removePart({
+                sessionID: ctx.assistantMessage.sessionID,
+                messageID: ctx.assistantMessage.id,
+                partID,
+              }),
+            )
+            ctx.attemptParts = []
             ctx.currentText = undefined
             ctx.reasoningMap = {}
             yield* status.set(ctx.sessionID, { type: "busy" })
@@ -657,8 +684,8 @@ const layer = Layer.effect(
               (cause) => !Cause.hasInterruptsOnly(cause),
               (cause) => Effect.fail(Cause.squash(cause)),
             ),
-            Effect.retry(
-              SessionRetry.policy({
+            Effect.retry({
+              schedule: SessionRetry.policy({
                 provider: input.model.providerID,
                 parse,
                 set: (info) => {
@@ -671,7 +698,10 @@ const layer = Layer.effect(
                   })
                 },
               }),
-            ),
+              // Text and reasoning written by a failed attempt are removed before
+              // the next one, but a tool that already ran cannot be undone.
+              while: () => !ctx.executed,
+            }),
             Effect.catch(halt),
             Effect.ensuring(cleanup()),
           )

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -85,6 +85,7 @@ export function retryable(error: Err, provider: string) {
   // context overflow errors should not be retried
   if (SessionV1.ContextOverflowError.isInstance(error)) return undefined
   if (SessionV1.APIError.isInstance(error)) {
+    if (MessageV2.isPermanentTransportCode(error.data.metadata?.code)) return undefined
     const status = error.data.statusCode
     // 5xx errors are transient server failures and should always be retried,
     // even when the provider SDK doesn't explicitly mark them as retryable.

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { APICallError } from "ai"
 import { MessageV2 } from "../../src/session/message-v2"
+import { SessionRetry } from "../../src/session/retry"
 import { ProviderTransform } from "@/provider/transform"
 import type { Provider } from "@/provider/provider"
 
@@ -1551,6 +1552,217 @@ describe("session.message-v2.fromError", () => {
     const result = MessageV2.fromError(zlibError, { providerID, aborted: true })
 
     expect(result.name).toBe("MessageAbortedError")
+  })
+
+  test("classifies user-cancelled AbortError as AbortedError when ctx.aborted is true", () => {
+    const err = new DOMException("Aborted", "AbortError")
+    const result = MessageV2.fromError(err, { providerID, aborted: true })
+    expect(result.name).toBe("MessageAbortedError")
+  })
+
+  test("classifies a bare AbortError as a cancel regardless of ctx.aborted", () => {
+    // A bare AbortError only comes from controller.abort() with no reason —
+    // i.e. a user/parent cancel. Transport timeouts surface as their own
+    // specific errors (TimeoutError/HeaderTimeoutError/ResponseStreamError),
+    // so a bare AbortError must NOT be reclassified as retryable — otherwise
+    // a cancel races the failure channel and gets retried.
+    const err = new DOMException("The operation was aborted", "AbortError")
+    const result = MessageV2.fromError(err, { providerID })
+    expect(result.name).toBe("MessageAbortedError")
+  })
+
+  test("classifies TimeoutError DOMException as retryable APIError", () => {
+    // AbortSignal.timeout() in modern fetch surfaces as TimeoutError.
+    const err = new DOMException("The operation timed out", "TimeoutError")
+    const result = MessageV2.fromError(err, { providerID })
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    expect((result as SessionV1.APIError).data.isRetryable).toBe(true)
+  })
+
+  test.each([
+    ["ETIMEDOUT", "Network error (ETIMEDOUT)"],
+    ["EAI_AGAIN", "Network error (EAI_AGAIN)"],
+    ["EHOSTUNREACH", "Network error (EHOSTUNREACH)"],
+    ["ENETUNREACH", "Network error (ENETUNREACH)"],
+    ["EPIPE", "Network error (EPIPE)"],
+    ["UND_ERR_CONNECT_TIMEOUT", "Network error (UND_ERR_CONNECT_TIMEOUT)"],
+    ["UND_ERR_HEADERS_TIMEOUT", "Network error (UND_ERR_HEADERS_TIMEOUT)"],
+    ["UND_ERR_BODY_TIMEOUT", "Network error (UND_ERR_BODY_TIMEOUT)"],
+    ["UND_ERR_SOCKET", "Network error (UND_ERR_SOCKET)"],
+    ["ConnectionClosed", "Network error (ConnectionClosed)"],
+    // Bun reports DNS failure, refused connection, TLS mismatch and unroutable
+    // network all as ConnectionRefused, so it has to retry (bounded) rather than
+    // fail outright or a wifi flap kills the turn.
+    ["ConnectionRefused", "Network error (ConnectionRefused)"],
+    ["FailedToOpenSocket", "Network error (FailedToOpenSocket)"],
+    ["Timeout", "Network error (Timeout)"],
+  ])("classifies %s SystemError as retryable APIError", (code, expectedMessage) => {
+    const err = Object.assign(new Error(`${code} from test`), { code })
+    const result = MessageV2.fromError(err, { providerID })
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    expect((result as SessionV1.APIError).data.isRetryable).toBe(true)
+    expect((result as SessionV1.APIError).data.message).toBe(expectedMessage)
+  })
+
+  test("classifies a fetch failure with a transient cause as retryable", () => {
+    const cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })
+    const wrapper = Object.assign(new TypeError("fetch failed", { cause }), { code: "ERR_FETCH_FAILED" })
+    const result = MessageV2.fromError(wrapper, { providerID })
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    expect((result as SessionV1.APIError).data.metadata?.code).toBe("ECONNRESET")
+  })
+
+  test.each([
+    ["ENOTFOUND", "getaddrinfo"],
+    ["ECONNREFUSED", "connect"],
+    ["DNSResolveFailed", "getaddrinfo"],
+    ["DNSResolutionFailed", "getaddrinfo"],
+  ])("overrides retryable APICallError caused by %s", (code, syscall) => {
+    const cause = Object.assign(new Error(`${syscall} ${code} api.invalid`), { code, syscall })
+    const wrapper = Object.assign(new TypeError("fetch failed", { cause }), { code: "ERR_FETCH_FAILED" })
+    const error = new APICallError({
+      message: "Cannot connect to API",
+      url: "https://api.invalid/v1/messages",
+      requestBodyValues: { model: "test" },
+      cause: wrapper,
+      isRetryable: true,
+    })
+
+    const result = MessageV2.fromError(error, { providerID })
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.isRetryable).toBe(false)
+    expect(result.data.metadata).toMatchObject({ code, syscall, url: "https://api.invalid/v1/messages" })
+    expect(SessionRetry.retryable(result, "test")).toBeUndefined()
+  })
+
+  test("keeps the response envelope when an APICallError wraps a transient fault", () => {
+    // Short-circuiting to a bare network error would drop retry-after and the
+    // body, which are the only useful diagnostics for a flapping provider.
+    const cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET", syscall: "read" })
+    const error = new APICallError({
+      message: "Cannot reach API",
+      url: "https://api.test/v1/messages",
+      requestBodyValues: { model: "test" },
+      cause,
+      isRetryable: false,
+      statusCode: 503,
+      responseHeaders: { "retry-after": "7" },
+      responseBody: "upstream unavailable",
+    })
+
+    const result = MessageV2.fromError(error, { providerID })
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.isRetryable).toBe(true)
+    expect(result.data.statusCode).toBe(503)
+    expect(result.data.responseHeaders).toMatchObject({ "retry-after": "7" })
+    expect(result.data.responseBody).toBe("upstream unavailable")
+    expect(result.data.metadata).toMatchObject({ code: "ECONNRESET", syscall: "read" })
+    // Still capped, so it cannot retry forever.
+    expect(MessageV2.isTransientTransportCode(result.data.metadata?.code)).toBe(true)
+  })
+
+  test.each(["ECONNRESET", "ConnectionRefused", "UND_ERR_SOCKET"])(
+    "classifies %s as an abort rather than a retry when the turn was cancelled",
+    (code) => {
+      // Abort can surface as a transport failure when it races the body read.
+      // Retrying a cancelled request would restart work the user just stopped.
+      const err = Object.assign(new Error(`${code} from test`), { code })
+      expect(MessageV2.fromError(err, { providerID, aborted: true }).name).toBe("MessageAbortedError")
+    },
+  )
+
+  test.each(["socket hang up", "terminated"])(
+    "classifies '%s' as an abort rather than a retry when the turn was cancelled",
+    (message) => {
+      expect(MessageV2.fromError(new Error(message), { providerID, aborted: true }).name).toBe("MessageAbortedError")
+    },
+  )
+
+  test("classifies a TimeoutError DOMException as an abort when the turn was cancelled", () => {
+    const err = new DOMException("The operation timed out", "TimeoutError")
+    expect(MessageV2.fromError(err, { providerID, aborted: true }).name).toBe("MessageAbortedError")
+  })
+
+  test("still reports a non-retryable failure during an abort", () => {
+    // The abort guard must only suppress retries, not rewrite permanent errors
+    // into cancellations and hide a real misconfiguration.
+    const cause = Object.assign(new Error("getaddrinfo ENOTFOUND api.invalid"), {
+      code: "ENOTFOUND",
+      syscall: "getaddrinfo",
+    })
+    const error = new APICallError({
+      message: "Cannot connect to API",
+      url: "https://api.invalid/v1/messages",
+      requestBodyValues: { model: "test" },
+      cause,
+      isRetryable: true,
+    })
+
+    const result = MessageV2.fromError(error, { providerID, aborted: true })
+    if (!SessionV1.APIError.isInstance(result)) throw new Error("expected APIError")
+    expect(result.data.isRetryable).toBe(false)
+  })
+
+  test("gives a nested permanent code precedence over a transient wrapper", () => {
+    const cause = Object.assign(new Error("getaddrinfo ENOTFOUND api.invalid"), { code: "ENOTFOUND" })
+    const wrapper = Object.assign(new Error("socket reset", { cause }), { code: "ECONNRESET" })
+    const result = MessageV2.fromError(wrapper, { providerID })
+    expect(result.name).toBe("UnknownError")
+  })
+
+  test("terminates on a cyclic cause chain instead of spinning", () => {
+    const first = Object.assign(new Error("first wrapper"), { code: "ERR_FIRST" })
+    const second = Object.assign(new Error("second wrapper", { cause: first }), { code: "ERR_SECOND" })
+    first.cause = second
+    expect(MessageV2.fromError(first, { providerID }).name).toBe("UnknownError")
+  })
+
+  test("still classifies a transient code reached through a cyclic chain", () => {
+    // Termination alone is not enough: the walk must keep inspecting codes up to
+    // the depth bound rather than bailing out on first revisit.
+    const transient = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })
+    const cycle = Object.assign(new Error("outer", { cause: transient }), { code: "ERR_OUTER" })
+    transient.cause = cycle
+    const result = MessageV2.fromError(cycle, { providerID })
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    expect((result as SessionV1.APIError).data.metadata?.code).toBe("ECONNRESET")
+  })
+
+  test("bounds deeply nested error causes", () => {
+    const cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" })
+    const wrapper = Array.from({ length: 32 }, (_, index) => index).reduce<Error>(
+      (current, index) => new Error(`wrapper ${index}`, { cause: current }),
+      cause,
+    )
+    const result = MessageV2.fromError(wrapper, { providerID })
+    expect(result.name).toBe("UnknownError")
+  })
+
+  test.each(["socket hang up", "SSE read timed out", "other side closed", "terminated"])(
+    "classifies '%s' bare Error message as retryable APIError",
+    (message) => {
+      const result = MessageV2.fromError(new Error(message), { providerID })
+      expect(SessionV1.APIError.isInstance(result)).toBe(true)
+      expect((result as SessionV1.APIError).data.isRetryable).toBe(true)
+    },
+  )
+
+  test.each([
+    "fetch failed",
+    "Failed to fetch account configuration",
+    "network error: certificate has expired",
+    "Network request failed because access is forbidden",
+    "connect error: invalid provider base URL",
+    "request terminated because the API key is invalid",
+  ])("does not treat '%s' as a transient transport error", (message) => {
+    const result = MessageV2.fromError(new Error(message), { providerID })
+    expect(result.name).toBe("UnknownError")
+  })
+
+  test("leaves unrelated Error messages classified as Unknown", () => {
+    const result = MessageV2.fromError(new Error("Some unrelated bug"), { providerID })
+    expect(result.name).toBe("UnknownError")
   })
 })
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -507,8 +507,9 @@ it.live("session.processor effect tests reset reasoning state across retries", (
 
         expect(value).toBe("continue")
         expect(yield* llm.calls).toBe(2)
-        expect(reasoning.some((part) => part.text === "two")).toBe(true)
-        expect(reasoning.some((part) => part.text === "onetwo")).toBe(false)
+        // The retry neither appends to the abandoned part nor leaves it behind:
+        // "one" is removed with the rest of the failed attempt.
+        expect(reasoning.map((part) => part.text)).toEqual(["two"])
       }),
     { config: (url) => providerCfg(url) },
   ),
@@ -700,6 +701,59 @@ it.live("session.processor effect tests publish retry status updates", () =>
         expect(value).toBe("continue")
         expect(yield* llm.calls).toBe(2)
         expect(states).toStrictEqual([1])
+      }),
+    { config: (url) => providerCfg(url) },
+  ),
+)
+
+it.live("session.processor effect tests discard a failed attempt's parts before retrying", () =>
+  provideTmpdirServer(
+    ({ dir, llm }) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+
+        // A genuine mid-stream drop: text is written, then the connection is
+        // reset. Retrying replays the request unchanged, so the truncated text
+        // has to be removed or the transcript ends up holding both it and the
+        // full replacement.
+        yield* llm.push(reply().text("partial out").reset())
+        yield* llm.text("recovered")
+
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "partial")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({
+          assistantMessage: msg,
+          sessionID: chat.id,
+          model: mdl,
+        })
+
+        const value = yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "partial" }],
+          tools: {},
+        })
+
+        expect(value).toBe("continue")
+        expect(yield* llm.calls).toBe(2)
+        expect(handle.message.error).toBeUndefined()
+        expect(
+          (yield* MessageV2.parts(msg.id))
+            .filter((part): part is SessionV1.TextPart => part.type === "text")
+            .map((part) => part.text),
+        ).toEqual(["recovered"])
       }),
     { config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -4,7 +4,8 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import type { NamedError } from "@opencode-ai/core/util/error"
 import { APICallError } from "ai"
 import { setTimeout as sleep } from "node:timers/promises"
-import { Effect, Schedule, Schema } from "effect"
+import { Clock, Duration, Effect, Fiber, Schedule, Schema } from "effect"
+import * as TestClock from "effect/testing/TestClock"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { SessionRetry } from "../../src/session/retry"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -18,12 +19,17 @@ const providerID = ProviderV2.ID.make("test")
 const retryProvider = "test"
 const it = testEffect(LayerNode.compile(LayerNode.group([SessionStatus.node, CrossSpawnSpawner.node])))
 
-function apiError(headers?: Record<string, string>): SessionV1.APIError {
+function apiError(
+  headers?: Record<string, string>,
+  message = "boom",
+  metadata?: Record<string, string>,
+): SessionV1.APIError {
   return Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
     new SessionV1.APIError({
-      message: "boom",
+      message,
       isRetryable: true,
       responseHeaders: headers,
+      metadata,
     }).toObject(),
   )
 }
@@ -146,6 +152,62 @@ describe("session.retry.delay", () => {
       expect(attempts).toStrictEqual([1, 2, 3, 4, 5])
     }),
   )
+
+  // A transport-classified error never carries responseHeaders, so the policy
+  // falls back to exponential backoff. Drive that real path rather than
+  // short-circuiting it with retry-after-ms, so the cap is exercised against the
+  // delays it will actually see.
+  for (const code of ["ECONNRESET", "ConnectionRefused", "TimeoutError", "NETWORK_ERROR"]) {
+    it.effect(`policy bounds transient transport retries for ${code}`, () =>
+      Effect.gen(function* () {
+        const attempts: number[] = []
+        const delays: number[] = []
+        const failures: SessionV1.APIError[] = []
+
+        const fiber = yield* Effect.gen(function* () {
+          const current = apiError(undefined, `boom ${failures.length + 1}`, { code })
+          failures.push(current)
+          return yield* Effect.fail(current)
+        }).pipe(
+          Effect.retry(
+            SessionRetry.policy({
+              provider: "test",
+              parse: Schema.decodeUnknownSync(SessionV1.APIError.Schema),
+              set: (info) =>
+                Effect.gen(function* () {
+                  attempts.push(info.attempt)
+                  delays.push(info.next - (yield* Clock.currentTimeMillis))
+                }),
+            }),
+          ),
+          Effect.flip,
+          Effect.forkScoped,
+        )
+
+        // Walk the real backoff ladder rather than collapsing it, so the cap is
+        // exercised against the delays production will actually see.
+        for (let step = 0; step <= SessionRetry.RETRY_MAX_RETRIES; step++) {
+          yield* TestClock.adjust(Duration.seconds(30))
+          yield* Effect.yieldNow
+        }
+        const failure = yield* Fiber.join(fiber)
+
+        const terminal = failures.at(-1)
+        if (!terminal) throw new Error("expected retry failures")
+        expect(failure).toBe(terminal)
+        expect(failure.data.message).toBe(`boom ${SessionRetry.RETRY_MAX_RETRIES + 1}`)
+        expect(attempts).toEqual(Array.from({ length: SessionRetry.RETRY_MAX_RETRIES }, (_, index) => index + 1))
+        expect(failures).toHaveLength(SessionRetry.RETRY_MAX_RETRIES + 1)
+        // 2s, 4s, 8s, 16s with 25% jitter, then clamped at 30s.
+        expect(delays).toHaveLength(SessionRetry.RETRY_MAX_RETRIES)
+        for (const [index, base] of [2_000, 4_000, 8_000, 16_000].entries()) {
+          expect(delays[index]).toBeGreaterThanOrEqual(base)
+          expect(delays[index]).toBeLessThanOrEqual(base * (1 + SessionRetry.RETRY_JITTER_FACTOR))
+        }
+        expect(delays.at(-1)).toBe(30_000)
+      }),
+    )
+  }
 })
 
 describe("session.retry.retryable", () => {
@@ -314,6 +376,22 @@ describe("session.retry.retryable", () => {
 
     expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
   })
+
+  test.each(["ENOTFOUND", "ECONNREFUSED"])(
+    "does not retry permanent transport code %s even when the API error is retryable",
+    (code) => {
+      const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+        new SessionV1.APIError({
+          message: "Connection failed",
+          isRetryable: true,
+          statusCode: 503,
+          metadata: { code },
+        }).toObject(),
+      )
+
+      expect(SessionRetry.retryable(error, retryProvider)).toBeUndefined()
+    },
+  )
 
   test("retries ZlibError decompression failures", () => {
     const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(


### PR DESCRIPTION
### Issue for this PR

Closes #30611

This replaces #30638, which was closed by automated cleanup. I rebased the change on the current `dev` branch, tightened the transport error handling, and limited retries for these failures.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Transport errors are often wrapped by the provider SDK, so checking only the top-level error misses failures such as dropped sockets and response timeouts. `MessageV2.fromError` now walks a bounded cause chain and recognizes transient Node, Bun, and Undici transport errors. Missing hosts, refused endpoints, and socket setup failures remain terminal. A plain `AbortError` still means the request was cancelled.

Transport retries stop after five attempts. Existing retry behavior for rate limits and provider errors is unchanged.

### How did you verify your code works?

`bun test test/session/message-v2.test.ts test/session/retry.test.ts` passes 107 tests. `bun typecheck` also passes in `packages/opencode`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR