### PR TITLE
fix(storage): index session list queries

### DIFF
--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,8 +1,8 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "f14a9b18-8207-487e-a3d3-227e629ba9ad",
-  "prevIds": ["169a0f0f-d58f-479f-b024-fa1c7b9a09db"],
+  "id": "40d5fbe0-94c3-434a-8751-a3e796d88d57",
+  "prevIds": ["f14a9b18-8207-487e-a3d3-227e629ba9ad"],
   "ddl": [
     {
       "name": "workspace",
@@ -2015,6 +2015,10 @@
         {
           "value": "project_id",
           "isExpression": false
+        },
+        {
+          "value": "time_updated",
+          "isExpression": false
         }
       ],
       "isUnique": false,
@@ -2043,12 +2047,38 @@
         {
           "value": "parent_id",
           "isExpression": false
+        },
+        {
+          "value": "time_updated",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
         }
       ],
       "isUnique": false,
       "where": null,
       "origin": "manual",
       "name": "session_parent_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "time_updated",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_time_updated_idx",
       "entityType": "indexes",
       "table": "session"
     },

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -40,5 +40,6 @@ export const migrations = (
     import("./migration/20260622142730_simplify_session_context_epoch"),
     import("./migration/20260622170816_reset_v2_session_state"),
     import("./migration/20260622202450_simplify_session_input"),
+    import("./migration/20260724103001_session_list_indexes"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260724103001_session_list_indexes.ts
+++ b/packages/core/src/database/migration/20260724103001_session_list_indexes.ts
@@ -1,0 +1,20 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260724103001_session_list_indexes",
+  up(tx) {
+    return Effect.gen(function* () {
+      // drizzle-kit does not diff index column lists, so widening an existing
+      // index has to be written by hand or migrated databases keep the narrow
+      // one forever and diverge from schema.gen.ts. DROP then CREATE rather
+      // than CREATE IF NOT EXISTS, which would silently retain the old shape.
+      yield* tx.run(`DROP INDEX IF EXISTS \`session_project_idx\`;`)
+      yield* tx.run(`DROP INDEX IF EXISTS \`session_parent_idx\`;`)
+      yield* tx.run(`DROP INDEX IF EXISTS \`session_time_updated_idx\`;`)
+      yield* tx.run(`CREATE INDEX \`session_project_idx\` ON \`session\` (\`project_id\`,\`time_updated\`);`)
+      yield* tx.run(`CREATE INDEX \`session_parent_idx\` ON \`session\` (\`parent_id\`,\`time_updated\`,\`id\`);`)
+      yield* tx.run(`CREATE INDEX \`session_time_updated_idx\` ON \`session\` (\`time_updated\`,\`id\`);`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -265,9 +265,10 @@ export default {
         `CREATE INDEX \`session_message_session_time_created_id_idx\` ON \`session_message\` (\`session_id\`,\`time_created\`,\`id\`);`,
       )
       yield* tx.run(`CREATE INDEX \`session_message_time_created_idx\` ON \`session_message\` (\`time_created\`);`)
-      yield* tx.run(`CREATE INDEX \`session_project_idx\` ON \`session\` (\`project_id\`);`)
+      yield* tx.run(`CREATE INDEX \`session_project_idx\` ON \`session\` (\`project_id\`,\`time_updated\`);`)
       yield* tx.run(`CREATE INDEX \`session_workspace_idx\` ON \`session\` (\`workspace_id\`);`)
-      yield* tx.run(`CREATE INDEX \`session_parent_idx\` ON \`session\` (\`parent_id\`);`)
+      yield* tx.run(`CREATE INDEX \`session_parent_idx\` ON \`session\` (\`parent_id\`,\`time_updated\`,\`id\`);`)
+      yield* tx.run(`CREATE INDEX \`session_time_updated_idx\` ON \`session\` (\`time_updated\`,\`id\`);`)
       yield* tx.run(`CREATE INDEX \`todo_session_idx\` ON \`todo\` (\`session_id\`);`)
     })
   },

--- a/packages/core/src/session/sql.ts
+++ b/packages/core/src/session/sql.ts
@@ -59,9 +59,10 @@ export const SessionTable = sqliteTable(
     time_archived: integer(),
   },
   (table) => [
-    index("session_project_idx").on(table.project_id),
+    index("session_project_idx").on(table.project_id, table.time_updated),
     index("session_workspace_idx").on(table.workspace_id),
-    index("session_parent_idx").on(table.parent_id),
+    index("session_parent_idx").on(table.parent_id, table.time_updated, table.id),
+    index("session_time_updated_idx").on(table.time_updated, table.id),
   ],
 )
 

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -8,6 +8,7 @@ import { Effect, Layer } from "effect"
 import { eq, inArray, sql } from "drizzle-orm"
 import { DatabaseMigration } from "@opencode-ai/core/database/migration"
 import { migrations } from "@opencode-ai/core/database/migration.gen"
+import sessionListIndexesMigration from "@opencode-ai/core/database/migration/20260724103001_session_list_indexes"
 import sessionUsageMigration from "@opencode-ai/core/database/migration/20260510033149_session_usage"
 import normalizeStoragePathsMigration from "@opencode-ai/core/database/migration/20260601010001_normalize_storage_paths"
 import sessionMessageProjectionOrderMigration from "@opencode-ai/core/database/migration/20260603040000_session_message_projection_order"
@@ -59,6 +60,114 @@ describe("DatabaseMigration", () => {
       expect(result.stdout.toString()).toContain("No schema changes, nothing to migrate")
     }, 30_000)
   }
+
+  // Mirrors the pre-migration shape of `session` well enough to exercise the
+  // index migration: every column the old and new indexes reference.
+  const legacySessionTable = (db: EffectDrizzleSqlite.EffectSQLiteDatabase) =>
+    Effect.gen(function* () {
+      yield* db.run(
+        sql`CREATE TABLE session (id text PRIMARY KEY, project_id text NOT NULL, workspace_id text, parent_id text, time_updated integer NOT NULL, time_archived integer)`,
+      )
+      yield* db.run(sql`CREATE INDEX session_project_idx ON session (project_id)`)
+      yield* db.run(sql`CREATE INDEX session_workspace_idx ON session (workspace_id)`)
+      yield* db.run(sql`CREATE INDEX session_parent_idx ON session (parent_id)`)
+    })
+
+  const sessionIndexes = (db: EffectDrizzleSqlite.EffectSQLiteDatabase) =>
+    Effect.gen(function* () {
+      const names = (yield* db.all<{ name: string }>(
+        sql`SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'session' AND name NOT LIKE 'sqlite_%' ORDER BY name`,
+      )).map((index) => index.name)
+      return yield* Effect.forEach(names, (name) =>
+        Effect.gen(function* () {
+          const columns = yield* db.all<{ name: string }>(sql`PRAGMA index_info(${sql.raw(name)})`)
+          return { name, columns: columns.map((column) => column.name) }
+        }),
+      )
+    })
+
+  test("widens session list indexes on an existing database", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* legacySessionTable(db)
+
+        yield* DatabaseMigration.applyOnly(db, [sessionListIndexesMigration])
+
+        expect(yield* sessionIndexes(db)).toEqual([
+          { name: "session_parent_idx", columns: ["parent_id", "time_updated", "id"] },
+          { name: "session_project_idx", columns: ["project_id", "time_updated"] },
+          { name: "session_time_updated_idx", columns: ["time_updated", "id"] },
+          // Untouched by this migration; asserted so a future widening of the
+          // three above cannot silently drop it.
+          { name: "session_workspace_idx", columns: ["workspace_id"] },
+        ])
+      }),
+    )
+  })
+
+  test("replaces a narrow session_time_updated_idx instead of skipping it", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* legacySessionTable(db)
+        yield* db.run(sql`CREATE INDEX session_time_updated_idx ON session (time_updated)`)
+
+        yield* DatabaseMigration.applyOnly(db, [sessionListIndexesMigration])
+
+        expect(
+          (yield* db.all<{ name: string }>(sql`PRAGMA index_info(session_time_updated_idx)`)).map(
+            (column) => column.name,
+          ),
+        ).toEqual(["time_updated", "id"])
+      }),
+    )
+  })
+
+  test("migrated and freshly created databases agree on session indexes", async () => {
+    // drizzle-kit does not diff index column lists, so the migration's SQL is
+    // hand-written and `bun script/migration.ts --check` cannot catch drift
+    // between it and schema.gen.ts. Compare the two paths directly.
+    const migrated = await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* legacySessionTable(db)
+        yield* DatabaseMigration.applyOnly(db, [sessionListIndexesMigration])
+        return yield* sessionIndexes(db)
+      }),
+    )
+    const fresh = await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* DatabaseMigration.apply(db)
+        return yield* sessionIndexes(db)
+      }),
+    )
+
+    expect(migrated).toEqual(fresh)
+  })
+
+  test("serves the global session list from session_time_updated_idx without sorting", async () => {
+    await run(
+      Effect.gen(function* () {
+        const db = yield* makeDb
+        yield* DatabaseMigration.apply(db)
+
+        // Matches Session.listGlobal's default query shape.
+        const plan = (yield* db.all<{ detail: string }>(
+          sql`EXPLAIN QUERY PLAN SELECT * FROM session WHERE time_archived IS NULL ORDER BY time_updated DESC, id DESC LIMIT 100`,
+        ))
+          .map((row) => row.detail)
+          .join("\n")
+
+        expect(plan).toContain("session_time_updated_idx")
+        // The composite (time_updated, id) index only removes the sort because
+        // the ORDER BY reverses both columns uniformly. A temp B-tree here means
+        // the index no longer matches the query and the scan is back.
+        expect(plan).not.toContain("TEMP B-TREE")
+      }),
+    )
+  })
 
   test("applies tracked migrations to an empty database", async () => {
     await run(


### PR DESCRIPTION
### Issue for this PR

Closes #30609

This replaces #30636, which was closed by automated cleanup. I rebased the change on the current `dev` branch and updated the indexes to match the queries now used by session lists.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Session lists sort by update time, but the existing indexes cover only their filter columns. The project index is now `(project_id, time_updated)`, the root-session index is `(parent_id, time_updated, id)`, and the global list has `(time_updated, id)`. Project and parent lookups can still use the leftmost columns of those indexes.

The migration replaces the old single-column indexes. It also handles databases that tested the earlier single-column `session_time_updated_idx`.

### How did you verify your code works?

`bun test test/database-migration.test.ts` passes all 18 tests. `bun typecheck` and `bun script/migration.ts --check` also pass in `packages/core`.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR