### PR TITLE
fix(app): restore optimistic timeline state

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -332,6 +332,7 @@ export function MessageTimeline(props: {
   const showHeader = createMemo(() => !!(titleValue() || parentID()))
   const projection = createTimelineProjection({
     messages: sessionMessages,
+    userMessages: () => props.userMessages,
     sessionMessages: projectedMessages,
     parts: getMsgParts,
     status: sessionStatus,

--- a/packages/app/src/pages/session/timeline/projection.ts
+++ b/packages/app/src/pages/session/timeline/projection.ts
@@ -8,6 +8,7 @@ export { reuseTimelineRows } from "./row-reconciliation"
 
 export function createTimelineProjection(input: {
   messages: Accessor<Message[]>
+  userMessages: Accessor<UserMessage[]>
   sessionMessages: Accessor<SessionMessageInfo[]>
   parts: (messageID: string) => Part[]
   status: Accessor<SessionStatus>
@@ -36,6 +37,7 @@ export function createTimelineProjection(input: {
       input.showReasoningSummaries(),
       input.status().type,
       input.inlineComments(),
+      input.userMessages(),
     ),
   )
   const activeMessageID = createMemo(() => projection().activeMessageID)

--- a/packages/app/src/pages/session/timeline/rows-current.test.ts
+++ b/packages/app/src/pages/session/timeline/rows-current.test.ts
@@ -46,6 +46,7 @@ describe("current session timeline rows", () => {
       true,
       "busy",
       true,
+      normalized.messages.filter((message) => message.role === "user"),
     )
 
     expect(result.activeMessageID).toBe("msg_3")
@@ -81,6 +82,7 @@ describe("current session timeline rows", () => {
       true,
       "idle",
       true,
+      normalized.messages.filter((message) => message.role === "user"),
     )
 
     expect(result.activeMessageID).toBe("msg_shell")
@@ -121,6 +123,7 @@ describe("current session timeline rows", () => {
       true,
       "idle",
       true,
+      normalized.messages.filter((message) => message.role === "user"),
     )
 
     expect(result.rows.map(TimelineRow.key)).toEqual([
@@ -129,6 +132,39 @@ describe("current session timeline rows", () => {
       "turn-gap:msg_user_2",
       "user-message:msg_user_2",
       "assistant-part:msg_user_2:msg_assistant_2:text:0",
+    ])
+  })
+
+  test("renders an optimistic user turn and thinking before the protocol message arrives", () => {
+    const source = [
+      { id: "msg_1", type: "user", text: "existing", time: { created: 1 } },
+    ] satisfies SessionMessageInfo[]
+    const normalized = normalizeSessionMessages("ses_1", source)
+    const optimistic = {
+      id: "msg_2",
+      sessionID: "ses_1",
+      role: "user" as const,
+      time: { created: 2 },
+      agent: "build",
+      model: { modelID: "model", providerID: "provider" },
+    }
+    const result = Timeline.constructSessionMessageRows(
+      source,
+      (messageID) =>
+        messageID === optimistic.id ? optimistic : normalized.messages.find((message) => message.id === messageID),
+      () => [],
+      true,
+      "busy",
+      true,
+      [...normalized.messages.filter((message) => message.role === "user"), optimistic],
+    )
+
+    expect(result.activeMessageID).toBe(optimistic.id)
+    expect(result.rows.map(TimelineRow.key)).toEqual([
+      "user-message:msg_1",
+      "turn-gap:msg_2",
+      "user-message:msg_2",
+      "thinking:msg_2",
     ])
   })
 })

--- a/packages/app/src/pages/session/timeline/rows.ts
+++ b/packages/app/src/pages/session/timeline/rows.ts
@@ -39,6 +39,7 @@ export namespace Timeline {
     showReasoning: boolean,
     status: SessionStatus["type"],
     inlineComments: boolean,
+    projectedUserMessages: UserMessage[],
   ) {
     const turns: { user: UserMessage; assistants: AssistantMessage[] }[] = []
     const turnByUserID = new Map<string, (typeof turns)[number]>()
@@ -67,6 +68,14 @@ export namespace Timeline {
       const user = getMessage(projected.parentID)
       if (user?.role !== "user") return
       const turn = { user, assistants: [projected] }
+      turns.push(turn)
+      turnByUserID.set(user.id, turn)
+    })
+    const latestUserMessageID = turns.at(-1)?.user.id
+    projectedUserMessages.forEach((user) => {
+      if (turnByUserID.has(user.id)) return
+      if (latestUserMessageID && user.id < latestUserMessageID) return
+      const turn = { user, assistants: [] }
       turns.push(turn)
       turnByUserID.set(user.id, turn)
     })


### PR DESCRIPTION
## Summary

- include visible projected user messages that are newer than the protocol-backed timeline
- restore the immediate optimistic message and thinking indicator after prompt submission
- preserve protocol ordering and pagination boundaries

## Validation

- `bun test --preload ./happydom.ts ./src/pages/session/timeline/rows-current.test.ts ./src/components/prompt-input/submit.test.ts`
- `bun typecheck` from `packages/app`
- repository pre-push typecheck: 30 tasks passed
- reduced production timeline benchmark passed before and after the change with no row or markdown replacement