### PR TITLE
fix(ai): forward Anthropic provider options

### DIFF
--- a/packages/ai/src/providers/anthropic-compatible.ts
+++ b/packages/ai/src/providers/anthropic-compatible.ts
@@ -3,7 +3,7 @@ import { AnthropicMessages } from "../protocols/anthropic-messages"
 import { Auth } from "../route/auth"
 import type { ProviderAuthOption } from "../route/auth-options"
 import type { RouteDefaultsInput } from "../route/client"
-import { ProviderID, type ModelID } from "../schema"
+import { ProviderID, type ModelID, type ProviderOptions } from "../schema"
 
 export const id = ProviderID.make("anthropic-compatible")
 
@@ -20,6 +20,7 @@ export type Settings = ProviderPackage.Settings &
   ) & {
     readonly baseURL: string
     readonly provider?: string
+    readonly providerOptions?: ProviderOptions
   }
 
 export const routes = [AnthropicMessages.route]
@@ -61,6 +62,7 @@ export const model: ProviderPackage.Definition<Settings>["model"] = (modelID, se
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
     limits: settings.limits,
     provider: settings.provider,
+    providerOptions: settings.providerOptions,
   }).model(modelID)
 }
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2,7 +2,7 @@ import type { RouteDefaultsInput } from "../route/client"
 import { Auth } from "../route/auth"
 import type { ProviderAuthOption } from "../route/auth-options"
 import type { ProviderPackage } from "../provider-package"
-import { ProviderID, type ModelID } from "../schema"
+import { ProviderID, type ModelID, type ProviderOptions } from "../schema"
 import { AnthropicMessages } from "../protocols/anthropic-messages"
 import { AnthropicCompatible } from "./anthropic-compatible"
 
@@ -18,6 +18,7 @@ export type Settings = ProviderPackage.Settings &
     | { readonly apiKey?: never; readonly authToken?: string }
   ) & {
     readonly baseURL?: string
+    readonly providerOptions?: ProviderOptions
   }
 
 const auth = (options: ProviderAuthOption<"optional">) => {
@@ -52,5 +53,6 @@ export const model: ProviderPackage.Definition<Settings>["model"] = (modelID, se
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
     http: settings.body === undefined ? undefined : { body: { ...settings.body } },
     limits: settings.limits,
+    providerOptions: settings.providerOptions,
   }).model(modelID)
 }

--- a/packages/ai/test/provider-package.test.ts
+++ b/packages/ai/test/provider-package.test.ts
@@ -85,6 +85,7 @@ describe("provider package entrypoints", () => {
       headers: { "x-application": "opencode" },
       body: { metadata: { user_id: "user_1" } },
       limits: { context: 200_000, output: 64_000 },
+      providerOptions: { anthropic: { effort: "low" } },
     })
 
     expect(String(selected.provider)).toBe("example")
@@ -96,6 +97,19 @@ describe("provider package entrypoints", () => {
     expect(selected.route.defaults.headers).toEqual({ "x-application": "opencode" })
     expect(selected.route.defaults.http?.body).toEqual({ metadata: { user_id: "user_1" } })
     expect(selected.route.defaults.limits).toEqual({ context: 200_000, output: 64_000 })
+    expect(selected.route.defaults.providerOptions).toEqual({ anthropic: { effort: "low" } })
+  })
+
+  test("maps Anthropic provider options onto the executable model", async () => {
+    const Anthropic = await import("@opencode-ai/ai/providers/anthropic")
+    const selected = Anthropic.model("claude-sonnet-4-6", {
+      apiKey: "fixture",
+      providerOptions: { anthropic: { thinking: { type: "adaptive" } } },
+    })
+
+    expect(selected.route.defaults.providerOptions).toEqual({
+      anthropic: { thinking: { type: "adaptive" } },
+    })
   })
 
   test("requires an Anthropic-compatible base URL at runtime", async () => {


### PR DESCRIPTION
## Summary

- forward provider options through the Anthropic and Anthropic-compatible package entrypoints
- expose package-level provider option settings and cover both paths with regressions

## Testing

- `bun test` in `packages/ai` (435 passed, 28 skipped)
- `bun typecheck` in `packages/ai`
- repository-wide `bun turbo typecheck --concurrency=3` via the pre-push hook