### PR TITLE
fix: handle Safari IME composition in prompt input

### DIFF
--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -540,7 +540,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   })
 
   const [composing, setComposing] = createSignal(false)
-  const isImeComposing = (event: KeyboardEvent) => event.isComposing || composing() || event.keyCode === 229
+  let lastCompositionEnd = 0
+  // Safari fires compositionend BEFORE the confirming Enter keydown, so that
+  // event reports isComposing=false and keyCode=13. Treat any key event within
+  // 100ms of compositionend as part of the IME confirmation.
+  const isImeComposing = (event: KeyboardEvent) =>
+    event.isComposing || composing() || event.keyCode === 229 || event.timeStamp - lastCompositionEnd < 100
 
   const handleBlur = () => {
     const cursor = currentCursor()
@@ -554,8 +559,11 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     setComposing(true)
   }
 
-  const handleCompositionEnd = () => {
+  const handleCompositionEnd = (event: CompositionEvent) => {
     setComposing(false)
+    lastCompositionEnd = event.timeStamp
+    // Input events are ignored while composing, so sync DOM -> state once now.
+    handleInput()
     requestAnimationFrame(() => {
       if (composing()) return
       reconcile(prompt.current().filter((part) => part.type !== "image"))
@@ -865,7 +873,10 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     on(
       () => prompt.current(),
       (parts) => {
-        if (composing()) return
+        // The time window also covers the gap between compositionend and the
+        // next compositionstart when Japanese IMEs confirm segment by segment;
+        // a DOM rewrite landing there aborts the rest of the composition.
+        if (composing() || performance.now() - lastCompositionEnd < 100) return
         reconcile(parts.filter((part) => part.type !== "image"))
       },
     ),
@@ -970,7 +981,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return parts
   }
 
-  const handleInput = () => {
+  const handleInput = (event?: InputEvent) => {
+    // During IME composition, never sync DOM -> state -> DOM: any programmatic
+    // DOM/selection mutation makes Safari abort the composition mid-way. Check
+    // the event too because Safari fires the first input event BEFORE
+    // compositionstart, when composing() is still false.
+    if (composing() || event?.isComposing || event?.inputType === "insertCompositionText") return
     const rawParts = parseFromDOM()
     const images = imageAttachments()
     const cursorPosition = getCursorPosition(editorRef)

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -542,10 +542,12 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
   const [composing, setComposing] = createSignal(false)
   let lastCompositionEnd = 0
   // Safari fires compositionend BEFORE the confirming Enter keydown, so that
-  // event reports isComposing=false and keyCode=13. Treat any key event within
-  // 100ms of compositionend as part of the IME confirmation.
+  // keydown reports isComposing=false (keyCode 229 on Safari 26, 13 in older
+  // reports). Treat any key event within 100ms of compositionend as part of
+  // the IME confirmation. Compare with performance.now() rather than
+  // event.timeStamp so the guard never depends on the event clock source.
   const isImeComposing = (event: KeyboardEvent) =>
-    event.isComposing || composing() || event.keyCode === 229 || event.timeStamp - lastCompositionEnd < 100
+    event.isComposing || composing() || event.keyCode === 229 || performance.now() - lastCompositionEnd < 100
 
   const handleBlur = () => {
     const cursor = currentCursor()
@@ -559,9 +561,9 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     setComposing(true)
   }
 
-  const handleCompositionEnd = (event: CompositionEvent) => {
+  const handleCompositionEnd = () => {
     setComposing(false)
-    lastCompositionEnd = event.timeStamp
+    lastCompositionEnd = performance.now()
     // Input events are ignored while composing, so sync DOM -> state once now.
     handleInput()
     requestAnimationFrame(() => {

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -167,12 +167,14 @@ export function PromptInputV2(props: PromptInputV2Props) {
             }}
             onKeyDown={(event) => {
               if (props.controller.onKeyDown(event)) return
-              if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
+              if (event.key === "Enter" && !event.shiftKey && !props.controller.imeComposing(event)) {
                 event.preventDefault()
                 if (event.repeat) return
                 props.controller.submit()
               }
             }}
+            onCompositionStart={props.controller.onCompositionStart}
+            onCompositionEnd={props.controller.onCompositionEnd}
             onKeyUp={updateCursor}
             onPointerUp={updateCursor}
             onPaste={props.controller.onPaste}

--- a/packages/session-ui/src/v2/components/prompt-input/interaction.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/interaction.ts
@@ -185,6 +185,14 @@ export function createPromptInputV2Controller(input: {
     return result.handled
   }
 
+  let composing = false
+  let lastCompositionEnd = 0
+  // Safari fires compositionend BEFORE the confirming Enter keydown, so that
+  // event reports isComposing=false and keyCode=13. Treat any key event within
+  // 100ms of compositionend as part of the IME confirmation.
+  const imeComposing = (event: KeyboardEvent) =>
+    event.isComposing || composing || event.keyCode === 229 || event.timeStamp - lastCompositionEnd < 100
+
   const onKeyDown = (event: KeyboardEvent) => {
     if (
       state.mode === "normal" &&
@@ -201,7 +209,7 @@ export function createPromptInputV2Controller(input: {
       type: "key.down",
       key: event.key,
       ctrl: event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey,
-      composing: event.isComposing,
+      composing: imeComposing(event),
       ids: suggestions().map((item) => item.id),
       empty: draft.state.prompt.every((part) => !("content" in part) || part.content.length === 0),
     })
@@ -295,6 +303,14 @@ export function createPromptInputV2Controller(input: {
     suggestions,
     dispatch,
     onKeyDown,
+    imeComposing,
+    onCompositionStart() {
+      composing = true
+    },
+    onCompositionEnd(event: CompositionEvent) {
+      composing = false
+      lastCompositionEnd = event.timeStamp
+    },
     value() {
       return draft.state.prompt.map((part) => ("content" in part ? part.content : "")).join("")
     },

--- a/packages/session-ui/src/v2/components/prompt-input/interaction.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/interaction.ts
@@ -188,10 +188,12 @@ export function createPromptInputV2Controller(input: {
   let composing = false
   let lastCompositionEnd = 0
   // Safari fires compositionend BEFORE the confirming Enter keydown, so that
-  // event reports isComposing=false and keyCode=13. Treat any key event within
-  // 100ms of compositionend as part of the IME confirmation.
+  // keydown reports isComposing=false (keyCode 229 on Safari 26, 13 in older
+  // reports). Treat any key event within 100ms of compositionend as part of
+  // the IME confirmation. Compare with performance.now() rather than
+  // event.timeStamp so the guard never depends on the event clock source.
   const imeComposing = (event: KeyboardEvent) =>
-    event.isComposing || composing || event.keyCode === 229 || event.timeStamp - lastCompositionEnd < 100
+    event.isComposing || composing || event.keyCode === 229 || performance.now() - lastCompositionEnd < 100
 
   const onKeyDown = (event: KeyboardEvent) => {
     if (
@@ -307,9 +309,9 @@ export function createPromptInputV2Controller(input: {
     onCompositionStart() {
       composing = true
     },
-    onCompositionEnd(event: CompositionEvent) {
+    onCompositionEnd() {
       composing = false
-      lastCompositionEnd = event.timeStamp
+      lastCompositionEnd = performance.now()
     },
     value() {
       return draft.state.prompt.map((part) => ("content" in part ? part.content : "")).join("")


### PR DESCRIPTION
## Summary

Fixes #35746
Fixes #38674

Safari handles IME composition differently from Chrome in two ways that broke the prompt input for CJK users:

- **Enter that confirms an IME candidate submitted the message** (#35746). Safari fires `compositionend` *before* the confirming Enter `keydown`, so that keydown reports `isComposing=false` (keyCode observed as 229 on Safari 26, 13 in older reports) and slipped past every existing guard. Chrome fires the keydown first with `isComposing=true`, so it was unaffected.
- **Composition was aborted mid-way** (#38674). The contenteditable editor synced DOM -> state -> DOM on every `input` event; any programmatic DOM/selection mutation makes Safari abort an in-progress composition. Safari also fires the first composition `input` event *before* `compositionstart`, so the `composing()` guard alone could not catch it, and Japanese IMEs with live conversion open a new composition milliseconds after committing a segment, so a rewrite landing in that gap cut off the rest of the sentence.

### Changes

- `packages/app/src/components/prompt-input.tsx` (legacy prompt input): record `lastCompositionEnd` with `performance.now()` on `compositionend` and treat any Enter within 100ms of it as part of the IME confirmation; skip DOM -> state sync during composition (including the pre-`compositionstart` input event, detected via `event.isComposing` / `insertCompositionText`) and sync once on `compositionend`; guard the state -> DOM reconcile effect with the same 100ms window so segment-by-segment Japanese confirmation is not interrupted.
- `packages/session-ui/src/v2/components/prompt-input/{index.tsx,interaction.ts}` (v2 prompt input): track composition state in the controller, apply the same Enter guard in the editor keydown handler, and pass the composition-aware flag to the interaction machine.
- The guard window compares against `performance.now()` rather than `event.timeStamp` so it never depends on the event clock source.

### Real-device verification (macOS 26.5.2, Safari 26.5.2, Chrome; system Simplified Pinyin + Japanese Kotoeri with live conversion)

Measured event order in Safari, driven by real keyboard events with an in-page event logger:

- The first composition keystroke lands as `insertText` (`isComposing=false`) *before* `compositionstart`.
- Confirming a candidate produces `beforeinput(deleteCompositionText)` -> `input(insertFromComposition)` -> `compositionend` -> Enter `keydown` (`isComposing=false`, `keyCode=229`) only 0-9ms later; the guard swallows it, and an Enter pressed later (measured 1.4s) submits normally.
- Japanese live conversion commits a leading segment and opens the next composition **3ms** after `compositionend`; the remainder of the sentence survives with zero editor DOM rewrites.
- Long pinyin input (`zhongwenshurufaceshi`) stays in a single composition and commits as 中文输入法测试.
- Chrome keeps its original order (Enter keydown with `isComposing=true` before `compositionend`) and is guarded by the existing `isComposing` check; English typing, Enter submit, and Shift+Enter newline behave unchanged in both browsers.

Both the v2 prompt input and the legacy one were verified.

## Test plan

- [x] Safari: pinyin candidate confirmation via Enter/Space does not submit; text is preserved; a later Enter submits
- [x] Safari: long pinyin and multi-segment Japanese (live conversion) input is never cut off mid-composition
- [x] Safari: Backspace while composing, `@` during composition, clearing and history navigation behave normally
- [x] Chrome: no behavior change (composition guard, Enter submit, Shift+Enter)
- [x] `bun typecheck` across packages; `machine.test.ts` (11 tests) passes

Made with [Cursor](https://cursor.com)