### PR TITLE
fix(opencode): sanitize NaN tokens in getUsage and recover null on read

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -77,12 +77,20 @@ export const cursor = {
   },
 }
 
-const info = (row: typeof MessageTable.$inferSelect) =>
-  ({
-    ...row.data,
+const info = (row: typeof MessageTable.$inferSelect) => {
+  const data = row.data as Record<string, any>
+  // JSON.stringify(NaN) → null in SQLite; on read-back null violates Schema.optional(Schema.Finite).
+  // Sanitize affected numeric fields so existing corrupted rows don't cause 500s.
+  if (data.tokens) {
+    if (data.tokens.total === null) data.tokens.total = undefined
+  }
+  if (data.cost === null) data.cost = 0
+  return {
+    ...data,
     id: row.id,
     sessionID: row.session_id,
-  }) as Info
+  } as Info
+}
 
 const part = (row: typeof PartTable.$inferSelect) =>
   ({

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -366,9 +366,10 @@ export const getUsage = (input: { model: Provider.Model; usage: Usage; metadata?
   const adjustedInputTokens = safe(inputTokens - cacheReadInputTokens - cacheWriteInputTokens)
 
   const total = input.usage.totalTokens
+  const safeTotal = total !== undefined && Number.isFinite(total) ? Math.max(0, total) : undefined
 
   const tokens = {
-    total,
+    total: safeTotal,
     input: adjustedInputTokens,
     output: safe(outputTokens - reasoningTokens),
     reasoning: reasoningTokens,


### PR DESCRIPTION
### Issue for this PR

Closes #38703

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`getUsage()` in `session.ts` passes `input.usage.totalTokens` through raw, unlike every other token field which goes through `safe()`. When a provider returns NaN (from undefined arithmetic), `JSON.stringify(NaN)` serializes as `null` in SQLite. On read-back, `null` violates `Schema.optional(Schema.Finite)` and the message API returns 500.

Two changes:

1. **Prevention** (`session.ts`): Apply `Number.isFinite` check to `totalTokens` before storing, matching the `safe()` pattern used for all other token fields.
2. **Recovery** (`message-v2.ts`): Sanitize `tokens.total === null → undefined` and `cost === null → 0` at read time so existing corrupted rows load without error.

### How did you verify your code works?

- `bun typecheck` passes for changed files
- Verified against a production DB with 189 affected rows — all sessions load without 500 after the recovery path
- Confirmed `JSON.stringify({total: NaN})` → `{"total":null}` reproduces the exact corruption pattern

### Screenshots / recordings

_N/A - not a UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR