### PR TITLE
feat(llm): add Apiario Dev as a native provider

### DIFF
--- a/packages/llm/src/providers/openai-compatible-profile.ts
+++ b/packages/llm/src/providers/openai-compatible-profile.ts
@@ -4,6 +4,7 @@ export interface OpenAICompatibleProfile {
 }
 
 export const profiles = {
+  apiario: { provider: "apiario", baseURL: "https://api.apiario.dev/v1" },
   baseten: { provider: "baseten", baseURL: "https://inference.baseten.co/v1" },
   cerebras: { provider: "cerebras", baseURL: "https://api.cerebras.ai/v1" },
   deepinfra: { provider: "deepinfra", baseURL: "https://api.deepinfra.com/v1/openai" },

--- a/packages/llm/src/providers/openai-compatible.ts
+++ b/packages/llm/src/providers/openai-compatible.ts
@@ -56,6 +56,7 @@ export const provider = {
   configure,
 }
 
+export const apiario = define(profiles.apiario)
 export const baseten = define(profiles.baseten)
 export const cerebras = define(profiles.cerebras)
 export const deepinfra = define(profiles.deepinfra)

--- a/packages/ui/src/assets/icons/provider/apiario.svg
+++ b/packages/ui/src/assets/icons/provider/apiario.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" width="40" height="40">
+  <!-- Background rounded square -->
+  <rect width="40" height="40" rx="8" fill="#1E2535"/>
+
+  <!-- Honeycomb hexagon -->
+  <polygon
+    points="20,7 29,12.5 29,23.5 20,29 11,23.5 11,12.5"
+    fill="none"
+    stroke="#F5A623"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+
+  <!-- Inner bee body (oval) -->
+  <ellipse cx="20" cy="20" rx="3.5" ry="5" fill="#F5A623"/>
+
+  <!-- Bee stripes -->
+  <rect x="16.5" y="18" width="7" height="1.5" rx="0.75" fill="#1E2535"/>
+  <rect x="16.5" y="21" width="7" height="1.5" rx="0.75" fill="#1E2535"/>
+
+  <!-- Wings -->
+  <ellipse cx="15" cy="16.5" rx="3" ry="1.8" fill="#F5A623" fill-opacity="0.5" transform="rotate(-20,15,16.5)"/>
+  <ellipse cx="25" cy="16.5" rx="3" ry="1.8" fill="#F5A623" fill-opacity="0.5" transform="rotate(20,25,16.5)"/>
+
+  <!-- Stinger -->
+  <line x1="20" y1="25" x2="20" y2="28" stroke="#F5A623" stroke-width="1.2" stroke-linecap="round"/>
+
+  <!-- Antennae -->
+  <line x1="18.5" y1="15" x2="16" y2="11.5" stroke="#F5A623" stroke-width="1" stroke-linecap="round"/>
+  <line x1="21.5" y1="15" x2="24" y2="11.5" stroke="#F5A623" stroke-width="1" stroke-linecap="round"/>
+  <circle cx="15.8" cy="11.2" r="1" fill="#F5A623"/>
+  <circle cx="24.2" cy="11.2" r="1" fill="#F5A623"/>
+</svg>


### PR DESCRIPTION

### Issue for this PR

N/A (Direct PR for new provider addition)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds **Apiário Dev** as a native OpenAI-compatible provider. 
This PR registers `apiario` in the LLM package profiles pointing to our `v1` endpoint and includes the official `.svg` logo in the UI package so it renders correctly in the desktop app provider list.

### How did you verify your code works?

Verified locally. The provider integrates seamlessly with the existing `OpenAICompatible` factory and the SVG icon is correctly picked up by the `provider-icons-plugin`.

### Screenshots / recordings

_Added `apiario.svg` to UI assets._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR