### PR TITLE
fix(core): preserve reasoning metadata on errored assistant turns

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -79,7 +79,7 @@ const assistant = (message: SessionMessage.Assistant, model: Model) => {
             {
               type: "reasoning",
               text: item.text,
-              providerMetadata: reuseProviderMetadata ? item.providerMetadata : undefined,
+              providerMetadata: item.providerMetadata,
             },
           ]
         : item.text.length > 0

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -327,7 +327,7 @@ Recent work
     ])
   })
 
-  test("drops provider-native continuation metadata from failed assistant turns", () => {
+  test("drops provider-native continuation metadata from failed assistant turn tools, but preserves reasoning", () => {
     const messages = toLLMMessages(
       [
         SessionMessage.Assistant.make({
@@ -370,7 +370,11 @@ Recent work
     )
 
     expect(messages[0]?.content).toEqual([
-      { type: "reasoning", text: "Partial thought", providerMetadata: undefined },
+      {
+        type: "reasoning",
+        text: "Partial thought",
+        providerMetadata: { openai: { itemId: "rs_failed", reasoningEncryptedContent: null } },
+      },
       {
         type: "tool-call",
         id: "hosted-failed",


### PR DESCRIPTION
Fixes #38620.

Anthropic rejects a replayed `tool_use` with a 400 if its preceding `thinking` block is dropped when extended thinking is enabled.

Previously, `reuseProviderMetadata` required `message.error === undefined`, meaning an aborted/failed step would drop all reasoning state on replay (both `anthropic.signature` and `anthropic.redactedData`) while still replaying that same message's `tool_use` parts.

This relaxes the guard strictly for reasoning blocks, ensuring the signature is retained when `sameModel` is true. This keeps the block from being filtered out as empty, keeping the message structurally valid for the provider.