### PR TITLE
refactor(core): unify tool fiber bookkeeping into one owned structure

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -1,6 +1,6 @@
 export * as SessionRunnerLLM from "./llm"
 
-import { LLMClient, LLMError, LLMEvent, isContextOverflowFailure, type ProviderErrorEvent } from "@opencode-ai/ai"
+import { LLMClient, LLMError, LLMEvent, isContextOverflowFailure, type ProviderErrorEvent, type ToolCall } from "@opencode-ai/ai"
 import { Cause, Data, Effect, Exit, Fiber, FiberSet, Layer, Option, Pull, Schedule, Semaphore, Stream } from "effect"
 import { Database } from "../../database/database"
 import { EventV2 } from "../../event"
@@ -203,8 +203,9 @@ const layer = Layer.effect(
         context: loaded,
         step: currentStep,
       })
-      const toolFibers = yield* FiberSet.make<void, ToolOutputStore.Error>()
-      const ownedToolFibers: Array<Fiber.Fiber<void, ToolOutputStore.Error>> = []
+      // Every local tool call forked here is owned until it reaches one durable settlement.
+      const toolRuns: Array<{ readonly call: ToolCall; readonly fiber: Fiber.Fiber<void, ToolOutputStore.Error> }> = []
+      const interruptTools = Effect.suspend(() => Fiber.interruptAll(toolRuns.map((run) => run.fiber)))
       let needsContinuation = false
       const startSnapshot = yield* snapshots.capture()
       const publisher = createLLMEventPublisher(events, {
@@ -277,8 +278,9 @@ const layer = Layer.effect(
             // continuation depends only on remaining Step allowance.
             if (!prepared.stepLimitReached) needsContinuation = true
             const assistantMessageID = yield* publisher.assistantMessageID(event.id)
-            ownedToolFibers.push(
-              yield* Effect.uninterruptibleMask((restore) =>
+            toolRuns.push({
+              call: event,
+              fiber: yield* Effect.uninterruptibleMask((restore) =>
                 restore(
                   prepared.executeTool({
                     sessionID: session.id,
@@ -290,8 +292,8 @@ const layer = Layer.effect(
                 ).pipe(
                   Effect.flatMap((execution) => serialized(publisher.toolExecution(event.id, event.name, execution))),
                 ),
-              ).pipe(FiberSet.run(toolFibers)),
-            )
+              ).pipe(Effect.forkScoped),
+            })
           }),
         ),
         Effect.ensuring(serialized(publisher.flush())),
@@ -339,13 +341,13 @@ const layer = Layer.effect(
           // Provider error events only arrive from the stream, so the flag is final here.
           const providerFailed = publisher.hasProviderError()
 
-          // Settle every owned tool fiber. FiberSet.join returns on the first failure, so retain
-          // the individual fibers and await all exits before publishing the terminal step event.
-          if (streamInterrupted) yield* FiberSet.clear(toolFibers)
+          // Settle every owned tool run: await all exits, not just the first failure,
+          // before publishing the terminal step event.
+          if (streamInterrupted) yield* interruptTools
           const settled = yield* restore(
-            Effect.forEach(ownedToolFibers, Fiber.await, { concurrency: "unbounded" }),
+            Effect.forEach(toolRuns, (run) => Fiber.await(run.fiber), { concurrency: "unbounded" }),
           ).pipe(Effect.exit)
-          if (settled._tag === "Failure") yield* FiberSet.clear(toolFibers)
+          if (settled._tag === "Failure") yield* interruptTools
           const tools = classifyToolExits(settled)
 
           if (tools.declined || streamInterrupted || tools.interrupted) {


### PR DESCRIPTION
> [!NOTE]
> Stacked on #38717 — review only the top commit until that merges; GitHub will retarget the base to `v2` automatically.

## What

`callModel` tracked every local tool-call fiber **twice**: a `FiberSet` (for interrupt-all plus scope-close safety) and a parallel `ownedToolFibers` array (for await-all-exits, since `FiberSet.join` returns on the first failure). Neither structure knew which call a fiber was running. This PR replaces both with one structure that does:

```ts
const toolRuns: Array<{ readonly call: ToolCall; readonly fiber: Fiber<void, ToolOutputStore.Error> }> = []
const interruptTools = Effect.suspend(() => Fiber.interruptAll(toolRuns.map((run) => run.fiber)))
```

## How

- Fork: `Effect.forkScoped` replaces `FiberSet.run`. Both fork detached from the stream fiber's lifetime and are interrupted when the ambient Scope closes — `FiberSet.run` is a detached `runForkWith(parent.context)` with set tracking, `forkScoped` attaches directly to the same Scope that `FiberSet.make` previously consumed, so the R channel and the leak-safety net are unchanged.
- Interrupt-all: `Fiber.interruptAll` replaces `FiberSet.clear`. Interrupting an already-completed fiber is a no-op, matching the set's auto-removal of finished fibers. One cosmetic difference: `FiberSet.clear` attributes the interrupt to an internal fiber id, `Fiber.interruptAll` to the caller — nothing reads that attribution.
- Await-all-exits: unchanged shape, iterating `toolRuns` instead of the bare fiber array; `classifyToolExits` keeps its exact input.
- The `call` on each run is the tool-call event that fiber executes. Settlement exits now pair with their originating calls by index, which is the per-call attribution needed for durable decline settlement (follow-up).

The `FiberSet` import stays: `forkTitle` (title generation) still uses `FiberSet.makeRuntime` legitimately — one fire-and-forget fiber, no exit inspection.

## Scope

Single file, `packages/core/src/session/runner/llm.ts`. No behavior change intended: fork detachment, interrupt safety, settlement ordering, and error classification are all preserved. Durable decline settlement consuming `toolRuns[i].call` is a separate follow-up.

## Testing

From `packages/core`:

- `bun typecheck` — clean
- `bun run test test/session-runner.test.ts test/session-runner-recorded.test.ts test/session-runner-tool-events.test.ts test/session-prompt.test.ts test/session-create.test.ts test/tool-subagent.test.ts` — 220/220
- `bun run test test/session-runner.test.ts test/session-runner-recorded.test.ts --rerun-each 3` — 417/417; the recorded suites pin exact durable event order, confirming `forkScoped`'s start timing matches `FiberSet.run`