### PR TITLE
fix(core): start all suspended sessions promptly

### DIFF
--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -24,7 +24,6 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/v2
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const scope = yield* Effect.scope
     const store = yield* SessionStore.Service
     const execution = yield* SessionExecution.Service
     return Service.of({
@@ -39,9 +38,9 @@ export const layer = Layer.effect(
             Effect.gen(function* () {
               if (!(yield* store.consumeSuspended(sessionID))) return
               // Drain failures are already logged and durably recorded by the execution layer.
-              yield* execution.resume(sessionID).pipe(Effect.ignore, Effect.forkIn(scope, { startImmediately: true }))
+              yield* Effect.ignore(execution.resume(sessionID))
             }),
-          { discard: true },
+          { concurrency: "unbounded", discard: true },
         )
       }),
     })

--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -41,8 +41,7 @@ export const layer = Layer.effect(
               // Drain failures are already logged and durably recorded by the execution layer.
               yield* execution.resume(sessionID).pipe(Effect.ignore, Effect.forkIn(scope, { startImmediately: true }))
             }),
-          // Bound recovery setup without waiting for long-running drains to finish.
-          { concurrency: 4, discard: true },
+          { discard: true },
         )
       }),
     })

--- a/packages/core/src/session/execution/restart.ts
+++ b/packages/core/src/session/execution/restart.ts
@@ -24,6 +24,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/v2
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
+    const scope = yield* Effect.scope
     const store = yield* SessionStore.Service
     const execution = yield* SessionExecution.Service
     return Service.of({
@@ -38,9 +39,9 @@ export const layer = Layer.effect(
             Effect.gen(function* () {
               if (!(yield* store.consumeSuspended(sessionID))) return
               // Drain failures are already logged and durably recorded by the execution layer.
-              yield* Effect.ignore(execution.resume(sessionID))
+              yield* execution.resume(sessionID).pipe(Effect.ignore, Effect.forkIn(scope, { startImmediately: true }))
             }),
-          // Each suspension is consumed atomically right before its drain; at most four drains run at once.
+          // Bound recovery setup without waiting for long-running drains to finish.
           { concurrency: 4, discard: true },
         )
       }),

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -105,6 +105,32 @@ describe("SessionExecution lifecycle", () => {
     }),
   )
 
+  it.effect("starts every suspended execution without waiting for earlier drains to finish", () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const sessionIDs = Array.from({ length: 5 }, (_, index) =>
+        SessionV2.ID.make(`ses_resume_concurrent_${index}`),
+      )
+      yield* seedSessions(database, sessionIDs, { time_suspended: Date.now() })
+
+      const fourStarted = yield* Deferred.make<void>()
+      const started: SessionV2.ID[] = []
+      const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
+      const context = yield* buildExecution(scope, ({ sessionID }) =>
+        Effect.sync(() => {
+          started.push(sessionID)
+          if (started.length === 4) Deferred.doneUnsafe(fourStarted, Effect.void)
+        }).pipe(Effect.andThen(Effect.never)),
+      )
+      const restart = Context.get(context, SessionRestart.Service)
+      yield* restart.resumeSuspendedSessions.pipe(Effect.forkIn(scope))
+      yield* Deferred.await(fourStarted)
+
+      expect(started.toSorted()).toEqual(sessionIDs.toSorted())
+    }),
+  )
+
   it.effect("resumes each suspended Session at most once", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service

--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -108,9 +108,7 @@ describe("SessionExecution lifecycle", () => {
   it.effect("starts every suspended execution without waiting for earlier drains to finish", () =>
     Effect.gen(function* () {
       const database = yield* Database.Service
-      const sessionIDs = Array.from({ length: 5 }, (_, index) =>
-        SessionV2.ID.make(`ses_resume_concurrent_${index}`),
-      )
+      const sessionIDs = Array.from({ length: 5 }, (_, index) => SessionV2.ID.make(`ses_resume_concurrent_${index}`))
       yield* seedSessions(database, sessionIDs, { time_suspended: Date.now() })
 
       const fourStarted = yield* Deferred.make<void>()
@@ -123,11 +121,12 @@ describe("SessionExecution lifecycle", () => {
           if (started.length === 4) Deferred.doneUnsafe(fourStarted, Effect.void)
         }).pipe(Effect.andThen(Effect.never)),
       )
+      const execution = Context.get(context, SessionExecution.Service)
       const restart = Context.get(context, SessionRestart.Service)
       yield* restart.resumeSuspendedSessions.pipe(Effect.forkIn(scope))
       yield* Deferred.await(fourStarted)
 
-      expect(started.toSorted()).toEqual(sessionIDs.toSorted())
+      expect([...(yield* execution.active)].toSorted()).toEqual(sessionIDs.toSorted())
     }),
   )
 
@@ -141,9 +140,11 @@ describe("SessionExecution lifecycle", () => {
       const drained: string[] = []
       const scope = yield* Scope.make()
       const context = yield* buildExecution(scope, ({ sessionID }) => Effect.sync(() => void drained.push(sessionID)))
+      const execution = Context.get(context, SessionExecution.Service)
       const restart = Context.get(context, SessionRestart.Service)
 
       yield* restart.resumeSuspendedSessions
+      yield* Effect.forEach([first, second], execution.awaitIdle, { discard: true })
       expect(drained.toSorted()).toEqual([first, second])
       expect(yield* suspensions(database)).toEqual({ [first]: false, [second]: false })
 


### PR DESCRIPTION
## What

Resume every session suspended by a managed-server restart promptly, even when four or more recovered sessions continue running for a long time.

## Before / After

**Before:** `resumeSuspendedSessions` applied a concurrency limit of four around `execution.resume`. Because `resume` joins the complete session drain, four long-running recovered sessions occupied every worker. A fifth suspended session remained queued and appeared not to resume after the service update.

**After:** recovery consumes suspension markers and resumes all suspended sessions with unbounded concurrency. The already-scoped recovery fiber remains joined to them, while the process-local execution coordinator independently owns every drain.

## How

- `packages/core/src/session/execution/restart.ts` changes recovery fanout from four workers to unbounded concurrency, restoring all previously active drains without extra nested forks.
- `packages/core/test/session-execution.test.ts` reproduces the failure with five non-terminating drains and verifies that the coordinator owns all five.

## Scope

This preserves the existing durable suspension claim and process-local session coordinator. It does not add clustered execution ownership or retry provider work that was not durably suspended.

## Testing

- `bun run test test/session-execution.test.ts` from `packages/core`
- Five repeated runs of the session execution regression test
- `bun run test` from `packages/core`: full suite passed
- `bun typecheck` from `packages/core`
- Repository-wide pre-push typecheck hook: 33 packages passed

## Flow

```mermaid
sequenceDiagram
    participant Restart as SessionRestart
    participant Store as SessionStore
    participant Execution as SessionExecution
    participant Coordinator as SessionRunCoordinator

    Restart->>Store: listSuspended()
    par Every suspended session
        Restart->>Store: consumeSuspended(sessionID)
        Restart->>Execution: resume(sessionID)
        Execution->>Coordinator: run(sessionID)
        Coordinator-->>Execution: own drain independently
    end
```
