### PR TITLE
refactor(core): name the unsettled-tool sweep scope and untangle hosted settlement

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -364,32 +364,17 @@ const layer = Layer.effect(
           // these sweeps only close calls that could not produce a truthful settlement.
           if (providerFailed)
             yield* serialized(publisher.failUnsettledTools({ type: "aborted", message: "Tool execution interrupted" }))
-          if (llmFailure && !providerFailed)
-            yield* serialized(
-              publisher.failUnsettledTools(
-                {
-                  type: "tool.result-missing",
-                  message: "Provider did not return a tool result",
-                },
-                true,
-              ),
-            )
-          const hostedResultMissing =
-            stream._tag === "Success" && !providerFailed
-              ? yield* serialized(
-                  publisher.failUnsettledTools(
-                    { type: "tool.result-missing", message: "Provider did not return a tool result" },
-                    true,
-                  ),
-                )
-              : false
-          if (hostedResultMissing && !publisher.stepSettlement())
-            yield* serialized(
-              publisher.failAssistant({
-                type: "tool.result-missing",
-                message: "Provider did not return a tool result",
-              }),
-            )
+          const resultMissing = {
+            type: "tool.result-missing",
+            message: "Provider did not return a tool result",
+          } as const
+          if (llmFailure && !providerFailed) yield* serialized(publisher.failUnsettledTools(resultMissing, "hosted"))
+          // A clean stream that still left hosted calls unresolved fails the step itself.
+          if (stream._tag === "Success" && !providerFailed) {
+            const hostedResultMissing = yield* serialized(publisher.failUnsettledTools(resultMissing, "hosted"))
+            if (hostedResultMissing && !publisher.stepSettlement())
+              yield* serialized(publisher.failAssistant(resultMissing))
+          }
 
           const stepFailure = publisher.stepFailure()
           const stepSettlement = publisher.stepSettlement()

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -277,9 +277,9 @@ export const createLLMEventPublisher = (events: Pick<EventV2.Interface, "publish
 
   const failUnsettledTools = Effect.fn("SessionRunner.failUnsettledTools")(function* (
     error: SessionError.Error,
-    hostedOnly = false,
+    scope: "hosted" | "all" = "all",
   ) {
-    return yield* failTools(error, hostedOnly ? "hosted" : "all")
+    return yield* failTools(error, scope)
   })
 
   const assistantMessageIDForTool = (callID: string) => {


### PR DESCRIPTION
> [!NOTE]
> Stacked on #38719 — review only the top commit until that merges; GitHub retargets the base automatically.

## What

Cleans up the hosted-result settlement tail in `callModel` and the sweep API it calls. Three small things, no behavior change:

1. **A durable publish was hiding inside a ternary arm.** `const hostedResultMissing = cond ? yield* serialized(publisher.failUnsettledTools(...)) : false` ran a durable event publish in value position with a dangling `: false`. It's now an if-block with the dependent `failAssistant` nested inside — semantically identical (the follow-up guard could only ever fire when the success arm had run) and legible as control flow.
2. **The `tool.result-missing` error literal appeared three times.** Hoisted to one `resultMissing` const.
3. **`failUnsettledTools(error, hostedOnly = false)` was a boolean flag wrapping a domain noun.** The inner `failTools` already speaks `"hosted" | "all"`; the wrapper now exposes that scope directly. Call sites go from `failUnsettledTools(error, true)` to `failUnsettledTools(error, "hosted")` — self-documenting at the point of use.

## Scope

`packages/core/src/session/runner/llm.ts` (settlement tail) and `publish-llm-event.ts` (one signature). No durable event shape or ordering changes.

## Testing

From `packages/core`:

- `bun typecheck` — clean
- Focused suites (`session-runner`, `session-runner-recorded`, `session-runner-tool-events`, `session-prompt`, `session-create`, `tool-subagent`) — 220/220
- `bun run test test/session-runner.test.ts test/session-runner-recorded.test.ts --rerun-each 3` — 417/417