### PR TITLE
fix(tui): flag likely cache busts accurately

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -81,7 +81,14 @@ import { PluginSlot } from "../../plugin/context"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { useLocation } from "../../context/location"
-import { createSessionRows, messageBoundaryIDs, resolvePart, type PartRef, type SessionRow } from "./rows"
+import {
+  cacheReuseDrop,
+  createSessionRows,
+  messageBoundaryIDs,
+  resolvePart,
+  type PartRef,
+  type SessionRow,
+} from "./rows"
 import { switchLabel } from "../../util/model"
 import { findMessageBoundary, messageNavigationSlack } from "./message-navigation"
 import { stringWidth } from "../../util/string-width"
@@ -1109,10 +1116,7 @@ function TurnTokenUsage(props: {
         message.tokens.cache.write
       if (total === 0) return []
       const newTokens = total - message.tokens.cache.read
-      const cacheBust =
-        previousCacheRead !== undefined && message.tokens.cache.read < previousCacheRead
-          ? previousCacheRead - message.tokens.cache.read
-          : undefined
+      const reuseDrop = cacheReuseDrop(previousCacheRead, message.tokens.cache.read, message.model.providerID)
       previousCacheRead = message.tokens.cache.read
       return [
         {
@@ -1120,7 +1124,7 @@ function TurnTokenUsage(props: {
           newTokens,
           cached: message.tokens.cache.read,
           total,
-          cacheBust,
+          reuseDrop,
         },
       ]
     })
@@ -1165,9 +1169,9 @@ function TurnTokenUsage(props: {
                 {"  "}
                 {item.total.toLocaleString().padStart(columns().total)}
               </text>
-              <Show when={item.cacheBust !== undefined}>
-                <text fg={themeV2.text.feedback.error.default}>
-                  ! Cache bust: {item.cacheBust?.toLocaleString()} fewer cached tokens than the previous step
+              <Show when={item.reuseDrop !== undefined}>
+                <text fg={themeV2.text.subdued}>
+                  Cache reuse dropped by {item.reuseDrop?.toLocaleString()} tokens from the previous step
                 </text>
               </Show>
             </box>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1172,8 +1172,8 @@ function TurnTokenUsage(props: {
                 {item.total.toLocaleString().padStart(columns().total)}
               </text>
               <Show when={item.reuseDrop !== undefined}>
-                <text fg={themeV2.text.subdued}>
-                  Cache reuse dropped by {item.reuseDrop?.toLocaleString()} tokens from the previous step
+                <text fg={themeV2.text.feedback.warning.default}>
+                  ! Likely cache bust: {item.reuseDrop?.toLocaleString()} fewer cached tokens than the previous step
                 </text>
               </Show>
             </box>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -86,6 +86,7 @@ import {
   createSessionRows,
   messageBoundaryIDs,
   resolvePart,
+  type CacheUsage,
   type PartRef,
   type SessionRow,
 } from "./rows"
@@ -1086,7 +1087,7 @@ function SessionRowView(props: SessionRowViewProps) {
           {(row) => (
             <TurnTokenUsage
               messageIDs={row().messageIDs}
-              previousCacheRead={row().previousCacheRead}
+              previousCache={row().previousCache}
               message={props.message}
             />
           )}
@@ -1098,13 +1099,13 @@ function SessionRowView(props: SessionRowViewProps) {
 
 function TurnTokenUsage(props: {
   messageIDs: string[]
-  previousCacheRead?: number
+  previousCache?: CacheUsage
   message: (messageID: string) => SessionMessageInfo | undefined
 }) {
   const config = useConfig()
   const { themeV2 } = useTheme()
   const steps = createMemo(() => {
-    let previousCacheRead = props.previousCacheRead
+    let previousCache = props.previousCache
     return props.messageIDs.flatMap((messageID) => {
       const message = props.message(messageID)
       if (message?.type !== "assistant" || !message.tokens) return []
@@ -1116,8 +1117,9 @@ function TurnTokenUsage(props: {
         message.tokens.cache.write
       if (total === 0) return []
       const newTokens = total - message.tokens.cache.read
-      const reuseDrop = cacheReuseDrop(previousCacheRead, message.tokens.cache.read, message.model.providerID)
-      previousCacheRead = message.tokens.cache.read
+      const currentCache = { read: message.tokens.cache.read, model: message.model }
+      const reuseDrop = cacheReuseDrop(previousCache, currentCache)
+      previousCache = currentCache
       return [
         {
           finish: message.finish === "tool-calls" ? "tool-call" : (message.finish ?? "unknown"),

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -294,6 +294,8 @@ export function reduceSessionRows(
   ].reduce<SessionRow[]>((rows, message) => {
     if (message.type !== "assistant") {
       if (message.type === "synthetic" && !message.description?.trim()) return rows
+      if (message.type === "compaction" && message.status === "completed" && usage)
+        usage.previousTurnCache = undefined
       if (!pending.has(message.id)) completePrevious(rows)
       rows.push({ type: "message", messageID: message.id })
       return rows

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -324,6 +324,14 @@ export function reduceSessionRows(
   }, [])
 }
 
+export function cacheReuseDrop(previous: number | undefined, current: number, providerID: string) {
+  if (previous === undefined) return
+  const drop = previous - current
+  // OpenAI cache reads can move by one or two 1,024-token buckets without a material loss of reuse.
+  if (providerID === "openai" && drop <= 2_048) return
+  return drop > 0 ? drop : undefined
+}
+
 function hasTokenUsage(
   message: SessionMessageAssistant,
 ): message is SessionMessageAssistant & { tokens: NonNullable<SessionMessageAssistant["tokens"]> } {

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -10,6 +10,11 @@ export type PartRef = {
   partID: string
 }
 
+export type CacheUsage = {
+  read: number
+  model: SessionMessageAssistant["model"]
+}
+
 export type SessionRow =
   | { type: "message"; messageID: string }
   | { type: "compaction-queued"; inputID: string }
@@ -28,7 +33,7 @@ export type SessionRow =
       completed: boolean
     }
   | { type: "assistant-footer"; messageID: string }
-  | { type: "turn-usage"; messageIDs: string[]; previousCacheRead?: number }
+  | { type: "turn-usage"; messageIDs: string[]; previousCache?: CacheUsage }
 
 export function createSessionRows(sessionID: Accessor<string>) {
   const data = useData()
@@ -280,7 +285,7 @@ export function reduceSessionRows(
   const pendingCompactions = messages.filter((message) => message.type === "compaction" && message.status === "running")
   const pending = new Set([...pendingCompactions.map((message) => message.id), ...inputs])
   const usage = turnTokens
-    ? { steps: [] as SessionMessageAssistant[], previousTurnCacheRead: undefined as number | undefined }
+    ? { steps: [] as SessionMessageAssistant[], previousTurnCache: undefined as CacheUsage | undefined }
     : undefined
   return [
     ...messages.filter((message) => !pending.has(message.id)),
@@ -312,11 +317,9 @@ export function reduceSessionRows(
         rows.push({
           type: "turn-usage",
           messageIDs: stepsWithUsage.map((step) => step.id),
-          ...(usage.previousTurnCacheRead === undefined
-            ? {}
-            : { previousCacheRead: usage.previousTurnCacheRead }),
+          ...(usage.previousTurnCache === undefined ? {} : { previousCache: usage.previousTurnCache }),
         })
-        usage.previousTurnCacheRead = last.tokens.cache.read
+        usage.previousTurnCache = { read: last.tokens.cache.read, model: last.model }
       }
       usage.steps.length = 0
     }
@@ -324,11 +327,17 @@ export function reduceSessionRows(
   }, [])
 }
 
-export function cacheReuseDrop(previous: number | undefined, current: number, providerID: string) {
+export function cacheReuseDrop(previous: CacheUsage | undefined, current: CacheUsage) {
   if (previous === undefined) return
-  const drop = previous - current
-  // OpenAI cache reads can move by one or two 1,024-token buckets without a material loss of reuse.
-  if (providerID === "openai" && drop <= 2_048) return
+  if (
+    previous.model.providerID !== current.model.providerID ||
+    previous.model.id !== current.model.id ||
+    previous.model.variant !== current.model.variant
+  )
+    return
+  const drop = previous.read - current.read
+  // OpenAI cache reads can move between one and two 1,024-token buckets without a material loss of reuse.
+  if (current.model.providerID === "openai" && drop >= 1_024 && drop <= 2_048) return
   return drop > 0 ? drop : undefined
 }
 

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -3,12 +3,57 @@ import type { SessionMessageAssistant, SessionMessageInfo } from "@opencode-ai/c
 import { cacheReuseDrop, messageBoundaryIDs, reduceSessionRows } from "../../../src/routes/session/rows"
 
 test("filters OpenAI cache quantization from cache reuse drops", () => {
-  expect(cacheReuseDrop(undefined, 10_000, "openai")).toBeUndefined()
-  expect(cacheReuseDrop(10_000, 11_000, "openai")).toBeUndefined()
-  expect(cacheReuseDrop(10_000, 8_976, "openai")).toBeUndefined()
-  expect(cacheReuseDrop(10_000, 7_952, "openai")).toBeUndefined()
-  expect(cacheReuseDrop(10_000, 7_951, "openai")).toBe(2_049)
-  expect(cacheReuseDrop(10_000, 8_976, "anthropic")).toBe(1_024)
+  const openai = { id: "gpt", providerID: "openai" }
+  expect(cacheReuseDrop(undefined, { read: 10_000, model: openai })).toBeUndefined()
+  expect(cacheReuseDrop({ read: 10_000, model: openai }, { read: 11_000, model: openai })).toBeUndefined()
+  expect(cacheReuseDrop({ read: 10_000, model: openai }, { read: 8_977, model: openai })).toBe(1_023)
+  expect(cacheReuseDrop({ read: 10_000, model: openai }, { read: 8_976, model: openai })).toBeUndefined()
+  expect(cacheReuseDrop({ read: 10_000, model: openai }, { read: 8_500, model: openai })).toBeUndefined()
+  expect(cacheReuseDrop({ read: 10_000, model: openai }, { read: 7_952, model: openai })).toBeUndefined()
+  expect(cacheReuseDrop({ read: 10_000, model: openai }, { read: 7_951, model: openai })).toBe(2_049)
+})
+
+test("compares cache reuse only for the same model", () => {
+  const previous = { read: 10_000, model: { id: "claude", providerID: "anthropic" } }
+  expect(cacheReuseDrop(previous, { read: 8_976, model: { id: "gpt", providerID: "openai" } })).toBeUndefined()
+  expect(cacheReuseDrop(previous, { read: 8_976, model: { id: "claude", providerID: "anthropic" } })).toBe(1_024)
+  expect(
+    cacheReuseDrop(
+      { read: 10_000, model: { id: "gpt", providerID: "openai", variant: "low" } },
+      { read: 8_976, model: { id: "gpt", providerID: "openai", variant: "high" } },
+    ),
+  ).toBeUndefined()
+})
+
+test("carries model identity with the cross-turn cache baseline", () => {
+  const first = assistant("assistant-1", [])
+  first.model = { id: "claude", providerID: "anthropic" }
+  first.finish = "stop"
+  first.tokens = { input: 1, output: 0, reasoning: 0, cache: { read: 10_000, write: 0 } }
+  const second = assistant("assistant-2", [])
+  second.model = { id: "gpt", providerID: "openai" }
+  second.finish = "stop"
+  second.tokens = { input: 1, output: 0, reasoning: 0, cache: { read: 8_976, write: 0 } }
+
+  const rows = reduceSessionRows(
+    [
+      { type: "user", id: "user-1", text: "First", time: { created: 0 } },
+      first,
+      { type: "user", id: "user-2", text: "Second", time: { created: 2 } },
+      second,
+    ],
+    new Set(),
+    true,
+  ).filter((row) => row.type === "turn-usage")
+
+  expect(rows).toEqual([
+    { type: "turn-usage", messageIDs: ["assistant-1"] },
+    {
+      type: "turn-usage",
+      messageIDs: ["assistant-2"],
+      previousCache: { read: 10_000, model: { id: "claude", providerID: "anthropic" } },
+    },
+  ])
 })
 
 test("assigns assistant boundaries to the first rendered row instead of the first text row", () => {

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -56,6 +56,38 @@ test("carries model identity with the cross-turn cache baseline", () => {
   ])
 })
 
+test("resets the cross-turn cache baseline after compaction", () => {
+  const first = assistant("assistant-1", [])
+  first.finish = "stop"
+  first.tokens = { input: 1, output: 0, reasoning: 0, cache: { read: 370_176, write: 0 } }
+  const second = assistant("assistant-2", [])
+  second.finish = "stop"
+  second.tokens = { input: 1, output: 0, reasoning: 0, cache: { read: 13_824, write: 0 } }
+
+  const rows = reduceSessionRows(
+    [
+      first,
+      {
+        type: "compaction",
+        id: "compaction-1",
+        status: "completed",
+        reason: "auto",
+        summary: "Compacted context",
+        recent: "",
+        time: { created: 2 },
+      },
+      second,
+    ],
+    new Set(),
+    true,
+  ).filter((row) => row.type === "turn-usage")
+
+  expect(rows).toEqual([
+    { type: "turn-usage", messageIDs: ["assistant-1"] },
+    { type: "turn-usage", messageIDs: ["assistant-2"] },
+  ])
+})
+
 test("assigns assistant boundaries to the first rendered row instead of the first text row", () => {
   const messages: SessionMessageInfo[] = [
     { type: "user", id: "user-1", text: "Question", time: { created: 0 } },

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -1,6 +1,15 @@
 import { expect, test } from "bun:test"
 import type { SessionMessageAssistant, SessionMessageInfo } from "@opencode-ai/client"
-import { messageBoundaryIDs, reduceSessionRows } from "../../../src/routes/session/rows"
+import { cacheReuseDrop, messageBoundaryIDs, reduceSessionRows } from "../../../src/routes/session/rows"
+
+test("filters OpenAI cache quantization from cache reuse drops", () => {
+  expect(cacheReuseDrop(undefined, 10_000, "openai")).toBeUndefined()
+  expect(cacheReuseDrop(10_000, 11_000, "openai")).toBeUndefined()
+  expect(cacheReuseDrop(10_000, 8_976, "openai")).toBeUndefined()
+  expect(cacheReuseDrop(10_000, 7_952, "openai")).toBeUndefined()
+  expect(cacheReuseDrop(10_000, 7_951, "openai")).toBe(2_049)
+  expect(cacheReuseDrop(10_000, 8_976, "anthropic")).toBe(1_024)
+})
 
 test("assigns assistant boundaries to the first rendered row instead of the first text row", () => {
   const messages: SessionMessageInfo[] = [


### PR DESCRIPTION
## What

Make the debug turn-token view warn about likely prompt-cache busts without flagging known cache resets or OpenAI accounting noise.

The TUI now:

- renders unexplained comparable drops as `! Likely cache bust`
- uses warning styling rather than neutral or error styling
- suppresses OpenAI movements between 1,024 and 2,048 tokens, which can reflect cache accounting quantization
- compares cache usage only when provider, model, and variant match
- starts a fresh comparison baseline after completed compaction

## Before / After

**Before**

Every lower cached-token count was labeled a definitive `Cache bust`, including normal OpenAI quantization, comparisons across model switches, and expected cache resets after compaction. An intermediate revision suppressed those false positives but made every remaining drop a subdued neutral observation.

```text
Cache reuse dropped by 62,464 tokens from the previous step
```

**After**

Known OpenAI bucket movements remain silent. Model switches and completed compactions establish a new baseline. A larger decrease between matching, uncompacted model steps is highlighted without claiming certainty about its cause.

```text
! Likely cache bust: 62,464 fewer cached tokens than the previous step
```

## How

- `packages/tui/src/routes/session/rows.ts` carries model identity with cross-turn cache baselines, clears the baseline at completed compaction boundaries, and centralizes reuse-drop classification.
- `packages/tui/src/routes/session/index.tsx` compares each step against the preceding comparable cache sample and renders unexplained drops with warning wording and color.
- `packages/tui/test/cli/tui/session-rows.test.ts` covers OpenAI threshold boundaries, non-OpenAI drops, model/variant switches, cross-turn baseline projection, and completed compaction resets.

## Scope

This changes debug-only reporting. It does not claim a proven cause, alter model requests, change cache policy, modify compaction, or change token accounting.

## Testing

- `bun run test test/cli/tui/session-rows.test.ts`: 15 passed, 0 failed
- `bun run test` in `packages/tui`: 519 passed, 5 skipped, 0 failed
- `bun typecheck` in `packages/tui`: passed
- pre-push `bun turbo typecheck --concurrency=3`: 33 tasks passed
- inspected real GPT-5.6 Sol session accounting: benign 1,024/2,048-token bucket movements are suppressed, while materially larger collapses remain reportable
