### PR TITLE
fix(core): support PDF files in V2 read tool

### DIFF
--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -209,7 +209,31 @@ export const read = Effect.fn("ReadTool.read")(function* (
           mime,
         }
       }
-      if (startsWith(first, [0x25, 0x50, 0x44, 0x46]) || extensions.has(path.extname(resource).toLowerCase()))
+      if (startsWith(first, [0x25, 0x50, 0x44, 0x46])) {
+        if (info.size > MAX_MEDIA_INGEST_BYTES)
+          return yield* Effect.fail(new MediaIngestLimitError({ resource, maximumBytes: MAX_MEDIA_INGEST_BYTES }))
+        const chunks = [first]
+        let total = first.length
+        while (total <= MAX_MEDIA_INGEST_BYTES) {
+          const chunk = yield* file.readAlloc(Math.min(64 * 1024, MAX_MEDIA_INGEST_BYTES + 1 - total))
+          if (Option.isNone(chunk)) break
+          chunks.push(chunk.value)
+          total += chunk.value.length
+        }
+        if (total > MAX_MEDIA_INGEST_BYTES)
+          return yield* Effect.fail(new MediaIngestLimitError({ resource, maximumBytes: MAX_MEDIA_INGEST_BYTES }))
+        return {
+          uri: pathToFileURL(real).href,
+          name: path.basename(real),
+          content: Buffer.concat(
+            chunks.map((chunk) => Buffer.from(chunk)),
+            total,
+          ).toString("base64"),
+          encoding: "base64" as const,
+          mime: "application/pdf",
+        }
+      }
+      if (extensions.has(path.extname(resource).toLowerCase()))
         return yield* Effect.fail(new BinaryFileError({ resource }))
       const paged = info.size > MAX_READ_BYTES || page.offset !== undefined || page.limit !== undefined
       if (!paged) {

--- a/packages/core/src/tool/read.ts
+++ b/packages/core/src/tool/read.ts
@@ -39,16 +39,22 @@ const layer = Layer.effectDiscard(
       .register({
         [name]: Tool.make({
           description:
-            "Read a text file or supported image, page through a large UTF-8 text file by line offset, or list a directory page. Relative paths resolve from the current location; absolute paths inside it are accepted, while external absolute paths require external_directory approval.",
+            "Read a text file, supported image, or PDF; page through a large UTF-8 text file by line offset; or list a directory page. Relative paths resolve from the current location; absolute paths inside it are accepted, while external absolute paths require external_directory approval.",
           input: Input,
           output: Output,
           toModelOutput: ({ input, output }) => {
-            if (!("encoding" in output) || output.encoding !== "base64" || !SUPPORTED_IMAGE_MIMES.has(output.mime))
-              return []
-            return [
-              { type: "text", text: "Image read successfully" },
-              { type: "file", data: output.content, mime: output.mime, name: input.path },
-            ]
+            if (!("encoding" in output) || output.encoding !== "base64") return []
+            if (SUPPORTED_IMAGE_MIMES.has(output.mime))
+              return [
+                { type: "text", text: "Image read successfully" },
+                { type: "file", data: output.content, mime: output.mime, name: input.path },
+              ]
+            if (output.mime === "application/pdf")
+              return [
+                { type: "text", text: "PDF read successfully" },
+                { type: "file", data: output.content, mime: output.mime, name: input.path },
+              ]
+            return []
           },
           execute: (input, context) => {
             return Effect.gen(function* () {
@@ -88,7 +94,7 @@ const layer = Layer.effectDiscard(
                   .normalize(resource, { ...content, encoding: "base64" })
                   .pipe(Effect.catchTag("Image.ResizerUnavailableError", () => Effect.succeed(content)))
               }
-              if ("encoding" in content && content.encoding === "base64")
+              if ("encoding" in content && content.encoding === "base64" && content.mime !== "application/pdf")
                 return yield* Effect.fail(new ReadToolFileSystem.BinaryFileError({ resource }))
               return content
             }).pipe(


### PR DESCRIPTION
### Issue for this PR

Closes #37323

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The V2 read tool (ReadToolFileSystem) rejects PDF files at its magic-byte check: when the first 4 bytes are `%PDF`, it throws `BinaryFileError` (`"Cannot read binary file"`). This is a regression from V1, whose read tool returned PDFs as `data:application/pdf;base64,...` attachments that the provider API could consume.

**What changed:**

1. `packages/core/src/tool/read-filesystem.ts` — Added a dedicated PDF ingest path that mirrors the image path: detect `%PDF` magic bytes, enforce the existing `MAX_MEDIA_INGEST_BYTES` (20 MiB) cap, read all bytes, and return `FileSystem.Content` with `encoding: "base64"` and `mime: "application/pdf"`. The old `BinaryFileError` rejection for `%PDF` was replaced.

2. `packages/core/src/tool/read.ts` — Updated `toModelOutput` to emit PDF content (`"PDF read successfully"` + `ToolFileContent`) alongside the existing image path. Updated the base64 guard to allow `application/pdf` through (PDFs skip image normalization since they can't be resized). Updated the tool description to mention PDF support.

**Why it works:**

The rest of the pipeline already handled `application/pdf`:
- Settlement (`processor.ts`) passes non-image attachments through untouched
- Message conversion (`message-v2.ts`) already handles PDFs via `isMedia()` and `supportsMediaInToolResult()`
- Provider lowering (Responses API, Bedrock) already supports `application/pdf`
- Model capability gating (`unsupportedParts`) already gates PDFs for models without PDF capability

### How did you verified your code works?

- Added 2 new tests covering the real-filesystem PDF ingest path (small PDF returns base64 with correct mime, oversized PDF returns `MediaIngestLimitError`)
- All 26 existing read tool tests still pass (no regressions)
- Full project typecheck passes across all 30 packages (turborepo typecheck)

### Screenshots / recordings

N/A — core library change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR