### PR TITLE
fix(provider): enable opus 5 adaptive thinking

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -637,8 +637,9 @@ function openaiCompatibleReasoningEfforts(id: string) {
 
 function anthropicOpus47OrLater(apiId: string) {
   // Matches "opus-4.7" (Anthropic/Bedrock/Vertex) and "claude-4.7-opus" (SAP AI Core inverted).
+  // The minor is optional: Anthropic dropped it at opus 5, so bare "claude-opus-5" must match too.
   // Greedy \d+ correctly extends to multi-digit majors (e.g. "claude-10.0-opus") for forward compatibility.
-  const version = /opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)/i.exec(apiId)
+  const version = /opus-(\d+)(?:[.-](\d+))?(?:[.@-]|$)|claude-(\d+)(?:[.-](\d+))?-opus(?:[.@-]|$)/i.exec(apiId)
   if (!version) return false
   const major = Number(version[1] ?? version[3])
   const minor = Number(version[2] ?? version[4])

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -4654,6 +4654,12 @@ describe("ProviderTransform.variants", () => {
         expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
       },
       {
+        name: "opus 5",
+        apiIds: ["claude-opus-5", "claude-opus-5-20260724"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        expectedHigh: { thinking: { type: "adaptive", display: "summarized" }, effort: "high" },
+      },
+      {
         name: "fable 5",
         apiIds: ["claude-fable-5"],
         efforts: ["low", "medium", "high", "xhigh", "max"],
@@ -4772,6 +4778,28 @@ describe("ProviderTransform.variants", () => {
         effort: "high",
       })
     })
+
+    test("opus 5 uses adaptive reasoning for Vertex model IDs", () => {
+      const result = ProviderTransform.variants(
+        createMockModel({
+          id: "google-vertex-anthropic/claude-opus-5@default",
+          providerID: "google-vertex-anthropic",
+          api: {
+            id: "claude-opus-5@default",
+            url: "https://us-central1-aiplatform.googleapis.com",
+            npm: "@ai-sdk/google-vertex/anthropic",
+          },
+        }),
+      )
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        thinking: {
+          type: "adaptive",
+          display: "summarized",
+        },
+        effort: "high",
+      })
+    })
   })
 
   describe("@ai-sdk/amazon-bedrock", () => {
@@ -4852,6 +4880,28 @@ describe("ProviderTransform.variants", () => {
           providerID: "bedrock",
           api: {
             id: "anthropic.claude-sonnet-5",
+            url: "https://bedrock.amazonaws.com",
+            npm: "@ai-sdk/amazon-bedrock",
+          },
+        }),
+      )
+      expect(Object.keys(result)).toEqual(["low", "medium", "high", "xhigh", "max"])
+      expect(result.high).toEqual({
+        reasoningConfig: {
+          type: "adaptive",
+          maxReasoningEffort: "high",
+          display: "summarized",
+        },
+      })
+    })
+
+    test("anthropic opus 5 returns adaptive reasoning options with xhigh", () => {
+      const result = ProviderTransform.variants(
+        createMockModel({
+          id: "bedrock/anthropic-claude-opus-5",
+          providerID: "bedrock",
+          api: {
+            id: "us.anthropic.claude-opus-5-v1:0",
             url: "https://bedrock.amazonaws.com",
             npm: "@ai-sdk/amazon-bedrock",
           },
@@ -5052,6 +5102,12 @@ describe("ProviderTransform.variants", () => {
       {
         name: "sonnet 5",
         apiIds: ["anthropic--claude-sonnet-5", "anthropic--claude-5-sonnet"],
+        efforts: ["low", "medium", "high", "xhigh", "max"],
+        thinking: { type: "adaptive", display: "summarized" },
+      },
+      {
+        name: "opus 5",
+        apiIds: ["anthropic--claude-opus-5", "anthropic--claude-5-opus"],
         efforts: ["low", "medium", "high", "xhigh", "max"],
         thinking: { type: "adaptive", display: "summarized" },
       },


### PR DESCRIPTION
## Problem

`claude-opus-5` fails with:

```
"thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

`anthropicOpus47OrLater()` requires a minor version:

```ts
/opus-(\d+)[.-](\d+)(?:[.@-]|$)|claude-(\d+)[.-](\d+)-opus(?:[.@-]|$)/i
```

Anthropic dropped the minor at opus 5, so bare `claude-opus-5` does not match. `anthropicAdaptiveEfforts()` returns `null` and the model falls through to the legacy `thinking: { type: "enabled", budgetTokens }` branch, which the API rejects.

The sibling predicate `anthropicSonnet5OrLater()` already treats the minor as optional (`/sonnet-(\d+)(?:[.@-]|$)/`), which is why `claude-sonnet-5` works and `claude-opus-5` does not. #34673 fixed this same bug class for sonnet 5 by adding a second function rather than reconciling the grammar, so the opus branch kept the defect.

## Impact

Two distinct failure modes depending on how the model is registered.

Providers without `reasoning_options` (custom `.well-known/opencode` endpoints, OpenAI-compatible proxies) go through `variants()` and get a hard 400:

```
claude-opus-5   -> thinking.type = "enabled"    400
claude-opus-4-8 -> thinking.type = "adaptive"   ok
claude-sonnet-5 -> thinking.type = "adaptive"   ok
```

Providers with `reasoning_options` from models.dev (Zen, Anthropic direct) go through `reasoningEffort()`, where `anthropicEffort()` returns `undefined` and the `?? { effort }` fallback applies. No error, but adaptive thinking and summarized display are silently dropped:

```
before: {"effort":"high"}
after:  {"thinking":{"type":"adaptive","display":"summarized"},"effort":"high"}
```

Zen lists `claude-opus-5` and models.dev gives it `reasoning_options: [{ type: "effort", values: ["low","medium","high","xhigh","max"] }]`, so both paths are affected.

## Fix

Make the minor optional in the opus regex, matching the sonnet predicate.

`Number(undefined)` is `NaN` and `NaN >= 7` is `false`, so bare `claude-opus-4` still returns `false`. Verified across Anthropic, Bedrock (`us.anthropic.claude-opus-5-v1:0`), Vertex (`claude-opus-5@default`), SAP inverted (`anthropic--claude-5-opus`), Copilot, and Databricks ID shapes, with no regressions on 4.1 / 4.5 / 4.6.

## Tests

Added `opus 5` to the existing anthropic and SAP tables, plus standalone Vertex and Bedrock cases, mirroring the coverage #34673 added for sonnet 5. All 509 tests in `test/provider/` pass.
