### PR TITLE
fix(core): scope MCP execute guidance to Code Mode

### DIFF
--- a/packages/core/src/mcp/instructions.ts
+++ b/packages/core/src/mcp/instructions.ts
@@ -11,16 +11,18 @@ import { Instructions } from "../instructions/index"
 const Summary = Schema.Struct({
   server: Schema.String,
   instructions: Schema.String,
-  codemode: Schema.optionalKey(Schema.Boolean),
+  topLevel: Schema.optionalKey(Schema.Literal(true)),
 })
 type Summary = typeof Summary.Type
 
 const entries = (servers: ReadonlyArray<Summary>) =>
   servers.flatMap((server) => [
     `  <server name="${server.server}">`,
-    server.codemode !== false
-      ? `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.namespace(server.server))}]\`.`
-      : "    Use tools from this server directly as top-level tools.",
+    ...(server.topLevel
+      ? []
+      : [
+          `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.namespace(server.server))}]\`.`,
+        ]),
     ...server.instructions.split("\n").map((line) => `    ${line}`),
     "  </server>",
   ])
@@ -33,8 +35,7 @@ const update = (previous: ReadonlyArray<Summary>, current: ReadonlyArray<Summary
     previous,
     current,
     (server) => server.server,
-    (before, after) =>
-      before.instructions !== after.instructions || (before.codemode !== false) !== (after.codemode !== false),
+    (before, after) => before.instructions !== after.instructions || before.topLevel !== after.topLevel,
   )
   // Additions and removals render as small deltas; anything else restates the full list.
   if (diff.changed.length > 0 || (diff.added.length === 0 && diff.removed.length === 0))
@@ -83,12 +84,13 @@ export const layer = Layer.effect(
         const [instructions, tools] = yield* Effect.all([mcp.instructions(), mcp.tools()], {
           concurrency: "unbounded",
         })
+        const canExecute = PermissionV2.evaluate("execute", "*", agent.permissions).effect !== "deny"
         // Instructions are useful only when this agent can reach at least one server tool.
         const visible = instructions
           .flatMap((item) => {
             const owned = tools.filter((tool) => tool.server === item.server)
-            const codemode = owned[0]?.codemode !== false
-            if (codemode && PermissionV2.evaluate("execute", "*", agent.permissions).effect === "deny") return []
+            const topLevel = owned[0]?.codemode === false
+            if (!topLevel && !canExecute) return []
             if (
               !owned.some(
                 (tool) =>
@@ -100,7 +102,7 @@ export const layer = Layer.effect(
               {
                 server: item.server,
                 instructions: item.instructions,
-                ...(codemode ? {} : { codemode: false }),
+                ...(topLevel ? { topLevel: true as const } : {}),
               },
             ]
           })

--- a/packages/core/src/mcp/instructions.ts
+++ b/packages/core/src/mcp/instructions.ts
@@ -11,13 +11,16 @@ import { Instructions } from "../instructions/index"
 const Summary = Schema.Struct({
   server: Schema.String,
   instructions: Schema.String,
+  codemode: Schema.optionalKey(Schema.Boolean),
 })
 type Summary = typeof Summary.Type
 
 const entries = (servers: ReadonlyArray<Summary>) =>
   servers.flatMap((server) => [
     `  <server name="${server.server}">`,
-    `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.namespace(server.server))}]\`.`,
+    server.codemode !== false
+      ? `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.namespace(server.server))}]\`.`
+      : "    Use tools from this server directly as top-level tools.",
     ...server.instructions.split("\n").map((line) => `    ${line}`),
     "  </server>",
   ])
@@ -30,7 +33,8 @@ const update = (previous: ReadonlyArray<Summary>, current: ReadonlyArray<Summary
     previous,
     current,
     (server) => server.server,
-    (before, after) => before.instructions !== after.instructions,
+    (before, after) =>
+      before.instructions !== after.instructions || (before.codemode !== false) !== (after.codemode !== false),
   )
   // Additions and removals render as small deltas; anything else restates the full list.
   if (diff.changed.length > 0 || (diff.added.length === 0 && diff.removed.length === 0))
@@ -76,21 +80,30 @@ export const layer = Layer.effect(
               removed: () => "MCP server instructions are no longer available.",
             },
           })
-        if (PermissionV2.evaluate("execute", "*", agent.permissions).effect === "deny")
-          return source(Instructions.removed)
         const [instructions, tools] = yield* Effect.all([mcp.instructions(), mcp.tools()], {
           concurrency: "unbounded",
         })
         // Instructions are useful only when this agent can reach at least one server tool.
         const visible = instructions
-          .filter((item) => {
+          .flatMap((item) => {
             const owned = tools.filter((tool) => tool.server === item.server)
-            return owned.some(
-              (tool) =>
-                PermissionV2.evaluate(McpTool.name(tool.server, tool.name), "*", agent.permissions).effect !== "deny",
+            const codemode = owned[0]?.codemode !== false
+            if (codemode && PermissionV2.evaluate("execute", "*", agent.permissions).effect === "deny") return []
+            if (
+              !owned.some(
+                (tool) =>
+                  PermissionV2.evaluate(McpTool.name(tool.server, tool.name), "*", agent.permissions).effect !== "deny",
+              )
             )
+              return []
+            return [
+              {
+                server: item.server,
+                instructions: item.instructions,
+                ...(codemode ? {} : { codemode: false }),
+              },
+            ]
           })
-          .map((item) => ({ server: item.server, instructions: item.instructions }))
           .toSorted((a, b) => a.server.localeCompare(b.server))
         return source(visible.length === 0 ? Instructions.removed : visible)
       }),

--- a/packages/core/src/mcp/instructions.ts
+++ b/packages/core/src/mcp/instructions.ts
@@ -11,21 +11,20 @@ import { Instructions } from "../instructions/index"
 const Summary = Schema.Struct({
   server: Schema.String,
   instructions: Schema.String,
-  topLevel: Schema.optionalKey(Schema.Literal(true)),
+  codemode: Schema.optionalKey(Schema.Literal(false)),
 })
 type Summary = typeof Summary.Type
 
 const entries = (servers: ReadonlyArray<Summary>) =>
-  servers.flatMap((server) => [
-    `  <server name="${server.server}">`,
-    ...(server.topLevel
-      ? []
-      : [
-          `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.namespace(server.server))}]\`.`,
-        ]),
-    ...server.instructions.split("\n").map((line) => `    ${line}`),
-    "  </server>",
-  ])
+  servers.flatMap((server) => {
+    const result = [`  <server name="${server.server}">`]
+    if (server.codemode !== false)
+      result.push(
+        `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.namespace(server.server))}]\`.`,
+      )
+    result.push(...server.instructions.split("\n").map((line) => `    ${line}`), "  </server>")
+    return result
+  })
 
 const render = (servers: ReadonlyArray<Summary>) =>
   ["<mcp_instructions>", ...entries(servers), "</mcp_instructions>"].join("\n")
@@ -35,7 +34,7 @@ const update = (previous: ReadonlyArray<Summary>, current: ReadonlyArray<Summary
     previous,
     current,
     (server) => server.server,
-    (before, after) => before.instructions !== after.instructions || before.topLevel !== after.topLevel,
+    (before, after) => before.instructions !== after.instructions || before.codemode !== after.codemode,
   )
   // Additions and removals render as small deltas; anything else restates the full list.
   if (diff.changed.length > 0 || (diff.added.length === 0 && diff.removed.length === 0))
@@ -89,8 +88,8 @@ export const layer = Layer.effect(
         const visible = instructions
           .flatMap((item) => {
             const owned = tools.filter((tool) => tool.server === item.server)
-            const topLevel = owned[0]?.codemode === false
-            if (!topLevel && !canExecute) return []
+            const codemode = owned[0]?.codemode !== false
+            if (codemode && !canExecute) return []
             if (
               !owned.some(
                 (tool) =>
@@ -99,11 +98,9 @@ export const layer = Layer.effect(
             )
               return []
             return [
-              {
-                server: item.server,
-                instructions: item.instructions,
-                ...(topLevel ? { topLevel: true as const } : {}),
-              },
+              codemode
+                ? { server: item.server, instructions: item.instructions }
+                : { server: item.server, instructions: item.instructions, codemode: false as const },
             ]
           })
           .toSorted((a, b) => a.server.localeCompare(b.server))

--- a/packages/core/test/mcp-instructions.test.ts
+++ b/packages/core/test/mcp-instructions.test.ts
@@ -20,8 +20,6 @@ const instructions = (server: string, text: string) =>
   new MCP.ServerInstructions({ server: MCP.ServerName.make(server), instructions: text })
 
 const tool = (server: string, name = "search") => new MCP.Tool({ server: MCP.ServerName.make(server), name })
-const nativeTool = (server: string, name = "search") =>
-  new MCP.Tool({ server: MCP.ServerName.make(server), name, codemode: false })
 
 const layer = (catalog: () => MCP.ServerInstructions[], tools: () => MCP.Tool[]) =>
   AppNodeBuilder.build(McpInstructions.node, [
@@ -95,7 +93,7 @@ describe("McpInstructions", () => {
     ),
   )
 
-  it.effect("keeps top-level MCP instructions when execute is denied", () =>
+  it.effect("keeps MCP instructions when Code Mode is disabled and execute is denied", () =>
     Effect.gen(function* () {
       const service = yield* McpInstructions.Service
       const generation = yield* service
@@ -105,8 +103,8 @@ describe("McpInstructions", () => {
       expect(generation.text).toBe(
         [
           "<mcp_instructions>",
-          '  <server name="native">',
-          "    Native instructions",
+          '  <server name="alpha">',
+          "    Alpha instructions",
           "  </server>",
           "</mcp_instructions>",
         ].join("\n"),
@@ -114,20 +112,20 @@ describe("McpInstructions", () => {
     }).pipe(
       Effect.provide(
         layer(
-          () => [instructions("native", "Native instructions")],
-          () => [nativeTool("native")],
+          () => [instructions("alpha", "Alpha instructions")],
+          () => [new MCP.Tool({ server: MCP.ServerName.make("alpha"), name: "search", codemode: false })],
         ),
       ),
     ),
   )
 
-  it.effect("restates guidance when a server moves to top-level tools", () => {
+  it.effect("restates guidance when Code Mode is disabled for a server", () => {
     let tools = [tool("alpha")]
     return Effect.gen(function* () {
       const service = yield* McpInstructions.Service
       const initialized = yield* service.load(selection()).pipe(Effect.flatMap(readInitial))
 
-      tools = [nativeTool("alpha")]
+      tools = [new MCP.Tool({ server: MCP.ServerName.make("alpha"), name: "search", codemode: false })]
       const changed = yield* readUpdate(yield* service.load(selection()), initialized)
       expect(changed.text).toBe(
         [

--- a/packages/core/test/mcp-instructions.test.ts
+++ b/packages/core/test/mcp-instructions.test.ts
@@ -20,6 +20,8 @@ const instructions = (server: string, text: string) =>
   new MCP.ServerInstructions({ server: MCP.ServerName.make(server), instructions: text })
 
 const tool = (server: string, name = "search") => new MCP.Tool({ server: MCP.ServerName.make(server), name })
+const nativeTool = (server: string, name = "search") =>
+  new MCP.Tool({ server: MCP.ServerName.make(server), name, codemode: false })
 
 const layer = (catalog: () => MCP.ServerInstructions[], tools: () => MCP.Tool[]) =>
   AppNodeBuilder.build(McpInstructions.node, [
@@ -92,6 +94,62 @@ describe("McpInstructions", () => {
       ),
     ),
   )
+
+  it.effect("renders native guidance when Code Mode is disabled for the server", () =>
+    Effect.gen(function* () {
+      const service = yield* McpInstructions.Service
+      const generation = yield* service
+        .load(selection([{ action: "execute", resource: "*", effect: "deny" }]))
+        .pipe(Effect.flatMap(readInitial))
+
+      expect(generation.text).toBe(
+        [
+          "<mcp_instructions>",
+          '  <server name="native">',
+          "    Use tools from this server directly as top-level tools.",
+          "    Native instructions",
+          "  </server>",
+          "</mcp_instructions>",
+        ].join("\n"),
+      )
+    }).pipe(
+      Effect.provide(
+        layer(
+          () => [instructions("native", "Native instructions")],
+          () => [nativeTool("native")],
+        ),
+      ),
+    ),
+  )
+
+  it.effect("restates guidance when a server moves to top-level tools", () => {
+    let tools = [tool("alpha")]
+    return Effect.gen(function* () {
+      const service = yield* McpInstructions.Service
+      const initialized = yield* service.load(selection()).pipe(Effect.flatMap(readInitial))
+
+      tools = [nativeTool("alpha")]
+      const changed = yield* readUpdate(yield* service.load(selection()), initialized)
+      expect(changed.text).toBe(
+        [
+          "The available MCP server instructions have changed. This list supersedes the previous one.",
+          "<mcp_instructions>",
+          '  <server name="alpha">',
+          "    Use tools from this server directly as top-level tools.",
+          "    Alpha instructions",
+          "  </server>",
+          "</mcp_instructions>",
+        ].join("\n"),
+      )
+    }).pipe(
+      Effect.provide(
+        layer(
+          () => [instructions("alpha", "Alpha instructions")],
+          () => tools,
+        ),
+      ),
+    )
+  })
 
   it.effect("renders additions, changes, and removal", () => {
     let catalog = [instructions("alpha", "Alpha instructions")]

--- a/packages/core/test/mcp-instructions.test.ts
+++ b/packages/core/test/mcp-instructions.test.ts
@@ -95,7 +95,7 @@ describe("McpInstructions", () => {
     ),
   )
 
-  it.effect("renders native guidance when Code Mode is disabled for the server", () =>
+  it.effect("keeps top-level MCP instructions when execute is denied", () =>
     Effect.gen(function* () {
       const service = yield* McpInstructions.Service
       const generation = yield* service
@@ -106,7 +106,6 @@ describe("McpInstructions", () => {
         [
           "<mcp_instructions>",
           '  <server name="native">',
-          "    Use tools from this server directly as top-level tools.",
           "    Native instructions",
           "  </server>",
           "</mcp_instructions>",
@@ -135,7 +134,6 @@ describe("McpInstructions", () => {
           "The available MCP server instructions have changed. This list supersedes the previous one.",
           "<mcp_instructions>",
           '  <server name="alpha">',
-          "    Use tools from this server directly as top-level tools.",
           "    Alpha instructions",
           "  </server>",
           "</mcp_instructions>",


### PR DESCRIPTION
## Summary
- render `execute` and namespace routing only for Code Mode MCP servers
- render only the server-provided instructions when Code Mode is disabled
- keep those instructions visible when `execute` is denied
- preserve historical guidance hashes by storing only the non-default `codemode: false` case

## Testing
- focused MCP tests: 26 passed before final naming cleanup
- focused MCP instruction tests: 5 passed after cleanup
- Prettier and `git diff --check`
- background implementation plus independent subagent audit