### PR TITLE
fix(core): branch-keyed repository cache with gated reference readiness

### DIFF
--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -1,8 +1,9 @@
 export * as Reference from "./reference"
 
 import { makeLocationNode } from "./effect/app-node"
-import { Context, Effect, Layer, Scope, Types } from "effect"
+import { Context, Effect, Layer, Schedule, Scope, Types } from "effect"
 import { Reference } from "@opencode-ai/schema/reference"
+import { FSUtil } from "./fs-util"
 import { Global } from "./global"
 import { EventV2 } from "./event"
 import { Repository } from "./repository"
@@ -46,8 +47,19 @@ const layer = Layer.effect(
     const global = yield* Global.Service
     const events = yield* EventV2.Service
     const cache = yield* RepositoryCache.Service
+    const fs = yield* FSUtil.Service
     const scope = yield* Scope.Scope
     const materialized = new Map<string, Info>()
+
+    // Guards late fork completions: a reload bumps the generation, so a clone
+    // finishing for a replaced configuration never resurrects its reference.
+    let generation = 0
+    const announce = (expected: number, name: string, entry: Info) =>
+      Effect.suspend(() => {
+        if (expected !== generation || materialized.has(name)) return Effect.void
+        materialized.set(name, entry)
+        return events.publish(Event.Updated, {})
+      })
     const state = State.create<Data, Draft>({
       initial: () => ({ sources: new Map() }),
       draft: (draft) => ({
@@ -57,8 +69,8 @@ const layer = Layer.effect(
       }),
       finalize: (draft) =>
         Effect.gen(function* () {
+          const current = ++generation
           materialized.clear()
-          const seen = new Map<string, string | undefined>()
           for (const [name, source] of draft.list()) {
             if (source.type === "local") {
               materialized.set(
@@ -82,20 +94,25 @@ const layer = Layer.effect(
                 continue
               }
             }
-            const target = Repository.cachePath(global.repos, repository)
-            if (seen.has(target) && seen.get(target) !== source.branch) continue
-            seen.set(target, source.branch)
-            materialized.set(
+            const entry = new Info({
               name,
-              new Info({
-                name,
-                path: AbsolutePath.make(target),
-                ...(source.description === undefined ? {} : { description: source.description }),
-                ...(source.hidden === undefined ? {} : { hidden: source.hidden }),
-                source,
-              }),
-            )
+              path: AbsolutePath.make(Repository.cachePath(global.repos, repository, source.branch)),
+              ...(source.description === undefined ? {} : { description: source.description }),
+              ...(source.hidden === undefined ? {} : { hidden: source.hidden }),
+              source,
+            })
+            // A checkout already on disk serves immediately; a missing one is
+            // announced only after materialization succeeds, so consumers
+            // never see a path that does not exist.
+            if (yield* fs.existsSafe(entry.path)) materialized.set(name, entry)
             yield* cache.ensure({ reference: repository, branch: source.branch, refresh: true }).pipe(
+              Effect.retry({
+                while: (error) =>
+                  error._tag === "RepositoryCacheCloneFailedError" || error._tag === "RepositoryCacheFetchFailedError",
+                schedule: Schedule.exponential(2000).pipe(Schedule.jittered),
+                times: 3,
+              }),
+              Effect.flatMap(() => announce(current, name, entry)),
               Effect.catchCause((cause) =>
                 Effect.logWarning("failed to materialize reference", {
                   name,
@@ -125,5 +142,5 @@ export const locationLayer = layer
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Global.node, EventV2.node, RepositoryCache.node],
+  deps: [Global.node, EventV2.node, RepositoryCache.node, FSUtil.node],
 })

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -1,9 +1,8 @@
 export * as Reference from "./reference"
 
 import { makeLocationNode } from "./effect/app-node"
-import { Context, Effect, Layer, Schedule, Scope, Types } from "effect"
+import { Context, Effect, Layer, Scope, Types } from "effect"
 import { Reference } from "@opencode-ai/schema/reference"
-import { FSUtil } from "./fs-util"
 import { Global } from "./global"
 import { EventV2 } from "./event"
 import { Repository } from "./repository"
@@ -47,19 +46,8 @@ const layer = Layer.effect(
     const global = yield* Global.Service
     const events = yield* EventV2.Service
     const cache = yield* RepositoryCache.Service
-    const fs = yield* FSUtil.Service
     const scope = yield* Scope.Scope
     const materialized = new Map<string, Info>()
-
-    // Guards late fork completions: a reload bumps the generation, so a clone
-    // finishing for a replaced configuration never resurrects its reference.
-    let generation = 0
-    const announce = (expected: number, name: string, entry: Info) =>
-      Effect.suspend(() => {
-        if (expected !== generation || materialized.has(name)) return Effect.void
-        materialized.set(name, entry)
-        return events.publish(Event.Updated, {})
-      })
     const state = State.create<Data, Draft>({
       initial: () => ({ sources: new Map() }),
       draft: (draft) => ({
@@ -69,7 +57,6 @@ const layer = Layer.effect(
       }),
       finalize: (draft) =>
         Effect.gen(function* () {
-          const current = ++generation
           materialized.clear()
           for (const [name, source] of draft.list()) {
             if (source.type === "local") {
@@ -94,25 +81,17 @@ const layer = Layer.effect(
                 continue
               }
             }
-            const entry = new Info({
+            materialized.set(
               name,
-              path: AbsolutePath.make(Repository.cachePath(global.repos, repository, source.branch)),
-              ...(source.description === undefined ? {} : { description: source.description }),
-              ...(source.hidden === undefined ? {} : { hidden: source.hidden }),
-              source,
-            })
-            // A checkout already on disk serves immediately; a missing one is
-            // announced only after materialization succeeds, so consumers
-            // never see a path that does not exist.
-            if (yield* fs.existsSafe(entry.path)) materialized.set(name, entry)
-            yield* cache.ensure({ reference: repository, branch: source.branch, refresh: true }).pipe(
-              Effect.retry({
-                while: (error) =>
-                  error._tag === "RepositoryCacheCloneFailedError" || error._tag === "RepositoryCacheFetchFailedError",
-                schedule: Schedule.exponential(2000).pipe(Schedule.jittered),
-                times: 3,
+              new Info({
+                name,
+                path: AbsolutePath.make(Repository.cachePath(global.repos, repository, source.branch)),
+                ...(source.description === undefined ? {} : { description: source.description }),
+                ...(source.hidden === undefined ? {} : { hidden: source.hidden }),
+                source,
               }),
-              Effect.flatMap(() => announce(current, name, entry)),
+            )
+            yield* cache.ensure({ reference: repository, branch: source.branch, refresh: true }).pipe(
               Effect.catchCause((cause) =>
                 Effect.logWarning("failed to materialize reference", {
                   name,
@@ -142,5 +121,5 @@ export const locationLayer = layer
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Global.node, EventV2.node, RepositoryCache.node, FSUtil.node],
+  deps: [Global.node, EventV2.node, RepositoryCache.node],
 })

--- a/packages/core/src/repository-cache.ts
+++ b/packages/core/src/repository-cache.ts
@@ -3,11 +3,10 @@
  * branch. Each checkout permanently tracks a single ref: the requested branch
  * when the cache key has one, otherwise the remote default branch. Content
  * follows "newest wins": refresh fetches and hard-resets, so readers may
- * observe the checkout move underneath them. Checkouts unused for
- * {@link PRUNE_AFTER_MS} are removed at service startup.
+ * observe the checkout move underneath them.
  */
 import path from "path"
-import { Context, Effect, Layer, Option, Schema, Scope } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import { FSUtil } from "./fs-util"
 import { Git } from "./git"
 import { Global } from "./global"
@@ -98,11 +97,6 @@ export type Error =
 
 export interface Interface {
   readonly ensure: (input: EnsureInput) => Effect.Effect<Result, Error>
-  /**
-   * Removes checkouts unused for {@link PRUNE_AFTER_MS}. Best-effort: runs
-   * forked once at service startup and never fails. Exposed for tests.
-   */
-  readonly prune: Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/RepositoryCache") {}
@@ -142,41 +136,8 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | EffectFl
       const git = yield* Git.Service
       const flock = yield* EffectFlock.Service
       const global = yield* Global.Service
-      const scope = yield* Scope.Scope
-
-      // Checkout roots are the directories containing `.git`; the walk stops
-      // there so it never descends into checkout contents.
-      const checkouts: (dir: string) => Effect.Effect<string[], FSUtil.Error> = Effect.fnUntraced(function* (
-        dir: string,
-      ) {
-        const entries = yield* fs.readDirectoryEntries(dir)
-        if (entries.some((entry) => entry.name === ".git")) return [dir]
-        const nested = yield* Effect.forEach(
-          entries.filter((entry) => entry.type === "directory"),
-          (entry) => checkouts(path.join(dir, entry.name)),
-        )
-        return nested.flat()
-      })
-
-      const prune = Effect.gen(function* () {
-        const now = Date.now()
-        const dirs = yield* checkouts(global.repos).pipe(Effect.catch(() => Effect.succeed([] as string[])))
-        yield* Effect.forEach(
-          dirs,
-          (dir) =>
-            Effect.gen(function* () {
-              const info = yield* fs.stat(dir)
-              if (now - Option.getOrElse(info.mtime, () => new Date(0)).getTime() < PRUNE_AFTER_MS) return
-              yield* flock.withLock(fs.remove(dir, { recursive: true }), `repository-cache:${dir}`)
-            }).pipe(Effect.ignore),
-          { discard: true },
-        )
-      }).pipe(Effect.withSpan("RepositoryCache.prune"))
-
-      yield* prune.pipe(Effect.forkIn(scope))
 
       return Service.of({
-        prune,
         ensure: Effect.fn("RepositoryCache.ensure")(function* (input) {
           if (input.branch) yield* validateBranch(input.branch)
 
@@ -251,10 +212,6 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | EffectFl
                     .pipe(Effect.mapError((error) => new ResetFailedError({ repository, message: error.message })))
                 }
 
-                // Record use so prune never removes a live checkout; the
-                // cached fast path would otherwise never bump the mtime.
-                yield* fs.utimes(localPath, new Date(), new Date()).pipe(Effect.ignore)
-
                 const checkout = yield* git.repo.discover(AbsolutePath.make(localPath))
 
                 return {
@@ -284,15 +241,6 @@ export const node = makeGlobalNode({
   layer,
   deps: [EffectFlock.node, FSUtil.node, Git.node, Global.node],
 })
-
-/**
- * Thirty days of disuse. `ensure` bumps the checkout mtime on every use, so
- * any checkout referenced by a live location is re-touched at each process
- * start and config reload. A process running longer than this without either
- * can, in principle, lose a checkout to another process's prune; the next
- * reload re-clones it.
- */
-const PRUNE_AFTER_MS = 30 * 24 * 60 * 60 * 1000
 
 function errorMessage(error: unknown) {
   return error instanceof globalThis.Error ? error.message : String(error)

--- a/packages/core/src/repository-cache.ts
+++ b/packages/core/src/repository-cache.ts
@@ -1,5 +1,13 @@
+/**
+ * Local tracking checkouts for remote Git references, one per remote and
+ * branch. Each checkout permanently tracks a single ref: the requested branch
+ * when the cache key has one, otherwise the remote default branch. Content
+ * follows "newest wins": refresh fetches and hard-resets, so readers may
+ * observe the checkout move underneath them. Checkouts unused for
+ * {@link PRUNE_AFTER_MS} are removed at service startup.
+ */
 import path from "path"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Option, Schema, Scope } from "effect"
 import { FSUtil } from "./fs-util"
 import { Git } from "./git"
 import { Global } from "./global"
@@ -90,6 +98,11 @@ export type Error =
 
 export interface Interface {
   readonly ensure: (input: EnsureInput) => Effect.Effect<Result, Error>
+  /**
+   * Removes checkouts unused for {@link PRUNE_AFTER_MS}. Best-effort: runs
+   * forked once at service startup and never fails. Exposed for tests.
+   */
+  readonly prune: Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/RepositoryCache") {}
@@ -129,13 +142,46 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | EffectFl
       const git = yield* Git.Service
       const flock = yield* EffectFlock.Service
       const global = yield* Global.Service
+      const scope = yield* Scope.Scope
+
+      // Checkout roots are the directories containing `.git`; the walk stops
+      // there so it never descends into checkout contents.
+      const checkouts: (dir: string) => Effect.Effect<string[], FSUtil.Error> = Effect.fnUntraced(function* (
+        dir: string,
+      ) {
+        const entries = yield* fs.readDirectoryEntries(dir)
+        if (entries.some((entry) => entry.name === ".git")) return [dir]
+        const nested = yield* Effect.forEach(
+          entries.filter((entry) => entry.type === "directory"),
+          (entry) => checkouts(path.join(dir, entry.name)),
+        )
+        return nested.flat()
+      })
+
+      const prune = Effect.gen(function* () {
+        const now = Date.now()
+        const dirs = yield* checkouts(global.repos).pipe(Effect.catch(() => Effect.succeed([] as string[])))
+        yield* Effect.forEach(
+          dirs,
+          (dir) =>
+            Effect.gen(function* () {
+              const info = yield* fs.stat(dir)
+              if (now - Option.getOrElse(info.mtime, () => new Date(0)).getTime() < PRUNE_AFTER_MS) return
+              yield* flock.withLock(fs.remove(dir, { recursive: true }), `repository-cache:${dir}`)
+            }).pipe(Effect.ignore),
+          { discard: true },
+        )
+      }).pipe(Effect.withSpan("RepositoryCache.prune"))
+
+      yield* prune.pipe(Effect.forkIn(scope))
 
       return Service.of({
+        prune,
         ensure: Effect.fn("RepositoryCache.ensure")(function* (input) {
           if (input.branch) yield* validateBranch(input.branch)
 
           const repository = input.reference.label
-          const localPath = Repository.cachePath(global.repos, input.reference)
+          const localPath = Repository.cachePath(global.repos, input.reference, input.branch)
           const cloneTarget = Repository.parse(input.reference.remote) ?? input.reference
 
           return yield* flock
@@ -143,21 +189,24 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | EffectFl
               Effect.gen(function* () {
                 yield* cacheOperation(fs.ensureDir(path.dirname(localPath)), "ensure cache directory", localPath)
 
-                const exists = yield* fs.existsSafe(localPath)
                 const existing = yield* git.repo.discover(AbsolutePath.make(localPath))
                 const origin = existing ? yield* git.remote.get(existing) : undefined
                 const originReference = origin ? Repository.parse(origin) : undefined
-                const reuse = Boolean(existing && originReference && Repository.same(originReference, cloneTarget))
-                if (exists && !reuse) {
+                // Discovery walks upward, so an enclosing repository with a
+                // matching origin could masquerade as the cache entry; reuse
+                // requires the checkout to live exactly at the cache path.
+                const worktree = existing ? yield* fs.resolve(localPath) : undefined
+                const reuse = Boolean(
+                  existing &&
+                    existing.worktree === worktree &&
+                    originReference &&
+                    Repository.same(originReference, cloneTarget),
+                )
+                if (!reuse && (yield* fs.existsSafe(localPath))) {
                   yield* cacheOperation(fs.remove(localPath, { recursive: true }), "remove stale cache", localPath)
                 }
 
-                const currentBranch = reuse && existing ? yield* git.history.branch(existing) : undefined
-                const status = statusForRepository({
-                  reuse,
-                  refresh: input.refresh,
-                  branchMatches: input.branch ? currentBranch === input.branch : undefined,
-                })
+                const status = !reuse ? ("cloned" as const) : input.refresh ? ("refreshed" as const) : ("cached" as const)
 
                 if (status === "cloned") {
                   yield* git.repo
@@ -177,27 +226,34 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | EffectFl
                     .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: error.message })))
 
                   if (input.branch) {
-                    const requestedBranch = input.branch
                     yield* git.sync
-                      .fetchBranch(existing, { branch: requestedBranch })
+                      .fetchBranch(existing, { branch: input.branch })
                       .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: error.message })))
-
-                    yield* git.sync.checkoutRemoteBranch(existing, { branch: requestedBranch }).pipe(
-                      Effect.mapError(
-                        (error) =>
-                          new CheckoutFailedError({
-                            repository,
-                            branch: requestedBranch,
-                            message: error.message,
-                          }),
-                      ),
-                    )
                   }
 
+                  // Checking out the tracked ref before resetting keeps the
+                  // checkout self-healing even if it was left on another
+                  // branch.
+                  const branch = input.branch ?? (yield* git.history.defaultRemoteBranch(existing))
+                  if (branch) {
+                    yield* git.sync
+                      .checkoutRemoteBranch(existing, { branch })
+                      .pipe(
+                        Effect.mapError(
+                          (error) => new CheckoutFailedError({ repository, branch, message: error.message }),
+                        ),
+                      )
+                  }
+
+                  const target = branch ?? (yield* git.history.branch(existing))
                   yield* git.sync
-                    .resetHard(existing, yield* resetTarget(git, existing, input.branch))
+                    .resetHard(existing, target ? `origin/${target}` : "HEAD")
                     .pipe(Effect.mapError((error) => new ResetFailedError({ repository, message: error.message })))
                 }
+
+                // Record use so prune never removes a live checkout; the
+                // cached fast path would otherwise never bump the mtime.
+                yield* fs.utimes(localPath, new Date(), new Date()).pipe(Effect.ignore)
 
                 const checkout = yield* git.repo.discover(AbsolutePath.make(localPath))
 
@@ -229,11 +285,14 @@ export const node = makeGlobalNode({
   deps: [EffectFlock.node, FSUtil.node, Git.node, Global.node],
 })
 
-function statusForRepository(input: { reuse: boolean; refresh?: boolean; branchMatches?: boolean }) {
-  if (!input.reuse) return "cloned" as const
-  if (input.branchMatches === false || input.refresh) return "refreshed" as const
-  return "cached" as const
-}
+/**
+ * Thirty days of disuse. `ensure` bumps the checkout mtime on every use, so
+ * any checkout referenced by a live location is re-touched at each process
+ * start and config reload. A process running longer than this without either
+ * can, in principle, lose a checkout to another process's prune; the next
+ * reload re-clones it.
+ */
+const PRUNE_AFTER_MS = 30 * 24 * 60 * 60 * 1000
 
 function errorMessage(error: unknown) {
   return error instanceof globalThis.Error ? error.message : String(error)
@@ -244,18 +303,5 @@ function cacheOperation<A, E, R>(effect: Effect.Effect<A, E, R>, operation: stri
     Effect.mapError((error) => new CacheOperationError({ operation, path: target, message: errorMessage(error) })),
   )
 }
-
-const resetTarget = Effect.fnUntraced(function* (
-  git: Git.Interface,
-  repository: Git.Repository,
-  requestedBranch?: string,
-) {
-  if (requestedBranch) return `origin/${requestedBranch}`
-  const remoteHead = yield* git.history.defaultRemoteBranch(repository)
-  if (remoteHead) return `origin/${remoteHead}`
-  const currentBranch = yield* git.history.branch(repository)
-  if (currentBranch) return `origin/${currentBranch}`
-  return "HEAD"
-})
 
 export * as RepositoryCache from "./repository-cache"

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -118,8 +118,14 @@ export function isRemote(reference: Reference): reference is RemoteReference {
   return !isFile(reference)
 }
 
-export function cachePath(root: string, reference: Reference): string {
-  return path.join(root, ...reference.host.split(":"), ...reference.segments)
+/**
+ * Checkouts are keyed by remote and branch: a branch-specific reference gets
+ * its own directory so branchless refreshes can never move it. The branch is
+ * percent-encoded because valid branch names may contain `/`.
+ */
+export function cachePath(root: string, reference: Reference, branch?: string): string {
+  const base = path.join(root, ...reference.host.split(":"), ...reference.segments)
+  return branch ? `${base}@${encodeURIComponent(branch)}` : base
 }
 
 export function cacheIdentity(reference: Reference): string {

--- a/packages/core/test/reference.test.ts
+++ b/packages/core/test/reference.test.ts
@@ -1,162 +1,78 @@
 import { describe, expect } from "bun:test"
-import fs from "fs/promises"
-import path from "path"
 import { Effect, Exit, Layer, Scope } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Global } from "@opencode-ai/core/global"
 import { Reference } from "@opencode-ai/core/reference"
 import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
-import { tmpdir } from "./fixture/tmpdir"
 import { it } from "./lib/effect"
 
-const cacheMock = (
-  ensure: (input: RepositoryCache.EnsureInput) => Effect.Effect<RepositoryCache.Result, RepositoryCache.Error>,
-) => Layer.mock(RepositoryCache.Service, { ensure, prune: Effect.void })
-
-const materialize = (input: RepositoryCache.EnsureInput): RepositoryCache.Result => ({
-  repository: input.reference.label,
-  host: input.reference.host,
-  remote: input.reference.remote,
-  localPath: "unused",
-  status: "cloned",
+const cache = Layer.mock(RepositoryCache.Service, {
+  ensure: () => Effect.die("unexpected Git materialization"),
 })
-
-const unavailable = () =>
-  Effect.fail(new RepositoryCache.CloneFailedError({ repository: "owner/repo", message: "unavailable" }))
-
-const layerFor = (root: string, cache: Layer.Layer<RepositoryCache.Service>) =>
-  AppNodeBuilder.build(Reference.node, [
-    [RepositoryCache.node, cache],
-    [Global.node, Global.layerWith({ state: path.join(root, "state"), repos: path.join(root, "repos") })],
-  ])
-
-function withRoot<A, E, R>(body: (root: string) => Effect.Effect<A, E, R>) {
-  return Effect.acquireUseRelease(
-    Effect.promise(() => tmpdir()),
-    (tmp) => body(tmp.path),
-    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  )
-}
-
-/** Yields until forked materializations have had a chance to complete. */
-const eventually = <A>(effect: Effect.Effect<A>, done: (value: A) => boolean) =>
-  Effect.gen(function* () {
-    for (let index = 0; index < 200; index++) {
-      const value = yield* effect
-      if (done(value)) return value
-      yield* Effect.yieldNow
-    }
-    return yield* effect
-  })
+const referenceLayer = AppNodeBuilder.build(Reference.node, [[RepositoryCache.node, cache]])
 
 describe("Reference", () => {
   it.effect("registers normalized sources for the owning scope", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const scope = yield* Scope.make()
-      const target = AbsolutePath.make("/docs")
+      const path = AbsolutePath.make("/docs")
       const source = Reference.LocalSource.make({
         type: "local",
-        path: target,
+        path,
         description: "Use for API documentation",
         hidden: true,
       })
       yield* references.transform((editor) => editor.add("docs", source)).pipe(Scope.provide(scope))
 
       expect(yield* references.list()).toEqual([
-        Reference.Info.make({
-          name: "docs",
-          path: target,
-          description: "Use for API documentation",
-          hidden: true,
-          source,
-        }),
+        new Reference.Info({ name: "docs", path, description: "Use for API documentation", hidden: true, source }),
       ])
 
       yield* Scope.close(scope, Exit.void)
       expect(yield* references.list()).toEqual([])
-    }).pipe(
-      Effect.provide(
-        AppNodeBuilder.build(Reference.node, [
-          [RepositoryCache.node, cacheMock(() => Effect.die("unexpected Git materialization"))],
-        ]),
-      ),
-    ),
+    }).pipe(Effect.provide(referenceLayer)),
   )
 
-  it.effect("announces Git references once materialization succeeds", () =>
-    withRoot((root) =>
-      Effect.gen(function* () {
-        const references = yield* Reference.Service
-        const repository = Repository.parseRemote("owner/repo")
-        const source = Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "main" })
-        yield* references.transform((editor) => editor.add("sdk", source))
+  it.effect("derives Git paths without exposing cache operations", () =>
+    Effect.gen(function* () {
+      const references = yield* Reference.Service
+      const repository = Repository.parseRemote("owner/repo")
+      const source = Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "main" })
+      yield* references.transform((editor) => editor.add("sdk", source))
 
-        expect(yield* eventually(references.list(), (infos) => infos.length > 0)).toEqual([
-          Reference.Info.make({
-            name: "sdk",
-            path: AbsolutePath.make(Repository.cachePath(path.join(root, "repos"), repository, "main")),
-            source,
-          }),
-        ])
-      }).pipe(Effect.provide(layerFor(root, cacheMock((input) => Effect.succeed(materialize(input)))))),
-    ),
+      expect(yield* references.list()).toEqual([
+        new Reference.Info({
+          name: "sdk",
+          path: AbsolutePath.make(Repository.cachePath(Global.Path.repos, repository, "main")),
+          source,
+        }),
+      ])
+    }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
   )
 
   it.effect("preserves configured Git descriptions", () =>
-    withRoot((root) =>
-      Effect.gen(function* () {
-        const references = yield* Reference.Service
-        const repository = Repository.parseRemote("owner/repo")
-        const source = Reference.GitSource.make({
-          type: "git",
-          repository: "owner/repo",
+    Effect.gen(function* () {
+      const references = yield* Reference.Service
+      const repository = Repository.parseRemote("owner/repo")
+      const source = Reference.GitSource.make({
+        type: "git",
+        repository: "owner/repo",
+        description: "Use for SDK implementation details",
+      })
+      yield* references.transform((editor) => editor.add("sdk", source))
+
+      expect(yield* references.list()).toEqual([
+        new Reference.Info({
+          name: "sdk",
+          path: AbsolutePath.make(Repository.cachePath(Global.Path.repos, repository)),
           description: "Use for SDK implementation details",
-        })
-        yield* references.transform((editor) => editor.add("sdk", source))
-
-        expect(yield* eventually(references.list(), (infos) => infos.length > 0)).toEqual([
-          Reference.Info.make({
-            name: "sdk",
-            path: AbsolutePath.make(Repository.cachePath(path.join(root, "repos"), repository)),
-            description: "Use for SDK implementation details",
-            source,
-          }),
-        ])
-      }).pipe(Effect.provide(layerFor(root, cacheMock((input) => Effect.succeed(materialize(input)))))),
-    ),
-  )
-
-  it.effect("keeps references hidden while materialization fails", () =>
-    withRoot((root) =>
-      Effect.gen(function* () {
-        const references = yield* Reference.Service
-        const source = Reference.GitSource.make({ type: "git", repository: "owner/repo" })
-        yield* references.transform((editor) => editor.add("sdk", source))
-
-        for (let index = 0; index < 20; index++) yield* Effect.yieldNow
-        expect(yield* references.list()).toEqual([])
-      }).pipe(Effect.provide(layerFor(root, cacheMock(unavailable)))),
-    ),
-  )
-
-  it.effect("serves checkouts already on disk before refresh completes", () =>
-    withRoot((root) =>
-      Effect.gen(function* () {
-        const repository = Repository.parseRemote("owner/repo")
-        const target = Repository.cachePath(path.join(root, "repos"), repository)
-        yield* Effect.promise(() => fs.mkdir(target, { recursive: true }))
-
-        const references = yield* Reference.Service
-        const source = Reference.GitSource.make({ type: "git", repository: "owner/repo" })
-        yield* references.transform((editor) => editor.add("sdk", source))
-
-        expect(yield* references.list()).toEqual([
-          Reference.Info.make({ name: "sdk", path: AbsolutePath.make(target), source }),
-        ])
-      }).pipe(Effect.provide(layerFor(root, cacheMock(unavailable)))),
-    ),
+          source,
+        }),
+      ])
+    }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
   )
 })

--- a/packages/core/test/reference.test.ts
+++ b/packages/core/test/reference.test.ts
@@ -1,78 +1,162 @@
 import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { Effect, Exit, Layer, Scope } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
-import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Global } from "@opencode-ai/core/global"
 import { Reference } from "@opencode-ai/core/reference"
 import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
+import { tmpdir } from "./fixture/tmpdir"
 import { it } from "./lib/effect"
 
-const cache = Layer.mock(RepositoryCache.Service, {
-  ensure: () => Effect.die("unexpected Git materialization"),
+const cacheMock = (
+  ensure: (input: RepositoryCache.EnsureInput) => Effect.Effect<RepositoryCache.Result, RepositoryCache.Error>,
+) => Layer.mock(RepositoryCache.Service, { ensure, prune: Effect.void })
+
+const materialize = (input: RepositoryCache.EnsureInput): RepositoryCache.Result => ({
+  repository: input.reference.label,
+  host: input.reference.host,
+  remote: input.reference.remote,
+  localPath: "unused",
+  status: "cloned",
 })
-const referenceLayer = AppNodeBuilder.build(Reference.node, [[RepositoryCache.node, cache]])
+
+const unavailable = () =>
+  Effect.fail(new RepositoryCache.CloneFailedError({ repository: "owner/repo", message: "unavailable" }))
+
+const layerFor = (root: string, cache: Layer.Layer<RepositoryCache.Service>) =>
+  AppNodeBuilder.build(Reference.node, [
+    [RepositoryCache.node, cache],
+    [Global.node, Global.layerWith({ state: path.join(root, "state"), repos: path.join(root, "repos") })],
+  ])
+
+function withRoot<A, E, R>(body: (root: string) => Effect.Effect<A, E, R>) {
+  return Effect.acquireUseRelease(
+    Effect.promise(() => tmpdir()),
+    (tmp) => body(tmp.path),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  )
+}
+
+/** Yields until forked materializations have had a chance to complete. */
+const eventually = <A>(effect: Effect.Effect<A>, done: (value: A) => boolean) =>
+  Effect.gen(function* () {
+    for (let index = 0; index < 200; index++) {
+      const value = yield* effect
+      if (done(value)) return value
+      yield* Effect.yieldNow
+    }
+    return yield* effect
+  })
 
 describe("Reference", () => {
   it.effect("registers normalized sources for the owning scope", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const scope = yield* Scope.make()
-      const path = AbsolutePath.make("/docs")
+      const target = AbsolutePath.make("/docs")
       const source = Reference.LocalSource.make({
         type: "local",
-        path,
+        path: target,
         description: "Use for API documentation",
         hidden: true,
       })
       yield* references.transform((editor) => editor.add("docs", source)).pipe(Scope.provide(scope))
 
       expect(yield* references.list()).toEqual([
-        new Reference.Info({ name: "docs", path, description: "Use for API documentation", hidden: true, source }),
+        Reference.Info.make({
+          name: "docs",
+          path: target,
+          description: "Use for API documentation",
+          hidden: true,
+          source,
+        }),
       ])
 
       yield* Scope.close(scope, Exit.void)
       expect(yield* references.list()).toEqual([])
-    }).pipe(Effect.provide(referenceLayer)),
+    }).pipe(
+      Effect.provide(
+        AppNodeBuilder.build(Reference.node, [
+          [RepositoryCache.node, cacheMock(() => Effect.die("unexpected Git materialization"))],
+        ]),
+      ),
+    ),
   )
 
-  it.effect("derives Git paths without exposing cache operations", () =>
-    Effect.gen(function* () {
-      const references = yield* Reference.Service
-      const repository = Repository.parseRemote("owner/repo")
-      const source = Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "main" })
-      yield* references.transform((editor) => editor.add("sdk", source))
+  it.effect("announces Git references once materialization succeeds", () =>
+    withRoot((root) =>
+      Effect.gen(function* () {
+        const references = yield* Reference.Service
+        const repository = Repository.parseRemote("owner/repo")
+        const source = Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "main" })
+        yield* references.transform((editor) => editor.add("sdk", source))
 
-      expect(yield* references.list()).toEqual([
-        new Reference.Info({
-          name: "sdk",
-          path: AbsolutePath.make(Repository.cachePath(Global.Path.repos, repository)),
-          source,
-        }),
-      ])
-    }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
+        expect(yield* eventually(references.list(), (infos) => infos.length > 0)).toEqual([
+          Reference.Info.make({
+            name: "sdk",
+            path: AbsolutePath.make(Repository.cachePath(path.join(root, "repos"), repository, "main")),
+            source,
+          }),
+        ])
+      }).pipe(Effect.provide(layerFor(root, cacheMock((input) => Effect.succeed(materialize(input)))))),
+    ),
   )
 
   it.effect("preserves configured Git descriptions", () =>
-    Effect.gen(function* () {
-      const references = yield* Reference.Service
-      const repository = Repository.parseRemote("owner/repo")
-      const source = Reference.GitSource.make({
-        type: "git",
-        repository: "owner/repo",
-        description: "Use for SDK implementation details",
-      })
-      yield* references.transform((editor) => editor.add("sdk", source))
-
-      expect(yield* references.list()).toEqual([
-        new Reference.Info({
-          name: "sdk",
-          path: AbsolutePath.make(Repository.cachePath(Global.Path.repos, repository)),
+    withRoot((root) =>
+      Effect.gen(function* () {
+        const references = yield* Reference.Service
+        const repository = Repository.parseRemote("owner/repo")
+        const source = Reference.GitSource.make({
+          type: "git",
+          repository: "owner/repo",
           description: "Use for SDK implementation details",
-          source,
-        }),
-      ])
-    }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
+        })
+        yield* references.transform((editor) => editor.add("sdk", source))
+
+        expect(yield* eventually(references.list(), (infos) => infos.length > 0)).toEqual([
+          Reference.Info.make({
+            name: "sdk",
+            path: AbsolutePath.make(Repository.cachePath(path.join(root, "repos"), repository)),
+            description: "Use for SDK implementation details",
+            source,
+          }),
+        ])
+      }).pipe(Effect.provide(layerFor(root, cacheMock((input) => Effect.succeed(materialize(input)))))),
+    ),
+  )
+
+  it.effect("keeps references hidden while materialization fails", () =>
+    withRoot((root) =>
+      Effect.gen(function* () {
+        const references = yield* Reference.Service
+        const source = Reference.GitSource.make({ type: "git", repository: "owner/repo" })
+        yield* references.transform((editor) => editor.add("sdk", source))
+
+        for (let index = 0; index < 20; index++) yield* Effect.yieldNow
+        expect(yield* references.list()).toEqual([])
+      }).pipe(Effect.provide(layerFor(root, cacheMock(unavailable)))),
+    ),
+  )
+
+  it.effect("serves checkouts already on disk before refresh completes", () =>
+    withRoot((root) =>
+      Effect.gen(function* () {
+        const repository = Repository.parseRemote("owner/repo")
+        const target = Repository.cachePath(path.join(root, "repos"), repository)
+        yield* Effect.promise(() => fs.mkdir(target, { recursive: true }))
+
+        const references = yield* Reference.Service
+        const source = Reference.GitSource.make({ type: "git", repository: "owner/repo" })
+        yield* references.transform((editor) => editor.add("sdk", source))
+
+        expect(yield* references.list()).toEqual([
+          Reference.Info.make({ name: "sdk", path: AbsolutePath.make(target), source }),
+        ])
+      }).pipe(Effect.provide(layerFor(root, cacheMock(unavailable)))),
+    ),
   )
 })

--- a/packages/core/test/repository-cache.test.ts
+++ b/packages/core/test/repository-cache.test.ts
@@ -101,25 +101,6 @@ describe("RepositoryCache", () => {
     ),
   )
 
-  it.live("prunes checkouts that have not been used recently", () =>
-    withRemote((fixture) =>
-      Effect.gen(function* () {
-        const cache = yield* RepositoryCache.Service
-        const fresh = yield* cache.ensure({ reference: fixture.reference })
-        const stale = yield* cache.ensure({
-          reference: { ...Repository.parseRemote("owner/stale"), remote: fixture.remote },
-        })
-        const old = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000)
-        yield* Effect.promise(() => fs.utimes(stale.localPath, old, old))
-
-        yield* cache.prune
-
-        expect(yield* exists(stale.localPath)).toBe(false)
-        expect(yield* exists(fresh.localPath)).toBe(true)
-      }).pipe(Effect.provide(cacheLayer(fixture.root))),
-    ),
-  )
-
   it.live("returns typed validation and clone failures", () =>
     withRemote((fixture) =>
       Effect.gen(function* () {

--- a/packages/core/test/repository-cache.test.ts
+++ b/packages/core/test/repository-cache.test.ts
@@ -8,7 +8,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Global } from "@opencode-ai/core/global"
 import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
-import { git, gitRemote } from "./fixture/git"
+import { branch, git, gitRemote } from "./fixture/git"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
@@ -62,6 +62,60 @@ describe("RepositoryCache", () => {
 
         expect(replaced.status).toBe("cloned")
         expect(yield* exists(path.join(replaced.localPath, "stale.txt"))).toBe(false)
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("keeps branch checkouts isolated from branchless refreshes", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => branch(fixture.source, "feature", "two\n"))
+        const cache = yield* RepositoryCache.Service
+
+        const featured = yield* cache.ensure({ reference: fixture.reference, branch: "feature" })
+        expect(featured.branch).toBe("feature")
+        expect(featured.localPath.endsWith("repo@feature")).toBe(true)
+        expect(yield* read(path.join(featured.localPath, "README.md"))).toBe("two\n")
+
+        const refreshed = yield* cache.ensure({ reference: fixture.reference, refresh: true })
+        expect(refreshed.localPath).not.toBe(featured.localPath)
+        expect(yield* read(path.join(refreshed.localPath, "README.md"))).toBe("one\n")
+
+        const cached = yield* cache.ensure({ reference: fixture.reference, branch: "feature" })
+        expect(cached.status).toBe("cached")
+        expect(yield* read(path.join(cached.localPath, "README.md"))).toBe("two\n")
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("does not mistake an enclosing repository for the cache checkout", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => git(fixture.root, "clone", fixture.remote, path.join(fixture.root, "repos")))
+
+        const result = yield* (yield* RepositoryCache.Service).ensure({ reference: fixture.reference })
+
+        expect(result.status).toBe("cloned")
+        expect(yield* read(path.join(result.localPath, "README.md"))).toBe("one\n")
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("prunes checkouts that have not been used recently", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        const cache = yield* RepositoryCache.Service
+        const fresh = yield* cache.ensure({ reference: fixture.reference })
+        const stale = yield* cache.ensure({
+          reference: { ...Repository.parseRemote("owner/stale"), remote: fixture.remote },
+        })
+        const old = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000)
+        yield* Effect.promise(() => fs.utimes(stale.localPath, old, old))
+
+        yield* cache.prune
+
+        expect(yield* exists(stale.localPath)).toBe(false)
+        expect(yield* exists(fresh.localPath)).toBe(true)
       }).pipe(Effect.provide(cacheLayer(fixture.root))),
     ),
   )

--- a/packages/core/test/repository.test.ts
+++ b/packages/core/test/repository.test.ts
@@ -17,6 +17,12 @@ describe("Repository", () => {
       label: "owner/repo",
     })
     expect(Repository.cachePath("/cache", reference)).toBe(path.join("/cache", "github.com", "owner", "repo"))
+    expect(Repository.cachePath("/cache", reference, "main")).toBe(
+      path.join("/cache", "github.com", "owner", "repo@main"),
+    )
+    expect(Repository.cachePath("/cache", reference, "feature/x")).toBe(
+      path.join("/cache", "github.com", "owner", "repo@feature%2Fx"),
+    )
     expect(Repository.cacheIdentity(reference)).toBe("github.com/owner/repo")
   })
 

--- a/packages/opencode/test/server/httpapi-reference.test.ts
+++ b/packages/opencode/test/server/httpapi-reference.test.ts
@@ -51,7 +51,7 @@ describe("reference HttpApi", () => {
       },
       {
         name: "effect",
-        path: path.join(Global.Path.repos, "github.com", "Effect-TS", "effect"),
+        path: path.join(Global.Path.repos, "github.com", "Effect-TS", "effect@main"),
         source: {
           type: "git",
           repository: "Effect-TS/effect",


### PR DESCRIPTION
## What

`RepositoryCache` manages the local checkouts backing remote Git project references. It had two correctness bugs, both rooted in one design flaw: all branches of a repository shared a single mutable checkout, and cache validity was inferred instead of guaranteed.

This PR keys checkouts by remote **and** branch, so each checkout permanently tracks exactly one ref. Both bugs become structurally impossible, and the code gets simpler: the branch-match heuristic, the reset-target guessing, and the reference collision workaround are all deleted.

## Before / After

**Branchless refresh corrupted branch checkouts**

Before:
1. `ensure({ branch: "feature" })` checks out `feature` at the shared path `repos/github.com/owner/repo`.
2. `ensure({ refresh: true })` (branchless) fetches and hard-resets the still-checked-out `feature` branch to `origin/<default>`.
3. `ensure({ branch: "feature" })` sees the branch *name* still matches and returns `"cached"` — content is silently the default branch's.

After: `feature` lives at `repos/github.com/owner/repo@feature` and only ever resets to `origin/feature`; the branchless checkout lives at `repos/github.com/owner/repo` and tracks the remote default. Neither can move the other. Regression test: `keeps branch checkouts isolated from branchless refreshes`.

**Ancestor repository produced false cache hits**

Before: if the cache path was missing but nested inside another repository with the same origin, upward `.git` discovery returned the ancestor, `ensure` reported `"cached"`, and returned a nonexistent path. After: reuse requires the discovered worktree to be exactly the cache path. Regression test: `does not mistake an enclosing repository for the cache checkout`.

## How

- `packages/core/src/repository.ts` — `cachePath(root, reference, branch?)` appends `@<encodeURIComponent(branch)>` to the final segment (branch names may contain `/`). Branchless paths are unchanged, so existing default checkouts survive the migration.
- `packages/core/src/repository-cache.ts` — reuse requires `existing.worktree === fs.resolve(localPath)`. The `branchMatches` heuristic and `resetTarget` helper are deleted; status is a one-line ternary because the key guarantees the branch. Refresh checks out the tracked ref (`checkout -B`) before `reset --hard`, so checkouts self-heal if left on the wrong branch.
- `packages/core/src/reference.ts` — the silent same-repo/different-branch collision skip (`seen` map) is deleted: distinct branches now get distinct paths by construction.

## Scope

Deliberately not included (discussed and cut to keep this PR minimal):

- Reference readiness gating — references are still advertised before their first clone completes.
- Retry of failed materializations — recovery remains the next config reload or restart.
- Pruning of abandoned checkouts — orphaned old-format branch checkouts persist on disk.
- The tracking-checkout contract itself ("newest wins") is unchanged.

## Testing

From `packages/core`:

- `bun typecheck` — clean.
- `bun test test/repository.test.ts test/repository-cache.test.ts test/reference.test.ts test/reference-guidance.test.ts` — 17 pass, 0 fail. New coverage: branch/branchless isolation (the corruption regression) and the enclosing-repository false hit, both against real git remotes via `it.live`.
