### PR TITLE
fix(core): preserve reasoning metadata on errored assistant turns

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -79,7 +79,7 @@ const assistant = (message: SessionMessage.Assistant, model: Model) => {
             {
               type: "reasoning",
               text: item.text,
-              providerMetadata: reuseProviderMetadata ? item.providerMetadata : undefined,
+              providerMetadata: item.providerMetadata,
             },
           ]
         : item.text.length > 0

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -327,7 +327,7 @@ Recent work
     ])
   })
 
-  test("drops provider-native continuation metadata from failed assistant turns", () => {
+  test("drops provider-native continuation metadata from failed assistant turn tools, but preserves reasoning", () => {
     const messages = toLLMMessages(
       [
         SessionMessage.Assistant.make({
@@ -370,7 +370,11 @@ Recent work
     )
 
     expect(messages[0]?.content).toEqual([
-      { type: "reasoning", text: "Partial thought", providerMetadata: undefined },
+      {
+        type: "reasoning",
+        text: "Partial thought",
+        providerMetadata: { openai: { itemId: "rs_failed", reasoningEncryptedContent: null } },
+      },
       {
         type: "tool-call",
         id: "hosted-failed",


### PR DESCRIPTION
### Issue for this PR

Closes #38620

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a session turn is interrupted (network error, timeout, etc.) and contains both a `thinking` block and a `tool_use` block, the existing replay logic in `to-llm-message.ts` stripped `providerMetadata` from the `reasoning` block because `message.error` was defined. This left the `tool_use` block without a valid preceding `thinking` block, causing Anthropic to return a 400 error on replay.

The fix is minimal: always pass `item.providerMetadata` for `reasoning` blocks, regardless of whether the message has an error. The `reuseProviderMetadata` flag still guards tool-related metadata on errored turns; only reasoning metadata is now unconditionally preserved.

### How did you verify your code works?

Updated the existing test `drops provider-native continuation metadata from failed assistant turns` (now renamed to reflect the new behavior) to assert that reasoning blocks retain their providerMetadata while tool-related continuation metadata is still dropped. All session tests pass:

```
bun test test/session
203 tests passed
```

### Screenshots / recordings

_No UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR