### PR TITLE
fix(tui): handle Windows path separators in status dialog plugin names

### DIFF
--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -20,7 +20,7 @@ export function DialogStatus() {
       const value = typeof item === "string" ? item : item[0]
       if (value.startsWith("file://")) {
         const path = fileURLToPath(value)
-        const parts = path.split("/")
+        const parts = path.split(/[\\/]/)
         const filename = parts.pop() || path
         if (!filename.includes(".")) return { name: filename }
         const basename = filename.split(".")[0]


### PR DESCRIPTION
### Issue for this PR

Closes #N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Very simple.

Right now on Windows if you do `/status`, the file paths are not correctly displayed, they render as
```
3 Plugins
•C:\Users\sewer\
•C:\Users\sewer\
•C:\Users\sewer\
```

etc.

This is because the path separator is written as `/` only for this dialog.
This PR makes the `\` separator also be accepted.

### Screenshots / recordings

Before:

<img width="265" height="131" alt="image" src="https://github.com/user-attachments/assets/385775f3-c95e-4770-95b0-20a324a4b271" />

After:

<img width="149" height="122" alt="image" src="https://github.com/user-attachments/assets/566b82d6-d7d4-4bfb-9e74-d72d3d7dc47f" />

(Matches Linux, shows file name)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
