### PR TITLE
feat(tui): show model variant in subagent footer

### DIFF
--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -107,71 +107,80 @@ export function SubagentFooter() {
         flexShrink={0}
         backgroundColor={theme.backgroundPanel}
       >
-        <box flexDirection="row" justifyContent="space-between" gap={1}>
-          <box flexDirection="row" gap={1} minWidth={0} flexShrink={1} overflow="hidden">
-            <text fg={theme.text} flexShrink={0} wrapMode="none">
-              <b>{subagentInfo().label}</b>
-            </text>
-            <Show when={modelInfo()}>
-              {(item) => (
-                <text flexShrink={1} wrapMode="none" truncate>
-                  <span style={{ fg: theme.textMuted }}>· </span>
-                  <span style={{ fg: theme.text }}>{item().model} </span>
-                  <span style={{ fg: theme.textMuted }}>{item().provider}</span>
-                  <Show when={item().variant}>
-                    {(variant) => (
-                      <>
-                        <span style={{ fg: theme.textMuted }}> · </span>
-                        <span style={{ fg: theme.warning, bold: true }}>{variant()}</span>
-                      </>
-                    )}
-                  </Show>
+        <box flexDirection="column" gap={0}>
+          <Show when={modelInfo()}>
+            {(item) => (
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.text} wrapMode="none">
+                  {item().model}
                 </text>
-              )}
-            </Show>
-            <Show when={subagentInfo().total > 0}>
-              <text style={{ fg: theme.textMuted }} flexShrink={0} wrapMode="none">
-                ({subagentInfo().index} of {subagentInfo().total})
-              </text>
-            </Show>
-            <Show when={usage()}>
-              {(item) => (
                 <text fg={theme.textMuted} wrapMode="none">
-                  {[item().context, item().cost].filter(Boolean).join(" · ")}
+                  {item().provider}
                 </text>
-              )}
-            </Show>
-          </box>
-          <box flexDirection="row" gap={2} flexShrink={0}>
-            <box
-              onMouseOver={() => setHover("parent")}
-              onMouseOut={() => setHover(null)}
-              onMouseUp={() => keymap.dispatchCommand("session.parent")}
-              backgroundColor={hover() === "parent" ? theme.backgroundElement : theme.backgroundPanel}
-            >
+                <Show when={item().variant}>
+                  {(variant) => (
+                    <>
+                      <text fg={theme.textMuted} wrapMode="none">
+                        ·
+                      </text>
+                      <text fg={theme.warning} wrapMode="none">
+                        <b>{variant()}</b>
+                      </text>
+                    </>
+                  )}
+                </Show>
+              </box>
+            )}
+          </Show>
+          <box flexDirection="row" justifyContent="space-between" gap={1}>
+            <box flexDirection="row" gap={1}>
               <text fg={theme.text}>
-                Parent <span style={{ fg: theme.textMuted }}>{parentShortcut()}</span>
+                <b>{subagentInfo().label}</b>
               </text>
+              <Show when={subagentInfo().total > 0}>
+                <text style={{ fg: theme.textMuted }}>
+                  ({subagentInfo().index} of {subagentInfo().total})
+                </text>
+              </Show>
+              <Show when={usage()}>
+                {(item) => (
+                  <text fg={theme.textMuted} wrapMode="none">
+                    {[item().context, item().cost].filter(Boolean).join(" · ")}
+                  </text>
+                )}
+              </Show>
             </box>
-            <box
-              onMouseOver={() => setHover("prev")}
-              onMouseOut={() => setHover(null)}
-              onMouseUp={() => keymap.dispatchCommand("session.child.previous")}
-              backgroundColor={hover() === "prev" ? theme.backgroundElement : theme.backgroundPanel}
-            >
-              <text fg={theme.text}>
-                Prev <span style={{ fg: theme.textMuted }}>{previousShortcut()}</span>
-              </text>
-            </box>
-            <box
-              onMouseOver={() => setHover("next")}
-              onMouseOut={() => setHover(null)}
-              onMouseUp={() => keymap.dispatchCommand("session.child.next")}
-              backgroundColor={hover() === "next" ? theme.backgroundElement : theme.backgroundPanel}
-            >
-              <text fg={theme.text}>
-                Next <span style={{ fg: theme.textMuted }}>{nextShortcut()}</span>
-              </text>
+            <box flexDirection="row" gap={2}>
+              <box
+                onMouseOver={() => setHover("parent")}
+                onMouseOut={() => setHover(null)}
+                onMouseUp={() => keymap.dispatchCommand("session.parent")}
+                backgroundColor={hover() === "parent" ? theme.backgroundElement : theme.backgroundPanel}
+              >
+                <text fg={theme.text}>
+                  Parent <span style={{ fg: theme.textMuted }}>{parentShortcut()}</span>
+                </text>
+              </box>
+              <box
+                onMouseOver={() => setHover("prev")}
+                onMouseOut={() => setHover(null)}
+                onMouseUp={() => keymap.dispatchCommand("session.child.previous")}
+                backgroundColor={hover() === "prev" ? theme.backgroundElement : theme.backgroundPanel}
+              >
+                <text fg={theme.text}>
+                  Prev <span style={{ fg: theme.textMuted }}>{previousShortcut()}</span>
+                </text>
+              </box>
+              <box
+                onMouseOver={() => setHover("next")}
+                onMouseOut={() => setHover(null)}
+                onMouseUp={() => keymap.dispatchCommand("session.child.next")}
+                backgroundColor={hover() === "next" ? theme.backgroundElement : theme.backgroundPanel}
+              >
+                <text fg={theme.text}>
+                  Next <span style={{ fg: theme.textMuted }}>{nextShortcut()}</span>
+                </text>
+              </box>
             </box>
           </box>
         </box>

--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -1,4 +1,5 @@
 import { createMemo, createSignal, Show } from "solid-js"
+import { useLocal } from "../../context/local"
 import { useRouteData } from "../../context/route"
 import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
@@ -29,6 +30,7 @@ export function resolveSubagentVariant(
 export function SubagentFooter() {
   const route = useRouteData("session")
   const sync = useSync()
+  const local = useLocal()
   const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
   const session = createMemo(() => sync.session.get(route.sessionID))
 
@@ -87,6 +89,10 @@ export function SubagentFooter() {
   })
 
   const { theme } = useTheme()
+  const agentColor = createMemo(() => {
+    const agent = session()?.agent
+    return agent ? local.agent.color(agent) : theme.text
+  })
   const keymap = useOpencodeKeymap()
   const parentShortcut = useCommandShortcut("session.parent")
   const previousShortcut = useCommandShortcut("session.child.previous")
@@ -134,7 +140,7 @@ export function SubagentFooter() {
           </Show>
           <box flexDirection="row" justifyContent="space-between" gap={1}>
             <box flexDirection="row" gap={1}>
-              <text fg={theme.text}>
+              <text fg={agentColor()}>
                 <b>{subagentInfo().label}</b>
               </text>
               <Show when={subagentInfo().total > 0}>

--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -3,10 +3,28 @@ import { useRouteData } from "../../context/route"
 import { useSync } from "../../context/sync"
 import { useTheme } from "../../context/theme"
 import { SplitBorder } from "../../ui/border"
-import type { AssistantMessage } from "@opencode-ai/sdk/v2"
+import type { Agent, AssistantMessage, Provider, Session } from "@opencode-ai/sdk/v2"
 import { Locale } from "../../util/locale"
 import { useTerminalDimensions } from "@opentui/solid"
 import { useCommandShortcut, useOpencodeKeymap } from "../../keymap"
+
+type AgentVariantConfig = Pick<Agent, "model" | "variant" | "options">
+type ProviderModelVariants = Pick<Provider["models"][string], "variants">
+
+export function resolveSubagentVariant(
+  sessionModel: Session["model"],
+  agent: AgentVariantConfig | undefined,
+  model: ProviderModelVariants | undefined,
+) {
+  const persisted = sessionModel?.variant
+  if (persisted && persisted !== "default") return persisted
+  if (!sessionModel || !agent?.model || !model?.variants) return undefined
+  if (agent.model.providerID !== sessionModel.providerID || agent.model.modelID !== sessionModel.id) return undefined
+  if (agent.variant && agent.variant in model.variants) return agent.variant
+  const effort = agent.options.reasoningEffort
+  if (typeof effort === "string" && effort in model.variants) return effort
+  return undefined
+}
 
 export function SubagentFooter() {
   const route = useRouteData("session")
@@ -28,6 +46,20 @@ export function SubagentFooter() {
     const index = siblings.findIndex((x) => x.id === s.id)
 
     return { label, index: index + 1, total: siblings.length }
+  })
+
+  const modelInfo = createMemo(() => {
+    const current = session()
+    if (!current?.model) return undefined
+    const sessionModel = current.model
+    const provider = sync.data.provider.find((item) => item.id === sessionModel.providerID)
+    const model = provider?.models[sessionModel.id]
+    const agent = sync.data.agent.find((item) => item.name === current.agent)
+    return {
+      model: model?.name ?? sessionModel.id,
+      provider: provider?.name ?? sessionModel.providerID,
+      variant: resolveSubagentVariant(sessionModel, agent, model),
+    }
   })
 
   const usage = createMemo(() => {
@@ -76,12 +108,29 @@ export function SubagentFooter() {
         backgroundColor={theme.backgroundPanel}
       >
         <box flexDirection="row" justifyContent="space-between" gap={1}>
-          <box flexDirection="row" gap={1}>
-            <text fg={theme.text}>
+          <box flexDirection="row" gap={1} minWidth={0} flexShrink={1} overflow="hidden">
+            <text fg={theme.text} flexShrink={0} wrapMode="none">
               <b>{subagentInfo().label}</b>
             </text>
+            <Show when={modelInfo()}>
+              {(item) => (
+                <text flexShrink={1} wrapMode="none" truncate>
+                  <span style={{ fg: theme.textMuted }}>· </span>
+                  <span style={{ fg: theme.text }}>{item().model} </span>
+                  <span style={{ fg: theme.textMuted }}>{item().provider}</span>
+                  <Show when={item().variant}>
+                    {(variant) => (
+                      <>
+                        <span style={{ fg: theme.textMuted }}> · </span>
+                        <span style={{ fg: theme.warning, bold: true }}>{variant()}</span>
+                      </>
+                    )}
+                  </Show>
+                </text>
+              )}
+            </Show>
             <Show when={subagentInfo().total > 0}>
-              <text style={{ fg: theme.textMuted }}>
+              <text style={{ fg: theme.textMuted }} flexShrink={0} wrapMode="none">
                 ({subagentInfo().index} of {subagentInfo().total})
               </text>
             </Show>
@@ -93,7 +142,7 @@ export function SubagentFooter() {
               )}
             </Show>
           </box>
-          <box flexDirection="row" gap={2}>
+          <box flexDirection="row" gap={2} flexShrink={0}>
             <box
               onMouseOver={() => setHover("parent")}
               onMouseOut={() => setHover(null)}

--- a/packages/tui/test/cli/tui/subagent-footer.test.ts
+++ b/packages/tui/test/cli/tui/subagent-footer.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test"
+import { resolveSubagentVariant } from "../../../src/routes/session/subagent-footer"
+
+const sessionModel = {
+  id: "gpt-5.6-sol",
+  providerID: "openai",
+  variant: "default",
+}
+
+const model = {
+  variants: {
+    medium: { reasoningEffort: "medium" },
+    high: { reasoningEffort: "high" },
+    xhigh: { reasoningEffort: "xhigh" },
+  },
+}
+
+describe("subagent footer variant", () => {
+  test("prefers the persisted non-default variant", () => {
+    const result = resolveSubagentVariant({ ...sessionModel, variant: "xhigh" }, undefined, undefined)
+
+    expect(result).toBe("xhigh")
+  })
+
+  test("uses the matching agent variant for a legacy session", () => {
+    const result = resolveSubagentVariant(
+      sessionModel,
+      {
+        model: { providerID: "openai", modelID: "gpt-5.6-sol" },
+        variant: "high",
+        options: {},
+      },
+      model,
+    )
+
+    expect(result).toBe("high")
+  })
+
+  test("falls back to a supported reasoning effort", () => {
+    const result = resolveSubagentVariant(
+      sessionModel,
+      {
+        model: { providerID: "openai", modelID: "gpt-5.6-sol" },
+        options: { reasoningEffort: "medium" },
+      },
+      model,
+    )
+
+    expect(result).toBe("medium")
+  })
+
+  test("omits configuration for a different model", () => {
+    const result = resolveSubagentVariant(
+      sessionModel,
+      {
+        model: { providerID: "openai", modelID: "gpt-5.6-terra" },
+        variant: "high",
+        options: { reasoningEffort: "medium" },
+      },
+      model,
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  test("omits unsupported configured levels", () => {
+    const result = resolveSubagentVariant(
+      sessionModel,
+      {
+        model: { providerID: "openai", modelID: "gpt-5.6-sol" },
+        variant: "max",
+        options: { reasoningEffort: "minimal" },
+      },
+      model,
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  test("falls through an unsupported agent variant to reasoning effort", () => {
+    const result = resolveSubagentVariant(
+      sessionModel,
+      {
+        model: { providerID: "openai", modelID: "gpt-5.6-sol" },
+        variant: "max",
+        options: { reasoningEffort: "high" },
+      },
+      model,
+    )
+
+    expect(result).toBe("high")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #26266

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds model, provider, and variant details to subagent sessions, similar to the main-agent footer.

A persisted non-default session variant is shown first. Legacy sessions fall back to a matching configured agent variant or supported `reasoningEffort`. Existing usage and navigation details stay unchanged.

### How did you verify your code works?

- `bun test test/cli/tui`
- `bun turbo typecheck`
- Manual TUI verification

### Screenshots / recordings

| Before | After |
| --- | --- |
| ![Subagent footer before](https://raw.githubusercontent.com/samiralibabic/opencode/pr-assets/subagent-footer-before.png) | ![Subagent footer after](https://raw.githubusercontent.com/samiralibabic/opencode/pr-assets/subagent-footer-after.png) |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
