### PR TITLE
fix(session): order messages by time so the run loop can terminate

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -582,18 +582,31 @@ export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: Ses
 // assistant doesn't get mistaken for the most recent turn. tasks are
 // compaction/subtask parts attached to user messages newer than the latest
 // finished assistant — i.e. unprocessed work.
+// Order by wall-clock first, id second. Ids minted by Identifier.ascending()
+// embed a timestamp and so sort chronologically on their own, but sessions can
+// also arrive via `opencode import` from third-party writers whose ids carry no
+// ordering. A single such id sorting above the live conversation used to make
+// the newest message unreachable here, so the run loop's exit test could never
+// pass and opencode re-requested until the provider rejected the
+// assistant-terminated conversation. `time.created` is authoritative; the id
+// stays as the tiebreaker for messages minted within the same millisecond.
+function isNewer(a: { id: string; time: { created: number } }, b: { id: string; time: { created: number } }) {
+  if (a.time.created !== b.time.created) return a.time.created > b.time.created
+  return a.id > b.id
+}
+
 export function latest(msgs: WithParts[]) {
   let user: User | undefined
   let assistant: Assistant | undefined
   let finished: Assistant | undefined
   for (const msg of msgs) {
     const info = msg.info
-    if (info.role === "user" && (!user || info.id > user.id)) user = info
-    if (info.role === "assistant" && (!assistant || info.id > assistant.id)) assistant = info
-    if (info.role === "assistant" && info.finish && (!finished || info.id > finished.id)) finished = info
+    if (info.role === "user" && (!user || isNewer(info, user))) user = info
+    if (info.role === "assistant" && (!assistant || isNewer(info, assistant))) assistant = info
+    if (info.role === "assistant" && info.finish && (!finished || isNewer(info, finished))) finished = info
   }
   const tasks = msgs.flatMap((m) =>
-    finished && m.info.id <= finished.id
+    finished && !isNewer(m.info, finished)
       ? []
       : m.parts.filter((p): p is CompactionPart | SubtaskPart => p.type === "compaction" || p.type === "subtask"),
   )

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1108,11 +1108,22 @@ const layer = Layer.effect(
               (part) => part.type === "tool" && !part.metadata?.providerExecuted && !isOrphanedInterruptedTool(part),
             ) ?? false
 
+          // Compare by wall-clock, not by raw id. Ids only sort chronologically
+          // when minted by Identifier.ascending(), which is not guaranteed for
+          // sessions brought in through `opencode import`; an unordered id here
+          // used to keep this test permanently false, so the loop never exited.
+          // The id remains the tiebreaker within a single millisecond.
+          const assistantFollowsUser =
+            !!lastAssistant &&
+            (lastUser.time.created !== lastAssistant.time.created
+              ? lastUser.time.created < lastAssistant.time.created
+              : lastUser.id < lastAssistant.id)
+
           if (
             lastAssistant?.finish &&
             !["tool-calls"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
-            lastUser.id < lastAssistant.id
+            assistantFollowsUser
           ) {
             const orphan = lastAssistantMsg?.parts.find(
               (part): part is SessionV1.ToolPart => part.type === "tool" && isOrphanedInterruptedTool(part),

--- a/packages/opencode/test/message-latest-ordering.test.ts
+++ b/packages/opencode/test/message-latest-ordering.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test"
+
+import { MessageV2 } from "../src/session/message-v2"
+
+/**
+ * `latest()` used to pick the newest user/assistant message by comparing ids as
+ * plain strings. That holds for ids minted by Identifier.ascending(), which
+ * embed a timestamp, but not for sessions written by anything else — e.g. a
+ * third-party importer emitting uuids. A single imported message whose id
+ * happens to sort high then masquerades as the newest message, the run loop's
+ * exit test (`lastUser.id < lastAssistant.id`) never passes, and opencode
+ * re-requests until the provider rejects the assistant-terminated conversation.
+ */
+function msg(id: string, role: "user" | "assistant", created: number, finish?: string) {
+  return {
+    info: {
+      id,
+      sessionID: "ses_test",
+      role,
+      time: { created },
+      ...(role === "assistant" ? { finish } : {}),
+    },
+    parts: [],
+  } as unknown as MessageV2.WithParts
+}
+
+describe("MessageV2.latest ordering", () => {
+  test("uses chronology, not raw id sort, to find the newest messages", () => {
+    // An imported history whose ids do not sort chronologically: the FIRST
+    // message carries the highest-sorting id.
+    const msgs = [
+      msg("msg_ffffffffffffffffffffffff", "assistant", 1_000, "stop"), // oldest, id sorts highest
+      msg("msg_0000000000000000000000aa", "user", 2_000),
+      msg("msg_0000000000000000000000bb", "assistant", 3_000, "stop"), // newest in time
+    ]
+
+    const { user, assistant } = MessageV2.latest(msgs)
+
+    expect(user?.id).toBe("msg_0000000000000000000000aa")
+    // Raw id sort would return the 1_000ms message here.
+    expect(assistant?.id).toBe("msg_0000000000000000000000bb")
+    expect(assistant?.time.created).toBe(3_000)
+  })
+
+  test("the newest assistant follows the newest user, so the run loop can exit", () => {
+    const msgs = [
+      msg("msg_ffffffffffffffffffffffff", "assistant", 1_000, "stop"),
+      msg("msg_0000000000000000000000aa", "user", 2_000),
+      msg("msg_0000000000000000000000bb", "assistant", 3_000, "stop"),
+    ]
+
+    const { user, assistant } = MessageV2.latest(msgs)
+
+    // What runLoop asserts before breaking out of the loop.
+    expect(user!.time.created).toBeLessThan(assistant!.time.created)
+  })
+
+  test("still orders correctly for natively minted, time-sortable ids", () => {
+    const msgs = [
+      msg("msg_f90250c84002aaaaaaaaaaaaaa", "user", 1_000),
+      msg("msg_f90253552001bbbbbbbbbbbbbb", "assistant", 2_000, "stop"),
+    ]
+
+    const { user, assistant } = MessageV2.latest(msgs)
+
+    expect(user?.id).toBe("msg_f90250c84002aaaaaaaaaaaaaa")
+    expect(assistant?.id).toBe("msg_f90253552001bbbbbbbbbbbbbb")
+  })
+
+  test("ties on timestamp fall back to id order", () => {
+    const msgs = [
+      msg("msg_aaa", "assistant", 5_000, "stop"),
+      msg("msg_bbb", "assistant", 5_000, "stop"),
+    ]
+
+    expect(MessageV2.latest(msgs).assistant?.id).toBe("msg_bbb")
+  })
+})

--- a/packages/opencode/test/message-latest-ordering.test.ts
+++ b/packages/opencode/test/message-latest-ordering.test.ts
@@ -75,4 +75,28 @@ describe("MessageV2.latest ordering", () => {
 
     expect(MessageV2.latest(msgs).assistant?.id).toBe("msg_bbb")
   })
+
+  test("survives compaction: array is reordered and messages are rewritten with new ids", () => {
+    // filterCompacted emits [compaction-user, summary, ...retained tail..., continue-user],
+    // so array position is NOT chronological, and compaction mints fresh ids for the
+    // rewritten messages. latest() must therefore resolve by time (id as tiebreaker only),
+    // never by array position: the OLD retained-tail assistant appears LATER in the array
+    // than the newer summary, and must not be mistaken for the most recent turn.
+    const msgs = [
+      msg("msg_rewrite_compactionuser", "user", 9_000), // compaction user, placed FIRST
+      msg("msg_rewrite_summary", "assistant", 9_001, "stop"), // summary (newest finished assistant)
+      msg("msg_retained_user", "user", 1_000), // retained tail, OLD, appears mid-array
+      msg("msg_retained_assistant", "assistant", 1_001, "stop"), // retained tail assistant, OLD
+      msg("msg_rewrite_continueuser", "user", 9_002), // continue user, newest overall
+    ]
+
+    const { user, assistant, finished } = MessageV2.latest(msgs)
+
+    // newest user is the continue-user, not the mid-array retained-tail user
+    expect(user?.id).toBe("msg_rewrite_continueuser")
+    // newest assistant is the summary, despite the older retained assistant sorting later
+    // in the array (position) — selection is by time, not index
+    expect(assistant?.id).toBe("msg_rewrite_summary")
+    expect(finished?.id).toBe("msg_rewrite_summary")
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #38791

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`latest()` and the run loop's exit test find the newest message by comparing ids as plain strings. That works because `Identifier.ascending()` puts a timestamp in the first 12 chars, so ids happen to sort chronologically. Nothing enforces that for sessions coming in through `opencode import`.

I hit this importing Claude Code sessions with a converter that emitted `msg_<uuid>`. If any imported id sorts above the ids of the live conversation, `latest()` hands back that old message as the newest one. `lastUser.id < lastAssistant.id` is then false forever, the loop never breaks, and it keeps re-requesting. Each retry ends on an assistant message, which Anthropic rejects with "does not support assistant message prefill" — the user just sees "Unexpected server error".

It looks flaky rather than broken because it depends on whether any random id happens to sort high: about 2.6% of them do, so a 3-message session usually survives and a 400-message one never does. That's what put me onto ids in the first place — the same small session passed once and failed once.

The fix is to compare `time.created` and fall back to the id when timestamps match. Nothing changes for normal sessions, since native ids already sort in timestamp order — it only differs when the ids were never chronological to begin with. I applied it in `latest()` (user, assistant, finished, and the `tasks` filter, which assumed the same thing) and in the loop's exit test.

I did not touch the `finish === "stop"` handling. Breaking out purely on the finish reason would also fix my case, but the comment right above says some providers return `stop` with tool calls still pending, so that seemed like a behaviour change rather than a bug fix.

### How did you verify your code works?

Added `packages/opencode/test/message-latest-ordering.test.ts` and checked it fails first: 2 pass / 2 fail on `dev`, 4 pass / 0 fail with the change. The failing assertion is the loop's own precondition — `latest()` returned the 1000ms assistant instead of the 3000ms one.

Before writing the test I confirmed the mechanism against a real provider by putting a proxy in front of it. The successful request came back `stop_reason: "end_turn"` with `message_stop`, and opencode still issued another request one second later with the assistant reply appended. I also ruled out plugins (same failure under `--pure`), missing `step-start`/`step-finish` parts, unpaired `tool_use`, and unsigned thinking blocks — and replaying the captured payload on its own returns 200, so the history itself was valid.

### Screenshots / recordings

N/A, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
