### PR TITLE
feat(app): Improve aesthetics and debuggability. Add a progress bar to TUI start…

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -24,7 +24,14 @@ import {
   Show,
   on,
 } from "solid-js"
-import { TuiPathsProvider, TuiStartupProvider, TuiTerminalEnvironmentProvider, useTuiStartup } from "./context/runtime"
+import {
+  TUI_STARTUP_STAGES,
+  TuiPathsProvider,
+  TuiStartupProvider,
+  TuiTerminalEnvironmentProvider,
+  useTuiStartup,
+  type TuiStartupStage,
+} from "./context/runtime"
 import { DialogProvider, useDialog } from "./ui/dialog"
 import { DialogProvider as DialogProviderList } from "./component/dialog-provider"
 import { ErrorComponent } from "./component/error-component"
@@ -235,120 +242,148 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
       )
       renderer.once("destroy", () => Deferred.doneUnsafe(shutdown, Effect.void))
       const pluginRuntime = createPluginRuntime()
+      const [startupMode, setStartupMode] = createSignal<"dark" | "light">()
+      const [startupStage, setStartupStage] = createSignal<TuiStartupStage>("terminal")
+      // Concurrent or fast-boot completions must never move the visible bar backward.
+      const progress = (stage: TuiStartupStage) => {
+        setStartupStage((current) =>
+          TUI_STARTUP_STAGES.indexOf(stage) > TUI_STARTUP_STAGES.indexOf(current) ? stage : current,
+        )
+      }
 
       yield* Effect.tryPromise(async () => {
+        // Mount before terminal theme detection so startup never presents a blank alternate screen.
+        await render(() => {
+          return (
+            <StartupLoading
+              stage={startupStage}
+              mode={startupMode}
+              hidden={Boolean(process.env.OPENCODE_FAST_BOOT)}
+            >
+              <Show when={startupMode()} keyed>
+                {(mode) => (
+                  <ExitProvider
+                    exit={(reason) => {
+                      if (renderer.isDestroyed) return
+                      exit.reason = reason
+                      destroyRenderer(renderer)
+                    }}
+                  >
+                    <EpilogueProvider set={(value) => (exit.epilogue = value)}>
+                      <ErrorBoundary
+                        fallback={(error, reset) => <ErrorComponent error={error} reset={reset} mode={mode} />}
+                      >
+                        <TuiPathsProvider
+                          value={{
+                            cwd: process.cwd(),
+                            home: global.home,
+                            state: global.state,
+                            worktree: global.data + "/worktree",
+                          }}
+                        >
+                          <TuiTerminalEnvironmentProvider
+                            value={{
+                              platform: process.platform,
+                              multiplexer: process.env.TMUX ? "tmux" : process.env.STY ? "screen" : undefined,
+                              displayServer: process.env.WAYLAND_DISPLAY
+                                ? "wayland"
+                                : process.env.DISPLAY
+                                  ? "x11"
+                                  : undefined,
+                            }}
+                          >
+                            <TuiStartupProvider
+                              value={{
+                                initialRoute: process.env.OPENCODE_ROUTE
+                                  ? JSON.parse(process.env.OPENCODE_ROUTE)
+                                  : undefined,
+                                skipInitialLoading: Boolean(process.env.OPENCODE_FAST_BOOT),
+                                progress,
+                              }}
+                            >
+                              <ClipboardProvider>
+                                <OpencodeKeymapProvider keymap={keymap}>
+                                  <ArgsProvider {...input.args}>
+                                    <KVProvider>
+                                      <ToastProvider>
+                                        <RouteProvider
+                                          initialRoute={
+                                            input.args.continue
+                                              ? {
+                                                  type: "session",
+                                                  sessionID: "dummy",
+                                                }
+                                              : undefined
+                                          }
+                                        >
+                                          <TuiConfigProvider config={input.config}>
+                                            <PluginRuntimeProvider value={pluginRuntime}>
+                                              <SDKProvider
+                                                url={input.url}
+                                                directory={input.directory}
+                                                fetch={input.fetch}
+                                                headers={input.headers}
+                                                events={input.events}
+                                              >
+                                                <PermissionProvider>
+                                                  <ProjectProvider>
+                                                    <SyncProvider>
+                                                      <DataProvider>
+                                                        <ThemeProvider mode={mode}>
+                                                          <LocalProvider>
+                                                            <PromptStashProvider>
+                                                              <DialogProvider>
+                                                                <FrecencyProvider>
+                                                                  <PromptHistoryProvider>
+                                                                    <PromptRefProvider>
+                                                                      <EditorContextProvider>
+                                                                        <LocationProvider>
+                                                                          <App
+                                                                            onSnapshot={input.onSnapshot}
+                                                                            pluginHost={input.pluginHost}
+                                                                          />
+                                                                        </LocationProvider>
+                                                                      </EditorContextProvider>
+                                                                    </PromptRefProvider>
+                                                                  </PromptHistoryProvider>
+                                                                </FrecencyProvider>
+                                                              </DialogProvider>
+                                                            </PromptStashProvider>
+                                                          </LocalProvider>
+                                                        </ThemeProvider>
+                                                      </DataProvider>
+                                                    </SyncProvider>
+                                                  </ProjectProvider>
+                                                </PermissionProvider>
+                                              </SDKProvider>
+                                            </PluginRuntimeProvider>
+                                          </TuiConfigProvider>
+                                        </RouteProvider>
+                                      </ToastProvider>
+                                    </KVProvider>
+                                  </ArgsProvider>
+                                </OpencodeKeymapProvider>
+                              </ClipboardProvider>
+                            </TuiStartupProvider>
+                          </TuiTerminalEnvironmentProvider>
+                        </TuiPathsProvider>
+                      </ErrorBoundary>
+                    </EpilogueProvider>
+                  </ExitProvider>
+                )}
+              </Show>
+            </StartupLoading>
+          )
+        }, renderer)
+
         // Prewarm palette before ThemeProvider mounts so `system` theme avoids a first-paint fallback flash.
         void renderer.getPalette({ size: 16 }).catch(() => undefined)
         const mode = (await renderer.waitForThemeMode(1000)) ?? "dark"
         if (renderer.isDestroyed) return
-
-        await render(() => {
-          return (
-            <ExitProvider
-              exit={(reason) => {
-                if (renderer.isDestroyed) return
-                exit.reason = reason
-                destroyRenderer(renderer)
-              }}
-            >
-              <EpilogueProvider set={(value) => (exit.epilogue = value)}>
-                <ErrorBoundary fallback={(error, reset) => <ErrorComponent error={error} reset={reset} mode={mode} />}>
-                  <TuiPathsProvider
-                    value={{
-                      cwd: process.cwd(),
-                      home: global.home,
-                      state: global.state,
-                      worktree: global.data + "/worktree",
-                    }}
-                  >
-                    <TuiTerminalEnvironmentProvider
-                      value={{
-                        platform: process.platform,
-                        multiplexer: process.env.TMUX ? "tmux" : process.env.STY ? "screen" : undefined,
-                        displayServer: process.env.WAYLAND_DISPLAY
-                          ? "wayland"
-                          : process.env.DISPLAY
-                            ? "x11"
-                            : undefined,
-                      }}
-                    >
-                      <TuiStartupProvider
-                        value={{
-                          initialRoute: process.env.OPENCODE_ROUTE ? JSON.parse(process.env.OPENCODE_ROUTE) : undefined,
-                          skipInitialLoading: Boolean(process.env.OPENCODE_FAST_BOOT),
-                        }}
-                      >
-                        <ClipboardProvider>
-                          <OpencodeKeymapProvider keymap={keymap}>
-                            <ArgsProvider {...input.args}>
-                              <KVProvider>
-                                <ToastProvider>
-                                  <RouteProvider
-                                    initialRoute={
-                                      input.args.continue
-                                        ? {
-                                            type: "session",
-                                            sessionID: "dummy",
-                                          }
-                                        : undefined
-                                    }
-                                  >
-                                    <TuiConfigProvider config={input.config}>
-                                      <PluginRuntimeProvider value={pluginRuntime}>
-                                        <SDKProvider
-                                          url={input.url}
-                                          directory={input.directory}
-                                          fetch={input.fetch}
-                                          headers={input.headers}
-                                          events={input.events}
-                                        >
-                                          <PermissionProvider>
-                                            <ProjectProvider>
-                                              <SyncProvider>
-                                                <DataProvider>
-                                                  <ThemeProvider mode={mode}>
-                                                    <LocalProvider>
-                                                      <PromptStashProvider>
-                                                        <DialogProvider>
-                                                          <FrecencyProvider>
-                                                            <PromptHistoryProvider>
-                                                              <PromptRefProvider>
-                                                                <EditorContextProvider>
-                                                                  <LocationProvider>
-                                                                    <App
-                                                                      onSnapshot={input.onSnapshot}
-                                                                      pluginHost={input.pluginHost}
-                                                                    />
-                                                                  </LocationProvider>
-                                                                </EditorContextProvider>
-                                                              </PromptRefProvider>
-                                                            </PromptHistoryProvider>
-                                                          </FrecencyProvider>
-                                                        </DialogProvider>
-                                                      </PromptStashProvider>
-                                                    </LocalProvider>
-                                                  </ThemeProvider>
-                                                </DataProvider>
-                                              </SyncProvider>
-                                            </ProjectProvider>
-                                          </PermissionProvider>
-                                        </SDKProvider>
-                                      </PluginRuntimeProvider>
-                                    </TuiConfigProvider>
-                                  </RouteProvider>
-                                </ToastProvider>
-                              </KVProvider>
-                            </ArgsProvider>
-                          </OpencodeKeymapProvider>
-                        </ClipboardProvider>
-                      </TuiStartupProvider>
-                    </TuiTerminalEnvironmentProvider>
-                  </TuiPathsProvider>
-                </ErrorBoundary>
-              </EpilogueProvider>
-            </ExitProvider>
-          )
-        }, renderer)
+        batch(() => {
+          setStartupMode(mode)
+          progress("settings")
+        })
       })
       yield* Deferred.await(shutdown)
       return { epilogue: exit.epilogue, reason: exit.reason }
@@ -416,7 +451,11 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       console.error("Failed to load TUI plugins", error)
     })
     .finally(() => {
-      setReady(true)
+      batch(() => {
+        setReady(true)
+        // Plugin settlement is the point where the main interface becomes usable.
+        startup.progress?.("ready")
+      })
     })
 
   // Let selection copy/dismiss win ahead of normal bindings when explicit copy is required.
@@ -1125,9 +1164,6 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
           <pluginRuntime.Slot name="app_bottom" />
         </box>
         <pluginRuntime.Slot name="app" />
-      </Show>
-      <Show when={!startup.skipInitialLoading}>
-        <StartupLoading ready={ready} />
       </Show>
     </box>
   )

--- a/packages/tui/src/component/startup-loading.tsx
+++ b/packages/tui/src/component/startup-loading.tsx
@@ -1,63 +1,69 @@
-import { createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js"
-import { useTheme } from "../context/theme"
-import { Spinner } from "./spinner"
+import { createMemo, Show, type ParentProps } from "solid-js"
+import { useTerminalDimensions } from "@opentui/solid"
+import { DEFAULT_THEMES, resolveTheme } from "../theme"
+import { TUI_STARTUP_STAGES, type TuiStartupStage } from "../context/runtime"
 
-export function StartupLoading(props: { ready: () => boolean }) {
-  const theme = useTheme().theme
-  const [show, setShow] = createSignal(false)
-  const text = createMemo(() => (props.ready() ? "Finishing startup..." : "Loading plugins..."))
-  let wait: NodeJS.Timeout | undefined
-  let hold: NodeJS.Timeout | undefined
-  let stamp = 0
+const labels: Record<TuiStartupStage, string> = {
+  terminal: "Initializing terminal...",
+  settings: "Loading local settings...",
+  workspace: "Loading workspace and providers...",
+  theme: "Applying theme...",
+  plugins: "Loading plugins...",
+  ready: "Ready",
+}
 
-  createEffect(() => {
-    if (props.ready()) {
-      if (wait) {
-        clearTimeout(wait)
-        wait = undefined
-      }
-      if (!show()) return
-      if (hold) return
-
-      const left = 3000 - (Date.now() - stamp)
-      if (left <= 0) {
-        setShow(false)
-        return
-      }
-
-      hold = setTimeout(() => {
-        hold = undefined
-        setShow(false)
-      }, left).unref()
-      return
-    }
-
-    if (hold) {
-      clearTimeout(hold)
-      hold = undefined
-    }
-    if (show()) return
-    if (wait) return
-
-    wait = setTimeout(() => {
-      wait = undefined
-      stamp = Date.now()
-      setShow(true)
-    }, 500).unref()
-  })
-
-  onCleanup(() => {
-    if (wait) clearTimeout(wait)
-    if (hold) clearTimeout(hold)
-  })
+export function StartupLoading(
+  props: ParentProps<{
+    stage: () => TuiStartupStage
+    mode: () => "dark" | "light" | undefined
+    hidden: boolean
+  }>,
+) {
+  const dimensions = useTerminalDimensions()
+  // This renders before KV and Theme providers exist, so use the built-in palette directly.
+  const theme = createMemo(() => resolveTheme(DEFAULT_THEMES.opencode!, props.mode() ?? "dark"))
+  const progress = createMemo(() => startupProgress(props.stage(), Math.max(4, Math.min(24, dimensions().width - 8))))
 
   return (
-    <Show when={show()}>
-      <box position="absolute" zIndex={5000} left={0} right={0} bottom={1} justifyContent="center" alignItems="center">
-        <box backgroundColor={theme.backgroundPanel} paddingLeft={1} paddingRight={1}>
-          <Spinner color={theme.textMuted}>{text()}</Spinner>
+    <box
+      width={dimensions().width}
+      height={dimensions().height}
+      flexDirection="column"
+      backgroundColor={theme().background}
+    >
+      {props.children}
+      <Show when={!props.hidden && props.stage() !== "ready"}>
+        <box
+          position="absolute"
+          zIndex={5000}
+          top={0}
+          bottom={0}
+          left={0}
+          right={0}
+          justifyContent="center"
+          alignItems="center"
+          backgroundColor={theme().background}
+        >
+          <box flexDirection="column" alignItems="center" gap={1}>
+            <text fg={theme().primary}>{progress().bar}</text>
+            <text fg={theme().textMuted}>
+              {progress().completed}/{progress().total} {progress().label}
+            </text>
+          </box>
         </box>
-      </box>
-    </Show>
+      </Show>
+    </box>
   )
+}
+
+export function startupProgress(stage: TuiStartupStage, width: number) {
+  const completed = TUI_STARTUP_STAGES.indexOf(stage)
+  const total = TUI_STARTUP_STAGES.length - 1
+  const filled = Math.round((completed / total) * width)
+  return {
+    bar: `[${"#".repeat(filled)}${"-".repeat(width - filled)}]`,
+    completed,
+    total,
+    label: labels[stage],
+  }
 }

--- a/packages/tui/src/context/kv.tsx
+++ b/packages/tui/src/context/kv.tsx
@@ -4,13 +4,14 @@ import { createSimpleContext } from "./helper"
 import { Flock } from "@opencode-ai/core/util/flock"
 import { Global } from "@opencode-ai/core/global"
 import { readJson, writeJsonAtomic } from "../util/persistence"
-import { useTuiPaths } from "./runtime"
+import { useTuiPaths, useTuiStartup } from "./runtime"
 import path from "path"
 
 export const { use: useKV, provider: KVProvider } = createSimpleContext({
   name: "KV",
   init: () => {
     const paths = useTuiPaths()
+    const startup = useTuiStartup()
     void Global.Path.state
     const file = path.join(paths.state, "kv.json")
     const lock = `tui-kv:${file}`
@@ -27,6 +28,8 @@ export const { use: useKV, provider: KVProvider } = createSimpleContext({
         console.error("Failed to read KV state", { error })
       })
       .finally(() => {
+        // KV gates every downstream provider, so workspace loading starts when this gate opens.
+        startup.progress?.("workspace")
         setReady(true)
       })
 

--- a/packages/tui/src/context/runtime.tsx
+++ b/packages/tui/src/context/runtime.tsx
@@ -13,9 +13,14 @@ export type TuiTerminalEnvironment = Readonly<{
   displayServer?: "wayland" | "x11"
 }>
 
+// Progress counts completed readiness gates, not elapsed startup time.
+export const TUI_STARTUP_STAGES = ["terminal", "settings", "workspace", "theme", "plugins", "ready"] as const
+export type TuiStartupStage = (typeof TUI_STARTUP_STAGES)[number]
+
 export type TuiStartup = Readonly<{
   initialRoute?: unknown
   skipInitialLoading: boolean
+  progress?(stage: TuiStartupStage): void
 }>
 
 const PathsContext = createContext<TuiPaths>()

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -509,6 +509,8 @@ export const {
           })
         })
         .then(() => {
+          // Only blocking workspace data affects readiness; secondary synchronization continues below.
+          startup.progress?.("theme")
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([

--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -28,6 +28,7 @@ import { Global } from "@opencode-ai/core/global"
 import { Glob } from "@opencode-ai/core/util/glob"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
+import { useTuiStartup } from "./runtime"
 
 export type ThemeSource = Readonly<{
   discover(): Promise<Record<string, unknown>>
@@ -105,6 +106,7 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
     const renderer = useRenderer()
     const config = useTuiConfig()
     const kv = useKV()
+    const startup = useTuiStartup()
     const themes = props.source ?? themeSource
     const pick = (value: unknown) => {
       if (value === "dark" || value === "light") return value
@@ -145,6 +147,8 @@ export const { use: useTheme, provider: ThemeProvider } = createSimpleContext({
 
     onMount(() => {
       void Promise.allSettled([resolveSystemTheme(store.mode), syncCustomThemes()]).finally(() => {
+        // Opening the theme gate mounts App, where plugins are the final blocking phase.
+        startup.progress?.("plugins")
         setStore("ready", true)
       })
     })

--- a/packages/tui/test/component/startup-loading.test.tsx
+++ b/packages/tui/test/component/startup-loading.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import { StartupLoading, startupProgress } from "../../src/component/startup-loading"
+
+let setup: Awaited<ReturnType<typeof testRender>> | undefined
+
+afterEach(() => {
+  setup?.renderer.destroy()
+  setup = undefined
+})
+
+test("reports completed startup stages", () => {
+  expect(startupProgress("terminal", 10)).toEqual({
+    bar: "[----------]",
+    completed: 0,
+    total: 5,
+    label: "Initializing terminal...",
+  })
+  expect(startupProgress("workspace", 10)).toEqual({
+    bar: "[####------]",
+    completed: 2,
+    total: 5,
+    label: "Loading workspace and providers...",
+  })
+  expect(startupProgress("ready", 10)).toEqual({
+    bar: "[##########]",
+    completed: 5,
+    total: 5,
+    label: "Ready",
+  })
+})
+
+test("renders progress above startup content", async () => {
+  setup = await testRender(
+    () => (
+      <StartupLoading stage={() => "workspace"} mode={() => "dark"} hidden={false}>
+        <text>Application</text>
+      </StartupLoading>
+    ),
+    { width: 40, height: 10 },
+  )
+  await setup.renderOnce()
+  await setup.renderOnce()
+
+  const frame = setup.captureCharFrame()
+  expect(frame).toContain("[##########--------------]")
+  expect(frame).toContain("2/5 Loading workspace and providers...")
+  expect(frame).not.toContain("Application")
+})
+
+test("reveals startup content when ready", async () => {
+  setup = await testRender(
+    () => (
+      <StartupLoading stage={() => "ready"} mode={() => "dark"} hidden={false}>
+        <text>Application</text>
+      </StartupLoading>
+    ),
+    { width: 40, height: 10 },
+  )
+  await setup.renderOnce()
+  await setup.renderOnce()
+
+  const frame = setup.captureCharFrame()
+  expect(frame).toContain("Application")
+  expect(frame).not.toContain("5/5 Ready")
+})


### PR DESCRIPTION
…up screen.

### Issue for this PR
The commit adds staged startup progress for terminal, settings, workspace, theme, and plugins, directly matching the issue’s frozen-looking startup concern. 


Closes #36195 

### Type of change

- [ ] Bug fix
- [ X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

Added a progress bar while plugins, themes, providers are loaded. This helps in understanding how much more time is there before TUI is usable. 

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?
Please see screenshot below. Ran code, added a simple test. 

### Screenshots / recordings

<img width="788" height="386" alt="image" src="https://github.com/user-attachments/assets/b99b810c-bc00-49d6-a04b-0e385c0a22ae" />


_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
