### PR TITLE
fix(core): harden flaky process and project-copy tests

### DIFF
--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -18,11 +18,13 @@ const waitForFile = (file: string) =>
   Effect.promise(async () => {
     while (true) {
       try {
-        return await fs.readFile(file, "utf8")
+        const content = await fs.readFile(file, "utf8")
+        // Retry empty reads: the path can appear before write contents are visible.
+        if (content !== "") return content
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
-        await new Promise<void>((resolve) => setTimeout(resolve, 10))
       }
+      await new Promise<void>((resolve) => setTimeout(resolve, 10))
     }
   })
 

--- a/packages/core/test/project-copy.test.ts
+++ b/packages/core/test/project-copy.test.ts
@@ -333,29 +333,32 @@ describe("ProjectCopy", () => {
     }),
   )
 
-  it.live("refresh ignores stale git worktree registrations", () =>
-    Effect.gen(function* () {
-      const input = yield* setup()
-      const copy = yield* ProjectCopy.Service
-      const stale = abs(`${input.root.path}-copy-stale`)
-      const target = abs(`${input.root.path}-copy-after-stale`)
-      yield* Effect.addFinalizer(() =>
-        Effect.promise(() => fs.rm(target, { recursive: true, force: true })).pipe(Effect.ignore),
-      )
-      yield* Effect.promise(() => $`git worktree add --detach ${stale} HEAD`.cwd(input.root.path).quiet())
-      yield* Effect.promise(() => fs.rm(stale, { recursive: true, force: true }))
-      yield* Effect.promise(() => $`git worktree add --detach ${target} HEAD`.cwd(input.root.path).quiet())
+  it.live(
+    "refresh ignores stale git worktree registrations",
+    () =>
+      Effect.gen(function* () {
+        const input = yield* setup()
+        const copy = yield* ProjectCopy.Service
+        const stale = abs(`${input.root.path}-copy-stale`)
+        const target = abs(`${input.root.path}-copy-after-stale`)
+        yield* Effect.addFinalizer(() =>
+          Effect.promise(() => fs.rm(target, { recursive: true, force: true })).pipe(Effect.ignore),
+        )
+        yield* Effect.promise(() => $`git worktree add --detach ${stale} HEAD`.cwd(input.root.path).quiet())
+        yield* Effect.promise(() => fs.rm(stale, { recursive: true, force: true }))
+        yield* Effect.promise(() => $`git worktree add --detach ${target} HEAD`.cwd(input.root.path).quiet())
 
-      yield* copy.refresh({ projectID: input.projectID })
+        yield* copy.refresh({ projectID: input.projectID })
 
-      const discovered = abs(yield* Effect.promise(() => fs.realpath(target)))
-      expect(yield* stored(input.projectID)).toEqual(
-        [
-          { directory: input.sourceDirectory, strategy: null },
-          { directory: discovered, strategy: "git_worktree" },
-        ].toSorted((a, b) => a.directory.localeCompare(b.directory)),
-      )
-    }),
+        const discovered = abs(yield* Effect.promise(() => fs.realpath(target)))
+        expect(yield* stored(input.projectID)).toEqual(
+          [
+            { directory: input.sourceDirectory, strategy: null },
+            { directory: discovered, strategy: "git_worktree" },
+          ].toSorted((a, b) => a.directory.localeCompare(b.directory)),
+        )
+      }),
+    15_000,
   )
 
   it.live("refresh ignores existing directories that are no longer git checkouts", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #37321

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Process readiness wait returned empty file contents under a CI race, and the project-copy stale-worktree refresh exceeded the default 5s timeout on Windows CI. `waitForFile` now retries empty reads, and the stale-worktree test timeout is raised to 15s.

### How did you verify your code works?

`bun typecheck` in `packages/core`; repeated `bun test` runs of the two flaky cases (process interrupt/timeout + project-copy stale refresh).

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR