### PR TITLE
fix(provider): allow provider hook for non-catalog providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1397,8 +1397,18 @@ const layer = Layer.effect(
           const providerID = ProviderV2.ID.make(p.id)
           if (disabled.has(providerID)) continue
 
-          const provider = database[providerID]
-          if (!provider) continue
+          let provider = database[providerID]
+          if (!provider) {
+            provider = {
+              id: providerID,
+              name: p.id,
+              source: "config",
+              env: [],
+              options: {},
+              models: {},
+            }
+            database[providerID] = provider
+          }
           const pluginAuth = yield* auth.get(providerID).pipe(Effect.orDie)
 
           provider.models = yield* Effect.promise(async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #38839

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a plugin registers a `ProviderHook` targeting a provider not in the models-dev catalog (e.g., cursor via `opencode-cursor-oauth`), the hook is silently skipped because `database[providerID]` is `undefined` at `provider.ts:1375`. The catalog builder only iterates providers that already exist in the built-in catalog, so third-party plugins can never populate models for custom providers.

The fix creates a skeleton provider entry when `database[providerID]` is undefined, allowing the plugins `models()` function to populate it. The skeleton is stored in `database` so the subsequent `auth.loader` step picks it up via `mergeProvider()`.

### How did you verify your code works?

Tested with `opencode-cursor-oauth` plugin on opencode 1.18.4:
- Cursor models appear in the model picker
- Inference works through the local proxy
- Token refresh works correctly

### Screenshots / recordings

_N/A — no UI change_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR