### PR TITLE
feat(app): add pinned sidebar option

### DIFF
--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -7,6 +7,7 @@ import { TextInputV2 } from "@opencode-ai/ui/v2/text-input-v2"
 import { useTheme, type ColorScheme } from "@opencode-ai/ui/theme/context"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { useLanguage } from "@/context/language"
+import { useLayout } from "@/context/layout"
 import { usePermission } from "@/context/permission"
 import { usePlatform } from "@/context/platform"
 import { useServerSync } from "@/context/server-sync"
@@ -86,6 +87,7 @@ export const SettingsGeneralV2: Component<{
 }> = (props) => {
   const theme = useTheme()
   const language = useLanguage()
+  const layout = useLayout()
   const permission = usePermission()
   const platform = usePlatform()
   const dialog = useDialog()
@@ -407,6 +409,18 @@ export const SettingsGeneralV2: Component<{
             <Switch
               checked={settings.general.showCustomAgents()}
               onChange={(checked) => settings.general.setShowCustomAgents(checked)}
+            />
+          </div>
+        </SettingsRowV2>
+
+        <SettingsRowV2
+          title={language.t("settings.general.row.pinSidebar.title")}
+          description={language.t("settings.general.row.pinSidebar.description")}
+        >
+          <div data-action="settings-pin-sidebar">
+            <Switch
+              checked={layout.sidebar.fixed()}
+              onChange={(checked) => layout.sidebar.setFixed(checked)}
             />
           </div>
         </SettingsRowV2>

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -273,6 +273,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       createStore({
         sidebar: {
           opened: false,
+          fixed: false,
           width: DEFAULT_SIDEBAR_WIDTH,
           workspaces: {} as Record<string, boolean>,
           workspacesDefault: false,
@@ -660,14 +661,22 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
       },
       sidebar: {
-        opened: createMemo(() => store.sidebar.opened),
+        opened: createMemo(() => store.sidebar.fixed || store.sidebar.opened),
+        fixed: createMemo(() => store.sidebar.fixed ?? false),
+        setFixed(value: boolean) {
+          setStore("sidebar", "fixed", value)
+          if (value) setStore("sidebar", "opened", true)
+        },
         open() {
+          if (store.sidebar.fixed) return
           setStore("sidebar", "opened", true)
         },
         close() {
+          if (store.sidebar.fixed) return
           setStore("sidebar", "opened", false)
         },
         toggle() {
+          if (store.sidebar.fixed) return
           setStore("sidebar", "opened", (x) => !x)
         },
         width: createMemo(() => store.sidebar.width),

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -895,6 +895,8 @@ export const dict = {
   "settings.general.row.showCustomAgents.title": "Show agent",
   "settings.general.row.showCustomAgents.description":
     "Switch between agents in the composer. When hidden, defaults to Build agent.",
+  "settings.general.row.pinSidebar.title": "Pin sidebar",
+  "settings.general.row.pinSidebar.description": "Always show the sidebar expanded",
   "settings.general.row.reasoningSummaries.title": "Show reasoning summaries",
   "settings.general.row.reasoningSummaries.description": "Display model reasoning summaries in the timeline",
   "settings.general.row.shellToolPartsExpanded.title": "Expand shell tool parts",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -792,6 +792,8 @@ export const dict = {
   "settings.general.row.mobileTitlebarBottom.description": "在移动设备上将标题栏和会话标签页置于屏幕底部",
   "settings.general.row.showCustomAgents.title": "自定义智能体",
   "settings.general.row.showCustomAgents.description": "在输入框中显示智能体选择器",
+  "settings.general.row.pinSidebar.title": "固定侧边栏",
+  "settings.general.row.pinSidebar.description": "始终展开显示侧边栏",
   "settings.general.row.reasoningSummaries.title": "显示推理摘要",
   "settings.general.row.reasoningSummaries.description": "在时间线中显示模型推理摘要",
   "settings.general.row.shellToolPartsExpanded.title": "展开 shell 工具部分",


### PR DESCRIPTION
## Summary

Add a **Pin sidebar** toggle in Settings > General > Advanced. When enabled, the sidebar stays expanded at all times and cannot be collapsed via toggle or keyboard shortcut.

## Changes

- **packages/app/src/context/layout.tsx**: Added ixed boolean to the sidebar persisted store (layout.v6). When ixed is true, opened() always returns 	rue and open()/close()/	oggle() become no-ops. Added ixed() accessor and setFixed() API.
- **packages/app/src/components/settings-v2/general.tsx**: Added a Switch toggle in the Advanced section bound to layout.sidebar.fixed / setFixed.
- **packages/app/src/i18n/en.ts**, **zh.ts**: Added translation keys for the new settings row.

## Why

Some users prefer the sidebar to always remain expanded rather than collapsing to the 48px rail with hover-to-expand behavior. This adds a persistent pin option while keeping the default (collapsible) behavior unchanged.