### PR TITLE
docs: add opencode-cliproxyapi to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-cliproxyapi](https://github.com/yourcasualdev/opencode-cliproxyapi)                      | Discover and use every model exposed by CLIProxyAPI directly in OpenCode                           |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — ecosystem listing.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds opencode-cliproxyapi to the Plugins table. The plugin discovers the live model catalog from a CLIProxyAPI server and exposes those models in OpenCode's standard model picker.

### How did you verify your code works?

Verified the table row is valid Markdown and the linked repository is public.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR