### PR TITLE
fix(session): reparent orphaned assistant messages after revert cleanup

### DIFF
--- a/packages/opencode/src/session/revert.ts
+++ b/packages/opencode/src/session/revert.ts
@@ -119,6 +119,18 @@ export const layer = Layer.effect(
         }
         remove.push(msg)
       }
+      const lastUserBeforeRevert = msgs.findLast((m) => m.info.role === "user" && m.info.id < messageID)
+      for (const msg of msgs) {
+        if (msg.info.role !== "assistant") continue
+        if (remove.some((r) => r.info.id === msg.info.id)) continue
+        const parentID = msg.info.parentID
+        if (!remove.some((r) => r.info.id === parentID)) continue
+        if (!lastUserBeforeRevert) continue
+        yield* sessions.updateMessage({
+          ...msg.info,
+          parentID: lastUserBeforeRevert.info.id,
+        })
+      }
       for (const msg of remove) {
         yield* sync.run(MessageV2.Event.Removed, {
           sessionID,


### PR DESCRIPTION
### Issue for this PR

Closes #38864

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When cleanup() in revert.ts removes messages during /undo revert, child assistant messages whose parentID points to a deleted message become orphaned. On next session load, the UI tries to resolve the missing parent and crashes with NotFoundError.

The fix adds a loop before message deletion that finds any assistant messages referencing a removed message and reparents them to the last surviving user message before the revert point.

I understand why this works: parentID is a required field on assistant messages pointing to the user message that triggered them. When the parent gets deleted by cleanup, the child still references it. Reparenting to the nearest surviving user message before the revert point preserves the conversation chain.

### How did you verify your code works?

Reproduced the bug locally: did /undo revert in a session with assistant messages referencing the reverted message, confirmed the 404 crash on session reload. Applied the fix, confirmed session loads without error. bun typecheck passes with no new errors.

### Screenshots / recordings

N/A - backend fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR