### PR TITLE
feat: PTY-based interactive secure input for sudo/ssh password prompts

### DIFF
--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -19,6 +19,7 @@ import { Agent } from "@/agent/agent"
 import { Skill } from "@/skill"
 import { Discovery } from "@/skill/discovery"
 import { Question } from "@/question"
+import { SecureInput } from "@/secure-input"
 import { Permission } from "@/permission"
 import { Todo } from "@/session/todo"
 import { Session } from "@/session/session"
@@ -74,6 +75,7 @@ export const AppLayer = AppNodeBuilderV1.build(
     Skill.node,
     Discovery.node,
     Question.node,
+    SecureInput.node,
     Permission.node,
     Todo.node,
     Session.node,

--- a/packages/opencode/src/id/id.ts
+++ b/packages/opencode/src/id/id.ts
@@ -11,6 +11,7 @@ const prefixes = {
   pty: "pty",
   tool: "tool",
   workspace: "wrk",
+  secureinput: "sec",
 } as const
 
 const LENGTH = 26

--- a/packages/opencode/src/secure-input/index.ts
+++ b/packages/opencode/src/secure-input/index.ts
@@ -1,0 +1,283 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer, Schema, Duration, Context } from "effect"
+import { InstanceState } from "@/effect/instance-state"
+import { SessionID } from "@/session/schema"
+import { SecureInputID, nextSecureInputID, SecureInputRequest } from "./schema"
+export { SecureInputID, SecureInputRequest } from "./schema"
+import { spawn } from "@opencode-ai/core/pty"
+
+const PASSWORD_PATTERNS = [
+  /\[sudo\] password for .+:/i,
+  /Password:/i,
+  /Enter passphrase for .+:/i,
+  /BECOME password:/i,
+  /SSH password:/i,
+  /passphrase for .+:/i,
+  /password for .+:/i,
+  /Sorry, try again\./i,
+] as const
+
+const INTERACTIVE_COMMANDS = [
+  /^sudo\s/,
+  /\bsudo\s/,
+  /^ssh\b/,
+  /\bssh\b/,
+  /^ansible\b.*-K\b/,
+  /^ansible\b.*--ask-become-pass\b/,
+  /^ansible-playbook\b.*-K\b/,
+  /^ansible-playbook\b.*--ask-become-pass\b/,
+  /^su\s/,
+  /^gpg\s/,
+] as const
+
+export function isInteractiveCommand(command: string): boolean {
+  return INTERACTIVE_COMMANDS.some((re) => re.test(command))
+}
+
+export function detectPasswordPrompt(output: string): string | undefined {
+  for (const re of PASSWORD_PATTERNS) {
+    const match = output.match(re)
+    if (match) return match[0]
+  }
+  return undefined
+}
+
+export class CancelledError extends Schema.TaggedErrorClass<CancelledError>()("SecureInputCancelledError", {}) {
+  override get message() {
+    return "The user cancelled the secure input prompt"
+  }
+}
+
+export class TimedOutError extends Schema.TaggedErrorClass<TimedOutError>()("SecureInputTimedOutError", {}) {
+  override get message() {
+    return "Secure input request timed out"
+  }
+}
+
+export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("SecureInput.NotFoundError", {
+  requestID: SecureInputID,
+}) {}
+
+interface PendingEntry {
+  info: SecureInputRequest
+  resolve: (value: string) => void
+  reject: (error: CancelledError | TimedOutError) => void
+  promise: Promise<string>
+}
+
+interface State {
+  pending: Map<SecureInputID, PendingEntry>
+}
+
+export interface Interface {
+  readonly request: (input: {
+    sessionID: SessionID
+    prompt: string
+    command?: string
+  }) => Effect.Effect<string, CancelledError | TimedOutError>
+  readonly submit: (input: { requestID: SecureInputID; input: string }) => Effect.Effect<void, NotFoundError>
+  readonly cancel: (requestID: SecureInputID) => Effect.Effect<void, NotFoundError>
+  readonly list: () => Effect.Effect<ReadonlyArray<SecureInputRequest>>
+  readonly execute: (input: {
+    command: string
+    cwd: string
+    env: Record<string, string>
+    sessionID: SessionID
+    timeout: Duration.DurationInput
+  }) => Effect.Effect<{ output: string; exitCode: number | null }>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SecureInput") {}
+
+
+function createEntry(info: SecureInputRequest): PendingEntry {
+  let resolve!: (value: string) => void
+  let reject!: (error: CancelledError | TimedOutError) => void
+  const promise = new Promise<string>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { info, resolve, reject, promise }
+}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const state = yield* InstanceState.make<State>(
+      Effect.fn("SecureInput.state")(function* () {
+        const pending = new Map<SecureInputID, PendingEntry>()
+        yield* Effect.addFinalizer(
+          Effect.sync(() => {
+            for (const item of pending.values()) {
+              item.reject(new CancelledError())
+            }
+            pending.clear()
+          }),
+        )
+        return { pending }
+      }),
+    )
+
+    const getPending = () => Effect.map(InstanceState.get(state), (s) => s.pending)
+
+    const request = Effect.fn("SecureInput.request")(function* (input: {
+      sessionID: SessionID
+      prompt: string
+      command?: string
+    }) {
+      const pending = yield* getPending()
+      const id = nextSecureInputID()
+      yield* Effect.logInfo("requesting secure input", { id })
+
+      const info: SecureInputRequest = {
+        id,
+        sessionID: input.sessionID,
+        prompt: input.prompt,
+        command: input.command,
+      }
+      const entry = createEntry(info)
+      pending.set(id, entry)
+
+      return yield* Effect.tryPromise({
+        try: () => entry.promise,
+        catch: (error) => error as CancelledError | TimedOutError,
+      }).pipe(
+        Effect.ensuring(Effect.sync(() => pending.delete(id))),
+      )
+    })
+
+    const submit = Effect.fn("SecureInput.submit")(function* (input: {
+      requestID: SecureInputID
+      input: string
+    }) {
+      const pending = yield* getPending()
+      const existing = pending.get(input.requestID)
+      if (!existing) {
+        yield* Effect.logWarning("submit for unknown request", { requestID: input.requestID })
+        return yield* new NotFoundError({ requestID: input.requestID })
+      }
+      pending.delete(input.requestID)
+      yield* Effect.logInfo("secure input submitted", { requestID: input.requestID })
+      existing.resolve(input.input)
+    })
+
+    const cancel = Effect.fn("SecureInput.cancel")(function* (requestID: SecureInputID) {
+      const pending = yield* getPending()
+      const existing = pending.get(requestID)
+      if (!existing) {
+        yield* Effect.logWarning("cancel for unknown request", { requestID })
+        return yield* new NotFoundError({ requestID })
+      }
+      pending.delete(requestID)
+      yield* Effect.logInfo("secure input cancelled", { requestID })
+      existing.reject(new CancelledError())
+    })
+
+    const list = Effect.fn("SecureInput.list")(function* () {
+      const pending = yield* getPending()
+      return Array.from(pending.values(), (x) => x.info)
+    })
+
+    const execute = Effect.fn("SecureInput.execute")(function* (input: {
+      command: string
+      cwd: string
+      env: Record<string, string>
+      sessionID: SessionID
+      timeout: Duration.DurationInput
+    }) {
+      const pending = yield* getPending()
+      const shell = process.platform === "win32" ? "cmd.exe" : "/bin/bash"
+      const timeoutMs = Duration.toMillis(Duration.decode(input.timeout))
+
+      const pty = yield* Effect.sync(() =>
+        spawn(shell, ["-c", input.command], {
+          name: "xterm-256color",
+          cwd: input.cwd,
+          env: { ...input.env, TERM: "xterm-256color" } as Record<string, string>,
+        }),
+      )
+
+      return yield* Effect.promise<{ output: string; exitCode: number | null }>(
+        () =>
+          new Promise<{ output: string; exitCode: number | null }>((resolve) => {
+            let output = ""
+            let exitCode: number | null = null
+            let passwordBuffer = ""
+            let currentEntry: PendingEntry | null = null
+            let currentID: SecureInputID | null = null
+
+            const dataDisp = pty.onData((chunk: string) => {
+              output += chunk
+
+              if (currentEntry) {
+                if (currentID) pending.delete(currentID)
+                currentEntry = null
+                currentID = null
+                passwordBuffer = ""
+                return
+              }
+
+              passwordBuffer += chunk
+              if (Buffer.byteLength(passwordBuffer, "utf-8") > 4096) {
+                passwordBuffer = passwordBuffer.slice(-2048)
+              }
+
+              const promptText = detectPasswordPrompt(passwordBuffer)
+              if (!promptText) return
+
+              const id = nextSecureInputID()
+              currentID = id
+              const info: SecureInputRequest = {
+                id,
+                sessionID: input.sessionID,
+                prompt: promptText,
+                command: input.command,
+              }
+              currentEntry = createEntry(info)
+              pending.set(id, currentEntry)
+              output = output.replace(promptText, "[password supplied]")
+              passwordBuffer = ""
+
+              currentEntry.promise.then((password) => {
+                pty.write(password + "\n")
+              }).catch(() => {
+                pty.kill()
+              })
+            })
+
+            const exitDisp = pty.onExit((event) => {
+              exitCode = event.exitCode
+              if (currentID && currentEntry) {
+                pending.delete(currentID)
+                currentEntry.reject(new CancelledError())
+              }
+              resolve({ output, exitCode })
+            })
+
+            const timeoutId = setTimeout(() => {
+              if (exitCode === null) {
+                pty.kill()
+                if (currentID && currentEntry) {
+                  pending.delete(currentID)
+                  currentEntry.reject(new TimedOutError())
+                }
+                resolve({ output, exitCode: null })
+              }
+            }, timeoutMs)
+
+            return () => {
+              clearTimeout(timeoutId)
+              dataDisp.dispose()
+              exitDisp.dispose()
+            }
+          }),
+      )
+    })
+
+    return Service.of({ request, submit, cancel, list, execute })
+  }),
+)
+
+export const node = LayerNode.make({ service: Service, layer, deps: [] })
+
+export * as SecureInput from "."

--- a/packages/opencode/src/secure-input/schema.ts
+++ b/packages/opencode/src/secure-input/schema.ts
@@ -1,0 +1,23 @@
+import { Schema } from "effect"
+import { create } from "@/id/id"
+
+const prefix = "sec"
+
+export const SecureInputID = Schema.String.pipe(Schema.brand("SecureInputID"))
+export type SecureInputID = typeof SecureInputID.Type
+
+export function nextSecureInputID(id?: string): SecureInputID {
+  if (id !== undefined) {
+    if (!id.startsWith(prefix + "_")) throw new Error(`ID ${id} does not start with ${prefix}_`)
+    return id as SecureInputID
+  }
+  return create(prefix, "ascending") as SecureInputID
+}
+
+export const SecureInputRequest = Schema.Struct({
+  id: SecureInputID,
+  sessionID: Schema.String,
+  prompt: Schema.String,
+  command: Schema.optional(Schema.String),
+})
+export type SecureInputRequest = Schema.Schema.Type<typeof SecureInputRequest>

--- a/packages/opencode/src/server/routes/instance/httpapi/api.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/api.ts
@@ -21,6 +21,7 @@ import { ProjectCopyApi } from "./groups/project-copy"
 import { ProviderApi } from "./groups/provider"
 import { PtyApi, PtyConnectApi } from "./groups/pty"
 import { QuestionApi } from "./groups/question"
+import { SecureInputApi } from "./groups/secure-input"
 import { SessionApi } from "./groups/session"
 import { SyncApi } from "./groups/sync"
 import { TuiApi } from "./groups/tui"
@@ -70,6 +71,7 @@ export const InstanceHttpApi = HttpApi.make("opencode-instance")
   .addHttpApi(QuestionApi)
   .addHttpApi(PermissionApi)
   .addHttpApi(ProviderApi)
+  .addHttpApi(SecureInputApi)
   .addHttpApi(SessionApi)
   .addHttpApi(SyncApi)
   .addHttpApi(TuiApi)

--- a/packages/opencode/src/server/routes/instance/httpapi/errors.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/errors.ts
@@ -122,6 +122,15 @@ export class SessionBusyError extends Schema.TaggedErrorClass<SessionBusyError>(
   { httpApiStatus: 409 },
 ) {}
 
+export class SecureInputNotFoundError extends Schema.TaggedErrorClass<SecureInputNotFoundError>()(
+  "SecureInputNotFoundError",
+  {
+    requestID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
 export class QuestionNotFoundError extends Schema.TaggedErrorClass<QuestionNotFoundError>()(
   "QuestionNotFoundError",
   {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/secure-input.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/secure-input.ts
@@ -1,0 +1,72 @@
+import { SecureInput } from "@/secure-input"
+import { SecureInputID } from "@/secure-input/schema"
+import { Schema } from "effect"
+import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { SecureInputNotFoundError } from "../errors"
+import { Authorization } from "../middleware/authorization"
+import { InstanceContextMiddleware } from "../middleware/instance-context"
+import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
+import { described } from "./metadata"
+
+const root = "/secure-input"
+const SubmitPayload = Schema.Struct({
+  input: Schema.String,
+})
+
+export const SecureInputApi = HttpApi.make("secure-input")
+  .add(
+    HttpApiGroup.make("secure-input")
+      .add(
+        HttpApiEndpoint.get("list", root, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Array(SecureInput.SecureInputRequest), "List of pending secure input requests"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "secure-input.list",
+            summary: "List pending secure input requests",
+            description: "Get all pending secure input (password) requests across all sessions.",
+          }),
+        ),
+        HttpApiEndpoint.post("submit", `${root}/:requestID/submit`, {
+          params: { requestID: SecureInputID },
+          query: WorkspaceRoutingQuery,
+          payload: SubmitPayload,
+          success: described(Schema.Boolean, "Secure input submitted successfully"),
+          error: [HttpApiError.BadRequest, SecureInputNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "secure-input.submit",
+            summary: "Submit secure input",
+            description: "Submit a password or other secure input for a pending request.",
+          }),
+        ),
+        HttpApiEndpoint.post("cancel", `${root}/:requestID/cancel`, {
+          params: { requestID: SecureInputID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "Secure input cancelled successfully"),
+          error: [HttpApiError.BadRequest, SecureInputNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "secure-input.cancel",
+            summary: "Cancel secure input request",
+            description: "Cancel a pending secure input request.",
+          }),
+        ),
+      )
+      .annotateMerge(
+        OpenApi.annotations({
+          title: "secure-input",
+          description: "Secure input (password) routes.",
+        }),
+      )
+      .middleware(InstanceContextMiddleware)
+      .middleware(WorkspaceRoutingMiddleware)
+      .middleware(Authorization),
+  )
+  .annotateMerge(
+    OpenApi.annotations({
+      title: "opencode HttpApi",
+      version: "0.0.1",
+      description: "Effect HttpApi surface for instance routes.",
+    }),
+  )

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Stream, Option } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -21,6 +21,7 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { ShellPrompt, type Parameters } from "./shell/prompt"
 import { BashArity } from "@/permission/arity"
+import { SecureInput } from "@/secure-input"
 
 export { Parameters } from "./shell/prompt"
 
@@ -627,6 +628,30 @@ export const ShellTool = Tool.define(
                   yield* ask(ctx, scan, params)
                 }),
               )
+
+              const wantsInteractive = params.interactive ?? SecureInput.isInteractiveCommand(params.command)
+              if (wantsInteractive) {
+                const secInputOpt = yield* Effect.serviceOption(SecureInput.Service)
+                if (Option.isSome(secInputOpt)) {
+                  const secInput = secInputOpt.value
+                  const ptyResult = yield* secInput.execute({
+                    command: params.command,
+                    cwd,
+                    env: yield* shellEnv(ctx, cwd),
+                    sessionID: ctx.sessionID,
+                    timeout,
+                  })
+                  return {
+                    title: params.command,
+                    metadata: {
+                      output: ptyResult.output || "(no output)",
+                      exit: ptyResult.exitCode,
+                      truncated: false,
+                    },
+                    output: ptyResult.output || "(no output)",
+                  }
+                }
+              }
 
               return yield* run(
                 {

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -19,6 +19,10 @@ export function parameterSchema() {
     workdir: Schema.optional(Schema.String).annotate({
       description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
     }),
+    interactive: Schema.optional(Schema.Boolean).annotate({
+      description:
+        "Set to true for commands that require interactive password/sudo input (sudo, ssh -t, ansible -K). When enabled, the user will be prompted securely for passwords. Auto-detected for common patterns.",
+    }),
   })
 }
 


### PR DESCRIPTION
## Summary

Adds a PTY-based interactive command execution path that intercepts password prompts (sudo, ssh, etc.) and routes them through a secure input mechanism, allowing users to respond to password prompts via the UI.

Based on and significantly revamped from PR #38640 by @ziuus which had become outdated.

## Key Changes

### New Module: `packages/opencode/src/secure-input/`
- **schema.ts** — Branded `SecureInputID` + `SecureInputRequest` schema (id, sessionID, prompt, command)
- **index.ts** — SecureInput service with:
  - `request()` — Creates a pending password prompt request, returning a Promise<string>
  - `submit()` — Fulfills a pending request with user-provided input
  - `cancel()` — Cancels a pending request
  - `list()` — Lists all pending requests
  - `execute()` — PTY-based command execution that detects password prompts and creates pending requests automatically using the @opencode-ai/core/pty spawn API

### Shell Tool Integration (`packages/opencode/src/tool/shell.ts`)
- Checks `params.interactive` boolean or auto-detects interactive commands via `SecureInput.isInteractiveCommand()`
- When interactive, executes via SecureInput PTY instead of normal ChildProcessSpawner
- Falls back to normal execution if SecureInput service is not available

### Shell Prompt (`packages/opencode/src/tool/shell/prompt.ts`)
- Added optional `interactive` parameter to the shell tool schema with description

### HTTP API Routes (`packages/opencode/src/server/routes/instance/httpapi/groups/secure-input.ts`)
- `GET /secure-input` — List pending requests
- `POST /secure-input/:requestID/submit` — Submit secure input
- `POST /secure-input/:requestID/cancel` — Cancel a request

### Registration
- `SecureInputApi` registered in `InstanceHttpApi`
- `SecureInput.node` registered in `AppLayer`
- `secureinput` prefix (`sec`) added to ID registry