### PR TITLE
feat(opencode): add --resume session picker

### DIFF
--- a/packages/opencode/src/cli/cmd/attach.ts
+++ b/packages/opencode/src/cli/cmd/attach.ts
@@ -28,6 +28,10 @@ export const AttachCommand = cmd({
         type: "string",
         describe: "session id to continue",
       })
+      .option("resume", {
+        type: "boolean",
+        describe: "pick a session to resume from the sessions in this directory",
+      })
       .option("fork", {
         type: "boolean",
         describe: "fork the session when continuing (use with --continue or --session)",
@@ -66,6 +70,17 @@ export const AttachCommand = cmd({
       return
     }
     const noReplay = args.replay === false || args.noReplay === true
+
+    if (args.resume && (args.continue || args.session)) {
+      UI.error("--resume cannot be used with --continue or --session")
+      process.exitCode = 1
+      return
+    }
+    if (args.resume && args.mini) {
+      UI.error("--resume is not supported with --mini; use --continue or --session")
+      process.exitCode = 1
+      return
+    }
 
     const directory = (() => {
       if (!args.dir) return undefined
@@ -138,6 +153,7 @@ export const AttachCommand = cmd({
         args: {
           continue: args.continue,
           sessionID: args.session,
+          resume: args.resume,
           fork: args.fork,
         },
         directory,

--- a/packages/opencode/src/cli/cmd/tui.ts
+++ b/packages/opencode/src/cli/cmd/tui.ts
@@ -93,6 +93,10 @@ export const TuiThreadCommand = cmd({
         type: "string",
         describe: "session id to continue",
       })
+      .option("resume", {
+        type: "boolean",
+        describe: "pick a session to resume from the sessions in this directory",
+      })
       .option("fork", {
         type: "boolean",
         describe: "fork the session when continuing (use with --continue or --session)",
@@ -148,6 +152,17 @@ export const TuiThreadCommand = cmd({
       return
     }
     const noReplay = args.replay === false || args.noReplay === true
+
+    if (args.resume && (args.continue || args.session)) {
+      UI.error("--resume cannot be used with --continue or --session")
+      process.exitCode = 1
+      return
+    }
+    if (args.resume && args.mini) {
+      UI.error("--resume is not supported with --mini; use --continue or --session")
+      process.exitCode = 1
+      return
+    }
 
     if (args.mini) {
       const network = ["--port", "--hostname", "--mdns", "--no-mdns", "--mdns-domain", "--cors"].find((option) =>
@@ -287,6 +302,7 @@ export const TuiThreadCommand = cmd({
             args: {
               continue: args.continue,
               sessionID: args.session,
+              resume: args.resume,
               agent: args.agent,
               model: args.model,
               prompt,

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -58,6 +58,7 @@ Options:
       --dir           directory to run in                                                   [string]
   -c, --continue      continue the last session                                            [boolean]
   -s, --session       session id to continue                                                [string]
+      --resume        pick a session to resume from the sessions in this directory         [boolean]
       --fork          fork the session when continuing (use with --continue or --session)  [boolean]
   -p, --password      basic auth password (defaults to OPENCODE_SERVER_PASSWORD)            [string]
   -u, --username      basic auth username (defaults to OPENCODE_SERVER_USERNAME or 'opencode')

--- a/packages/opencode/test/cli/tui/thread.test.ts
+++ b/packages/opencode/test/cli/tui/thread.test.ts
@@ -98,4 +98,50 @@ describe("tui thread", () => {
       expect(result.stderr).toContain("--port cannot be used with --mini")
     }),
   )
+
+  cliIt.live("rejects --resume with --continue", ({ opencode }) =>
+    Effect.gen(function* () {
+      const result = yield* opencode.spawn(["--resume", "--continue"])
+
+      opencode.expectExit(result, 1)
+      expect(result.stderr).toContain("--resume cannot be used with --continue or --session")
+    }),
+  )
+
+  cliIt.live("rejects --resume with --mini", ({ opencode }) =>
+    Effect.gen(function* () {
+      const result = yield* opencode.spawn(["--resume", "--mini"])
+
+      opencode.expectExit(result, 1)
+      expect(result.stderr).toContain("--resume is not supported with --mini; use --continue or --session")
+    }),
+  )
+
+  cliIt.live("rejects --resume with --fork", ({ opencode, home }) =>
+    Effect.gen(function* () {
+      // The fork check runs after `await import("@/config/tui")`, which loads
+      // packages/tui .tsx files. Bun resolves JSX settings from the tsconfig at
+      // the subprocess cwd, so mirror the package tsconfig's @opentui/solid
+      // settings or transpilation falls back to react/jsx-dev-runtime.
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(home, "tsconfig.json"),
+          JSON.stringify({ compilerOptions: { jsx: "preserve", jsxImportSource: "@opentui/solid" } }),
+        ),
+      )
+      const result = yield* opencode.spawn(["--resume", "--fork"])
+
+      opencode.expectExit(result, 1)
+      expect(result.stderr).toContain("--fork requires --continue or --session")
+    }),
+  )
+
+  cliIt.live("rejects --resume with --continue on attach", ({ opencode }) =>
+    Effect.gen(function* () {
+      const result = yield* opencode.spawn(["attach", "http://localhost:4096", "--resume", "--continue"])
+
+      opencode.expectExit(result, 1)
+      expect(result.stderr).toContain("--resume cannot be used with --continue or --session")
+    }),
+  )
 })

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -47,7 +47,7 @@ import { DialogDebug } from "./component/dialog-debug"
 import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
-import { DialogSessionList } from "./component/dialog-session-list"
+import { DialogSessionList, loadDialogSessionList } from "./component/dialog-session-list"
 import { DialogWorkspaceList } from "./component/dialog-workspace-list"
 import { DialogConsoleOrg } from "./component/dialog-console-org"
 import { ThemeProvider, useTheme } from "./context/theme"
@@ -519,6 +519,28 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         route.navigate({ type: "session", sessionID: match })
       }
     }
+  })
+
+  // Handle --resume: open the session picker so any session for this
+  // directory can be resumed, once the session list has loaded
+  let resumed = false
+  createEffect(() => {
+    if (resumed || sync.status === "loading" || !args.resume) return
+    // Provider setup replaces dialogs at "complete"; wait it out rather than lose the picker
+    if (sync.data.provider.length === 0) return
+    resumed = true
+    const filter = sync.session.query()
+    void loadDialogSessionList({ filter, list: (query) => sdk.client.session.list(query) }).then((sessions) => {
+      if (sessions === undefined || sessions.length > 0) {
+        dialog.replace(() => <DialogSessionList />)
+        return
+      }
+      toast.show({
+        variant: "info",
+        message: filter.scope === "project" ? "No sessions to resume" : "No sessions to resume in this directory",
+        duration: 3000,
+      })
+    })
   })
 
   // Handle --session with --fork: wait for sync to be fully complete before forking

--- a/packages/tui/src/context/args.tsx
+++ b/packages/tui/src/context/args.tsx
@@ -5,6 +5,7 @@ export interface Args {
   agent?: string
   prompt?: string
   continue?: boolean
+  resume?: boolean
   sessionID?: string
   fork?: boolean
   auto?: boolean

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -448,7 +448,7 @@ export const {
       const projectPromise = project.sync()
       const sessionListPromise = projectPromise.then(() => listSessions())
 
-      // blocking - include session.list when continuing a session
+      // blocking - include session.list when continuing or resuming a session
       const providersPromise = sdk.client.config.providers({ workspace }, { throwOnError: true })
       const providerListPromise = sdk.client.provider.list({ workspace }, { throwOnError: true })
       const capabilitiesPromise = sdk.client.experimental.capabilities
@@ -468,7 +468,7 @@ export const {
         agentsPromise,
         configPromise,
         projectPromise,
-        ...(args.continue ? [sessionListPromise] : []),
+        ...(args.continue || args.resume ? [sessionListPromise] : []),
       ])
         .then(async () => {
           const providersResponse = providersPromise.then((x) => x.data!)
@@ -477,7 +477,7 @@ export const {
           const consoleStateResponse = consoleStatePromise
           const agentsResponse = agentsPromise.then((x) => x.data ?? [])
           const configResponse = configPromise.then((x) => x.data!)
-          const sessionListResponse = args.continue ? sessionListPromise : undefined
+          const sessionListResponse = args.continue || args.resume ? sessionListPromise : undefined
 
           return Promise.all([
             providersResponse,
@@ -512,7 +512,9 @@ export const {
           if (store.status !== "complete") setStore("status", "partial")
           // non-blocking
           void Promise.all([
-            ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
+            ...(args.continue || args.resume
+              ? []
+              : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
             consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -1,11 +1,23 @@
 import { expect, mock, test } from "bun:test"
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
-import { createTestRenderer } from "@opentui/core/testing"
+import { createTestRenderer, type TestRendererSetup } from "@opentui/core/testing"
 import { Effect } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Global } from "@opencode-ai/core/global"
 import { createTuiResolvedConfig } from "./fixture/tui-runtime"
 import { createEventSource, createFetch, directory, json } from "./fixture/tui-sdk"
+
+async function waitForText(setup: TestRendererSetup, text: string) {
+  const start = Date.now()
+  let frame = setup.captureCharFrame()
+  while (!frame.includes(text)) {
+    if (Date.now() - start > 5000) throw new Error(`timed out waiting for frame text: ${text}`)
+    await setup.renderOnce()
+    await Bun.sleep(10)
+    frame = setup.captureCharFrame()
+  }
+  return frame
+}
 
 test("SIGHUP clears title and disposes scoped resources once", async () => {
   const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
@@ -122,6 +134,112 @@ test("app.exit prints the session epilogue after scoped cleanup", async () => {
     expect(stdout).toContain("opencode -s dummy")
   } finally {
     process.stdout.write = originalWrite
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})
+
+// The --resume effect waits for sync.data.provider, so the fake server needs
+// one connected provider to keep the provider-setup dialog from taking over.
+const provider = {
+  providers: [{ id: "test", name: "Test", source: "custom", env: [], options: {}, models: {} }],
+  default: {},
+}
+
+test("--resume opens the session list dialog once sessions load", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  const core = await import("@opentui/core")
+  mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+  const events = createEventSource()
+  const calls = createFetch((url) => {
+    if (url.pathname === "/config/providers") return json(provider)
+    if (url.pathname === "/session")
+      return json([
+        {
+          id: "ses_resume",
+          title: "Resume target session",
+          slug: "resume-target",
+          projectID: "project",
+          directory,
+          version: "0.0.0-test",
+          time: { created: 0, updated: 0 },
+        },
+      ])
+  })
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch: calls.fetch,
+        events: events.source,
+        args: { resume: true },
+        pluginHost: {
+          async start() {
+            started()
+          },
+          async dispose() {},
+        },
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node))),
+    )
+    await ready
+    const frame = await waitForText(setup, "Resume target session")
+
+    expect(frame).toContain("Sessions")
+    process.emit("SIGHUP")
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    mock.restore()
+  }
+})
+
+test("--resume shows an info toast when there are no sessions to resume", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
+  const core = await import("@opentui/core")
+  mock.module("@opentui/core", () => ({ ...core, createCliRenderer: async () => setup.renderer }))
+  const events = createEventSource()
+  const calls = createFetch((url) => {
+    if (url.pathname === "/config/providers") return json(provider)
+  })
+  let started!: () => void
+  const ready = new Promise<void>((resolve) => {
+    started = resolve
+  })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        url: "http://test",
+        directory,
+        config: createTuiResolvedConfig({ plugin_enabled: {} }),
+        fetch: calls.fetch,
+        events: events.source,
+        args: { resume: true },
+        pluginHost: {
+          async start() {
+            started()
+          },
+          async dispose() {},
+        },
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node))),
+    )
+    await ready
+    // common prefix of both message variants (project scope vs directory filter)
+    const frame = await waitForText(setup, "No sessions to resume")
+
+    expect(frame).not.toContain("Sessions")
+    process.emit("SIGHUP")
+    await task
+  } finally {
     if (!setup.renderer.isDestroyed) setup.renderer.destroy()
     mock.restore()
   }

--- a/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-fixture.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import { testRender } from "@opentui/solid"
 import { onMount } from "solid-js"
-import { ArgsProvider } from "../../../../src/context/args"
+import { ArgsProvider, type Args } from "../../../../src/context/args"
 import { KVProvider, useKV } from "../../../../src/context/kv"
 import { ProjectProvider, useProject } from "../../../../src/context/project"
 import { SDKProvider } from "../../../../src/context/sdk"
@@ -22,7 +22,7 @@ export async function wait(fn: () => boolean, timeout = 2000) {
 
 type Ctx = { kv: ReturnType<typeof useKV>; project: ReturnType<typeof useProject>; sync: ReturnType<typeof useSync> }
 
-export async function mount(override?: FetchHandler, state?: string) {
+export async function mount(override?: FetchHandler, state?: string, options?: { args?: Args }) {
   const calls = createFetch(override)
   const events = createEventSource()
   let sync!: ReturnType<typeof useSync>
@@ -46,7 +46,7 @@ export async function mount(override?: FetchHandler, state?: string) {
 
   const app = await testRender(() => (
     <TestTuiContexts paths={state ? { state } : undefined}>
-      <ArgsProvider>
+      <ArgsProvider {...(options?.args ?? {})}>
         <KVProvider>
           <SDKProvider url="http://test" directory={directory} fetch={calls.fetch} events={events.source}>
             <PermissionProvider>

--- a/packages/tui/test/cli/cmd/tui/sync-resume.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-resume.test.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @opentui/solid */
+import { describe, expect, test } from "bun:test"
+import { tmpdir } from "../../../fixture/fixture"
+import { directory, json, mount, wait } from "./sync-fixture"
+
+const session = {
+  id: "ses_resume",
+  title: "Resume target",
+  slug: "resume-target",
+  projectID: "proj_test",
+  directory,
+  version: "1.15.13",
+  time: { created: 0, updated: 0 },
+}
+
+// /vcs is only fetched by bootstrap's non-blocking phase, so its position in
+// the request log marks when bootstrap leaves the blocking ("loading") phase.
+// The fixture's sync handle is gated behind sync.ready, so blocking-phase
+// behavior is observed through the request log instead of sync.status.
+describe("tui sync --resume", () => {
+  test("bootstrap blocks on the session list and fetches it once", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+    const order: string[] = []
+    let release!: (response: Response) => void
+    const pending = new Promise<Response>((resolve) => {
+      release = resolve
+    })
+    const mounted = mount(
+      (url) => {
+        if (url.pathname === "/session") {
+          order.push("session")
+          return pending
+        }
+        if (url.pathname === "/vcs") order.push("vcs")
+        return undefined
+      },
+      tmp.path,
+      { args: { resume: true } },
+    )
+
+    await wait(() => order.includes("session"))
+    await Bun.sleep(30)
+    const blocked = !order.includes("vcs")
+    release(json([session]))
+    const { app, sync, session: calls } = await mounted
+
+    try {
+      expect(blocked).toBe(true)
+      expect(order).toEqual(["session", "vcs"])
+      expect(sync.data.session.map((x) => x.id)).toEqual([session.id])
+      expect(calls).toHaveLength(1)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+
+  test("without --resume the session list loads after bootstrap unblocks", async () => {
+    await using tmp = await tmpdir()
+    await Bun.write(`${tmp.path}/kv.json`, "{}")
+
+    const order: string[] = []
+    let release!: (response: Response) => void
+    const pending = new Promise<Response>((resolve) => {
+      release = resolve
+    })
+    const mounted = mount(
+      (url) => {
+        if (url.pathname === "/session") {
+          order.push("session")
+          return pending
+        }
+        if (url.pathname === "/vcs") order.push("vcs")
+        return undefined
+      },
+      tmp.path,
+    )
+
+    await wait(() => order.includes("session"))
+    await wait(() => order.includes("vcs"))
+    release(json([session]))
+    const { app, sync, session: calls } = await mounted
+
+    try {
+      expect(order).toEqual(["session", "vcs"])
+      expect(sync.data.session.map((x) => x.id)).toEqual([session.id])
+      expect(calls).toHaveLength(1)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+})

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -33,6 +33,7 @@ opencode [project]
 | ------------------------------------------- | ----- | ----------------------------------------------------------------------- |
 | <nobr><code>{"--continue"}</code></nobr>    | `-c`  | Continue the last session                                               |
 | <nobr><code>{"--session"}</code></nobr>     | `-s`  | Session ID to continue                                                  |
+| <nobr><code>{"--resume"}</code></nobr>      |       | Pick a session to resume from the sessions in this directory            |
 | <nobr><code>{"--fork"}</code></nobr>        |       | Fork the session when continuing (use with `--continue` or `--session`) |
 | <nobr><code>{"--prompt"}</code></nobr>      |       | Prompt to use                                                           |
 | <nobr><code>{"--model"}</code></nobr>       | `-m`  | Model to use in the form of provider/model                              |
@@ -121,6 +122,7 @@ opencode attach http://10.20.30.40:4096
 | <nobr><code>{"--dir"}</code></nobr>      |       | Working directory to start TUI in                                          |
 | <nobr><code>{"--continue"}</code></nobr> | `-c`  | Continue the last session                                                  |
 | <nobr><code>{"--session"}</code></nobr>  | `-s`  | Session ID to continue                                                     |
+| <nobr><code>{"--resume"}</code></nobr>   |       | Pick a session to resume from the sessions in this directory               |
 | <nobr><code>{"--fork"}</code></nobr>     |       | Fork the session when continuing (use with `--continue` or `--session`)    |
 | <nobr><code>{"--password"}</code></nobr> | `-p`  | Basic auth password (defaults to `OPENCODE_SERVER_PASSWORD`)               |
 | <nobr><code>{"--username"}</code></nobr> | `-u`  | Basic auth username (defaults to `OPENCODE_SERVER_USERNAME` or `opencode`) |


### PR DESCRIPTION
### Issue for this PR

Closes #36134

Refs #18569 — the picker covers the "find and resume an old session" friction there, but resuming by session *name* (what it literally asks for) is not part of this PR.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `opencode --resume` (and `opencode attach --resume`): boots the TUI straight into the existing session picker for the current directory. This is option A from the linked issue.

Today, resuming anything but the latest session means either `opencode session list` + copy-pasting an opaque `ses_...` id into `-s`, or booting the TUI and opening `/sessions` by hand. Claude Code (`claude --resume` opens its picker) and Codex (`codex resume` opens a picker scoped to the cwd, `--last` for most recent) both ship this; not having it is recurring friction for people switching over (both linked issues).

Implementation:

- `--resume` flag on the default command and `attach`; mutually exclusive with `--continue`/`--session`, rejected with `--mini` (no picker surface there). Headless `run` intentionally untouched, per the issue's scope.
- Bootstrap now awaits the session list in the blocking phase for `--resume` (previously `--continue`-only), then opens `DialogSessionList` — the same dialog `/sessions` uses, directory-scoped; no new UI.
- Empty result shows a toast instead of an empty dialog; the check uses the picker's own query so the two can't disagree (the startup store list has a 30-day cutoff the dialog doesn't).
- With zero providers configured, the picker waits for provider setup instead of being replaced by the provider dialog at startup.
- `--fork` still requires `--continue`/`--session`; forking from the picker would need fork-on-select in the dialog and is deliberately out of scope.
- CLI reference row added (English; translations sync separately).

### How did you verify your code works?

- New tests: CLI flag-validation cases (`test/cli/tui/thread.test.ts`), bootstrap blocking/fetch-once for `resume` (`packages/tui/test/cli/cmd/tui/sync-resume.test.tsx`), and app-lifecycle tests for picker-opens vs toast-when-empty (`packages/tui/test/app-lifecycle.test.tsx`). Regenerated the `attach --help` snapshot.
- `bun test` from `packages/opencode` (15 pass) and `packages/tui` (28 pass); `bun typecheck` clean in both; repo-wide typecheck also ran green via the pre-commit hook.
- Manual: `bun dev --resume` in a directory with sessions -> picker opens (below), selecting one resumes it; in a directory with none -> toast. `--resume --continue`, `--resume --mini`, `--resume --fork` all exit 1 with clear errors.
- Repro: `bun dev --resume` in any directory with sessions.

### Screenshots / recordings

`opencode --resume` in a directory with existing sessions:

```text
 Sessions                                                           esc

 Search

 Today
 Opencode session management framework feature branch
 Next expected Intel CPU release date

 Wed Jul 22 2026
 Bunenv installation and zshenv path configuration

 pin/unpin ctrl+f  delete ctrl+d  rename ctrl+r
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
