### PR TITLE
fix(core): clarify empty Code Mode guidance

### DIFF
--- a/packages/core/src/codemode/instructions.ts
+++ b/packages/core/src/codemode/instructions.ts
@@ -18,7 +18,7 @@ Use \`search\` to discover exact paths and signatures for additional tools:
 
 export function render(catalog: CodeModeCatalog.Summary) {
   if (catalog.total === 0)
-    return "No Code Mode tools are currently available. Do not call `execute` until a later system update announces available tools."
+    return "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool."
 
   const tools = catalog.namespaces.flatMap((namespace) => {
     const count = namespace.count === 1 ? "1 tool" : `${namespace.count} tools`

--- a/packages/core/test/codemode/catalog.test.ts
+++ b/packages/core/test/codemode/catalog.test.ts
@@ -114,7 +114,7 @@ describe("CodeModeInstructions.render", () => {
 
   test("renders only the no-tools notice for an empty catalog", () => {
     expect(render([])).toBe(
-      "No Code Mode tools are currently available. Do not call `execute` until a later system update announces available tools.",
+      "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool.",
     )
   })
 })

--- a/packages/core/test/codemode/instructions.test.ts
+++ b/packages/core/test/codemode/instructions.test.ts
@@ -25,7 +25,7 @@ describe("CodeModeInstructions", () => {
     Effect.gen(function* () {
       const initialized = yield* readInitial(CodeModeInstructions.make([]))
       expect(initialized.text).toBe(
-        "No Code Mode tools are currently available. Do not call `execute` until a later system update announces available tools.",
+        "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool.",
       )
 
       const added = yield* readUpdate(CodeModeInstructions.make([echo]), initialized)
@@ -35,7 +35,7 @@ describe("CodeModeInstructions", () => {
       expect(yield* readUpdate(CodeModeInstructions.make([]), { values: added.values })).toMatchObject({
         text:
           "The Code Mode tool catalog has changed. This catalog supersedes the previous Code Mode tool catalog.\n\n" +
-          "No Code Mode tools are currently available. Do not call `execute` until a later system update announces available tools.",
+          "No Code Mode tools are currently available. Later Code Mode catalog updates may add or remove tools. Do not call `execute` unless there is at least one available Code Mode tool.",
       })
     }),
   )


### PR DESCRIPTION
## Summary
- clarify that Code Mode tool availability can change in either direction
- make `execute` guidance depend on the current availability of at least one Code Mode tool
- avoid implying that tools will eventually become available

## Testing
- `bun test test/codemode/catalog.test.ts test/codemode/instructions.test.ts` in `packages/core`
- `bun typecheck` in `packages/core`