### PR TITLE
docs: make 'Estimated Token Usage per Request' details as markdown table

### DIFF
--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -113,7 +113,7 @@ The table below provides an estimated request count based on typical Go usage pa
 
 The estimates are based on observed request patterns:
 
-| Model             | Input | Cached | Output<br>(tokens/request) |
+| Model             | Input | Cached | Output<br />(tokens/request) |
 | :---------------- | :---: | :----: | :-----------------------:  |
 | Grok 4.5          | 1,100 | 71,500 |            220             |
 | GLM-5.2/5.1       |  700  | 52,000 |            150             |

--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -113,20 +113,22 @@ The table below provides an estimated request count based on typical Go usage pa
 
 The estimates are based on observed request patterns:
 
-- Grok 4.5 — 1,100 input, 71,500 cached, 220 output tokens per request
-- GLM-5.2/5.1 — 700 input, 52,000 cached, 150 output tokens per request
-- Kimi K3 — 1,050 input, 76,500 cached, 300 output tokens per request
-- Kimi K2.7/K2.6 — 870 input, 55,000 cached, 200 output tokens per request
-- DeepSeek V4 Pro — 750 input, 82,000 cached, 290 output tokens per request
-- DeepSeek V4 Flash — 790 input, 68,000 cached, 280 output tokens per request
-- MiniMax M3 — 510 input, 56,000 cached, 190 output tokens per request
-- MiniMax M2.7 — 300 input, 55,000 cached, 125 output tokens per request
-- MiMo-V2.5 — 830 input, 71,500 cached, 295 output tokens per request
-- MiMo-V2.5-Pro — 790 input, 86,000 cached, 305 output tokens per request
-- Qwen3.7 Max — 420 input, 66,000 cached, 200 output tokens per request
-- Qwen3.7 Plus — 500 input, 57,000 cached, 190 output tokens per request
-- Qwen3.6 Plus — 500 input, 57,000 cached, 190 output tokens per request
-- Hy3 — 830 input, 71,500 cached, 295 output tokens per request
+| Model             | Input | Cached | Output<br>(tokens/request) |
+| :---------------- | :---: | :----: | :-----------------------:  |
+| Grok 4.5          | 1,100 | 71,500 |            220             |
+| GLM-5.2/5.1       |  700  | 52,000 |            150             |
+| Kimi K3           | 1,050 | 76,500 |            300             |
+| Kimi K2.7/K2.6    |  870  | 55,000 |            200             |
+| DeepSeek V4 Pro   |  750  | 82,000 |            290             |
+| DeepSeek V4 Flash |  790  | 68,000 |            280             |
+| MiniMax M3        |  510  | 56,000 |            190             |
+| MiniMax M2.7      |  300  | 55,000 |            125             |
+| MiMo-V2.5         |  830  | 71,500 |            295             |
+| MiMo-V2.5-Pro     |  790  | 86,000 |            305             |
+| Qwen3.7 Max       |  420  | 66,000 |            200             |
+| Qwen3.7 Plus      |  500  | 57,000 |            190             |
+| Qwen3.6 Plus      |  500  | 57,000 |            190             |
+| Hy3               |  830  | 71,500 |            295             |
 
 The estimates are also based on the following prices per 1M tokens and the monthly usage included with each model:
 


### PR DESCRIPTION
**Note:** I done the edits from GitHub itself. I cloned the repo locally and got an issue when running `git push`, that automatically invokes `bun run typecheck`, spend some time to fix it but didn't worked. So I pushed the exact changes from GitHub. 

### Issue for this PR

Closes #38886

### Type of change

- [x] Documentation

### What does this PR do?

This converts the bullet points written for 'Estimated Token Usage per Request' in the page "https://opencode.ai/docs/go/" to a markdown table.

### How did you verify your code works?

I rendered it locally on my system.

### Screenshots / recordings

preview in browser:
<img width="987" height="952" alt="image" src="https://github.com/user-attachments/assets/13784a85-8b02-4599-863a-a78f8a821c2e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR