### PR TITLE
feat(desktop): add OPENCODE_PROJECT_DIR env var for CWD override

### DIFF
--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -115,7 +115,7 @@ const main = Effect.gen(function* () {
 
   // on macOS apps run in `/` which can cause issues with ripgrep
   try {
-    process.chdir(homedir())
+    process.chdir(process.env.OPENCODE_PROJECT_DIR || homedir())
   } catch {}
 
   process.env.OPENCODE_DISABLE_EMBEDDED_WEB_UI = "true"


### PR DESCRIPTION
The desktop app hardcodes `process.chdir(homedir())` on startup (for ripgrep compatibility on macOS). This prevents users from setting a custom working directory — plugins that derive project identity from `process.cwd()`, shell-env-based configs, and project-level `opencode.json` traversal all resolve against `$HOME` instead of the intended project directory.

This PR adds an `OPENCODE_PROJECT_DIR` environment variable override. When set, the desktop app uses that path instead of `homedir()`. If unset, behavior is unchanged.

Fixes the CWD aspect of #34553.

\`\`\`diff
- process.chdir(homedir())
+ process.chdir(process.env.OPENCODE_PROJECT_DIR || homedir())
\`\`\`