### PR TITLE
fix(native-llm): replace hardcoded provider gate with shared support set

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1523,7 +1523,7 @@ const layer = Layer.effect(
           if (!apiKey) continue
           mergeProvider(providerID, {
             source: "env",
-            key: provider.env.length === 1 ? apiKey : undefined,
+            key: apiKey,
           })
         }
 

--- a/packages/opencode/src/session/llm/native-request.ts
+++ b/packages/opencode/src/session/llm/native-request.ts
@@ -13,6 +13,16 @@ import type { ModelMessage } from "ai"
 import type { Provider } from "@/provider/provider"
 import { isRecord } from "@/util/record"
 
+export const SUPPORTED_NPM_PACKAGES = new Set([
+  "@ai-sdk/openai",
+  "@ai-sdk/azure",
+  "@ai-sdk/anthropic",
+  "@ai-sdk/google",
+  "@ai-sdk/amazon-bedrock",
+  "@ai-sdk/openai-compatible",
+  "@openrouter/ai-sdk-provider",
+])
+
 type ToolInput = {
   readonly description?: string
   readonly inputSchema?: unknown

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -51,12 +51,9 @@ function statusWithFetch(
   input: Pick<StreamInput, "model" | "provider" | "auth">,
   fetch: typeof globalThis.fetch | undefined,
 ): RuntimeStatus {
-  const providerID = input.model.providerID
-  if (providerID !== "openai" && providerID !== "anthropic" && !providerID.startsWith("opencode"))
-    return { type: "unsupported", reason: "provider is not openai, opencode, or anthropic" }
   const npm = input.model.api.npm
-  if (npm !== "@ai-sdk/openai" && npm !== "@ai-sdk/openai-compatible" && npm !== "@ai-sdk/anthropic")
-    return { type: "unsupported", reason: "provider package is not OpenAI, OpenAI-compatible, or Anthropic" }
+  if (!LLMNative.SUPPORTED_NPM_PACKAGES.has(npm))
+    return { type: "unsupported", reason: `provider package ${npm} is not supported by native runtime` }
   if (input.auth?.type === "oauth" && !(input.provider.id === "openai" && fetch)) {
     return { type: "unsupported", reason: "OAuth auth requires a provider fetch override" }
   }


### PR DESCRIPTION
Closes #38893.

The native LLM runtime at `packages/opencode/src/session/llm/native-runtime.ts` had a hardcoded allowlist in `statusWithFetch()` that blocked Google, Amazon Bedrock, Azure, and OpenRouter from the native LLM path, even though `native-request.ts` had working adapters for them.

The two lists were duplicated and had drifted apart as new providers were added.

Changes:
- Export `SUPPORTED_NPM_PACKAGES` from `native-request.ts` (one source of truth)
- Use the shared set in `statusWithFetch()` gate instead of hardcoded checks
- Fix API key propagation: remove `env.length === 1` guard that dropped keys for providers with multiple env vars (e.g. Google has GOOGLE_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY, GEMINI_API_KEY)

Verification: the native LLM path now accepts any provider whose npm package is in SUPPORTED_NPM_PACKAGES. Adding a new provider only requires updating the set in native-request.ts.