### PR TITLE
feat(opencode): expose POST /question/ask for plugins and SDK

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/groups/question.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/question.ts
@@ -1,5 +1,6 @@
 import { Question } from "@/question"
 import { QuestionID } from "@/question/schema"
+import { SessionID } from "@/session/schema"
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { QuestionNotFoundError } from "../errors"
@@ -15,6 +16,11 @@ const ReplyPayload = Schema.Struct({
   }),
 })
 
+const AskPayload = Schema.Struct({
+  sessionID: SessionID,
+  questions: Schema.Array(Question.Info).annotate({ description: "Questions to ask" }),
+})
+
 export const QuestionApi = HttpApi.make("question")
   .add(
     HttpApiGroup.make("question")
@@ -27,6 +33,19 @@ export const QuestionApi = HttpApi.make("question")
             identifier: "question.list",
             summary: "List pending questions",
             description: "Get all pending question requests across all sessions.",
+          }),
+        ),
+        HttpApiEndpoint.post("ask", `${root}/ask`, {
+          query: WorkspaceRoutingQuery,
+          payload: AskPayload,
+          success: described(Schema.Array(Question.Answer), "User answers in order of questions"),
+          error: [HttpApiError.BadRequest],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "question.ask",
+            summary: "Ask question request",
+            description:
+              "Create a pending question, publish question.asked for the TUI wizard, and block until the user replies or rejects.",
           }),
         ),
         HttpApiEndpoint.post("reply", `${root}/:requestID/reply`, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/question.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/question.ts
@@ -1,7 +1,8 @@
 import { Question } from "@/question"
 import { QuestionID } from "@/question/schema"
+import { SessionID } from "@/session/schema"
 import { Effect } from "effect"
-import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
 import { QuestionNotFoundError } from "../errors"
 
@@ -11,6 +12,20 @@ export const questionHandlers = HttpApiBuilder.group(InstanceHttpApi, "question"
 
     const list = Effect.fn("QuestionHttpApi.list")(function* () {
       return yield* svc.list()
+    })
+
+    const ask = Effect.fn("QuestionHttpApi.ask")(function* (ctx: {
+      payload: {
+        sessionID: SessionID
+        questions: ReadonlyArray<Question.Info>
+      }
+    }) {
+      return yield* svc
+        .ask({
+          sessionID: ctx.payload.sessionID,
+          questions: ctx.payload.questions,
+        })
+        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
     })
 
     const reply = Effect.fn("QuestionHttpApi.reply")(function* (ctx: {
@@ -49,6 +64,6 @@ export const questionHandlers = HttpApiBuilder.group(InstanceHttpApi, "question"
       return true
     })
 
-    return handlers.handle("list", list).handle("reply", reply).handle("reject", reject)
+    return handlers.handle("list", list).handle("ask", ask).handle("reply", reply).handle("reject", reject)
   }),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #8384

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins and the SDK can already reply to questions (`POST /question/:requestID/reply`), but they cannot start one: `Question.ask` is only reachable from the built-in question tool.

This adds a blocking `POST /question/ask` that calls the same `Question.ask` path, so a plugin can open the native question UI and get the answers back on the HTTP response.

### How did you verify your code works?

Called `POST /question/ask` from an in-process OpenCode client (`client._client.post({ path: "/question/ask", ... })`). The native question dialog appeared in the TUI; answering it returned the selected options on the HTTP response. A raw `fetch` to `localhost:4096` did not work from inside the same process (connection refused); the SDK client path did.

### Screenshots / recordings

_N/A — no UI change; reuses the existing question dialog._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR