### PR TITLE
fix(session): defer auto-compaction until the next model input

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -12,7 +12,6 @@ import { Snapshot } from "@/snapshot"
 import { Session } from "./session"
 import { LLM } from "./llm"
 import { MessageV2 } from "./message-v2"
-import { isOverflow } from "./overflow"
 import { PartID } from "./schema"
 import type { SessionID } from "./schema"
 import { SessionRetry } from "./retry"
@@ -474,12 +473,6 @@ const layer = Layer.effect(
                 messageID: ctx.assistantMessage.parentID,
               })
               .pipe(Effect.ignore, Effect.forkIn(scope))
-            if (
-              !ctx.assistantMessage.summary &&
-              isOverflow({ cfg: yield* config.get(), tokens: usage.tokens, model: ctx.model })
-            ) {
-              ctx.needsCompaction = true
-            }
             return
           }
 

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -371,7 +371,7 @@ it.live("session.processor effect tests preserve text start time", () =>
   ),
 )
 
-it.live("session.processor effect tests stop after token overflow requests compaction", () =>
+it.live("session.processor effect tests defer proactive compaction after token overflow", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
@@ -410,7 +410,7 @@ it.live("session.processor effect tests stop after token overflow requests compa
 
         const parts = yield* MessageV2.parts(msg.id)
 
-        expect(value).toBe("compact")
+        expect(value).toBe("continue")
         expect(parts.some((part) => part.type === "text" && part.text === "after")).toBe(true)
         expect(parts.some((part) => part.type === "step-finish")).toBe(true)
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #<issue-number>

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor / code improvement
* [ ] Documentation

### What does this PR do?

Automatic compaction was being scheduled immediately after an assistant step exceeded the context threshold. This could trigger compaction after a final subagent response even when no further model input was needed.

This PR removes the post-`step-finish` overflow check from `SessionProcessor`. The existing check in `SessionPrompt` now handles compaction before the next model request.

As a result, the completed response is returned without starting unnecessary compaction. If the user sends another message, or the parent agent needs another model call, the context is compacted before that request.

The related processor test was updated, and a regression test was added for the next-user-message case.

### How did you verify your code works?

Added regression coverage for both parts of the behavior:

* An assistant response exceeding the context threshold does not immediately request compaction.
* After the next user message, compaction runs before the next assistant response.

Tests:

```bash
bun test packages/opencode/test/session/processor-effect.test.ts
bun test packages/opencode/test/session/prompt.test.ts
```

### Screenshots / recordings

Not applicable.

### Checklist

* [x] I have tested my changes locally
* [x] I have not included unrelated changes in this PR
