### PR TITLE
feat(plugin): route ChatGPT OAuth inference via codexApiEndpoint option

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -104,6 +104,24 @@ interface CodexAuthPluginOptions {
   experimentalWebSockets?: boolean
 }
 
+export function resolveCodexApiEndpoint(
+  info: { options?: Record<string, unknown> } | undefined,
+  pluginOption: string | undefined,
+): string {
+  const options = info?.options
+  if (options) {
+    const endpoint = options.codexApiEndpoint
+    if (typeof endpoint === "string" && endpoint !== "") return endpoint
+    const baseURL = options.baseURL
+    if (typeof baseURL === "string" && baseURL !== "") {
+      const trimmed = baseURL.replace(/\/+$/, "")
+      if (trimmed.endsWith("/codex")) return `${trimmed}/responses`
+    }
+  }
+  if (typeof pluginOption === "string" && pluginOption !== "") return pluginOption
+  return CODEX_API_ENDPOINT
+}
+
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
@@ -262,7 +280,6 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
 
 export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPluginOptions = {}): Promise<Hooks> {
   const issuer = options.issuer ?? ISSUER
-  const codexApiEndpoint = options.codexApiEndpoint ?? CODEX_API_ENDPOINT
   let websocketFetchInstalled = false
   const websocketFetches: Array<ReturnType<typeof OpenAIWebSocketPool.createWebSocketFetch>> = []
 
@@ -319,8 +336,9 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
     },
     auth: {
       provider: "openai",
-      async loader(getAuth) {
+      async loader(getAuth, info) {
         const auth = await getAuth()
+        const codexApiEndpoint = resolveCodexApiEndpoint(info, options.codexApiEndpoint)
         const websocketFetch = options.experimentalWebSockets
           ? OpenAIWebSocketPool.createWebSocketFetch({ httpFetch: fetch })
           : undefined

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -293,10 +293,7 @@ describe("plugin.codex", () => {
   describe("resolveCodexApiEndpoint", () => {
     test("returns provider.options.codexApiEndpoint when set", () => {
       expect(
-        resolveCodexApiEndpoint(
-          { options: { codexApiEndpoint: "https://gw.example/codex/responses" } },
-          undefined,
-        ),
+        resolveCodexApiEndpoint({ options: { codexApiEndpoint: "https://gw.example/codex/responses" } }, undefined),
       ).toBe("https://gw.example/codex/responses")
     })
 
@@ -337,9 +334,7 @@ describe("plugin.codex", () => {
       expect(resolveCodexApiEndpoint({ options: {} }, undefined)).toBe(
         "https://chatgpt.com/backend-api/codex/responses",
       )
-      expect(resolveCodexApiEndpoint(undefined, undefined)).toBe(
-        "https://chatgpt.com/backend-api/codex/responses",
-      )
+      expect(resolveCodexApiEndpoint(undefined, undefined)).toBe("https://chatgpt.com/backend-api/codex/responses")
     })
   })
 
@@ -372,10 +367,9 @@ describe("plugin.codex", () => {
 
       const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
       const hooks = await CodexAuthPlugin(createPluginInput())
-      const loaded = await hooks.auth!.loader!(
-        async () => nonExpiringAuth as never,
-        { options: { codexApiEndpoint } } as never,
-      )
+      const loaded = await hooks.auth!.loader!(async () => nonExpiringAuth as never, {
+        options: { codexApiEndpoint },
+      } as never)
 
       await loaded.fetch!("https://api.openai.com/v1/responses")
 
@@ -403,10 +397,9 @@ describe("plugin.codex", () => {
       })
 
       const hooks = await CodexAuthPlugin(createPluginInput())
-      const loaded = await hooks.auth!.loader!(
-        async () => nonExpiringAuth as never,
-        { options: { baseURL: new URL("/codex", server.url).toString() } } as never,
-      )
+      const loaded = await hooks.auth!.loader!(async () => nonExpiringAuth as never, {
+        options: { baseURL: new URL("/codex", server.url).toString() },
+      } as never)
 
       await loaded.fetch!("https://api.openai.com/v1/responses")
 
@@ -424,7 +417,7 @@ describe("plugin.codex", () => {
           if (url.pathname === "/backend-api/codex/responses") {
             upgradePath = url.pathname
             upgradeHost = request.headers.get("host") ?? undefined
-            if (ctx.upgrade(request)) return
+            if (ctx.upgrade(request)) return undefined
             return new Response("upgrade failed", { status: 500 })
           }
           return new Response("unexpected request", { status: 500 })
@@ -443,10 +436,9 @@ describe("plugin.codex", () => {
       const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
       const serverHostPort = new URL(server.url).host
       const hooks = await CodexAuthPlugin(createPluginInput(), { experimentalWebSockets: true })
-      const loaded = await hooks.auth!.loader!(
-        async () => ({ ...nonExpiringAuth } as never),
-        { options: { codexApiEndpoint } } as never,
-      )
+      const loaded = await hooks.auth!.loader!(async () => ({ ...nonExpiringAuth }) as never, {
+        options: { codexApiEndpoint },
+      } as never)
 
       await loaded.fetch!("https://api.openai.com/v1/responses", {
         method: "POST",

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -5,6 +5,7 @@ import {
   extractAccountIdFromClaims,
   extractAccountId,
   renderOAuthError,
+  resolveCodexApiEndpoint,
   type IdTokenClaims,
 } from "../../src/plugin/openai/codex"
 
@@ -288,7 +289,196 @@ describe("plugin.codex", () => {
       { authorization: "Bearer access-new", accountId: "acc-123" },
     ])
   })
+
+  describe("resolveCodexApiEndpoint", () => {
+    test("returns provider.options.codexApiEndpoint when set", () => {
+      expect(
+        resolveCodexApiEndpoint(
+          { options: { codexApiEndpoint: "https://gw.example/codex/responses" } },
+          undefined,
+        ),
+      ).toBe("https://gw.example/codex/responses")
+    })
+
+    test("prefers provider.options.codexApiEndpoint over the plugin option fallback", () => {
+      expect(
+        resolveCodexApiEndpoint(
+          { options: { codexApiEndpoint: "https://gw.example/codex/responses" } },
+          "https://plugin.example/codex/responses",
+        ),
+      ).toBe("https://gw.example/codex/responses")
+    })
+
+    test("falls back to the plugin option when provider options omits codexApiEndpoint", () => {
+      expect(resolveCodexApiEndpoint({ options: {} }, "https://plugin.example/codex/responses")).toBe(
+        "https://plugin.example/codex/responses",
+      )
+    })
+
+    test("appends /responses when provider.options.baseURL ends in /codex", () => {
+      expect(resolveCodexApiEndpoint({ options: { baseURL: "https://gw.example/codex" } }, undefined)).toBe(
+        "https://gw.example/codex/responses",
+      )
+    })
+
+    test("trims a trailing slash before appending /responses", () => {
+      expect(resolveCodexApiEndpoint({ options: { baseURL: "https://gw.example/codex/" } }, undefined)).toBe(
+        "https://gw.example/codex/responses",
+      )
+    })
+
+    test("does not trigger the baseURL convenience when the baseURL does not end in /codex", () => {
+      expect(resolveCodexApiEndpoint({ options: { baseURL: "https://gw.example" } }, undefined)).toBe(
+        "https://chatgpt.com/backend-api/codex/responses",
+      )
+    })
+
+    test("falls back to the hardcoded CODEX_API_ENDPOINT when no option is set", () => {
+      expect(resolveCodexApiEndpoint({ options: {} }, undefined)).toBe(
+        "https://chatgpt.com/backend-api/codex/responses",
+      )
+      expect(resolveCodexApiEndpoint(undefined, undefined)).toBe(
+        "https://chatgpt.com/backend-api/codex/responses",
+      )
+    })
+  })
+
+  describe("codexApiEndpoint routing", () => {
+    const nonExpiringAuth = {
+      type: "oauth" as const,
+      access: "access-routing",
+      refresh: "refresh-routing",
+      expires: Number.MAX_SAFE_INTEGER,
+      accountId: "acc-routing",
+    }
+
+    test("routes to provider.options.codexApiEndpoint with WebSockets disabled", async () => {
+      const requests: Array<{ pathname: string; authorization: string | null; accountId: string | null }> = []
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url)
+          if (url.pathname === "/backend-api/codex/responses") {
+            requests.push({
+              pathname: url.pathname,
+              authorization: request.headers.get("authorization"),
+              accountId: request.headers.get("ChatGPT-Account-Id"),
+            })
+            return Response.json({})
+          }
+          return new Response("unexpected request", { status: 500 })
+        },
+      })
+
+      const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
+      const hooks = await CodexAuthPlugin(createPluginInput())
+      const loaded = await hooks.auth!.loader!(
+        async () => nonExpiringAuth as never,
+        { options: { codexApiEndpoint } } as never,
+      )
+
+      await loaded.fetch!("https://api.openai.com/v1/responses")
+
+      expect(requests).toEqual([
+        {
+          pathname: "/backend-api/codex/responses",
+          authorization: "Bearer access-routing",
+          accountId: "acc-routing",
+        },
+      ])
+    })
+
+    test("routes to baseURL /codex via /responses convenience with WebSockets disabled", async () => {
+      const requests: string[] = []
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url)
+          if (url.pathname === "/codex/responses") {
+            requests.push(url.pathname)
+            return Response.json({})
+          }
+          return new Response("unexpected request", { status: 500 })
+        },
+      })
+
+      const hooks = await CodexAuthPlugin(createPluginInput())
+      const loaded = await hooks.auth!.loader!(
+        async () => nonExpiringAuth as never,
+        { options: { baseURL: new URL("/codex", server.url).toString() } } as never,
+      )
+
+      await loaded.fetch!("https://api.openai.com/v1/responses")
+
+      expect(requests).toEqual(["/codex/responses"])
+    })
+
+    test("routes codexApiEndpoint through the websocket fetch when WebSockets are enabled", async () => {
+      let upgradePath: string | undefined
+      let upgradeHost: string | undefined
+      let wsSawMessage = false
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request, ctx) {
+          const url = new URL(request.url)
+          if (url.pathname === "/backend-api/codex/responses") {
+            upgradePath = url.pathname
+            upgradeHost = request.headers.get("host") ?? undefined
+            if (ctx.upgrade(request)) return
+            return new Response("upgrade failed", { status: 500 })
+          }
+          return new Response("unexpected request", { status: 500 })
+        },
+        websocket: {
+          open() {},
+          message(ws) {
+            wsSawMessage = true
+            ws.send(JSON.stringify({ type: "response.done", response: { id: "resp_ws" } }))
+            ws.close(1000, "done")
+          },
+          close() {},
+        },
+      })
+
+      const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
+      const serverHostPort = new URL(server.url).host
+      const hooks = await CodexAuthPlugin(createPluginInput(), { experimentalWebSockets: true })
+      const loaded = await hooks.auth!.loader!(
+        async () => ({ ...nonExpiringAuth } as never),
+        { options: { codexApiEndpoint } } as never,
+      )
+
+      await loaded.fetch!("https://api.openai.com/v1/responses", {
+        method: "POST",
+        headers: { "session-id": "session-ws" },
+        body: JSON.stringify({ stream: true, input: "hi" }),
+      })
+
+      expect(upgradePath).toBe("/backend-api/codex/responses")
+      expect(upgradeHost).toBe(serverHostPort)
+      expect(wsSawMessage).toBe(true)
+      await hooks.dispose?.()
+    })
+  })
 })
+
+function createPluginInput() {
+  return {
+    client: {
+      auth: {
+        async set() {},
+      },
+    } as never,
+    project: {} as never,
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {} as never,
+  }
+}
 
 async function waitFor(predicate: () => boolean) {
   const started = Date.now()


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

OpenCode's ChatGPT Plus/Pro (OAuth) path hardcodes the inference endpoint to `https://chatgpt.com/backend-api/codex/responses` (`packages/opencode/src/plugin/openai/codex.ts`). The auth loader's `fetch` rewrites every `/v1/responses` or `/chat/completions` request to that constant, so a `provider.openai.options.baseURL` override is ignored on the OAuth path. This means a ChatGPT subscription cannot be routed through an AI gateway (e.g. Tailscale Aperture) for logging, quotas, or routing — something the Codex CLI already supports via `requires_openai_auth` + a user-settable `base_url`.

This PR adds a `codexApiEndpoint` provider option that, when set, is used as the rewrite target instead of the hardcoded constant. When unset, behavior is byte-identical to today (the constant is used), so no existing user is affected.

Implementation:
- A module-scope `resolveCodexApiEndpoint(info?, plugin_option?)` helper with precedence: (1) `provider.options.codexApiEndpoint`, (2) `provider.options.baseURL` ending in `/codex` → append `/responses`, (3) plugin-options fallback (preserves the existing test override), (4) the `CODEX_API_ENDPOINT` constant (default, unchanged when nothing is configured).
- The `auth.loader` accepts the provider `info` (already passed at `provider.ts:1556` as `toPublicInfo(database[plugin.auth.provider])`) as its second argument, so both config-file and runtime options are honored.
- Both the regular `fetch` URL rewrite (`codex.ts:414-417`) and the experimental `websocketFetch` branch (`codex.ts:424`) receive the resolved endpoint via the same variable.
- The OAuth token (`Authorization: Bearer …`) and `ChatGPT-Account-Id` header continue to be set by the plugin and transit a gateway unchanged. OAuth login and token refresh are untouched (they still go directly to OpenAI).

### How did you verify your code works?

- `bun typecheck` (tsgo --noEmit) from `packages/opencode` — clean.
- `bun test test/plugin/codex.test.ts` — 27 pass / 0 fail, including:
  - 7 unit tests for `resolveCodexApiEndpoint` (precedence, `/codex` baseURL convenience, and regression to the hardcoded constant when unset).
  - 3 `Bun.serve` integration tests: ws-off with `codexApiEndpoint` set, ws-off with `baseURL` ending in `/codex`, and ws-on verifying the experimental websocket fetch routes to the configured endpoint.
- Confirmed the no-option path is unchanged (regression test asserts the hardcoded constant is used).

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
