### PR TITLE
docs: add PR conventions pointer section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,13 @@
 - The default branch in this repo is `dev`.
 - Local `main` ref may not exist; use `dev` or `origin/dev` for diffs.
 
+## PR conventions
+
+- The PR body MUST follow `.github/pull_request_template.md`. It enumerates the required sections (`Issue for this PR`, `Type of change`, `What does this PR do?`, `How did you verify your code works?`, `Screenshots / recordings`, `Checklist`). PRs that miss the template get auto-closed by `pr-standards.yml` — typically within a couple of hours — so fill every section before requesting review.
+- Open PRs against `dev` (see the bullet above); a local `main` ref may not exist.
+- Read `CONTRIBUTING.md` before opening a PR. In particular: any core product or UI feature must go through a design review with the core team before implementation. If you are unsure whether a PR would be accepted, ask a maintainer or look for issues labelled `help wanted`, `good first issue`, `bug`, or `perf`.
+- Commit messages and PR titles follow conventional commits (see `## Commits and PR Titles`); this PR is itself a `docs:` change and should set `Type of change` to `Documentation`.
+
 ## Branch Names
 
 Use a short branch name of at most three words, separated by hyphens. Do not use slashes or type prefixes such as `feat/` or `fix/`.


### PR DESCRIPTION
### Issue for this PR

Adds the missing `## PR conventions` pointer section to `AGENTS.md` so future contributor and agent PRs follow `.github/pull_request_template.md`. Triggered by PR #38903, which was auto-closed for missing required template sections.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

This PR adds a short `## PR conventions` section to `AGENTS.md` (at the repo root). The section is a pointer, not a duplicated copy: it routes future contributors and agents to the authoritative sources (`CONTRIBUTING.md`, `.github/pull_request_template.md`, the existing `## Commits and PR Titles` section) so every PR follows the repo's required template before review.

Why the pointers-over-copies approach: the template text and CONTRIBUTING.md content are the source of truth — duplicating them in `AGENTS.md` would let them drift the moment those files change. `AGENTS.md` should refer agents to those files instead.

Specifically the new section covers:

- The PR body MUST follow `.github/pull_request_template.md`. Missing sections cause `pr-standards.yml` to auto-close the PR (typically within a couple of hours) — this was the root cause for #38903.
- Open PRs against `dev` (the repo's default branch); a local `main` ref may not exist.
- Read `CONTRIBUTING.md` first: core product or UI features require a design review with the core team before implementation; if unsure whether a PR would be accepted, ask a maintainer or look for issues labelled `help wanted`, `good first issue`, `bug`, or `perf`.
- Commit messages and PR titles follow conventional commits (`type(scope): summary`); for this PR that means `docs:` with `Type of change` set to Documentation.

The section is placed between the top intro bullets and `## Branch Names`, so process guidance comes before branch-name and commit-style guidance. No other file is touched.

### How did you verify your code works?

- `git diff AGENTS.md` shows only the seven-line `## PR conventions` block, inserted between the top bullets and `## Branch Names`.
- Confirmed `AGENTS.md` did not already contain `## PR conventions` before the edit.
- Confirmed the template at `.github/pull_request_template.md` enumerates the exact required sections the new section references (Issue, Type of change, What does this PR do, How did you verify, Screenshots/recordings, Checklist).
- Grepped `CONTRIBUTING.md` to confirm the labels and design-review guidance cited in the new section are still present in its current text.
- This PR body itself follows `.github/pull_request_template.md` end-to-end (dogfooding the rule the section is enforcing) and marks `Type of change` as Documentation as a `docs:` commit requires.

### Screenshots / recordings

Not applicable — docs-only change with no UI surface.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
