### PR TITLE
docs(ecosystem): add opencode-session-manager

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 
+| [@enerjizeit/opencode-session-manager](https://github.com/EnerJizeIT/opencode-session-manager) | Pin, back up, restore & auto-cleanup opencode AI sessions -- never lose a conversation |
 ---
 
 ## Projects


### PR DESCRIPTION
### Issue for this PR

N/A — the [Ecosystem page](https://opencode.ai/docs/ecosystem) says "Want to add your OpenCode related project to this list? Submit a PR."

### Type of change

- [x] Documentation

### What does this PR do?

Adds [opencode-session-manager](https://github.com/EnerJizeIT/opencode-session-manager) to the Plugins table — a plugin for pinning, backing up, and restoring opencode AI sessions. Published on [npm](https://www.npmjs.com/package/@enerjizeit/opencode-session-manager), MIT, 12 tools + 2 hooks, actively used.

### How did you verify your code works?

Verified the MDX table row matches the format of existing entries and renders correctly.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR