### PR TITLE
fix(opencode): drop undefined from v1 permission metadata

### DIFF
--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -25,6 +25,36 @@ interface State {
   approved: PermissionV1.Rule[]
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+function sanitize(value: unknown, path: Set<unknown>): unknown {
+  if (!isPlainObject(value) && !Array.isArray(value)) return value
+  if (path.has(value)) return value
+  path.add(value)
+  const result = Array.isArray(value)
+    ? value.map((item) => sanitize(item, path))
+    : Object.fromEntries(
+        Object.entries(value)
+          .filter(([, item]) => item !== undefined)
+          .map(([key, item]) => [key, sanitize(item, path)]),
+      )
+  path.delete(value)
+  return result
+}
+
+function sanitizeMetadata(metadata: PermissionV1.Request["metadata"]): PermissionV1.Request["metadata"] {
+  const path = new Set<unknown>([metadata])
+  return Object.fromEntries(
+    Object.entries(metadata)
+      .filter(([, item]) => item !== undefined)
+      .map(([key, item]) => [key, sanitize(item, path)]),
+  )
+}
+
 export function evaluate(permission: string, pattern: string, ...rulesets: PermissionV1.Ruleset[]): PermissionV1.Rule {
   return (
     rulesets
@@ -89,7 +119,7 @@ const layer = Layer.effect(
         sessionID: request.sessionID,
         permission: request.permission,
         patterns: request.patterns,
-        metadata: request.metadata,
+        metadata: sanitizeMetadata(request.metadata),
         always: request.always,
         tool: request.tool,
       }

--- a/packages/opencode/test/permission/metadata-undefined.test.ts
+++ b/packages/opencode/test/permission/metadata-undefined.test.ts
@@ -1,0 +1,99 @@
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { expect } from "bun:test"
+import { Effect, Layer, Schema } from "effect"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Permission } from "../../src/permission"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
+import { InstanceStore } from "../../src/project/instance-store"
+import { testEffect } from "../lib/effect"
+import { SessionID } from "../../src/session/schema"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+
+const noopBootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+const env = AppNodeBuilder.build(
+  LayerNode.group([Permission.node, EventV2Bridge.node, CrossSpawnSpawner.node, InstanceStore.node]),
+  [[InstanceStore.bootstrapNode, noopBootstrap]],
+)
+const it = testEffect(env)
+
+// Mirrors the success schema GET /permission declares, so these assert the
+// encoding that actually fails in production rather than a proxy for it.
+const encode = Schema.encodeUnknownResult(Schema.toCodecJson(Schema.Array(PermissionV1.Request)))
+
+const waitForPending = (count: number) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* Effect.gen(function* () {
+      while (true) {
+        const list = yield* permission.list()
+        if (list.length === count) return list
+        yield* Effect.sleep("10 millis")
+      }
+    }).pipe(
+      Effect.timeoutOrElse({
+        duration: "1 second",
+        orElse: () => Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`)),
+      }),
+    )
+  })
+
+const askAndEncode = (id: string, permission: string, metadata: Record<string, unknown>) =>
+  Effect.gen(function* () {
+    const service = yield* Permission.Service
+    yield* service
+      .ask({
+        id: PermissionV1.ID.make(id),
+        sessionID: SessionID.make("session_" + id),
+        permission,
+        patterns: ["**/*.txt"],
+        metadata,
+        always: ["*"],
+        ruleset: [],
+      })
+      .pipe(Effect.forkScoped)
+    yield* waitForPending(1)
+    const pending = yield* service.list()
+    const result = encode(pending)
+    for (const request of pending) yield* service.reply({ requestID: request.id, reply: "reject" })
+    return result
+  })
+
+it.instance(
+  "pending permission with undefined optional metadata encodes",
+  () =>
+    Effect.gen(function* () {
+      const result = yield* askAndEncode("per_flat", "glob", {
+        pattern: "**/*.txt",
+        path: undefined,
+        limit: undefined,
+      })
+      expect(result._tag).toBe("Success")
+    }),
+  { git: true },
+)
+
+it.instance(
+  "pending permission with undefined nested in metadata encodes",
+  () =>
+    Effect.gen(function* () {
+      const result = yield* askAndEncode("per_nested", "edit", {
+        filepath: "a.ts",
+        diff: "Index: a.ts",
+        files: [{ filePath: "a.ts", type: "update", patch: "Index: a.ts", movePath: undefined }],
+      })
+      expect(result._tag).toBe("Success")
+    }),
+  { git: true },
+)
+
+it.instance(
+  "metadata that cannot encode for other reasons still fails",
+  () =>
+    Effect.gen(function* () {
+      const result = yield* askAndEncode("per_hole", "glob", { pattern: "**/*.txt", matches: [1, undefined, 2] })
+      expect(result._tag).toBe("Failure")
+    }),
+  { git: true },
+)


### PR DESCRIPTION
### Issue for this PR

Closes #38912

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

v1 tools write absent optional inputs into permission metadata as `undefined`, because `path: params.path` creates the key instead of omitting it. Metadata is `Schema.Record(Schema.String, Schema.Unknown)`, and `Unknown` encodes through `Schema.Json`, whose guard rejects `undefined` and recurses. One pending request therefore breaks the whole `GET /permission` response, not just its own entry.

Five tools hit it: glob, grep, webfetch and websearch flat, plus apply_patch, which nests `movePath` inside `metadata.files[]`.

Fixed where the pending request is built, the only place one is constructed, so it covers both the listing and the `Event.Asked` publish. Recursive because apply_patch nests, and because plugin tools feed the same bag (`AskInput.metadata` is `{ [key: string]: any }`), so the producer set is open. Plain objects and arrays only, so a `Date` is not flattened to `{}` by `Object.entries`, and ancestors are tracked the way `SchemaAST.isJson` does, so genuine cycles still fail instead of looping forever.

### How did you verify your code works?

Three tests boot the real Permission service and encode `list()` through the schema `GET /permission` declares, so they assert the operation that actually fails rather than a proxy. Reverting only the source change makes the flat and nested tests fail while the negative one still passes. 145 tests pass across the permission, acp and apply_patch suites, `tsgo --noEmit` is clean, and oxlint reports the same 3 warnings as before.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
