### PR TITLE
fix(core): clarify custom question answers

### DIFF
--- a/packages/core/src/tool/question.ts
+++ b/packages/core/src/tool/question.ts
@@ -17,7 +17,7 @@ export const description = `Use this tool when you need to ask the user question
 4. Offer choices to the user about what direction to take.
 
 Usage notes:
-- When \`custom\` is enabled (default), a "Type your own answer" option is added automatically; don't include "Other" or catch-all options
+- A "Type your own answer" option is added automatically; don't include a separate option for free form answers
 - Answers are returned as arrays of labels; set \`multiple: true\` to allow selecting more than one
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label`
 

--- a/packages/core/src/tool/question.ts
+++ b/packages/core/src/tool/question.ts
@@ -18,7 +18,7 @@ export const description = `Use this tool when you need to ask the user question
 
 Usage notes:
 - A "Type your own answer" option is added automatically; don't include a separate option for free form answers
-- Answers are returned as arrays of labels; set \`multiple: true\` to allow selecting more than one
+- Set \`multiple: true\` to allow selecting more than one option
 - If you recommend a specific option, make that the first option in the list and add "(Recommended)" at the end of the label`
 
 export const Input = Schema.Struct({


### PR DESCRIPTION
## Summary
- clarify that custom answers are always available in the Question tool
- tell the model not to add a separate free form answer option

## Testing
- Not run (prompt wording only).