### PR TITLE
fix(native-llm): replace hardcoded provider gate with shared support set

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1523,7 +1523,7 @@ const layer = Layer.effect(
           if (!apiKey) continue
           mergeProvider(providerID, {
             source: "env",
-            key: provider.env.length === 1 ? apiKey : undefined,
+            key: apiKey,
           })
         }
 

--- a/packages/opencode/src/session/llm/native-request.ts
+++ b/packages/opencode/src/session/llm/native-request.ts
@@ -13,6 +13,16 @@ import type { ModelMessage } from "ai"
 import type { Provider } from "@/provider/provider"
 import { isRecord } from "@/util/record"
 
+export const SUPPORTED_NPM_PACKAGES = new Set([
+  "@ai-sdk/openai",
+  "@ai-sdk/azure",
+  "@ai-sdk/anthropic",
+  "@ai-sdk/google",
+  "@ai-sdk/amazon-bedrock",
+  "@ai-sdk/openai-compatible",
+  "@openrouter/ai-sdk-provider",
+])
+
 type ToolInput = {
   readonly description?: string
   readonly inputSchema?: unknown

--- a/packages/opencode/src/session/llm/native-runtime.ts
+++ b/packages/opencode/src/session/llm/native-runtime.ts
@@ -51,12 +51,9 @@ function statusWithFetch(
   input: Pick<StreamInput, "model" | "provider" | "auth">,
   fetch: typeof globalThis.fetch | undefined,
 ): RuntimeStatus {
-  const providerID = input.model.providerID
-  if (providerID !== "openai" && providerID !== "anthropic" && !providerID.startsWith("opencode"))
-    return { type: "unsupported", reason: "provider is not openai, opencode, or anthropic" }
   const npm = input.model.api.npm
-  if (npm !== "@ai-sdk/openai" && npm !== "@ai-sdk/openai-compatible" && npm !== "@ai-sdk/anthropic")
-    return { type: "unsupported", reason: "provider package is not OpenAI, OpenAI-compatible, or Anthropic" }
+  if (!LLMNative.SUPPORTED_NPM_PACKAGES.has(npm))
+    return { type: "unsupported", reason: `provider package ${npm} is not supported by native runtime` }
   if (input.auth?.type === "oauth" && !(input.provider.id === "openai" && fetch)) {
     return { type: "unsupported", reason: "OAuth auth requires a provider fetch override" }
   }


### PR DESCRIPTION
### Issue for this PR

Closes #38893

### Type of change

- [x] Bug fix

### What does this PR do?

The native LLM runtime in `packages/opencode/src/session/llm/native-runtime.ts` has a hardcoded provider allowlist in `statusWithFetch()` that blocks Google, Amazon Bedrock, Azure, and OpenRouter from the native LLM path, even though `packages/opencode/src/session/llm/native-request.ts` has working adapters for them. These two lists are duplicated and drift apart when new providers are added.

Changes:
- Export `SUPPORTED_NPM_PACKAGES` set from `native-request.ts` (single source of truth)
- Use the shared set in the `statusWithFetch()` gate instead of hardcoded providerID/npm checks
- Fix API key propagation: drop the `provider.env.length === 1` guard that discarded discovered keys for providers with multiple env vars

### How did you verify your code works?

- TypeScript compiles in packages/llm, packages/core, packages/opencode
- The SUPPORTED_NPM_PACKAGES set is verified to contain every package that native-request.ts routes
- Native LLM now accepts all known provider packages

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR