### PR TITLE
[FEATURE]: Add cursor_style config support

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -190,8 +190,8 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
     Effect.gen(function* () {
       const renderer = yield* Effect.acquireRelease(
         Effect.tryPromise({
-          try: () =>
-            createCliRenderer({
+          try: () => {
+            const renderer = createCliRenderer({
               externalOutputMode: "passthrough",
               targetFps: 60,
               gatherStats: false,
@@ -203,7 +203,18 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
               consoleOptions: {
                 keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }],
               },
-            }),
+            })
+            // Apply cursor style if configured in tui.json
+            if (input.config?.cursor_style) {
+              const styleMap: Record<string, any> = {
+                beam: "line",
+                underline: "underline",
+                block: "block",
+              } as const
+              renderer.setCursorStyle({ style: styleMap[input.config.cursor_style] })
+            }
+            return renderer;
+          },
           catch: (error) => (error instanceof Error ? error : new Error(String(error))),
         }),
         (renderer) =>

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -63,6 +63,9 @@ export const Info = Schema.Struct({
   scroll_acceleration: Schema.optional(ScrollAcceleration),
   diff_style: Schema.optional(DiffStyle),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  // New cursor_style option: "beam" (vertical line), "underline", or "block".
+  cursor_style: Schema.optional(Schema.Literals(["beam", "underline", "block"]))
+    .annotate({ description: "Terminal cursor shape: 'beam' (vertical line), 'underline', or 'block'." }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 


### PR DESCRIPTION
This PR adds a `cursor_style` option to `tui.json` (beam/underline/block) and applies the style via `renderer.setCursorStyle` during TUI initialization. Closes #38931.