### PR TITLE
fix(core): prevent allBounded listener leak via PubSub subscription

### DIFF
--- a/packages/core/src/event.ts
+++ b/packages/core/src/event.ts
@@ -1,6 +1,6 @@
 export * as EventV2 from "./event"
 
-import { Cause, Context, Effect, Layer, Option, PubSub, Queue, Schema, Stream } from "effect"
+import { Cause, Context, Effect, Layer, Option, PubSub, Queue, Schema, Scope, Stream } from "effect"
 import { Event } from "@opencode-ai/schema/event"
 import type { Data, Definition, Payload } from "@opencode-ai/schema/event"
 import { and, asc, eq, gt, inArray } from "drizzle-orm"
@@ -145,23 +145,12 @@ export interface Interface {
   ) => Effect.Effect<string | undefined>
   readonly remove: (aggregateID: string) => Effect.Effect<void>
   readonly claim: (aggregateID: string, ownerID: string) => Effect.Effect<void>
+  readonly allBounded: (capacity: number) => Effect.Effect<Stream.Stream<Payload, SubscriberOverflowError>, never, Scope.Scope>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Event") {}
 
-export const allBounded = (events: Interface, capacity: number) =>
-  Effect.gen(function* () {
-    const queue = yield* Queue.dropping<Payload, SubscriberOverflowError>(capacity)
-    const unsubscribe = yield* events.listen((event) =>
-      Queue.offer(queue, event).pipe(
-        Effect.flatMap((accepted) =>
-          accepted ? Effect.void : Queue.fail(queue, new SubscriberOverflowError({ capacity })).pipe(Effect.asVoid),
-        ),
-      ),
-    )
-    yield* Effect.addFinalizer(() => unsubscribe.pipe(Effect.andThen(Queue.shutdown(queue)), Effect.asVoid))
-    return Stream.fromQueue(queue)
-  })
+export const allBounded = (events: Interface, capacity: number) => events.allBounded(capacity)
 
 export interface LayerOptions {
   readonly beforeAggregateRead?: (aggregateID: string) => Effect.Effect<void>
@@ -178,7 +167,7 @@ export const layerWith = (options?: LayerOptions) =>
       }
       const projectors = new Map<string, Subscriber[]>()
       // TODO: Bind durable projectors to exact type+version before supporting incompatible historical payloads.
-      const listeners = new Array<Subscriber>()
+      const listeners = new Set<Subscriber>()
       const { db } = yield* Database.Service
 
       const getOrCreate = (definition: Definition) =>
@@ -605,10 +594,9 @@ export const layerWith = (options?: LayerOptions) =>
 
       const listen = (listener: Subscriber): Effect.Effect<Unsubscribe> =>
         Effect.sync(() => {
-          listeners.push(listener)
+          listeners.add(listener)
           return Effect.sync(() => {
-            const index = listeners.indexOf(listener)
-            if (index >= 0) listeners.splice(index, 1)
+            listeners.delete(listener)
           })
         })
 
@@ -617,6 +605,27 @@ export const layerWith = (options?: LayerOptions) =>
           const list = projectors.get(definition.type) ?? []
           list.push((event) => projector(event as Payload<D>))
           projectors.set(definition.type, list)
+        })
+
+      const allBounded = (capacity: number) =>
+        Effect.gen(function* () {
+          const queue = yield* Queue.dropping<Payload, SubscriberOverflowError>(capacity)
+          const subscription = yield* PubSub.subscribe(pubsub.all)
+          yield* Effect.forkScoped(
+            Stream.fromSubscription(subscription).pipe(
+              Stream.runForEach((event) =>
+                Queue.offer(queue, event).pipe(
+                  Effect.flatMap((accepted) =>
+                    accepted
+                      ? Effect.void
+                      : Queue.fail(queue, new SubscriberOverflowError({ capacity })).pipe(Effect.asVoid),
+                  ),
+                ),
+              ),
+            ),
+          )
+          yield* Effect.addFinalizer(() => Queue.shutdown(queue))
+          return Stream.fromQueue(queue)
         })
 
       return Service.of({
@@ -630,6 +639,7 @@ export const layerWith = (options?: LayerOptions) =>
         replayAll,
         remove,
         claim,
+        allBounded,
       })
     }),
   )

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -35,6 +35,7 @@ const capture = () => {
     replayAll: () => Effect.succeed(undefined),
     remove: () => Effect.void,
     claim: () => Effect.void,
+    allBounded: () => Effect.die("unused"),
   })
   return {
     published,

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts
@@ -30,7 +30,7 @@ function eventResponse(events: EventV2.Interface) {
     // be lost while the HTTP body fiber is starting or emitting server.connected.
     const queue = yield* Queue.unbounded<EventV2.Payload>()
     const unsubscribe = yield* events.listen((event) => Effect.sync(() => Queue.offerUnsafe(queue, event)))
-    yield* Effect.addFinalizer(() => unsubscribe)
+    yield* Effect.addFinalizer(() => unsubscribe.pipe(Effect.andThen(Queue.shutdown(queue))))
     const stream = Stream.fromQueue(queue).pipe(
       Stream.filter(
         (event) =>

--- a/packages/opencode/src/share/share-next.ts
+++ b/packages/opencode/src/share/share-next.ts
@@ -163,17 +163,22 @@ const layer = Layer.effect(
 
         if (disabled) return cache
 
+        const unsubs: EventV2.Unsubscribe[] = []
+
         const watch = <D extends EventV2.Definition>(
           def: D,
           fn: (data: EventV2.Data<D>) => Effect.Effect<void, unknown>,
         ) =>
-          events.listen((event) => {
-            if (event.type !== def.type || event.location?.directory !== _ctx.directory) return Effect.void
-            return fn(event.data as EventV2.Data<D>).pipe(
-              Effect.catchCause((cause) =>
-                Effect.logError("share subscriber failed", { type: def.type, cause: cause }),
-              ),
-            )
+          Effect.gen(function* () {
+            const unsub = yield* events.listen((event) => {
+              if (event.type !== def.type || event.location?.directory !== _ctx.directory) return Effect.void
+              return fn(event.data as EventV2.Data<D>).pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logError("share subscriber failed", { type: def.type, cause: cause }),
+                ),
+              )
+            })
+            unsubs.push(unsub)
           })
 
         yield* watch(Session.Event.Updated, (data) =>
@@ -198,6 +203,10 @@ const layer = Layer.effect(
           sync(data.sessionID, [{ type: "session_diff", data: structuredClone(data.diff) as SDK.SnapshotFileDiff[] }]),
         )
         yield* watch(Session.Event.Deleted, (data) => remove(data.sessionID))
+
+        yield* Effect.addFinalizer(() =>
+          Effect.forEach(unsubs, (unsub) => unsub, { discard: true }),
+        )
 
         return cache
       }),


### PR DESCRIPTION
### Issue for this PR

Closes #36677

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The root cause of #36677 is that `EventV2.allBounded` relied on `events.listen()`, which registers the callback in a global `listeners` Set inside the EventV2 service. The cleanup of that registration depended on `Effect.addFinalizer` running inside the scope provided by `Stream.unwrap` → `Channel.unwrap`. When that scope didn't close reliably (location expiry/reboot cycles, or SSE client disconnect patterns that skip channel finalization), the listener stayed in the Set permanently.

What this means for a leaked listener: every call to `EventV2.notify` iterates the entire `listeners` Set and calls each listener function. A leaked `allBounded` listener calls `Queue.offer` on every published event, allocating regardless of whether the queue is already failed. Over hours of uptime with repeated location reboots, these allocations push the JSC heap into continuous GC cycles — the 80% CPU / constant madvise behavior reported in the issue.

The fix has three parts:

**1. Move `allBounded` out of `events.listen()` and into the Interface directly.**

The old module-level function:

```ts
Effect.gen(function* () {
  const queue = Queue.dropping(capacity)
  const unsubscribe = yield* events.listen(callback)  // registers in global Set
  yield* addFinalizer(() => unsubscribe.then(shutdown))  // depends on scope close
  return Stream.fromQueue(queue)
})
```

The new Interface method inside the layer:

```ts
Effect.gen(function* () {
  const queue = Queue.dropping(capacity)
  const subscription = yield* PubSub.subscribe(pubsub.all)  // synchronous, no race
  yield* forkScoped(Stream.fromSubscription(subscription).pipe(runForEach(callback)))
  yield* addFinalizer(() => Queue.shutdown(queue))
  return Stream.fromQueue(queue)
})
```

The key difference: `PubSub.subscribe(pubsub.all)` registers the subscriber directly on the PubSub, not in a separate global Set. The subscription is managed by Scope — when the scope closes (stream ends or is interrupted), the subscriber is removed atomically as part of PubSub's internal subscriber tracking. There is no separate cleanup step that can be skipped.

`PubSub.subscribe` is also synchronous — it returns the subscriber immediately after registering it. This means there is no race between subscribing and publishing events, so the existing test (which creates bounded streams then immediately publishes) continues to pass.

**2. Added missing `Queue.shutdown` in the opencode SSE handler finalizer.**

At `packages/opencode/src/server/routes/instance/httpapi/handlers/event.ts:32`, the finalizer was calling `unsubscribe` but never `Queue.shutdown(queue)`. This meant the unbounded queue survived the SSE disconnect, holding references to buffered events.

**3. Collected unsubscription effects in share-next `watch` helper.**

At `packages/opencode/src/share/share-next.ts`, the `watch` function called `events.listen()` but never stored or ran the returned `Unsubscribe` effect. The listeners accumulated for the process lifetime. The fix stores each unsubscribe and registers them as a scope finalizer.

### How did you verify your code works?

- All 44 event tests pass, specifically including `ends only an overflowing bounded subscriber without blocking other listeners` which tests the exact bounded-stream pattern used in production.
- Full core test suite: 1080 tests pass, 0 fail across 142 files.
- TypeScript typecheck passes in `packages/core` and `packages/server`.
- The monorepo-wide `bun turbo typecheck` passes across all 36 packages.

### Screenshots / recordings

Not applicable — logic change only.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR