### PR TITLE
docs: add opencode-plugin-loop to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-plugin-loop](https://github.com/jkrandom-sudo/opencode-plugin-loop)                      | Fixed, adaptive, one-shot, and maintenance `/loop` scheduling for OpenCode                         |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #38945

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-plugin-loop` to the ecosystem plugin table. The entry links to the public repository and briefly describes its fixed, adaptive, one-shot, and maintenance `/loop` scheduling modes.

### How did you verify your code works?

Ran `git diff --check` and confirmed the PR changes only `packages/web/src/content/docs/ecosystem.mdx`. The linked repository and npm package are public, and the plugin main-branch CI passes.

### Screenshots / recordings

Not applicable; this is a documentation-only table entry.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR