### PR TITLE
fix(session): cap retry attempts to prevent infinite thinking on API errors

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -27,6 +27,7 @@ export const RETRY_INITIAL_DELAY = 2000
 export const RETRY_BACKOFF_FACTOR = 2
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
+export const RETRY_MAX_ATTEMPTS = 5 // give up after ~60s of backoff (2+4+8+16+30)
 
 function cap(ms: number) {
   return Math.min(ms, RETRY_MAX_DELAY)
@@ -183,6 +184,7 @@ export function policy(opts: {
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)
+      if (meta.attempt >= RETRY_MAX_ATTEMPTS) return Cause.done(meta.attempt)
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis


### PR DESCRIPTION
### Issue for this PR

Closes #38951

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a provider returns a timeout error (e.g. `HeaderTimeoutError` from nvapi), the error is converted to an `APIError` with `isRetryable: true`. The session processor wraps the LLM stream with `Effect.retry(SessionRetry.policy(...))`, but since the error remains retryable indefinitely, the retry schedule never terminates — the session stays stuck in "thinking" state forever.

This PR adds `RETRY_MAX_ATTEMPTS = 5` to the retry policy. After ~60 seconds of backoff (2s → 4s → 8s → 16s → 30s) the schedule gives up, the error propagates to the processor halt handler, the session transitions to idle, and a `Session.Event.Error` is published so configured fallback chains can take over.

### How did you verify your code works?

I traced the full error propagation path through the code:

1. `MessageV2.fromError()` — timeout errors are marked `isRetryable: true` (message-v2.ts:653-664)
2. `SessionRetry.policy()` — the schedule step returns the retryable error (retry.ts:184-185)
3. Without an attempt cap, `Effect.retry` loops forever — the session never exits thinking state
4. With the cap, `Cause.done` propagates -> `Effect.catch(halt)` sets the session to idle (processor.ts:599-625)

The diff is minimal: one new constant and one guard check.

### Screenshots / recordings

N/A

### Checklist

- [X] I have tested my changes locally (code trace / analysis)
- [X] I have not included unrelated changes in this PR