### PR TITLE
fix(opencode): keep the session model on injected prompts

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -467,13 +467,14 @@ const layer = Layer.effect(
               throw error
             }
             const model = input.model ?? agent.model ?? (yield* currentModel(input.sessionID))
+            const variant = "variant" in model && typeof model.variant === "string" ? model.variant : undefined
             const userMsg: SessionV1.User = {
               id: input.messageID ?? MessageID.ascending(),
               sessionID: input.sessionID,
               time: { created: Date.now() },
               role: "user",
               agent: input.agent,
-              model: { providerID: model.providerID, modelID: model.modelID },
+              model: { providerID: model.providerID, modelID: model.modelID, variant },
             }
             yield* sessions.updateMessage(userMsg)
             const userPart: SessionV1.Part = {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,7 +10,7 @@ import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
-import { Effect, Exit, Schema, Scope } from "effect"
+import { Effect, Exit, Option, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Database } from "@opencode-ai/core/database/database"
@@ -218,11 +218,19 @@ export const TaskTool = Tool.define(
         text: string,
       ) {
         const currentParent = yield* sessions.get(ctx.sessionID)
+        const parentMessages = yield* sessions.messages({ sessionID: ctx.sessionID }).pipe(Effect.option)
+        if (Option.isNone(parentMessages)) return
+        const { user: lastUser } = MessageV2.latest(parentMessages.value)
+        if (!lastUser) return
         yield* ops
           .prompt({
             sessionID: ctx.sessionID,
             agent: currentParent.agent ?? ctx.agent,
-            variant,
+            model: {
+              providerID: lastUser.model.providerID,
+              modelID: lastUser.model.modelID,
+            },
+            variant: lastUser.model.variant ?? variant,
             parts: [
               {
                 type: "text",

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1518,6 +1518,29 @@ unixNoLLMServer(
 )
 
 unixNoLLMServer(
+  "shell preserves the current model variant",
+  () =>
+    Effect.gen(function* () {
+      const { prompt, sessions, chat } = yield* boot()
+      const seeded = yield* seed(chat.id)
+      yield* sessions.updateMessage({
+        ...seeded.user,
+        model: { ...seeded.user.model, variant: "xhigh" },
+      })
+
+      yield* prompt.shell({
+        sessionID: chat.id,
+        agent: "build",
+        command: "printf ok",
+      })
+
+      const latest = MessageV2.latest(yield* sessions.messages({ sessionID: chat.id }))
+      expect(latest.user?.model).toEqual({ ...ref, variant: "xhigh" })
+    }),
+  { config: cfg },
+)
+
+unixNoLLMServer(
   "shell completes a fast command on the preferred shell",
   () =>
     Effect.gen(function* () {

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -739,10 +739,23 @@ describe("tool.task", () => {
       expect(waited.info?.status).toBe("completed")
       expect(waited.info?.output).toBe("second done")
       const notification = yield* Effect.promise(() => injected.promise)
+      expect(notification.model).toEqual({
+        providerID: ref.providerID,
+        modelID: ref.modelID,
+      })
       expect(notification.variant).toBe("xhigh")
       expect(notification.parts[0]?.type).toBe("text")
       if (notification.parts[0]?.type === "text") expect(notification.parts[0].text).toContain("second done")
     }),
+    {
+      config: {
+        agent: {
+          build: {
+            model: "configured/configured-model",
+          },
+        },
+      },
+    },
   )
 
   background.instance("background tasks complete through the background job service", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #38770

Also relevant to #28735 and #23369, which describe the same symptom through paths this does not fully cover.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A background subagent finishing can silently switch the parent session's model to the agent's configured default. Since Anthropic prompt caching keys on the model, the next turn misses the cache prefix and re-uploads the entire context — on a long session that is the expensive kind of silent. #38770 reports being billed on both models sequentially, which is the same thing seen from the invoice side.

`createUserMessage` resolves an injected prompt's model as:

```ts
const model = input.model ?? ag.model ?? (yield* currentModel(input.sessionID))
```

So any injected prompt that omits `model` lands on `ag.model` — the *configured* default — regardless of what the session was actually using. Two call sites on `dev` do exactly that:

**`TaskTool.injectBackgroundResult`** (`packages/opencode/src/tool/task.ts`) passes `agent` and `variant` but no `model`. This is #38770: the completion notification for a background child re-prompts the parent, and the parent's model changes underneath them. It now reads the parent's latest user message and forwards that model explicitly, with the existing `variant` retained as a fallback.

That also explains the detail in #38770 that looks strange at first — the agent kept reporting the old model as its identity. The system prompt was assembled before the switch; nothing re-runs it when an injected message changes the resolved model, so the prompt and the billed model disagree until the next assembly.

**The shell-execution message** (`packages/opencode/src/session/prompt.ts`) carries provider and model but drops the variant, so a session running `xhigh` quietly falls back to default reasoning effort. The variant is now preserved when the resolved model carries one. Separate bug, same shape, found while fixing the first.

Both fixes only supply what was already implied — neither changes agent resolution, so a genuine agent switch still adopts the new agent's model as before.

I found this from the other end: a live session moved `claude-fable-5` → `claude-opus-5` at a user message with no text (the injected notification), timestamp-matched to its child session completing, landing on exactly that agent's configured default.

### How did you verify your code works?

Red-first, one test per site, each failing for its own distinct reason against unmodified `dev`:

```
task injection:  19 pass, 1 fail — expected parent model, received undefined
shell execution: 56 pass, 1 skip, 1 fail — expected variant "xhigh", received none
```

Mutation-checked separately, so neither fix is riding on the other's coverage:

```
task.ts reverted    → RED 19 pass / 1 fail   restored → GREEN 20 pass / 0 fail
prompt.ts reverted  → RED 56 pass / 1 fail   restored → GREEN 57 pass / 0 fail
```

Full suite in `packages/opencode`: 3208 pass / 0 fail. `bun typecheck` exit 0.

Note on scope: #35195 fixes this class more broadly at the shared resolution point, by consulting the durable session row before the agent default — these two sites would be covered by it. This PR fixes the call sites directly, which is independently useful and does not conflict with that approach.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR