### PR TITLE
fix: use 'environment' key for MCP env vars in skill example

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -112,7 +112,7 @@ Every field is optional.
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp"],
       "enabled": true,
-      "env": {}
+      "environment": {}
     },
     "remote-thing": {
       "type": "remote",
@@ -371,7 +371,7 @@ Special object-shaped (not callbacks): `tool: { my_tool: { ... } }`,
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp"],
       "enabled": true,
-      "env": { "BROWSER": "chromium" }
+      "environment": { "BROWSER": "chromium" }
     },
     "github": {
       "type": "remote",


### PR DESCRIPTION
### Issue for this PR

Fixes (partially) #35860 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The built-in skill example uses `env` for local MCP servers. The schema and runtime expect `environment`. This causes env vars to silently drop when users or models follow the example provided by OpenCode.

### How did you verify your code works?

Tested before/after making this one change.  I was working through this using a local model and it even said it followed the skill example verbatim.

> 1. I copied the skill example verbatim. The skill doc at customize-opencode shows "env": {} as the example and I used that directly, instead of cross-checking against the actual schema at https://opencode.ai/config.json.
> 2. The skill doc is wrong. That env in the example contradicts the real schema which uses environment. I should have noticed the discrepancy or validated against the authoritative reference before applying anything.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR