### PR TITLE
feat: search session contents

### DIFF
--- a/packages/app/src/context/global-sync/home-session-index.test.ts
+++ b/packages/app/src/context/global-sync/home-session-index.test.ts
@@ -3,8 +3,10 @@ import type { SessionV2Info } from "@opencode-ai/sdk/v2/client"
 import {
   applyHomeSessionEvent,
   appendHomeSessionEvent,
+  HOME_SESSION_SEARCH_LIMIT,
   HOME_V2_SESSION_PAGE_LIMIT,
   loadHomeSessionIndex,
+  loadHomeSessionSearch,
   homeSessionIndexSessions,
   homeSessionIndexRefresh,
   parseHomeSessionIndex,
@@ -67,6 +69,69 @@ describe("Home V2 session index", () => {
       { input: { limit: HOME_V2_SESSION_PAGE_LIMIT, order: "desc" }, signal: controller.signal },
       {
         input: { limit: HOME_V2_SESSION_PAGE_LIMIT, order: "desc", cursor: "next-page" },
+        signal: controller.signal,
+      },
+    ])
+  })
+
+  test("searches scoped session content until a visible page is found", async () => {
+    const calls: unknown[] = []
+    const controller = new AbortController()
+    const result = await loadHomeSessionSearch(
+      async (input, options) => {
+        calls.push({ input, signal: options.signal })
+        if (!("cursor" in input)) {
+          return {
+            data: {
+              data: Array.from({ length: HOME_SESSION_SEARCH_LIMIT }, (_, index) =>
+                index % 2 === 0
+                  ? session({ id: `child-${index}`, parentID: "root" })
+                  : session({ id: `archived-${index}`, archived: 2 }),
+              ),
+              cursor: { next: "next-page" },
+            },
+          }
+        }
+        return {
+          data: {
+            data: [
+              session({ id: "content-match" }),
+              session({ id: "other-project", directory: "/other" }),
+              session({ id: "child", parentID: "content-match" }),
+            ],
+            snippets: {
+              "content-match": "inspect the spectral cache invalidation path",
+              "other-project": "spectral cache in another project",
+            },
+            cursor: {},
+          },
+        }
+      },
+      "spectral cache",
+      { project: "project", directories: ["/project"] },
+      controller.signal,
+    )
+
+    expect(result.sessions.map((item) => item.id)).toEqual(["content-match"])
+    expect(result.snippets).toEqual({ "content-match": "inspect the spectral cache invalidation path" })
+    expect(calls).toEqual([
+      {
+        input: {
+          search: "spectral cache",
+          limit: HOME_SESSION_SEARCH_LIMIT,
+          order: "desc",
+          project: "project",
+        },
+        signal: controller.signal,
+      },
+      {
+        input: {
+          search: "spectral cache",
+          limit: HOME_SESSION_SEARCH_LIMIT,
+          order: "desc",
+          project: "project",
+          cursor: "next-page",
+        },
         signal: controller.signal,
       },
     ])

--- a/packages/app/src/context/global-sync/home-session-index.ts
+++ b/packages/app/src/context/global-sync/home-session-index.ts
@@ -4,6 +4,7 @@ import { trimSessions } from "./session-trim"
 import { pathKey } from "@/utils/path-key"
 
 export const HOME_V2_SESSION_PAGE_LIMIT = 5_000
+export const HOME_SESSION_SEARCH_LIMIT = 100
 
 export type HomeSessionEvent = {
   type: "session.created" | "session.updated" | "session.deleted"
@@ -47,6 +48,60 @@ export async function loadHomeSessionIndex(
     data.push(...page.data)
     if (page.data.length < HOME_V2_SESSION_PAGE_LIMIT || !page.cursor.next)
       return { sessions: parseHomeSessionIndex(data), eventSequence }
+    cursor = page.cursor.next
+  }
+}
+
+export async function loadHomeSessionSearch(
+  list: (
+    input: { search: string; limit: number; order: "desc"; project?: string; cursor?: string },
+    options: { signal?: AbortSignal },
+  ) => Promise<HomeSessionPage>,
+  search: string,
+  options: { project?: string; directories?: string[] } = {},
+  signal?: AbortSignal,
+) {
+  const directories = options.directories ? new Set(options.directories.map(pathKey)) : undefined
+  const sessions: Session[] = []
+  const snippets: Record<string, string> = {}
+  let cursor: string | undefined
+
+  for (;;) {
+    const response = await list(
+      {
+        search,
+        limit: HOME_SESSION_SEARCH_LIMIT,
+        order: "desc",
+        ...(options.project ? { project: options.project } : {}),
+        ...(cursor ? { cursor } : {}),
+      },
+      { signal },
+    )
+    const page = response.data!
+    const visible = parseHomeSessionIndex(page.data)
+      .filter((session) => !directories || directories.has(pathKey(session.directory)))
+      .slice(0, HOME_SESSION_SEARCH_LIMIT - sessions.length)
+    const pageSnippets = Object.fromEntries(
+      Object.entries(page.snippets ?? {}).filter((entry): entry is [string, string] => {
+        return typeof entry[1] === "string"
+      }),
+    )
+    sessions.push(...visible)
+    Object.assign(
+      snippets,
+      Object.fromEntries(
+        visible.flatMap((session) => {
+          const snippet = pageSnippets[session.id]
+          return snippet === undefined ? [] : [[session.id, snippet]]
+        }),
+      ),
+    )
+    if (
+      sessions.length === HOME_SESSION_SEARCH_LIMIT ||
+      page.data.length < HOME_SESSION_SEARCH_LIMIT ||
+      !page.cursor.next
+    )
+      return { sessions, snippets }
     cursor = page.cursor.next
   }
 }

--- a/packages/app/src/pages/home-session-search.test.ts
+++ b/packages/app/src/pages/home-session-search.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import {
+  isHomeSessionSearchResultCurrent,
+  mergeHomeSessionSearchResults,
+  splitHomeSessionSearchSnippet,
+} from "./home-session-search"
+
+describe("isHomeSessionSearchResultCurrent", () => {
+  const result = { query: "spectral cache", server: "local", scope: "/project" }
+
+  test("accepts only the resolved query in the same server scope", () => {
+    expect(
+      isHomeSessionSearchResultCurrent(result, { query: "spectral cache", server: "local", scope: "/project" }),
+    ).toBe(true)
+    expect(
+      isHomeSessionSearchResultCurrent(result, { query: "spectral caches", server: "local", scope: "/project" }),
+    ).toBe(false)
+    expect(
+      isHomeSessionSearchResultCurrent(result, { query: "spectral cache", server: "remote", scope: "/project" }),
+    ).toBe(false)
+    expect(
+      isHomeSessionSearchResultCurrent(result, { query: "spectral cache", server: "local", scope: "/other" }),
+    ).toBe(false)
+  })
+})
+
+describe("mergeHomeSessionSearchResults", () => {
+  test("keeps settled server results while the next local filter is empty", () => {
+    const settled = [{ id: "content-match", title: "Cache investigation" }]
+
+    expect(mergeHomeSessionSearchResults({ local: [], remote: settled, key: (item) => item.id })).toEqual(settled)
+  })
+
+  test("prefers server records carrying search context", () => {
+    expect(
+      mergeHomeSessionSearchResults({
+        local: [{ id: "content-match", snippet: undefined }],
+        remote: [{ id: "content-match", snippet: "spectral cache" }],
+        key: (item) => item.id,
+      }),
+    ).toEqual([{ id: "content-match", snippet: "spectral cache" }])
+  })
+})
+
+describe("splitHomeSessionSearchSnippet", () => {
+  test("preserves the original casing while marking the matching phrase", () => {
+    expect(splitHomeSessionSearchSnippet("Inspect the Spectral Cache invalidation path", "spectral cache")).toEqual([
+      { text: "Inspect the ", match: false },
+      { text: "Spectral Cache", match: true },
+      { text: " invalidation path", match: false },
+    ])
+  })
+
+  test("keeps an unmatched snippet as plain context", () => {
+    expect(splitHomeSessionSearchSnippet("Database migration settings", "spectral cache")).toEqual([
+      { text: "Database migration settings", match: false },
+    ])
+  })
+})

--- a/packages/app/src/pages/home-session-search.test.ts
+++ b/packages/app/src/pages/home-session-search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  findHomeSessionSearchResult,
   isHomeSessionSearchResultCurrent,
   mergeHomeSessionSearchResults,
   settledHomeSessionSearchResult,
@@ -69,6 +70,18 @@ describe("mergeHomeSessionSearchResults", () => {
         key: (item) => item.id,
       }),
     ).toEqual([{ id: "content-match", snippet: "spectral cache" }])
+  })
+})
+
+describe("findHomeSessionSearchResult", () => {
+  test("matches arbitrary directory characters without parsing them as a selector", () => {
+    const root = document.createElement("div")
+    const expected = document.createElement("button")
+    const key = String.raw`/project/with "quotes"] and \slashes:ses_match`
+    expected.dataset.key = key
+    root.append(document.createElement("button"), expected)
+
+    expect(findHomeSessionSearchResult(root, key)).toBe(expected)
   })
 })
 

--- a/packages/app/src/pages/home-session-search.test.ts
+++ b/packages/app/src/pages/home-session-search.test.ts
@@ -2,8 +2,38 @@ import { describe, expect, test } from "bun:test"
 import {
   isHomeSessionSearchResultCurrent,
   mergeHomeSessionSearchResults,
+  settledHomeSessionSearchResult,
   splitHomeSessionSearchSnippet,
 } from "./home-session-search"
+
+describe("settledHomeSessionSearchResult", () => {
+  test("does not read query data before the first search settles", () => {
+    let reads = 0
+    const result = { sessions: [], snippets: {} }
+
+    expect(
+      settledHomeSessionSearchResult({
+        isSuccess: false,
+        get data() {
+          reads++
+          return result
+        },
+      }),
+    ).toBeUndefined()
+    expect(reads).toBe(0)
+
+    expect(
+      settledHomeSessionSearchResult({
+        isSuccess: true,
+        get data() {
+          reads++
+          return result
+        },
+      }),
+    ).toBe(result)
+    expect(reads).toBe(1)
+  })
+})
 
 describe("isHomeSessionSearchResultCurrent", () => {
   const result = { query: "spectral cache", server: "local", scope: "/project" }

--- a/packages/app/src/pages/home-session-search.ts
+++ b/packages/app/src/pages/home-session-search.ts
@@ -3,6 +3,11 @@ export type HomeSessionSearchSnippetSegment = {
   match: boolean
 }
 
+export function settledHomeSessionSearchResult<T>(query: { isSuccess: boolean; data: T | undefined }) {
+  // Solid Query suspends when data is read during the first lazy fetch, which replaces the home tree at its boundary.
+  return query.isSuccess ? query.data : undefined
+}
+
 export function isHomeSessionSearchResultCurrent(
   result: { query: string; server: string; scope: string },
   current: { query: string; server: string; scope: string },

--- a/packages/app/src/pages/home-session-search.ts
+++ b/packages/app/src/pages/home-session-search.ts
@@ -1,0 +1,28 @@
+export type HomeSessionSearchSnippetSegment = {
+  text: string
+  match: boolean
+}
+
+export function isHomeSessionSearchResultCurrent(
+  result: { query: string; server: string; scope: string },
+  current: { query: string; server: string; scope: string },
+) {
+  return result.query === current.query && result.server === current.server && result.scope === current.scope
+}
+
+export function mergeHomeSessionSearchResults<T>(input: { local: T[]; remote?: T[]; key: (item: T) => string }) {
+  if (!input.remote) return input.local
+  return [...new Map([...input.local, ...input.remote].map((item) => [input.key(item), item])).values()]
+}
+
+export function splitHomeSessionSearchSnippet(snippet: string, query: string): HomeSessionSearchSnippetSegment[] {
+  const term = query.trim()
+  if (!term) return [{ text: snippet, match: false }]
+  const start = snippet.toLocaleLowerCase().indexOf(term.toLocaleLowerCase())
+  if (start === -1) return [{ text: snippet, match: false }]
+  return [
+    { text: snippet.slice(0, start), match: false },
+    { text: snippet.slice(start, start + term.length), match: true },
+    { text: snippet.slice(start + term.length), match: false },
+  ].filter((segment) => segment.text)
+}

--- a/packages/app/src/pages/home-session-search.ts
+++ b/packages/app/src/pages/home-session-search.ts
@@ -20,6 +20,10 @@ export function mergeHomeSessionSearchResults<T>(input: { local: T[]; remote?: T
   return [...new Map([...input.local, ...input.remote].map((item) => [input.key(item), item])).values()]
 }
 
+export function findHomeSessionSearchResult(root: ParentNode | undefined, key: string) {
+  return [...(root?.querySelectorAll<HTMLElement>("[data-key]") ?? [])].find((element) => element.dataset.key === key)
+}
+
 export function splitHomeSessionSearchSnippet(snippet: string, query: string): HomeSessionSearchSnippetSegment[] {
   const term = query.trim()
   if (!term) return [{ text: snippet, match: false }]

--- a/packages/app/src/pages/home/home-session-search-controller.ts
+++ b/packages/app/src/pages/home/home-session-search-controller.ts
@@ -9,6 +9,7 @@ import { useQuery } from "@tanstack/solid-query"
 import { createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
 import {
+  findHomeSessionSearchResult,
   isHomeSessionSearchResultCurrent,
   mergeHomeSessionSearchResults,
   settledHomeSessionSearchResult,
@@ -179,7 +180,7 @@ export function createHomeSessionSearchController(home: HomeController, sessions
         const index = records.findIndex((record) => homeSessionSearchKey(record) === active())
         const next = ((index === -1 ? 0 : index) + delta + records.length) % records.length
         setState("highlighted", homeSessionSearchKey(records[next]))
-        list?.querySelector<HTMLElement>(`[data-key="${state.highlighted}"]`)?.scrollIntoView({ block: "nearest" })
+        findHomeSessionSearchResult(list, state.highlighted)?.scrollIntoView({ block: "nearest" })
       },
       select,
       selectActive: () => {

--- a/packages/app/src/pages/home/home-session-search-controller.ts
+++ b/packages/app/src/pages/home/home-session-search-controller.ts
@@ -99,6 +99,13 @@ export function createHomeSessionSearchController(home: HomeController, sessions
       (a, b) => (b.session.time.updated ?? b.session.time.created) - (a.session.time.updated ?? a.session.time.created),
     )
   })
+  const loading = createMemo(
+    () =>
+      sessions.data.loading() ||
+      (query().length > 0 &&
+        results().length === 0 &&
+        (serverSearch() !== query() || sessionSearchLoad.isFetching)),
+  )
   const active = createMemo(() => {
     const records = results().filter((record) => !record.stale)
     if (records.some((record) => homeSessionSearchKey(record) === state.highlighted)) return state.highlighted
@@ -159,7 +166,7 @@ export function createHomeSessionSearchController(home: HomeController, sessions
       close,
     },
     result: {
-      loading: sessions.data.loading,
+      loading,
       list: results,
       active,
       noResultsLabel: () => language.t("home.sessions.search.noResults", { query: query() }),

--- a/packages/app/src/pages/home/home-session-search-controller.ts
+++ b/packages/app/src/pages/home/home-session-search-controller.ts
@@ -1,10 +1,14 @@
 import { useCommand } from "@/context/command"
+import { loadHomeSessionSearch } from "@/context/global-sync/home-session-index"
 import { useLanguage } from "@/context/language"
 import { serverName } from "@/context/server"
 import { displayName } from "@/pages/layout/helpers"
 import { makeEventListener } from "@solid-primitives/event-listener"
-import { createMemo, onCleanup } from "solid-js"
+import { debounce } from "@solid-primitives/scheduled"
+import { useQuery } from "@tanstack/solid-query"
+import { createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
+import { isHomeSessionSearchResultCurrent, mergeHomeSessionSearchResults } from "../home-session-search"
 import type { HomeController } from "./home-controller"
 import { homeSessionSearchKey, type HomeSessionRecord, type HomeSessionsController } from "./home-sessions-controller"
 
@@ -18,15 +22,81 @@ export function createHomeSessionSearchController(home: HomeController, sessions
   let input: HTMLInputElement | undefined
   let list: HTMLDivElement | undefined
   const query = createMemo(() => state.value.trim())
+  const [serverSearch, setServerSearch] = createSignal("")
+  const scheduleServerSearch = debounce(setServerSearch, 150)
+  createEffect(
+    on(query, (value) => {
+      if (value) {
+        scheduleServerSearch(value)
+        return
+      }
+      scheduleServerSearch.clear()
+      setServerSearch("")
+    }),
+  )
+  const sessionSearchLoad = useQuery(() => ({
+    queryKey: [
+      "home",
+      "session-search",
+      home.selection.value().server,
+      home.selection.value().directory,
+      home.project.selected()?.id,
+      serverSearch(),
+    ],
+    enabled: !!home.server.focusedContext() && serverSearch().length > 0,
+    queryFn: async ({ signal }) => {
+      const value = serverSearch()
+      const server = home.selection.value().server
+      const scope = home.selection.value().directory ?? ""
+      const ctx = home.server.focusedContext()
+      if (!ctx) return { sessions: [], snippets: {}, query: value, server, scope }
+      const project = home.project.selected()
+      const result = await loadHomeSessionSearch(
+        (input, options) => ctx.sdk.client.v2.session.list(input, options),
+        value,
+        {
+          project: project?.id,
+          directories: project ? [project.worktree, ...(project.sandboxes ?? [])] : undefined,
+        },
+        signal,
+      )
+      return { ...result, query: value, server, scope }
+    },
+    placeholderData: (previous) => previous,
+    retry: false,
+  }))
   const results = createMemo(() => {
-    const value = query().toLowerCase()
-    if (!value) return []
-    return sessions.data
+    const current = {
+      query: query(),
+      server: home.selection.value().server,
+      scope: home.selection.value().directory ?? "",
+    }
+    if (!current.query) return []
+    const local = sessions.data
       .searchRecords()
-      .filter((record) => `${record.session.title} ${record.projectName}`.toLowerCase().includes(value))
+      .filter((record) =>
+        `${record.session.title} ${record.projectName}`.toLowerCase().includes(current.query.toLowerCase()),
+      )
+    const result = sessionSearchLoad.data
+    const resultCurrent = result ? isHomeSessionSearchResultCurrent(result, current) : false
+    const remote =
+      result?.server === current.server
+        ? sessions.data.searchResultRecords({
+            sessions: result.sessions,
+            snippets: result.snippets,
+            stale: !resultCurrent,
+          })
+        : undefined
+    const merged =
+      remote && !resultCurrent
+        ? mergeHomeSessionSearchResults({ local: remote, remote: local, key: homeSessionSearchKey })
+        : mergeHomeSessionSearchResults({ local, remote, key: homeSessionSearchKey })
+    return merged.sort(
+      (a, b) => (b.session.time.updated ?? b.session.time.created) - (a.session.time.updated ?? a.session.time.created),
+    )
   })
   const active = createMemo(() => {
-    const records = results()
+    const records = results().filter((record) => !record.stale)
     if (records.some((record) => homeSessionSearchKey(record) === state.highlighted)) return state.highlighted
     return records[0] ? homeSessionSearchKey(records[0]) : ""
   })
@@ -40,6 +110,17 @@ export function createHomeSessionSearchController(home: HomeController, sessions
     }
     return language.t("home.sessions.search.placeholder")
   })
+
+  createEffect(
+    on(results, () => {
+      if (!open()) return
+      queueMicrotask(() => {
+        if (!open() || !input) return
+        if (document.activeElement !== document.body && document.activeElement !== document.documentElement) return
+        input.focus({ preventScroll: true })
+      })
+    }),
+  )
 
   onCleanup(
     makeEventListener(document, "pointerdown", (event) => {
@@ -77,6 +158,7 @@ export function createHomeSessionSearchController(home: HomeController, sessions
   return {
     query: {
       value: () => state.value,
+      search: query,
       placeholder,
       open,
       focus,
@@ -88,9 +170,11 @@ export function createHomeSessionSearchController(home: HomeController, sessions
       list: results,
       active,
       noResultsLabel: () => language.t("home.sessions.search.noResults", { query: query() }),
-      highlight: (record: HomeSessionRecord) => setState("highlighted", homeSessionSearchKey(record)),
+      highlight: (record: HomeSessionRecord) => {
+        if (!record.stale) setState("highlighted", homeSessionSearchKey(record))
+      },
       move: (delta: number) => {
-        const records = results()
+        const records = results().filter((record) => !record.stale)
         if (records.length === 0) return
         const index = records.findIndex((record) => homeSessionSearchKey(record) === active())
         const next = ((index === -1 ? 0 : index) + delta + records.length) % records.length
@@ -99,7 +183,7 @@ export function createHomeSessionSearchController(home: HomeController, sessions
       },
       select,
       selectActive: () => {
-        const record = results().find((item) => homeSessionSearchKey(item) === active())
+        const record = results().find((item) => !item.stale && homeSessionSearchKey(item) === active())
         if (record) select(record)
       },
     },

--- a/packages/app/src/pages/home/home-session-search-controller.ts
+++ b/packages/app/src/pages/home/home-session-search-controller.ts
@@ -8,7 +8,11 @@ import { debounce } from "@solid-primitives/scheduled"
 import { useQuery } from "@tanstack/solid-query"
 import { createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import { createStore } from "solid-js/store"
-import { isHomeSessionSearchResultCurrent, mergeHomeSessionSearchResults } from "../home-session-search"
+import {
+  isHomeSessionSearchResultCurrent,
+  mergeHomeSessionSearchResults,
+  settledHomeSessionSearchResult,
+} from "../home-session-search"
 import type { HomeController } from "./home-controller"
 import { homeSessionSearchKey, type HomeSessionRecord, type HomeSessionsController } from "./home-sessions-controller"
 
@@ -77,7 +81,7 @@ export function createHomeSessionSearchController(home: HomeController, sessions
       .filter((record) =>
         `${record.session.title} ${record.projectName}`.toLowerCase().includes(current.query.toLowerCase()),
       )
-    const result = sessionSearchLoad.data
+    const result = settledHomeSessionSearchResult(sessionSearchLoad)
     const resultCurrent = result ? isHomeSessionSearchResultCurrent(result, current) : false
     const remote =
       result?.server === current.server
@@ -110,17 +114,6 @@ export function createHomeSessionSearchController(home: HomeController, sessions
     }
     return language.t("home.sessions.search.placeholder")
   })
-
-  createEffect(
-    on(results, () => {
-      if (!open()) return
-      queueMicrotask(() => {
-        if (!open() || !input) return
-        if (document.activeElement !== document.body && document.activeElement !== document.documentElement) return
-        input.focus({ preventScroll: true })
-      })
-    }),
-  )
 
   onCleanup(
     makeEventListener(document, "pointerdown", (event) => {

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -29,6 +29,8 @@ export type HomeSessionRecord = {
   session: Session
   project: LocalProject
   projectName: string
+  snippet?: string
+  stale?: boolean
 }
 
 export type HomeSessionGroup = {
@@ -174,6 +176,18 @@ export function createHomeSessionsController(home: HomeController) {
       groups,
       loading: () => sessionLoad.isLoading,
       searchRecords: allRecords,
+      searchResultRecords: (input: { sessions: Session[]; snippets: Record<string, string>; stale: boolean }) =>
+        buildHomeSessionRecords({
+          sessions: () => input.sessions,
+          projectDirectories,
+          projects: home.project.list,
+          projectByID,
+          includeUnknown: !home.project.selected(),
+        }).map((record) => ({
+          ...record,
+          snippet: input.snippets[record.session.id],
+          stale: input.stale,
+        })),
     },
     session: {
       showProjectName: () => !home.project.selected(),
@@ -252,9 +266,12 @@ function buildHomeSessionRecords(input: {
   projectDirectories: () => string[]
   projects: () => LocalProject[]
   projectByID: () => Map<string, LocalProject>
-}) {
+  includeUnknown?: boolean
+}): HomeSessionRecord[] {
   const directories = new Set(input.projectDirectories().map(pathKey))
-  const sessions = input.sessions().filter((session) => directories.has(pathKey(session.directory)))
+  const sessions = input.includeUnknown
+    ? input.sessions()
+    : input.sessions().filter((session) => directories.has(pathKey(session.directory)))
   return [...new Map(sessions.map((session) => [session.id, session] as const)).values()]
     .sort((a, b) => (b.time.updated ?? b.time.created) - (a.time.updated ?? a.time.created))
     .flatMap((session) => {
@@ -266,8 +283,9 @@ function buildHomeSessionRecords(input: {
             (item) =>
               pathKey(item.worktree) === directory || item.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
           ) ?? projectForSession(session, input.projects(), input.projectByID())
-      if (!project) return []
-      return { session, project, projectName: displayName(project) }
+      const resolved = project ?? (input.includeUnknown ? { worktree: session.directory, expanded: false } : undefined)
+      if (!resolved) return []
+      return { session, project: resolved, projectName: displayName(resolved) }
     })
 }
 

--- a/packages/app/src/pages/home/home-sessions-view.tsx
+++ b/packages/app/src/pages/home/home-sessions-view.tsx
@@ -11,6 +11,7 @@ import { ServerConnection } from "@/context/server"
 import { SessionTabAvatarView } from "@/pages/layout/session-tab-avatar"
 import { sessionTitle } from "@/utils/session-title"
 import { shouldOpenSessionInBackground } from "../home-session-open"
+import { splitHomeSessionSearchSnippet } from "../home-session-search"
 import {
   HomeSessionStatusController,
   homeSessionSearchKey,
@@ -44,6 +45,7 @@ export type HomeSessionsViewProps = {
   server: Accessor<ServerConnection.Key>
   canCreateSession: Accessor<boolean>
   searchValue: Accessor<string>
+  searchQuery: Accessor<string>
   searchPlaceholder: Accessor<string>
   searchOpen: Accessor<boolean>
   searchLoading: Accessor<boolean>
@@ -246,14 +248,14 @@ function HomeSessionSearch(props: HomeSessionsViewProps) {
                       >
                         {props.language.t("home.sessions.search.sessions")}
                       </p>
-                      <ScrollView class="max-h-80" viewportRef={props.onSetSearchList}>
+                      <ScrollView class="max-h-80" viewportRef={props.onSetSearchList} viewportTabIndex={-1}>
                         <div class="flex flex-col gap-px pb-2">
                           <For each={props.searchResults()}>
                             {(record) => (
                               <HomeSessionSearchResultRow
                                 {...props}
                                 record={record}
-                                selected={props.searchActive() === homeSessionSearchKey(record)}
+                                selected={!record.stale && props.searchActive() === homeSessionSearchKey(record)}
                               />
                             )}
                           </For>
@@ -356,8 +358,10 @@ function HomeSessionSearchResultRow(
       data-component="home-session-search-row"
       role="option"
       aria-selected={props.selected}
+      aria-disabled={props.record.stale}
+      disabled={props.record.stale}
       class={`
-        flex h-10 w-full shrink-0 cursor-default items-center gap-2 border-0 py-3 pl-[18px] pr-6 text-left
+        flex min-h-10 w-full shrink-0 cursor-default items-center gap-2 border-0 py-2 pl-[18px] pr-6 text-left
         transition-[background-color] duration-[120ms] ease-in-out
         hover:bg-v2-overlay-simple-overlay-hover focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:outline-none
       `}
@@ -369,9 +373,11 @@ function HomeSessionSearchResultRow(
       onMouseDown={(event) => {
         if (event.button === 1) event.preventDefault()
       }}
-      onClick={(event) => props.onSearchSelect(props.record, { background: isBackgroundOpen(event) })}
+      onClick={(event) => {
+        if (!props.record.stale) props.onSearchSelect(props.record, { background: isBackgroundOpen(event) })
+      }}
       onAuxClick={(event) => {
-        if (!isBackgroundOpen(event)) return
+        if (props.record.stale || !isBackgroundOpen(event)) return
         event.preventDefault()
         props.onSearchSelect(props.record, { background: true })
       }}
@@ -382,10 +388,37 @@ function HomeSessionSearchResultRow(
         record={props.record}
         revealProjectOnHover={!!showProjectName()}
       />
-      <div class="flex min-w-0 flex-1 items-center gap-1.5">
-        <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} search />
-        <Show when={showProjectName()}>
-          <HomeSessionProjectName name={props.record.projectName} search />
+      <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div class="flex min-w-0 items-center gap-1.5">
+          <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} search />
+          <Show when={showProjectName()}>
+            <HomeSessionProjectName name={props.record.projectName} search />
+          </Show>
+        </div>
+        <Show when={props.record.snippet}>
+          {(snippet) => (
+            <p
+              class={`
+                min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[11px] leading-4
+                tracking-[-0.01px] text-v2-text-text-faint [font-weight:440]
+              `}
+            >
+              <For each={splitHomeSessionSearchSnippet(snippet(), props.searchQuery())}>
+                {(segment) => (
+                  <Show when={segment.match} fallback={segment.text}>
+                    <mark
+                      class={`
+                        rounded-[3px] bg-v2-icon-icon-accent/15 px-0.5
+                        text-v2-text-text-accent [font-weight:530]
+                      `}
+                    >
+                      {segment.text}
+                    </mark>
+                  </Show>
+                )}
+              </For>
+            </p>
+          )}
         </Show>
       </div>
     </button>

--- a/packages/app/src/pages/home/home-sessions.tsx
+++ b/packages/app/src/pages/home/home-sessions.tsx
@@ -17,6 +17,7 @@ export function HomeSessions(props: {
       server={props.sessions.session.server}
       canCreateSession={props.sessions.session.canCreate}
       searchValue={props.search.query.value}
+      searchQuery={props.search.query.search}
       searchPlaceholder={props.search.query.placeholder}
       searchOpen={props.search.query.open}
       searchLoading={props.search.result.loading}

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -263,6 +263,7 @@ export type SessionsListOutput = {
       }>
     }
   }>
+  readonly snippets?: { readonly [x: string]: string } | null
   readonly cursor: { readonly previous?: string | null; readonly next?: string | null }
 }
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -3,7 +3,7 @@ export * from "./session/schema"
 
 import { DateTime, Effect, Layer, Schema, Context, Stream } from "effect"
 import { ListAnchor } from "@opencode-ai/schema/session"
-import { and, asc, desc, eq, gt, like, lt, or, type SQL } from "drizzle-orm"
+import { and, asc, desc, eq, gt, inArray, lt, or, type SQL } from "drizzle-orm"
 import { ProjectV2 } from "./project"
 import { WorkspaceV2 } from "./workspace"
 import { ModelV2 } from "./model"
@@ -14,7 +14,7 @@ import { PromptInput } from "@opencode-ai/schema/prompt-input"
 import { EventV2 } from "./event"
 import { Database } from "./database/database"
 import { SessionProjector } from "./session/projector"
-import { SessionMessageTable, SessionTable } from "./session/sql"
+import { PartTable, SessionMessageTable, SessionTable } from "./session/sql"
 import { SessionSchema } from "./session/schema"
 import { AbsolutePath, PositiveInt, RelativePath } from "./schema"
 import { AgentV2 } from "./agent"
@@ -37,6 +37,7 @@ import { SessionRevert } from "./session/revert"
 import { Revert } from "@opencode-ai/schema/revert"
 import { FSUtil } from "./fs-util"
 import { SessionDurable } from "@opencode-ai/schema/durable-event-manifest"
+import { SessionSearch } from "./session/search"
 
 export const RevertState = Revert.State
 export type RevertState = Revert.State
@@ -112,6 +113,10 @@ export type Error = NotFoundError | MessageDecodeError | OperationUnavailableErr
 
 export interface Interface {
   readonly list: (input?: ListInput) => Effect.Effect<SessionSchema.Info[]>
+  readonly searchSnippets: (input: {
+    sessionIDs: SessionSchema.ID[]
+    search: string
+  }) => Effect.Effect<Array<{ sessionID: SessionSchema.ID; snippet: string }>>
   readonly create: (input: CreateInput) => Effect.Effect<SessionSchema.Info>
   readonly get: (sessionID: SessionSchema.ID) => Effect.Effect<SessionSchema.Info, NotFoundError>
   readonly messages: (input: {
@@ -274,7 +279,7 @@ const layer = Layer.effect(
         if ("directory" in input) conditions.push(eq(SessionTable.directory, input.directory))
         if (input.workspaceID) conditions.push(eq(SessionTable.workspace_id, input.workspaceID))
         if ("project" in input) conditions.push(eq(SessionTable.project_id, input.project))
-        if (input.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
+        if (input.search) conditions.push(SessionSearch.where(input.search))
         if (input.anchor) {
           conditions.push(
             order === "asc"
@@ -300,6 +305,41 @@ const layer = Layer.effect(
           Effect.orDie,
         )
         return (direction === "previous" ? rows.toReversed() : rows).map((row) => fromRow(row))
+      }),
+      searchSnippets: Effect.fn("V2Session.searchSnippets")(function* (input) {
+        if (input.sessionIDs.length === 0 || !input.search) return []
+        const fields = SessionSearch.match(input.search)
+        const [parts, messages] = yield* Effect.all([
+          db
+            .select({
+              sessionID: PartTable.session_id,
+              timeCreated: PartTable.time_created,
+              snippet: fields.part.snippet,
+            })
+            .from(PartTable)
+            .where(and(inArray(PartTable.session_id, input.sessionIDs), fields.part.where))
+            .orderBy(asc(PartTable.time_created), asc(PartTable.id))
+            .all()
+            .pipe(Effect.orDie),
+          db
+            .select({
+              sessionID: SessionMessageTable.session_id,
+              timeCreated: SessionMessageTable.time_created,
+              snippet: fields.message.snippet,
+            })
+            .from(SessionMessageTable)
+            .where(and(inArray(SessionMessageTable.session_id, input.sessionIDs), fields.message.where))
+            .orderBy(asc(SessionMessageTable.time_created), asc(SessionMessageTable.id))
+            .all()
+            .pipe(Effect.orDie),
+        ])
+        return [
+          ...new Map(
+            [...parts.map((row) => ({ ...row, source: 0 })), ...messages.map((row) => ({ ...row, source: 1 }))]
+              .sort((a, b) => a.timeCreated - b.timeCreated || a.source - b.source)
+              .map((row) => [row.sessionID, { sessionID: row.sessionID, snippet: row.snippet }] as const),
+          ).values(),
+        ]
       }),
       messages: Effect.fn("V2Session.messages")(function* (input) {
         yield* result.get(input.sessionID)

--- a/packages/core/src/session/search.ts
+++ b/packages/core/src/session/search.ts
@@ -6,7 +6,7 @@ import { PartTable, SessionMessageTable, SessionTable } from "./sql"
 export function where(input: string) {
   const pattern = searchPattern(input)
   const fields = match(input)
-  // Search readable values explicitly so JSON field names and type tags do not become false matches.
+  // Search conversational values explicitly so JSON metadata and generated tool output do not become false matches.
   return or(
     matches(SessionTable.title, pattern),
     sql`exists (
@@ -31,8 +31,6 @@ export function match(input: string) {
       sql`json_extract(${PartTable.data}, '$.text')`,
       sql`json_extract(${PartTable.data}, '$.prompt')`,
       sql`json_extract(${PartTable.data}, '$.description')`,
-      sql`json_extract(${PartTable.data}, '$.state.output')`,
-      sql`json_extract(${PartTable.data}, '$.state.error')`,
     ],
     pattern,
   )
@@ -47,7 +45,6 @@ export function match(input: string) {
       [
         sql`json_extract(${SessionMessageTable.data}, '$.text')`,
         sql`json_extract(${SessionMessageTable.data}, '$.command')`,
-        sql`json_extract(${SessionMessageTable.data}, '$.output')`,
         sql`json_extract(${SessionMessageTable.data}, '$.summary')`,
         sql`json_extract(${SessionMessageTable.data}, '$.recent')`,
       ],

--- a/packages/core/src/session/search.ts
+++ b/packages/core/src/session/search.ts
@@ -1,0 +1,87 @@
+export * as SessionSearch from "./search"
+
+import { or, sql, type SQL, type SQLWrapper } from "drizzle-orm"
+import { PartTable, SessionMessageTable, SessionTable } from "./sql"
+
+export function where(input: string) {
+  const pattern = searchPattern(input)
+  const fields = match(input)
+  // Search readable values explicitly so JSON field names and type tags do not become false matches.
+  return or(
+    matches(SessionTable.title, pattern),
+    sql`exists (
+      select 1
+      from ${PartTable}
+      where ${PartTable.session_id} = ${SessionTable.id}
+        and ${fields.part.where}
+    )`,
+    sql`exists (
+      select 1
+      from ${SessionMessageTable}
+      where ${SessionMessageTable.session_id} = ${SessionTable.id}
+        and ${fields.message.where}
+    )`,
+  )!
+}
+
+export function match(input: string) {
+  const pattern = searchPattern(input)
+  const part = matchedValue(
+    [
+      sql`json_extract(${PartTable.data}, '$.text')`,
+      sql`json_extract(${PartTable.data}, '$.prompt')`,
+      sql`json_extract(${PartTable.data}, '$.description')`,
+      sql`json_extract(${PartTable.data}, '$.state.output')`,
+      sql`json_extract(${PartTable.data}, '$.state.error')`,
+    ],
+    pattern,
+  )
+  const content = sql<string | null>`(
+    select json_extract(content.value, '$.text')
+    from json_each(${SessionMessageTable.data}, '$.content') as content
+    where ${matches(sql`json_extract(content.value, '$.text')`, pattern)}
+    limit 1
+  )`
+  const message = sql<string | null>`coalesce(
+    ${matchedValue(
+      [
+        sql`json_extract(${SessionMessageTable.data}, '$.text')`,
+        sql`json_extract(${SessionMessageTable.data}, '$.command')`,
+        sql`json_extract(${SessionMessageTable.data}, '$.output')`,
+        sql`json_extract(${SessionMessageTable.data}, '$.summary')`,
+        sql`json_extract(${SessionMessageTable.data}, '$.recent')`,
+      ],
+      pattern,
+    )},
+    ${content}
+  )`
+  return {
+    part: { where: sql`${part} is not null`, snippet: excerpt(part, input) },
+    message: { where: sql`${message} is not null`, snippet: excerpt(message, input) },
+  }
+}
+
+function matchedValue(values: SQL[], pattern: string) {
+  return sql<string | null>`case ${sql.join(
+    values.map((value) => sql`when ${matches(value, pattern)} then ${value}`),
+    sql` `,
+  )} end`
+}
+
+function searchPattern(input: string) {
+  return `%${input.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_")}%`
+}
+
+function matches(value: SQLWrapper, pattern: string) {
+  return sql`${value} like ${pattern} escape '\\'`
+}
+
+function excerpt(value: SQL, input: string) {
+  const position = sql<number>`instr(lower(${value}), lower(${input}))`
+  const start = sql<number>`max(1, ${position} - 72)`
+  return sql<string>`(
+    case when ${start} > 1 then '…' else '' end
+    || trim(replace(replace(substr(${value}, ${start}, 180), char(10), ' '), char(13), ' '))
+    || case when length(${value}) > ${start} + 179 then '…' else '' end
+  )`
+}

--- a/packages/core/src/session/search.ts
+++ b/packages/core/src/session/search.ts
@@ -26,43 +26,32 @@ export function where(input: string) {
 
 export function match(input: string) {
   const pattern = searchPattern(input)
-  const part = matchedValue(
-    [
-      sql`json_extract(${PartTable.data}, '$.text')`,
-      sql`json_extract(${PartTable.data}, '$.prompt')`,
-      sql`json_extract(${PartTable.data}, '$.description')`,
-    ],
-    pattern,
-  )
+  const partText = sql`json_extract(${PartTable.data}, '$.text')`
+  const part = sql<string | null>`case
+    when json_extract(${PartTable.data}, '$.type') = 'text'
+      and coalesce(json_extract(${PartTable.data}, '$.synthetic'), 0) = 0
+      and coalesce(json_extract(${PartTable.data}, '$.ignored'), 0) = 0
+      and ${matches(partText, pattern)}
+    then ${partText}
+  end`
   const content = sql<string | null>`(
     select json_extract(content.value, '$.text')
     from json_each(${SessionMessageTable.data}, '$.content') as content
-    where ${matches(sql`json_extract(content.value, '$.text')`, pattern)}
+    where json_extract(content.value, '$.type') = 'text'
+      and ${matches(sql`json_extract(content.value, '$.text')`, pattern)}
     limit 1
   )`
-  const message = sql<string | null>`coalesce(
-    ${matchedValue(
-      [
-        sql`json_extract(${SessionMessageTable.data}, '$.text')`,
-        sql`json_extract(${SessionMessageTable.data}, '$.command')`,
-        sql`json_extract(${SessionMessageTable.data}, '$.summary')`,
-        sql`json_extract(${SessionMessageTable.data}, '$.recent')`,
-      ],
-      pattern,
-    )},
-    ${content}
-  )`
+  const text = sql`json_extract(${SessionMessageTable.data}, '$.text')`
+  const command = sql`json_extract(${SessionMessageTable.data}, '$.command')`
+  const message = sql<string | null>`case
+    when ${SessionMessageTable.type} = 'user' and ${matches(text, pattern)} then ${text}
+    when ${SessionMessageTable.type} = 'shell' and ${matches(command, pattern)} then ${command}
+    when ${SessionMessageTable.type} = 'assistant' and ${content} is not null then ${content}
+  end`
   return {
     part: { where: sql`${part} is not null`, snippet: excerpt(part, input) },
     message: { where: sql`${message} is not null`, snippet: excerpt(message, input) },
   }
-}
-
-function matchedValue(values: SQL[], pattern: string) {
-  return sql<string | null>`case ${sql.join(
-    values.map((value) => sql`when ${matches(value, pattern)} then ${value}`),
-    sql` `,
-  )} end`
 }
 
 function searchPattern(input: string) {

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import path from "path"
-import { Effect, Layer, Stream } from "effect"
+import { DateTime, Effect, Layer, Schema, Stream } from "effect"
 import { AgentV2 } from "@opencode-ai/core/agent"
 import { asc, eq } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
@@ -15,13 +15,14 @@ import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
+import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Prompt } from "@opencode-ai/core/session/prompt"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionInput } from "@opencode-ai/core/session/input"
 import { SessionEvent } from "@opencode-ai/core/session/event"
-import { SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import { testEffect } from "./lib/effect"
@@ -70,6 +71,48 @@ describe("SessionV2.create", () => {
 
       expect(retried).toEqual(first)
       expect(yield* session.list()).toEqual([first])
+    }),
+  )
+
+  it.effect("returns a bounded context snippet for a content search match", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionV2.Service
+      const db = (yield* Database.Service).db
+      const created = yield* session.create({ location })
+      const text = `${"Earlier context ".repeat(8)}inspect the spectral cache invalidation path${" later context".repeat(10)}`
+      const messageID = SessionMessage.ID.make("msg_search")
+      const encoded = Schema.encodeSync(SessionMessage.User)(
+        SessionMessage.User.make({
+          id: messageID,
+          type: "user",
+          text,
+          files: [],
+          agents: [],
+          time: { created: DateTime.makeUnsafe(1) },
+        }),
+      )
+      const { id: _, type, ...data } = encoded
+      yield* db
+        .insert(SessionMessageTable)
+        .values({
+          id: messageID,
+          session_id: created.id,
+          type,
+          seq: 1,
+          time_created: 1,
+          data,
+        })
+        .run()
+        .pipe(Effect.orDie)
+
+      const snippets = yield* session.searchSnippets({ sessionIDs: [created.id], search: "spectral cache" })
+
+      expect(snippets).toHaveLength(1)
+      expect(snippets[0]).toMatchObject({ sessionID: created.id })
+      expect(snippets[0].snippet).toContain("spectral cache")
+      expect(snippets[0].snippet.startsWith("…")).toBe(true)
+      expect(snippets[0].snippet.endsWith("…")).toBe(true)
+      expect(snippets[0].snippet.length).toBeLessThanOrEqual(182)
     }),
   )
 

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -116,6 +116,78 @@ describe("SessionV2.create", () => {
     }),
   )
 
+  it.effect("excludes hidden and generated current messages from content search", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionV2.Service
+      const db = (yield* Database.Service).db
+      const created = yield* session.create({ location })
+      const messages = [
+        SessionMessage.System.make({
+          id: SessionMessage.ID.make("msg_search_system"),
+          type: "system",
+          text: "private-system-context",
+          time: { created: DateTime.makeUnsafe(1) },
+        }),
+        SessionMessage.Synthetic.make({
+          id: SessionMessage.ID.make("msg_search_synthetic"),
+          sessionID: created.id,
+          type: "synthetic",
+          text: "synthetic-internal-context",
+          time: { created: DateTime.makeUnsafe(2) },
+        }),
+        SessionMessage.Shell.make({
+          id: SessionMessage.ID.make("msg_search_shell"),
+          type: "shell",
+          callID: "shell-search",
+          command: "visible-shell-command",
+          output: "private-shell-output",
+          time: { created: DateTime.makeUnsafe(3), completed: DateTime.makeUnsafe(4) },
+        }),
+        SessionMessage.Assistant.make({
+          id: SessionMessage.ID.make("msg_search_assistant"),
+          type: "assistant",
+          agent: "build",
+          model: { id: ModelV2.ID.make("test"), providerID: ProviderV2.ID.make("test") },
+          content: [
+            SessionMessage.AssistantReasoning.make({
+              type: "reasoning",
+              id: "reasoning-search",
+              text: "private-generated-reasoning",
+            }),
+          ],
+          time: { created: DateTime.makeUnsafe(4), completed: DateTime.makeUnsafe(5) },
+        }),
+      ]
+      yield* db
+        .insert(SessionMessageTable)
+        .values(
+          messages.map((message, index) => {
+            const { id: _, type: __, ...data } = Schema.encodeSync(SessionMessage.Message)(message)
+            return {
+              id: message.id,
+              session_id: created.id,
+              type: message.type,
+              seq: index + 1,
+              time_created: index + 1,
+              data,
+            }
+          }),
+        )
+        .run()
+        .pipe(Effect.orDie)
+
+      expect(yield* session.list({ search: "private-system-context" })).toEqual([])
+      expect(yield* session.list({ search: "synthetic-internal-context" })).toEqual([])
+      expect(yield* session.list({ search: "private-shell-output" })).toEqual([])
+      expect(yield* session.list({ search: "private-generated-reasoning" })).toEqual([])
+      expect((yield* session.list({ search: "visible-shell-command" })).map((item) => item.id)).toEqual([created.id])
+      expect(yield* session.searchSnippets({ sessionIDs: [created.id], search: "private-system-context" })).toEqual([])
+      expect(
+        (yield* session.searchSnippets({ sessionIDs: [created.id], search: "visible-shell-command" }))[0]?.snippet,
+      ).toContain("visible-shell-command")
+    }),
+  )
+
   it.effect("stores supplied immutable create attributes", () =>
     Effect.gen(function* () {
       const session = yield* SessionV2.Service

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -44,6 +44,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { SessionMessage } from "@opencode-ai/schema/session-message"
+import { SessionSearch } from "@opencode-ai/core/session/search"
 
 const parentTitlePrefix = "New session - "
 const childTitlePrefix = "Child session - "
@@ -560,7 +561,7 @@ const layer: Layer.Layer<
       if (input?.roots) conditions.push(isNull(SessionTable.parent_id))
       if (input?.start) conditions.push(gte(SessionTable.time_updated, input.start))
       if (input?.cursor) conditions.push(lt(SessionTable.time_updated, input.cursor))
-      if (input?.search) conditions.push(like(SessionTable.title, `%${input.search}%`))
+      if (input?.search) conditions.push(SessionSearch.where(input.search))
       if (!input?.archived) conditions.push(isNull(SessionTable.time_archived))
 
       const query =
@@ -991,7 +992,7 @@ function listByProject(
     conditions.push(gte(SessionTable.time_updated, input.start))
   }
   if (input.search) {
-    conditions.push(like(SessionTable.title, `%${input.search}%`))
+    conditions.push(SessionSearch.where(input.search))
   }
 
   const limit = input.limit ?? 100

--- a/packages/opencode/test/server/httpapi-session.test.ts
+++ b/packages/opencode/test/server/httpapi-session.test.ts
@@ -428,6 +428,44 @@ describe("session HttpApi", () => {
   )
 
   it.instance(
+    "preserves content search snippets across cursor pages",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const headers = { "x-opencode-directory": test.directory }
+        const first = yield* createSession({ title: "first unrelated title" })
+        const second = yield* createSession({ title: "second unrelated title" })
+        yield* createTextMessage(first.id, "inspect the spectral cache in the first session")
+        yield* createTextMessage(second.id, "inspect the spectral cache in the second session")
+
+        const page = yield* requestJson<{
+          data: Session.Info[]
+          snippets?: Record<string, string>
+          cursor: { next?: string }
+        }>(
+          `/api/session?${new URLSearchParams({
+            limit: "1",
+            order: "asc",
+            directory: test.directory,
+            search: "spectral cache",
+          })}`,
+          { headers },
+        )
+        expect(page.data).toHaveLength(1)
+        expect(page.snippets?.[page.data[0]!.id]).toContain("spectral cache")
+        expect(page.cursor.next).toBeTruthy()
+
+        const next = yield* requestJson<{
+          data: Session.Info[]
+          snippets?: Record<string, string>
+        }>(`/api/session?cursor=${page.cursor.next}`, { headers })
+        expect(next.data).toHaveLength(1)
+        expect(next.snippets?.[next.data[0]!.id]).toContain("spectral cache")
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+
+  it.instance(
     "returns v2 public request errors for cursor and workspace query failures",
     () =>
       Effect.gen(function* () {

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -12,6 +12,10 @@ import { SessionTable } from "@opencode-ai/core/session/sql"
 import { eq } from "drizzle-orm"
 import { testEffect } from "../lib/effect"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { MessageID, PartID } from "@/session/schema"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 
 const layer = (experimentalWorkspaces: boolean) =>
   AppNodeBuilder.build(LayerNode.group([Database.node, SessionNs.node, SessionProjector.node]), [
@@ -266,6 +270,45 @@ describe("session.list", () => {
 
         expect(titles).toContain("unique-search-term-abc")
         expect(titles).not.toContain("other-session-xyz")
+      }),
+    { git: true },
+  )
+
+  it.instance(
+    "finds search terms in session text",
+    () =>
+      Effect.gen(function* () {
+        const matching = yield* withSession({ title: "unrelated-title" })
+        const unrelated = yield* withSession({ title: "another-title" })
+        const session = yield* SessionNs.Service
+        const messageID = MessageID.ascending()
+        yield* session.updateMessage({
+          id: messageID,
+          sessionID: matching.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+        } satisfies SessionV1.User)
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          sessionID: matching.id,
+          messageID,
+          type: "text",
+          text: "We discussed a phosphorescent database migration.",
+        } satisfies SessionV1.TextPart)
+
+        const sessions = yield* SessionNs.use.list({ search: "phosphorescent" })
+        const ids = sessions.map((item) => item.id)
+        const serializedField = yield* SessionNs.use.list({ search: "text" })
+        const underscoreWildcard = yield* SessionNs.use.list({ search: "phosphorescent_" })
+        const percentWildcard = yield* SessionNs.use.list({ search: "%" })
+
+        expect(ids).toContain(matching.id)
+        expect(ids).not.toContain(unrelated.id)
+        expect(serializedField.map((item) => item.id)).not.toContain(matching.id)
+        expect(underscoreWildcard.map((item) => item.id)).not.toContain(matching.id)
+        expect(percentWildcard.map((item) => item.id)).not.toContain(matching.id)
       }),
     { git: true },
   )

--- a/packages/opencode/test/server/session-list.test.ts
+++ b/packages/opencode/test/server/session-list.test.ts
@@ -297,16 +297,36 @@ describe("session.list", () => {
           type: "text",
           text: "We discussed a phosphorescent database migration.",
         } satisfies SessionV1.TextPart)
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          sessionID: matching.id,
+          messageID,
+          type: "text",
+          text: "synthetic-internal-context",
+          synthetic: true,
+        } satisfies SessionV1.TextPart)
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          sessionID: matching.id,
+          messageID,
+          type: "reasoning",
+          text: "generated-private-reasoning",
+          time: { start: Date.now() },
+        } satisfies SessionV1.ReasoningPart)
 
         const sessions = yield* SessionNs.use.list({ search: "phosphorescent" })
         const ids = sessions.map((item) => item.id)
         const serializedField = yield* SessionNs.use.list({ search: "text" })
+        const syntheticText = yield* SessionNs.use.list({ search: "synthetic-internal-context" })
+        const reasoningText = yield* SessionNs.use.list({ search: "generated-private-reasoning" })
         const underscoreWildcard = yield* SessionNs.use.list({ search: "phosphorescent_" })
         const percentWildcard = yield* SessionNs.use.list({ search: "%" })
 
         expect(ids).toContain(matching.id)
         expect(ids).not.toContain(unrelated.id)
         expect(serializedField.map((item) => item.id)).not.toContain(matching.id)
+        expect(syntheticText.map((item) => item.id)).not.toContain(matching.id)
+        expect(reasoningText.map((item) => item.id)).not.toContain(matching.id)
         expect(underscoreWildcard.map((item) => item.id)).not.toContain(matching.id)
         expect(percentWildcard.map((item) => item.id)).not.toContain(matching.id)
       }),

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -110,6 +110,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
         query: SessionsQuery,
         success: Schema.Struct({
           data: Schema.Array(Session.Info),
+          snippets: Schema.Record(Session.ID, Schema.String).pipe(Schema.optional),
           cursor: Schema.Struct({
             previous: SessionsCursor.pipe(Schema.optional),
             next: SessionsCursor.pipe(Schema.optional),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2680,6 +2680,9 @@ export type UnauthorizedError = {
 
 export type SessionsResponse = {
   data: Array<SessionV2Info>
+  snippets?: {
+    [key: string]: unknown | string
+  }
   cursor: {
     previous?: string
     next?: string

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -35,11 +35,11 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
             workspaceID: query.workspace,
             limit: ctx.query.limit ?? DefaultSessionsLimit,
           })
-          const snippets = ctx.query.search
+          const snippets = query.search
             ? Object.fromEntries(
                 (yield* session.searchSnippets({
                   sessionIDs: sessions.map((item) => item.id),
-                  search: ctx.query.search,
+                  search: query.search,
                 })).map((item) => [item.sessionID, item.snippet]),
               )
             : undefined

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -35,10 +35,19 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
             workspaceID: query.workspace,
             limit: ctx.query.limit ?? DefaultSessionsLimit,
           })
+          const snippets = ctx.query.search
+            ? Object.fromEntries(
+                (yield* session.searchSnippets({
+                  sessionIDs: sessions.map((item) => item.id),
+                  search: ctx.query.search,
+                })).map((item) => [item.sessionID, item.snippet]),
+              )
+            : undefined
           const first = sessions[0]
           const last = sessions.at(-1)
           return {
             data: sessions,
+            snippets,
             cursor: {
               previous: first
                 ? SessionsCursor.make({

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -42,6 +42,30 @@ export function loadDialogSessionList<T>(input: {
   )
 }
 
+export function filterDialogSessionList<T extends { id: string; title: string }>(input: {
+  sessions: T[]
+  resultIDs: Set<string>
+  search: string
+}) {
+  const query = input.search.trim().toLowerCase()
+  return input.sessions.filter(
+    (session) => !query || input.resultIDs.has(session.id) || session.title.toLowerCase().includes(query),
+  )
+}
+
+export function currentDialogSessionSearch<T>(
+  result: { query: string; filter: SessionListFilter; sessions: T[] } | undefined,
+  input: { query: string; filter: SessionListFilter },
+) {
+  if (
+    result?.query !== input.query ||
+    result.filter.scope !== input.filter.scope ||
+    result.filter.path !== input.filter.path
+  )
+    return undefined
+  return result.sessions
+}
+
 export function DialogSessionList() {
   const dialog = useDialog()
   const route = useRoute()
@@ -71,13 +95,17 @@ export function DialogSessionList() {
         search: input.query,
         filter: input.filter,
         list: (query) => sdk.client.session.list(query),
-      })
+      }).then((sessions) => (sessions ? { query: input.query, filter: input.filter, sessions } : undefined))
     },
   )
 
+  const currentSearchResults = createMemo(() =>
+    currentDialogSessionSearch(searchResults(), { query: search(), filter: sync.session.query() }),
+  )
   const currentSessionID = createMemo(() => (route.data.type === "session" ? route.data.sessionID : undefined))
   const sessions = createMemo(() => {
-    const result = searchResults() ?? browseResults() ?? sync.data.session
+    const matches = currentSearchResults()
+    const result = matches ?? browseResults() ?? sync.data.session
     const synced = new Map(sync.data.session.map((session) => [session.id, session]))
     const ids = new Set(result.map((session) => session.id))
     const extra = [currentSessionID(), ...local.session.pinned()].flatMap((id) => {
@@ -86,10 +114,13 @@ export function DialogSessionList() {
       if (session) ids.add(id)
       return session ? [session] : []
     })
-    const query = search().trim().toLowerCase()
-    return [...result.map((session) => synced.get(session.id) ?? session), ...extra]
-      .filter((session) => !deleted().has(session.id))
-      .filter((session) => !query || session.title.toLowerCase().includes(query))
+    return filterDialogSessionList({
+      sessions: [...result.map((session) => synced.get(session.id) ?? session), ...extra].filter(
+        (session) => !deleted().has(session.id),
+      ),
+      resultIDs: new Set(matches?.map((session) => session.id)),
+      search: search(),
+    })
   })
 
   onCleanup(
@@ -213,7 +244,7 @@ export function DialogSessionList() {
         .map((x) => [x.id, x]),
     )
 
-    const searchResult = searchResults()
+    const searchResult = currentSearchResults()
     const order = searchResult ? orderByRecency(sessions()) : browseOrder()
     const current = currentSessionID()
     const displayOrder = current && sessionMap.has(current) && !order.includes(current) ? [...order, current] : order

--- a/packages/tui/test/component/dialog-session-list.test.ts
+++ b/packages/tui/test/component/dialog-session-list.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import { createDialogSessionListQuery, loadDialogSessionList } from "../../src/component/dialog-session-list"
+import {
+  createDialogSessionListQuery,
+  currentDialogSessionSearch,
+  filterDialogSessionList,
+  loadDialogSessionList,
+} from "../../src/component/dialog-session-list"
 
 describe("dialog session list", () => {
   test("requests root sessions for the default browse list", () => {
@@ -42,5 +47,35 @@ describe("dialog session list", () => {
         list: () => Promise.reject(new Error("offline")),
       }),
     ).toBeUndefined()
+  })
+
+  test("keeps server-side content matches whose titles do not match", () => {
+    const content = { id: "content", title: "Unrelated title" }
+    const title = { id: "title", title: "Deploy the app" }
+    const unrelated = { id: "unrelated", title: "Other session" }
+
+    expect(
+      filterDialogSessionList({
+        sessions: [content, title, unrelated],
+        resultIDs: new Set([content.id]),
+        search: "deploy",
+      }),
+    ).toEqual([content, title])
+  })
+
+  test("does not reuse content matches from a previous query", () => {
+    const result = {
+      query: "deploy",
+      filter: { path: "packages/tui" },
+      sessions: [{ id: "content", title: "Unrelated title" }],
+    }
+
+    expect(currentDialogSessionSearch(result, { query: "deploy", filter: { path: "packages/tui" } })).toEqual(
+      result.sessions,
+    )
+    expect(
+      currentDialogSessionSearch(result, { query: "deployment", filter: { path: "packages/tui" } }),
+    ).toBeUndefined()
+    expect(currentDialogSessionSearch(result, { query: "deploy", filter: { path: "packages/app" } })).toBeUndefined()
   })
 })

--- a/packages/ui/src/components/scroll-view.tsx
+++ b/packages/ui/src/components/scroll-view.tsx
@@ -18,6 +18,8 @@ export type ScrollViewThumbVisibility = "hover" | "scroll"
 
 export interface ScrollViewProps extends ComponentProps<"div"> {
   viewportRef?: (el: HTMLDivElement) => void
+  /** Tab index for the inner scroll viewport. Defaults to 0. */
+  viewportTabIndex?: number
   orientation?: "vertical" | "horizontal" // currently only vertical is fully implemented for thumb
   /**
    * `hover`: show while hovered or scrolling. `scroll`: show only while scrolling.
@@ -105,6 +107,7 @@ export function ScrollView(props: ScrollViewProps) {
       "class",
       "children",
       "viewportRef",
+      "viewportTabIndex",
       "orientation",
       "thumbVisibility",
       "thumbContainer",
@@ -366,7 +369,7 @@ export function ScrollView(props: ScrollViewProps) {
         onTouchCancel={events.onTouchCancel as any}
         onPointerDown={events.onPointerDown as any}
         onClick={events.onClick as any}
-        tabIndex={0}
+        tabIndex={local.viewportTabIndex ?? 0}
         role="region"
         aria-label={i18n.t("ui.scrollView.ariaLabel")}
         onKeyDown={(e) => {


### PR DESCRIPTION
### Issue for this PR

Closes #38973

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Session pickers previously searched session titles only. This adds content matching for stored user and assistant text in the desktop Home / Cmd+B picker and the TUI `/sessions` picker.

The session list API now matches escaped literal search terms against titles and searchable message text. V2 results include a bounded context snippet for each content match. The desktop highlights the matching phrase and keeps results stable through debounced requests. It also avoids reading lazy query data before the first search settles, preventing the Home tree from suspending and remounting while typing. The TUI preserves server-side content matches even when their titles do not match.

### How did you verify your code works?

- Focused Core, server, TUI, and desktop search tests pass: 53 tests total.
- Typechecks pass in Core, Protocol, Server, OpenCode, TUI, UI, Client, and the generated SDK.
- Oxlint reports zero errors in the added search-mount fix and zero errors across the complete changed-file check.
- Manually verified desktop content search, highlighted snippets, retained input focus, and stable rendering while typing.

### Screenshots / recordings

<img width="739" height="180" alt="image" src="https://github.com/user-attachments/assets/1fe00aa7-a373-4500-920b-9c9dd26f7b8d" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
