### PR TITLE
fix(core): commit state before finalize publishes

### DIFF
--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -59,7 +59,11 @@ export interface Options<State, DraftApi> {
   readonly initial: () => State
   /** Wraps mutable state in a domain-specific draft API. */
   readonly draft: MakeDraft<State, DraftApi>
-  /** Runs after all active transforms and before the rebuilt state becomes visible. */
+  /**
+   * Runs after the rebuilt state becomes visible. Update events published here
+   * act as read barriers: subscribers refetching on the event observe the
+   * committed state.
+   */
   readonly finalize?: (draft: DraftApi) => Effect.Effect<void>
 }
 
@@ -81,9 +85,8 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
   const semaphore = Semaphore.makeUnsafe(1)
 
   const commit = Effect.fn("State.commit")(function* (next: State) {
-    const api = options.draft(next)
-    if (options.finalize) yield* options.finalize(api)
     state = next
+    if (options.finalize) yield* options.finalize(options.draft(next))
   })
 
   const apply = (transform: TransformCallback<DraftApi>, draft: DraftApi) =>

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -36,6 +36,25 @@ describe("State", () => {
     }),
   )
 
+  it.effect("commits rebuilt state before finalize runs", () =>
+    Effect.gen(function* () {
+      const observed: string[][] = []
+      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        finalize: () => Effect.sync(() => observed.push([...state.get().values])),
+      })
+
+      yield* state.transform((draft) => {
+        draft.add("value")
+      })
+
+      // Update events publish from finalize, so consumers reading on the event
+      // must observe the rebuilt state, not the previous one.
+      expect(observed).toEqual([["value"]])
+    }),
+  )
+
   it.effect("runs transforms during every reload", () =>
     Effect.gen(function* () {
       let value = "first"


### PR DESCRIPTION
## What

`State` update events now act as read barriers: a subscriber that observes a domain update event (`command.updated`, `agent.updated`, `catalog.updated`, ...) and immediately refetches is guaranteed to see the rebuilt state.

Fixes #37422.

## Before / After

**Before:** `State.commit` ran `finalize` (where every domain publishes its update event) *before* assigning the rebuilt state:

1. A command file changes and command state rebuilds.
2. `finalize` publishes `command.updated`.
3. A subscriber receives the event and calls `command.list()`.
4. The swap `state = next` has not happened yet, so the subscriber reads the **old** commands and never refetches again.

**After:** the rebuilt state is assigned first, then `finalize` runs. Any consumer reading on the event observes committed state.

## How

- `packages/core/src/state.ts` — `State.commit` swaps `state = next` before invoking `finalize`, and the `finalize` doc comment now states the read-barrier contract.
- `packages/core/test/state.test.ts` — new test `commits rebuilt state before finalize runs`, written and confirmed red against the old ordering.

All seven `finalize` consumers were audited (`agent`, `command`, `catalog`, `skill`, `websearch`, `integration`, `reference`): six only publish their update event; `reference` rebuilds its derived `materialized` map and then publishes, so its event also still fires after both the swap and the rebuild. None rely on pre-commit ordering.

## Scope

First slice of the config source reload plan (`docs/design/config-source-reload.md` on the `config-source-reload` branch). Deliberately excluded, coming as separate PRs:

- Domain-owned source invalidation for command/agent/plugin files inside config directories (#37429).
- Exposing `config.changes` and narrowing Config's rediscovery.

## Testing

```
bun test test/state.test.ts                      # 6 pass (new test red before fix)
bun test test/{agent,command,catalog,skill,websearch,reference,integration}.test.ts \
         test/config/{agent,command}.test.ts     # 58 pass
```

`bun typecheck` in `packages/core` reports only pre-existing sdk-drift diagnostics also present at the base commit; none reference `state.ts`.
