### PR TITLE
feat(tui): stream file mutation previews

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -964,6 +964,7 @@
         "fuzzysort": "catalog:",
         "open": "10.1.2",
         "opentui-spinner": "catalog:",
+        "partial-json": "0.1.7",
         "remeda": "catalog:",
         "solid-js": "catalog:",
         "strip-ansi": "7.1.2",

--- a/packages/opencode/src/cli/cmd/run/session-data.ts
+++ b/packages/opencode/src/cli/cmd/run/session-data.ts
@@ -25,6 +25,7 @@
 //   event arrives, the queue entry is removed and the footer falls back
 //   to the next pending request or to the prompt view.
 import type { Event, Part, PermissionRequest, QuestionRequest, ToolPart } from "@opencode-ai/sdk/v2"
+import { parseJSON } from "partial-json"
 import * as Locale from "@/util/locale"
 import { toolView } from "./tool"
 import type { FooterOutput, FooterPatch, FooterView, StreamCommit } from "./types"
@@ -54,6 +55,8 @@ type SessionCommit = StreamCommit
 //
 // - ids:    parts and error keys we've already committed (dedup guard)
 // - tools:  tool parts we've emitted a "start" for but not yet completed
+// - toolParts/toolRaw/toolPreview: pending mutation input streamed to scrollback
+// - toolDiff: edit previews already emitted for running tools
 // - call:   tool call inputs, keyed by msg:call, for enriching permission views
 // - role:   message ID → "assistant" | "user", learned from message.updated
 // - msg:    part ID → message ID
@@ -74,6 +77,10 @@ export type SessionData = {
   announced: boolean
   ids: Set<string>
   tools: Set<string>
+  toolParts: Map<string, ToolPart>
+  toolRaw: Map<string, string>
+  toolPreview: Map<string, string>
+  toolDiff: Set<string>
   call: Map<string, Dict>
   shell: Map<string, ShellCall>
   permissions: PermissionRequest[]
@@ -112,6 +119,10 @@ export function createSessionData(
     announced: false,
     ids: new Set(),
     tools: new Set(),
+    toolParts: new Map(),
+    toolRaw: new Map(),
+    toolPreview: new Map(),
+    toolDiff: new Set(),
     call: new Map(),
     shell: new Map(),
     permissions: [],
@@ -634,6 +645,45 @@ function toolCommit(
   }
 }
 
+function partialTool(part: ToolPart, raw: string): ToolPart {
+  if (part.state.status !== "pending") return part
+
+  try {
+    const input = parseJSON(raw)
+    if (!input || typeof input !== "object" || Array.isArray(input)) return part
+    return {
+      ...part,
+      state: {
+        ...part.state,
+        input: { ...input },
+        raw,
+      },
+    }
+  } catch {
+    return part
+  }
+}
+
+function toolPreview(part: ToolPart): string {
+  if (part.state.status !== "pending") return ""
+  if (part.tool === "write") {
+    const content = part.state.input.content
+    return typeof content === "string" ? content : ""
+  }
+  if (part.tool === "apply_patch") {
+    const patch = part.state.input.patchText
+    return typeof patch === "string" ? patch : ""
+  }
+  return ""
+}
+
+function clearToolPreview(data: SessionData, partID: string) {
+  data.toolParts.delete(partID)
+  data.toolRaw.delete(partID)
+  data.toolPreview.delete(partID)
+  data.toolDiff.delete(partID)
+}
+
 function shellPartID(callID: string): string {
   return `shell:${callID}`
 }
@@ -882,6 +932,29 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
       return out(data, commits)
     }
 
+    if (event.properties.field === "raw") {
+      const part = data.toolParts.get(event.properties.partID)
+      if (!part || part.state.status !== "pending") return out(data, commits)
+
+      const raw = (data.toolRaw.get(part.id) ?? "") + event.properties.delta
+      data.toolRaw.set(part.id, raw)
+      const next = partialTool(part, raw)
+      data.toolParts.set(part.id, next)
+      const preview = toolPreview(next)
+      const sent = data.toolPreview.get(part.id) ?? ""
+      if (!preview.startsWith(sent) || preview.length === sent.length) return out(data, commits)
+
+      data.toolPreview.set(part.id, preview)
+      commits.push(
+        toolCommit(next, {
+          text: preview.slice(sent.length),
+          phase: "progress",
+          toolState: "running",
+        }),
+      )
+      return out(data, commits)
+    }
+
     if (event.properties.field !== "text") {
       return out(data, commits)
     }
@@ -929,7 +1002,14 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
         }
       }
 
+      if (part.state.status === "pending") {
+        data.toolParts.set(part.id, part)
+        return out(data, commits, view)
+      }
+
       if (part.state.status === "running") {
+        data.toolParts.delete(part.id)
+        data.toolRaw.delete(part.id)
         if (data.ids.has(part.id)) {
           return out(data, commits, view)
         }
@@ -939,10 +1019,24 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
           commits.push(startTool(part))
         }
 
+        const diff =
+          part.tool === "edit" && typeof part.state.metadata?.diff === "string" ? part.state.metadata.diff : ""
+        if (diff && !data.toolDiff.has(part.id)) {
+          data.toolDiff.add(part.id)
+          commits.push(
+            toolCommit(part, {
+              text: diff,
+              phase: "progress",
+              toolState: "running",
+            }),
+          )
+        }
+
         return out(data, commits, view ?? patch({ status: toolStatus(part) }))
       }
 
       if (part.state.status === "completed") {
+        clearToolPreview(data, part.id)
         const seen = data.tools.has(part.id)
         const mode = toolView(part.tool)
         data.tools.delete(part.id)
@@ -980,6 +1074,7 @@ export function reduceSessionData(input: SessionDataInput): SessionDataOutput {
       }
 
       if (part.state.status === "error") {
+        clearToolPreview(data, part.id)
         const seen = data.tools.has(part.id)
         data.tools.delete(part.id)
         if (data.ids.has(part.id)) {

--- a/packages/opencode/src/cli/cmd/run/tool.ts
+++ b/packages/opencode/src/cli/cmd/run/tool.ts
@@ -1433,6 +1433,23 @@ export function toolEntryBody(commit: StreamCommit, raw: string): RunEntryBody |
   const ctx = toolFrame(commit, raw)
   const view = toolView(ctx.name)
 
+  if (commit.phase === "progress" && ctx.name === "write") {
+    const file = text(ctx.input.filePath) || text(ctx.input.path)
+    return {
+      type: "code",
+      content: raw,
+      filetype: toolFiletype(file),
+    }
+  }
+
+  if (commit.phase === "progress" && (ctx.name === "edit" || ctx.name === "apply_patch")) {
+    return {
+      type: "code",
+      content: raw,
+      filetype: "diff",
+    }
+  }
+
   if (ctx.name === "task") {
     if (commit.phase === "start") {
       return undefined

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -319,9 +319,17 @@ const layer = Layer.effect(
             yield* ensureToolCall(value)
             return
 
-          case "tool-input-delta":
-            yield* ensureToolCall(value)
+          case "tool-input-delta": {
+            const pending = yield* ensureToolCall(value)
+            yield* session.updatePartDelta({
+              sessionID: pending.part.sessionID,
+              messageID: pending.part.messageID,
+              partID: pending.part.id,
+              field: "raw",
+              delta: value.text,
+            })
             return
+          }
 
           case "tool-input-end": {
             yield* ensureToolCall(value)

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -99,6 +99,7 @@ export const EditTool = Tool.define(
                 contentOld = ""
                 contentNew = next.text
                 diff = trimDiff(createTwoFilesPatch(filePath, filePath, contentOld, contentNew))
+                yield* ctx.metadata({ metadata: { diff } })
                 yield* ctx.ask({
                   permission: "edit",
                   patterns: [path.relative(instance.worktree, filePath)],
@@ -142,6 +143,7 @@ export const EditTool = Tool.define(
                   normalizeLineEndings(contentNew),
                 ),
               )
+              yield* ctx.metadata({ metadata: { diff } })
               yield* ctx.ask({
                 permission: "edit",
                 patterns: [path.relative(instance.worktree, filePath)],

--- a/packages/opencode/test/cli/run/entry.body.test.ts
+++ b/packages/opencode/test/cli/run/entry.body.test.ts
@@ -50,6 +50,40 @@ function structured(next: StreamCommit) {
 }
 
 describe("run entry body", () => {
+  test("renders live file mutations as streaming code", () => {
+    expect(
+      entryBody(
+        toolCommit({
+          tool: "write",
+          phase: "progress",
+          toolState: "running",
+          text: "const answer = ",
+          state: {
+            status: "pending",
+            input: { filePath: "src/a.ts", content: "const answer = " },
+            raw: "",
+          },
+        }),
+      ),
+    ).toEqual({ type: "code", content: "const answer = ", filetype: "typescript" })
+
+    expect(
+      entryBody(
+        toolCommit({
+          tool: "apply_patch",
+          phase: "progress",
+          toolState: "running",
+          text: "@@ -1 +1 @@\n-old\n+new",
+          state: {
+            status: "pending",
+            input: { patchText: "@@ -1 +1 @@\n-old\n+new" },
+            raw: "",
+          },
+        }),
+      ),
+    ).toEqual({ type: "code", content: "@@ -1 +1 @@\n-old\n+new", filetype: "diff" })
+  })
+
   test("renders assistant, reasoning, and user entries in their display formats", () => {
     expect(
       entryBody(

--- a/packages/opencode/test/cli/run/session-data.test.ts
+++ b/packages/opencode/test/cli/run/session-data.test.ts
@@ -93,6 +93,19 @@ function delta(messageID: string, partID: string, value: string) {
   }
 }
 
+function rawDelta(messageID: string, partID: string, value: string) {
+  return {
+    type: "message.part.delta",
+    properties: {
+      sessionID: "session-1",
+      messageID,
+      partID,
+      field: "raw",
+      delta: value,
+    },
+  }
+}
+
 function tool(input: { id: string; messageID: string; tool: string; state: Record<string, unknown>; callID?: string }) {
   return {
     type: "message.part.updated",
@@ -111,6 +124,57 @@ function tool(input: { id: string; messageID: string; tool: string; state: Recor
 }
 
 describe("run session data", () => {
+  test("streams write content from partial tool input", () => {
+    let data = createSessionData()
+    data = reduce(
+      data,
+      tool({
+        id: "write-1",
+        messageID: "msg-1",
+        tool: "write",
+        state: { status: "pending", input: {}, raw: "" },
+      }),
+    ).data
+
+    let out = reduce(data, rawDelta("msg-1", "write-1", '{"filePath":"src/a.ts","content":"hel'))
+    expect(out.commits).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        text: "hel",
+        phase: "progress",
+        toolState: "running",
+        part: expect.objectContaining({
+          state: expect.objectContaining({ input: { filePath: "src/a.ts", content: "hel" } }),
+        }),
+      }),
+    ])
+
+    out = reduce(out.data, rawDelta("msg-1", "write-1", 'lo\\nworld"}'))
+    expect(out.commits).toEqual([expect.objectContaining({ text: "lo\nworld" })])
+  })
+
+  test("streams a prepared edit diff while the tool is running", () => {
+    const out = reduce(
+      createSessionData(),
+      tool({
+        id: "edit-1",
+        messageID: "msg-1",
+        tool: "edit",
+        state: {
+          status: "running",
+          input: { filePath: "src/a.ts" },
+          metadata: { diff: "@@ -1 +1 @@\n-old\n+new" },
+          time: { start: 1 },
+        },
+      }),
+    )
+
+    expect(out.commits).toEqual([
+      expect.objectContaining({ phase: "start", toolState: "running" }),
+      expect.objectContaining({ text: "@@ -1 +1 @@\n-old\n+new", phase: "progress", toolState: "running" }),
+    ])
+  })
+
   test("buffers delayed assistant text until the role is known", () => {
     let data = createSessionData()
     data = reduce(data, delta("msg-1", "txt-1", "hello")).data

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -61,6 +61,7 @@
     "fuzzysort": "catalog:",
     "open": "10.1.2",
     "opentui-spinner": "catalog:",
+    "partial-json": "0.1.7",
     "remeda": "catalog:",
     "strip-ansi": "7.1.2",
     "solid-js": "catalog:"

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -32,6 +32,7 @@ import { batch, onMount } from "solid-js"
 import path from "path"
 import { useKV } from "./kv"
 import { usePermission } from "./permission"
+import { parseJSON } from "partial-json"
 
 const emptyConsoleState: ConsoleState = {
   consoleManagedProviders: [],
@@ -49,6 +50,19 @@ function search<T>(items: T[], target: string, key: (item: T) => string) {
     else right = middle - 1
   }
   return { found: false, index: left }
+}
+
+function appendToolInput(part: Part, delta: string) {
+  if (part.type !== "tool" || part.state.status !== "pending") return false
+  const raw = part.state.raw + delta
+  part.state.raw = raw
+  try {
+    const input = parseJSON(raw)
+    if (input && typeof input === "object" && !Array.isArray(input)) part.state.input = { ...input }
+  } catch {
+    // Partial JSON can be temporarily invalid between streamed tokens.
+  }
+  return true
 }
 
 export const {
@@ -400,6 +414,7 @@ export const {
             event.properties.messageID,
             produce((draft) => {
               const part = draft[result.index]
+              if (event.properties.field === "raw" && appendToolInput(part, event.properties.delta)) return
               const field = event.properties.field as keyof typeof part
               const existing = part[field] as string | undefined
               ;(part[field] as string) = (existing ?? "") + event.properties.delta

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -78,6 +78,7 @@ import { getScrollAcceleration } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { usePluginRuntime } from "../../plugin/runtime"
 import { DialogRetryAction } from "../../component/dialog-retry-action"
+import { createTwoFilesPatch } from "diff"
 import { getRevertDiffFiles } from "../../util/revert-diff"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 import { usePathFormatter } from "../../context/path-format"
@@ -2101,6 +2102,7 @@ function Write(props: ToolProps) {
   const code = createMemo(() => {
     return stringValue(props.input.content) ?? ""
   })
+  const streaming = createMemo(() => props.part.state.status === "pending")
 
   return (
     <Switch>
@@ -2116,6 +2118,20 @@ function Write(props: ToolProps) {
             />
           </line_number>
           <Diagnostics diagnostics={props.metadata.diagnostics} filePath={stringValue(props.input.filePath) ?? ""} />
+        </BlockTool>
+      </Match>
+      <Match when={code()}>
+        <BlockTool title={"# Writing " + pathFormatter.format(stringValue(props.input.filePath))} part={props.part}>
+          <line_number fg={theme.textMuted} minWidth={3} paddingRight={1}>
+            <code
+              conceal={false}
+              fg={theme.text}
+              filetype={filetype(stringValue(props.input.filePath))}
+              syntaxStyle={syntax()}
+              streaming={streaming()}
+              content={code()}
+            />
+          </line_number>
         </BlockTool>
       </Match>
       <Match when={true}>
@@ -2399,11 +2415,14 @@ function Edit(props: ToolProps) {
 
   const ft = createMemo(() => filetype(stringValue(props.input.filePath)))
 
-  const diffContent = createMemo(() => stringValue(props.metadata.diff) ?? "")
+  const diffContent = createMemo(
+    () =>
+      stringValue(props.metadata.diff) ?? (props.part.state.status === "pending" ? streamedEditDiff(props.input) : ""),
+  )
 
   return (
     <Switch>
-      <Match when={stringValue(props.metadata.diff) !== undefined}>
+      <Match when={diffContent()}>
         <BlockTool title={"← Edit " + pathFormatter.format(stringValue(props.input.filePath))} part={props.part}>
           <box paddingLeft={1}>
             <diff
@@ -2444,6 +2463,7 @@ function ApplyPatch(props: ToolProps) {
   const pathFormatter = usePathFormatter()
 
   const files = createMemo(() => parseApplyPatchFiles(props.metadata.files))
+  const patch = createMemo(() => stringValue(props.input.patchText) ?? "")
 
   const view = createMemo(() => {
     const diffStyle = ctx.tui.diff_style
@@ -2504,6 +2524,20 @@ function ApplyPatch(props: ToolProps) {
             </BlockTool>
           )}
         </For>
+      </Match>
+      <Match when={patch()}>
+        <BlockTool title="# Preparing patch" part={props.part}>
+          <box paddingLeft={1}>
+            <code
+              conceal={false}
+              fg={theme.text}
+              filetype="diff"
+              syntaxStyle={syntax()}
+              streaming={props.part.state.status === "pending"}
+              content={patch()}
+            />
+          </box>
+        </BlockTool>
       </Match>
       <Match when={true}>
         <InlineTool icon="%" pending="Preparing patch..." failure="Patch failed" complete={false} part={props.part}>
@@ -2646,6 +2680,14 @@ const toolDisplays = new Set([
 
 export function toolDisplay(tool: string) {
   return toolDisplays.has(tool) ? tool : "generic"
+}
+
+export function streamedEditDiff(input: Record<string, unknown>) {
+  const oldString = stringValue(input.oldString)
+  const newString = stringValue(input.newString)
+  if (oldString === undefined || newString === undefined) return ""
+  const filePath = stringValue(input.filePath) ?? "file"
+  return createTwoFilesPatch(filePath, filePath, oldString, newString)
 }
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {

--- a/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/sync-live-hydration.test.tsx
@@ -85,6 +85,68 @@ test("stale session hydration does not overwrite live message parts", async () =
   }
 })
 
+test("raw tool deltas hydrate pending write input", async () => {
+  await using tmp = await tmpdir()
+  await Bun.write(`${tmp.path}/kv.json`, "{}")
+  const { app, emit, sync } = await mount(undefined, tmp.path)
+
+  try {
+    emit(global({ id: "evt_message", type: "message.updated", properties: { sessionID, info: assistant } }))
+    emit(
+      global({
+        id: "evt_tool",
+        type: "message.part.updated",
+        properties: {
+          sessionID,
+          time: 1,
+          part: {
+            id: partID,
+            sessionID,
+            messageID,
+            type: "tool",
+            callID: "call_write",
+            tool: "write",
+            state: { status: "pending", input: {}, raw: "" },
+          },
+        },
+      }),
+    )
+    emit(
+      global({
+        id: "evt_delta_1",
+        type: "message.part.delta",
+        properties: {
+          sessionID,
+          messageID,
+          partID,
+          field: "raw",
+          delta: '{"filePath":"src/a.ts","content":"hel',
+        },
+      }),
+    )
+    emit(
+      global({
+        id: "evt_delta_2",
+        type: "message.part.delta",
+        properties: { sessionID, messageID, partID, field: "raw", delta: 'lo\\nworld"}' },
+      }),
+    )
+
+    await wait(() => {
+      const part = sync.data.part[messageID]?.[0]
+      return part?.type === "tool" && part.state.status === "pending" && part.state.input.content === "hello\nworld"
+    })
+    expect(sync.data.part[messageID][0]).toMatchObject({
+      state: {
+        status: "pending",
+        input: { filePath: "src/a.ts", content: "hello\nworld" },
+      },
+    })
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
 test("orphan live deltas do not suppress hydrated parts", async () => {
   await using tmp = await tmpdir()
   await Bun.write(`${tmp.path}/kv.json`, "{}")

--- a/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
+++ b/packages/tui/test/cli/tui/inline-tool-wrap-snapshot.test.tsx
@@ -15,6 +15,7 @@ import {
   parseTodos,
   alwaysSeparate,
   toolDisplay,
+  streamedEditDiff,
 } from "../../../src/routes/session"
 
 let testSetup: Awaited<ReturnType<typeof testRender>> | undefined
@@ -226,6 +227,17 @@ describe("TUI inline tool wrapping", () => {
   test("falls back for unknown tool names", () => {
     expect(toolDisplay("bash")).toBe("bash")
     expect(toolDisplay("plugin_tool")).toBe("generic")
+  })
+
+  test("builds a live diff from streamed edit input", () => {
+    const diff = streamedEditDiff({
+      filePath: "src/a.ts",
+      oldString: "const answer = 41\n",
+      newString: "const answer = 42\n",
+    })
+    expect(diff).toContain("-const answer = 41")
+    expect(diff).toContain("+const answer = 42")
+    expect(streamedEditDiff({ oldString: "old" })).toBe("")
   })
 
   test("replaces pending copy when a tool fails before completion", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #38972

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

File-writing tools previously showed only a pending label while the model generated their input. This forwards partial tool JSON through session delta events, parses it incrementally, and renders live write, edit, and patch previews in both `opencode run` and the full TUI. Completed tools still replace the preview with the authoritative result.

### How did you verify your code works?

- Ran package typechecks for `packages/opencode` and `packages/tui`.
- Ran 45 focused opencode tests and 24 TUI tests with 8 snapshots.
- The pre-push workspace typecheck passed for all 30 participating packages.
- Manually ran the TUI against another project and verified write, edit, and apply-patch previews update before completion.

### Screenshots / recordings

The behavior can be reproduced with `bun dev <directory>` by asking the model to create a file, edit an existing file with the edit tool, or apply a patch. Each operation now displays its content or diff while the tool input streams.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR