### PR TITLE
fix(app): adopt the server directory when no project is open

### DIFF
--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -127,6 +127,15 @@ function createServerCtx(
     return base
   }
 
+  // A browser that has never opened a project keeps an empty local project list, which
+  // leaves the home session list, the sidebar and New Session with nothing to anchor to
+  // even when the server has sessions. Adopt the directory the server was started in so
+  // a fresh client lands on the same project the CLI would use there.
+  createEffect(() => {
+    const directory = sync.data.path.directory
+    if (directory) projects.adopt(directory)
+  })
+
   const projectsList = createMemo(() => projects.list().map(enrich))
   const recentlyClosedList = createMemo(() => {
     const known = new Set(sync.data.project.map((project) => pathKey(project.worktree)))

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -185,6 +185,63 @@ describe("createServerProjects", () => {
     })
   })
 
+  test("adopts a directory for a server with no projects", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.adopt("/srv/repo")
+      expect(projects.list()).toEqual([{ worktree: "/srv/repo", expanded: true }])
+      expect(projects.last()).toBe("/srv/repo")
+      dispose()
+    })
+  })
+
+  test("leaves an existing project list untouched when adopting", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("/repo")
+      projects.adopt("/srv/repo")
+      expect(projects.list()).toEqual([{ worktree: "/repo", expanded: true }])
+      expect(projects.last()).toBeUndefined()
+      dispose()
+    })
+  })
+
+  test("does not adopt a directory the user closed", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("/srv/repo")
+      projects.close("/srv/repo")
+      projects.adopt("/srv/repo")
+      expect(projects.list()).toEqual([])
+      expect(projects.recentlyClosed()).toEqual(["/srv/repo"])
+      dispose()
+    })
+  })
+
+  test("adopts per server scope", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const local = createServerProjects({ scope, store, setStore })
+      const remote = createServerProjects({ scope: () => "https://debian.example" as ServerScope, store, setStore })
+
+      local.open("/repo")
+      remote.adopt("/srv/repo")
+      expect(remote.list()).toEqual([{ worktree: "/srv/repo", expanded: true }])
+      expect(local.list()).toEqual([{ worktree: "/repo", expanded: true }])
+      dispose()
+    })
+  })
+
   test("dedupes recently closed entries by normalized path", () => {
     createRoot((dispose) => {
       const [scope] = createSignal(ServerScope.local)

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -91,23 +91,38 @@ export function createServerProjects<T extends ServerProjectState>(input: {
       current().filter((project) => project.worktree !== directory),
     )
   }
+  const open = (directory: string) => {
+    const scope = input.scope()
+    const key = pathKey(directory)
+    const closed = currentClosed()
+    if (closed.some((worktree) => pathKey(worktree) === key)) {
+      setStore(
+        "recentlyClosed",
+        scope,
+        closed.filter((worktree) => pathKey(worktree) !== key),
+      )
+    }
+    if (current().some((project) => project.worktree === directory)) return
+    setStore("projects", scope, [{ worktree: directory, expanded: true }, ...current()])
+  }
+  const touch = (directory: string) => {
+    setStore("lastProject", input.scope(), directory)
+  }
   return {
     list: current,
     recentlyClosed: currentClosed,
     remove,
-    open(directory: string) {
-      const scope = input.scope()
+    open,
+    touch,
+    // Opens a directory only when this server has no projects at all, so a client
+    // that has never opened one still lands somewhere. Directories the user closed
+    // stay closed.
+    adopt(directory: string) {
+      if (current().length > 0) return
       const key = pathKey(directory)
-      const closed = currentClosed()
-      if (closed.some((worktree) => pathKey(worktree) === key)) {
-        setStore(
-          "recentlyClosed",
-          scope,
-          closed.filter((worktree) => pathKey(worktree) !== key),
-        )
-      }
-      if (current().some((project) => project.worktree === directory)) return
-      setStore("projects", scope, [{ worktree: directory, expanded: true }, ...current()])
+      if (currentClosed().some((worktree) => pathKey(worktree) === key)) return
+      open(directory)
+      touch(directory)
     },
     // User-initiated close: removes the project and records it in recently closed.
     // Internal, non-user removals (e.g. sandbox/worktree normalization) should use remove().
@@ -138,9 +153,6 @@ export function createServerProjects<T extends ServerProjectState>(input: {
     },
     last() {
       return input.store.lastProject[input.scope()]
-    },
-    touch(directory: string) {
-      setStore("lastProject", input.scope(), directory)
     },
   }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #37096

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode web` opens to an empty UI: the sidebar shows "Nothing here yet" even when the server has sessions in the directory it was started in, and New Session does nothing.

The opened-project list is browser-local state (`createServerProjects`, backed by the persisted `projects` map in localStorage). Nothing ever seeds it, so a client that has never opened a project has an empty list, and everything downstream is keyed off that list:

- `buildHomeSessionRecords` filters sessions with `directories.has(pathKey(session.directory))` where `directories` comes from `home.project.list().flatMap(directories)`. Empty list means every session is dropped, so the home page renders `home.sessions.empty`.
- `newSessionProject` resolves to `selected ?? last ?? projects()[0]`, so it is `undefined`, so `canCreate()` is false and the New Session action is inert.

Note the empty list is what breaks this, not the `project` row itself. The issue diagnoses it as the `project` table failing to auto-register, but that part is working as designed: `Project.resolve` returns `ID.global` with worktree `/` for any directory that is not a git repo, and sessions there legitimately carry `project_id = "global"`. Those sessions still come back from the server with their real `directory`, and the UI would show them fine — it just never has a directory to match them against.

So this seeds the missing state instead: `createServerProjects` gets an `adopt(directory)` that opens a directory only when that server has no opened projects at all, and `createServerCtx` calls it with `sync.data.path.directory`, the directory the server was started in. A fresh client then lands on the same project the CLI would use in that directory, which restores both the session list and New Session.

`adopt` is deliberately narrow so it does not fight the user:

- it is a no-op once any project is open, so it never reorders or re-adds anything on later loads;
- it skips directories present in `recentlyClosed`, so closing the adopted project keeps it closed;
- it is scoped per server, so connecting to a second server does not disturb the first.

`open` and `touch` are hoisted to consts so `adopt` can reuse them; they are otherwise unchanged.

This overlaps a little with #37607, which makes the New Session action fall back to the server directory. That one fixes the action for a client that still has no project; this one gives the client a project, so both the list and the action work. They touch different files and do not conflict. The empty directory picker from the same report is a separate bug (#37611 / #37612) and is not touched here.

### How did you verify your code works?

Reproduced against a real server, in a fresh Chrome profile with empty localStorage:

1. `mkdir /tmp/webrepro && cd /tmp/webrepro && opencode serve --port 47320` (non-git directory, the case from the issue).
2. Created a session in it, confirming the DB state the issue describes — `project` holds only `global | / | null`, and the session has `projectID: "global"` with `directory: /tmp/webrepro`.
3. Ran the app with `VITE_OPENCODE_SERVER_HOST/PORT` pointed at that server and loaded it in a clean browser context.

Before: sidebar shows `Projects / Add project`, body shows "Nothing here yet — Create a session to get started", and localStorage has no server entry.

After: sidebar shows the `webrepro` project, the session is listed under Today, New Session is available, and localStorage holds `projects: { local: [{ worktree: "/tmp/webrepro", expanded: true }] }`.

Also ran:

- `bun test --preload ./happydom.ts ./src/context/server.test.ts` — 16 passed, including the 4 added below.
- `bun run test:unit` — 674 passed, 1 failed. The failure is `src/i18n/parity.test.ts` (missing non-English keys); it fails identically on a clean `dev` checkout and is unrelated to this change.
- `bun run typecheck` — clean.
- `prettier --check` on the three touched files — clean.

Added four tests to `createServerProjects`: adopting into an empty list, leaving a non-empty list untouched, refusing to adopt a directory the user closed, and adopting per server scope.

### Screenshots / recordings

Before — `opencode web` in a directory that has a session:

```
Projects
Add project
Settings
Help

Nothing here yet
Create a session to get started
```

After — same server, same clean browser profile:

```
Projects
W  webrepro
Settings
Help

New session

Today
W  Repro session for issue 37096
   webrepro
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
