### PR TITLE
fix(tui): render LaTeX math as Unicode in the CLI

### DIFF
--- a/packages/opencode/src/cli/cmd/run/entry.body.ts
+++ b/packages/opencode/src/cli/cmd/run/entry.body.ts
@@ -1,3 +1,4 @@
+import { latexToUnicode } from "./latex-unicode"
 import { toolEntryBody } from "./tool"
 import type { RunEntryBody, StreamCommit } from "./types"
 
@@ -44,7 +45,8 @@ function markdownBody(content: string): RunEntryBody {
 
   return {
     type: "markdown",
-    content,
+    // Terminal cannot run KaTeX; rewrite common math to Unicode first.
+    content: latexToUnicode(content),
   }
 }
 
@@ -59,7 +61,7 @@ function userBody(raw: string): RunEntryBody {
 }
 
 function reasoningBody(raw: string): RunEntryBody {
-  const clean = raw.replace(/\[REDACTED\]/g, "")
+  const clean = latexToUnicode(raw.replace(/\[REDACTED\]/g, ""))
   if (!clean) {
     return RUN_ENTRY_NONE
   }

--- a/packages/opencode/src/cli/cmd/run/latex-unicode.ts
+++ b/packages/opencode/src/cli/cmd/run/latex-unicode.ts
@@ -1,0 +1,531 @@
+/**
+ * Best-effort LaTeX → Unicode for the OpenCode TUI.
+ *
+ * Terminals cannot run KaTeX. This module rewrites common math delimiters into
+ * readable Unicode so assistant replies stay legible without a full TeX engine.
+ *
+ * Scope (intentionally limited):
+ *   - Delimiters: $$…$$, \[…\], \(…\), $…$ (when math-like), \begin{equation|align|…}
+ *   - Commands: greek, relations, sum/prod/int, frac, sqrt, mathbb/mathrm/…
+ *   - Scripts: unicode sub/superscripts where glyphs exist; otherwise ₍…₎ / ⁽…⁾
+ *
+ * Non-goals:
+ *   - Pixel-perfect layout, stacked fractions, matrices, aligned columns
+ *   - Web/desktop KaTeX (separate surface — see linked issues)
+ *
+ * Currency safety: bare $…$ only converts when the body looks like math
+ * (contains \ or ^ or _), so "$0.02/GB" is left alone.
+ */
+
+// ---------------------------------------------------------------------------
+// Symbol tables
+// ---------------------------------------------------------------------------
+
+const GREEK: Record<string, string> = {
+  alpha: "α",
+  beta: "β",
+  gamma: "γ",
+  delta: "δ",
+  epsilon: "ε",
+  varepsilon: "ε",
+  zeta: "ζ",
+  eta: "η",
+  theta: "θ",
+  vartheta: "ϑ",
+  iota: "ι",
+  kappa: "κ",
+  lambda: "λ",
+  mu: "μ",
+  nu: "ν",
+  xi: "ξ",
+  pi: "π",
+  varpi: "ϖ",
+  rho: "ρ",
+  varrho: "ϱ",
+  sigma: "σ",
+  varsigma: "ς",
+  tau: "τ",
+  upsilon: "υ",
+  phi: "φ",
+  varphi: "ϕ",
+  chi: "χ",
+  psi: "ψ",
+  omega: "ω",
+  Gamma: "Γ",
+  Delta: "Δ",
+  Theta: "Θ",
+  Lambda: "Λ",
+  Xi: "Ξ",
+  Pi: "Π",
+  Sigma: "Σ",
+  Upsilon: "Υ",
+  Phi: "Φ",
+  Psi: "Ψ",
+  Omega: "Ω",
+}
+
+/** Commands that expand to a fixed string (empty = strip). */
+const CMDS: Record<string, string> = {
+  // operators
+  cdot: "·",
+  times: "×",
+  div: "÷",
+  pm: "±",
+  mp: "∓",
+  ast: "∗",
+  star: "⋆",
+  circ: "∘",
+  bullet: "•",
+  oplus: "⊕",
+  otimes: "⊗",
+  ominus: "⊖",
+  oslash: "⊘",
+  odot: "⊙",
+  // infinity / calculus
+  infty: "∞",
+  partial: "∂",
+  nabla: "∇",
+  // logic / sets
+  forall: "∀",
+  exists: "∃",
+  nexists: "∄",
+  emptyset: "∅",
+  varnothing: "∅",
+  in: "∈",
+  notin: "∉",
+  ni: "∋",
+  subset: "⊂",
+  supset: "⊃",
+  subseteq: "⊆",
+  supseteq: "⊇",
+  cup: "∪",
+  cap: "∩",
+  vee: "∨",
+  wedge: "∧",
+  neg: "¬",
+  lnot: "¬",
+  land: "∧",
+  lor: "∨",
+  // arrows
+  to: "→",
+  rightarrow: "→",
+  leftarrow: "←",
+  leftrightarrow: "↔",
+  Rightarrow: "⇒",
+  Leftarrow: "⇐",
+  Leftrightarrow: "⇔",
+  mapsto: "↦",
+  implies: "⟹",
+  iff: "⟺",
+  // relations
+  leq: "≤",
+  le: "≤",
+  geq: "≥",
+  ge: "≥",
+  neq: "≠",
+  ne: "≠",
+  approx: "≈",
+  sim: "∼",
+  simeq: "≃",
+  cong: "≅",
+  equiv: "≡",
+  propto: "∝",
+  ll: "≪",
+  gg: "≫",
+  prec: "≺",
+  succ: "≻",
+  preceq: "⪯",
+  succeq: "⪰",
+  models: "⊨",
+  vdash: "⊢",
+  dashv: "⊣",
+  perp: "⊥",
+  parallel: "∥",
+  mid: "∣",
+  nmid: "∤",
+  // big ops
+  sum: "∑",
+  prod: "∏",
+  int: "∫",
+  oint: "∮",
+  bigcup: "⋃",
+  bigcap: "⋂",
+  bigvee: "⋁",
+  bigwedge: "⋀",
+  bigoplus: "⨁",
+  bigotimes: "⨂",
+  // delimiters
+  langle: "⟨",
+  rangle: "⟩",
+  lfloor: "⌊",
+  rfloor: "⌋",
+  lceil: "⌈",
+  rceil: "⌉",
+  vert: "|",
+  Vert: "‖",
+  lVert: "‖",
+  rVert: "‖",
+  // misc
+  ell: "ℓ",
+  hbar: "ℏ",
+  Re: "ℜ",
+  Im: "ℑ",
+  aleph: "ℵ",
+  wp: "℘",
+  degree: "°",
+  prime: "′",
+  primes: "′",
+  backslash: "\\",
+  angle: "∠",
+  triangle: "△",
+  square: "□",
+  diamond: "⋄",
+  // spacing
+  quad: "  ",
+  qquad: "    ",
+  comma: ",",
+  colon: ":",
+  // function names kept as text
+  log: "log",
+  ln: "ln",
+  exp: "exp",
+  sin: "sin",
+  cos: "cos",
+  tan: "tan",
+  max: "max",
+  min: "min",
+  arg: "arg",
+  det: "det",
+  dim: "dim",
+  ker: "ker",
+  // sizing / style no-ops
+  left: "",
+  right: "",
+  big: "",
+  Big: "",
+  bigg: "",
+  Bigg: "",
+  biggl: "",
+  biggr: "",
+  Biggl: "",
+  Biggr: "",
+  displaystyle: "",
+  textstyle: "",
+  scriptstyle: "",
+  scriptscriptstyle: "",
+  limits: "",
+  nolimits: "",
+  notag: "",
+  nonumber: "",
+}
+
+const SUP: Record<string, string> = {
+  "0": "⁰",
+  "1": "¹",
+  "2": "²",
+  "3": "³",
+  "4": "⁴",
+  "5": "⁵",
+  "6": "⁶",
+  "7": "⁷",
+  "8": "⁸",
+  "9": "⁹",
+  "+": "⁺",
+  "-": "⁻",
+  "=": "⁼",
+  "(": "⁽",
+  ")": "⁾",
+  n: "ⁿ",
+  i: "ⁱ",
+  a: "ᵃ",
+  b: "ᵇ",
+  c: "ᶜ",
+  d: "ᵈ",
+  e: "ᵉ",
+  f: "ᶠ",
+  g: "ᵍ",
+  h: "ʰ",
+  j: "ʲ",
+  k: "ᵏ",
+  l: "ˡ",
+  m: "ᵐ",
+  o: "ᵒ",
+  p: "ᵖ",
+  r: "ʳ",
+  s: "ˢ",
+  t: "ᵗ",
+  u: "ᵘ",
+  v: "ᵛ",
+  w: "ʷ",
+  x: "ˣ",
+  y: "ʸ",
+  z: "ᶻ",
+  T: "ᵀ",
+}
+
+const SUB: Record<string, string> = {
+  "0": "₀",
+  "1": "₁",
+  "2": "₂",
+  "3": "₃",
+  "4": "₄",
+  "5": "₅",
+  "6": "₆",
+  "7": "₇",
+  "8": "₈",
+  "9": "₉",
+  "+": "₊",
+  "-": "₋",
+  "=": "₌",
+  "(": "₍",
+  ")": "₎",
+  a: "ₐ",
+  e: "ₑ",
+  h: "ₕ",
+  i: "ᵢ",
+  j: "ⱼ",
+  k: "ₖ",
+  l: "ₗ",
+  m: "ₘ",
+  n: "ₙ",
+  o: "ₒ",
+  p: "ₚ",
+  r: "ᵣ",
+  s: "ₛ",
+  t: "ₜ",
+  u: "ᵤ",
+  v: "ᵥ",
+  x: "ₓ",
+}
+
+const MATHBB: Record<string, string> = {
+  R: "ℝ",
+  N: "ℕ",
+  Z: "ℤ",
+  Q: "ℚ",
+  C: "ℂ",
+  P: "ℙ",
+  E: "𝔼",
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mapAll(s: string, table: Record<string, string>): string | null {
+  let out = ""
+  for (const ch of s) {
+    if (ch === " " || ch === ",") {
+      out += ch
+      continue
+    }
+    const m = table[ch]
+    if (!m) return null
+    out += m
+  }
+  return out
+}
+
+function takeBrace(src: string, start: number): { body: string; end: number } | null {
+  if (src[start] !== "{") return null
+  let depth = 0
+  for (let i = start; i < src.length; i++) {
+    if (src[i] === "{") depth++
+    else if (src[i] === "}") {
+      depth--
+      if (depth === 0) return { body: src.slice(start + 1, i), end: i + 1 }
+    }
+  }
+  return null
+}
+
+const SUB_RUN = /^[₀₁₂₃₄₅₆₇₈₉₊₋₌₍₎ₐₑₕᵢⱼₖₗₘₙₒₚᵣₛₜᵤᵥₓ]+$/
+const SUP_RUN = /^[⁰¹²³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ⁿⁱᵃᵇᶜᵈᵉᶠᵍʰʲᵏˡᵐᵒᵖʳˢᵗᵘᵛʷˣʸᶻᵀ]+$/
+
+/** Map to unicode scripts; multi-char without full coverage uses ₍…₎ / ⁽…⁾ (never bare _). */
+function toScript(inner: string, table: Record<string, string>, kind: "sup" | "sub"): string {
+  const full = mapAll(inner, table)
+  if (full !== null) return full
+
+  // e^{z_i} body becomes "zᵢ" after inner conversion — prefer ᶻᵢ over ⁽zᵢ⁾
+  if (kind === "sup" && inner.length >= 2) {
+    const base = inner[0]
+    const rest = inner.slice(1)
+    if (SUP[base] && SUB_RUN.test(rest)) return SUP[base] + rest
+  }
+  if (kind === "sub" && inner.length >= 2) {
+    const base = inner[0]
+    const rest = inner.slice(1)
+    if (SUB[base] && SUP_RUN.test(rest)) return SUB[base] + rest
+  }
+
+  let out = ""
+  let complete = true
+  for (const ch of inner) {
+    if (table[ch]) out += table[ch]
+    else if (" ,:<>".includes(ch)) out += ch
+    else {
+      out += ch
+      complete = false
+    }
+  }
+  if (complete) return out
+  return kind === "sub" ? `₍${inner}₎` : `⁽${inner}⁾`
+}
+
+/** Heuristic: bare $…$ is math only if it contains TeX structure. */
+function looksLikeMath(body: string): boolean {
+  if (/\\[a-zA-Z]/.test(body)) return true
+  if (/[_^]/.test(body)) return true
+  if (/\{|\}/.test(body)) return true
+  // single greek-ish letter sequences are not enough; require operator-ish content
+  if (/[=<>≤≥≠≈∈∑∏∫]/.test(body) && /[A-Za-z]/.test(body)) return true
+  return false
+}
+
+// ---------------------------------------------------------------------------
+// Core conversion of a math body (no outer delimiters)
+// ---------------------------------------------------------------------------
+
+function convertMath(src: string): string {
+  let s = src
+
+  // 1. \frac{a}{b} (nested, iterative)
+  for (let n = 0; n < 8; n++) {
+    if (!s.includes("\\frac")) break
+    let out = ""
+    let i = 0
+    while (i < s.length) {
+      if (s.startsWith("\\frac", i)) {
+        let j = i + 5
+        while (s[j] === " ") j++
+        const a = takeBrace(s, j)
+        if (!a) {
+          out += s[i++]
+          continue
+        }
+        let k = a.end
+        while (s[k] === " ") k++
+        const b = takeBrace(s, k)
+        if (!b) {
+          out += s.slice(i, a.end)
+          i = a.end
+          continue
+        }
+        out += `(${convertMath(a.body).trim()})/(${convertMath(b.body).trim()})`
+        i = b.end
+        continue
+      }
+      out += s[i++]
+    }
+    s = out
+  }
+
+  // 2. roots
+  s = s.replace(/\\sqrt\s*\[([^\]]*)\]\s*\{([^}]*)\}/g, (_, n, x) => `${n}√(${convertMath(x)})`)
+  s = s.replace(/\\sqrt\s*\{([^}]*)\}/g, (_, x) => `√(${convertMath(x)})`)
+
+  // 3. font wrappers / blackboard
+  s = s.replace(/\\mathbb\s*\{([A-Za-z])\}/g, (_, ch) => MATHBB[ch] ?? ch)
+  s = s.replace(/\\mathcal\s*\{([A-Za-z]+)\}/g, "$1")
+  s = s.replace(
+    /\\(?:text|textbf|textrm|textit|mathrm|mathbf|mathit|mathsf|mathtt|operatorname)\s*\{([^{}]*)\}/g,
+    "$1",
+  )
+
+  // 4. named commands and greek (before scripts so \pi_\theta works)
+  s = s.replace(/\\([a-zA-Z]+)/g, (_, name: string) => {
+    if (GREEK[name]) return GREEK[name]
+    if (name in CMDS) return CMDS[name]
+    return name
+  })
+
+  // 5. braced then single-char scripts (repeat for nesting)
+  for (let n = 0; n < 4; n++) {
+    const before = s
+    s = s.replace(/\^\{([^{}]*)\}/g, (_, body) => toScript(convertMath(body).trim(), SUP, "sup"))
+    s = s.replace(/_\{([^{}]*)\}/g, (_, body) => toScript(convertMath(body).trim(), SUB, "sub"))
+    if (s === before) break
+  }
+  // BMP letters/digits/greek already substituted
+  s = s.replace(/_([\w\u0370-\u03FF+\-=])/gu, (_, ch) => SUB[ch] ?? `₍${ch}₎`)
+  s = s.replace(/\^([\w\u0370-\u03FF+\-=])/gu, (_, ch) => SUP[ch] ?? `⁽${ch}⁾`)
+
+  // 6. cleanup
+  s = s.replace(/[{}]/g, "")
+  s = s.replace(/\\[,;]/g, " ")
+  s = s.replace(/\\!/g, "")
+  s = s.replace(/~/g, " ")
+  s = s.replace(/\\/g, "")
+
+  // 7. spacing around relations; keep minus readable
+  s = s.replace(/\s*([=≈≠≤≥×·])\s*/g, " $1 ")
+  s = s.replace(/([^\s])-([^\s])/g, "$1 - $2")
+  s = s.replace(/\s*,\s*/g, ", ")
+  s = s.replace(/\s+/g, " ").trim()
+
+  // collapse spaces inside pure subscript/superscript runs (∑ₜ ₌ ₁ → ∑ₜ₌₁)
+  s = s.replace(/([∑∏∫])\s+([ₜᵢⱼₖₙₘₓ])/g, "$1$2")
+  s = s.replace(/([₀-₉ₐ-ₓ₍₎₊₋₌])\s+([₀-₉ₐ-ₓ₍₎₊₋₌])/g, "$1$2")
+  s = s.replace(/([⁰-⁹ⁿⁱᵃ-ᶻᵀ⁽⁾⁺⁻⁼])\s+([⁰-⁹ⁿⁱᵃ-ᶻᵀ⁽⁾⁺⁻⁼])/g, "$1$2")
+
+  // conditioned-on bar
+  s = s.replace(/\s+\|\s+/g, " ∣ ")
+  s = s.replace(/\|/g, "∣")
+  s = s.replace(/\(\s+/g, "(").replace(/\s+\)/g, ")")
+
+  // No raw _ / * left for the markdown layer to interpret as emphasis
+  s = s.replace(/_/g, "")
+  s = s.replace(/\*/g, "·")
+
+  return s
+}
+
+// ---------------------------------------------------------------------------
+// Delimiter rewrite
+// ---------------------------------------------------------------------------
+
+function displayBlock(body: string): string {
+  return `\n\n    ${convertMath(body)}\n\n`
+}
+
+function replaceDelimiters(text: string): string {
+  let s = text
+
+  s = s.replace(/\$\$([\s\S]+?)\$\$/g, (_, body) => displayBlock(body))
+  s = s.replace(/\\\[([\s\S]+?)\\\]/g, (_, body) => displayBlock(body))
+  s = s.replace(/\\\(([\s\S]+?)\\\)/g, (_, body) => convertMath(body))
+
+  // bare $…$ — only when math-like (avoids $0.02/GB currency breakage)
+  s = s.replace(/(?<!\$)\$(?!\$)([^$\n]+?)\$(?!\$)/g, (full, body: string) => {
+    if (!looksLikeMath(body)) return full
+    return convertMath(body)
+  })
+
+  s = s.replace(
+    /\\begin\{(?:equation|align|align\*|eqnarray|gather)\*?\}([\s\S]*?)\\end\{(?:equation|align|align\*|eqnarray|gather)\*?\}/g,
+    (_, body: string) => {
+      const lines = body
+        .split("\\\\")
+        .map((line) => convertMath(line.replace(/&/g, "  ")))
+        .filter((line) => line.length > 0)
+      return "\n\n" + lines.map((line) => `    ${line}`).join("\n") + "\n\n"
+    },
+  )
+
+  return s
+}
+
+/**
+ * Convert LaTeX math in markdown text to Unicode-friendly plain text for TUI display.
+ * Safe to call on every assistant text/reasoning part; no-ops when no math markers present.
+ */
+export function latexToUnicode(text: string): string {
+  if (!text) return text
+  if (!/[\\$]/.test(text)) return text
+  try {
+    return replaceDelimiters(text)
+  } catch {
+    return text
+  }
+}

--- a/packages/opencode/src/cli/ui.ts
+++ b/packages/opencode/src/cli/ui.ts
@@ -1,6 +1,7 @@
 import { EOL } from "os"
 import { Schema } from "effect"
 import { logo as glyphs } from "./logo"
+import { latexToUnicode } from "./cmd/run/latex-unicode"
 
 const wordmark = [
   `⠀                                ▄     `,
@@ -125,8 +126,9 @@ export function error(message: string) {
   println(Style.TEXT_DANGER_BOLD + "Error: " + Style.TEXT_NORMAL + message)
 }
 
+
 export function markdown(text: string): string {
-  return text
+  return latexToUnicode(text)
 }
 
 export * as UI from "./ui"

--- a/packages/opencode/test/cli/cmd/run/latex-unicode.test.ts
+++ b/packages/opencode/test/cli/cmd/run/latex-unicode.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { latexToUnicode } from "../../../../src/cli/cmd/run/latex-unicode"
+
+describe("latexToUnicode", () => {
+  test("leaves plain text alone", () => {
+    expect(latexToUnicode("hello world")).toBe("hello world")
+  })
+
+  test("leaves currency bare-dollars alone", () => {
+    expect(latexToUnicode("costs $0.02/GB or $203/month")).toBe("costs $0.02/GB or $203/month")
+    expect(latexToUnicode("price is $100 today")).toBe("price is $100 today")
+  })
+
+  test("converts display math with frac and greek", () => {
+    const out = latexToUnicode(String.raw`\[ D_{KL}(P \| Q) = \sum_x P(x) \log \frac{P(x)}{Q(x)} \]`)
+    expect(out).toContain("∑")
+    expect(out).toContain("(P(x))/(Q(x))")
+    expect(out).not.toContain("\\frac")
+    expect(out).not.toContain("\\sum")
+  })
+
+  test("converts inline \\( \\) delimiters", () => {
+    const out = latexToUnicode(String.raw`Advantage \( A_t = \log \pi_T - \log \pi_\theta \) here`)
+    expect(out).toContain("Aₜ")
+    expect(out).toContain("π₍T₎")
+    expect(out).toContain("π₍θ₎")
+    expect(out).not.toContain("\\(")
+    expect(out).not.toContain("\\pi")
+  })
+
+  test("converts $$ blocks", () => {
+    const out = latexToUnicode(String.raw`$$ \mathbb{E}_{x \sim p}[f(x)] $$`)
+    expect(out).toContain("𝔼")
+    expect(out).toContain("∼")
+    expect(out).not.toContain("$$")
+  })
+
+  test("converts math-like bare dollars", () => {
+    const out = latexToUnicode(String.raw`score $x_i^2$ done`)
+    expect(out).toContain("xᵢ")
+    expect(out).toContain("²")
+    expect(out).not.toContain("$")
+  })
+
+  test("mathrm subscript", () => {
+    const out = latexToUnicode(String.raw`$D_{\mathrm{KL}}(p\|q)$`)
+    expect(out).toMatch(/D.*KL/)
+    expect(out).not.toContain("\\mathrm")
+    expect(out.includes("_")).toBe(false)
+  })
+
+  test("softmax fraction", () => {
+    const out = latexToUnicode(
+      String.raw`$$\operatorname{softmax}(z)_i = \frac{e^{z_i}}{\sum_j e^{z_j}}$$`,
+    )
+    expect(out).toContain("softmax")
+    expect(out).toContain("∑")
+    expect(out).not.toContain("\\frac")
+  })
+
+  test("reverse KL study example", () => {
+    const src = String.raw`
+On-policy distillation uses
+\[
+A_t = \log \pi_T(a_t \mid s_t) - \log \pi_\theta(a_t \mid s_t)
+\]
+which is reverse $D_{KL}(\pi_\theta \| \pi_T)$.
+`
+    const out = latexToUnicode(src)
+    expect(out).toContain("Aₜ")
+    expect(out).toContain("π₍T₎")
+    expect(out).toContain("π₍θ₎")
+    expect(out).not.toContain("\\log")
+    expect(out).not.toContain("\\pi")
+  })
+
+  test("no raw underscore survives (markdown-safe)", () => {
+    const out = latexToUnicode(String.raw`$a_b + \pi_T + x_{1:L}$`)
+    expect(out.includes("_")).toBe(false)
+  })
+
+  test("sequence likelihood", () => {
+    const out = latexToUnicode(
+      String.raw`$$\pi(a_{1:L}\mid s) = \prod_{t=1}^{L} \pi(a_t\mid s, a_{<t})$$`,
+    )
+    expect(out).toContain("π")
+    expect(out).toContain("∏")
+    expect(out).toContain("∣")
+  })
+})


### PR DESCRIPTION
## Summary

Terminals cannot run KaTeX, so assistant replies with `\(…\)`, `\[…\]`, `$$…$$`, or math-like `$…$` currently show raw LaTeX source and are hard to read.

This adds a small, pure LaTeX→Unicode rewrite on the CLI text path **before** markdown rendering:

- `packages/opencode/src/cli/cmd/run/latex-unicode.ts` — converter (no deps)
- Wired into `entry.body.ts` for assistant markdown + reasoning bodies
- Also applied in `UI.markdown` for non-TUI println paths
- Unit tests covering common ML/post-training equations and currency safety

**Not a full TeX engine.** Goal is legibility in the TUI, not pixel-perfect layout. Web/desktop KaTeX remains a separate surface.

## Design choices (kept intentionally non-hacky)

| Choice | Why |
|--------|-----|
| Pure string rewrite, no KaTeX/MathJax | TUI has no HTML/canvas; keep zero new deps |
| Apply once at the entry-body boundary | Single choke point; scrollback/writer stay dumb |
| Bare `$…$` only when body looks like math (`\`, `^`, `_`, or relation+letter) | Avoids breaking `$0.02/GB` / `$203/month` (#15892, #30712) |
| No raw `_` left in output | Markdown layer was turning `_T` into emphasis/links |
| Multi-char scripts → `π₍T₎` when no unicode glyph | Readable fallback instead of broken `_T` or fake greek subs |
| `e^{z_i}` → `eᶻᵢ` (compose base + already-scripted rest) | Nested scripts stay compact |
| Display math padded as its own block | Scannable, not run-on with prose |

## Examples

| Input | Output |
|-------|--------|
| `$A_t = \log \pi_T - \log \pi_\theta$` | `Aₜ = log π₍T₎ - log π₍θ₎` |
| `$$\operatorname{softmax}(z)_i = \frac{e^{z_i}}{\sum_j e^{z_j}}$$` | `softmax(z)ᵢ = (eᶻᵢ)/(∑ⱼ eᶻⱼ)` |
| `costs $0.02/GB` | unchanged |
| `D_{\mathrm{KL}}(p\|q)` | `D₍KL₎(p∣q)` |

## Test plan

- [x] `bun test ./test/cli/cmd/run/latex-unicode.test.ts` — 11 pass
- [ ] Manual: start CLI TUI, ask for a KL / softmax equation, confirm unicode not raw `\$\...`
- [ ] Manual: response with `$0.02/GB` stays intact
- [ ] Manual: reasoning/thinking blocks with math also convert

## Fixes

Fixes #34407

Related: #37326, #15892, #30712