### PR TITLE
fix(core): remove unused FetchHttpClient import in skill discovery

### DIFF
--- a/packages/core/src/skill/discovery.ts
+++ b/packages/core/src/skill/discovery.ts
@@ -2,7 +2,7 @@ export * as SkillDiscovery from "./discovery"
 
 import path from "path"
 import { Context, Effect, Layer, Schedule, Schema } from "effect"
-import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { FSUtil } from "../fs-util"
 import { Global } from "../global"
 import { makeGlobalNode } from "../effect/app-node"


### PR DESCRIPTION
Removes the unused \FetchHttpClient\ import from \packages/core/src/skill/discovery.ts\. This import was declared but never referenced in the file body, causing unnecessary module resolution noise.