### PR TITLE
docs: add cc-oc and omoctl to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [cc-oc](https://github.com/anfreire/cc-oc)                                                 | Claude Code slash commands for detached OpenCode sessions        |
+| [omoctl](https://github.com/anfreire/omoctl)                                               | Define, patch, and switch oh-my-openagent profiles from the CLI  |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — the ecosystem page invites additions by PR.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds two rows to the Projects table on the ecosystem docs page:

- [cc-oc](https://github.com/anfreire/cc-oc) — Claude Code plugin that launches detached opencode sessions via slash commands wrapping `opencode run`.
- [omoctl](https://github.com/anfreire/omoctl) — CLI that manages oh-my-openagent profiles: define in YAML, patch models, switch the active config.

Both are mine, MIT-licensed, and maintained.

### How did you verify your code works?

Markdown-only change; previewed the table and matched the existing column alignment.

### Screenshots / recordings

N/A — two table rows.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
