### PR TITLE
fix(core): remove unused NodeFileSystem import in cross-spawn spawner

### DIFF
--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -1,5 +1,5 @@
 import type * as Arr from "effect/Array"
-import { NodeFileSystem, NodeSink, NodeStream } from "@effect/platform-node"
+import { NodeSink, NodeStream } from "@effect/platform-node"
 import * as NodePath from "@effect/platform-node/NodePath"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"


### PR DESCRIPTION
Removes the unused \NodeFileSystem\ import from \packages/core/src/cross-spawn-spawner.ts\. Only \NodeSink\ and \NodeStream\ from \@effect/platform-node\ are used in this file.