### PR TITLE
fix(core): remove commented-out interface members in copilot provider

### DIFF
--- a/packages/core/src/github-copilot/copilot-provider.ts
+++ b/packages/core/src/github-copilot/copilot-provider.ts
@@ -40,10 +40,6 @@ export interface OpenaiCompatibleProvider {
   chat(modelId: OpenaiCompatibleModelId): LanguageModelV3
   responses(modelId: OpenaiCompatibleModelId): LanguageModelV3
   languageModel(modelId: OpenaiCompatibleModelId): LanguageModelV3
-
-  // embeddingModel(modelId: any): EmbeddingModelV2
-
-  // imageModel(modelId: any): ImageModelV2
 }
 
 /**


### PR DESCRIPTION
Removes two commented-out method signatures (\embeddingModel\ and \imageModel\) from the \OpenaiCompatibleProvider\ interface in \packages/core/src/github-copilot/copilot-provider.ts\. Dead code that has been left commented out should be removed to keep the codebase clean.