### PR TITLE
fix(core): remove commented-out property labels in GitHub Copilot chat model

### DIFF
--- a/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
@@ -175,10 +175,8 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
         reasoning_effort: compatibleOptions.reasoningEffort,
         verbosity: compatibleOptions.textVerbosity,
 
-        // messages:
         messages: convertToOpenAICompatibleChatMessages(prompt),
 
-        // tools:
         tools: openaiTools,
         tool_choice: openaiToolChoice,
 


### PR DESCRIPTION
Removes two commented-out property label comments (\// messages:\ and \// tools:\) from \packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts\. These were leftover from a refactor where the actual properties were uncommented but the old labels were left as dead comments.