### PR TITLE
fix(core): remove commented-out Retried event projection in session projector

### DIFF
--- a/packages/core/src/session/projector.ts
+++ b/packages/core/src/session/projector.ts
@@ -391,7 +391,6 @@ const layer = Layer.effectDiscard(
     yield* events.project(SessionEvent.Tool.Failed, (event) => run(db, event))
     yield* events.project(SessionEvent.Reasoning.Started, (event) => run(db, event))
     yield* events.project(SessionEvent.Reasoning.Ended, (event) => run(db, event))
-    // yield* events.project(SessionEvent.Retried, (event) => run(db, event))
     yield* events.project(SessionEvent.Compaction.Ended, (event) => run(db, event))
     yield* events.project(SessionEvent.RevertEvent.Staged, (event) =>
       db


### PR DESCRIPTION
Removes a commented-out \yield* events.project(SessionEvent.Retried, ...)\ call from \packages/core/src/session/projector.ts\. This line has been left commented out and should be removed to keep the codebase clean.