### PR TITLE
fix(llm): enable Anthropic prompt caching on the OpenRouter route

### DIFF
--- a/packages/llm/src/cache-policy.ts
+++ b/packages/llm/src/cache-policy.ts
@@ -30,11 +30,16 @@ const NONE: CachePolicyObject = {}
 //   - "auto"      → tools + system + latest user msg.
 //   - "none"      → no auto placement; manual `CacheHint`s still flow.
 //   - object form → exactly what the caller asked for.
-const resolve = (policy: CachePolicy | undefined): CachePolicyObject => {
+export const resolvePolicy = (policy: CachePolicy | undefined): CachePolicyObject => {
   if (policy === undefined || policy === "auto") return AUTO
   if (policy === "none") return NONE
   return policy
 }
+
+// Protocols that cache a whole request in one directive, rather than at the
+// breakpoints `applyCachePolicy` places, have no placements to read — only this.
+export const policyEnabled = (policy: CachePolicyObject): boolean =>
+  Boolean(policy.tools || policy.system || policy.messages)
 
 // Protocols whose wire format ignores inline cache markers (OpenAI's implicit
 // prefix caching, Gemini's implicit + out-of-band CachedContent). Skip the
@@ -98,8 +103,8 @@ const markMessages = (
 
 export const applyCachePolicy = (request: LLMRequest): LLMRequest => {
   if (!RESPECTS_INLINE_HINTS.has(request.model.route.id)) return request
-  const policy = resolve(request.cache)
-  if (!policy.tools && !policy.system && !policy.messages) return request
+  const policy = resolvePolicy(request.cache)
+  if (!policyEnabled(policy)) return request
 
   const hint = makeHint(policy.ttlSeconds)
   const tools = policy.tools ? markLastTool(request.tools, hint) : request.tools

--- a/packages/llm/src/cache-policy.ts
+++ b/packages/llm/src/cache-policy.ts
@@ -36,8 +36,7 @@ export const resolvePolicy = (policy: CachePolicy | undefined): CachePolicyObjec
   return policy
 }
 
-// Protocols that cache a whole request in one directive, rather than at the
-// breakpoints `applyCachePolicy` places, have no placements to read — only this.
+// For protocols that cache a whole request in one directive and have no placements to read.
 export const policyEnabled = (policy: CachePolicyObject): boolean =>
   Boolean(policy.tools || policy.system || policy.messages)
 

--- a/packages/llm/src/providers/openrouter.ts
+++ b/packages/llm/src/providers/openrouter.ts
@@ -4,11 +4,12 @@ import { Endpoint } from "../route/endpoint"
 import { Framing } from "../route/framing"
 import { Protocol } from "../route/protocol"
 import { AuthOptions, type ProviderAuthOption } from "../route/auth-options"
-import { ProviderID, type ModelID, type ProviderOptions } from "../schema"
+import { ProviderID, type LLMRequest, type ModelID, type ProviderOptions } from "../schema"
 import * as OpenAICompatibleProfiles from "./openai-compatible-profile"
 import * as OpenAIChat from "../protocols/openai-chat"
 import { isRecord } from "../protocols/shared"
 import { ttlBucket } from "../protocols/utils/cache"
+import { policyEnabled, resolvePolicy } from "../cache-policy"
 
 export const profile = OpenAICompatibleProfiles.profiles.openrouter
 export const id = ProviderID.make(profile.provider)
@@ -19,11 +20,7 @@ export interface OpenRouterOptions {
   readonly usage?: boolean | Record<string, unknown>
   readonly reasoning?: Record<string, unknown>
   readonly promptCacheKey?: string
-  readonly prompt_cache_key?: string
-  readonly sessionID?: string
-  readonly session_id?: string
   readonly cacheControl?: Record<string, unknown>
-  readonly cache_control?: Record<string, unknown>
 }
 
 export type OpenRouterProviderOptionsInput = ProviderOptions & {
@@ -41,6 +38,21 @@ const OpenRouterBody = Schema.StructWithRest(Schema.Struct(OpenAIChat.bodyFields
 ])
 export type OpenRouterBody = Schema.Schema.Type<typeof OpenRouterBody>
 
+const EPHEMERAL_5M = { type: "ephemeral" as const }
+const EPHEMERAL_1H = { type: "ephemeral" as const, ttl: "1h" as const }
+
+// `~anthropic/*` are OpenRouter catalog aliases for the same upstream models.
+const isAnthropicModel = (modelID: string) => modelID.replace(/^~/, "").startsWith("anthropic/")
+
+// "Automatic" caching is a whole-request directive, so the policy's breakpoint
+// placements do not apply here — only whether it is on, and its TTL.
+const automaticCacheControl = (request: LLMRequest) => {
+  if (!isAnthropicModel(request.model.id)) return undefined
+  const policy = resolvePolicy(request.cache)
+  if (!policyEnabled(policy)) return undefined
+  return ttlBucket(policy.ttlSeconds) === "1h" ? EPHEMERAL_1H : EPHEMERAL_5M
+}
+
 export const protocol = Protocol.make({
   id: "openrouter-chat",
   body: {
@@ -48,25 +60,11 @@ export const protocol = Protocol.make({
     from: (request) =>
       OpenAIChat.protocol.body.from(request).pipe(
         Effect.map((body) => {
-          const options = bodyOptions(request.providerOptions?.openrouter)
-          const policy = request.cache
-          const cacheEnabled =
-            policy === undefined ||
-            policy === "auto" ||
-            (typeof policy === "object" && Boolean(policy.tools || policy.system || policy.messages))
-          const automaticCacheControl =
-            request.model.id.replace(/^~/, "").startsWith("anthropic/") && cacheEnabled
-              ? {
-                  type: "ephemeral",
-                  ...(ttlBucket(typeof policy === "object" ? policy.ttlSeconds : undefined) === "1h"
-                    ? { ttl: "1h" }
-                    : {}),
-                }
-              : undefined
+          const automatic = automaticCacheControl(request)
           return {
             ...body,
-            ...(automaticCacheControl ? { cache_control: automaticCacheControl } : {}),
-            ...options,
+            ...(automatic ? { cache_control: automatic } : {}),
+            ...bodyOptions(request.providerOptions?.openrouter),
           } as OpenRouterBody
         }),
       ),
@@ -76,11 +74,6 @@ export const protocol = Protocol.make({
 
 const bodyOptions = (input: unknown) => {
   const openrouter = isRecord(input) ? input : {}
-  const cacheControl = isRecord(openrouter.cacheControl)
-    ? openrouter.cacheControl
-    : isRecord(openrouter.cache_control)
-      ? openrouter.cache_control
-      : undefined
   return {
     ...(openrouter.usage === true
       ? { usage: { include: true } }
@@ -88,17 +81,8 @@ const bodyOptions = (input: unknown) => {
         ? { usage: openrouter.usage }
         : {}),
     ...(isRecord(openrouter.reasoning) ? { reasoning: openrouter.reasoning } : {}),
-    ...(typeof openrouter.promptCacheKey === "string"
-      ? { prompt_cache_key: openrouter.promptCacheKey }
-      : typeof openrouter.prompt_cache_key === "string"
-        ? { prompt_cache_key: openrouter.prompt_cache_key }
-        : {}),
-    ...(typeof openrouter.sessionID === "string"
-      ? { session_id: openrouter.sessionID }
-      : typeof openrouter.session_id === "string"
-        ? { session_id: openrouter.session_id }
-        : {}),
-    ...(cacheControl ? { cache_control: cacheControl } : {}),
+    ...(typeof openrouter.promptCacheKey === "string" ? { prompt_cache_key: openrouter.promptCacheKey } : {}),
+    ...(isRecord(openrouter.cacheControl) ? { cache_control: openrouter.cacheControl } : {}),
   }
 }
 

--- a/packages/llm/src/providers/openrouter.ts
+++ b/packages/llm/src/providers/openrouter.ts
@@ -8,6 +8,7 @@ import { ProviderID, type ModelID, type ProviderOptions } from "../schema"
 import * as OpenAICompatibleProfiles from "./openai-compatible-profile"
 import * as OpenAIChat from "../protocols/openai-chat"
 import { isRecord } from "../protocols/shared"
+import { ttlBucket } from "../protocols/utils/cache"
 
 export const profile = OpenAICompatibleProfiles.profiles.openrouter
 export const id = ProviderID.make(profile.provider)
@@ -18,6 +19,11 @@ export interface OpenRouterOptions {
   readonly usage?: boolean | Record<string, unknown>
   readonly reasoning?: Record<string, unknown>
   readonly promptCacheKey?: string
+  readonly prompt_cache_key?: string
+  readonly sessionID?: string
+  readonly session_id?: string
+  readonly cacheControl?: Record<string, unknown>
+  readonly cache_control?: Record<string, unknown>
 }
 
 export type OpenRouterProviderOptionsInput = ProviderOptions & {
@@ -41,13 +47,28 @@ export const protocol = Protocol.make({
     schema: OpenRouterBody,
     from: (request) =>
       OpenAIChat.protocol.body.from(request).pipe(
-        Effect.map(
-          (body) =>
-            ({
-              ...body,
-              ...bodyOptions(request.providerOptions?.openrouter),
-            }) as OpenRouterBody,
-        ),
+        Effect.map((body) => {
+          const options = bodyOptions(request.providerOptions?.openrouter)
+          const policy = request.cache
+          const cacheEnabled =
+            policy === undefined ||
+            policy === "auto" ||
+            (typeof policy === "object" && Boolean(policy.tools || policy.system || policy.messages))
+          const automaticCacheControl =
+            request.model.id.replace(/^~/, "").startsWith("anthropic/") && cacheEnabled
+              ? {
+                  type: "ephemeral",
+                  ...(ttlBucket(typeof policy === "object" ? policy.ttlSeconds : undefined) === "1h"
+                    ? { ttl: "1h" }
+                    : {}),
+                }
+              : undefined
+          return {
+            ...body,
+            ...(automaticCacheControl ? { cache_control: automaticCacheControl } : {}),
+            ...options,
+          } as OpenRouterBody
+        }),
       ),
   },
   stream: OpenAIChat.protocol.stream,
@@ -55,6 +76,11 @@ export const protocol = Protocol.make({
 
 const bodyOptions = (input: unknown) => {
   const openrouter = isRecord(input) ? input : {}
+  const cacheControl = isRecord(openrouter.cacheControl)
+    ? openrouter.cacheControl
+    : isRecord(openrouter.cache_control)
+      ? openrouter.cache_control
+      : undefined
   return {
     ...(openrouter.usage === true
       ? { usage: { include: true } }
@@ -62,7 +88,17 @@ const bodyOptions = (input: unknown) => {
         ? { usage: openrouter.usage }
         : {}),
     ...(isRecord(openrouter.reasoning) ? { reasoning: openrouter.reasoning } : {}),
-    ...(typeof openrouter.promptCacheKey === "string" ? { prompt_cache_key: openrouter.promptCacheKey } : {}),
+    ...(typeof openrouter.promptCacheKey === "string"
+      ? { prompt_cache_key: openrouter.promptCacheKey }
+      : typeof openrouter.prompt_cache_key === "string"
+        ? { prompt_cache_key: openrouter.prompt_cache_key }
+        : {}),
+    ...(typeof openrouter.sessionID === "string"
+      ? { session_id: openrouter.sessionID }
+      : typeof openrouter.session_id === "string"
+        ? { session_id: openrouter.session_id }
+        : {}),
+    ...(cacheControl ? { cache_control: cacheControl } : {}),
   }
 }
 

--- a/packages/llm/src/providers/openrouter.ts
+++ b/packages/llm/src/providers/openrouter.ts
@@ -41,11 +41,10 @@ export type OpenRouterBody = Schema.Schema.Type<typeof OpenRouterBody>
 const EPHEMERAL_5M = { type: "ephemeral" as const }
 const EPHEMERAL_1H = { type: "ephemeral" as const, ttl: "1h" as const }
 
-// `~anthropic/*` are OpenRouter catalog aliases for the same upstream models.
+// `~anthropic/*` are catalog aliases for the same models.
 const isAnthropicModel = (modelID: string) => modelID.replace(/^~/, "").startsWith("anthropic/")
 
-// "Automatic" caching is a whole-request directive, so the policy's breakpoint
-// placements do not apply here — only whether it is on, and its TTL.
+// Whole-request directive, so only the policy's on/off and TTL apply, not its placements.
 const automaticCacheControl = (request: LLMRequest) => {
   if (!isAnthropicModel(request.model.id)) return undefined
   const policy = resolvePolicy(request.cache)

--- a/packages/llm/test/provider/openrouter.test.ts
+++ b/packages/llm/test/provider/openrouter.test.ts
@@ -39,7 +39,7 @@ describe("OpenRouter", () => {
               openrouter: {
                 usage: true,
                 reasoning: { effort: "high" },
-                session_id: "session_123",
+                promptCacheKey: "session_123",
                 cacheControl: { type: "ephemeral", ttl: "1h" },
               },
             },
@@ -51,7 +51,7 @@ describe("OpenRouter", () => {
       expect(prepared.body).toMatchObject({
         usage: { include: true },
         reasoning: { effort: "high" },
-        session_id: "session_123",
+        prompt_cache_key: "session_123",
         cache_control: { type: "ephemeral", ttl: "1h" },
       })
     }),
@@ -78,6 +78,15 @@ describe("OpenRouter", () => {
         }),
       )
       expect(disabled.body).not.toHaveProperty("cache_control")
+
+      const hourly = yield* LLMClient.prepare(
+        LLM.request({
+          model: OpenRouter.configure({ apiKey: "test-key" }).model("anthropic/claude-opus-4.8"),
+          prompt: "Say hello.",
+          cache: { system: true, ttlSeconds: 3600 },
+        }),
+      )
+      expect(hourly.body).toMatchObject({ cache_control: { type: "ephemeral", ttl: "1h" } })
     }),
   )
 

--- a/packages/llm/test/provider/openrouter.test.ts
+++ b/packages/llm/test/provider/openrouter.test.ts
@@ -25,6 +25,7 @@ describe("OpenRouter", () => {
         messages: [{ role: "user", content: "Say hello." }],
         stream: true,
       })
+      expect(prepared.body).not.toHaveProperty("cache_control")
     }),
   )
 
@@ -38,7 +39,8 @@ describe("OpenRouter", () => {
               openrouter: {
                 usage: true,
                 reasoning: { effort: "high" },
-                promptCacheKey: "session_123",
+                session_id: "session_123",
+                cacheControl: { type: "ephemeral", ttl: "1h" },
               },
             },
           }).model("anthropic/claude-3.7-sonnet:thinking"),
@@ -49,7 +51,47 @@ describe("OpenRouter", () => {
       expect(prepared.body).toMatchObject({
         usage: { include: true },
         reasoning: { effort: "high" },
-        prompt_cache_key: "session_123",
+        session_id: "session_123",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      })
+    }),
+  )
+
+  it.effect("enables automatic prompt caching for Anthropic models", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare(
+        LLM.request({
+          model: OpenRouter.configure({ apiKey: "test-key" }).model("anthropic/claude-opus-4.8"),
+          prompt: "Say hello.",
+        }),
+      )
+
+      expect(prepared.body).toMatchObject({
+        cache_control: { type: "ephemeral" },
+      })
+
+      const disabled = yield* LLMClient.prepare(
+        LLM.request({
+          model: OpenRouter.configure({ apiKey: "test-key" }).model("anthropic/claude-opus-4.8"),
+          prompt: "Say hello.",
+          cache: "none",
+        }),
+      )
+      expect(disabled.body).not.toHaveProperty("cache_control")
+    }),
+  )
+
+  it.effect("enables automatic prompt caching for tilde-prefixed Anthropic aliases", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare(
+        LLM.request({
+          model: OpenRouter.configure({ apiKey: "test-key" }).model("~anthropic/claude-opus-latest"),
+          prompt: "Say hello.",
+        }),
+      )
+
+      expect(prepared.body).toMatchObject({
+        cache_control: { type: "ephemeral" },
       })
     }),
   )

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1255,13 +1255,12 @@ export function options(input: {
     }
   }
 
-  // Anthropic models proxied through OpenRouter cache nothing without an explicit
-  // breakpoint. `~anthropic/*` are catalog aliases for the same models.
-  if (
-    input.model.api.npm === "@openrouter/ai-sdk-provider" &&
-    input.model.api.id.replace(/^~/, "").startsWith("anthropic/")
-  ) {
-    result["cache_control"] = { type: "ephemeral" }
+  if (input.model.api.npm === "@openrouter/ai-sdk-provider") {
+    result["session_id"] = input.sessionID
+    // `~anthropic/*` are catalog aliases for the same models.
+    if (input.model.api.id.replace(/^~/, "").startsWith("anthropic/")) {
+      result["cache_control"] = { type: "ephemeral" }
+    }
   }
 
   if (input.model.api.npm === "@ai-sdk/gateway") {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1255,6 +1255,15 @@ export function options(input: {
     }
   }
 
+  // Anthropic models proxied through OpenRouter cache nothing without an explicit
+  // breakpoint. `~anthropic/*` are catalog aliases for the same models.
+  if (
+    input.model.api.npm === "@openrouter/ai-sdk-provider" &&
+    input.model.api.id.replace(/^~/, "").startsWith("anthropic/")
+  ) {
+    result["cache_control"] = { type: "ephemeral" }
+  }
+
   if (input.model.api.npm === "@ai-sdk/gateway") {
     result["gateway"] = { caching: "auto" }
   }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1255,12 +1255,13 @@ export function options(input: {
     }
   }
 
-  if (input.model.api.npm === "@openrouter/ai-sdk-provider") {
-    result["session_id"] = input.sessionID
-    // `~anthropic/*` are catalog aliases for the same models.
-    if (input.model.api.id.replace(/^~/, "").startsWith("anthropic/")) {
-      result["cache_control"] = { type: "ephemeral" }
-    }
+  // `~anthropic/*` are catalog aliases for the same models.
+  if (
+    input.model.api.npm === "@openrouter/ai-sdk-provider" &&
+    input.model.api.id.replace(/^~/, "").startsWith("anthropic/")
+  ) {
+    result["cache_control"] = { type: "ephemeral" }
+    if (input.providerOptions?.setCacheKey !== false) result["session_id"] = input.sessionID
   }
 
   if (input.model.api.npm === "@ai-sdk/gateway") {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -305,7 +305,7 @@ describe("ProviderTransform.options - setCacheKey", () => {
     })
   }
 
-  test("should keep OpenRouter sticky routing but not caching for non-Anthropic models", () => {
+  test("should leave non-Anthropic OpenRouter models untouched", () => {
     const result = ProviderTransform.options({
       model: {
         ...mockModel,
@@ -315,9 +315,23 @@ describe("ProviderTransform.options - setCacheKey", () => {
       sessionID,
       providerOptions: {},
     })
-    expect(result.session_id).toBe(sessionID)
     expect(result.cache_control).toBeUndefined()
+    expect(result.session_id).toBeUndefined()
     expect(result.prompt_cache_key).toBeUndefined()
+  })
+
+  test("should disable the OpenRouter session key but keep caching when opted out", () => {
+    const result = ProviderTransform.options({
+      model: {
+        ...mockModel,
+        providerID: "openrouter",
+        api: { ...mockModel.api, id: "anthropic/claude-opus-4.8", npm: "@openrouter/ai-sdk-provider" },
+      },
+      sessionID,
+      providerOptions: { setCacheKey: false },
+    })
+    expect(result.cache_control).toEqual({ type: "ephemeral" })
+    expect(result.session_id).toBeUndefined()
   })
 })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -288,16 +288,33 @@ describe("ProviderTransform.options - setCacheKey", () => {
     expect(result.promptCacheKey).toBe(sessionID)
   })
 
-  test("should not send an undocumented OpenRouter prompt_cache_key", () => {
+  for (const id of ["anthropic/claude-opus-4.8", "~anthropic/claude-opus-latest"]) {
+    test(`should enable OpenRouter automatic caching for ${id}`, () => {
+      const result = ProviderTransform.options({
+        model: {
+          ...mockModel,
+          providerID: "openrouter",
+          api: { ...mockModel.api, id, npm: "@openrouter/ai-sdk-provider" },
+        },
+        sessionID,
+        providerOptions: {},
+      })
+      expect(result.cache_control).toEqual({ type: "ephemeral" })
+      expect(result.prompt_cache_key).toBeUndefined()
+    })
+  }
+
+  test("should not enable OpenRouter automatic caching for non-Anthropic models", () => {
     const result = ProviderTransform.options({
       model: {
         ...mockModel,
         providerID: "openrouter",
-        api: { ...mockModel.api, npm: "@openrouter/ai-sdk-provider" },
+        api: { ...mockModel.api, id: "google/gemini-3.6-flash", npm: "@openrouter/ai-sdk-provider" },
       },
       sessionID,
       providerOptions: {},
     })
+    expect(result.cache_control).toBeUndefined()
     expect(result.prompt_cache_key).toBeUndefined()
   })
 })

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -300,11 +300,12 @@ describe("ProviderTransform.options - setCacheKey", () => {
         providerOptions: {},
       })
       expect(result.cache_control).toEqual({ type: "ephemeral" })
+      expect(result.session_id).toBe(sessionID)
       expect(result.prompt_cache_key).toBeUndefined()
     })
   }
 
-  test("should not enable OpenRouter automatic caching for non-Anthropic models", () => {
+  test("should keep OpenRouter sticky routing but not caching for non-Anthropic models", () => {
     const result = ProviderTransform.options({
       model: {
         ...mockModel,
@@ -314,6 +315,7 @@ describe("ProviderTransform.options - setCacheKey", () => {
       sessionID,
       providerOptions: {},
     })
+    expect(result.session_id).toBe(sessionID)
     expect(result.cache_control).toBeUndefined()
     expect(result.prompt_cache_key).toBeUndefined()
   })

--- a/packages/opencode/test/session/llm-native.test.ts
+++ b/packages/opencode/test/session/llm-native.test.ts
@@ -378,6 +378,32 @@ describe("session.llm-native.request", () => {
     expect(openrouter.route.endpoint.baseURL).toBe("https://openrouter.ai/api/v1")
   })
 
+  it.effect("enables OpenRouter prompt caching for Anthropic models", () =>
+    Effect.gen(function* () {
+      const prepared = yield* prepareNativeRequest({
+        model: {
+          ...baseModel,
+          id: ModelV2.ID.make("anthropic/claude-opus-4.8"),
+          providerID: ProviderV2.ID.openrouter,
+          api: {
+            id: "anthropic/claude-opus-4.8",
+            url: "https://openrouter.ai/api/v1",
+            npm: "@openrouter/ai-sdk-provider",
+          },
+        },
+        apiKey: "test-key",
+        messages: [storedSession.user("Say hello.")],
+      })
+
+      expect(prepared).toMatchObject({
+        route: "openrouter",
+        body: {
+          cache_control: { type: "ephemeral" },
+        },
+      })
+    }),
+  )
+
   test("fails fast for unsupported provider packages", () => {
     expect(() =>
       LLMNative.request({


### PR DESCRIPTION
_Researched and written with AI assistance; measurements are real but verify before relying on them._

### Issue for this PR

Closes #39009

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Anthropic models routed through OpenRouter never get `cache_control`, so every turn is billed at full input price.

The native `openrouter-chat` route is not what runs — the gate at `native-runtime.ts:55-59` rejects OpenRouter, so it executes on the AI SDK path. The fix therefore belongs in `ProviderTransform.options`, for `anthropic/*` and `~anthropic/*` on `@openrouter/ai-sdk-provider`:

- **`cache_control`** — OpenRouter's documented top-level directive for Anthropic automatic caching. This is the config workaround from #39009 made the default; a user's own `options.cache_control` still wins.
- **`session_id`** — without it OpenRouter derives its sticky-routing key by hashing the opening messages, and those drift, so a cache written on turn 1 is unreachable if turn 2 routes elsewhere. Scoped to Anthropic because it also pins the resolved model for router models. `setCacheKey: false` opts out.

The native route is fixed too, with the provider policy behind an `automaticCacheControl` helper and cache-policy semantics shared with `applyCachePolicy`. It becomes reachable when #38925 lands.

### How did you verify your code works?

Unit tests in `packages/opencode/test/provider/transform.test.ts` and `packages/llm/test/provider/openrouter.test.ts` — 382 and 300 pass, both packages typecheck.

End to end from a build of this branch against `openrouter/anthropic/claude-haiku-4.5`, ~21k-token system prompt, two-prompt sessions, 6 turns per row:

| build | turn-2 read | cost per turn |
|---|---|---|
| `dev` | 0 | ~$0.0161 |
| this branch | **0** | ~$0.0267 |
| this branch + deterministic skill precedence (#32202) | **21384** | **$0.00216** |

The middle row is why this PR is necessary but not sufficient. `cache_control` makes the write happen, but skill discovery resolves duplicate names by file-I/O completion order, so the system prompt changes on every request and nothing is ever read back. With both fixes, ~92% off.

That skill race is a separate bug affecting every provider and is deliberately not in this PR. It should land alongside for users to see the saving.

### Screenshots / recordings

n/a

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
