### PR TITLE
fix(core): replace catch (e: any) with unknown in fs-util resolve

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -248,8 +248,8 @@ export namespace FSUtil {
     const resolved = pathResolve(windowsPath(p))
     try {
       return normalizePath(realpathSync(resolved))
-    } catch (e: any) {
-      if (e?.code === "ENOENT") return normalizePath(resolved)
+    } catch (e: unknown) {
+      if ((e as { code?: string })?.code === "ENOENT") return normalizePath(resolved)
       throw e
     }
   }


### PR DESCRIPTION
Replaces the \catch (e: any)\ with \catch (e: unknown)\ in \packages/core/src/fs-util.ts\ and adds a proper type assertion for the \.code\ access. This improves type safety by avoiding the \ny\ escape hatch.