### PR TITLE
refactor(core): replace else if with early return in binary search

### DIFF
--- a/packages/core/src/util/binary.ts
+++ b/packages/core/src/util/binary.ts
@@ -9,7 +9,9 @@ export namespace Binary {
 
       if (midId === id) {
         return { found: true, index: mid }
-      } else if (midId < id) {
+      }
+
+      if (midId < id) {
         left = mid + 1
       } else {
         right = mid - 1


### PR DESCRIPTION
Replaces the \else if\ with an early return pattern in \Binary.search\ to align with the project style guide which recommends avoiding else statements in favor of early returns.