### PR TITLE
fix(core): resolve npm edge by package name instead of first entry

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -127,7 +127,7 @@ const layer = Layer.effect(
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
-      const first = tree.edgesOut.values().next().value?.to
+      const first = tree.edgesOut.get(name)?.to
       if (!first) {
         const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))
         if (result.entrypoint) return result


### PR DESCRIPTION
When installing an npm package with peer dependencies, \	ree.edgesOut.values().next().value\ can return the peer dependency's edge instead of the installed package's edge because Map iteration follows insertion order.\n\nThis causes \Npm.add()\ to return the wrong package's path and name (the peer dependency), or fall through to the error path even when the install succeeded.\n\nFix: look up the edge by package name (\	ree.edgesOut.get(name)\) instead of grabbing the first entry.