### PR TITLE
fix(schema): break circular type reference in Prompt by inlining parameter type

### DIFF
--- a/packages/schema/src/prompt.ts
+++ b/packages/schema/src/prompt.ts
@@ -47,7 +47,7 @@ export const Prompt = Schema.Struct({
   .pipe(
     statics((schema) => ({
       equivalence: Schema.toEquivalence(schema),
-      fromUserMessage: (input: Pick<Prompt, "text" | "files" | "agents">) =>
+      fromUserMessage: (input: { text: string; files?: FileAttachment[]; agents?: AgentAttachment[] }) =>
         schema.make({
           text: input.text,
           ...(input.files === undefined ? {} : { files: input.files }),


### PR DESCRIPTION
The Prompt interface extends Schema.Schema.Type<typeof Prompt> and the Prompt const's statics callback referenced Pick<Prompt, ...> back, creating a circular type reference. TypeScript resolves this as TS7022 and gives Prompt the implicit type 'any', losing all type safety for downstream consumers.\n\nFix: inline the parameter type in fromUserMessage instead of referencing the Prompt interface, matching the pattern used elsewhere in the codebase.