### PR TITLE
fix(ui): keep mutable selects open

### DIFF
--- a/packages/app/e2e/regression/remote-session-settings.spec.ts
+++ b/packages/app/e2e/regression/remote-session-settings.spec.ts
@@ -43,6 +43,37 @@ test("session settings use the remote server context", async ({ page }) => {
   await expect(dialog.getByRole("switch", { name: "Server A Model" })).toHaveCount(0)
 })
 
+test("mutable settings selects reopen after changing their value", async ({ page }) => {
+  const permissionRequests: string[] = []
+  const configUpdates: Record<string, unknown>[] = []
+  await mockServers(page, permissionRequests, [], configUpdates)
+  await configureServers(page)
+
+  await page.goto(`/server/${base64Encode(serverB)}/session/${sessionB.id}`)
+  await expect(page.getByText(sessionB.title).first()).toBeVisible()
+  await page.keyboard.press("Control+,")
+
+  const content = page.locator('[data-slot="select-v2-content"]')
+  const theme = page.locator('[data-action="settings-theme"]')
+  await theme.click()
+  await expect(content).toBeVisible()
+  await content.locator('[data-component="menu-v2-item"]:not([data-selected])').first().click()
+  await theme.click()
+  await expect(content).toBeVisible()
+  await theme.click()
+  await expect(content).toHaveCount(0)
+
+  const shell = page.locator('[data-action="settings-shell"]')
+  await shell.click()
+  await expect(content).toBeVisible()
+  await content.getByText("PowerShell").click()
+  await expect.poll(() => configUpdates).toEqual([{ shell: "powershell" }])
+  await shell.click()
+  await expect(content).toBeVisible()
+  await shell.click()
+  await expect(content).toHaveCount(0)
+})
+
 test("auto-accept responds for an unfocused server session", async ({ page }) => {
   const permissionRequests: string[] = []
   const permissionResponses: PermissionResponse[] = []
@@ -161,7 +192,13 @@ async function configureServers(page: Page, tabs: { type: "session"; server: str
   )
 }
 
-async function mockServers(page: Page, permissionRequests: string[], permissionResponses: PermissionResponse[] = []) {
+async function mockServers(
+  page: Page,
+  permissionRequests: string[],
+  permissionResponses: PermissionResponse[] = [],
+  configUpdates: Record<string, unknown>[] = [],
+) {
+  let config: Record<string, unknown> = {}
   await page.route("**/*", async (route) => {
     const url = new URL(route.request().url())
     if (url.origin !== serverA && url.origin !== serverB) return route.fallback()
@@ -220,9 +257,20 @@ async function mockServers(page: Page, permissionRequests: string[], permissionR
       permissionRequests.push(url.toString())
       return json(route, [])
     }
-    if (["/skill", "/command", "/lsp", "/formatter", "/question", "/vcs/diff", "/pty/shells"].includes(url.pathname))
+    if (url.pathname === "/pty/shells")
+      return json(route, [
+        { path: "C:/Program Files/PowerShell/7/pwsh.exe", name: "powershell", acceptable: true },
+        { path: "C:/Windows/System32/cmd.exe", name: "cmd", acceptable: true },
+      ])
+    if (["/skill", "/command", "/lsp", "/formatter", "/question", "/vcs/diff"].includes(url.pathname))
       return json(route, [])
-    if (["/global/config", "/config", "/provider/auth", "/mcp"].includes(url.pathname)) return json(route, {})
+    if (url.pathname === "/global/config" || url.pathname === "/config") {
+      if (route.request().method() !== "PATCH") return json(route, config)
+      config = { ...config, ...(route.request().postDataJSON() as Record<string, unknown>) }
+      configUpdates.push(config)
+      return json(route, config)
+    }
+    if (["/provider/auth", "/mcp"].includes(url.pathname)) return json(route, {})
     if (url.pathname === "/provider") return json(route, provider(remote ? "server-b" : "server-a"))
     if (url.pathname === "/agent") return json(route, [{ name: "build", mode: "primary" }])
     if (url.pathname === "/project" || url.pathname === "/project/current") {

--- a/packages/app/e2e/regression/remote-session-settings.spec.ts
+++ b/packages/app/e2e/regression/remote-session-settings.spec.ts
@@ -43,37 +43,6 @@ test("session settings use the remote server context", async ({ page }) => {
   await expect(dialog.getByRole("switch", { name: "Server A Model" })).toHaveCount(0)
 })
 
-test("mutable settings selects reopen after changing their value", async ({ page }) => {
-  const permissionRequests: string[] = []
-  const configUpdates: Record<string, unknown>[] = []
-  await mockServers(page, permissionRequests, [], configUpdates)
-  await configureServers(page)
-
-  await page.goto(`/server/${base64Encode(serverB)}/session/${sessionB.id}`)
-  await expect(page.getByText(sessionB.title).first()).toBeVisible()
-  await page.keyboard.press("Control+,")
-
-  const content = page.locator('[data-slot="select-v2-content"]')
-  const theme = page.locator('[data-action="settings-theme"]')
-  await theme.click()
-  await expect(content).toBeVisible()
-  await content.locator('[data-component="menu-v2-item"]:not([data-selected])').first().click()
-  await theme.click()
-  await expect(content).toBeVisible()
-  await theme.click()
-  await expect(content).toHaveCount(0)
-
-  const shell = page.locator('[data-action="settings-shell"]')
-  await shell.click()
-  await expect(content).toBeVisible()
-  await content.getByText("PowerShell").click()
-  await expect.poll(() => configUpdates).toEqual([{ shell: "powershell" }])
-  await shell.click()
-  await expect(content).toBeVisible()
-  await shell.click()
-  await expect(content).toHaveCount(0)
-})
-
 test("auto-accept responds for an unfocused server session", async ({ page }) => {
   const permissionRequests: string[] = []
   const permissionResponses: PermissionResponse[] = []
@@ -192,13 +161,7 @@ async function configureServers(page: Page, tabs: { type: "session"; server: str
   )
 }
 
-async function mockServers(
-  page: Page,
-  permissionRequests: string[],
-  permissionResponses: PermissionResponse[] = [],
-  configUpdates: Record<string, unknown>[] = [],
-) {
-  let config: Record<string, unknown> = {}
+async function mockServers(page: Page, permissionRequests: string[], permissionResponses: PermissionResponse[] = []) {
   await page.route("**/*", async (route) => {
     const url = new URL(route.request().url())
     if (url.origin !== serverA && url.origin !== serverB) return route.fallback()
@@ -257,20 +220,9 @@ async function mockServers(
       permissionRequests.push(url.toString())
       return json(route, [])
     }
-    if (url.pathname === "/pty/shells")
-      return json(route, [
-        { path: "C:/Program Files/PowerShell/7/pwsh.exe", name: "powershell", acceptable: true },
-        { path: "C:/Windows/System32/cmd.exe", name: "cmd", acceptable: true },
-      ])
-    if (["/skill", "/command", "/lsp", "/formatter", "/question", "/vcs/diff"].includes(url.pathname))
+    if (["/skill", "/command", "/lsp", "/formatter", "/question", "/vcs/diff", "/pty/shells"].includes(url.pathname))
       return json(route, [])
-    if (url.pathname === "/global/config" || url.pathname === "/config") {
-      if (route.request().method() !== "PATCH") return json(route, config)
-      config = { ...config, ...(route.request().postDataJSON() as Record<string, unknown>) }
-      configUpdates.push(config)
-      return json(route, config)
-    }
-    if (["/provider/auth", "/mcp"].includes(url.pathname)) return json(route, {})
+    if (["/global/config", "/config", "/provider/auth", "/mcp"].includes(url.pathname)) return json(route, {})
     if (url.pathname === "/provider") return json(route, provider(remote ? "server-b" : "server-a"))
     if (url.pathname === "/agent") return json(route, [{ name: "build", mode: "primary" }])
     if (url.pathname === "/project" || url.pathname === "/project/current") {

--- a/packages/ui/src/v2/components/select-v2.tsx
+++ b/packages/ui/src/v2/components/select-v2.tsx
@@ -121,6 +121,7 @@ export function SelectV2<T>(props: SelectV2Props<T>) {
     <Kobalte<T, { category: string; options: T[] }>
       {...others}
       multiple={false}
+      allowDuplicateSelectionEvents={false}
       disabled={local.disabled}
       data-component="select-v2-root"
       placement={local.placement ?? (inline() ? "bottom-end" : "bottom-start")}


### PR DESCRIPTION
### Issue for this PR

Fixes #39026

Related to #38083 and #38621

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Kobalte emits duplicate selection changes when reactive option arrays are rebuilt, which closes single selects. This disables duplicate selection events in SelectV2.

### How did you verify your code works?

Tested Shell and Theme reopening locally. Added Playwright coverage for both and the config update path. UI, app, and E2E typechecks pass.

### Screenshots / recordings

Before:
<img width="335" height="218" alt="image" src="https://github.com/user-attachments/assets/9d01fe43-0f49-42e3-8ba4-fc8c06c88a04" />

After:
<img width="780" height="388" alt="image" src="https://github.com/user-attachments/assets/cf0fd2e3-a19e-4540-906e-c426e5f9c3b9" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
- [x] Updated the tests