### PR TITLE
fix(web): reconnect SSE stream when mobile tab becomes visible again

### DIFF
--- a/packages/app/src/context/server-sdk.tsx
+++ b/packages/app/src/context/server-sdk.tsx
@@ -322,9 +322,19 @@ function createServerSdkContextBase(server: ServerConnection.Any, scope: ServerS
     attempt?.abort()
   }
 
+  const restart = () => {
+    started = false
+    generation++
+    attempt?.abort()
+    return start()
+  }
+
   onMount(() => {
     makeEventListener(window, "pagehide", stop)
     makeEventListener(window, "pageshow", (event) => resumeStreamAfterPageShow(event, start))
+    makeEventListener(document, "visibilitychange", () => {
+      if (document.visibilityState === "visible") restart()
+    })
   })
 
   onCleanup(() => {


### PR DESCRIPTION
## Problem

When using `opencode serve` or `opencode web` from a mobile browser (Chrome), switching to another app and coming back leaves the chat frozen. No new messages appear until the user manually refreshes the page.

## Root cause

The SSE event stream in `server-sdk.tsx` only handles tab lifecycle via `pagehide`/`pageshow`, which are designed for bfcache (back-forward cache) navigation between pages. On mobile:

1. `pagehide` often does not fire when the tab is backgrounded by switching apps
2. When it does fire, it calls `stop()` which aborts the SSE connection and cancels server-side generation
3. `pageshow` fires with `persisted=false` on resume (not a bfcache restore), so `resumeStreamAfterPageShow` returns without restarting the stream
4. The stream stays dead until manual refresh

## Fix

- Add a `restart()` helper that safely tears down and recreates the SSE connection
- Listen to `document.visibilitychange` and call `restart()` when the page becomes visible
- Do NOT stop the stream on hidden, preserving server-side generation

```diff
+  const restart = () => {
+    started = false
+    generation++
+    attempt?.abort()
+    return start()
+  }
+
   onMount(() => {
     makeEventListener(window, "pagehide", stop)
     makeEventListener(window, "pageshow", (event) => resumeStreamAfterPageShow(event, start))
+    makeEventListener(document, "visibilitychange", () => {
+      if (document.visibilityState === "visible") restart()
+    })
   })
```

## Testing

Tested on Android Chrome by initiating a long response, switching to another app, waiting several seconds, and returning. The response appeared without manual refresh.

## Files changed

- `packages/app/src/context/server-sdk.tsx` — add `restart()` and `visibilitychange` listener