### PR TITLE
fix(prompt): drop non-existent multi_tool_use.parallel from gpt system prompt

### DIFF
--- a/packages/opencode/src/session/prompt/gpt.txt
+++ b/packages/opencode/src/session/prompt/gpt.txt
@@ -3,7 +3,7 @@ You are OpenCode, You and the user share the same workspace and collaborate to a
 You are a deeply pragmatic, effective software engineer. You take engineering quality seriously, and collaboration comes through as direct, factual statements. You communicate efficiently, keeping the user clearly informed about ongoing actions without unnecessary detail. You build context by examining the codebase first without making assumptions or jumping to conclusions. You think through the nuances of the code you encounter, and embody the mentality of a skilled senior software engineer.
 
 - When searching for text or files, prefer using Glob and Grep tools (they are powered by `rg`)
-- Parallelize tool calls whenever possible - especially file reads. Use `multi_tool_use.parallel` to parallelize tool calls and only this. Never chain together bash commands with separators like `echo "====";` as this renders to the user poorly.
+- Parallelize tool calls whenever possible - especially file reads, by sending a single message with multiple tool calls. Never chain together bash commands with separators like `echo "====";` as this renders to the user poorly.
 
 ## Editing Approach
 

--- a/packages/opencode/test/session/prompt-files.test.ts
+++ b/packages/opencode/test/session/prompt-files.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test"
+import { readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+
+// Resolves to packages/opencode/src/session/prompt regardless of where bun is invoked from.
+const promptDir = path.join(import.meta.dir, "../../src/session/prompt")
+
+describe("system prompt files", () => {
+  // Regression for #38332: gpt.txt told the model to "Use `multi_tool_use.parallel`
+  // to parallelize tool calls". `multi_tool_use.parallel` is an OpenAI legacy
+  // pseudo-tool from the old parallel function-calling shim; opencode's provider
+  // adapters do not expose it, so models that followed the instruction attempted
+  // to call a tool that does not exist (surfacing as failed tool calls).
+  // Other prompts (anthropic/gemini/codex/...) already describe the correct
+  // mechanism — "send a single message with multiple tool calls".
+  it("no prompt references the multi_tool_use.parallel pseudo-tool", () => {
+    const files = readdirSync(promptDir).filter((file) => file.endsWith(".txt"))
+    expect(files.length).toBeGreaterThan(0)
+    for (const file of files) {
+      const content = readFileSync(path.join(promptDir, file), "utf8")
+      expect(content, `prompt file ${file} references multi_tool_use.parallel`).not.toContain(
+        "multi_tool_use.parallel",
+      )
+    }
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #38332

### Type of change

- [x] Bug fix

### What does this PR do?

`packages/opencode/src/session/prompt/gpt.txt:6` instructed the model to "Use `multi_tool_use.parallel` to parallelize tool calls and only this." `multi_tool_use.parallel` is an OpenAI legacy pseudo-tool from the old parallel function-calling shim. opencode does not register or expose it — `grep -rn multi_tool_use packages/` returns only that single line in `gpt.txt`, nothing in any tool registry or adapter — so a model that emits it gets a tool-not-found.

This is a copy-paste leftover, not an intentional instruction. The line was introduced in #19220 ("feat: add gpt prompt ... modeled after codex cli") and preserved verbatim by #19585 ("tweak: adjust gpt prompt to be more minimal") — a minimal-wording pass that never reviewed it.

Every sibling prompt already describes the real mechanism — "send a single message with multiple tool calls": `anthropic.txt:84`, `codex.txt:15`, `gemini.txt:54`, `default.txt:82`, `meta.txt:48`, `kimi.txt:13`. `gpt.txt` was the only outlier referencing a pseudo-tool.

**Fix**: drop the `multi_tool_use.parallel` sentence and replace it with the same wording the other prompts already use ("by sending a single message with multiple tool calls"). The rest of the line is unchanged (prefer parallel calls especially for reads; don't chain bash with `echo "====";` separators).

Not a duplicate of #34557 ("align v2 prompt tool names"): its summary claims to have removed the non-existent `multi_tool_use` instruction, but `git log -- packages/opencode/src/session/prompt/gpt.txt` shows only two commits ever touched the file (#19220, #19585) — #34557 never did. This PR fills the gap it left in gpt.txt specifically.

### How did you verify your code works?

- `grep -rn multi_tool_use packages/` → matches only `gpt.txt:6` (before this PR). No tool registry or adapter references the name, so the pseudo-tool is unconditionally unresolvable.
- Added a regression test `packages/opencode/test/session/prompt-files.test.ts` that scans every `src/session/prompt/*.txt` and asserts none references `multi_tool_use.parallel`. On this branch it iterates 14 prompt files (15 assertions) and passes.
- `git diff --stat` is one line in `gpt.txt` plus the new test file — no unrelated changes.

Local-test caveat (Windows): running `bun test` under Windows produces one pre-existing unrelated failure — an unnamed test whose `beforeEach/afterEach` hook times out, sourced from the global test preload in `packages/opencode/bunfig.toml` (`preload = ["@opentui/solid/preload", "./test/preload.ts"]`, the @opentui/solid native TUI module). The new test's own `it` block passes (15 `expect()` calls). Relying on CI (Linux) for a clean full run.

### Screenshots / recordings

N/A — system prompt text change only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
