### PR TITLE
fix(desktop): install Electron before development

### DIFF
--- a/packages/desktop/scripts/predev.ts
+++ b/packages/desktop/scripts/predev.ts
@@ -1,5 +1,7 @@
 import { $ } from "bun"
 
+await $`bun run install-electron`
+
 await $`bun ./scripts/copy-icons.ts ${process.env.OPENCODE_CHANNEL ?? "dev"}`
 
 await $`cd ../opencode && bun script/build-node.ts`


### PR DESCRIPTION
## Summary

- install the Electron binary during desktop predev setup
- avoid electron-vite 5 failing with `Error: Electron uninstall` after a clean Electron 42 install
- keep the download scoped to desktop development instead of restoring an install-time lifecycle hook

Electron 42 intentionally moved binary downloads from `postinstall` to first use and provides the `install-electron` command for explicit downloads. electron-vite 5 reads `electron/path.txt` directly, bypassing Electron's lazy download; upstream support remains open in alex8088/electron-vite#904 and alex8088/electron-vite#905.

## Testing

- reproduced `Error: Electron uninstall` from electron-vite with a clean Electron 42 install and no `path.txt`
- ran `bun run predev` and verified Electron 42.3.3 was installed
- reran the same electron-vite launch path and verified it resolved Electron 42.3.3
- `bun typecheck` in `packages/desktop`
- repository pre-push typecheck (30 tasks)
- `bunx prettier --check packages/desktop/scripts/predev.ts`