### PR TITLE
test(core): implement catalog host model list

### DIFF
--- a/packages/core/test/plugin/host.ts
+++ b/packages/core/test/plugin/host.ts
@@ -155,7 +155,16 @@ export function catalogHost(catalog: Catalog.Interface): Plugin.Context["catalog
       get: () => Effect.die("unused catalog.provider.get"),
     },
     model: {
-      list: () => Effect.die("unused catalog.model.list"),
+      list: () =>
+        catalog.model.available().pipe(
+          Effect.map((data) => ({
+            location: new Location.Info({
+              directory: AbsolutePath.make("/"),
+              project: { id: Project.ID.make("test"), directory: AbsolutePath.make("/") },
+            }),
+            data: data.map(modelInfo),
+          })),
+        ),
       default: () => Effect.die("unused catalog.model.default"),
     },
     reload: catalog.reload,


### PR DESCRIPTION
## Summary
- implement the test plugin host model-list adapter used by system-prompt plugins
- mirror the production host projection instead of dying on the newly required call
- remove the shared defect responsible for the SessionRunnerLLM timeout cascade

## Testing
- `bun typecheck` in `packages/core`
- `bun test test/session-runner-recorded.test.ts --timeout 30000 --only-failures` (1 pass)
- `bun test test/session-runner.test.ts --timeout 30000 --only-failures` (114 pass, 24 pre-existing post-refactor expectation failures; down from roughly 89 failures)