### PR TITLE
feat(app): add project selector shortcut

### DIFF
--- a/packages/app/src/pages/new-session.tsx
+++ b/packages/app/src/pages/new-session.tsx
@@ -126,6 +126,14 @@ export default function NewSessionPage() {
       keybind: "ctrl+l",
       onSelect: () => promptInputV2Controller.restoreFocus(),
     },
+    {
+      id: "project.select",
+      title: language.t("session.new.project.search"),
+      category: language.t("command.category.project"),
+      keybind: "mod+shift+o",
+      disabled: projectController.empty(),
+      onSelect: () => projectController.setOpen(true),
+    },
   ])
 
   createEffect(() => {


### PR DESCRIPTION
## Summary
- add `mod+shift+o` to open the project selector on the new-session page
- disable the command when no projects are available

## Testing
- `bun typecheck` in `packages/app`
- `bun turbo typecheck` (pre-push hook)
- `bun run test:unit` in `packages/app` (670 pass; existing i18n parity test fails because Arabic translations are missing unrelated keys)