### PR TITLE
tweak: match codex limits for openai models exactly when using chatgpt subscription

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -299,16 +299,11 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
                   output: 0,
                   cache: { read: 0, write: 0 },
                 },
-                limit: model.id.includes("gpt-5.5")
-                  ? {
-                      context: 400_000,
-                      input: 272_000,
-                      output: 128_000,
-                    }
-                  : model.id.includes("gpt-5.6")
+                limit:
+                  model.id.includes("gpt-5.5") || model.id.includes("gpt-5.6")
                     ? {
-                        context: 500_000,
-                        input: 372_000,
+                        context: 400_000,
+                        input: 272_000,
                         output: 128_000,
                       }
                     : model.limit,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -181,9 +181,9 @@ describe("plugin.codex", () => {
 
     expect(models["gpt-5.4"]?.limit).toEqual(limit)
     expect(models["gpt-5.5"]?.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
-    expect(models["gpt-5.6-sol"]?.limit).toEqual({ context: 500_000, input: 372_000, output: 128_000 })
-    expect(models["gpt-5.6-terra"]?.limit).toEqual({ context: 500_000, input: 372_000, output: 128_000 })
-    expect(models["gpt-5.6-luna"]?.limit).toEqual({ context: 500_000, input: 372_000, output: 128_000 })
+    expect(models["gpt-5.6-sol"]?.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
+    expect(models["gpt-5.6-terra"]?.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
+    expect(models["gpt-5.6-luna"]?.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
     expect(models["gpt-5.4-pro"]).toBeUndefined()
     expect(models["gpt-5.7-pro"]).toBeDefined()
     expect(models["gpt-5.6-sol-high"]).toBeDefined()


### PR DESCRIPTION
### Issue for this PR

Closes #38976

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Codex OAuth transform still pins GPT-5.6 Sol/Terra/Luna to a 372k input window. OpenAI corrected those context windows to 272k in Codex CLI 0.144.6, so we were letting sessions run past the window the Codex harness itself advertises, which delays compaction.

Codex 0.145.0's bundled `models.json` reports `context_window: 272000` for all three 5.6 variants — the same as 5.5. Since the two branches now produce an identical object, I merged them rather than duplicating it.

Only affects the OAuth path; API-key metadata still uses the provider's own limits.

### How did you verify your code works?

Pulled `models.json` from `openai/codex` at `rust-v0.145.0` and confirmed `gpt-5.6-sol`, `gpt-5.6-terra` and `gpt-5.6-luna` all report `context_window` and `max_context_window` of `272000`.

The existing test in `packages/opencode/test/plugin/codex.test.ts` asserted the old 500k/372k values, so I updated those three expectations and ran:

```
bun test test/plugin/codex.test.ts
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
