### PR TITLE
feat(desktop): use bg layer 4 for v2 switch

### DIFF
--- a/packages/ui/src/v2/components/switch-v2.css
+++ b/packages/ui/src/v2/components/switch-v2.css
@@ -30,7 +30,7 @@
     border: none;
     background:
       linear-gradient(180deg, var(--v2-alpha-light-0) 0%, var(--v2-alpha-light-20) 100%),
-      var(--v2-background-bg-layer-03);
+      var(--v2-background-bg-layer-04);
     box-shadow: var(--v2-elevation-switch-off);
     transition:
       background 90ms ease-out,
@@ -90,7 +90,7 @@
     background:
       linear-gradient(0deg, var(--v2-overlay-simple-overlay-hover), var(--v2-overlay-simple-overlay-hover)),
       linear-gradient(180deg, var(--v2-alpha-light-0) 0%, var(--v2-alpha-light-20) 100%),
-      var(--v2-background-bg-layer-03);
+      var(--v2-background-bg-layer-04);
   }
 
   &:hover:not([data-disabled], [data-readonly]) [data-slot="switch-thumb"] {


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the v2 switch unchecked track to use the layer 04 background token in both its default and hover states. The checked accent styling remains unchanged.

### How did you verify your code works?

The pre-push hook completed all 30 repository typecheck tasks successfully.

### Screenshots / recordings

**Before**

<img width="1486" height="988" alt="Screenshot 2026-07-27 at 12 09 43@2x" src="https://github.com/user-attachments/assets/debf1af2-18df-4952-b425-96829212a3cc" />

**After**

<img width="688" height="860" alt="Screenshot 2026-07-27 at 12 13 49@2x" src="https://github.com/user-attachments/assets/1e563aa4-a2b2-4f8b-9719-e6957c3fdec6" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._