### PR TITLE
docs: replace machine-local effect-smol path in effect-drizzle-sqlite AGENTS.md

### DIFF
--- a/packages/effect-drizzle-sqlite/AGENTS.md
+++ b/packages/effect-drizzle-sqlite/AGENTS.md
@@ -8,7 +8,7 @@ This package vendors a Drizzle Effect SQLite adapter for this repo.
 - Concrete SQLite clients such as `@effect/sql-sqlite-bun` belong in tests or examples unless this package intentionally adds a driver-specific helper.
 - Preserve Drizzle adapter naming and behavior where possible so this can be replaced by upstream `drizzle-orm/effect-sqlite` later.
 - If touching copied Drizzle internals, compare with current `drizzle-orm@1.0.0-rc.2` declarations and runtime JS.
-- If touching Effect APIs, verify against `/Users/kit/code/open-source/effect-smol`.
+- If touching Effect APIs, verify against the effect-smol source (https://github.com/Effect-TS/effect-smol).
 
 Useful entry points:
 


### PR DESCRIPTION
### Issue for this PR

No issue filed — one-line docs fix, happy to open one if preferred.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`packages/effect-drizzle-sqlite/AGENTS.md` tells agents to verify Effect APIs against `/Users/kit/code/open-source/effect-smol` — a path that only exists on one maintainer's machine, so the instruction fails for everyone else and for CI agents. This replaces it with the public repo (https://github.com/Effect-TS/effect-smol), which is the same source the local checkout mirrors.

Found while validating [unrot](https://github.com/unrot-dev/unrot), a linter for agent config files.

### How did you verify your code works?

Docs-only change to an AGENTS.md instruction file; verified https://github.com/Effect-TS/effect-smol is the correct upstream (the repo the local path pointed at), and re-ran the linter to confirm the machine-local path warning clears.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)