### PR TITLE
fix(core): resolve npm edge by package name instead of first entry

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -127,7 +127,7 @@ const layer = Layer.effect(
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
-      const first = tree.edgesOut.values().next().value?.to
+      const first = tree.edgesOut.get(name)?.to
       if (!first) {
         const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))
         if (result.entrypoint) return result


### PR DESCRIPTION
Closes #39104

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When installing an npm package with peer dependencies, `tree.edgesOut.values().next().value` grabs the first entry from the Map by insertion order. Peer dependencies are often inserted first, so the wrong package's path and name get returned. This causes callers to look up the wrong package or hit the error path even though the install succeeded.

Fix: look up the edge by package name with `tree.edgesOut.get(name)`.

### How did you verify your code works?

Reviewed the Arborist API docs — `edgesOut` is a `Map<string, Edge>` keyed by package name. The `name` variable is already computed earlier in the function from `npa(pkg).name`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR