### PR TITLE
fix(core): propagate download failures as Effect errors in skill discovery

### DIFF
--- a/packages/core/src/skill/discovery.ts
+++ b/packages/core/src/skill/discovery.ts
@@ -172,11 +172,11 @@ const layer = Layer.effect(
                     (file) => download(file.url, path.resolve(staging, file.file)),
                     { concurrency: fileConcurrency },
                   )
-                  if (!downloaded.every(Boolean)) return
+                  if (!downloaded.every(Boolean)) return yield* Effect.fail("download failed")
                   const exists =
                     (yield* fs.exists(path.join(staging, "SKILL.md")).pipe(Effect.orDie)) ||
                     (yield* fs.exists(path.join(staging, `${skill.name}.md`)).pipe(Effect.orDie))
-                  if (!exists) return
+                  if (!exists) return yield* Effect.fail("skill entry point not found")
                   yield* fs.writeFileString(path.join(staging, ".opencode-version"), version)
                   yield* Effect.uninterruptible(
                     Effect.gen(function* () {


### PR DESCRIPTION
Closes #39106

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When refreshing a skill during a version-mismatch update, if file downloads fail the code hits `return` (successful Effect completion) instead of `Effect.fail`. The surrounding `Effect.catch` never fires, so no error is logged and the stale cached version is silently returned.

Same issue on the next line: if downloaded files don't contain a SKILL.md entry point, the incomplete staging dir is silently discarded with no diagnostic.

Fix: use `return yield* Effect.fail(...)` so errors propagate to the catch handler.

### How did you verify your code works?

Reviewed the Effect control flow. The `.pipe(Effect.catch(...))` handler on line 197 only catches typed failures from `Effect.fail`. The `return` statements previously exited the inner generator successfully, bypassing the catch entirely.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR