### PR TITLE
fix(schema): break circular type reference in Prompt by inlining parameter type

### DIFF
--- a/packages/schema/src/prompt.ts
+++ b/packages/schema/src/prompt.ts
@@ -47,7 +47,7 @@ export const Prompt = Schema.Struct({
   .pipe(
     statics((schema) => ({
       equivalence: Schema.toEquivalence(schema),
-      fromUserMessage: (input: Pick<Prompt, "text" | "files" | "agents">) =>
+      fromUserMessage: (input: { text: string; files?: FileAttachment[]; agents?: AgentAttachment[] }) =>
         schema.make({
           text: input.text,
           ...(input.files === undefined ? {} : { files: input.files }),


### PR DESCRIPTION
Closes #39110

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `Prompt` interface extends `Schema.Schema.Type<typeof Prompt>` and the `Prompt` const's `statics` callback referenced `Pick<Prompt, ...>` back, creating a circular type reference. TypeScript resolves this as TS7022 and gives `Prompt` the implicit type `any`.

Fix: inline the parameter type in `fromUserMessage` to match the pattern used by `FileAttachment` and other schemas in this file that don't have this cycle.

### How did you verify your code works?

Checked that `FileAttachment` uses the same pattern (`create: (input: FileAttachment) =>`) and doesn't have a circular reference because its `statics` callback references the interface directly, not via the const. For `Prompt`, the reference goes through `Pick<Prompt, ...>` where `Prompt` is the const, creating the cycle. Inlining breaks it.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR