### PR TITLE
docs(opencode): fix typo in control-plane dev README

### DIFF
--- a/packages/opencode/src/control-plane/dev/README.md
+++ b/packages/opencode/src/control-plane/dev/README.md
@@ -16,4 +16,4 @@ How this works:
 
 - The workspace server needs to know the workspace id and port to run. It waits for this information to be written to a file and starts the server when the data is written.
 - The debug plugin writes this information in the `create` call to the workspace. So create a `debug` workspace will always kick off a new external server.
-- The server script watches for file changes, so whenver you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.
+- The server script watches for file changes, so whenever you create a new `debug` workspace it will restart with the new information. This means that there is only ever one working `debug` workspace at a time; when you create a new one all previous sessions will show that it can't connect because previous debug workspaces do not exist.


### PR DESCRIPTION
### Issue for this PR

Fixes #27485

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

There was a spelling typo in `packages/opencode/src/control-plane/dev/README.md`: `whenver` instead of `whenever` in the debug workspace docs. This PR corrects that single word so the sentence reads clearly.

### How did you verify your code works?

Opened the README and confirmed the line now says `whenever`. No code paths changed.

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR