### PR TITLE
docs: Improve docs to use 'permission' instead of deprecated 'tools' param

### DIFF
--- a/packages/web/src/content/docs/ar/config.mdx
+++ b/packages/web/src/content/docs/ar/config.mdx
@@ -207,19 +207,23 @@ opencode run "Hello world"
 
 ---
 
-### الأدوات
+### الأذونات
 
-يمكنك إدارة الأدوات التي يمكن لـ LLM استخدامها عبر الخيار `tools`.
+يمكنك إدارة الأدوات التي يمكن لـ LLM استخدامها عبر الخيار `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` مُهمَّل. منفضل استخدام حقل [`permission`](/docs/permissions) للإعدادات الجديدة والتحديثات والتحكم الدقيق.
+:::
 
 [تعرف على المزيد حول الأدوات هنا](/docs/tools).
 
@@ -325,10 +329,10 @@ opencode run "Hello world"
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // تعطيل أدوات تعديل الملفات لوكيل المراجعة فقط
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/ar/mcp-servers.mdx
+++ b/packages/web/src/content/docs/ar/mcp-servers.mdx
@@ -299,6 +299,10 @@ opencode mcp debug my-oauth-server
 
 هذا يعني أنه يمكنك تفعيلها أو تعطيلها على مستوى عام.
 
+:::note
+`tools` مُهمَّل. منفضل استخدام حقل [`permission`](/docs/permissions) للإعدادات الجديدة والتحديثات والتحكم الدقيق.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ opencode mcp debug my-oauth-server
 إذا كان لديك عدد كبير من خوادم MCP فقد ترغب في تفعيلها لكل وكيل على حدة وتعطيلها على المستوى العام. للقيام بذلك:
 
 1. عطّلها كأداة على المستوى العام.
-2. في [إعدادات الوكيل](/docs/agents#tools)، فعّل خادم MCP كأداة.
+2. في [إعدادات الوكيل](/docs/agents#permissions)، فعّل خادم MCP كأداة.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ opencode mcp debug my-oauth-server
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/ar/skills.mdx
+++ b/packages/web/src/content/docs/ar/skills.mdx
@@ -189,8 +189,8 @@ permission:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/bs/config.mdx
+++ b/packages/web/src/content/docs/bs/config.mdx
@@ -207,19 +207,23 @@ Dostupne opcije:
 
 ---
 
-### Alati
+### Dozvole
 
-Možete upravljati alatima koje LLM može koristiti putem opcije `tools`.
+Možete upravljati alatima koje LLM može koristiti putem opcije `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` je **zastarjelo**. Preporučuje se korištenje [`permission`](/docs/permissions) polja za nove konfiguracije, ažuriranja i precizniji kontrola.
+:::
 
 [Saznajte više o alatima ovdje](/docs/tools).
 
@@ -325,10 +329,10 @@ Možete konfigurirati specijalizirane agente za određene zadatke putem opcije `
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/bs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/bs/mcp-servers.mdx
@@ -277,6 +277,10 @@ Vaši MCP serveri su dostupni kao alati u OpenCode, zajedno s ugrađenim alatima
 
 To znači da ih možete omogućiti ili onemogućiti globalno.
 
+:::note
+`tools` je **zastarjelo**. Preporučuje se korištenje [`permission`](/docs/permissions) polja za nove konfiguracije, ažuriranja i precizniji kontrola.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -290,8 +294,8 @@ To znači da ih možete omogućiti ili onemogućiti globalno.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -311,8 +315,8 @@ Također možemo koristiti glob obrazac da onemogućimo sve odgovarajuće MCP-ov
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -324,7 +328,7 @@ Ovdje koristimo glob obrazac `my-mcp*` da onemogućimo sve MCP servere.
 Ako imate veliki broj MCP servera, možda ćete želeti da ih omogućite samo po agentu i da ih onemogućite globalno. Da biste to učinili:
 
 1. Onemogućite ga kao alat globalno.
-2. U vašem [agent config](/docs/agents#tools), omogućite MCP server kao alat.
+2. U vašem [agent config](/docs/agents#permissions), omogućite MCP server kao alat.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -341,8 +345,8 @@ Ako imate veliki broj MCP servera, možda ćete želeti da ih omogućite samo po
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/bs/skills.mdx
+++ b/packages/web/src/content/docs/bs/skills.mdx
@@ -189,8 +189,8 @@ Potpuno iskljucite skills za agente koji ih ne bi trebali koristiti:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -337,17 +337,21 @@ If not specified, OpenCode will automatically discover and use a sensible defaul
 
 ### Tools
 
-You can manage the tools an LLM can use through the `tools` option.
+You can manage the tools an LLM can use through the `permission` option.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` is **deprecated**. Prefer the [`permission`](/docs/permissions) field for new configs, updates and more fine-grained control.
+:::
 
 [Learn more about tools here](/docs/tools).
 
@@ -507,10 +511,10 @@ You can configure specialized agents for specific tasks through the `agent` opti
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/da/config.mdx
+++ b/packages/web/src/content/docs/da/config.mdx
@@ -209,19 +209,23 @@ Tilgængelige muligheder:
 
 ---
 
-### Værktøjer (`tools`)
+### Tilladelser (`permission`)
 
-Du kan administrere de værktøjer, en LLM kan bruge, gennem indstillingen `tools`.
+Du kan administrere de værktøjer, en LLM kan bruge, gennem indstillingen `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` er **forældet**. Foretræk det [`permission`](/docs/permissions)-felt for nye konfigurationer, opdateringer og mere fint kontrol.
+:::
 
 [Learn more about tools here](/docs/tools).
 
@@ -327,10 +331,10 @@ Du kan konfigurere opgaver specialiserede agenter til specifikke indstillinger g
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/da/mcp-servers.mdx
+++ b/packages/web/src/content/docs/da/mcp-servers.mdx
@@ -299,6 +299,10 @@ Dine MCPs er tilgængelige som værktøjer i **TK\_** sammen med indbyggede vær
 
 Det betyder, at du kan aktivere eller deaktivere dem globalt.
 
+:::note
+`tools` er **forældet**. Foretræk det [`permission`](/docs/permissions)-felt for nye konfigurationer, opdateringer og mere fint kontrol.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Det betyder, at du kan aktivere eller deaktivere dem globalt.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Vi kan også bruge et globmønster til at deaktivere alle matchende MCPs.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Her bruger vi globmønsteret `my-mcp*` til at deaktivere alle MCPs.
 Hvis du har et stort antal MCP-servere, vil du måske kun aktivere dem pr. agent og deaktivere dem globalt. Sådan gør du:
 
 1. Deaktiver det som et værktøj globalt.
-2. Aktiver MCP-serveren som et værktøj i din [agent config](/docs/agents#tools).
+2. Aktiver MCP-serveren som et værktøj i din [agent config](/docs/agents#permissions).
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Hvis du har et stort antal MCP-servere, vil du måske kun aktivere dem pr. agent
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/da/skills.mdx
+++ b/packages/web/src/content/docs/da/skills.mdx
@@ -189,8 +189,8 @@ Deaktiver ferdigheter fullstendig for agenter som ikke bør bruge dem:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/de/config.mdx
+++ b/packages/web/src/content/docs/de/config.mdx
@@ -208,19 +208,23 @@ Verfügbare Optionen:
 
 ---
 
-### Werkzeuge
+### Berechtigungen
 
-Sie können die Tools, die ein LLM verwenden kann, über die Option `tools` verwalten.
+Sie können die Tools, die ein LLM verwenden kann, über die Option `permission` verwalten.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` ist **veraltet**. Verwenden Sie statt dessen das [`permission`](/docs/permissions)-Feld für neue Konfigurationen, Aktualisierungen und eine präzisere Steuerung.
+:::
 
 [Erfahren Sie hier mehr über Tools](/docs/tools).
 
@@ -326,10 +330,10 @@ Sie können das Thema, das Sie in Ihrer OpenCode-Konfiguration verwenden möchte
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/de/mcp-servers.mdx
+++ b/packages/web/src/content/docs/de/mcp-servers.mdx
@@ -299,6 +299,10 @@ Ihre MCPs sind neben integrierten Tools auch als Tools in OpenCode verfügbar. S
 
 Das bedeutet, dass Sie sie global aktivieren oder deaktivieren können.
 
+:::note
+`tools` ist **veraltet**. Verwenden Sie statt dessen das [`permission`](/docs/permissions)-Feld für neue Konfigurationen, Aktualisierungen und eine präzisere Steuerung.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Das bedeutet, dass Sie sie global aktivieren oder deaktivieren können.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Wir können auch ein Glob-Muster verwenden, um alle passenden MCPs zu deaktivier
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Hier verwenden wir das Glob-Muster `my-mcp*`, um alle MCPs zu deaktivieren.
 Wenn Sie über eine große Anzahl von MCP-Servern verfügen, möchten Sie diese möglicherweise nur pro Agent aktivieren und global deaktivieren. Gehen Sie dazu wie folgt vor:
 
 1. Deaktivieren Sie es global als Tool.
-2. Aktivieren Sie in Ihrem [agent config](/docs/agents#tools) den MCP-Server als Tool.
+2. Aktivieren Sie in Ihrem [agent config](/docs/agents#permissions) den MCP-Server als Tool.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Wenn Sie über eine große Anzahl von MCP-Servern verfügen, möchten Sie diese 
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/de/skills.mdx
+++ b/packages/web/src/content/docs/de/skills.mdx
@@ -189,8 +189,8 @@ Deaktiviere Skills komplett fuer Agenten, die sie nicht nutzen sollen:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/es/config.mdx
+++ b/packages/web/src/content/docs/es/config.mdx
@@ -208,19 +208,23 @@ Opciones disponibles:
 
 ---
 
-### Herramientas
+### Permisos
 
-Puede administrar las herramientas que un LLM puede usar a través de la opción `tools`.
+Puede gestionar las herramientas que puede usar un LLM a través de la opción `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` is **deprecated**. Prefer the [`permission`](/docs/permissions) field for new configs, updates and more fine-grained control.
+:::
 
 [Obtenga más información sobre las herramientas aquí](/docs/tools).
 
@@ -326,10 +330,10 @@ Puedes configurar agentes especializados para tareas específicas a través de l
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/es/mcp-servers.mdx
+++ b/packages/web/src/content/docs/es/mcp-servers.mdx
@@ -299,6 +299,10 @@ Sus MCP están disponibles como herramientas en OpenCode, junto con herramientas
 
 Esto significa que puede habilitarlos o deshabilitarlos globalmente.
 
+:::note
+`tools` is **deprecated**. Prefer the [`permission`](/docs/permissions) field for new configs, updates and more fine-grained control.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Esto significa que puede habilitarlos o deshabilitarlos globalmente.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ También podemos usar un patrón global para deshabilitar todos los MCP coincide
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Aquí estamos usando el patrón global `my-mcp*` para deshabilitar todos los MCP
 Si tiene una gran cantidad de servidores MCP, es posible que desee habilitarlos solo por agente y deshabilitarlos globalmente. Para hacer esto:
 
 1. Desactívelo como herramienta a nivel global.
-2. En su [configuración del agente](/docs/agents#tools), habilite el servidor MCP como herramienta.
+2. En su [configuración del agente](/docs/agents#permissions), habilite el servidor MCP como herramienta.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Si tiene una gran cantidad de servidores MCP, es posible que desee habilitarlos 
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/es/skills.mdx
+++ b/packages/web/src/content/docs/es/skills.mdx
@@ -189,8 +189,8 @@ Deshabilite completamente las habilidades para los agentes que no deberían usar
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/fr/config.mdx
+++ b/packages/web/src/content/docs/fr/config.mdx
@@ -208,19 +208,23 @@ Options disponibles :
 
 ---
 
-### Outils
+### Autorisations
 
-Vous pouvez gérer les outils qu'un LLM peut utiliser via l'option `tools`.
+Vous pouvez gérer les outils qu'un LLM peut utiliser via l'option `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` est **obsolète**. Préférez le champ [`permission`](/docs/permissions) pour les nouvelles configurations, les mises à jour et un contrôle plus fines.
+:::
 
 [En savoir plus sur les outils ici](/docs/tools).
 
@@ -326,10 +330,10 @@ Vous pouvez configurer des agents spécialisés pour des tâches spécifiques vi
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/fr/mcp-servers.mdx
+++ b/packages/web/src/content/docs/fr/mcp-servers.mdx
@@ -299,6 +299,10 @@ Vos MCP sont disponibles sous forme d'outils dans OpenCode, aux côtés des outi
 
 Cela signifie que vous pouvez les activer ou les désactiver globalement.
 
+:::note
+`tools` est **obsolète**. Préférez le champ [`permission`](/docs/permissions) pour les nouvelles configurations, les mises à jour et un contrôle plus fines.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Cela signifie que vous pouvez les activer ou les désactiver globalement.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Nous pouvons également utiliser un modèle global pour désactiver tous les MCP
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Ici, nous utilisons le modèle global `my-mcp*` pour désactiver tous les MCP.
 Si vous disposez d'un grand nombre de serveurs MCP, vous souhaiterez peut-être les activer uniquement par agent et les désactiver globalement. Pour ce faire :
 
 1. Désactivez-le en tant qu'outil à l'échelle mondiale.
-2. Dans votre [agent config](/docs/agents#tools), activez le serveur MCP en tant qu'outil.
+2. Dans votre [agent config](/docs/agents#permissions), activez le serveur MCP en tant qu'outil.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Si vous disposez d'un grand nombre de serveurs MCP, vous souhaiterez peut-être 
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/fr/skills.mdx
+++ b/packages/web/src/content/docs/fr/skills.mdx
@@ -189,8 +189,8 @@ Désactivez complètement les compétences pour les agents qui ne devraient pas 
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/it/config.mdx
+++ b/packages/web/src/content/docs/it/config.mdx
@@ -207,19 +207,23 @@ Opzioni disponibili:
 
 ---
 
-### Strumenti
+### Autorizzazioni
 
-Puoi gestire gli strumenti che un LLM puo usare tramite l'opzione `tools`.
+Puoi gestire gli strumenti che un LLM puo usare tramite l'opzione `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` e **deprecato**. Preferisci il campo [`permission`](/docs/permissions) per nuove configurazioni, aggiornamenti e un controllo piu fine.
+:::
 
 [Scopri di piu sugli strumenti](/docs/tools).
 
@@ -325,10 +329,10 @@ Puoi configurare agenti specializzati per task specifici tramite l'opzione `agen
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/it/mcp-servers.mdx
+++ b/packages/web/src/content/docs/it/mcp-servers.mdx
@@ -299,6 +299,10 @@ I tuoi MCP sono disponibili come strumenti in OpenCode insieme agli strumenti in
 
 Questo significa che puoi abilitarli o disabilitarli globalmente.
 
+:::note
+`tools` e **deprecato**. Preferisci il campo [`permission`](/docs/permissions) per nuove configurazioni, aggiornamenti e un controllo piu fine.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Questo significa che puoi abilitarli o disabilitarli globalmente.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Possiamo anche usare un pattern glob per disabilitare tutti gli MCP corrisponden
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Qui stiamo usando il pattern glob `my-mcp*` per disabilitare tutti gli MCP.
 Se hai molti server MCP, potresti volerli abilitare solo per agente e disabilitarli globalmente. Per farlo:
 
 1. Disabilitalo globalmente come strumento.
-2. Nella tua [config dell'agente](/docs/agents#tools), abilita il server MCP come strumento.
+2. Nella tua [config dell'agente](/docs/agents#permissions), abilita il server MCP come strumento.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Se hai molti server MCP, potresti volerli abilitare solo per agente e disabilita
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/it/skills.mdx
+++ b/packages/web/src/content/docs/it/skills.mdx
@@ -189,8 +189,8 @@ Disabilita completamente le skill per agenti che non dovrebbero usarle:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/ja/config.mdx
+++ b/packages/web/src/content/docs/ja/config.mdx
@@ -210,19 +210,23 @@ TUI 固有の設定には、専用の `tui.json` (または `tui.jsonc`) ファ�
 
 ---
 
-### ツール
+### 権限
 
-LLM が使用できるツールは、`tools` オプションを通じて管理できます。
+LLM が使用できるツールは、`permission` オプションを通じて管理できます。
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` は **非推奨** です。新しい構成、更新、より細かい制御には [`permission`](/docs/permissions) フィールドを使用してください。
+:::
 
 [ツールの詳細については、こちらをご覧ください](/docs/tools)。
 
@@ -328,10 +332,10 @@ UI テーマを `tui.json` で設定します。
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/ja/mcp-servers.mdx
+++ b/packages/web/src/content/docs/ja/mcp-servers.mdx
@@ -299,6 +299,10 @@ MCP は、組み込みツールと並んで、OpenCode のツールとして利�
 
 これは、それらをグローバルに有効または無効にできることを意味します。
 
+:::note
+`tools` は **非推奨** です。新しい構成、更新、より細かい制御には [`permission`](/docs/permissions) フィールドを使用してください。
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ MCP は、組み込みツールと並んで、OpenCode のツールとして利�
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ MCP は、組み込みツールと並んで、OpenCode のツールとして利�
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ MCP は、組み込みツールと並んで、OpenCode のツールとして利�
 多数の MCP サーバーがある場合は、エージェントごとにのみ有効にし、グローバルに無効にすることができます。これを行うには:
 
 1. ツールとしてグローバルに無効にします。
-2. [エージェント設定](/docs/agents#tools) で、MCP サーバーをツールとして有効にします。
+2. [エージェント設定](/docs/agents#permissions) で、MCP サーバーをツールとして有効にします。
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ MCP は、組み込みツールと並んで、OpenCode のツールとして利�
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/ja/skills.mdx
+++ b/packages/web/src/content/docs/ja/skills.mdx
@@ -189,8 +189,8 @@ permission:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/ko/config.mdx
+++ b/packages/web/src/content/docs/ko/config.mdx
@@ -207,19 +207,23 @@ TUI 관련 설정에는 전용 `tui.json` (또는 `tui.jsonc`) 파일을 사용�
 
 ---
 
-### Tools
+### Permissions
 
-`tools` 옵션으로 LLM이 사용할 수 있는 tool을 관리할 수 있습니다.
+`permission` 옵션으로 LLM이 사용할 수 있는 tool을 관리할 수 있습니다.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools`는 **사용되지 않습니다**. 새로운 구성, 업데이트 및 세밀한 제어를 위해 [`permission`](/docs/permissions) 필드를 사용하세요.
+:::
 
 [tool에 대해 더 알아보기](/docs/tools).
 
@@ -325,10 +329,10 @@ Bearer token(`AWS_BEARER_TOKEN_BEDROCK` 또는 `/connect`)은 profile 기반 인
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/ko/mcp-servers.mdx
+++ b/packages/web/src/content/docs/ko/mcp-servers.mdx
@@ -312,8 +312,8 @@ MCP는 opencode의 도구로 사용할 수 있으며 내장 도구와 함께 사
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +333,8 @@ MCP는 opencode의 도구로 사용할 수 있으며 내장 도구와 함께 사
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +348,7 @@ MCP는 opencode의 도구로 사용할 수 있으며 내장 도구와 함께 사
 많은 MCP 서버가 있다면 전역적으로는 비활성화하고 에이전트별로만 활성화할 수 있습니다. 이 작업을 수행:
 
 1. 글로벌 도구로 사용 가능.
-2. [agent config](/docs/agents#tools)에서 MCP 서버를 도구로 사용할 수 있습니다.
+2. [agent config](/docs/agents#permissions)에서 MCP 서버를 도구로 사용할 수 있습니다.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -360,13 +360,13 @@ MCP는 opencode의 도구로 사용할 수 있으며 내장 도구와 함께 사
       "enabled": true
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/ko/skills.mdx
+++ b/packages/web/src/content/docs/ko/skills.mdx
@@ -189,8 +189,8 @@ permission:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -300,6 +300,10 @@ Your MCPs are available as tools in OpenCode, alongside built-in tools. So you c
 
 This means that you can enable or disable them globally.
 
+:::note
+`tools` is **deprecated**. Prefer the [`permission`](/docs/permissions) field for new configs, updates and more fine-grained control.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -313,8 +317,8 @@ This means that you can enable or disable them globally.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -334,8 +338,8 @@ We can also use a glob pattern to disable all matching MCPs.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -349,7 +353,7 @@ Here we are using the glob pattern `my-mcp*` to disable all MCPs.
 If you have a large number of MCP servers you may want to only enable them per agent and disable them globally. To do this:
 
 1. Disable it as a tool globally.
-2. In your [agent config](/docs/agents#tools), enable the MCP server as a tool.
+2. In your [agent config](/docs/agents#permissions), enable the MCP server as a tool.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -361,13 +365,13 @@ If you have a large number of MCP servers you may want to only enable them per a
       "enabled": true
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/nb/config.mdx
+++ b/packages/web/src/content/docs/nb/config.mdx
@@ -209,19 +209,23 @@ Tilgjengelige alternativer:
 
 ---
 
-### Verktøy
+### Tillatelser
 
-Du kan administrere verktøyene en LLM kan bruke gjennom alternativet `tools`.
+Du kan administrere verktøyene en LLM kan bruke gjennom alternativet `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` er **foreldet**. Foretrekk feltet [`permission`](/docs/permissions) for nye konfigurasjoner, oppdateringer og mer finjustert kontroll.
+:::
 
 [Les mer om verktøy her](/docs/tools).
 
@@ -327,10 +331,10 @@ Du kan konfigurere spesialiserte agenter for spesifikke oppgaver gjennom alterna
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/nb/mcp-servers.mdx
+++ b/packages/web/src/content/docs/nb/mcp-servers.mdx
@@ -299,6 +299,10 @@ MCP-ene dine er tilgjengelige som verktøy i OpenCode, sammen med innebygde verk
 
 Dette betyr at du kan aktivere eller deaktivere dem globalt.
 
+:::note
+`tools` er **foreldet**. Foretrekk feltet [`permission`](/docs/permissions) for nye konfigurasjoner, oppdateringer og mer finjustert kontroll.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Dette betyr at du kan aktivere eller deaktivere dem globalt.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Vi kan også bruke et globmønster for å deaktivere alle matchende MCP-er.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Her bruker vi globmønsteret `my-mcp*` for å deaktivere alle MCP-er.
 Hvis du har et stort antall MCP-servere, vil du kanskje bare aktivere dem per agent og deaktivere dem globalt. Slik gjør du dette:
 
 1. Deaktiver det som et verktøy globalt.
-2. Aktiver MCP-serveren som et verktøy i [agent config](/docs/agents#tools).
+2. Aktiver MCP-serveren som et verktøy i [agent config](/docs/agents#permissions).
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Hvis du har et stort antall MCP-servere, vil du kanskje bare aktivere dem per ag
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/nb/skills.mdx
+++ b/packages/web/src/content/docs/nb/skills.mdx
@@ -189,8 +189,8 @@ Deaktiver ferdigheter fullstendig for agenter som ikke bør bruke dem:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/pl/config.mdx
+++ b/packages/web/src/content/docs/pl/config.mdx
@@ -204,19 +204,23 @@ Dostępne opcje:
 
 ---
 
-### Tools (Narzędzia)
+### Uprawnienia
 
-Kontroluj, które narzędzia są dostępne dla LLM, za pomocą opcji `tools`.
+Kontroluj, które narzędzia są dostępne dla LLM, za pomocą opcji `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` jest **przestarzałe**. Preferuj pole [`permission`](/docs/permissions) dla nowych konfiguracji, aktualizacji i bardziej precyzyjnej kontroli.
+:::
 
 [Dowiedz się więcej o narzędziach](/docs/tools).
 
@@ -322,10 +326,10 @@ Możesz zdefiniować i skonfigurować agentów za pomocą opcji `agent`.
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/pl/mcp-servers.mdx
+++ b/packages/web/src/content/docs/pl/mcp-servers.mdx
@@ -299,6 +299,10 @@ Twoje MCP są dostępne jako narzędzie w opencode, obok narzędzi dodatkowych. 
 
 Możesz to włączyć lub wyłączyć globalnie.
 
+:::note
+`tools` jest **przestarzałe**. Preferuj pole [`permission`](/docs/permissions) dla nowych konfiguracji, aktualizacji i bardziej precyzyjnej kontroli.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Możesz to włączyć lub wyłączyć globalnie.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Dostępne są również wzorca globu, aby wyłączyć wszystkie dyski MCP.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Tutaj znajdziesz wzorca globalnego `my-mcp*`, aby wyłączyć wszystkie MCP.
 Jeśli masz największe serwery MCP, możesz włączyć je tylko dla poszczególnych agentów i być globalnie. Aby to zrobić:
 
 1. Wyłącz go jako narzędzie globalnie.
-2. W [konfiguracji agenta](/docs/agents#tools) włącz serwer MCP jako narzędzie.
+2. W [konfiguracji agenta](/docs/agents#permissions) włącz serwer MCP jako narzędzie.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Jeśli masz największe serwery MCP, możesz włączyć je tylko dla poszczegól
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/pl/skills.mdx
+++ b/packages/web/src/content/docs/pl/skills.mdx
@@ -189,8 +189,8 @@ Całkowicie wyłącz umiejętności agentów, którzy nie powinni ich używać:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/pt-br/config.mdx
+++ b/packages/web/src/content/docs/pt-br/config.mdx
@@ -208,19 +208,23 @@ Opções disponíveis:
 
 ---
 
-### Ferramentas
+### Permissões
 
-Você pode gerenciar as ferramentas que um LLM pode usar através da opção `tools`.
+Você pode gerenciar as ferramentas que um LLM pode usar através da opção `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` está **obsoleto**. Prefira o campo [`permission`](/docs/permissions) para novas configurações, atualizações e controle mais refinado.
+:::
 
 [Saiba mais sobre ferramentas aqui](/docs/tools).
 
@@ -326,10 +330,10 @@ Você pode configurar agentes especializados para tarefas específicas através 
       "description": "Revisa código para melhores práticas e potenciais problemas",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "Você é um revisor de código. Foque em segurança, performance e manutenibilidade.",
-      "tools": {
+      "permission": {
         // Desabilitar ferramentas de modificação de arquivo para agente de apenas revisão
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/pt-br/mcp-servers.mdx
+++ b/packages/web/src/content/docs/pt-br/mcp-servers.mdx
@@ -299,6 +299,10 @@ Seus MCPs estão disponíveis como ferramentas no opencode, juntamente com ferra
 
 Isso significa que você pode habilitá-los ou desabilitá-los globalmente.
 
+:::note
+`tools` está **obsoleto**. Prefira o campo [`permission`](/docs/permissions) para novas configurações, atualizações e controle mais refinado.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Isso significa que você pode habilitá-los ou desabilitá-los globalmente.
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Também podemos usar um padrão glob para desabilitar todos os MCPs corresponden
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Aqui estamos usando o padrão glob `my-mcp*` para desabilitar todos os MCPs.
 Se você tiver um grande número de servidores MCP, pode querer habilitá-los apenas por agente e desabilitá-los globalmente. Para fazer isso:
 
 1. Desabilite-o como uma ferramenta globalmente.
-2. Em sua [configuração de agente](/docs/agents#tools), habilite o servidor MCP como uma ferramenta.
+2. Em sua [configuração de agente](/docs/agents#permissions), habilite o servidor MCP como uma ferramenta.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Se você tiver um grande número de servidores MCP, pode querer habilitá-los ap
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/pt-br/skills.mdx
+++ b/packages/web/src/content/docs/pt-br/skills.mdx
@@ -189,8 +189,8 @@ Desative completamente as habilidades para agentes que não devem usá-las:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/ru/config.mdx
+++ b/packages/web/src/content/docs/ru/config.mdx
@@ -207,19 +207,23 @@ opencode run "Hello world"
 
 ---
 
-### Инструменты
+### Разрешения
 
-Вы можете управлять инструментами, которые LLM может использовать, с помощью опции `tools`.
+Вы можете управлять инструментами, которые LLM может использовать, с помощью опции `permission`.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` устарел. Используйте поле [`permission`](/docs/permissions) для новых конфигураций, обновлений и более точного контроля.
+:::
 
 [Подробнее об инструментах можно узнать здесь](/docs/tools).
 
@@ -325,10 +329,10 @@ Amazon Bedrock поддерживает конфигурацию, специфи
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/ru/mcp-servers.mdx
+++ b/packages/web/src/content/docs/ru/mcp-servers.mdx
@@ -299,6 +299,10 @@ opencode mcp debug my-oauth-server
 
 Это означает, что вы можете включать или отключать их глобально.
 
+:::note
+`tools` устарел. Используйте поле [`permission`](/docs/permissions) для новых конфигураций, обновлений и более точного контроля.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ opencode mcp debug my-oauth-server
 Если у вас большое количество серверов MCP, вы можете включить их только для каждого агента и отключить глобально. Для этого:
 
 1. Отключите его как инструмент глобально.
-2. В вашей [конфигурации агента](/docs/agents#tools) включите сервер MCP в качестве инструмента.
+2. В вашей [конфигурации агента](/docs/agents#permissions) включите сервер MCP в качестве инструмента.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ opencode mcp debug my-oauth-server
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/ru/skills.mdx
+++ b/packages/web/src/content/docs/ru/skills.mdx
@@ -189,8 +189,8 @@ permission:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -189,8 +189,8 @@ Completely disable skills for agents that shouldn't use them:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/th/config.mdx
+++ b/packages/web/src/content/docs/th/config.mdx
@@ -211,19 +211,23 @@ opencode run "Hello world"
 
 ---
 
-### เครื่องมือ
+### สิทธิ์
 
-คุณสามารถจัดการเครื่องมือที่ LLM สามารถใช้ได้ผ่านตัวเลือก `tools`
+คุณสามารถจัดการเครื่องมือที่ LLM สามารถใช้ได้ผ่านตัวเลือก `permission`
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` ล้าสมัยแล้ว ควรใช้ฟิลด์ [`permission`](/docs/permissions) สำหรับการกำหนดค่าใหม่ การอัปเดต และการควบคุมที่ละเอียดยิ่งขึ้น
+:::
 
 [เรียนรู้เพิ่มเติมเกี่ยวกับเครื่องมือที่นี่](/docs/tools)
 
@@ -329,10 +333,10 @@ Bearer Token (`AWS_BEARER_TOKEN_BEDROCK` หรือ `/connect`) มีคว�
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/th/mcp-servers.mdx
+++ b/packages/web/src/content/docs/th/mcp-servers.mdx
@@ -299,6 +299,10 @@ MCP ของคุณพร้อมใช้งานในฐานะเค�
 
 ซึ่งหมายความว่าคุณสามารถเปิดหรือปิดใช้งานได้ทั่วโลก
 
+:::note
+`tools` ล้าสมัยแล้ว ควรใช้ฟิลด์ [`permission`](/docs/permissions) สำหรับการกำหนดค่าใหม่ การอัปเดต และการควบคุมที่ละเอียดยิ่งขึ้น
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ MCP ของคุณพร้อมใช้งานในฐานะเค�
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ MCP ของคุณพร้อมใช้งานในฐานะเค�
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ MCP ของคุณพร้อมใช้งานในฐานะเค�
 หากคุณมีเซิร์ฟเวอร์ MCP จำนวนมาก คุณอาจต้องการเปิดใช้งานเซิร์ฟเวอร์เหล่านี้ต่อตัวแทนเท่านั้น และปิดใช้งานเซิร์ฟเวอร์เหล่านั้นทั่วโลก เมื่อต้องการทำสิ่งนี้:
 
 1. ปิดการใช้งานเป็นเครื่องมือทั่วโลก
-2. ใน [agent config](/docs/agents#tools) ให้เปิดใช้งานเซิร์ฟเวอร์ MCP เป็นเครื่องมือ
+2. ใน [agent config](/docs/agents#permissions) ให้เปิดใช้งานเซิร์ฟเวอร์ MCP เป็นเครื่องมือ
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ MCP ของคุณพร้อมใช้งานในฐานะเค�
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/th/skills.mdx
+++ b/packages/web/src/content/docs/th/skills.mdx
@@ -189,8 +189,8 @@ permission:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/tr/config.mdx
+++ b/packages/web/src/content/docs/tr/config.mdx
@@ -208,19 +208,23 @@ Mevcut seçenekler:
 
 ---
 
-### Araçlar
+### İzinler
 
-Bir LLM'nin kullanabileceği araçları `tools` seçeneği aracılığıyla yönetebilirsiniz.
+Bir LLM'nin kullanabileceği araçları `permission` seçeneği aracılığıyla yönetebilirsiniz.
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` **eski**. Yeni yapılandırmalar, güncellemeler ve daha hassas kontrol için [`permission`](/docs/permissions) alanını tercih edin.
+:::
 
 [Araçlar hakkında daha fazla bilgi](/docs/tools).
 
@@ -326,11 +330,11 @@ opencode yapılandırmanızda kullanmak istediğiniz temayı `theme` seçeneği 
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
-        "bash": true,
+        "write": "deny",
+        "edit": "deny",
+        "bash": "allow",
       },
     },
   },

--- a/packages/web/src/content/docs/tr/mcp-servers.mdx
+++ b/packages/web/src/content/docs/tr/mcp-servers.mdx
@@ -299,6 +299,10 @@ MCP'leriniz yerleşik araçların yanı sıra opencode'da araç olarak mevcuttur
 
 Bu, bunları global olarak etkinleştirebileceğiniz veya devre dışı bırakabileceğiniz anlamına gelir.
 
+:::note
+`tools` **eski**. Yeni yapılandırmalar, güncellemeler ve daha hassas kontrol için [`permission`](/docs/permissions) alanını tercih edin.
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ Bu, bunları global olarak etkinleştirebileceğiniz veya devre dışı bırakab
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ Eşleşen tüm MCP'leri devre dışı bırakmak için bir glob modeli de kullana
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ Burada tüm MCP'leri devre dışı bırakmak için `my-mcp*` glob modelini kulla
 Çok sayıda MCP sunucunuz varsa, bunları yalnızca aracı başına etkinleştirmek ve genel olarak devre dışı bırakmak isteyebilirsiniz. Bunu yapmak için:
 
 1. Global olarak bir araç olarak devre dışı bırakın.
-2. [agent config](/docs/agents#tools)'nizde, MCP sunucusunu bir araç olarak etkinleştirin.
+2. [agent config](/docs/agents#permissions)'nizde, MCP sunucusunu bir araç olarak etkinleştirin.
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ Burada tüm MCP'leri devre dışı bırakmak için `my-mcp*` glob modelini kulla
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/tr/skills.mdx
+++ b/packages/web/src/content/docs/tr/skills.mdx
@@ -189,8 +189,8 @@ Beceri kullanmamasi gereken ajanlar icin skill aracini tamamen kapatabilirsiniz:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/zh-cn/config.mdx
+++ b/packages/web/src/content/docs/zh-cn/config.mdx
@@ -207,17 +207,21 @@ opencode run "Hello world"
 
 ### 工具
 
-您可以通过 `tools` 选项管理 LLM 可以使用的工具。
+您可以通过 `permission` 选项管理 LLM 可以使用的工具。
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` 已被**弃用**。对于新配置、更新和更细粒度的控制，请优先使用 [`permission`](/docs/permissions) 字段。
+:::
 
 [在此了解更多关于工具的信息](/docs/tools)。
 
@@ -323,10 +327,10 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）优先于基于配置
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/zh-cn/mcp-servers.mdx
+++ b/packages/web/src/content/docs/zh-cn/mcp-servers.mdx
@@ -299,6 +299,10 @@ opencode mcp debug my-oauth-server
 
 你可以全局启用或禁用 MCP 工具。
 
+:::note
+`tools` 已被**弃用**。对于新配置、更新和更细粒度的控制，请优先使用 [`permission`](/docs/permissions) 字段。
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ opencode mcp debug my-oauth-server
 如果你有大量 MCP 服务器，可以选择全局禁用它们，然后仅在特定代理中启用。具体做法：
 
 1. 全局禁用该工具。
-2. 在[代理配置](/docs/agents#tools)中，将 MCP 服务器作为工具启用。
+2. 在[代理配置](/docs/agents#permissions)中，将 MCP 服务器作为工具启用。
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ opencode mcp debug my-oauth-server
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/zh-cn/skills.mdx
+++ b/packages/web/src/content/docs/zh-cn/skills.mdx
@@ -189,8 +189,8 @@ permission:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }

--- a/packages/web/src/content/docs/zh-tw/config.mdx
+++ b/packages/web/src/content/docs/zh-tw/config.mdx
@@ -209,19 +209,23 @@ opencode run "Hello world"
 
 ---
 
-### 工具
+### 權限
 
-您可以透過 `tools` 選項管理 LLM 可以使用的工具。
+您可以透過 `permission` 選項管理 LLM 可以使用的工具。
 
 ```json title="opencode.json"
 {
   "$schema": "https://opencode.ai/config.json",
-  "tools": {
-    "write": false,
-    "bash": false
+  "permission": {
+    "write": "deny",
+    "bash": "deny"
   }
 }
 ```
+
+:::note
+`tools` 已被**棄用**。對於新設定、更新和更細粒度的控制，請優先使用 [`permission`](/docs/permissions) 欄位。
+:::
 
 [在此了解更多關於工具的資訊](/docs/tools)。
 
@@ -327,10 +331,10 @@ Bearer Token（`AWS_BEARER_TOKEN_BEDROCK` 或 `/connect`）優先於基於設定
       "description": "Reviews code for best practices and potential issues",
       "model": "anthropic/claude-sonnet-4-5",
       "prompt": "You are a code reviewer. Focus on security, performance, and maintainability.",
-      "tools": {
+      "permission": {
         // Disable file modification tools for review-only agent
-        "write": false,
-        "edit": false,
+        "write": "deny",
+        "edit": "deny",
       },
     },
   },

--- a/packages/web/src/content/docs/zh-tw/mcp-servers.mdx
+++ b/packages/web/src/content/docs/zh-tw/mcp-servers.mdx
@@ -299,6 +299,10 @@ opencode mcp debug my-oauth-server
 
 您可以全域啟用或停用 MCP 工具。
 
+:::note
+`tools` 已被**棄用**。對於新設定、更新和更細粒度的控制，請優先使用 [`permission`](/docs/permissions) 欄位。
+:::
+
 ```json title="opencode.json" {14}
 {
   "$schema": "https://opencode.ai/config.json",
@@ -312,8 +316,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp-foo": false
+  "permission": {
+    "my-mcp-foo": "deny"
   }
 }
 ```
@@ -333,8 +337,8 @@ opencode mcp debug my-oauth-server
       "command": ["bun", "x", "my-mcp-command-bar"]
     }
   },
-  "tools": {
-    "my-mcp*": false
+  "permission": {
+    "my-mcp*": "deny"
   }
 }
 ```
@@ -348,7 +352,7 @@ opencode mcp debug my-oauth-server
 如果您有大量 MCP 伺服器，可以選擇全域停用它們，然後僅在特定代理中啟用。具體做法：
 
 1. 全域停用該工具。
-2. 在[代理設定](/docs/agents#tools)中，將 MCP 伺服器作為工具啟用。
+2. 在[代理設定](/docs/agents#permissions)中，將 MCP 伺服器作為工具啟用。
 
 ```json title="opencode.json" {11, 14-18}
 {
@@ -365,8 +369,8 @@ opencode mcp debug my-oauth-server
   },
   "agent": {
     "my-agent": {
-      "tools": {
-        "my-mcp*": true
+      "permission": {
+        "my-mcp*": "allow"
       }
     }
   }

--- a/packages/web/src/content/docs/zh-tw/skills.mdx
+++ b/packages/web/src/content/docs/zh-tw/skills.mdx
@@ -189,8 +189,8 @@ permission:
 
 ```yaml
 ---
-tools:
-  skill: false
+permission:
+  skill: deny
 ---
 ```
 
@@ -200,8 +200,8 @@ tools:
 {
   "agent": {
     "plan": {
-      "tools": {
-        "skill": false
+      "permission": {
+        "skill": "deny"
       }
     }
   }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Improve docs to use 'permission' instead of deprecated 'tools' param, for English and all other languages.

### How did you verify your code works?

Yes I ran the docs locally, it seems fine.

### Screenshots / recordings

Example for /docs/mcp-servers/#global:

<img width="2000" height="1239" alt="image" src="https://github.com/user-attachments/assets/e46ee940-048f-41cd-9a0e-8e7a3e00a5f8" />
### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
