### PR TITLE
docs: expand AGENTS.md, add test docs, cross-ref style guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,31 @@
-- To test opencode in the `packages/opencode` directory you can run `bun dev`
-- To regenerate the javascript SDK, run ./packages/sdk/js/script/build.ts
-- ALWAYS USE PARALLEL TOOLS WHEN APPLICABLE.
-- the default branch in this repo is `dev`
+# OpenCode Development Guide
+
+## Quick Start
+- Run OpenCode in dev mode: `bun dev` (from repo root, targets `packages/opencode` by default)
+- Run against a different directory: `bun dev <directory>`
+- Run OpenCode TUI against this repo itself: `bun dev .`
+
+## Build & Type Check
+- Type-check all packages: `bun turbo typecheck` or `bun run typecheck`
+- Regenerate JavaScript SDK (after API changes): `./packages/sdk/js/script/build.ts`
+- Build standalone binary: `./packages/opencode/script/build.ts --single`
+- Do NOT run tests from repo root (`bun test` at root is a no-op); run tests within individual packages
+
+## Architecture
+- `packages/opencode`: Core business logic & server
+- `packages/opencode/src/cli/cmd/tui/`: TUI code (SolidJS + opentui)
+- `packages/plugin`: `@opencode-ai/plugin` source
+- `packages/sdk/js`: JavaScript SDK for OpenCode API
+
+## Important Conventions
+- **ALWAYS USE PARALLEL TOOLS WHEN APPLICABLE** — batch independent operations
+- Default branch is `dev` — target all PRs to `dev`, not `master`
+- After modifying API routes (in `packages/opencode/src/server/server.ts`), run `./script/generate.ts` to regenerate SDK
+- Follow the [style guide](./STYLE_GUIDE.md)
+- Use `bun` as package manager (bun@1.3.5)
+- Prettier config: no semicolons, 120 char print width
+
+## Debugging
+- Debug server: `bun run --inspect=ws://localhost:6499/ ./src/index.ts serve --port 4096`
+- Attach TUI: `opencode attach http://localhost:4096`
+- For TUI + server breakpoints, use `bun dev spawn` instead of `bun dev`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,20 @@ Then run it with:
 
 Replace `<platform>` with your platform (e.g., `darwin-arm64`, `linux-x64`).
 
+### Running Tests
+
+Tests live inside individual packages (e.g., `packages/opencode/test/`). Run `bun test` from within a package directory — NOT from the repo root (root-level `bun test` is a no-op):
+
+```bash
+cd packages/opencode && bun test
+```
+
+To run a specific test file:
+
+```bash
+cd packages/opencode && bun test test/session/prompt.test.ts
+```
+
 - Core pieces:
   - `packages/opencode`: OpenCode core business logic & server.
   - `packages/opencode/src/cli/cmd/tui/`: The TUI code, written in SolidJS with [opentui](https://github.com/sst/opentui)

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,5 +1,7 @@
 ## Style Guide
 
+> See also: [CONTRIBUTING.md § Style Preferences](./CONTRIBUTING.md#style-preferences) for expanded guidance with examples.
+
 - Try to keep things in one function unless composable or reusable
 - DO NOT do unnecessary destructuring of variables
 - DO NOT use `else` statements unless necessary


### PR DESCRIPTION
## Summary

Three documentation improvements for contributor onboarding:

1. **Expand AGENTS.md** — Adds Quick Start, Build & Type Check, Architecture, Conventions, and Debugging sections (previously only 4 lines)
2. **Add "Running Tests" section to CONTRIBUTING.md** — Documents how to run tests within individual packages (root `bun test` is a no-op)
3. **Cross-reference STYLE_GUIDE.md** — Links to CONTRIBUTING.md's expanded Style Preferences section

All changes are documentation-only and follow the contributing guidelines.