### PR TITLE
fix(core): clarify web search provider prompt

### DIFF
--- a/packages/core/src/tool/plugin/websearch.ts
+++ b/packages/core/src/tool/plugin/websearch.ts
@@ -58,13 +58,13 @@ export const Plugin = {
                       if (providers.length === 0) return yield* new WebSearch.ProviderRequiredError()
                       const response = yield* forms.ask({
                         sessionID: context.sessionID,
-                        title: "Choose a web search provider",
+                        title: "The agent wants to search the web",
                         metadata: { kind: "websearch.provider" },
                         fields: [
                           {
                             key: "provider",
                             title: "Provider",
-                            description: "This becomes your default and can be changed later in configuration.",
+                            description: "Choose a provider. OpenCode will use it for future searches.",
                             type: "string",
                             required: true,
                             custom: false,

--- a/packages/core/src/tool/plugin/websearch.ts
+++ b/packages/core/src/tool/plugin/websearch.ts
@@ -58,13 +58,13 @@ export const Plugin = {
                       if (providers.length === 0) return yield* new WebSearch.ProviderRequiredError()
                       const response = yield* forms.ask({
                         sessionID: context.sessionID,
-                        title: "The agent wants to search the web",
+                        title: "Choose a provider so the agent can search the web",
                         metadata: { kind: "websearch.provider" },
                         fields: [
                           {
                             key: "provider",
                             title: "Provider",
-                            description: "Choose a provider. OpenCode will use it for future searches.",
+                            description: "OpenCode will use your choice for future searches.",
                             type: "string",
                             required: true,
                             custom: false,


### PR DESCRIPTION
## summary
- explain that the agent wants to search the web before asking for a provider
- clarify that OpenCode will reuse the selected provider for future searches

## testing
- `bun test test/tool-websearch.test.ts`
- `bun typecheck` (blocked by missing local `@opencode-ai/sdk/v2` and `@standard-schema/spec` modules)