### PR TITLE
fix(opencode): tolerate orphan reasoning/text stream-state parts

### DIFF
--- a/packages/opencode/src/session/llm/ai-sdk.ts
+++ b/packages/opencode/src/session/llm/ai-sdk.ts
@@ -73,6 +73,18 @@ function currentReasoningID(state: ReturnType<typeof adapterState>, id: string |
   return state.currentReasoningID
 }
 
+// The AI SDK enqueues a non-fatal in-band error part
+//   { type: "error", error: `${"reasoning" | "text"} part ${id} not found` }
+// when a reasoning/text delta (or its end) arrives with no preceding *-start
+// block. This is common with OpenAI-compatible and Anthropic proxies that omit
+// the start events. The SDK returns and keeps streaming, so this must not be
+// promoted to a fatal turn failure. Verified against vercel/ai@6 stream-text.ts
+// (text part: L1171/L1190, reasoning part: L1220/L1239).
+function isOrphanStreamStateError(error: unknown) {
+  const message = errorMessage(error).trim()
+  return message.endsWith(" not found") && (message.startsWith("reasoning part ") || message.startsWith("text part "))
+}
+
 export function toLLMEvents(
   state: ReturnType<typeof adapterState>,
   event: AISDKEvent,
@@ -262,6 +274,10 @@ export function toLLMEvents(
       })
 
     case "error":
+      if (isOrphanStreamStateError(event.error))
+        return Effect.logDebug("dropping orphan reasoning/text stream part", {
+          detail: errorMessage(event.error),
+        }).pipe(Effect.as<LLMEvent[]>([]))
       return Effect.fail(event.error)
 
     case "abort":

--- a/packages/opencode/test/session/ai-sdk.test.ts
+++ b/packages/opencode/test/session/ai-sdk.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Exit } from "effect"
+import { LLMAISDK } from "@/session/llm/ai-sdk"
+
+type ErrorEvent = Extract<Parameters<typeof LLMAISDK.toLLMEvents>[1], { type: "error" }>
+
+const errorEvent = (error: unknown): ErrorEvent => ({ type: "error", error })
+
+const run = (error: unknown) => Effect.runPromiseExit(LLMAISDK.toLLMEvents(LLMAISDK.adapterState(), errorEvent(error)))
+
+describe("LLMAISDK.toLLMEvents error handling", () => {
+  test("drops orphan reasoning/text stream-state errors without failing the turn", async () => {
+    // vercel/ai stream-text.ts enqueues these exact strings as non-fatal in-band
+    // error parts when a reasoning/text delta (or its end) has no preceding
+    // *-start block. They must not abort the assistant turn.
+    for (const message of [
+      "reasoning part 0 not found",
+      "reasoning part 7 not found",
+      "reasoning part rs_abc:0 not found",
+      "text part 0 not found",
+      "text part X not found",
+    ]) {
+      const exit = await run(message)
+      expect(Exit.isSuccess(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) expect(exit.value).toEqual([])
+    }
+  })
+
+  test("tolerates surrounding whitespace via trim", async () => {
+    const exit = await run("  reasoning part 0 not found  ")
+    expect(Exit.isSuccess(exit)).toBe(true)
+  })
+
+  test("still fails on genuine provider errors", async () => {
+    for (const error of ["rate limit exceeded", 'Tool "foo" not found', "context length exceeded", new Error("boom")]) {
+      const exit = await run(error)
+      expect(Exit.isFailure(exit)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Sessions using reasoning-capable models behind OpenAI-compatible / Anthropic proxies repeatedly fail with:

```
ERROR message=process error="reasoning part 0 not found" stack=undefined
```

Each occurrence aborts the assistant turn. In one local log this fired ~1500 times across multiple sessions, making such proxies effectively unusable.

## Root cause

The Vercel AI SDK's `streamText` reasoning/text state machine enqueues a **non-fatal** in-band error part when a `reasoning-delta` / `text-delta` (or its `-end`) arrives with no preceding `reasoning-start` / `text-start` block:

```
{ type: "error", error: `reasoning part ${id} not found` }   // or `text part ${id} not found`
```

(`packages/ai/src/generate-text/stream-text.ts` — text part L1171/L1190, reasoning part L1220/L1239). The SDK `return`s and keeps streaming, i.e. it treats this as recoverable bookkeeping. Proxies that stream thinking deltas without emitting the start block trigger it constantly.

opencode's AI SDK adapter promoted **every** `error` part to a fatal `Effect.fail`:

```ts
case "error":
  return Effect.fail(event.error)
```

which `SessionProcessor.halt()` logs (`stack=undefined`, because the payload is a plain string) and turns into an aborted turn + `Session.Event.Error`.

Note that opencode already tolerates the same orphan condition on the delta path (`session/processor.ts`: "silently drop orphan deltas (no preceding reasoning-start)"). The SDK-internal error part simply took a different code path that bypassed that existing tolerance.

## Fix

Recognize these narrow, SDK-internal orphan stream-state errors in the adapter (`session/llm/ai-sdk.ts`) and drop them (debug log, no emitted events) instead of failing the turn. Matching is intentionally strict — prefix `reasoning part ` / `text part ` plus suffix ` not found` — so genuine provider errors (rate limits, `Tool "x" not found`, etc.) still fail as before. If the SDK ever changes the wording, the matcher simply stops matching and behavior reverts to the prior fatal path (fails loud, never swallows silently).

## Testing

- `bun run typecheck` — clean
- `bun test test/session/ai-sdk.test.ts` — 3 pass / 15 assertions
  - orphan `reasoning part …` / `text part …` strings (incl. colon ids like `rs_abc:0`) → dropped, turn continues
  - genuine errors (`rate limit exceeded`, `Tool "foo" not found`, `Error`) → still fail
