### PR TITLE
test(provider): drain Mistral doStream stream via reader

### DIFF
--- a/packages/core/test/provider-mistral.test.ts
+++ b/packages/core/test/provider-mistral.test.ts
@@ -208,7 +208,12 @@ test("Mistral preserves native reasoning metadata while streaming", async () => 
     prompt: [{ role: "user", content: [{ type: "text", text: "Hello" }] }],
   })
   const events = []
-  for await (const event of result.stream) events.push(event)
+  const reader = result.stream.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    events.push(value)
+  }
 
   expect(events.find((event) => event.type === "reasoning-end")?.providerMetadata).toEqual({
     mistral: {


### PR DESCRIPTION
The Mistral reasoning-history test in `packages/core/test/provider-mistral.test.ts` iterates `result.stream` with `for await`:

```ts
for await (const event of result.stream) events.push(event)
```

`result.stream` is a `ReadableStream<LanguageModelV3StreamPart>`. Under `@tsconfig/bun` (lib `ESNext`, no DOM) the ambient `ReadableStream` type has no `[Symbol.asyncIterator]`, so `tsgo --noEmit` fails on `packages/core`:

```
test/provider-mistral.test.ts(211,29): error TS2504: Type 'ReadableStream<LanguageModelV3StreamPart>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
```

This is the only place in the test suite that iterates a `doStream` result with `for await`; every other provider test drains it with `getReader()` (see `convertReadableStreamToArray` in `test/github-copilot/copilot-chat-model.test.ts`). This change switches the Mistral test to the same reader-based drain, which is behavior-equivalent and typechecks.

No runtime behavior changes; the loop still collects every stream event into `events`.
