### PR TITLE
fix(github): run bundled installer at pinned ref and allow pinning the CLI version

### DIFF
--- a/github/action.yml
+++ b/github/action.yml
@@ -38,14 +38,28 @@ inputs:
     description: "Base URL for OIDC token exchange API. Only required when running a custom GitHub App install. Defaults to https://api.opencode.ai"
     required: false
 
+  version:
+    description: "opencode CLI version to install (e.g. '1.18.7'). Defaults to the latest release."
+    required: false
+
 runs:
   using: "composite"
   steps:
     - name: Get opencode version
       id: version
       shell: bash
+      env:
+        REQUESTED_VERSION: ${{ inputs.version }}
       run: |
-        VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+        if [ -n "$REQUESTED_VERSION" ]; then
+          VERSION="$REQUESTED_VERSION"
+        else
+          VERSION=$(curl -sf https://api.github.com/repos/anomalyco/opencode/releases/latest | grep -o '"tag_name": *"[^"]*"' | cut -d'"' -f4)
+        fi
+        # `resolved` is handed to the installer; empty means "let the installer pick
+        # the latest release itself", preserving prior behaviour when the API lookup
+        # fails. `version` is the cache key only, hence the `latest` placeholder.
+        echo "resolved=${VERSION}" >> $GITHUB_OUTPUT
         echo "version=${VERSION:-latest}" >> $GITHUB_OUTPUT
 
     - name: Cache opencode
@@ -58,7 +72,13 @@ runs:
     - name: Install opencode
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      run: curl -fsSL https://opencode.ai/install | bash
+      # Run the installer bundled at the *pinned* action ref rather than fetching it
+      # from opencode.ai at run time, so a SHA-pinned `uses:` also pins the installer.
+      # `bash` (not `sh`) is required: ./install is `#!/usr/bin/env bash` and uses
+      # `[[ ]]` throughout.
+      run: bash "$GITHUB_ACTION_PATH/../install"
+      env:
+        VERSION: ${{ steps.version.outputs.resolved }}
 
     - name: Add opencode to PATH
       shell: bash


### PR DESCRIPTION
### Issue for this PR

Closes #39163

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pinning the action to a commit SHA didn't pin anything that runs: the installer was fetched from opencode.ai at run time, and the CLI was always the latest release. The version resolved from the releases API only fed the cache key — it was never passed to the installer.

Two changes:

1. `curl -fsSL https://opencode.ai/install | bash` → `bash "$GITHUB_ACTION_PATH/../install"`. The whole repo is checked out when a subdirectory action runs, so `./install` is already there at the pinned ref.
2. New optional `version` input, passed to the installer as `VERSION`. The installer already reads it.

Two details that aren't obvious from the diff:

- It has to be `bash`, not `sh` — `./install` is `#!/usr/bin/env bash` and uses `[[ ]]`.
- The step now emits `resolved` (given to the installer) separately from `version` (cache key). They differ when the API lookup fails: `version` keeps the existing `latest` placeholder, but sending `VERSION=latest` to the installer would make it look for a release tagged `vlatest`, so `resolved` is left empty and the installer picks latest itself, as before.

`./install` is sha256-identical to what opencode.ai serves today, so this changes where the script comes from, not what it does.

### How did you verify your code works?

Ran both paths on an `ubuntu-latest` runner against this branch.

With `version: "1.18.6"` (latest was 1.18.7):

```
key: opencode-Linux-X64-1.18.6
Installing opencode version: 1.18.6
$ opencode --version
1.18.6
```

Without the input — same as before this PR:

```
key: opencode-Linux-X64-v1.18.7
Installing opencode version: 1.18.7
$ opencode --version
1.18.7
```

I also checked `$GITHUB_ACTION_PATH/../install` resolves on a runner before writing this: for a subdirectory action `action_path` is `_actions/<owner>/<repo>/<ref>/github`, so `../install` lands on the repo-root script.

To reproduce: point a workflow at this branch with and without `version`, and check `opencode --version`.

### Screenshots / recordings

n/a — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR