### PR TITLE
docs(ecosystem): add openwts to projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -72,6 +72,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [openwts](https://github.com/atpaawej/openwts)                                             | Isolated git worktrees for AI coding agents — opencode, Claude Code, and more |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Adds openwts to the ecosystem Projects table.

### Type of change

- [x] Documentation

### What does this PR do?

Adds [openwts](https://github.com/atpaawej/openwts) to the Projects table in `packages/web/src/content/docs/ecosystem.mdx`.

openwts creates isolated git worktrees for each task and opens your AI coding agent inside them — no stashing, no partial commits, no context loss. With native opencode support (`openwts opencode <task>`), it integrates directly into your opencode workflow. One command. Zero friction.

### How did you verify your code works?

Verified the row matches the column format and fits alphabetically in the Projects table.

### Screenshots / recordings

N/A — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR