### PR TITLE
docs: add OpenCode Governance to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -81,3 +81,4 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | ----------------------------------------------------------------- | ------------------------------------------------------------ |
 | [Agentic](https://github.com/Cluster444/agentic)                  | Modular AI agents and commands for structured development    |
 | [opencode-agents](https://github.com/darrenhinde/opencode-agents) | Configs, prompts, agents, and plugins for enhanced workflows |
+| [OpenCode Governance](https://github.com/jannotix/opencode-governance) | Provider-agnostic governance workflow with requirement provenance, independent review, and evidence-driven verification |


### PR DESCRIPTION
### Issue for this PR

Closes #39136

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds OpenCode Governance to the Agents section of the ecosystem page.
The project provides a provider- and model-agnostic governance workflow for OpenCode, including requirement provenance, independent implementation and architecture/security review, evidence-driven verification, resumable task state, and operational assurance.
This PR only adds the project to the existing ecosystem listing; it does not change OpenCode behavior or runtime code.

### How did you verify your code works?

Verified the PR changes only `packages/web/src/content/docs/ecosystem.mdx` and adds a single Markdown table row pointing to the public repository.

### Screenshots / recordings

Not applicable; documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
