### PR TITLE
fix(core): correct MCP environment field in built-in skill

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -112,7 +112,7 @@ Every field is optional.
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp"],
       "enabled": true,
-      "env": {}
+      "environment": {}
     },
     "remote-thing": {
       "type": "remote",
@@ -371,7 +371,7 @@ Special object-shaped (not callbacks): `tool: { my_tool: { ... } }`,
       "type": "local",
       "command": ["npx", "-y", "@playwright/mcp"],
       "enabled": true,
-      "env": { "BROWSER": "chromium" }
+      "environment": { "BROWSER": "chromium" }
     },
     "github": {
       "type": "remote",
@@ -384,7 +384,8 @@ Special object-shaped (not callbacks): `tool: { my_tool: { ... } }`,
 }
 ```
 
-`command` is an array of strings. `type` is required. Use `enabled: false` to
+`command` is an array of strings. `environment` sets environment variables for
+a local MCP server. `type` is required. Use `enabled: false` to
 disable a server inherited from a parent config. String values such as header
 tokens support `{env:VAR}` interpolation (and `{file:path}`); the shell-style
 `${VAR}` is not substituted.


### PR DESCRIPTION
### Issue for this PR

Closes #39135

### Type of change

- [x] Documentation

### What does this PR do?

- Corrects the MCP examples in the customize-opencode skill to use `environment` rather than the unsupported `env` field.
- Documents that `environment` supplies variables to local MCP server processes.
- This matches the active MCP configuration schema, preventing agents from generating invalid configuration.

### How did you verify your code works?

- `git diff --check`
- `bun turbo typecheck` via the repository pre-push hook

### Screenshots / recordings

- Not applicable: documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR