### PR TITLE
fix(app): read the message from structured server error payloads

### DIFF
--- a/packages/app/src/utils/server-errors.test.ts
+++ b/packages/app/src/utils/server-errors.test.ts
@@ -101,6 +101,23 @@ describe("formatServerError", () => {
     )
   })
 
+  test("returns the message of unrecognized server error payloads", () => {
+    expect(formatServerError({ name: "ProviderAuthError", data: { message: "  token expired  " } }, language.t)).toBe(
+      "token expired",
+    )
+    expect(formatServerError({ message: "Connection refused" }, language.t)).toBe("Connection refused")
+  })
+
+  test("prefers a payload message over the generic fallback", () => {
+    expect(
+      formatServerError({ name: "APIError", data: { message: "Sidecar unavailable" } }, language.t, "Falhou"),
+    ).toBe("Sidecar unavailable")
+  })
+
+  test("ignores blank payload messages", () => {
+    expect(formatServerError({ name: "APIError", data: { message: "   " } }, language.t)).toBe("Erro desconhecido")
+  })
+
   test("formats provider model errors using provider/model", () => {
     const error = {
       name: "ProviderModelNotFoundError",
@@ -141,6 +158,14 @@ describe("formatServerError", () => {
     const wrapped = new Error("ConfigInvalidError", { cause: { body, status: 400 } })
 
     expect(formatServerError(wrapped, language.t)).toBe("Arquivo de config em config invalido: Missing host")
+  })
+
+  test("keeps preferring the error message over an unrecognized cause.body", () => {
+    const wrapped = new Error("Request failed with status 401", {
+      cause: { body: { name: "ProviderAuthError", data: { message: "token expired" } }, status: 401 },
+    })
+
+    expect(formatServerError(wrapped, language.t)).toBe("Request failed with status 401")
   })
 })
 

--- a/packages/app/src/utils/server-errors.ts
+++ b/packages/app/src/utils/server-errors.ts
@@ -31,8 +31,20 @@ export function formatServerError(error: unknown, translate?: Translator, fallba
   if (isProviderModelNotFoundErrorLike(unwrapped)) return parseReadableProviderModelNotFoundError(unwrapped, translate)
   if (error instanceof Error && error.message) return error.message
   if (typeof error === "string" && error) return error
+  const detail = structuredMessage(unwrapped)
+  if (detail) return detail
   if (fallback) return fallback
   return tr(translate, "error.chain.unknown", "Unknown error")
+}
+
+// Declared error responses arrive as raw NamedError payloads (`{ name, data }`) rather than Error
+// instances, so error names without a dedicated branch above still carry a usable message.
+function structuredMessage(error: unknown) {
+  if (typeof error !== "object" || error === null) return
+  const o = error as { data?: { message?: unknown }; message?: unknown }
+  return [o.data?.message, o.message]
+    .find((value): value is string => typeof value === "string" && !!value.trim())
+    ?.trim()
 }
 
 function unwrapNamedError(error: unknown): unknown {


### PR DESCRIPTION
### Issue for this PR

Fixes #31643

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Structured API failures often arrive as plain objects instead of `Error` instances. `formatServerError` handled typed config/model errors, `Error` objects, and strings, but otherwise discarded useful `data.message`, top-level `message`, and `name` fields and showed `Unknown error` in app and desktop error toasts.

This change reads non-empty nested and top-level messages from unrecognized structured payloads, then uses a meaningful structured error name before the generic fallback. Existing typed-error precedence is unchanged, and blank messages or the generic `UnknownError` name still use the translated fallback.

### How did you verify your code works?

- `bun test src/utils/server-errors.test.ts` from `packages/app`: 16 tests pass, including nested messages, top-level messages, blank values, named fallback, and existing typed errors.
- `bun typecheck` from `packages/app`: existing workspace dependency-resolution errors remain; no errors are reported in the changed files.

### Screenshots / recordings

N/A, this changes error formatting only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
