### PR TITLE
fix(tui): restore queued messages when a session is interrupted

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -32,7 +32,8 @@ import { promptOffsetWidth } from "../../prompt/display"
 import { createStore, produce, unwrap } from "solid-js/store"
 import { usePromptHistory, type PromptInfo } from "../../prompt/history"
 import { computePromptTraits } from "../../prompt/traits"
-import { expandPastedTextPlaceholders, expandTrackedPastedText } from "../../prompt/part"
+import { expandPastedTextPlaceholders, expandTrackedPastedText, stripPromptPartIDs } from "../../prompt/part"
+import { queuedMessages } from "../../prompt/queued"
 import { usePromptStash } from "../../prompt/stash"
 import { DialogStash } from "../dialog-stash"
 import { type AutocompleteRef, Autocomplete } from "./autocomplete"
@@ -411,6 +412,24 @@ export function Prompt(props: PromptProps) {
           }, 5000)
 
           if (store.interrupt >= 2) {
+            // Aborting drops queued follow-ups, so hand their text back unless a new draft started.
+            const queued =
+              store.prompt.input || store.prompt.parts.length > 0
+                ? []
+                : queuedMessages(sync.data.message[props.sessionID] ?? [])
+            if (queued.length > 0)
+              ref.set(
+                queued
+                  .flatMap((message) => sync.data.part[message.id] ?? [])
+                  .reduce(
+                    (agg, part) => {
+                      if (part.type === "text" && !part.synthetic) agg.input += part.text
+                      if (part.type === "file") agg.parts.push(stripPromptPartIDs(part))
+                      return agg
+                    },
+                    { input: "", parts: [] as PromptInfo["parts"] },
+                  ),
+              )
             void sdk.client.session.abort({
               sessionID: props.sessionID,
             })

--- a/packages/tui/src/prompt/queued.ts
+++ b/packages/tui/src/prompt/queued.ts
@@ -1,0 +1,14 @@
+/**
+ * User messages submitted while a turn is still running. The server holds them until the
+ * turn finishes, so they are only queued while an assistant message is still incomplete.
+ */
+export function queuedMessages<
+  Message extends { id: string; role: string; time: { created: number; completed?: number } },
+>(messages: Message[]) {
+  const completed = messages.findLast((message) => message.role === "assistant" && message.time.completed)?.id
+  const pending = messages.findLast(
+    (message) => message.role === "assistant" && !message.time.completed && (!completed || message.id > completed),
+  )?.id
+  if (!pending) return []
+  return messages.filter((message) => message.role === "user" && message.id > pending)
+}

--- a/packages/tui/test/prompt/queued.test.ts
+++ b/packages/tui/test/prompt/queued.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import { queuedMessages } from "../../src/prompt/queued"
+
+const assistant = (id: string, completed?: number) => ({ id, role: "assistant", time: { created: 1, completed } })
+const user = (id: string) => ({ id, role: "user", time: { created: 1 } })
+
+describe("prompt queued", () => {
+  test("returns user messages sent while a turn is still running", () => {
+    expect(
+      queuedMessages([user("msg_1"), assistant("msg_2", 2), user("msg_3"), assistant("msg_4"), user("msg_5")]).map(
+        (message) => message.id,
+      ),
+    ).toEqual(["msg_5"])
+  })
+
+  test("returns every queued message when several stack up", () => {
+    expect(
+      queuedMessages([user("msg_1"), assistant("msg_2"), user("msg_3"), user("msg_4")]).map((message) => message.id),
+    ).toEqual(["msg_3", "msg_4"])
+  })
+
+  test("returns nothing when the session is idle", () => {
+    expect(queuedMessages([user("msg_1"), assistant("msg_2", 2)])).toEqual([])
+  })
+
+  test("ignores an abandoned turn that a later turn already completed", () => {
+    expect(queuedMessages([user("msg_1"), assistant("msg_2"), assistant("msg_3", 3)])).toEqual([])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33812

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

If you type a follow-up while the agent is streaming and then press ESC twice to interrupt, the message you typed is lost. It is still persisted server-side, but no turn ever runs for it and the QUEUED badge disappears, so you have to retype it.

The cause is that the interrupt handler aborts without checking whether a user message arrived after the running assistant turn started. `runLoop` only picks up a queued message when the current assistant message completes, so interrupting before that point leaves the message with nothing to consume it.

Before aborting, the handler now collects user messages newer than the running turn and puts their text and file parts back into the prompt box via `PromptRef.set` — the same call `session.undo` already uses to return a reverted message's text to the input. It only restores when the prompt is empty, so it will not overwrite a draft you have already started typing.

I used the client-side restore rather than re-arming the runner after `cancel`. Re-arming would make double-ESC sometimes stop the session and sometimes immediately start another turn, and when you interrupt you usually want to edit the message before resending it anyway.

One thing this does not fix: the orphaned user message still sits in the transcript. Removing it needs a `session.revert` call, which seemed like a separate change.

### How did you verify your code works?

`bun test test/prompt/queued.test.ts` in `packages/tui` — 4 new tests covering the `queuedMessages` selector: one queued message, several stacked up, an idle session, and an abandoned turn that a later turn already completed.

Full `packages/tui` suite: 195 pass, 1 skip, 0 fail. Baseline on `dev` is 191 pass, so that is the 4 added here and no regressions.

To reproduce by hand: start a turn, type a second message while it is streaming, then press ESC twice. Before this change the input box is empty and the text is gone; after it, the text is back in the box.

### Screenshots / recordings

No visual change — the diff is behavioural. The observable difference is that the prompt box contains your text after an interrupt instead of being empty.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR