### PR TITLE
fix(opencode): apply the configured provider filter to recent models

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1956,14 +1956,15 @@ const layer = Layer.effect(
         }),
         Effect.catch(() => Effect.succeed([] as { providerID: ProviderV2.ID; modelID: ModelV2.ID }[])),
       )
+      const configured = Object.keys(cfg.provider ?? {})
       for (const entry of recent) {
+        if (configured.length > 0 && !configured.includes(entry.providerID)) continue
         const provider = s.providers[entry.providerID]
         if (!provider) continue
         if (!provider.models[entry.modelID]) continue
         return { providerID: entry.providerID, modelID: entry.modelID }
       }
 
-      const configured = Object.keys(cfg.provider ?? {})
       const provider = Object.values(s.providers).find((p) => configured.length === 0 || configured.includes(p.id))
       if (!provider) return yield* new NoProvidersError()
       const [model] = sort(Object.values(provider.models))

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -375,6 +375,43 @@ it.instance(
 )
 
 it.instance(
+  "defaultModel ignores recent models from providers the config excludes",
+  Effect.gen(function* () {
+    yield* setProcessEnv("ANTHROPIC_API_KEY", "test-api-key")
+    const recent = path.join(Global.Path.state, "model.json")
+    yield* Effect.acquireRelease(
+      Effect.promise(() =>
+        Bun.write(recent, JSON.stringify({ recent: [{ providerID: "anthropic", modelID: "claude-sonnet-4-5" }] })),
+      ),
+      () => Effect.promise(() => unlink(recent).catch(() => undefined)),
+    )
+
+    const model = yield* Provider.use.defaultModel()
+    expect(String(model.providerID)).toBe("local-provider")
+    expect(String(model.modelID)).toBe("local-model")
+  }),
+  {
+    config: {
+      provider: {
+        "local-provider": {
+          name: "Local Provider",
+          npm: "@ai-sdk/openai-compatible",
+          api: "http://localhost:11434/v1",
+          models: {
+            "local-model": {
+              name: "Local Model",
+            },
+          },
+          options: {
+            apiKey: "local-key",
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
   "defaultModel returns a typed error when config excludes every provider",
   Effect.gen(function* () {
     const error = yield* Provider.use.defaultModel().pipe(Effect.flip)


### PR DESCRIPTION
### Issue for this PR

Closes #39191

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

If you have used a model from one provider and then change your config to declare only a different provider, opencode keeps starting sessions on the old model. My config listed only a local OpenAI-compatible provider, but new sessions still came up on `claude-sonnet-4-5`.

`defaultModel` walks the recently-used list from `model.json` before `configured` (the `cfg.provider` key list) is computed, and the loop only checks that the provider is loaded and still has the model. The allowlist is built after the loop and only gates the fallback path below it, so a recent entry always wins over the config.

This moves `configured` above the loop and skips recent entries whose provider is not in it. When no providers are configured the list is empty, so the guard is a no-op and the loop behaves exactly as before — that is what keeps the default path unchanged for people who do not set `provider` at all.

### How did you verify your code works?

`bun test test/provider/provider.test.ts` in `packages/opencode` — 100 pass, 0 fail. Baseline on `dev` is 99 pass, so that is the one test added here and no regressions.

The added test is `defaultModel ignores recent models from providers the config excludes`: it seeds `model.json` with an `anthropic` entry, configures only a `local-provider`, and asserts `defaultModel()` returns `local-provider/local-model`.

To reproduce by hand: use an Anthropic model once, then set your config `provider` to only a local endpoint and start a new session without `-m`. Before this change you get the Anthropic model back; after it you get the local one.

### Screenshots / recordings

No visual change. The observable difference is which model a new session starts on when your config no longer includes the provider you last used.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
