### PR TITLE
fix(opencode): correct the webfetch description about HTTP URLs

### DIFF
--- a/packages/opencode/src/tool/webfetch.txt
+++ b/packages/opencode/src/tool/webfetch.txt
@@ -7,7 +7,7 @@
 Usage notes:
   - IMPORTANT: if another tool is present that offers better web fetching capabilities, is more targeted to the task, or has fewer restrictions, prefer using that tool instead of this one.
   - The URL must be a fully-formed valid URL
-  - HTTP URLs will be automatically upgraded to HTTPS
+  - HTTP and HTTPS URLs are both fetched as provided
   - Format options: "markdown" (default), "text", or "html"
   - This tool is read-only and does not modify any files
   - Results may be summarized if the content is very large

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -98,6 +98,25 @@ describe("tool.webfetch", () => {
     ),
   )
 
+  it.instance("fetches http urls as provided and does not promise an https upgrade", () =>
+    withFetch(
+      () =>
+        new Response("plain http", {
+          status: 200,
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        }),
+      (url) =>
+        Effect.gen(function* () {
+          const info = yield* WebFetchTool
+          expect((yield* info.init()).description).not.toContain("upgraded to HTTPS")
+
+          const target = new URL("/plain.txt", url).toString()
+          expect(target.startsWith("http://")).toBe(true)
+          expect((yield* exec({ url: target, format: "text" })).output).toBe("plain http")
+        }),
+    ),
+  )
+
   it.instance("extracts text from html without scripts or styles", () =>
     withFetch(
       () =>


### PR DESCRIPTION
### Issue for this PR

Closes #39194

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The WebFetch tool description claims "HTTP URLs will be automatically upgraded to HTTPS". `webfetch.ts` never does this — it checks that the URL starts with `http://` or `https://` and then fetches it as given. Since the description goes into the prompt, the model is being told something untrue about a tool it calls.

There are two ways to close the gap and I took the documentation one rather than implementing the upgrade. Upgrading would break plain-HTTP hosts, and every existing webfetch test fetches from `http://localhost` — that is exactly the case that would start failing. Local dev servers and intranet hosts are a normal thing to point this tool at, so the behaviour looks deliberate and it is the description that drifted away from it.

The line now reads "HTTP and HTTPS URLs are both fetched as provided".

### How did you verify your code works?

`bun test test/tool/webfetch.test.ts` in `packages/opencode` — 5 pass, 0 fail. Baseline on `dev` is 4 pass, so that is the one test added here and no regressions.

The added test is `fetches http urls as provided and does not promise an https upgrade`. It asserts the rendered description no longer contains "upgraded to HTTPS", and separately that an `http://` URL is fetched and returns its body — so the test also fails if someone later adds a real upgrade without updating the text.

To confirm the original claim was wrong: there is no scheme rewriting anywhere in `webfetch.ts`, only the `startsWith` validation on line 35.

### Screenshots / recordings

No visual change. This is a one-line edit to a tool description file; the only observable difference is the text the model sees in the WebFetch tool definition.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
