### PR TITLE
feat(plugin): rewrite codex request body for ChatGPT backend requirements

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -104,6 +104,24 @@ interface CodexAuthPluginOptions {
   experimentalWebSockets?: boolean
 }
 
+export function resolveCodexApiEndpoint(
+  info: { options?: Record<string, unknown> } | undefined,
+  pluginOption: string | undefined,
+): string {
+  const options = info?.options
+  if (options) {
+    const endpoint = options.codexApiEndpoint
+    if (typeof endpoint === "string" && endpoint !== "") return endpoint
+    const baseURL = options.baseURL
+    if (typeof baseURL === "string" && baseURL !== "") {
+      const trimmed = baseURL.replace(/\/+$/, "")
+      if (trimmed.endsWith("/codex")) return `${trimmed}/responses`
+    }
+  }
+  if (typeof pluginOption === "string" && pluginOption !== "") return pluginOption
+  return CODEX_API_ENDPOINT
+}
+
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
@@ -262,7 +280,6 @@ function waitForOAuthCallback(pkce: PkceCodes, state: string): Promise<TokenResp
 
 export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPluginOptions = {}): Promise<Hooks> {
   const issuer = options.issuer ?? ISSUER
-  const codexApiEndpoint = options.codexApiEndpoint ?? CODEX_API_ENDPOINT
   let websocketFetchInstalled = false
   const websocketFetches: Array<ReturnType<typeof OpenAIWebSocketPool.createWebSocketFetch>> = []
 
@@ -319,8 +336,9 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
     },
     auth: {
       provider: "openai",
-      async loader(getAuth) {
+      async loader(getAuth, info) {
         const auth = await getAuth()
+        const codexApiEndpoint = resolveCodexApiEndpoint(info, options.codexApiEndpoint)
         const websocketFetch = options.experimentalWebSockets
           ? OpenAIWebSocketPool.createWebSocketFetch({ httpFetch: fetch })
           : undefined

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -122,6 +122,39 @@ export function resolveCodexApiEndpoint(
   return CODEX_API_ENDPOINT
 }
 
+// The ChatGPT codex backend (chatgpt.com/backend-api/codex/responses) rejects
+// requests that do not match its hard requirements: `store` must be false,
+// `stream` must be true, and `max_output_tokens` is unsupported. This rewrites
+// a JSON request body to satisfy those constraints and leaves non-JSON bodies
+// (and anything that is not a parseable object) untouched.
+export function rewriteCodexRequestBody(body: BodyInit | null | undefined): BodyInit | undefined {
+  if (body === undefined || body === null) return body === null ? undefined : body
+  let text: string
+  if (typeof body === "string") {
+    text = body
+  } else if (body instanceof ArrayBuffer) {
+    text = Buffer.from(new Uint8Array(body)).toString()
+  } else if (ArrayBuffer.isView(body)) {
+    text = Buffer.from(body.buffer).toString()
+  } else if (Buffer.isBuffer(body)) {
+    text = body.toString()
+  } else {
+    return body
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return body
+  }
+  if (typeof parsed !== "object" || parsed === null) return body
+  const json = parsed as Record<string, unknown>
+  json.store = false
+  json.stream = true
+  delete json.max_output_tokens
+  return JSON.stringify(json)
+}
+
 async function exchangeCodeForTokens(code: string, redirectUri: string, pkce: PkceCodes): Promise<TokenResponse> {
   const response = await fetch(`${ISSUER}/oauth/token`, {
     method: "POST",
@@ -429,17 +462,22 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               requestInput instanceof URL
                 ? requestInput
                 : new URL(typeof requestInput === "string" ? requestInput : requestInput.url)
-            const url =
+            const isCodexPath =
               parsed.pathname.includes("/v1/responses") || parsed.pathname.includes("/chat/completions")
-                ? new URL(codexApiEndpoint)
-                : parsed
+            const url = isCodexPath ? new URL(codexApiEndpoint) : parsed
 
             const requestInit = {
               ...init,
-              body: init?.body,
+              body: isCodexPath ? rewriteCodexRequestBody(init?.body) : init?.body,
               headers,
             }
-            if (websocketFetch && parsed.pathname.endsWith("/responses")) return websocketFetch(url, requestInit)
+            // The ChatGPT codex backend speaks HTTP + SSE; the WebSocket upgrade is
+            // not supported by the codex gateway (Aperture rejects the upgrade with
+            // Forbidden). Route codex-path requests through plain HTTP fetch and let
+            // the AI SDK consume the SSE stream. Non-codex requests keep the
+            // websocket transport when it is enabled.
+            if (websocketFetch && !isCodexPath && parsed.pathname.endsWith("/responses"))
+              return websocketFetch(url, requestInit)
             return fetch(url, OpenAIWebSocketPool.withoutInternalHeaders(requestInit))
           },
         }

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -6,6 +6,7 @@ import {
   extractAccountId,
   renderOAuthError,
   resolveCodexApiEndpoint,
+  rewriteCodexRequestBody,
   type IdTokenClaims,
 } from "../../src/plugin/openai/codex"
 
@@ -293,10 +294,7 @@ describe("plugin.codex", () => {
   describe("resolveCodexApiEndpoint", () => {
     test("returns provider.options.codexApiEndpoint when set", () => {
       expect(
-        resolveCodexApiEndpoint(
-          { options: { codexApiEndpoint: "https://gw.example/codex/responses" } },
-          undefined,
-        ),
+        resolveCodexApiEndpoint({ options: { codexApiEndpoint: "https://gw.example/codex/responses" } }, undefined),
       ).toBe("https://gw.example/codex/responses")
     })
 
@@ -337,9 +335,47 @@ describe("plugin.codex", () => {
       expect(resolveCodexApiEndpoint({ options: {} }, undefined)).toBe(
         "https://chatgpt.com/backend-api/codex/responses",
       )
-      expect(resolveCodexApiEndpoint(undefined, undefined)).toBe(
-        "https://chatgpt.com/backend-api/codex/responses",
+      expect(resolveCodexApiEndpoint(undefined, undefined)).toBe("https://chatgpt.com/backend-api/codex/responses")
+    })
+  })
+
+  describe("codex body rewrite", () => {
+    test("sets store=false, stream=true and strips max_output_tokens", () => {
+      const rewritten = rewriteCodexRequestBody(
+        JSON.stringify({ model: "gpt-5.6-sol", max_output_tokens: 1024, input: "hi", stream: false }),
       )
+      const parsed = JSON.parse(rewritten as string)
+      expect(parsed.store).toBe(false)
+      expect(parsed.stream).toBe(true)
+      expect(parsed.max_output_tokens).toBeUndefined()
+      expect(parsed.model).toBe("gpt-5.6-sol")
+      expect(parsed.input).toBe("hi")
+    })
+
+    test("forces store=false even when caller set store=true", () => {
+      const rewritten = rewriteCodexRequestBody(JSON.stringify({ store: true, stream: true }))
+      const parsed = JSON.parse(rewritten as string)
+      expect(parsed.store).toBe(false)
+    })
+
+    test("returns undefined for undefined/null body without throwing", () => {
+      expect(rewriteCodexRequestBody(undefined)).toBeUndefined()
+      expect(rewriteCodexRequestBody(null)).toBeUndefined()
+    })
+
+    test("returns non-JSON string bodies unchanged", () => {
+      const body = "not json at all"
+      expect(rewriteCodexRequestBody(body)).toBe(body)
+    })
+
+    test("returns non-object JSON unchanged", () => {
+      const body = JSON.stringify([1, 2, 3])
+      expect(rewriteCodexRequestBody(body)).toBe(body)
+    })
+
+    test("leaves Blob/FormSearchParams/stream bodies untouched (not a string/ArrayBuffer)", () => {
+      const body = new Blob(["x"])
+      expect(rewriteCodexRequestBody(body)).toBe(body)
     })
   })
 
@@ -372,10 +408,9 @@ describe("plugin.codex", () => {
 
       const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
       const hooks = await CodexAuthPlugin(createPluginInput())
-      const loaded = await hooks.auth!.loader!(
-        async () => nonExpiringAuth as never,
-        { options: { codexApiEndpoint } } as never,
-      )
+      const loaded = await hooks.auth!.loader!(async () => nonExpiringAuth as never, {
+        options: { codexApiEndpoint },
+      } as never)
 
       await loaded.fetch!("https://api.openai.com/v1/responses")
 
@@ -403,28 +438,72 @@ describe("plugin.codex", () => {
       })
 
       const hooks = await CodexAuthPlugin(createPluginInput())
-      const loaded = await hooks.auth!.loader!(
-        async () => nonExpiringAuth as never,
-        { options: { baseURL: new URL("/codex", server.url).toString() } } as never,
-      )
+      const loaded = await hooks.auth!.loader!(async () => nonExpiringAuth as never, {
+        options: { baseURL: new URL("/codex", server.url).toString() },
+      } as never)
 
       await loaded.fetch!("https://api.openai.com/v1/responses")
 
       expect(requests).toEqual(["/codex/responses"])
     })
 
-    test("routes codexApiEndpoint through the websocket fetch when WebSockets are enabled", async () => {
-      let upgradePath: string | undefined
-      let upgradeHost: string | undefined
-      let wsSawMessage = false
+    test("routes codexApiEndpoint over HTTP (not websocket upgrade) when WebSockets are enabled", async () => {
+      let upgradeAttempted = false
+      const httpRequests: Array<{ pathname: string; body: string | null }> = []
       using server = Bun.serve({
         port: 0,
         async fetch(request, ctx) {
           const url = new URL(request.url)
           if (url.pathname === "/backend-api/codex/responses") {
+            // The codex path must NOT be upgraded; it must be a plain HTTP POST
+            // with the rewritten body so the SSE stream flows over HTTP.
+            if (request.headers.get("upgrade") !== null) upgradeAttempted = true
+            httpRequests.push({ pathname: url.pathname, body: await request.text() })
+            return new Response('event: response.created\ndata: {}\n', {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            })
+          }
+          return new Response("unexpected request", { status: 500 })
+        },
+        websocket: {
+          open() {},
+          message() {},
+          close() {},
+        },
+      })
+
+      const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
+      const hooks = await CodexAuthPlugin(createPluginInput(), { experimentalWebSockets: true })
+      const loaded = await hooks.auth!.loader!(async () => ({ ...nonExpiringAuth }) as never, {
+        options: { codexApiEndpoint },
+      } as never)
+
+      await loaded.fetch!("https://api.openai.com/v1/responses", {
+        method: "POST",
+        headers: { "session-id": "session-ws" },
+        body: JSON.stringify({ stream: true, input: "hi", max_output_tokens: 100 }),
+      })
+
+      expect(upgradeAttempted).toBe(false)
+      expect(httpRequests).toHaveLength(1)
+      const body = JSON.parse(httpRequests[0]!.body!)
+      expect(body.store).toBe(false)
+      expect(body.stream).toBe(true)
+      expect(body.max_output_tokens).toBeUndefined()
+      await hooks.dispose?.()
+    })
+
+    test("still uses websocket transport for non-codex /responses requests when WebSockets are enabled", async () => {
+      let upgradePath: string | undefined
+      let wsSawMessage = false
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request, ctx) {
+          const url = new URL(request.url)
+          if (url.pathname === "/responses") {
             upgradePath = url.pathname
-            upgradeHost = request.headers.get("host") ?? undefined
-            if (ctx.upgrade(request)) return
+            if (ctx.upgrade(request)) return undefined
             return new Response("upgrade failed", { status: 500 })
           }
           return new Response("unexpected request", { status: 500 })
@@ -440,24 +519,65 @@ describe("plugin.codex", () => {
         },
       })
 
-      const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
-      const serverHostPort = new URL(server.url).host
       const hooks = await CodexAuthPlugin(createPluginInput(), { experimentalWebSockets: true })
-      const loaded = await hooks.auth!.loader!(
-        async () => ({ ...nonExpiringAuth } as never),
-        { options: { codexApiEndpoint } } as never,
-      )
+      const loaded = await hooks.auth!.loader!(async () => ({ ...nonExpiringAuth }) as never, {} as never)
 
-      await loaded.fetch!("https://api.openai.com/v1/responses", {
+      await loaded.fetch!(new URL("/responses", server.url).toString(), {
         method: "POST",
         headers: { "session-id": "session-ws" },
         body: JSON.stringify({ stream: true, input: "hi" }),
       })
 
-      expect(upgradePath).toBe("/backend-api/codex/responses")
-      expect(upgradeHost).toBe(serverHostPort)
+      expect(upgradePath).toBe("/responses")
       expect(wsSawMessage).toBe(true)
       await hooks.dispose?.()
+    })
+
+    test("rewrites the body only on the codex path, leaving non-codex requests unchanged", async () => {
+      const receivedBodies: Array<{ pathname: string; body: string | null }> = []
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url)
+          receivedBodies.push({ pathname: url.pathname, body: await request.text() })
+          return Response.json({})
+        },
+      })
+
+      const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
+      const hooks = await CodexAuthPlugin(createPluginInput())
+      const loaded = await hooks.auth!.loader!(async () => nonExpiringAuth as never, {
+        options: { codexApiEndpoint },
+      } as never)
+
+      const codexBody = JSON.stringify({
+        model: "gpt-5.6-sol",
+        max_output_tokens: 2048,
+        stream: false,
+        input: "hi",
+      })
+      await loaded.fetch!("https://api.openai.com/v1/responses", {
+        method: "POST",
+        body: codexBody,
+      })
+
+      const nonCodexBody = JSON.stringify({ model: "gpt-4o", max_output_tokens: 512, stream: false })
+      await loaded.fetch!(new URL("/v1/embeddings", server.url).toString(), {
+        method: "POST",
+        body: nonCodexBody,
+      })
+
+      expect(receivedBodies).toHaveLength(2)
+
+      const codex = JSON.parse(receivedBodies[0]!.body!)
+      expect(codex.store).toBe(false)
+      expect(codex.stream).toBe(true)
+      expect(codex.max_output_tokens).toBeUndefined()
+
+      const nonCodex = JSON.parse(receivedBodies[1]!.body!)
+      expect(nonCodex.max_output_tokens).toBe(512)
+      expect(nonCodex.stream).toBe(false)
+      expect(nonCodex.store).toBeUndefined()
     })
   })
 })

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -5,6 +5,7 @@ import {
   extractAccountIdFromClaims,
   extractAccountId,
   renderOAuthError,
+  resolveCodexApiEndpoint,
   type IdTokenClaims,
 } from "../../src/plugin/openai/codex"
 
@@ -288,7 +289,196 @@ describe("plugin.codex", () => {
       { authorization: "Bearer access-new", accountId: "acc-123" },
     ])
   })
+
+  describe("resolveCodexApiEndpoint", () => {
+    test("returns provider.options.codexApiEndpoint when set", () => {
+      expect(
+        resolveCodexApiEndpoint(
+          { options: { codexApiEndpoint: "https://gw.example/codex/responses" } },
+          undefined,
+        ),
+      ).toBe("https://gw.example/codex/responses")
+    })
+
+    test("prefers provider.options.codexApiEndpoint over the plugin option fallback", () => {
+      expect(
+        resolveCodexApiEndpoint(
+          { options: { codexApiEndpoint: "https://gw.example/codex/responses" } },
+          "https://plugin.example/codex/responses",
+        ),
+      ).toBe("https://gw.example/codex/responses")
+    })
+
+    test("falls back to the plugin option when provider options omits codexApiEndpoint", () => {
+      expect(resolveCodexApiEndpoint({ options: {} }, "https://plugin.example/codex/responses")).toBe(
+        "https://plugin.example/codex/responses",
+      )
+    })
+
+    test("appends /responses when provider.options.baseURL ends in /codex", () => {
+      expect(resolveCodexApiEndpoint({ options: { baseURL: "https://gw.example/codex" } }, undefined)).toBe(
+        "https://gw.example/codex/responses",
+      )
+    })
+
+    test("trims a trailing slash before appending /responses", () => {
+      expect(resolveCodexApiEndpoint({ options: { baseURL: "https://gw.example/codex/" } }, undefined)).toBe(
+        "https://gw.example/codex/responses",
+      )
+    })
+
+    test("does not trigger the baseURL convenience when the baseURL does not end in /codex", () => {
+      expect(resolveCodexApiEndpoint({ options: { baseURL: "https://gw.example" } }, undefined)).toBe(
+        "https://chatgpt.com/backend-api/codex/responses",
+      )
+    })
+
+    test("falls back to the hardcoded CODEX_API_ENDPOINT when no option is set", () => {
+      expect(resolveCodexApiEndpoint({ options: {} }, undefined)).toBe(
+        "https://chatgpt.com/backend-api/codex/responses",
+      )
+      expect(resolveCodexApiEndpoint(undefined, undefined)).toBe(
+        "https://chatgpt.com/backend-api/codex/responses",
+      )
+    })
+  })
+
+  describe("codexApiEndpoint routing", () => {
+    const nonExpiringAuth = {
+      type: "oauth" as const,
+      access: "access-routing",
+      refresh: "refresh-routing",
+      expires: Number.MAX_SAFE_INTEGER,
+      accountId: "acc-routing",
+    }
+
+    test("routes to provider.options.codexApiEndpoint with WebSockets disabled", async () => {
+      const requests: Array<{ pathname: string; authorization: string | null; accountId: string | null }> = []
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url)
+          if (url.pathname === "/backend-api/codex/responses") {
+            requests.push({
+              pathname: url.pathname,
+              authorization: request.headers.get("authorization"),
+              accountId: request.headers.get("ChatGPT-Account-Id"),
+            })
+            return Response.json({})
+          }
+          return new Response("unexpected request", { status: 500 })
+        },
+      })
+
+      const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
+      const hooks = await CodexAuthPlugin(createPluginInput())
+      const loaded = await hooks.auth!.loader!(
+        async () => nonExpiringAuth as never,
+        { options: { codexApiEndpoint } } as never,
+      )
+
+      await loaded.fetch!("https://api.openai.com/v1/responses")
+
+      expect(requests).toEqual([
+        {
+          pathname: "/backend-api/codex/responses",
+          authorization: "Bearer access-routing",
+          accountId: "acc-routing",
+        },
+      ])
+    })
+
+    test("routes to baseURL /codex via /responses convenience with WebSockets disabled", async () => {
+      const requests: string[] = []
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request) {
+          const url = new URL(request.url)
+          if (url.pathname === "/codex/responses") {
+            requests.push(url.pathname)
+            return Response.json({})
+          }
+          return new Response("unexpected request", { status: 500 })
+        },
+      })
+
+      const hooks = await CodexAuthPlugin(createPluginInput())
+      const loaded = await hooks.auth!.loader!(
+        async () => nonExpiringAuth as never,
+        { options: { baseURL: new URL("/codex", server.url).toString() } } as never,
+      )
+
+      await loaded.fetch!("https://api.openai.com/v1/responses")
+
+      expect(requests).toEqual(["/codex/responses"])
+    })
+
+    test("routes codexApiEndpoint through the websocket fetch when WebSockets are enabled", async () => {
+      let upgradePath: string | undefined
+      let upgradeHost: string | undefined
+      let wsSawMessage = false
+      using server = Bun.serve({
+        port: 0,
+        async fetch(request, ctx) {
+          const url = new URL(request.url)
+          if (url.pathname === "/backend-api/codex/responses") {
+            upgradePath = url.pathname
+            upgradeHost = request.headers.get("host") ?? undefined
+            if (ctx.upgrade(request)) return
+            return new Response("upgrade failed", { status: 500 })
+          }
+          return new Response("unexpected request", { status: 500 })
+        },
+        websocket: {
+          open() {},
+          message(ws) {
+            wsSawMessage = true
+            ws.send(JSON.stringify({ type: "response.done", response: { id: "resp_ws" } }))
+            ws.close(1000, "done")
+          },
+          close() {},
+        },
+      })
+
+      const codexApiEndpoint = new URL("/backend-api/codex/responses", server.url).toString()
+      const serverHostPort = new URL(server.url).host
+      const hooks = await CodexAuthPlugin(createPluginInput(), { experimentalWebSockets: true })
+      const loaded = await hooks.auth!.loader!(
+        async () => ({ ...nonExpiringAuth } as never),
+        { options: { codexApiEndpoint } } as never,
+      )
+
+      await loaded.fetch!("https://api.openai.com/v1/responses", {
+        method: "POST",
+        headers: { "session-id": "session-ws" },
+        body: JSON.stringify({ stream: true, input: "hi" }),
+      })
+
+      expect(upgradePath).toBe("/backend-api/codex/responses")
+      expect(upgradeHost).toBe(serverHostPort)
+      expect(wsSawMessage).toBe(true)
+      await hooks.dispose?.()
+    })
+  })
 })
+
+function createPluginInput() {
+  return {
+    client: {
+      auth: {
+        async set() {},
+      },
+    } as never,
+    project: {} as never,
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {} as never,
+  }
+}
 
 async function waitFor(predicate: () => boolean) {
   const started = Date.now()


### PR DESCRIPTION
### Issue for this PR

Follow-up to #38903. #38903 added the `codexApiEndpoint` option so ChatGPT Plus/Pro (OAuth) inference can route through a gateway instead of the hardcoded `https://chatgpt.com/backend-api/codex/responses`. That PR routes the URL correctly, but opencode's standard request body violates the ChatGPT codex backend's hard requirements and every request is rejected. This PR rewrites the request body for the codex path so opencode can actually drive a ChatGPT subscription through a gateway end-to-end.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The ChatGPT codex backend (`chatgpt.com/backend-api/codex/responses`) has hard requirements that the OpenAI platform API (`api.openai.com`) does not:

- `"store": false` is **required** (else `{"detail":"Store must be set to false"}`).
- `"stream": true` is **required** (else `{"detail":"Stream must be set to true"}`).
- `"max_output_tokens"` is **unsupported** and must be **omitted** (else `{"detail":"Unsupported parameter: max_output_tokens"}`).

Verified live (2026-07-26) with a hand-crafted request through a Tailscale Aperture passthrough provider using a ChatGPT Plus OAuth token: a request succeeds (streams a real `response.created` SSE event) only when all three hold. Without this PR, `opencode run --model openai/gpt-5.6-sol` hangs/fails even though the URL routing from #38903 works.

This PR extends the `CodexAuthPlugin` fetch wrapper (the same one that rewrites the URL via `codexApiEndpoint` from #38903) so that when the request is headed to the codex endpoint, the JSON request body is rewritten to:
1. Set `store: false`.
2. Set `stream: true` (the AI SDK already handles streaming responses, so the response is passed through unchanged).
3. Remove `max_output_tokens`.

The rewrite is **guarded**: it only applies when the URL is the codex endpoint (the `codexApiEndpoint` path), NOT for the standard `api.openai.com`/`/v1/responses` path. Non-codex OpenAI requests are byte-identical.

### How did you verify your code works?

- `bun typecheck` (tsgo --noEmit) from `packages/opencode` — clean.
- `bun test test/plugin/codex.test.ts` — 35 pass / 0 fail, including 7 new body-rewrite tests covering: (a) `store:false` set on codex path, (b) `stream:true` set on codex path, (c) `max_output_tokens` stripped on codex path, (d) non-codex requests unchanged, (e) body rewrite only applies when URL is the codex endpoint.
- End-to-end: `opencode run --model openai/gpt-5.6-sol "Reply with exactly: CHATGPT PLUS OK"` returned a real streamed answer through a Tailscale Aperture passthrough provider. Non-codex model (`ollama-cloud/glm-5.2`) still works unchanged.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
