### PR TITLE
fix(session): finalize assistant messages on failure

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1078,6 +1078,26 @@ const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
+    const finalizeAssistant = Effect.fnUntraced(function* (input: {
+      message: SessionV1.Assistant
+      error: unknown
+      aborted?: boolean
+    }) {
+      const stored = yield* MessageV2.get({ sessionID: input.message.sessionID, messageID: input.message.id }).pipe(
+        Effect.provideService(Database.Service, database),
+        Effect.option,
+      )
+      if (Option.isNone(stored)) return
+      if (stored.value.info.role !== "assistant") return
+      if (stored.value.info.time.completed) return
+      stored.value.info.error ??= MessageV2.fromError(input.error, {
+        providerID: stored.value.info.providerID,
+        aborted: input.aborted,
+      })
+      stored.value.info.time.completed = Date.now()
+      yield* sessions.updateMessage(stored.value.info)
+    })
+
     const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
@@ -1198,25 +1218,33 @@ const layer = Layer.effect(
             time: { created: Date.now() },
             sessionID,
           }
-          yield* sessions.updateMessage(msg)
 
-          const finalizeInterruptedAssistant = Effect.gen(function* () {
-            if (msg.time.completed) return
-            msg.error ??= MessageV2.fromError(new DOMException("Aborted", "AbortError"), {
-              providerID: msg.providerID,
-              aborted: true,
-            })
-            msg.time.completed = Date.now()
+          const finalizeFailedAssistant = (cause: Cause.Cause<never>) => {
+            const aborted = Cause.hasInterruptsOnly(cause)
+            return finalizeAssistant({
+              message: msg,
+              error: aborted ? new DOMException("Aborted", "AbortError") : Cause.squash(cause),
+              aborted,
+            }).pipe(
+              Effect.catchCause((finalizeCause) =>
+                Effect.logError("failed to finalize assistant message", {
+                  "session.id": sessionID,
+                  messageID: msg.id,
+                  error: Cause.squash(finalizeCause),
+                }),
+              ),
+              Effect.asVoid,
+            )
+          }
+
+          const handle = yield* Effect.gen(function* () {
             yield* sessions.updateMessage(msg)
-          })
-
-          const handle = yield* processor
-            .create({
+            return yield* processor.create({
               assistantMessage: msg,
               sessionID,
               model,
             })
-            .pipe(Effect.onInterrupt(() => finalizeInterruptedAssistant))
+          }).pipe(Effect.onError(finalizeFailedAssistant))
 
           const outcome: "break" | "continue" = yield* Effect.gen(function* () {
             const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
@@ -1327,10 +1355,7 @@ const layer = Layer.effect(
               })
             }
             return "continue" as const
-          }).pipe(
-            Effect.ensuring(instruction.clear(handle.message.id)),
-            Effect.onInterrupt(() => finalizeInterruptedAssistant),
-          )
+          }).pipe(Effect.ensuring(instruction.clear(handle.message.id)), Effect.onError(finalizeFailedAssistant))
           if (outcome === "break") break
           continue
         }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -163,6 +163,21 @@ const blockingProcessor = Layer.succeed(
     create: () => Effect.sync(() => processorCreateStarted.shift()?.()).pipe(Effect.andThen(Effect.never)),
   }),
 )
+const failingCreateProcessor = Layer.mock(SessionProcessor.Service, {
+  create: () => Effect.die(new Error("processor creation failed")),
+})
+const failingProcessProcessor = Layer.mock(SessionProcessor.Service, {
+  create: (input) =>
+    Effect.succeed({
+      message: input.assistantMessage,
+      updateToolCall: () => Effect.succeed(undefined),
+      completeToolCall: () => Effect.void,
+      process: () =>
+        Effect.sync(() => {
+          input.assistantMessage.finish = "stop"
+        }).pipe(Effect.andThen(Effect.die(new Error("processor execution failed")))),
+    } satisfies SessionProcessor.Handle),
+})
 
 const runtimeFlags = RuntimeFlags.layer({ experimentalEventSystem: true })
 
@@ -208,7 +223,10 @@ const promptRoot = LayerNode.group([
   RuntimeFlags.node,
 ])
 
-function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makePrompt(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking" | "failing-create" | "failing-process"
+}) {
   const replacements = [
     [SessionSummary.node, summary],
     [LSP.node, lsp],
@@ -217,6 +235,12 @@ function makePrompt(input?: { mcpInstructions?: MCP.ServerInstructions[]; proces
   ] as const
   if (input?.processor === "blocking") {
     return LayerNode.compile(promptRoot, [...replacements, [SessionProcessor.node, blockingProcessor]])
+  }
+  if (input?.processor === "failing-create") {
+    return LayerNode.compile(promptRoot, [...replacements, [SessionProcessor.node, failingCreateProcessor]])
+  }
+  if (input?.processor === "failing-process") {
+    return LayerNode.compile(promptRoot, [...replacements, [SessionProcessor.node, failingProcessProcessor]])
   }
   return LayerNode.compile(promptRoot, replacements)
 }
@@ -235,13 +259,18 @@ function makeHttp(input?: { mcpInstructions?: MCP.ServerInstructions[]; processo
   return LayerNode.compile(root, replacements)
 }
 
-function makeHttpNoLLMServer(input?: { mcpInstructions?: MCP.ServerInstructions[]; processor?: "blocking" }) {
+function makeHttpNoLLMServer(input?: {
+  mcpInstructions?: MCP.ServerInstructions[]
+  processor?: "blocking" | "failing-create" | "failing-process"
+}) {
   return makePrompt(input)
 }
 
 const it = testEffect(makeHttp())
 const noLLMServer = testEffect(makeHttpNoLLMServer())
 const raceNoLLMServer = testEffect(makeHttpNoLLMServer({ processor: "blocking" }))
+const failingCreateNoLLMServer = testEffect(makeHttpNoLLMServer({ processor: "failing-create" }))
+const failingProcessNoLLMServer = testEffect(makeHttpNoLLMServer({ processor: "failing-process" }))
 const withMcpInstructions = testEffect(
   makeHttp({
     mcpInstructions: [
@@ -1215,6 +1244,74 @@ raceNoLLMServer.instance(
     }),
   { config: cfg },
   3_000,
+)
+
+failingCreateNoLLMServer.instance(
+  "finalizes assistant when processor creation defects",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Processor creation defect" })
+      const parent = yield* user(chat.id, "hello")
+
+      const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasDies(exit.cause)).toBe(true)
+        expect(Cause.squash(exit.cause)).toMatchObject({ message: "processor creation failed" })
+      }
+
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const assistant = messages.find(
+        (message) => message.info.role === "assistant" && message.info.parentID === parent.id,
+      )
+      expect(assistant?.parts).toHaveLength(0)
+      expect(assistant?.info.role).toBe("assistant")
+      if (assistant?.info.role === "assistant") {
+        expect(assistant.info.finish).toBeUndefined()
+        expect(assistant.info.error).toMatchObject({
+          name: "UnknownError",
+          data: { message: "processor creation failed" },
+        })
+        expect(assistant.info.time.completed).toBeNumber()
+      }
+    }),
+  { config: cfg },
+)
+
+failingProcessNoLLMServer.instance(
+  "finalizes assistant when processor execution defects",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Processor execution defect" })
+      const parent = yield* user(chat.id, "hello")
+
+      const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.exit)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        expect(Cause.hasDies(exit.cause)).toBe(true)
+        expect(Cause.squash(exit.cause)).toMatchObject({ message: "processor execution failed" })
+      }
+
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const assistant = messages.find(
+        (message) => message.info.role === "assistant" && message.info.parentID === parent.id,
+      )
+      expect(assistant?.parts).toHaveLength(0)
+      expect(assistant?.info.role).toBe("assistant")
+      if (assistant?.info.role === "assistant") {
+        expect(assistant.info.finish).toBeUndefined()
+        expect(assistant.info.error).toMatchObject({
+          name: "UnknownError",
+          data: { message: "processor execution failed" },
+        })
+        expect(assistant.info.time.completed).toBeNumber()
+      }
+    }),
+  { config: cfg },
 )
 
 noLLMServer.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #38431

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The prompt loop saves an assistant message before processor setup. If setup or execution defects, that message can remain unfinished even though the failure propagates.

This adds failed-exit cleanup for the current provider turn. It reloads that turn's exact message, records the error and completion time when the message is still unfinished, leaves `finish` unchanged, and preserves the original failure. It does not scan or modify historical messages.

This replaces #38432, which was closed by compliance automation.

### How did you verify your code works?

- `bun test --timeout 30000 test/session/prompt.test.ts` (58 pass, 1 skip)
- `bun typecheck` (30 successful tasks)
- `bun run test:httpapi` (208 scenarios pass in each of coverage, auth, and effect modes)
- `bun run check:generated` from `packages/client`
- Prettier, Oxlint (0 errors), and `git diff --check origin/dev...HEAD`

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
