### PR TITLE
docs(providers): add Rapid-MLX as a local OpenAI-compatible provider

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1861,6 +1861,48 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### Rapid-MLX
+
+You can configure opencode to use local models through [Rapid-MLX](https://rapidmlx.com), an Apple-Silicon-native inference server that exposes an OpenAI-compatible API.
+
+Start the server with any [supported model](https://models.rapidmlx.com/):
+
+```bash
+rapid-mlx serve qwen3.5-9b-4bit
+```
+
+Then point opencode at it:
+
+```json title="opencode.json" "rapid-mlx" {5, 6, 8, 10-12}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "rapid-mlx": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Rapid-MLX (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:8000/v1"
+      },
+      "models": {
+        "qwen3.5-9b-4bit": {
+          "name": "Qwen3.5-9B (local)"
+        }
+      }
+    }
+  }
+}
+```
+
+In this example:
+
+- `rapid-mlx` is the custom provider ID. This can be any string you want.
+- `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
+- `name` is the display name for the provider in the UI.
+- `options.baseURL` is the endpoint for the local server. Rapid-MLX serves on port `8000` by default.
+- `models` is a map of model IDs to their configurations. Use any alias from the [Rapid-MLX model catalog](https://models.rapidmlx.com/).
+
+---
+
 ### SAP AI Core
 
 SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon, Meta, Mistral, and AI21 through a unified platform.


### PR DESCRIPTION
## What

Adds a **Rapid-MLX** section to the providers docs, under the same local / OpenAI-compatible pattern already documented for llama.cpp, LM Studio, and Ollama.

[Rapid-MLX](https://rapidmlx.com) is an Apple-Silicon-native inference server (MLX kernels, runs on any M-series Mac) that exposes an OpenAI-compatible API on `http://127.0.0.1:8000/v1`. Because it's OpenAI-compatible, it plugs into opencode through `@ai-sdk/openai-compatible` with no adapter — identical wiring to the existing local-provider entries.

## Why

opencode users on Macs increasingly run models locally; Rapid-MLX is a common Apple-Silicon serving option alongside Ollama / LM Studio / llama.cpp, and the config is currently undocumented. The new section is a ready-to-paste `opencode.json` mirroring the house style of the adjacent local-provider docs (server ID, `npm`, `name`, `options.baseURL`, `models`).

Docs-only change to `packages/web/src/content/docs/providers.mdx`.