### PR TITLE
fix(desktop): use channel database in local runs

### DIFF
--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -214,7 +214,6 @@ function createSidecarEnv(): Record<string, string> {
   )
   delete env.DEBUG
   if (process.platform === "linux") delete env.LD_PRELOAD
-  if (!app.isPackaged) env.OPENCODE_DISABLE_CHANNEL_DB = "1"
   return env
 }
 


### PR DESCRIPTION
## Summary
- stop disabling the channel database for unpackaged desktop runs
- use the local database during desktop development

## Testing
- `bun typecheck` in `packages/desktop`
- pre-push repository typecheck (30 packages)