### PR TITLE
test(core): add native watcher command reload test

### DIFF
--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -248,64 +248,54 @@ const describeNative = Watcher.hasNativeBinding() && !process.env.CI ? describe 
 // the debounced reload — no mocked change feed.
 describeNative("ConfigCommandPlugin native watcher", () => {
   it.live("reloads commands from real file edits", () =>
-    Effect.acquireRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ).pipe(
-      Effect.flatMap((tmp) => {
-        const global = path.join(tmp.path, "global")
-        const project = path.join(tmp.path, "project")
-        return Effect.promise(async () => {
-          await fs.mkdir(path.join(global, "commands"), { recursive: true })
-          await fs.mkdir(project, { recursive: true })
-        }).pipe(
-          Effect.andThen(
-            Effect.gen(function* () {
-              const command = yield* Command.Service
-              const config = yield* Config.Service
-              const bus = yield* Bus.Service
-              yield* ConfigCommandPlugin.Plugin.effect(
-                host({
-                  command: {
-                    list: () => Effect.die("unused command.list"),
-                    transform: command.transform,
-                    reload: command.reload,
-                  },
-                }),
-              )
-              yield* watchReady(config, global)
-
-              const created = yield* nextCommandUpdate(bus)
-              yield* Effect.promise(() => fs.writeFile(path.join(global, "commands", "review.md"), "Review native"))
-              yield* Fiber.join(created).pipe(Effect.timeout("10 seconds"))
-              expect((yield* command.get("review"))?.template).toBe("Review native")
-
-              const updated = yield* nextCommandUpdate(bus)
-              yield* Effect.promise(() =>
-                fs.writeFile(path.join(global, "commands", "review.md"), "Review native again"),
-              )
-              yield* Fiber.join(updated).pipe(Effect.timeout("10 seconds"))
-              expect((yield* command.get("review"))?.template).toBe("Review native again")
-            }).pipe(
-              Effect.provide(
-                AppNodeBuilder.build(LayerNode.group([Command.node, Config.node, Bus.node, FSUtil.node]), [
-                  [
-                    Location.node,
-                    Layer.succeed(
-                      Location.Service,
-                      Location.Service.of(location({ directory: AbsolutePath.make(project) })),
-                    ),
-                  ],
-                  [Global.node, Global.layerWith({ config: global, home: path.join(global, "home") })],
-                  [Credential.node, emptyCredentialNode],
-                  [WellKnown.node, emptyWellknownNode],
-                ]),
-              ),
-            ),
-          ),
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      // Watcher events report real paths, so resolve the tempdir symlink up front.
+      const tmp = yield* fs.makeTempDirectoryScoped({ prefix: "opencode-core-test-" }).pipe(Effect.flatMap(fs.realPath))
+      const global = path.join(tmp, "global")
+      yield* fs.makeDirectory(path.join(global, "commands"), { recursive: true })
+      yield* fs.makeDirectory(path.join(tmp, "project"))
+      yield* Effect.gen(function* () {
+        const command = yield* Command.Service
+        const config = yield* Config.Service
+        const bus = yield* Bus.Service
+        yield* ConfigCommandPlugin.Plugin.effect(
+          host({
+            command: {
+              list: () => Effect.die("unused command.list"),
+              transform: command.transform,
+              reload: command.reload,
+            },
+          }),
         )
-      }),
-    ),
+        yield* watchReady(config, global)
+
+        const created = yield* nextCommandUpdate(bus)
+        yield* fs.writeFileString(path.join(global, "commands", "review.md"), "Review native")
+        yield* Fiber.join(created).pipe(Effect.timeout("10 seconds"))
+        expect((yield* command.get("review"))?.template).toBe("Review native")
+
+        const updated = yield* nextCommandUpdate(bus)
+        yield* fs.writeFileString(path.join(global, "commands", "review.md"), "Review native again")
+        yield* Fiber.join(updated).pipe(Effect.timeout("10 seconds"))
+        expect((yield* command.get("review"))?.template).toBe("Review native again")
+      }).pipe(
+        Effect.provide(
+          AppNodeBuilder.build(LayerNode.group([Command.node, Config.node, Bus.node, FSUtil.node]), [
+            [
+              Location.node,
+              Layer.succeed(
+                Location.Service,
+                Location.Service.of(location({ directory: AbsolutePath.make(path.join(tmp, "project")) })),
+              ),
+            ],
+            [Global.node, Global.layerWith({ config: global, home: path.join(global, "home") })],
+            [Credential.node, emptyCredentialNode],
+            [WellKnown.node, emptyWellknownNode],
+          ]),
+        ),
+      )
+    }),
   )
 })
 
@@ -319,6 +309,7 @@ function nextCommandUpdate(bus: Bus.Interface) {
 // until the change feed delivers so command edits afterwards cannot be missed.
 function watchReady(config: Config.Interface, directory: string) {
   return Effect.gen(function* () {
+    const fs = yield* FSUtil.Service
     const seen = yield* Deferred.make<void>()
     const listener = yield* config.changes().pipe(
       Stream.runForEach(() => Deferred.succeed(seen, undefined).pipe(Effect.asVoid)),
@@ -327,12 +318,12 @@ function watchReady(config: Config.Interface, directory: string) {
     yield* Effect.yieldNow
     const probe = path.join(directory, ".watch-probe")
     while (true) {
-      yield* Effect.promise(() => fs.writeFile(probe, `ready-${Math.random()}`))
+      yield* fs.writeFileString(probe, `ready-${Math.random()}`)
       const result = yield* Deferred.await(seen).pipe(Effect.timeoutOption("250 millis"))
       if (Option.isSome(result)) break
     }
     yield* Fiber.interrupt(listener)
-    yield* Effect.promise(() => fs.rm(probe, { force: true }))
+    yield* fs.remove(probe, { force: true })
   }).pipe(
     Effect.timeoutOrElse({
       duration: "10 seconds",

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises"
 import path from "path"
 import { describe, expect } from "bun:test"
-import { Effect, Fiber, PubSub, Schema, Stream } from "effect"
+import { Deferred, Effect, Fiber, Layer, Option, PubSub, Schema, Stream } from "effect"
 import { advance, drain } from "../lib/clock"
 import { Config as ConfigSchema } from "@opencode-ai/schema/config"
 import { Command } from "@opencode-ai/core/command"
@@ -12,12 +12,18 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Bus } from "@opencode-ai/core/bus"
+import { Credential } from "@opencode-ai/core/credential"
+import { WellKnown } from "@opencode-ai/core/wellknown"
+import { Global } from "@opencode-ai/util/global"
 import { Location } from "@opencode-ai/core/location"
 import { MCP } from "@opencode-ai/core/mcp/index"
 import { Model } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { emptyCredentialNode, emptyWellknownNode } from "../fixture/config-nodes"
 import { emptyConfigLayer, emptyMcpLayer, testLocationLayer } from "../fixture/mcp"
+import { location } from "../fixture/location"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 import { host } from "../plugin/host"
@@ -234,6 +240,106 @@ Review files`,
     ),
   )
 })
+
+const describeNative = Watcher.hasNativeBinding() && !process.env.CI ? describe : describe.skip
+
+// End-to-end proof for #37429: a real file edit reaches the command registry
+// through the native watcher, Config's watch topology, the source filter, and
+// the debounced reload — no mocked change feed.
+describeNative("ConfigCommandPlugin native watcher", () => {
+  it.live("reloads commands from real file edits", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) => {
+        const global = path.join(tmp.path, "global")
+        const project = path.join(tmp.path, "project")
+        return Effect.promise(async () => {
+          await fs.mkdir(path.join(global, "commands"), { recursive: true })
+          await fs.mkdir(project, { recursive: true })
+        }).pipe(
+          Effect.andThen(
+            Effect.gen(function* () {
+              const command = yield* Command.Service
+              const config = yield* Config.Service
+              const bus = yield* Bus.Service
+              yield* ConfigCommandPlugin.Plugin.effect(
+                host({
+                  command: {
+                    list: () => Effect.die("unused command.list"),
+                    transform: command.transform,
+                    reload: command.reload,
+                  },
+                }),
+              )
+              yield* watchReady(config, global)
+
+              const created = yield* nextCommandUpdate(bus)
+              yield* Effect.promise(() => fs.writeFile(path.join(global, "commands", "review.md"), "Review native"))
+              yield* Fiber.join(created).pipe(Effect.timeout("10 seconds"))
+              expect((yield* command.get("review"))?.template).toBe("Review native")
+
+              const updated = yield* nextCommandUpdate(bus)
+              yield* Effect.promise(() =>
+                fs.writeFile(path.join(global, "commands", "review.md"), "Review native again"),
+              )
+              yield* Fiber.join(updated).pipe(Effect.timeout("10 seconds"))
+              expect((yield* command.get("review"))?.template).toBe("Review native again")
+            }).pipe(
+              Effect.provide(
+                AppNodeBuilder.build(LayerNode.group([Command.node, Config.node, Bus.node, FSUtil.node]), [
+                  [
+                    Location.node,
+                    Layer.succeed(
+                      Location.Service,
+                      Location.Service.of(location({ directory: AbsolutePath.make(project) })),
+                    ),
+                  ],
+                  [Global.node, Global.layerWith({ config: global, home: path.join(global, "home") })],
+                  [Credential.node, emptyCredentialNode],
+                  [WellKnown.node, emptyWellknownNode],
+                ]),
+              ),
+            ),
+          ),
+        )
+      }),
+    ),
+  )
+})
+
+function nextCommandUpdate(bus: Bus.Interface) {
+  return bus
+    .subscribe(Command.Event.Updated)
+    .pipe(Stream.take(1), Stream.runDrain, Effect.forkScoped({ startImmediately: true }))
+}
+
+// Native directory watches start asynchronously; probe with unrelated files
+// until the change feed delivers so command edits afterwards cannot be missed.
+function watchReady(config: Config.Interface, directory: string) {
+  return Effect.gen(function* () {
+    const seen = yield* Deferred.make<void>()
+    const listener = yield* config.changes().pipe(
+      Stream.runForEach(() => Deferred.succeed(seen, undefined).pipe(Effect.asVoid)),
+      Effect.forkScoped({ startImmediately: true }),
+    )
+    yield* Effect.yieldNow
+    const probe = path.join(directory, ".watch-probe")
+    while (true) {
+      yield* Effect.promise(() => fs.writeFile(probe, `ready-${Math.random()}`))
+      const result = yield* Deferred.await(seen).pipe(Effect.timeoutOption("250 millis"))
+      if (Option.isSome(result)) break
+    }
+    yield* Fiber.interrupt(listener)
+    yield* Effect.promise(() => fs.rm(probe, { force: true }))
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: "10 seconds",
+      orElse: () => Effect.fail(new Error("timed out waiting for the config watch to become ready")),
+    }),
+  )
+}
 
 function directoryEntry(directory: string) {
   return new Config.Directory({ type: "directory", path: AbsolutePath.make(directory) })

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -23,44 +23,13 @@ import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { WellKnown } from "@opencode-ai/core/wellknown"
 import { Integration } from "@opencode-ai/schema/integration"
+import { emptyCredentialNode, emptyWellknownNode } from "../fixture/config-nodes"
 import { location } from "../fixture/location"
 import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(Layer.empty)
 const selection = Schema.decodeUnknownSync(ConfigModel.Selection)
-
-const emptyCredentialNode = makeGlobalNode({
-  service: Credential.Service,
-  layer: Layer.succeed(
-    Credential.Service,
-    Credential.Service.of({
-      all: () => Effect.succeed([]),
-      list: () => Effect.succeed([]),
-      get: () => Effect.succeed(undefined),
-      create: () => Effect.die("unused Credential.create"),
-      update: () => Effect.die("unused Credential.update"),
-      remove: () => Effect.die("unused Credential.remove"),
-    }),
-  ),
-  deps: [],
-})
-
-const emptyWellknownNode = makeGlobalNode({
-  service: WellKnown.Service,
-  layer: Layer.succeed(
-    WellKnown.Service,
-    WellKnown.Service.of({
-      entries: () => Effect.succeed([]),
-      snapshot: () => [],
-      refresh: () => Effect.succeed(false),
-      add: () => Effect.die("unused Wellknown.add"),
-      remove: () => Effect.die("unused Wellknown.remove"),
-      resolve: () => Effect.die("unused Wellknown.resolve"),
-    }),
-  ),
-  deps: [],
-})
 
 function testLayer(
   directory: string,

--- a/packages/core/test/fixture/config-nodes.ts
+++ b/packages/core/test/fixture/config-nodes.ts
@@ -1,0 +1,36 @@
+import { Effect, Layer } from "effect"
+import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import { Credential } from "@opencode-ai/core/credential"
+import { WellKnown } from "@opencode-ai/core/wellknown"
+
+export const emptyCredentialNode = makeGlobalNode({
+  service: Credential.Service,
+  layer: Layer.succeed(
+    Credential.Service,
+    Credential.Service.of({
+      all: () => Effect.succeed([]),
+      list: () => Effect.succeed([]),
+      get: () => Effect.succeed(undefined),
+      create: () => Effect.die("unused Credential.create"),
+      update: () => Effect.die("unused Credential.update"),
+      remove: () => Effect.die("unused Credential.remove"),
+    }),
+  ),
+  deps: [],
+})
+
+export const emptyWellknownNode = makeGlobalNode({
+  service: WellKnown.Service,
+  layer: Layer.succeed(
+    WellKnown.Service,
+    WellKnown.Service.of({
+      entries: () => Effect.succeed([]),
+      snapshot: () => [],
+      refresh: () => Effect.succeed(false),
+      add: () => Effect.die("unused Wellknown.add"),
+      remove: () => Effect.die("unused Wellknown.remove"),
+      resolve: () => Effect.die("unused Wellknown.resolve"),
+    }),
+  ),
+  deps: [],
+})


### PR DESCRIPTION
## What

Adds the end-to-end native watcher integration test for command reload — the last unmet acceptance criterion on #37429. A real markdown file write must reach the live command registry through the full production chain: parcel native watcher → Config's watch topology → `config.changes()` → `isCommandSource` filter → debounced reload → `Command.Event.Updated`.

The merged reload work (#39160, #39171, #39174, and the agent equivalent) is covered by deterministic tests that drive a *mocked* change feed (`Config.testLayer` + `emitChange`); none of them prove Config's real watch reconciliation actually observes command directories. The issue's original repro was a real Vim `:saveas`, so the end-to-end proof is the point.

Closes #37429.

## How

- `packages/core/test/config/command.test.ts`: new `describeNative` block (gated on `Watcher.hasNativeBinding() && !process.env.CI`, matching the existing live watcher suites) building the real `Command + Config + Bus + FSUtil` node graph with the default native `Watcher` — no watcher replacement. Covers create and edit, each awaited through a `Command.Event.Updated` bus barrier.
- `watchReady` helper: native directory watches start asynchronously, so the test probes the global config root with unrelated files until `config.changes()` delivers, guaranteeing later command edits cannot be missed. Probe files don't match `isCommandSource` and don't change the discovered config, so they cause no spurious reloads.
- `packages/core/test/fixture/config-nodes.ts`: `emptyCredentialNode` / `emptyWellknownNode` stubs extracted from `config.test.ts` (now shared by both test files).

## Scope

- Test-only; no runtime changes.
- Configured local plugin source watching remains out of scope (needs the versioned-source design).

## Testing

From `packages/core`:

- `bun run test test/config/command.test.ts` — 8/8, including the new native test; the native test passed 5/5 consecutive runs.
- `bun run test test/config/config.test.ts` — 27/27 (fixture extraction).
- `bun typecheck` — clean.

## Flow

```mermaid
sequenceDiagram
    participant T as Test
    participant FS as Real filesystem
    participant W as Parcel watcher
    participant C as Config
    participant P as ConfigCommandPlugin
    participant R as Command registry

    T->>FS: probe writes until watch is live
    W-->>C: probe event → changes() delivers (ready)
    T->>FS: write commands/review.md
    W-->>C: native event
    C-->>P: changes() → isCommandSource → debounce
    P->>R: reload
    R-->>T: Command.Event.Updated (read barrier)
    T->>R: get("review") → "Review native"
```