### PR TITLE
fix(app): use blue for server status attention

### DIFF
--- a/packages/app/src/components/status-popover-indicator.test.ts
+++ b/packages/app/src/components/status-popover-indicator.test.ts
@@ -1,23 +1,45 @@
 import { describe, expect, test } from "bun:test"
-import { hasServiceNeedingAttention, serverStatusDotClass } from "./status-popover-indicator"
+import {
+  hasNonBlockingServiceIssue,
+  hasServiceNeedingAttention,
+  serverStatusDotClass,
+} from "./status-popover-indicator"
 
 describe("serverStatusDotClass", () => {
   test("uses the success token while the server and services are healthy", () => {
-    expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: false })).toBe("bg-icon-success-base")
+    expect(serverStatusDotClass({ ready: true, serverHealth: true, attention: false, issue: false })).toBe(
+      "bg-icon-success-base",
+    )
   })
 
   test("uses the session attention token when a service needs attention", () => {
-    expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: true })).toBe("bg-v2-background-bg-accent")
+    expect(serverStatusDotClass({ ready: true, serverHealth: true, attention: true, issue: true })).toBe(
+      "bg-v2-background-bg-accent",
+    )
+  })
+
+  test("uses the warning token for non-blocking errors", () => {
+    expect(serverStatusDotClass({ ready: true, serverHealth: true, attention: false, issue: true })).toBe(
+      "bg-icon-warning-base",
+    )
   })
 
   test("uses the critical token only after the server connection drops", () => {
-    expect(serverStatusDotClass({ ready: true, serverHealth: false, issue: false })).toBe("bg-icon-critical-base")
-    expect(serverStatusDotClass({ ready: true, serverHealth: false, issue: true })).toBe("bg-icon-critical-base")
+    expect(serverStatusDotClass({ ready: true, serverHealth: false, attention: false, issue: false })).toBe(
+      "bg-icon-critical-base",
+    )
+    expect(serverStatusDotClass({ ready: true, serverHealth: false, attention: true, issue: true })).toBe(
+      "bg-icon-critical-base",
+    )
   })
 
   test("stays neutral before status is ready", () => {
-    expect(serverStatusDotClass({ ready: false, serverHealth: true, issue: false })).toBe("bg-border-weak-base")
-    expect(serverStatusDotClass({ ready: false, serverHealth: undefined, issue: false })).toBe("bg-border-weak-base")
+    expect(serverStatusDotClass({ ready: false, serverHealth: true, attention: false, issue: false })).toBe(
+      "bg-border-weak-base",
+    )
+    expect(serverStatusDotClass({ ready: false, serverHealth: undefined, attention: false, issue: false })).toBe(
+      "bg-border-weak-base",
+    )
   })
 })
 
@@ -30,5 +52,21 @@ describe("hasServiceNeedingAttention", () => {
   test("ignores states that do not need user attention", () => {
     expect(hasServiceNeedingAttention({ mcp: ["failed"] })).toBe(false)
     expect(hasServiceNeedingAttention({ mcp: ["connected", "pending", "disabled"] })).toBe(false)
+  })
+})
+
+describe("hasNonBlockingServiceIssue", () => {
+  test("detects MCP and LSP failures", () => {
+    expect(hasNonBlockingServiceIssue({ mcp: ["failed"], lsp: [] })).toBe(true)
+    expect(hasNonBlockingServiceIssue({ mcp: [], lsp: ["error"] })).toBe(true)
+  })
+
+  test("includes attention states in the issue set", () => {
+    expect(hasNonBlockingServiceIssue({ mcp: ["needs_auth"], lsp: [] })).toBe(true)
+    expect(hasNonBlockingServiceIssue({ mcp: ["needs_client_registration"], lsp: [] })).toBe(true)
+  })
+
+  test("ignores healthy and inactive states", () => {
+    expect(hasNonBlockingServiceIssue({ mcp: ["connected", "pending", "disabled"], lsp: ["connected"] })).toBe(false)
   })
 })

--- a/packages/app/src/components/status-popover-indicator.test.ts
+++ b/packages/app/src/components/status-popover-indicator.test.ts
@@ -7,9 +7,7 @@ import {
 
 describe("serverStatusDotClass", () => {
   test("uses the success token while the server and services are healthy", () => {
-    expect(serverStatusDotClass({ ready: true, serverHealth: true, attention: false, issue: false })).toBe(
-      "bg-icon-success-base",
-    )
+    expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: false })).toBe("bg-icon-success-base")
   })
 
   test("uses the session attention token when a service needs attention", () => {
@@ -18,28 +16,32 @@ describe("serverStatusDotClass", () => {
     )
   })
 
-  test("uses the warning token for non-blocking errors", () => {
-    expect(serverStatusDotClass({ ready: true, serverHealth: true, attention: false, issue: true })).toBe(
-      "bg-icon-warning-base",
-    )
+  test("uses the warning token for non-blocking issues while the server is online", () => {
+    expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: true })).toBe("bg-icon-warning-base")
   })
 
   test("uses the critical token only after the server connection drops", () => {
-    expect(serverStatusDotClass({ ready: true, serverHealth: false, attention: false, issue: false })).toBe(
-      "bg-icon-critical-base",
-    )
-    expect(serverStatusDotClass({ ready: true, serverHealth: false, attention: true, issue: true })).toBe(
-      "bg-icon-critical-base",
-    )
+    expect(serverStatusDotClass({ ready: true, serverHealth: false, issue: false })).toBe("bg-icon-critical-base")
+    expect(serverStatusDotClass({ ready: true, serverHealth: false, issue: true })).toBe("bg-icon-critical-base")
   })
 
   test("stays neutral before status is ready", () => {
-    expect(serverStatusDotClass({ ready: false, serverHealth: true, attention: false, issue: false })).toBe(
-      "bg-border-weak-base",
-    )
-    expect(serverStatusDotClass({ ready: false, serverHealth: undefined, attention: false, issue: false })).toBe(
-      "bg-border-weak-base",
-    )
+    expect(serverStatusDotClass({ ready: false, serverHealth: true, issue: false })).toBe("bg-border-weak-base")
+    expect(serverStatusDotClass({ ready: false, serverHealth: undefined, issue: false })).toBe("bg-border-weak-base")
+  })
+})
+
+describe("hasNonBlockingServiceIssue", () => {
+  test("detects MCP failures that do not block chatting", () => {
+    expect(hasNonBlockingServiceIssue({ mcp: ["failed"], lsp: [] })).toBe(true)
+    expect(hasNonBlockingServiceIssue({ mcp: ["needs_auth"], lsp: [] })).toBe(true)
+    expect(hasNonBlockingServiceIssue({ mcp: ["needs_client_registration"], lsp: [] })).toBe(true)
+    expect(hasNonBlockingServiceIssue({ mcp: ["connected", "pending", "disabled"], lsp: [] })).toBe(false)
+  })
+
+  test("detects LSP failures that do not block chatting", () => {
+    expect(hasNonBlockingServiceIssue({ mcp: [], lsp: ["error"] })).toBe(true)
+    expect(hasNonBlockingServiceIssue({ mcp: [], lsp: ["connected"] })).toBe(false)
   })
 })
 
@@ -52,21 +54,5 @@ describe("hasServiceNeedingAttention", () => {
   test("ignores states that do not need user attention", () => {
     expect(hasServiceNeedingAttention({ mcp: ["failed"] })).toBe(false)
     expect(hasServiceNeedingAttention({ mcp: ["connected", "pending", "disabled"] })).toBe(false)
-  })
-})
-
-describe("hasNonBlockingServiceIssue", () => {
-  test("detects MCP and LSP failures", () => {
-    expect(hasNonBlockingServiceIssue({ mcp: ["failed"], lsp: [] })).toBe(true)
-    expect(hasNonBlockingServiceIssue({ mcp: [], lsp: ["error"] })).toBe(true)
-  })
-
-  test("includes attention states in the issue set", () => {
-    expect(hasNonBlockingServiceIssue({ mcp: ["needs_auth"], lsp: [] })).toBe(true)
-    expect(hasNonBlockingServiceIssue({ mcp: ["needs_client_registration"], lsp: [] })).toBe(true)
-  })
-
-  test("ignores healthy and inactive states", () => {
-    expect(hasNonBlockingServiceIssue({ mcp: ["connected", "pending", "disabled"], lsp: ["connected"] })).toBe(false)
   })
 })

--- a/packages/app/src/components/status-popover-indicator.test.ts
+++ b/packages/app/src/components/status-popover-indicator.test.ts
@@ -6,8 +6,8 @@ describe("serverStatusDotClass", () => {
     expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: false })).toBe("bg-icon-success-base")
   })
 
-  test("uses the warning token for non-blocking issues while the server is online", () => {
-    expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: true })).toBe("bg-icon-warning-base")
+  test("uses the session attention token when a service needs attention", () => {
+    expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: true })).toBe("bg-v2-background-bg-accent")
   })
 
   test("uses the critical token only after the server connection drops", () => {

--- a/packages/app/src/components/status-popover-indicator.test.ts
+++ b/packages/app/src/components/status-popover-indicator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { hasNonBlockingServiceIssue, serverStatusDotClass } from "./status-popover-indicator"
+import { hasServiceNeedingAttention, serverStatusDotClass } from "./status-popover-indicator"
 
 describe("serverStatusDotClass", () => {
   test("uses the success token while the server and services are healthy", () => {
@@ -21,16 +21,14 @@ describe("serverStatusDotClass", () => {
   })
 })
 
-describe("hasNonBlockingServiceIssue", () => {
-  test("detects MCP failures that do not block chatting", () => {
-    expect(hasNonBlockingServiceIssue({ mcp: ["failed"], lsp: [] })).toBe(true)
-    expect(hasNonBlockingServiceIssue({ mcp: ["needs_auth"], lsp: [] })).toBe(true)
-    expect(hasNonBlockingServiceIssue({ mcp: ["needs_client_registration"], lsp: [] })).toBe(true)
-    expect(hasNonBlockingServiceIssue({ mcp: ["connected", "pending", "disabled"], lsp: [] })).toBe(false)
+describe("hasServiceNeedingAttention", () => {
+  test("detects MCP states that need user attention", () => {
+    expect(hasServiceNeedingAttention({ mcp: ["needs_auth"] })).toBe(true)
+    expect(hasServiceNeedingAttention({ mcp: ["needs_client_registration"] })).toBe(true)
   })
 
-  test("detects LSP failures that do not block chatting", () => {
-    expect(hasNonBlockingServiceIssue({ mcp: [], lsp: ["error"] })).toBe(true)
-    expect(hasNonBlockingServiceIssue({ mcp: [], lsp: ["connected"] })).toBe(false)
+  test("ignores states that do not need user attention", () => {
+    expect(hasServiceNeedingAttention({ mcp: ["failed"] })).toBe(false)
+    expect(hasServiceNeedingAttention({ mcp: ["connected", "pending", "disabled"] })).toBe(false)
   })
 })

--- a/packages/app/src/components/status-popover-indicator.ts
+++ b/packages/app/src/components/status-popover-indicator.ts
@@ -1,14 +1,7 @@
-import type { LspStatus } from "@opencode-ai/sdk/v2/client"
 import type { McpServer } from "@opencode-ai/client/promise"
 
-export function hasNonBlockingServiceIssue(input: {
-  mcp: Array<McpServer["status"]["status"]>
-  lsp: Array<LspStatus["status"]>
-}) {
-  return (
-    input.mcp.some((status) => status !== "connected" && status !== "pending" && status !== "disabled") ||
-    input.lsp.some((status) => status === "error")
-  )
+export function hasServiceNeedingAttention(input: { mcp: Array<McpServer["status"]["status"]> }) {
+  return input.mcp.some((status) => status === "needs_auth" || status === "needs_client_registration")
 }
 
 export function serverStatusDotClass(input: { ready: boolean; serverHealth: boolean | undefined; issue: boolean }) {

--- a/packages/app/src/components/status-popover-indicator.ts
+++ b/packages/app/src/components/status-popover-indicator.ts
@@ -18,7 +18,7 @@ export function hasNonBlockingServiceIssue(input: {
 export function serverStatusDotClass(input: {
   ready: boolean
   serverHealth: boolean | undefined
-  attention: boolean
+  attention?: boolean
   issue: boolean
 }) {
   if (input.serverHealth === false) return "bg-icon-critical-base"

--- a/packages/app/src/components/status-popover-indicator.ts
+++ b/packages/app/src/components/status-popover-indicator.ts
@@ -7,7 +7,7 @@ export function hasServiceNeedingAttention(input: { mcp: Array<McpServer["status
 export function serverStatusDotClass(input: { ready: boolean; serverHealth: boolean | undefined; issue: boolean }) {
   if (input.serverHealth === false) return "bg-icon-critical-base"
   if (!input.ready || input.serverHealth === undefined) return "bg-border-weak-base"
-  if (input.issue) return "bg-icon-warning-base"
+  if (input.issue) return "bg-v2-background-bg-accent"
   if (input.serverHealth === true) return "bg-icon-success-base"
   return "bg-border-weak-base"
 }

--- a/packages/app/src/components/status-popover-indicator.ts
+++ b/packages/app/src/components/status-popover-indicator.ts
@@ -1,13 +1,30 @@
+import type { LspStatus } from "@opencode-ai/sdk/v2/client"
 import type { McpServer } from "@opencode-ai/client/promise"
 
 export function hasServiceNeedingAttention(input: { mcp: Array<McpServer["status"]["status"]> }) {
   return input.mcp.some((status) => status === "needs_auth" || status === "needs_client_registration")
 }
 
-export function serverStatusDotClass(input: { ready: boolean; serverHealth: boolean | undefined; issue: boolean }) {
+export function hasNonBlockingServiceIssue(input: {
+  mcp: Array<McpServer["status"]["status"]>
+  lsp: Array<LspStatus["status"]>
+}) {
+  return (
+    input.mcp.some((status) => status !== "connected" && status !== "pending" && status !== "disabled") ||
+    input.lsp.some((status) => status === "error")
+  )
+}
+
+export function serverStatusDotClass(input: {
+  ready: boolean
+  serverHealth: boolean | undefined
+  attention: boolean
+  issue: boolean
+}) {
   if (input.serverHealth === false) return "bg-icon-critical-base"
   if (!input.ready || input.serverHealth === undefined) return "bg-border-weak-base"
-  if (input.issue) return "bg-v2-background-bg-accent"
+  if (input.attention) return "bg-v2-background-bg-accent"
+  if (input.issue) return "bg-icon-warning-base"
   if (input.serverHealth === true) return "bg-icon-success-base"
   return "bg-border-weak-base"
 }

--- a/packages/app/src/components/status-popover.tsx
+++ b/packages/app/src/components/status-popover.tsx
@@ -9,7 +9,11 @@ import { ServerConnection, useServer } from "@/context/server"
 import { useServerSDK } from "@/context/server-sdk"
 import { useSync } from "@/context/sync"
 import { useGlobal } from "@/context/global"
-import { hasServiceNeedingAttention, serverStatusDotClass } from "./status-popover-indicator"
+import {
+  hasNonBlockingServiceIssue,
+  hasServiceNeedingAttention,
+  serverStatusDotClass,
+} from "./status-popover-indicator"
 
 const Body = lazy(() => import("./status-popover-body").then((x) => ({ default: x.StatusPopoverBody })))
 const ServerBody = lazy(() => import("./status-popover-body").then((x) => ({ default: x.StatusPopoverServerBody })))
@@ -22,9 +26,15 @@ export function StatusPopover() {
   const [shown, setShown] = createSignal(false)
   const serverHealth = () => global.servers.health[server.key]?.healthy
   const ready = createMemo(() => serverHealth() === false || (sync().data.mcp_ready && sync().data.lsp_ready))
-  const issue = createMemo(() =>
+  const attention = createMemo(() =>
     hasServiceNeedingAttention({
       mcp: Object.values(sync().data.mcp ?? {}).map((item) => item.status),
+    }),
+  )
+  const issue = createMemo(() =>
+    hasNonBlockingServiceIssue({
+      mcp: Object.values(sync().data.mcp ?? {}).map((item) => item.status),
+      lsp: (sync().data.lsp ?? []).map((item) => item.status),
     }),
   )
 
@@ -48,6 +58,7 @@ export function StatusPopover() {
             class={`absolute -top-px -right-px size-1.5 rounded-full ${serverStatusDotClass({
               ready: ready(),
               serverHealth: serverHealth(),
+              attention: attention(),
               issue: issue(),
             })}`}
           />
@@ -84,15 +95,22 @@ function DirectoryStatusPopover() {
   const [shown, setShown] = createSignal(false)
   const serverHealth = () => global.servers.health[ServerConnection.key(server().server)]?.healthy
   const ready = createMemo(() => serverHealth() === false || (sync().data.mcp_ready && sync().data.lsp_ready))
-  const issue = createMemo(() =>
+  const attention = createMemo(() =>
     hasServiceNeedingAttention({
       mcp: Object.values(sync().data.mcp ?? {}).map((item) => item.status),
+    }),
+  )
+  const issue = createMemo(() =>
+    hasNonBlockingServiceIssue({
+      mcp: Object.values(sync().data.mcp ?? {}).map((item) => item.status),
+      lsp: (sync().data.lsp ?? []).map((item) => item.status),
     }),
   )
   const state = createMemo<StatusPopoverState>(() => ({
     shown: shown(),
     ready: ready(),
     serverHealth: serverHealth(),
+    attention: attention(),
     issue: issue(),
     label: language.t("status.popover.trigger"),
     onOpenChange: setShown,
@@ -116,6 +134,7 @@ function ServerStatusPopover() {
     shown: shown(),
     ready: serverHealth() !== undefined,
     serverHealth: serverHealth(),
+    attention: false,
     issue: false,
     label: language.t("status.popover.trigger"),
     onOpenChange: setShown,
@@ -133,6 +152,7 @@ type StatusPopoverState = {
   shown: boolean
   ready: boolean
   serverHealth: boolean | undefined
+  attention: boolean
   issue: boolean
   label: string
   onOpenChange: (value: boolean) => void

--- a/packages/app/src/components/status-popover.tsx
+++ b/packages/app/src/components/status-popover.tsx
@@ -9,7 +9,7 @@ import { ServerConnection, useServer } from "@/context/server"
 import { useServerSDK } from "@/context/server-sdk"
 import { useSync } from "@/context/sync"
 import { useGlobal } from "@/context/global"
-import { hasNonBlockingServiceIssue, serverStatusDotClass } from "./status-popover-indicator"
+import { hasServiceNeedingAttention, serverStatusDotClass } from "./status-popover-indicator"
 
 const Body = lazy(() => import("./status-popover-body").then((x) => ({ default: x.StatusPopoverBody })))
 const ServerBody = lazy(() => import("./status-popover-body").then((x) => ({ default: x.StatusPopoverServerBody })))
@@ -23,9 +23,8 @@ export function StatusPopover() {
   const serverHealth = () => global.servers.health[server.key]?.healthy
   const ready = createMemo(() => serverHealth() === false || (sync().data.mcp_ready && sync().data.lsp_ready))
   const issue = createMemo(() =>
-    hasNonBlockingServiceIssue({
+    hasServiceNeedingAttention({
       mcp: Object.values(sync().data.mcp ?? {}).map((item) => item.status),
-      lsp: (sync().data.lsp ?? []).map((item) => item.status),
     }),
   )
 
@@ -86,9 +85,8 @@ function DirectoryStatusPopover() {
   const serverHealth = () => global.servers.health[ServerConnection.key(server().server)]?.healthy
   const ready = createMemo(() => serverHealth() === false || (sync().data.mcp_ready && sync().data.lsp_ready))
   const issue = createMemo(() =>
-    hasNonBlockingServiceIssue({
+    hasServiceNeedingAttention({
       mcp: Object.values(sync().data.mcp ?? {}).map((item) => item.status),
-      lsp: (sync().data.lsp ?? []).map((item) => item.status),
     }),
   )
   const state = createMemo<StatusPopoverState>(() => ({


### PR DESCRIPTION
## Summary

- use the same blue accent as session tabs when MCP authentication or client registration requires action
- preserve the existing orange indicator for MCP/LSP errors
- preserve green for healthy connections and red for server disconnections

## Testing

- `bun test src/components/status-popover-indicator.test.ts` (packages/app)
- `bun typecheck` (packages/app)
- pre-push repository typecheck (30 tasks)