### PR TITLE
feat(core): reload configured plugins from source edits

### DIFF
--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -1,7 +1,7 @@
 export * as PluginSupervisor from "./supervisor"
 
 import { Event } from "@opencode-ai/schema/config"
-import { Context, Deferred, Effect, Exit, Layer, Option, PubSub, RcMap, Schema, Scope, Semaphore, Stream } from "effect"
+import { Context, Deferred, Effect, Layer, Option, PubSub, Schema, Semaphore, Stream } from "effect"
 import path from "path"
 import { fileURLToPath, pathToFileURL } from "url"
 import { Agent } from "../agent"
@@ -236,50 +236,33 @@ const layer = Layer.effect(
 
     // Configured local plugin files can live outside config roots, where the
     // config change feed cannot see them; watch those entrypoints directly.
-    // Each entry holds one background watch alive while any generation
-    // references its target.
+    // Watches start on first sighting and are never torn down individually:
+    // a stale watch after a config edit costs one deduped fs handle and a
+    // no-op activation, and every watch dies with this layer's scope.
     const configuredChanges = yield* PubSub.unbounded<void>()
-    const watches = yield* RcMap.make({
-      lookup: (target: string) =>
-        watcher.subscribe({ path: target, type: "file" }).pipe(
-          Stream.runForEach(() => PubSub.publish(configuredChanges, undefined)),
-          Effect.catchCause((cause) => Effect.logError("configured plugin watch failed", { target, cause })),
-          Effect.forkScoped({ startImmediately: true }),
-          Effect.asVoid,
-        ),
-    })
-    // Watches live in per-activation scopes: acquiring the next generation
-    // before closing the previous one keeps unchanged targets subscribed
-    // through the refcount overlap.
-    let generation: Scope.Closeable | undefined
-    yield* Effect.addFinalizer(() =>
-      Effect.suspend(() => (generation ? Scope.close(generation, Exit.void) : Effect.void)),
-    )
-    const rotateWatches = Effect.fn("PluginSupervisor.rotateWatches")(function* (
+    const watched = new Set<string>()
+    const watchConfiguredSources = Effect.fn("PluginSupervisor.watchConfiguredSources")(function* (
       entries: readonly Config.Entry[],
       operations: readonly Operation[],
     ) {
-      const targets = yield* Effect.filter(
-        operations.flatMap((operation) =>
-          operation.type === "add" &&
-          path.isAbsolute(operation.target) &&
-          // The config change feed already covers {plugin,plugins} directories.
-          !isPluginSource(entries, operation.target)
-            ? [operation.target]
-            : [],
-        ),
+      for (const operation of operations) {
+        if (operation.type !== "add" || !path.isAbsolute(operation.target)) continue
+        if (watched.has(operation.target)) continue
+        // The config change feed already covers {plugin,plugins} directories.
+        if (isPluginSource(entries, operation.target)) continue
         // Watch file entrypoints only. Editing inside a directory target does
         // not change the directory's mtime, so the ?mtime= cache-busting could
         // not reload it anyway; directory targets behave as before.
-        (target) => Effect.map(fs.isDir(target), (isDir) => !isDir),
-      )
-      const next = yield* Scope.make()
-      yield* Effect.forEach(targets, (target) => RcMap.get(watches, target), { discard: true }).pipe(
-        Scope.provide(next),
-      )
-      const previous = generation
-      generation = next
-      if (previous) yield* Scope.close(previous, Exit.void)
+        if (yield* fs.isDir(operation.target)) continue
+        watched.add(operation.target)
+        yield* watcher.subscribe({ path: operation.target, type: "file" }).pipe(
+          Stream.runForEach(() => PubSub.publish(configuredChanges, undefined)),
+          Effect.catchCause((cause) =>
+            Effect.logError("configured plugin watch failed", { target: operation.target, cause }),
+          ),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+      }
     })
 
     const activate = Effect.fn("PluginSupervisor.activate")(function* (target: number) {
@@ -293,7 +276,7 @@ const layer = Layer.effect(
           const post = internal.post.map((plugin) => ({ ...plugin, version: "internal" }))
           const entries = yield* config.entries()
           const operations = yield* scan(entries)
-          yield* rotateWatches(entries, operations)
+          yield* watchConfiguredSources(entries, operations)
           // Apply config operations and load enabled package plugins into one ordered generation.
           const plugins = yield* resolve(pre, post, operations)
           // Replace the active generation in one scoped, batched activation.

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -1,7 +1,7 @@
 export * as PluginSupervisor from "./supervisor"
 
 import { Event } from "@opencode-ai/schema/config"
-import { Context, Deferred, Effect, Layer, Option, Schema, Semaphore, Stream } from "effect"
+import { Context, Deferred, Effect, Fiber, Layer, Option, PubSub, Schema, Semaphore, Stream } from "effect"
 import path from "path"
 import { fileURLToPath, pathToFileURL } from "url"
 import { Agent } from "../agent"
@@ -14,6 +14,7 @@ import { httpClient } from "@opencode-ai/util/effect/app-node-platform"
 import { Bus } from "../bus"
 import { FileMutation } from "../file-mutation"
 import { FileSystem } from "../filesystem"
+import { Watcher } from "../filesystem/watcher"
 import { Form } from "../form"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
@@ -45,9 +46,9 @@ const PluginModule = Schema.Struct({
   default: Schema.Union([
     Schema.Struct({
       id: Schema.String,
-    effect: Schema.declare<import("@opencode-ai/plugin/effect/plugin").Plugin["effect"]>(
-      (input): input is import("@opencode-ai/plugin/effect/plugin").Plugin["effect"] => typeof input === "function",
-    ),
+      effect: Schema.declare<import("@opencode-ai/plugin/effect/plugin").Plugin["effect"]>(
+        (input): input is import("@opencode-ai/plugin/effect/plugin").Plugin["effect"] => typeof input === "function",
+      ),
     }),
     Schema.Struct({
       id: Schema.String,
@@ -226,10 +227,46 @@ const layer = Layer.effect(
     const sdk = yield* SdkPlugins.Service
     const config = yield* Config.Service
     const bus = yield* Bus.Service
+    const watcher = yield* Watcher.Service
+    const fs = yield* FSUtil.Service
     const lock = Semaphore.makeUnsafe(1)
     const ready = yield* Deferred.make<void>()
     let observed = 0
     let applied = -1
+
+    // Configured local plugin files can live outside config roots, where the
+    // config change feed cannot see them; watch those entrypoints directly.
+    const configuredChanges = yield* PubSub.unbounded<void>()
+    const watches = new Map<string, Effect.Effect<void>>()
+    const reconcileWatches = Effect.fn("PluginSupervisor.reconcileWatches")(function* (
+      entries: readonly Config.Entry[],
+      operations: readonly Operation[],
+    ) {
+      const targets = new Set<string>()
+      for (const operation of operations) {
+        if (operation.type !== "add" || !path.isAbsolute(operation.target)) continue
+        // The config change feed already covers {plugin,plugins} directories.
+        if (isPluginSource(entries, operation.target)) continue
+        // File entrypoints only: directory targets keep reloading on config
+        // changes alone, and their revisions need a separate design.
+        if (yield* fs.isDir(operation.target)) continue
+        targets.add(operation.target)
+      }
+      for (const [target, stop] of watches) {
+        if (targets.has(target)) continue
+        watches.delete(target)
+        yield* stop
+      }
+      for (const target of targets) {
+        if (watches.has(target)) continue
+        const fiber = yield* watcher.subscribe({ path: target, type: "file" }).pipe(
+          Stream.runForEach(() => PubSub.publish(configuredChanges, undefined)),
+          Effect.catchCause((cause) => Effect.logError("configured plugin watch failed", { target, cause })),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        watches.set(target, Fiber.interrupt(fiber).pipe(Effect.asVoid))
+      }
+    })
 
     const activate = Effect.fn("PluginSupervisor.activate")(function* (target: number) {
       yield* lock.withPermit(
@@ -240,7 +277,9 @@ const layer = Layer.effect(
           // Combine internal plugins with host-contributed SDK plugins in boot order.
           const pre = [...internal.pre.map((plugin) => ({ ...plugin, version: "internal" })), ...sdk.all()]
           const post = internal.post.map((plugin) => ({ ...plugin, version: "internal" }))
-          const operations = yield* scan(yield* config.entries())
+          const entries = yield* config.entries()
+          const operations = yield* scan(entries)
+          yield* reconcileWatches(entries, operations)
           // Apply config operations and load enabled package plugins into one ordered generation.
           const plugins = yield* resolve(pre, post, operations)
           // Replace the active generation in one scoped, batched activation.
@@ -249,26 +288,22 @@ const layer = Layer.effect(
         }),
       )
     })
-    const sourceChanges = config
-      .changes()
-      .pipe(
-        Stream.filterEffect((update) =>
-          Effect.map(config.entries(), (entries) => isPluginSource(entries, update.path)),
-        ),
-        // Make accepted filesystem work visible to flush before coalescing the burst.
-        Stream.mapEffect(() => Effect.sync(() => ++observed)),
-        Stream.debounce("100 millis"),
-      )
+    const sourceChanges = config.changes().pipe(
+      Stream.filterEffect((update) => Effect.map(config.entries(), (entries) => isPluginSource(entries, update.path))),
+      Stream.merge(Stream.fromPubSub(configuredChanges)),
+      // Make accepted filesystem work visible to flush before coalescing the burst.
+      Stream.mapEffect(() => Effect.sync(() => ++observed)),
+      Stream.debounce("100 millis"),
+    )
     const busUpdates = bus
       .subscribe([Event.Updated, SdkPlugins.Updated])
       .pipe(Stream.mapEffect(() => Effect.sync(() => ++observed)))
     const updates = yield* Stream.merge(busUpdates, sourceChanges).pipe(
       Stream.toQueue({ capacity: 1, strategy: "sliding" }),
     )
-    const signals = yield* Stream.concat(
-      Stream.succeed(0),
-      Stream.fromQueue(updates),
-    ).pipe(Stream.broadcast({ capacity: 1, strategy: "sliding", replay: 1 }))
+    const signals = yield* Stream.concat(Stream.succeed(0), Stream.fromQueue(updates)).pipe(
+      Stream.broadcast({ capacity: 1, strategy: "sliding", replay: 1 }),
+    )
     const attempt = (target: number) =>
       activate(target).pipe(
         Effect.map(() => observed === target),
@@ -329,6 +364,7 @@ export const node = makeLocationNode({
     Shell.node,
     Skill.node,
     Tool.node,
+    Watcher.node,
     WebSearch.node,
     WellKnown.node,
   ],

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -1,7 +1,7 @@
 export * as PluginSupervisor from "./supervisor"
 
 import { Event } from "@opencode-ai/schema/config"
-import { Context, Deferred, Effect, Fiber, Layer, Option, PubSub, Schema, Semaphore, Stream } from "effect"
+import { Context, Deferred, Effect, Exit, Layer, Option, PubSub, RcMap, Schema, Scope, Semaphore, Stream } from "effect"
 import path from "path"
 import { fileURLToPath, pathToFileURL } from "url"
 import { Agent } from "../agent"
@@ -236,36 +236,50 @@ const layer = Layer.effect(
 
     // Configured local plugin files can live outside config roots, where the
     // config change feed cannot see them; watch those entrypoints directly.
+    // Each entry holds one background watch alive while any generation
+    // references its target.
     const configuredChanges = yield* PubSub.unbounded<void>()
-    const watches = new Map<string, Effect.Effect<void>>()
-    const reconcileWatches = Effect.fn("PluginSupervisor.reconcileWatches")(function* (
-      entries: readonly Config.Entry[],
-      operations: readonly Operation[],
-    ) {
-      const targets = new Set<string>()
-      for (const operation of operations) {
-        if (operation.type !== "add" || !path.isAbsolute(operation.target)) continue
-        // The config change feed already covers {plugin,plugins} directories.
-        if (isPluginSource(entries, operation.target)) continue
-        // File entrypoints only: directory targets keep reloading on config
-        // changes alone, and their revisions need a separate design.
-        if (yield* fs.isDir(operation.target)) continue
-        targets.add(operation.target)
-      }
-      for (const [target, stop] of watches) {
-        if (targets.has(target)) continue
-        watches.delete(target)
-        yield* stop
-      }
-      for (const target of targets) {
-        if (watches.has(target)) continue
-        const fiber = yield* watcher.subscribe({ path: target, type: "file" }).pipe(
+    const watches = yield* RcMap.make({
+      lookup: (target: string) =>
+        watcher.subscribe({ path: target, type: "file" }).pipe(
           Stream.runForEach(() => PubSub.publish(configuredChanges, undefined)),
           Effect.catchCause((cause) => Effect.logError("configured plugin watch failed", { target, cause })),
           Effect.forkScoped({ startImmediately: true }),
-        )
-        watches.set(target, Fiber.interrupt(fiber).pipe(Effect.asVoid))
-      }
+          Effect.asVoid,
+        ),
+    })
+    // Watches live in per-activation scopes: acquiring the next generation
+    // before closing the previous one keeps unchanged targets subscribed
+    // through the refcount overlap.
+    let generation: Scope.Closeable | undefined
+    yield* Effect.addFinalizer(() =>
+      Effect.suspend(() => (generation ? Scope.close(generation, Exit.void) : Effect.void)),
+    )
+    const rotateWatches = Effect.fn("PluginSupervisor.rotateWatches")(function* (
+      entries: readonly Config.Entry[],
+      operations: readonly Operation[],
+    ) {
+      const targets = yield* Effect.filter(
+        operations.flatMap((operation) =>
+          operation.type === "add" &&
+          path.isAbsolute(operation.target) &&
+          // The config change feed already covers {plugin,plugins} directories.
+          !isPluginSource(entries, operation.target)
+            ? [operation.target]
+            : [],
+        ),
+        // Watch file entrypoints only. Editing inside a directory target does
+        // not change the directory's mtime, so the ?mtime= cache-busting could
+        // not reload it anyway; directory targets behave as before.
+        (target) => Effect.map(fs.isDir(target), (isDir) => !isDir),
+      )
+      const next = yield* Scope.make()
+      yield* Effect.forEach(targets, (target) => RcMap.get(watches, target), { discard: true }).pipe(
+        Scope.provide(next),
+      )
+      const previous = generation
+      generation = next
+      if (previous) yield* Scope.close(previous, Exit.void)
     })
 
     const activate = Effect.fn("PluginSupervisor.activate")(function* (target: number) {
@@ -279,7 +293,7 @@ const layer = Layer.effect(
           const post = internal.post.map((plugin) => ({ ...plugin, version: "internal" }))
           const entries = yield* config.entries()
           const operations = yield* scan(entries)
-          yield* reconcileWatches(entries, operations)
+          yield* rotateWatches(entries, operations)
           // Apply config operations and load enabled package plugins into one ordered generation.
           const plugins = yield* resolve(pre, post, operations)
           // Replace the active generation in one scoped, batched activation.

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -1,5 +1,6 @@
 export * as PluginSupervisor from "./supervisor"
 
+import type { Plugin as PluginDefinition } from "@opencode-ai/plugin/effect/plugin"
 import { Event } from "@opencode-ai/schema/config"
 import { Context, Deferred, Effect, Layer, Option, PubSub, Schema, Semaphore, Stream } from "effect"
 import path from "path"
@@ -46,8 +47,8 @@ const PluginModule = Schema.Struct({
   default: Schema.Union([
     Schema.Struct({
       id: Schema.String,
-      effect: Schema.declare<import("@opencode-ai/plugin/effect/plugin").Plugin["effect"]>(
-        (input): input is import("@opencode-ai/plugin/effect/plugin").Plugin["effect"] => typeof input === "function",
+      effect: Schema.declare<PluginDefinition["effect"]>(
+        (input): input is PluginDefinition["effect"] => typeof input === "function",
       ),
     }),
     Schema.Struct({
@@ -250,9 +251,8 @@ const layer = Layer.effect(
         if (watched.has(operation.target)) continue
         // The config change feed already covers {plugin,plugins} directories.
         if (isPluginSource(entries, operation.target)) continue
-        // Watch file entrypoints only. Editing inside a directory target does
-        // not change the directory's mtime, so the ?mtime= cache-busting could
-        // not reload it anyway; directory targets behave as before.
+        // Directory targets can't hot-reload (their stat mtime ignores edits
+        // inside), so don't watch what can't trigger anything.
         if (yield* fs.isDir(operation.target)) continue
         watched.add(operation.target)
         yield* watcher.subscribe({ path: operation.target, type: "file" }).pipe(

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -195,6 +195,41 @@ describe("PluginSupervisor config", () => {
     ),
   )
 
+  it.live("reloads a configured plugin when its source file changes", () =>
+    withLocation(
+      { plugins: ["-*", "./external/mutable.ts"] },
+      Effect.gen(function* () {
+        yield* ready()
+        const agents = yield* Agent.Service
+        const bus = yield* Bus.Service
+        const location = yield* Location.Service
+        const file = path.join(location.directory, "external", "mutable.ts")
+
+        expect((yield* agents.get(Agent.ID.make("mutable")))?.description).toBe("first")
+
+        const changed = yield* bus
+          .subscribe(Plugin.Event.Updated)
+          .pipe(Stream.take(1), Stream.runDrain, Effect.forkScoped({ startImmediately: true }))
+        yield* Effect.promise(async () => {
+          await fs.writeFile(file, mutablePlugin("second"))
+          const modified = new Date(Date.now() + 5_000)
+          await fs.utimes(file, modified, modified)
+        })
+        yield* Fiber.join(changed).pipe(Effect.timeout("5 seconds"))
+
+        expect((yield* agents.get(Agent.ID.make("mutable")))?.description).toBe("second")
+      }),
+      false,
+      async (directory) => {
+        // Outside any {plugin,plugins} config-source directory, so only the
+        // configured-entrypoint watch can observe the edit.
+        const external = path.join(directory, "external")
+        await fs.mkdir(external, { recursive: true })
+        await fs.writeFile(path.join(external, "mutable.ts"), mutablePlugin("first"))
+      },
+    ),
+  )
+
   it.live("applies explicit removals after auto-discovery", () =>
     withLocation(
       { plugins: ["-*"] },
@@ -251,9 +286,9 @@ describe("PluginSupervisor config", () => {
         expect((yield* registry.list()).map((plugin) => String(plugin.id))).not.toContain("opencode.variant")
 
         const catalog = yield* Catalog.Service
-        expect(
-          (yield* catalog.model.get(Provider.ID.make("configured"), Model.ID.make("glm-5.2")))?.variants,
-        ).toEqual([expect.objectContaining({ id: "high", headers: { custom: "true" } })])
+        expect((yield* catalog.model.get(Provider.ID.make("configured"), Model.ID.make("glm-5.2")))?.variants).toEqual([
+          expect.objectContaining({ id: "high", headers: { custom: "true" } }),
+        ])
       }),
     ),
   )


### PR DESCRIPTION
## What

Editing a locally configured plugin (`"plugins": ["./tools/my-plugin.ts"]`) now hot-reloads it, matching the dev loop auto-discovered `.opencode/plugin/` sources have had since #39174.

## Before / After

**Before:** configured local plugin paths resolve to absolute entrypoints that usually live outside config roots. `config.changes()` only carries events under config roots, so no trigger existed: editing the plugin did nothing until opencode restarted or `opencode.json` was touched. The symlink-into-`.opencode/plugin` workaround also fails, since fs events don't fire when a symlink target changes.

**After:** each activation reconciles one file watch per configured local entrypoint (via the existing `Watcher` service, so equivalent watches share one native subscription). A watch event feeds the supervisor's existing signal queue; the next activation re-stats mtimes and re-imports with the existing `?mtime=` cache-busting. Edit → debounce → new plugin generation.

## How

`packages/core/src/plugin/supervisor.ts` (+ `Watcher.node` dep):
- `reconcileWatches(entries, operations)`: a `Map<path, stop>` reconciled from each scan's absolute-path add operations — the same reconcile pattern Config uses for its roots. Skips targets the config change feed already covers (`isPluginSource`) and directory targets (file entrypoints only; directory revisions need a separate design and keep today's reload-on-config-change behavior).
- Watch events publish into a PubSub merged into the existing `sourceChanges` pipeline, sharing its pre-debounce `observed` increment (flush stays honest) and the sliding-queue coalescing.

No new coordination: versioning already existed (`operation.mtime` in `Plugin.Versioned.version`), triggering machinery already existed (#39174). This adds only the missing event source.

## Scope

- File entrypoints only. Editing a module the entrypoint *imports* does not retrigger (and would not cache-bust); touch the entrypoint. Import-graph fidelity is a separate project.
- npm/remote targets unwatched (version-pinned).

## Testing

From `packages/core`:

- `bun run test test/config/plugin.test.ts` — 12/12, 3 consecutive runs. New end-to-end live test: configured plugin outside any config-source directory, real file edit through the real watcher, asserting the reloaded behavior.
- Reverting the supervisor change makes the new test time out (no trigger exists), confirming it covers the gap.
- `bun run test test/plugin` — 233/233.
- `bun typecheck` — clean.

