### PR TITLE
fix(core): keep config root watches alive and ignore vendored trees

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,7 +4,7 @@ import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import path from "path"
 import { isDeepStrictEqual } from "node:util"
 import { type ParseError, parse } from "jsonc-parser"
-import { Context, Effect, Fiber, Layer, Option, PubSub, Ref, Schema, Semaphore, Stream } from "effect"
+import { Context, Effect, Layer, Option, PubSub, Ref, Schema, Semaphore, Stream } from "effect"
 import { Permission } from "@opencode-ai/schema/permission"
 import { Config as ConfigSchema } from "@opencode-ai/schema/config"
 import { Integration } from "@opencode-ai/schema/integration"
@@ -373,29 +373,30 @@ export const layer = (options?: Options) => Layer.effect(
     const initial = yield* discover()
     let configs = initial
     const updates = yield* PubSub.unbounded<Watcher.Update>()
-    const subscriptions = new Map<string, Effect.Effect<unknown>>()
+    // Vendored trees inside config roots (a plugin's node_modules, a nested
+    // .git) produce event blizzards that can never change discovery output.
+    const ignore = ["node_modules", ".git", "**/{node_modules,.git}/**"]
+    // Watch-once: roots leave discovery only by deletion, so a stale watch is
+    // inert, bounded, and dies with this layer — and keeping a deleted root's
+    // watch alive is exactly what makes its recreation observable.
+    const watched = new Set<string>()
     const reconcile = Effect.fn("Config.reconcileWatches")(function* (entries: readonly Entry[]) {
       const directories = entries.flatMap((entry) => (entry.type === "directory" ? [entry.path] : []))
       const files = entries.flatMap((entry) => (entry.type === "file" ? [entry.path] : []))
       const targets = [
-        ...directories.map((path) => ({ path, type: "directory" as const })),
+        ...directories.map((path) => ({ path, type: "directory" as const, ignore })),
         ...files
           .filter((file) => !directories.some((directory) => FSUtil.contains(directory, file)))
           .map((path) => ({ path, type: "file" as const })),
       ]
-      const next = new Map(targets.map((target) => [JSON.stringify(target), target]))
-      for (const [key, stop] of subscriptions) {
-        if (next.has(key)) continue
-        yield* stop
-        subscriptions.delete(key)
-      }
-      for (const [key, target] of next) {
-        if (subscriptions.has(key)) continue
-        const fiber = yield* watcher.subscribe(target).pipe(
+      for (const target of targets) {
+        const key = JSON.stringify(target)
+        if (watched.has(key)) continue
+        watched.add(key)
+        yield* watcher.subscribe(target).pipe(
           Stream.runForEach((update) => PubSub.publish(updates, update)),
           Effect.forkScoped({ startImmediately: true }),
         )
-        subscriptions.set(key, Fiber.interrupt(fiber))
       }
     })
 

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -209,6 +209,64 @@ describe("Config", () => {
     ),
   )
 
+  // Real watcher on purpose: the regression this pins (a deleted config file's
+  // watch being torn down, making recreation invisible) only reproduces with
+  // path-faithful event delivery.
+  it.live("keeps watching a deleted config file so recreating it reloads", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const global = path.join(tmp.path, "global")
+          const project = path.join(tmp.path, "project")
+          const file = path.join(project, "opencode.json")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(global, { recursive: true })
+            await fs.mkdir(project, { recursive: true })
+            await fs.writeFile(file, JSON.stringify({ shell: "one" }))
+          })
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const bus = yield* Bus.Service
+            expect(Config.latest(yield* config.entries(), "shell")).toBe("one")
+            yield* Effect.sleep("10 millis")
+
+            const removed = yield* bus
+              .subscribe(ConfigSchema.Event.Updated)
+              .pipe(Stream.take(1), Stream.runDrain, Effect.forkScoped({ startImmediately: true }))
+            yield* Effect.promise(() => fs.rm(file))
+            yield* Fiber.join(removed).pipe(Effect.timeout("5 seconds"))
+            expect(Config.latest(yield* config.entries(), "shell")).toBeUndefined()
+
+            const recreated = yield* bus
+              .subscribe(ConfigSchema.Event.Updated)
+              .pipe(Stream.take(1), Stream.runDrain, Effect.forkScoped({ startImmediately: true }))
+            yield* Effect.promise(() => fs.writeFile(file, JSON.stringify({ shell: "two" })))
+            yield* Fiber.join(recreated).pipe(Effect.timeout("5 seconds"))
+            expect(Config.latest(yield* config.entries(), "shell")).toBe("two")
+          }).pipe(
+            Effect.provide(
+              AppNodeBuilder.build(LayerNode.group([Config.node, Bus.node]), [
+                [
+                  Location.node,
+                  Layer.succeed(
+                    Location.Service,
+                    Location.Service.of(location({ directory: AbsolutePath.make(project) })),
+                  ),
+                ],
+                [Global.node, Global.layerWith({ config: global, home: path.join(global, "home") })],
+                [Credential.node, emptyCredentialNode],
+                [WellKnown.node, emptyWellknownNode],
+              ]),
+            ),
+          )
+        }),
+      ),
+    ),
+  )
+
   it.effect("backs Config.Service and Config.Test with one shared test implementation", () =>
     Effect.gen(function* () {
       const config = yield* Config.Service
@@ -524,7 +582,11 @@ describe("Config", () => {
             yield* config.entries()
 
             expect(yield* watcher.subscriptions()).toEqual([
-              { type: "directory", path: AbsolutePath.make(path.join(tmp.path, "global")) },
+              {
+                type: "directory",
+                path: AbsolutePath.make(path.join(tmp.path, "global")),
+                ignore: ["**/{node_modules,.git}/**", ".git", "node_modules"],
+              },
             ])
           }).pipe(Effect.provide(testLayer(tmp.path, undefined, undefined, undefined, Watcher.testLayer)))
         }),


### PR DESCRIPTION
## What

Two config-root watching fixes surfaced by the watch-pipeline audit:

1. **Deleted config files stay watched, so recreating them reloads.** Config's watch reconciliation is now watch-once (the same lifecycle the plugin supervisor uses).
2. **Vendored trees inside config roots are ignored.** `node_modules` and `.git` under a config root (e.g. a `bun install` inside `.opencode/plugin/`) no longer flood the change feed.

## Before / After

**Before (1):** deleting a project's only `opencode.json` dropped its entry from discovery, and the reconcile diff tore the file watch down. Recreating `opencode.json` produced no event for Config — the file was invisible until restart.

**After (1):** watches start on first sighting and are never torn down individually. A watch on a deleted path is inert (the underlying `fs.watch` sits on the parent directory), so recreation fires, discovery picks the file back up, and `config.updated` publishes. Stale watches are bounded by root count and die with the layer scope.

**Before (2):** config-root directory watches had no ignore list. Installing dependencies inside `.opencode/plugin/` produced an event blizzard that passed the plugin-source filter and churned debounced plugin activations.

**After (2):** root watches ignore `node_modules` and `.git` at any depth. Deliberately *not* the full `Ignore.PATTERNS` set — that includes `dist`/`build`/`bin`, which would silently unwatch legitimate config sources like `.opencode/commands/build/`.

## How

`packages/core/src/config.ts`: `subscriptions: Map<key, stop>` + diff loops → `watched: Set<key>` + subscribe-on-first-sighting; `ignore` list added to directory targets; `Fiber` import dropped.

## Scope

- No event, locking, or ordering changes; `reload`'s deep-equal guard and debounce untouched.
- The watch-pipeline audit's other findings (supervisor signal collapse, git preview lock) are separate follow-ups.

## Testing

From `packages/core`:

- New regression test `keeps watching a deleted config file so recreating it reloads` — uses the real watcher deliberately (the bug only reproduces with path-faithful event delivery; the in-memory test watcher broadcasts to all subscribers). **Fails on the previous implementation** (recreate phase times out), passes 3/3 on this one.
- `bun run test test/config/config.test.ts` — 28/28.
- `bun run test test/config` — 79 tests green.
- `bun typecheck` — clean.