### PR TITLE
docs(providers): add Rapid-MLX as a local OpenAI-compatible provider

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1861,6 +1861,48 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### Rapid-MLX
+
+You can configure opencode to use local models through [Rapid-MLX](https://rapidmlx.com), an Apple-Silicon-native inference server that exposes an OpenAI-compatible API.
+
+Start the server with any [supported model](https://models.rapidmlx.com/):
+
+```bash
+rapid-mlx serve qwen3.5-9b-4bit
+```
+
+Then point opencode at it:
+
+```json title="opencode.json" "rapid-mlx" {5, 6, 8, 10-12}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "rapid-mlx": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Rapid-MLX (local)",
+      "options": {
+        "baseURL": "http://127.0.0.1:8000/v1"
+      },
+      "models": {
+        "qwen3.5-9b-4bit": {
+          "name": "Qwen3.5-9B (local)"
+        }
+      }
+    }
+  }
+}
+```
+
+In this example:
+
+- `rapid-mlx` is the custom provider ID. This can be any string you want.
+- `npm` specifies the package to use for this provider. Here, `@ai-sdk/openai-compatible` is used for any OpenAI-compatible API.
+- `name` is the display name for the provider in the UI.
+- `options.baseURL` is the endpoint for the local server. Rapid-MLX serves on port `8000` by default.
+- `models` is a map of model IDs to their configurations. Use any alias from the [Rapid-MLX model catalog](https://models.rapidmlx.com/).
+
+---
+
 ### SAP AI Core
 
 SAP AI Core provides access to 40+ models from OpenAI, Anthropic, Google, Amazon, Meta, Mistral, and AI21 through a unified platform.


### PR DESCRIPTION
### Issue for this PR

Closes # — no tracking issue. Documentation addition that follows the same pattern as the existing llama.cpp / LM Studio / Ollama local-provider sections already in `providers.mdx`.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a **Rapid-MLX** section to `packages/web/src/content/docs/providers.mdx`. Rapid-MLX is an Apple-Silicon inference server that exposes an OpenAI-compatible API on `http://127.0.0.1:8000/v1`, so it connects through `@ai-sdk/openai-compatible` with the exact same config shape as the llama.cpp / LM Studio / Ollama sections already documented right above it. No code changes — just a docs section with a ready-to-paste `opencode.json` so Mac users know how to point opencode at it.

### How did you verify your code works?

The `opencode.json` snippet is the same shape as the adjacent LM Studio / Ollama examples (`npm: "@ai-sdk/openai-compatible"`, a local `baseURL`, and a `models` map); rapid-mlx serves the OpenAI-compatible `/v1` API on port 8000 that the config points at. I checked the mdx renders and sits in the right place in the provider list.

### Screenshots / recordings

N/A — text-only docs addition, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR