### PR TITLE
fix(desktop): use channel database in local runs

### DIFF
--- a/packages/desktop/src/main/server.ts
+++ b/packages/desktop/src/main/server.ts
@@ -213,7 +213,6 @@ function createSidecarEnv(): Record<string, string> {
   )
   delete env.DEBUG
   if (process.platform === "linux") delete env.LD_PRELOAD
-  if (!app.isPackaged) env.OPENCODE_DISABLE_CHANNEL_DB = "1"
   return env
 }
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix

### What does this PR do?

Keeps local V2 Desktop runs on their channel-specific database instead of disabling channel database selection.

### How did you verify your code works?

Desktop typecheck and test suite pass in the complete stack.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR