### PR TITLE
fix(app): localize home session suspense

### DIFF
--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -4,7 +4,7 @@ import { ServerConnection, useServer } from "@/context/server"
 import { useServerSync } from "@/context/server-sync"
 import { useTabs } from "@/context/tabs"
 import { toggleHomeProjectSelection } from "@/pages/layout/helpers"
-import { createEffect, createMemo, startTransition } from "solid-js"
+import { createEffect, createMemo } from "solid-js"
 
 export function createHomeController() {
   const sync = useServerSync()
@@ -43,7 +43,7 @@ export function createHomeController() {
   })
 
   function setSelection(next: HomeProjectSelection) {
-    void startTransition(() => layout.home.setSelection(next))
+    layout.home.setSelection(next)
   }
 
   function openProjectNewSession(conn: ServerConnection.Any, directory: string) {

--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -4,7 +4,7 @@ import { ServerConnection, useServer } from "@/context/server"
 import { useServerSync } from "@/context/server-sync"
 import { useTabs } from "@/context/tabs"
 import { toggleHomeProjectSelection } from "@/pages/layout/helpers"
-import { createEffect, createMemo } from "solid-js"
+import { createEffect, createMemo, startTransition } from "solid-js"
 
 export function createHomeController() {
   const sync = useServerSync()
@@ -43,7 +43,7 @@ export function createHomeController() {
   })
 
   function setSelection(next: HomeProjectSelection) {
-    layout.home.setSelection(next)
+    void startTransition(() => layout.home.setSelection(next))
   }
 
   function openProjectNewSession(conn: ServerConnection.Any, directory: string) {

--- a/packages/app/src/pages/home/home-sessions-view.tsx
+++ b/packages/app/src/pages/home/home-sessions-view.tsx
@@ -1,5 +1,5 @@
 import type { Session } from "@opencode-ai/sdk/v2/client"
-import { type Accessor, createMemo, For, Show } from "solid-js"
+import { type Accessor, createMemo, For, Show, Suspense } from "solid-js"
 import { Spinner } from "@opencode-ai/ui/spinner"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
@@ -39,7 +39,6 @@ function isBackgroundOpen(event: MouseEvent) {
 export type HomeSessionsViewProps = {
   language: ReturnType<typeof useLanguage>
   groups: Accessor<HomeSessionGroup[]>
-  loading: Accessor<boolean>
   showProjectName: Accessor<boolean>
   server: Accessor<ServerConnection.Key>
   canCreateSession: Accessor<boolean>
@@ -81,20 +80,22 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
     >
       <div class="sticky top-0 z-30 shrink-0 bg-v2-background-bg-base pb-3 pt-6 lg:pt-12" onWheel={props.onWheel}>
         <HomeSessionSearch {...props} />
-        <Show when={props.groups().length > 0 && props.canCreateSession()}>
-          <div class="pointer-events-none absolute right-0 top-[84px] z-20 flex lg:top-[108px]">
-            <ButtonV2
-              data-action="home-new-session"
-              variant="ghost-muted"
-              size="normal"
-              icon="edit"
-              class="pointer-events-auto h-7 px-2 [font-weight:530]"
-              onClick={props.onCreateSession}
-            >
-              {props.language.t("command.session.new")}
-            </ButtonV2>
-          </div>
-        </Show>
+        <Suspense>
+          <Show when={props.groups().length > 0 && props.canCreateSession()}>
+            <div class="pointer-events-none absolute right-0 top-[84px] z-20 flex lg:top-[108px]">
+              <ButtonV2
+                data-action="home-new-session"
+                variant="ghost-muted"
+                size="normal"
+                icon="edit"
+                class="pointer-events-auto h-7 px-2 [font-weight:530]"
+                onClick={props.onCreateSession}
+              >
+                {props.language.t("command.session.new")}
+              </ButtonV2>
+            </div>
+          </Show>
+        </Suspense>
       </div>
       <div class="pointer-events-none sticky top-[84px] z-40 h-0 -mr-3 lg:top-[108px]">
         <div
@@ -104,8 +105,7 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
         />
       </div>
       <div class="-mr-3 min-h-[calc(100cqh-72px)] lg:min-h-[calc(100cqh-96px)]">
-        <Show
-          when={!props.loading()}
+        <Suspense
           fallback={
             <div class="pt-3">
               <HomeSessionSkeleton label={props.language.t("common.loading")} />
@@ -141,7 +141,7 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
               </For>
             </div>
           </Show>
-        </Show>
+        </Suspense>
       </div>
     </section>
   )

--- a/packages/app/src/pages/home/home-sessions.tsx
+++ b/packages/app/src/pages/home/home-sessions.tsx
@@ -12,7 +12,6 @@ export function HomeSessions(props: {
     <HomeSessionsView
       language={props.sessions.copy.language}
       groups={props.sessions.data.groups}
-      loading={props.sessions.data.loading}
       showProjectName={props.sessions.session.showProjectName}
       server={props.sessions.session.server}
       canCreateSession={props.sessions.session.canCreate}


### PR DESCRIPTION
## Summary
- localize unloaded session index suspension to the sessions pane
- use the existing session skeleton as the Suspense fallback
- allow server switches to reveal the loading fallback immediately

## Testing
- `bun typecheck`
- `bun test --preload ./happydom.ts ./src/pages/home-session-open.test.ts ./src/pages/home-session-archive.test.ts ./src/context/global-sync/home-session-index.test.ts` (11 tests)