### PR TITLE
fix(app): preserve agent picker for existing users

### DIFF
--- a/packages/app/src/context/settings.test.ts
+++ b/packages/app/src/context/settings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   hasExistingWebState,
+  initialAgentVisibility,
   isAppUpgrade,
   layoutTransitionState,
   maximumSunsetTimeout,
@@ -10,6 +11,18 @@ import {
   shouldDisplayTabsToast,
   shouldEnableNewLayout,
 } from "./settings"
+
+describe("agent visibility", () => {
+  test("shows the picker for existing profiles and hides it for new profiles", () => {
+    expect(initialAgentVisibility(undefined, true)).toBe(true)
+    expect(initialAgentVisibility(undefined, false)).toBe(false)
+  })
+
+  test("preserves the preference after initialization", () => {
+    expect(initialAgentVisibility(true, true)).toBeUndefined()
+    expect(initialAgentVisibility(true, false)).toBeUndefined()
+  })
+})
 
 describe("layout transition", () => {
   test("blank profiles default to the new layout", () => {

--- a/packages/app/src/context/settings.test.ts
+++ b/packages/app/src/context/settings.test.ts
@@ -13,13 +13,17 @@ import {
 } from "./settings"
 
 describe("agent visibility", () => {
-  test("shows the picker for existing profiles and hides it for new profiles", () => {
+  test("shows the picker for existing profiles and hides it for first-time installs", () => {
     expect(initialAgentVisibility(undefined, true)).toBe(true)
     expect(initialAgentVisibility(undefined, false)).toBe(false)
   })
 
+  test("shows the picker when updating from a recent release", () => {
+    expect(initialAgentVisibility(undefined, false, "1.18.8")).toBe(true)
+  })
+
   test("preserves the preference after initialization", () => {
-    expect(initialAgentVisibility(true, true)).toBeUndefined()
+    expect(initialAgentVisibility(true, true, "1.18.8")).toBeUndefined()
     expect(initialAgentVisibility(true, false)).toBeUndefined()
   })
 })

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -94,9 +94,13 @@ export function hasExistingWebState(settings: Promise<string> | string | null, p
   return settings !== null || previousVersion !== undefined
 }
 
-export function initialAgentVisibility(initialized: boolean | undefined, existing: boolean) {
+export function initialAgentVisibility(
+  initialized: boolean | undefined,
+  existing: boolean,
+  previousVersion?: string,
+) {
   if (initialized === true) return
-  return existing
+  return existing || previousVersion !== undefined
 }
 
 export function shouldEnableNewLayout(previous: string | undefined, current: string | undefined) {
@@ -278,7 +282,11 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
     })
     const visible = (preference: () => boolean) => createMemo(() => !newLayoutDesigns() || preference())
     const initializeAgentVisibility = (existing: boolean) => {
-      const initial = initialAgentVisibility(store.general?.agentVisibilityInitialized, existing)
+      const initial = initialAgentVisibility(
+        store.general?.agentVisibilityInitialized,
+        existing,
+        launchState.previous,
+      )
       if (initial === undefined) return
       batch(() => {
         setStore("general", "showCustomAgents", initial)

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -1,5 +1,5 @@
 import { createStore, reconcile } from "solid-js/store"
-import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { batch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { persisted } from "@/utils/persist"
 import { usePlatform } from "@/context/platform"
@@ -36,6 +36,7 @@ export interface Settings {
     mobileTitlebarPosition: "top" | "bottom"
     newLayoutDesigns?: boolean
     layoutTransitionEligible?: boolean
+    agentVisibilityInitialized?: boolean
     newInterfaceNoticeDismissed?: boolean
     shouldDisplayTabsToast?: boolean
   }
@@ -91,6 +92,11 @@ export function shouldDisplayTabsToast(
 
 export function hasExistingWebState(settings: Promise<string> | string | null, previousVersion: string | undefined) {
   return settings !== null || previousVersion !== undefined
+}
+
+export function initialAgentVisibility(initialized: boolean | undefined, existing: boolean) {
+  if (initialized === true) return
+  return existing
 }
 
 export function shouldEnableNewLayout(previous: string | undefined, current: string | undefined) {
@@ -271,6 +277,14 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
       )
     })
     const visible = (preference: () => boolean) => createMemo(() => !newLayoutDesigns() || preference())
+    const initializeAgentVisibility = (existing: boolean) => {
+      const initial = initialAgentVisibility(store.general?.agentVisibilityInitialized, existing)
+      if (initial === undefined) return
+      batch(() => {
+        setStore("general", "showCustomAgents", initial)
+        setStore("general", "agentVisibilityInitialized", true)
+      })
+    }
 
     if (sunset && !oldInterfaceRetired()) {
       const timeout = { current: undefined as ReturnType<typeof setTimeout> | undefined }
@@ -299,8 +313,9 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
 
     createEffect(() => {
       if (!ready() || !launchState.classified || platform.platform !== "web") return
-      if (layoutTransitionClassified()) return
-      setStore("general", "layoutTransitionEligible", hasExistingWebState(settingsInit, launchState.previous))
+      const existing = hasExistingWebState(settingsInit, launchState.previous)
+      if (!layoutTransitionClassified()) setStore("general", "layoutTransitionEligible", existing)
+      initializeAgentVisibility(existing)
     })
 
     createEffect(() => {
@@ -426,6 +441,7 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
           if (typeof current === "boolean") return
           setStore("general", "layoutTransitionEligible", eligible)
         },
+        initializeAgentVisibility,
         layoutTransitionAvailable: createMemo(() => ready() && layoutTransition().available),
         newInterfaceNoticeVisible: createMemo(() => ready() && layoutTransition().notice),
         dismissNewInterfaceNotice() {

--- a/packages/desktop/src/renderer/onboarding.tsx
+++ b/packages/desktop/src/renderer/onboarding.tsx
@@ -17,6 +17,7 @@ export function DesktopFirstLaunchOnboarding(props: { initialUrl: string; onLoad
       )
       const existingInstall = await window.api.isOldLayoutEligible()
       settings.general.setOldLayoutEligible(existingInstall)
+      settings.general.initializeAgentVisibility(existingInstall)
       if (!server.isLocal()) return
 
       const pending = await window.api.isFirstLaunchOnboardingPending()


### PR DESCRIPTION
## Summary
- initialize the agent picker as visible for existing web and desktop installs
- keep the picker hidden for brand-new users
- persist one-time initialization so later user preferences are preserved

## Testing
- `bun test --preload ./happydom.ts ./src/context/settings.test.ts` (`packages/app`)
- `bun typecheck` (`packages/app`)
- `bun typecheck` (`packages/desktop`)
- pre-push repository typecheck