### PR TITLE
feat(opencode): add Devin provider support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -624,6 +624,7 @@
         "@zip.js/zip.js": "2.7.62",
         "ai": "catalog:",
         "ai-gateway-provider": "3.1.2",
+        "ai-sdk-devin": "0.3.6",
         "bonjour-service": "1.3.0",
         "chokidar": "4.0.3",
         "cross-spawn": "catalog:",
@@ -3068,6 +3069,8 @@
     "ai": ["ai@6.0.168", "", { "dependencies": { "@ai-sdk/gateway": "3.0.104", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ=="],
 
     "ai-gateway-provider": ["ai-gateway-provider@3.1.2", "", { "optionalDependencies": { "@ai-sdk/amazon-bedrock": "^4.0.62", "@ai-sdk/anthropic": "^3.0.46", "@ai-sdk/azure": "^3.0.31", "@ai-sdk/cerebras": "^2.0.34", "@ai-sdk/cohere": "^3.0.21", "@ai-sdk/deepgram": "^2.0.20", "@ai-sdk/deepseek": "^2.0.20", "@ai-sdk/elevenlabs": "^2.0.20", "@ai-sdk/fireworks": "^2.0.34", "@ai-sdk/google": "^3.0.30", "@ai-sdk/google-vertex": "^4.0.61", "@ai-sdk/groq": "^3.0.24", "@ai-sdk/mistral": "^3.0.20", "@ai-sdk/openai": "^3.0.30", "@ai-sdk/perplexity": "^3.0.19", "@ai-sdk/xai": "^3.0.57", "@openrouter/ai-sdk-provider": "^2.2.3" }, "peerDependencies": { "@ai-sdk/openai-compatible": "^2.0.0", "@ai-sdk/provider": "^3.0.0", "@ai-sdk/provider-utils": "^4.0.0", "ai": "^6.0.0" } }, "sha512-krGNnJSoO/gJ7Hbe5nQDlsBpDUGIBGtMQTRUaW7s1MylsfvLduba0TLWzQaGtOmNRkP0pGhtGlwsnS6FNQMlyw=="],
+
+    "ai-sdk-devin": ["ai-sdk-devin@0.3.6", "", { "dependencies": { "@ai-sdk/provider": "^3.0.0" } }, "sha512-1yylOVYCfJ73tpUeSeOWlQdPCTlbdxMntF09jpVf1gHZTDoGZD+Bo49ireK7LFqAdxStGinIZlX2zx6EQgnxNw=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -6182,6 +6185,8 @@
     "ai-gateway-provider/@ai-sdk/xai": ["@ai-sdk/xai@3.0.82", "", { "dependencies": { "@ai-sdk/openai-compatible": "2.0.41", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-A0VFMufnVf4wODcT3SPQUUzvYXiIO1VhFuXj9r6z/vP4rlo+QRDPw3WSTchcz93ROQWSfBE3I6Szqz342OHi5w=="],
 
     "ai-gateway-provider/@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@2.8.1", "", { "peerDependencies": { "ai": "^6.0.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Y6j3yivgoEUf/kutD/k5GX/mzZfioRFoSx0gbQ+mIOzMaH/vJv1rCkztiuvlLw5xRYQil7oxHUZvmSfXqOx1NQ=="],
+
+    "ai-sdk-devin/@ai-sdk/provider": ["@ai-sdk/provider@3.0.14", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA=="],
 
     "ajv-keywords/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -61,6 +61,7 @@
     "@ai-sdk/anthropic": "3.0.82",
     "@ai-sdk/azure": "3.0.88",
     "@ai-sdk/cerebras": "2.0.60",
+    "ai-sdk-devin": "0.3.6",
     "@ai-sdk/cohere": "3.0.27",
     "@ai-sdk/deepinfra": "2.0.41",
     "@ai-sdk/gateway": "3.0.104",

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -131,6 +131,7 @@ const BUNDLED_PROVIDERS: Record<string, () => Promise<(opts: any) => BundledSDK>
   "@ai-sdk/github-copilot": () =>
     import("@opencode-ai/core/github-copilot/copilot-provider").then((m) => m.createOpenaiCompatible),
   "venice-ai-sdk-provider": () => import("venice-ai-sdk-provider").then((m) => m.createVenice),
+  "ai-sdk-devin": () => import("ai-sdk-devin").then((m) => m.createDevin),
 }
 
 type CustomModelLoader = (sdk: any, modelID: string, options?: Record<string, any>, model?: Model) => Promise<any>
@@ -859,6 +860,70 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
           },
         },
       }),
+    devin: Effect.fnUntraced(function* (input: Info) {
+      const env = yield* dep.env()
+      const auth = yield* dep.auth(input.id)
+      const apiKey = env["DEVIN_API_KEY"] || (auth?.type === "api" ? auth.key : undefined)
+
+      if (!apiKey) {
+        return {
+          autoload: false,
+          async getModel() {
+            throw new Error("DEVIN_API_KEY is missing. Set it with: export DEVIN_API_KEY=<your-devin-api-key>")
+          },
+        }
+      }
+
+      return {
+        autoload: !input.env.length || input.env.some((item) => env[item]),
+        options: {
+          apiKey,
+        },
+        async discoverModels(): Promise<Record<string, Model>> {
+          try {
+            // ponytail: ai-sdk-devin may not be installed at discovery time; catch handles it
+            const { createDevin } = await import("ai-sdk-devin")
+            const devin = createDevin({ apiKey })
+            const modelList = (await devin.models()) as any[]
+            const models: Record<string, Model> = {}
+
+            for (const m of modelList) {
+              const modelId = m.modelId || m.id
+              if (!modelId) continue
+              if (input.models[modelId]) continue
+
+              models[modelId] = {
+                id: ModelV2.ID.make(modelId),
+                providerID: ProviderV2.ID.make("devin"),
+                name: m.name || modelId,
+                family: "",
+                api: { id: modelId, url: "", npm: "ai-sdk-devin" },
+                status: "active",
+                headers: {},
+                options: {},
+                cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+                limit: { context: 128_000, output: 8_192 },
+                capabilities: {
+                  temperature: false,
+                  reasoning: true,
+                  attachment: true,
+                  toolcall: true,
+                  input: { text: true, audio: false, image: false, video: false, pdf: true },
+                  output: { text: true, audio: false, image: false, video: false, pdf: false },
+                  interleaved: false,
+                },
+                release_date: "",
+                variants: {},
+              }
+            }
+
+            return models
+          } catch {
+            return {}
+          }
+        },
+      }
+    }),
     "snowflake-cortex": Effect.fnUntraced(function* (input: Info) {
       const env = yield* dep.env()
       const auth = yield* dep.auth(input.id)
@@ -1516,6 +1581,19 @@ const layer = Layer.effect(
 
         // load env
         const envs = yield* env.all()
+
+        // Pre-populate Devin in database for env auto-activation when DEVIN_API_KEY is set
+        if (envs["DEVIN_API_KEY"] && !database["devin"]) {
+          database["devin"] = {
+            id: ProviderV2.ID.make("devin"),
+            name: "Devin (ai)",
+            env: ["DEVIN_API_KEY"],
+            source: "custom",
+            models: {},
+            options: {},
+          }
+        }
+
         for (const [id, provider] of Object.entries(database)) {
           const providerID = ProviderV2.ID.make(id)
           if (disabled.has(providerID)) continue
@@ -1597,6 +1675,20 @@ const layer = Layer.effect(
               for (const [modelID, model] of Object.entries(discovered)) {
                 if (!providers[gitlab].models[modelID]) {
                   providers[gitlab].models[modelID] = model
+                }
+              }
+            } catch (e) {}
+          })
+        }
+
+        const devin = ProviderV2.ID.make("devin")
+        if (discoveryLoaders[devin] && providers[devin] && isProviderAllowed(devin)) {
+          yield* Effect.promise(async () => {
+            try {
+              const discovered = await discoveryLoaders[devin]()
+              for (const [modelID, model] of Object.entries(discovered)) {
+                if (!providers[devin].models[modelID]) {
+                  providers[devin].models[modelID] = model
                 }
               }
             } catch (e) {}


### PR DESCRIPTION
### Issue for this PR

Closes #24072

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Devin.ai as a provider in OpenCode via the `ai-sdk-devin` npm package (v0.3.6), which wraps Devin/Cognition LLM models through the AI SDK interface.

**Changes:**
- `packages/opencode/package.json` — added `ai-sdk-devin: "0.3.6"` dependency
- `packages/opencode/src/provider/provider.ts`:
  - Added `ai-sdk-devin` to `BUNDLED_PROVIDERS` for SDK creation via the bundled loader mechanism
  - Added Devin custom loader in `custom(dep)` that detects `DEVIN_API_KEY` env var and exposes a `discoverModels()` function for dynamic model discovery from the Devin API
  - Pre-populate Devin in the provider database when `DEVIN_API_KEY` is set, enabling auto-activation without config
  - Added Devin discovery handler (matching the existing GitLab pattern) that merges API-discovered models into the provider at startup

The custom loader follows the same pattern used by GitLab, Snowflake Cortex, Cloudflare Workers AI, and other bundled providers. The `discoverModels()` function lazily imports `ai-sdk-devin`, calls its `models()` API, and constructs Model objects with `api.npm: "ai-sdk-devin"` so model calls route through the bundled provider SDK loader.

### How did you verify your code works?

- Verified `bun typecheck` passes across all 30 packages in the monorepo (0 errors)
- Verified `bun install` resolves and installs `ai-sdk-devin@0.3.6` successfully
- Verified the custom loader compiles with the existing `CustomLoader`, `Info`, `Model` types
- Verified the database pre-population and discovery handler match the established GitLab pattern

### Screenshots / recordings

N/A — provider configuration change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR