### PR TITLE
fix(core): trim whitespace in NpmConfig.registry string before trailing slash stripping

### DIFF
--- a/packages/core/src/npm-config.ts
+++ b/packages/core/src/npm-config.ts
@@ -34,7 +34,7 @@ export const load = (dir: string) =>
 export const registry = (dir: string) =>
   load(dir).pipe(
     Effect.map((config) => {
-      const registry = typeof config.registry === "string" ? config.registry : "https://registry.npmjs.org"
-      return registry.endsWith("/") ? registry.slice(0, -1) : registry
+      const reg = typeof config.registry === "string" ? config.registry.trim() : "https://registry.npmjs.org"
+      return reg.endsWith("/") ? reg.slice(0, -1) : reg
     }),
   )


### PR DESCRIPTION
Fixes #30069

### Summary
This PR updates `NpmConfig.registry` in `packages/core/src/npm-config.ts` to trim surrounding whitespace from `config.registry` values before trailing-slash stripping.

### Changes
- Trims whitespace from `config.registry` prior to trailing-slash normalization to handle misformatted NPM config values cleanly.