### PR TITLE
feat(desktop): remove v2 vertical menu borders

### DIFF
--- a/packages/app/src/pages/home/home-projects-view.tsx
+++ b/packages/app/src/pages/home/home-projects-view.tsx
@@ -588,11 +588,12 @@ function HomeProjectNavButton(props: JSX.ButtonHTMLAttributes<HTMLButtonElement>
       {...rest}
       class={`
         flex h-7 min-w-0 w-full shrink-0 cursor-default items-center gap-2 rounded-[6px] bg-transparent px-1.5 text-left
-        text-v2-text-text-muted [font-weight:440] transition-[background-color,color] duration-[120ms] ease-in-out
+        text-v2-text-text-muted [font-weight:440] transition-[background-color,color,box-shadow] duration-[120ms] ease-in-out
         hover:bg-v2-background-bg-layer-01 hover:text-v2-text-text-base
         data-[selected]:bg-v2-background-bg-layer-03 data-[selected]:text-v2-text-text-base
         data-[selected]:hover:bg-v2-background-bg-layer-03
         focus-visible:bg-v2-background-bg-layer-01 focus-visible:text-v2-text-text-base focus-visible:outline-none
+        focus-visible:[box-shadow:inset_0_0_0_0.5px_var(--v2-border-border-muted)]
         ${local.class ?? ""}
       `}
       classList={local.classList}

--- a/packages/app/src/pages/home/home-projects-view.tsx
+++ b/packages/app/src/pages/home/home-projects-view.tsx
@@ -482,7 +482,6 @@ function HomeProjectRow(
         class="pr-16 disabled:opacity-60"
         classList={{
           "bg-v2-background-bg-layer-01 text-v2-text-text-base": sortable.isDragSource(),
-          "[box-shadow:inset_0_0_0_0.5px_var(--v2-border-border-muted)]": sortable.isDragSource(),
         }}
         data-selected={props.selected ? "" : undefined}
         aria-current={props.selected ? "page" : undefined}
@@ -589,12 +588,11 @@ function HomeProjectNavButton(props: JSX.ButtonHTMLAttributes<HTMLButtonElement>
       {...rest}
       class={`
         flex h-7 min-w-0 w-full shrink-0 cursor-default items-center gap-2 rounded-[6px] bg-transparent px-1.5 text-left
-        text-v2-text-text-muted [font-weight:440] transition-[background-color,color,box-shadow] duration-[120ms] ease-in-out
-        hover:bg-v2-background-bg-layer-01 hover:text-v2-text-text-base hover:[box-shadow:inset_0_0_0_0.5px_var(--v2-border-border-muted)]
+        text-v2-text-text-muted [font-weight:440] transition-[background-color,color] duration-[120ms] ease-in-out
+        hover:bg-v2-background-bg-layer-01 hover:text-v2-text-text-base
         data-[selected]:bg-v2-background-bg-layer-03 data-[selected]:text-v2-text-text-base
-        data-[selected]:[box-shadow:inset_0_0_0_0.5px_var(--v2-border-border-muted)] data-[selected]:hover:bg-v2-background-bg-layer-03
+        data-[selected]:hover:bg-v2-background-bg-layer-03
         focus-visible:bg-v2-background-bg-layer-01 focus-visible:text-v2-text-text-base focus-visible:outline-none
-        focus-visible:[box-shadow:inset_0_0_0_0.5px_var(--v2-border-border-muted)]
         ${local.class ?? ""}
       `}
       classList={local.classList}

--- a/packages/ui/src/v2/components/tabs-v2.css
+++ b/packages/ui/src/v2/components/tabs-v2.css
@@ -199,7 +199,6 @@
   width: 100%;
   height: 28px;
   border-radius: 4px;
-  border: 0.5px solid transparent;
   box-sizing: border-box;
   color: var(--v2-text-text-muted);
 }
@@ -222,5 +221,4 @@
   [data-slot="tabs-v2-trigger-wrapper"]:has([data-selected]) {
   background-color: var(--v2-background-bg-layer-03);
   color: var(--v2-text-text-base);
-  border: 0.5px solid var(--v2-border-border-muted);
 }


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes state borders from the v2 vertical menus used by Home and Settings. Hover, selected, and drag states now rely on background and text color changes instead. 

Legacy menu styles are unchanged.

### How did you verify your code works?

- Ran `git diff --check origin/dev...HEAD`.
- Reviewed the final diff to confirm the changes only affect v2 Home and Settings menu states.

### Screenshots / recordings

**Before**

<img width="1208" height="1072" alt="file-60bd5c5d09eb72893ee120349723e13f" src="https://github.com/user-attachments/assets/dfe63879-8b9e-498a-add6-d7ecffafe28a" />

**After**

![Uploading file-c797989039dd8d1b9ba74e42b8a0fc70.png…]()


### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
