### PR TITLE
fix: keep manually selected model across turns

### DIFF
--- a/packages/app/src/context/local-agent.test.ts
+++ b/packages/app/src/context/local-agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { hasCustomAgent, resolveAgent } from "./local-agent"
+import { hasCustomAgent, resolveAgent, shouldApplyAgent } from "./local-agent"
 
 describe("hasCustomAgent", () => {
   test("detects explicitly custom agents", () => {
@@ -25,5 +25,19 @@ describe("resolveAgent", () => {
 
   test("uses the first agent when build is unavailable", () => {
     expect(resolveAgent([{ name: "custom" }], "missing")?.name).toBe("custom")
+  })
+})
+
+describe("shouldApplyAgent", () => {
+  test("applies the first selection so state is persisted", () => {
+    expect(shouldApplyAgent({ agent: "build", persisted: undefined })).toBe(true)
+  })
+
+  test("applies a real agent switch", () => {
+    expect(shouldApplyAgent({ agent: "plan", persisted: "build" })).toBe(true)
+  })
+
+  test("skips re-applying the already-persisted agent", () => {
+    expect(shouldApplyAgent({ agent: "build", persisted: "build" })).toBe(false)
   })
 })

--- a/packages/app/src/context/local-agent.ts
+++ b/packages/app/src/context/local-agent.ts
@@ -5,3 +5,12 @@ export function hasCustomAgent(items: Array<{ native?: boolean }>) {
 export function resolveAgent<T extends { name: string }>(items: T[], name?: string) {
   return items.find((item) => item.name === name) ?? items.find((item) => item.name === "build") ?? items[0]
 }
+
+// An agent carries a configured model, so applying an agent also overwrites the
+// active model. Re-applying the already-persisted agent must therefore be skipped,
+// otherwise a control that re-emits the current agent silently discards an explicit
+// model pick. The first write for an agent must still land, so this compares against
+// persisted state rather than the resolved current agent (which falls back to build).
+export function shouldApplyAgent(input: { agent: string; persisted: string | undefined }) {
+  return input.persisted !== input.agent
+}

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -7,7 +7,7 @@ import { useModels } from "@/context/models"
 import { useSettings } from "@/context/settings"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
-import { hasCustomAgent, resolveAgent } from "./local-agent"
+import { hasCustomAgent, resolveAgent, shouldApplyAgent } from "./local-agent"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
@@ -192,6 +192,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           setStore("current", undefined)
           return
         }
+
+        if (!shouldApplyAgent({ agent: item.name, persisted: scope()?.agent })) return
 
         batch(() => {
           setStore("current", item.name)

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -307,7 +307,8 @@ export function Prompt(props: PromptProps) {
     ),
   )
 
-  // Initialize agent/model/variant from last user message when session changes
+  // Initialize the agent from the last user message when the session changes.
+  // The model follows durable session updates while preserving local picks.
   let syncedSessionID: string | undefined
   createEffect(() => {
     const sessionID = props.sessionID
@@ -323,10 +324,6 @@ export function Prompt(props: PromptProps) {
       if (msg.agent && isPrimaryAgent) {
         // Keep command line --agent if specified.
         if (!args.agent) local.agent.set(msg.agent)
-        if (msg.model) {
-          local.model.set(msg.model)
-          local.model.variant.set(msg.model.variant)
-        }
       }
     }
   })

--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -32,6 +32,14 @@ export function parseModel(model: string) {
   }
 }
 
+// A session carries the model used for its last turn, which is the agent's
+// configured model unless the user picked one. Seeding from it must therefore be
+// skipped once the agent has a local override, or the pick is silently reverted
+// on the next session update.
+export function shouldSeedSessionModel(override: { providerID: string; modelID: string } | undefined) {
+  return !override
+}
+
 export function recentModels(
   model: { providerID: string; modelID: string },
   recent: { providerID: string; modelID: string }[],
@@ -242,6 +250,27 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             fallbackModel,
           ) ?? undefined
         )
+      })
+
+      // Seed the model from durable session state, but never overwrite a model the
+      // user picked for this agent. Otherwise a session update mid-conversation
+      // reverts the selection to the agent's configured model.
+      createEffect(() => {
+        const currentRoute = route.data
+        if (currentRoute.type !== "session") return
+
+        const session = sync.data.session.find((item) => item.id === currentRoute.sessionID)
+        const selected = session?.model
+        const a = agent.current()
+        if (!a || !selected) return
+        if (!shouldSeedSessionModel(modelStore.model[a.name])) return
+
+        const model = { providerID: selected.providerID, modelID: selected.id }
+        if (!isModelValid(model)) return
+        batch(() => {
+          setModelStore("model", a.name, model)
+          setModelStore("variant", `${selected.providerID}/${selected.id}`, selected.variant ?? "default")
+        })
       })
 
       return {

--- a/packages/tui/test/context/local.test.ts
+++ b/packages/tui/test/context/local.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { parseModel, recentModels } from "../../src/context/local"
+import { parseModel, recentModels, shouldSeedSessionModel } from "../../src/context/local"
 
 test("parses model IDs containing slashes", () => {
   expect(parseModel("provider/family/model")).toEqual({
@@ -19,4 +19,12 @@ test("moves a model to the front, deduplicates, and limits recents", () => {
     ...recent.slice(0, 5),
     ...recent.slice(6, 10),
   ])
+})
+
+test("seeds the model from session state when the agent has no override", () => {
+  expect(shouldSeedSessionModel(undefined)).toBe(true)
+})
+
+test("keeps a picked model instead of reseeding it from session state", () => {
+  expect(shouldSeedSessionModel({ providerID: "provider", modelID: "model" })).toBe(false)
 })


### PR DESCRIPTION
### Issue for this PR

Closes #39319

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

If your agent has a model configured, picking a different model in the picker doesn't stick. The prompt runs on your pick, then it snaps back to the agent's model for the next turn.

Two separate causes, one per UI:

**TUI** — `Prompt` restored the model from the last user message whenever a session hydrated, which overwrote the pick. I removed that. The model is now seeded from durable session state in `context/local.tsx`, but only when the agent has no local override, so reopening a session still restores its model.

**App/desktop** — the agent `Select` calls `agents.select(value)` even when the value hasn't changed, and `agent.set` always rewrote state with `model: item.model ?? prev?.model`. Because the agent has a configured model, `item.model` is always set and always won. Now re-applying the already-persisted agent is skipped.

The guard compares against persisted state rather than `agent.current()` on purpose: `store.current` is initialised to the first agent in the list, so comparing against the resolved current agent would make the first genuine `agent.set` a no-op and never persist anything.

Switching agents still applies that agent's configured model — only redundant re-application is skipped.

### How did you verify your code works?

Built a local binary (`script/build.ts --single`) and ran the desktop app (`bun run --cwd packages/desktop dev`), with a `build` agent pinned to one model:

1. Confirm the session shows the agent's model
2. Pick a different model
3. Send two prompts — model stays on the pick (it reverted before this change)
4. Switch agent away and back — model follows the agent's config, as expected

Also added unit tests for both guards, and `bun test` passes in `packages/tui` (193) and `packages/app` (548), with typecheck clean in both.

### Screenshots / recordings

The change is behavioural, not visual: the model label in the composer stops reverting between turns.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
