### PR TITLE
fix(tui): standardize shortcut hint order in subagent footer

### DIFF
--- a/packages/tui/src/routes/session/subagent-footer.tsx
+++ b/packages/tui/src/routes/session/subagent-footer.tsx
@@ -101,7 +101,7 @@ export function SubagentFooter() {
               backgroundColor={hover() === "parent" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Parent <span style={{ fg: theme.textMuted }}>{parentShortcut()}</span>
+                {parentShortcut()} <span style={{ fg: theme.textMuted }}>parent</span>
               </text>
             </box>
             <box
@@ -111,7 +111,7 @@ export function SubagentFooter() {
               backgroundColor={hover() === "prev" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Prev <span style={{ fg: theme.textMuted }}>{previousShortcut()}</span>
+                {previousShortcut()} <span style={{ fg: theme.textMuted }}>prev</span>
               </text>
             </box>
             <box
@@ -121,7 +121,7 @@ export function SubagentFooter() {
               backgroundColor={hover() === "next" ? theme.backgroundElement : theme.backgroundPanel}
             >
               <text fg={theme.text}>
-                Next <span style={{ fg: theme.textMuted }}>{nextShortcut()}</span>
+                {nextShortcut()} <span style={{ fg: theme.textMuted }}>next</span>
               </text>
             </box>
           </box>


### PR DESCRIPTION
### Issue for this PR

Closes #35740

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The subagent footer renders keyboard hints as `Action shortcut` (e.g. `Parent esc`) while every other TUI surface uses `shortcut action` (e.g. `esc parent`). This swaps the order in the three subagent navigation hints to match.

Only `subagent-footer.tsx` had the reversed order — the prompt footer, session view, diff viewer, permission view, and dialog prompts all use the `shortcut action` convention already.

### How did you verify your code works?

- `bun typecheck` in `packages/tui` — passes
- `bun test` in `packages/tui` — 191 pass, 0 fail

### Screenshots / recordings

N/A — the change is shortcut label ordering, not layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR