### PR TITLE
feat(app): add abbreviation matching to model selector search

### DIFF
--- a/packages/app/src/components/dialog-select-model-search.test.ts
+++ b/packages/app/src/components/dialog-select-model-search.test.ts
@@ -16,4 +16,23 @@ describe("matchesModelSearch", () => {
   test("does not match unrelated searches", () => {
     expect(matchesModelSearch("claude", ["GPT-5.5", "gpt-5.5", "OpenAI"])).toBe(false)
   })
+
+  test("matches model names via word-initial abbreviation", () => {
+    // "deepseek v4 flash free" → initials "dvff", compact "deepseekv4flashfree"
+    // "deepseek v4 pro" → initials "dvp", compact "deepseekv4pro"
+    expect(matchesModelSearch("deepff", ["Deepseek V4 Flash Free"])).toBe(true)
+    expect(matchesModelSearch("deepp", ["Deepseek V4 Pro"])).toBe(true)
+    expect(matchesModelSearch("dvff", ["Deepseek V4 Flash Free"])).toBe(true)
+    expect(matchesModelSearch("deepv4", ["Deepseek V4 Flash Free"])).toBe(true)
+    // Should NOT match unrelated abbreviations
+    expect(matchesModelSearch("deepff", ["Deepseek V4 Pro"])).toBe(false)
+    expect(matchesModelSearch("deepp", ["Deepseek V4 Flash Free"])).toBe(false)
+  })
+
+  test("abbreviation matching distinguishes similar models", () => {
+    const models = ["Deepseek V4 Flash Free", "Deepseek V4 Flash", "Deepseek V4 Pro"]
+    expect(matchesModelSearch("deepff", models)).toBe(true) // matches Flash Free only via abbreviation
+    expect(matchesModelSearch("deepf", models)).toBe(true)  // matches both Flash Free and Flash
+    expect(matchesModelSearch("deepp", models)).toBe(true)  // matches Pro only
+  })
 })

--- a/packages/app/src/components/dialog-select-model-search.ts
+++ b/packages/app/src/components/dialog-select-model-search.ts
@@ -7,12 +7,47 @@ export const normalizeModelSearch = (value: string) =>
 
 export const compactModelSearch = (value: string) => normalizeModelSearch(value).replaceAll(" ", "")
 
+export const abbreviationModelSearch = (value: string) =>
+  normalizeModelSearch(value)
+    .split(/\W+/)
+    .filter(Boolean)
+    .map((w) => w[0])
+    .join("")
+
+// Try matching query against model name words as a mix of word-prefixes and initials.
+// "deepseekv4" → prefix "deepseek" + prefix "v4"
+// "deepff" → prefix "deep" + initial "f" + initial "f"
+// "dvff" → initial "d" + initial "v" + initial "f" + initial "f"
+const matchWordsPrefixOrInitial = (query: string, words: string[], wi: number): boolean => {
+  if (!query) return true
+  if (wi >= words.length) return false
+
+  const word = words[wi]
+  // Try skipping this word
+  if (matchWordsPrefixOrInitial(query, words, wi + 1)) return true
+
+  // Try matching a prefix of this word (1 to min(query.length, word.length) chars)
+  const maxLen = Math.min(query.length, word.length)
+  for (let len = 1; len <= maxLen; len++) {
+    if (query.slice(0, len) !== word.slice(0, len)) break
+    if (matchWordsPrefixOrInitial(query.slice(len), words, wi + 1)) return true
+  }
+  return false
+}
+
 export const matchesModelSearch = (query: string, values: string[]) => {
   const search = normalizeModelSearch(query)
   if (!search) return true
 
   const compactSearch = compactModelSearch(query)
-  return values.some(
-    (value) => normalizeModelSearch(value).includes(search) || compactModelSearch(value).includes(compactSearch),
-  )
+  return values.some((value) => {
+    if (normalizeModelSearch(value).includes(search)) return true
+    if (compactModelSearch(value).includes(compactSearch)) return true
+
+    // Abbreviation matching: treat query as a mix of word-prefixes and word-initials.
+    const words = normalizeModelSearch(value)
+      .split(/\W+/)
+      .filter(Boolean)
+    return matchWordsPrefixOrInitial(compactSearch, words, 0)
+  })
 }


### PR DESCRIPTION
### Issue for this PR

Closes #39346

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The model selector search only supported exact substring matching and compact (no-separator) matching. When the model list contains similar names like Deepseek V4 Flash Free, Deepseek V4 Flash, and Deepseek V4 Pro, users had to type the full name or enough unique characters to disambiguate.

This adds abbreviation matching as a fallback: the query is walked against model name words, where each segment of the query can be a prefix of a word or just the word's initial letter. Skipped words are allowed.

Examples:
- `deepff` → Deepseek V4 Flash Free (deep→Deepseek + f→Flash + f→Free)
- `deepp` → Deepseek V4 Pro (deep→Deepseek + p→Pro)
- `dvff` → Deepseek V4 Flash Free (d→Deepseek + v→V4 + f→Flash + f→Free)

The algorithm is a recursive walk: for each word, try matching 1 to N characters as a prefix of that word, then recurse on the remaining query and next word. Words can also be skipped. This is tried after existing spaced-normalized and compact substring matching, so all current search behavior is preserved.

### How did you verify your code works?

- `bun test dialog-select-model-search` — all 5 tests pass (2 new abbreviation tests added)
- `bun typecheck` — passes
- Full test suite — 688 pass, 1 pre-existing i18n failure (unrelated)

### Screenshots / recordings

_This is not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR