### PR TITLE
refactor(core): simplify plugin reload loop

### DIFF
--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -2,7 +2,7 @@ export * as PluginSupervisor from "./supervisor"
 
 import type { Plugin as PluginDefinition } from "@opencode-ai/plugin/effect/plugin"
 import { Event } from "@opencode-ai/schema/config"
-import { Context, Deferred, Effect, Layer, Option, PubSub, Schema, Semaphore, Stream } from "effect"
+import { Context, Deferred, Effect, Layer, Option, PubSub, Schema, Stream } from "effect"
 import path from "path"
 import { fileURLToPath, pathToFileURL } from "url"
 import { Agent } from "../agent"
@@ -230,10 +230,8 @@ const layer = Layer.effect(
     const bus = yield* Bus.Service
     const watcher = yield* Watcher.Service
     const fs = yield* FSUtil.Service
-    const lock = Semaphore.makeUnsafe(1)
     const ready = yield* Deferred.make<void>()
     let observed = 0
-    let applied = -1
 
     // Configured local plugin files can live outside config roots, where the
     // config change feed cannot see them; watch those entrypoints directly.
@@ -265,25 +263,19 @@ const layer = Layer.effect(
       }
     })
 
-    const activate = Effect.fn("PluginSupervisor.activate")(function* (target: number) {
-      yield* lock.withPermit(
-        Effect.gen(function* () {
-          if (applied >= target) return
-          // Resolve OpenCode's internal plugins with their privileged Location services.
-          const internal = yield* PluginInternal.list()
-          // Combine internal plugins with host-contributed SDK plugins in boot order.
-          const pre = [...internal.pre.map((plugin) => ({ ...plugin, version: "internal" })), ...sdk.all()]
-          const post = internal.post.map((plugin) => ({ ...plugin, version: "internal" }))
-          const entries = yield* config.entries()
-          const operations = yield* scan(entries)
-          yield* watchConfiguredSources(entries, operations)
-          // Apply config operations and load enabled package plugins into one ordered generation.
-          const plugins = yield* resolve(pre, post, operations)
-          // Replace the active generation in one scoped, batched activation.
-          yield* registry.activate(plugins)
-          applied = target
-        }),
-      )
+    const activate = Effect.fn("PluginSupervisor.activate")(function* () {
+      // Resolve OpenCode's internal plugins with their privileged Location services.
+      const internal = yield* PluginInternal.list()
+      // Combine internal plugins with host-contributed SDK plugins in boot order.
+      const pre = [...internal.pre.map((plugin) => ({ ...plugin, version: "internal" })), ...sdk.all()]
+      const post = internal.post.map((plugin) => ({ ...plugin, version: "internal" }))
+      const entries = yield* config.entries()
+      const operations = yield* scan(entries)
+      yield* watchConfiguredSources(entries, operations)
+      // Apply config operations and load enabled package plugins into one ordered generation.
+      const plugins = yield* resolve(pre, post, operations)
+      // Replace the active generation in one scoped, batched activation.
+      yield* registry.activate(plugins)
     })
     const sourceChanges = config.changes().pipe(
       Stream.filterEffect((update) => Effect.map(config.entries(), (entries) => isPluginSource(entries, update.path))),
@@ -295,31 +287,16 @@ const layer = Layer.effect(
     const busUpdates = bus
       .subscribe([Event.Updated, SdkPlugins.Updated])
       .pipe(Stream.mapEffect(() => Effect.sync(() => ++observed)))
-    const updates = yield* Stream.merge(busUpdates, sourceChanges).pipe(
-      Stream.toQueue({ capacity: 1, strategy: "sliding" }),
-    )
-    const signals = yield* Stream.concat(Stream.succeed(0), Stream.fromQueue(updates)).pipe(
-      Stream.broadcast({ capacity: 1, strategy: "sliding", replay: 1 }),
-    )
-    const attempt = (target: number) =>
-      activate(target).pipe(
-        Effect.map(() => observed === target),
-        Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause }).pipe(Effect.as(false))),
-      )
-
-    yield* signals.pipe(
-      Stream.runForEach((target) =>
-        activate(target).pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause }))),
-      ),
-      Effect.forkScoped({ startImmediately: true }),
-    )
-    yield* signals.pipe(
+    yield* Stream.concat(Stream.succeed(0), Stream.merge(busUpdates, sourceChanges)).pipe(
+      // Keep observing updates while activation runs, retaining only the latest generation request.
+      Stream.buffer({ capacity: 1, strategy: "sliding" }),
       Stream.debounce("100 millis"),
-      Stream.mapEffect(attempt),
-      Stream.filter((settled) => settled),
-      Stream.take(1),
-      Stream.runDrain,
-      Effect.andThen(Deferred.succeed(ready, undefined)),
+      Stream.runForEach((target) =>
+        Effect.gen(function* () {
+          yield* activate()
+          if (observed === target) yield* Deferred.succeed(ready, undefined)
+        }).pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause }))),
+      ),
       Effect.forkScoped({ startImmediately: true }),
     )
     return Service.of({ flush: Deferred.await(ready) })


### PR DESCRIPTION
## What

Simplify `PluginSupervisor` reload orchestration to one debounced activation owner while preserving startup readiness and latest-update behavior.

Config and SDK updates continue to be observed while activation is running. The loop retains only the latest pending generation request, activates it after the 100ms debounce, and opens the one-time startup `flush` gate only after a successful activation with no newer observed update.

## How

- Replace the queue, broadcast, two consumers, semaphore, and applied-version deduplication in `packages/core/src/plugin/supervisor.ts` with one buffered stream consumer.
- Place a capacity-one sliding buffer before the debounce so update observation can progress independently of activation.
- Log activation failures and wait for the next Config or SDK signal instead of retrying identical state automatically.

## Scope

This keeps `flush` as a one-time startup-readiness gate and does not rename it or change its callers. Reload-trigger deduplication, global-skill reload behavior, and MCP config subscription remain separate follow-ups.

## Testing

- `bun typecheck` from `packages/core`
- `bun run test test/location-layer.test.ts test/config/plugin.test.ts` from `packages/core`, repeated twice after the initial individual focused runs
- `bun run test` from `packages/core`: 1,487 passed, 6 skipped, 0 failed
- `git diff --check`

## Flow

```mermaid
sequenceDiagram
    participant Source as Config / SDK updates
    participant Buffer as Sliding buffer
    participant Owner as Activation owner
    participant Registry as Plugin registry
    participant Ready as Startup gate

    Source->>Buffer: observe versioned signal
    Note over Buffer: retain latest pending signal
    Buffer->>Owner: debounce 100ms
    Owner->>Registry: activate resolved generation
    alt newer update observed
        Owner->>Buffer: await latest signal
    else generation settled
        Owner->>Ready: open once
    end
    alt activation fails
        Owner->>Owner: log failure
        Owner->>Buffer: await a new signal
    end
```
