### PR TITLE
fix(opencode): strip unused location from skill system prompt

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -16,7 +16,6 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Glob } from "@opencode-ai/core/util/glob"
 import { Discovery } from "./discovery"
 import { isRecord } from "@/util/record"
-import { escapeHtml } from "@/util/html"
 
 const CLAUDE_EXTERNAL_DIR = ".claude"
 const AGENTS_EXTERNAL_DIR = ".agents"
@@ -330,7 +329,6 @@ export function fmt(list: Info[], opts: { verbose: boolean }) {
           "  <skill>",
           `    <name>${skill.name}</name>`,
           `    <description>${skill.description}</description>`,
-          `    <location>${escapeHtml(skill.location)}</location>`,
           "  </skill>",
         ]),
       "</available_skills>",

--- a/packages/opencode/test/skill/skill.test.ts
+++ b/packages/opencode/test/skill/skill.test.ts
@@ -64,7 +64,7 @@ const withHome = <A, E, R>(home: string, self: Effect.Effect<A, E, R>) =>
   )
 
 describe("skill", () => {
-  it.effect("formats verbose locations as XML-safe filesystem paths", () =>
+  it.effect("verbose format omits location tags", () =>
     Effect.sync(() => {
       const output = Skill.fmt(
         [
@@ -84,10 +84,9 @@ describe("skill", () => {
         { verbose: true },
       )
 
-      expect(output).toContain("<location>/tmp/plugin.git#v1.3.0/SKILL.md</location>")
-      expect(output).toContain("<location>&lt;built-in&gt;</location>")
-      expect(output).not.toContain("file://")
-      expect(output).not.toContain("%23")
+      expect(output).not.toContain("<location>")
+      expect(output).toContain("<name>tagged-skill</name>")
+      expect(output).toContain("<description>A tagged skill.</description>")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #39294

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Removes the `<location>` tag from the verbose skill system prompt. The location is never consumed by the model—skills are invoked by name, not by filesystem path—so emitting it wastes ~3K tokens/turn when many skills are loaded.

Also removes the now-unused `escapeHtml` import and updates the existing test to assert that `<location>` is no longer present.

### How did you verify your code works?

- Confirmed `bun typecheck` in `packages/opencode` passes (pre-existing MCP module errors only, unrelated)
- Updated the `"verbose format omits location tags"` test to assert `<location>` is absent and name/description tags remain

### Screenshots / recordings

N/A — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR