### PR TITLE
fix(core): preserve plugin update order

### DIFF
--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -277,17 +277,17 @@ const layer = Layer.effect(
       // Replace the active generation in one scoped, batched activation.
       yield* registry.activate(plugins)
     })
-    const sourceChanges = config.changes().pipe(
-      Stream.filterEffect((update) => Effect.map(config.entries(), (entries) => isPluginSource(entries, update.path))),
-      Stream.merge(Stream.fromPubSub(configuredChanges)),
-      // Make accepted filesystem work visible to flush before coalescing the burst.
+    const updates = Stream.merge(
+      config.changes().pipe(
+        Stream.filterEffect((update) => Effect.map(config.entries(), (entries) => isPluginSource(entries, update.path))),
+        Stream.merge(Stream.fromPubSub(configuredChanges)),
+      ),
+      bus.subscribe([Event.Updated, SdkPlugins.Updated]),
+    ).pipe(
+      // Make accepted work visible to flush before coalescing the burst.
       Stream.mapEffect(() => Effect.sync(() => ++observed)),
-      Stream.debounce("100 millis"),
     )
-    const busUpdates = bus
-      .subscribe([Event.Updated, SdkPlugins.Updated])
-      .pipe(Stream.mapEffect(() => Effect.sync(() => ++observed)))
-    yield* Stream.concat(Stream.succeed(0), Stream.merge(busUpdates, sourceChanges)).pipe(
+    yield* Stream.concat(Stream.succeed(0), updates).pipe(
       // Keep observing updates while activation runs, retaining only the latest generation request.
       Stream.buffer({ capacity: 1, strategy: "sliding" }),
       Stream.debounce("100 millis"),


### PR DESCRIPTION
## What

Follow-up to #39356. Assign one monotonic revision after filesystem and bus invalidations converge, while retaining the single activation owner and capacity-one sliding buffer. This also removes the filesystem path's duplicate debounce.

## Before / After

**Before:** A filesystem change could increment `observed` to `1` and wait in its branch-local debounce. A later bus update could increment it to `2` and emit first, followed by the stale filesystem target `1`. The downstream debounce could retain `1`; activation would succeed, but `observed === target` would remain false with no newer signal available to open startup readiness.

**After:** Accepted filesystem and bus invalidations merge before revision assignment. Targets therefore enter the single debounce in monotonic emission order, so the retained target always represents the latest observed inputs.

## How

- `packages/core/src/plugin/supervisor.ts` merges accepted filesystem invalidations with config and SDK bus updates before incrementing `observed`.
- One downstream debounce coalesces all update sources and preserves the existing 100 ms startup settling window.
- The sliding buffer and single serialized activation owner are unchanged.

## Scope

This does not change `flush` into a general hot-reload barrier, add retries for failed identical state, or alter which filesystem and bus events count as plugin invalidations.

## Testing

- `OPENCODE_CONFIG_DIR=/tmp/opencode-empty-config bun run test test/location-layer.test.ts`
- `OPENCODE_CONFIG_DIR=/tmp/opencode-empty-config bun run test test/config/plugin.test.ts`
- `OPENCODE_CONFIG_DIR=/tmp/opencode-empty-config bun run test` (1,487 passed, 6 skipped)
- `bun typecheck`