### PR TITLE
fix(snapshot): seed index from the worktree's git dir

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -226,7 +226,13 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
 
           // Seed the index from the source repo so already-hashed entries are reused.
           // Best-effort: a missing/incompatible index just falls back to a full add.
-          const sourceIndex = path.join(source, "index")
+          // Resolve the index from the worktree's own git dir (--git-dir), not the
+          // common dir: in a linked worktree --git-common-dir points at the main
+          // repo's .git, whose index does not match the worktree's working tree.
+          const gitdir = yield* git(["rev-parse", "--path-format=absolute", "--git-dir"], {
+            cwd: state.worktree,
+          })
+          const sourceIndex = gitdir.code === 0 ? path.join(gitdir.text.trim(), "index") : path.join(source, "index")
           if (yield* exists(sourceIndex)) {
             yield* fs.copyFile(sourceIndex, path.join(state.gitdir, "index")).pipe(Effect.catch(() => Effect.void))
           }


### PR DESCRIPTION
### Issue for this PR

Closes #39388

### Type of change

- [x] Bug fix

### What does this PR do?

#31798 seeds the snapshot repo with the source repo's git index so `git add --all`
reuses already-hashed entries instead of re-hashing the whole tree. In a linked worktree
`--git-common-dir` resolves to the main repository's `.git`, so the copied index is the
main repo's, which does not match the worktree's working tree. `git add --all` then
re-hashes every file, reintroducing the hang on large worktrees.

Resolve the index from `--git-dir` (cwd = the worktree) instead, which in a linked worktree
points at the worktree's own `.git/worktrees/<name>` (whose index matches its working tree).
Falls back to the common dir's index when `rev-parse` fails, preserving the existing
best-effort behavior.

### How did you verify your code works?

**End-to-end** (`opencode run "say hi"` in a chromium `--depth 1` worktree, ~500k files):

| Binary | Location | Time | Result |
|---|---|---|---|
| Official 1.18.4 | main repo | 9.8s | completes |
| Official 1.18.4 | worktree | 1m50s+ (killed) | hangs — `git add --all` re-hashing |
| This fix | worktree | 38.5s | completes, model responds |

**Isolated git-level reproduction** (replicating `Snapshot.seed()` at `packages/opencode/src/snapshot/index.ts:198-239`):

| Scenario | Index source | Time | Tree hash |
|---|---|---|---|
| A: no seeding (pre-#31798) | none | >180s (timeout) | `4b825dc6...` (empty) |
| B: common-dir index (bug) | main repo | 166s | `36e0ef8a...` |
| C: git-dir index (fix) | worktree | 6s | `36e0ef8a...` |

B and C produce identical tree hashes — the fix preserves correctness. C is 27x faster.

- `bun test test/snapshot/snapshot.test.ts` from `packages/opencode` — 55 pass, 1 skip, 0 fail.
- `bun typecheck` from `packages/opencode` — clean.
- 
### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

