### PR TITLE
docs: add Layerz to MCP server examples

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -515,7 +515,7 @@ If you are unsure how to do something, use `gh_grep` to search code examples fro
 
 ### Layerz
 
-Add the [Layerz MCP server](https://app.layerz.cc/for-agents) to build, version, and audit
+Add the [Layerz MCP server](https://layerz.cc/for-agents) to build, version, and audit
 structured financial models, and export them to Excel.
 
 ```json title="opencode.json" {4-8}
@@ -524,7 +524,7 @@ structured financial models, and export them to Excel.
   "mcp": {
     "layerz": {
       "type": "remote",
-      "url": "https://app.layerz.cc/mcp",
+      "url": "https://layerz.cc/mcp",
       "oauth": {}
     }
   }

--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,39 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### Layerz
+
+Add the [Layerz MCP server](https://app.layerz.cc/for-agents) to build, version, and audit
+structured financial models, and export them to Excel.
+
+```json title="opencode.json" {4-8}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "layerz": {
+      "type": "remote",
+      "url": "https://app.layerz.cc/mcp",
+      "oauth": {}
+    }
+  }
+}
+```
+
+After adding the configuration, authenticate with Layerz:
+
+```bash
+opencode mcp auth layerz
+```
+
+This will open a browser window to complete the OAuth flow and connect OpenCode to your
+Layerz account.
+
+Once authenticated, you can read and modify models, inspect the dependency graph between
+variables, and export to `.xlsx`.
+
+```txt "use layerz"
+Add a 5% monthly churn assumption to my SaaS forecast and show the impact on ARR. use layerz
+```


### PR DESCRIPTION
### Issue for this PR

No issue. The `## Examples` section says "You can submit a PR if you want to document other servers", so I'm doing that.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds Layerz as a fourth entry under `## Examples` in the MCP servers docs. Layerz is a remote MCP server for financial modelling: you build and version models, and export them to Excel.

It follows the Sentry entry because that's the closest case in the page, a remote server behind OAuth. Same shape: the config block, the `opencode mcp auth` step, one example prompt.

Nothing in OpenCode needed changing. The server already implements OAuth 2.1 with dynamic client registration, which is what the automatic OAuth path in `MCP.state()` expects, so the documented config works as-is.

Only the English source file is edited. I left the translations alone since they're handled separately.

### How did you verify your code works?

Ran the exact config in the diff against opencode 1.18.9.

`opencode mcp debug layerz`:

```
HTTP response: 401 Unauthorized
WWW-Authenticate: Bearer realm="layerz", resource_metadata="https://app.layerz.cc/.well-known/oauth-protected-resource/mcp"
Initial unauthenticated check returned 401, so this server requires OAuth
OAuth flow triggered: Unauthorized
Client ID available: lzc_...
```

So discovery resolves and RFC 7591 registration succeeds.

`opencode mcp auth layerz` completes the browser flow, and `opencode mcp list` then reports:

```
✓ layerz connected (OAuth)
```

Then I exercised tools in both directions to make sure the connection is actually usable, not just authenticated:

- read: `layerz_list_models` returned my 62 models
- write: `layerz_patch` with `dry_run: true` returned `{"ok":true,"applied_ops":1,"dry_run":true}`

The example prompt in the diff is the kind of thing that goes through that write path.

One thing worth knowing, though it doesn't affect this PR: tools get prefixed with the server name, so naming the server `layerz` gives `layerz_layerz_list_models`. Harmless, just surprising the first time. I kept the name `layerz` for consistency with the other examples.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
