### PR TITLE
docs: typo in enterprise.mdx documentation IT lang

### DIFF
--- a/packages/web/src/content/docs/it/enterprise.mdx
+++ b/packages/web/src/content/docs/it/enterprise.mdx
@@ -21,7 +21,7 @@ Per iniziare con OpenCode Enterprise:
 
 ## Prova
 
-OpenCode e open source e non memorizza alcun tuo codice o dato di contesto, quindi i tuoi sviluppatori possono semplicemente [iniziare](/docs/) e fare una prova.
+OpenCode è open source e non memorizza alcun tuo codice o dato di contesto, quindi i tuoi sviluppatori possono semplicemente [iniziare](/docs/) e fare una prova.
 
 ---
 


### PR DESCRIPTION
Typo in Prova paragraph, missing "e" accented

### Issue for this PR

Closes #39404

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [X] Documentation

### What does this PR do?

This PR fix a typo in enterprise.mdx file, paragraph Prova, for IT lang: there is a missing "e" accented between "OpenCode" and "open source"

### How did you verify your code works?
Verified the change by reviewing the diff. This is a documentation IT lang typo fix only.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
