### PR TITLE
fix(tui): roll over compact counts to M at 999,950

### DIFF
--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -28,7 +28,8 @@ export function todayTimeOrDateTime(input: number): string {
 }
 
 export function number(num: number): string {
-  if (num >= 1000000) {
+  // 999,950 and up round to 1000.0K at one decimal place, so roll over to M there
+  if (num >= 999950) {
     return (num / 1000000).toFixed(1) + "M"
   } else if (num >= 1000) {
     return (num / 1000).toFixed(1) + "K"

--- a/packages/tui/test/util/locale.test.ts
+++ b/packages/tui/test/util/locale.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { number } from "../../src/util/locale"
+
+describe("util.locale.number", () => {
+  test("formats counts below a thousand as-is", () => {
+    expect(number(0)).toBe("0")
+    expect(number(999)).toBe("999")
+  })
+
+  test("formats thousands with a K suffix", () => {
+    expect(number(1000)).toBe("1.0K")
+    expect(number(1500)).toBe("1.5K")
+    expect(number(999949)).toBe("999.9K")
+  })
+
+  test("rolls over to M once the K value would round to 1000.0", () => {
+    expect(number(999950)).toBe("1.0M")
+    expect(number(999999)).toBe("1.0M")
+  })
+
+  test("formats millions with an M suffix", () => {
+    expect(number(1000000)).toBe("1.0M")
+    expect(number(1500000)).toBe("1.5M")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33947

### Type of change

- [x] Bug fix

### What does this PR do?

`Locale.number()` formats the thousands value with `toFixed(1)`, so any count from 999,950 to 999,999 rounds to `1000.0` and renders as `1000.0K`. The `>= 1000000` branch never gets a chance to promote it to `M`, because the value itself is still below a million. It shows up in the TUI context indicator on models with a ~1M token context window, e.g. `1000.0K (100%)`.

Rolling over at 999,950 — the point where one-decimal rounding first reaches `1000.0K` — makes those values render as `1.0M` instead. Nothing below that boundary changes.

### How did you verify your code works?

Added `test/util/locale.test.ts`: 999,949 still formats as `999.9K`, 999,950 and 999,999 now format as `1.0M`, and the existing plain/K/M cases are covered so the fix can't regress them. `bun test test/util/locale.test.ts` and `bun typecheck` both pass in `packages/tui`.

No screenshot — reproducing it in the UI needs a session grown to ~999,950 tokens, so the boundary is covered by the unit test instead.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
