### PR TITLE
fix(tui): hide single session tab

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1185,7 +1185,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         <box flexGrow={1} minWidth={0} flexDirection="column">
           <Show when={plugins.ready()}>
             <box flexGrow={1} minHeight={0} flexDirection="column">
-              <Show when={sessionTabs.enabled() && sessionTabs.tabs().length > 0 && route.data.type !== "plugin"}>
+              <Show when={sessionTabs.enabled() && sessionTabs.tabs().length > 1 && route.data.type !== "plugin"}>
                 <SessionTabs />
               </Show>
               <Switch>


### PR DESCRIPTION
## What

Hide the opt-in session tab strip when only one real tab is open. The strip appears once a second tab is added, where tab navigation becomes useful.

## Before / After

**Before:** Enabling session tabs showed a full tab row even when the working set contained only the current session.

**After:** Zero or one tab uses the full terminal height. Opening a second tab reveals the strip; closing back to one hides it again.

## How

- Update the `SessionTabs` render guard in `packages/tui/src/app.tsx` to require more than one real tab.
- Keep tab persistence, unread state, commands, and keyboard navigation unchanged.

## Scope

This only changes strip visibility. It does not alter which sessions belong to the tab working set or when tabs are created and closed.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui` (`562 pass`, `5 skip`, `0 fail`)
- Push-hook workspace typecheck (`33` tasks passed)
- `bunx prettier --check packages/tui/src/app.tsx`
- `git diff --check`
