### PR TITLE
fix(tui): fade full-width tab titles

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -7,6 +7,7 @@ import { useTheme, useThemes } from "../context/theme"
 import { adaptiveSessionTabLayout, sessionTabComplete, SESSION_TAB_OVERFLOW_WIDTH } from "../context/session-tabs-model"
 import { createAnimatable, spring } from "../ui/animation"
 import { Locale } from "../util/locale"
+import { stringWidth } from "../util/string-width"
 import { TabPulse } from "./tab-pulse"
 import { tint } from "../theme/color"
 
@@ -138,7 +139,9 @@ export function SessionTabs() {
           const visibleTitleParts = createMemo(() => Locale.graphemes(visibleTitle()))
           const fadeWidth = () => (hovered() === tab.sessionID ? 6 : 4)
           const fadedTitleParts = createMemo(() => visibleTitleParts().slice(-fadeWidth()))
-          const titleFades = createMemo(() => visibleTitle() !== title() && availableTitleWidth() > fadeWidth())
+          const titleFades = createMemo(
+            () => stringWidth(title()) >= availableTitleWidth() && availableTitleWidth() > fadeWidth(),
+          )
           const foreground = () => {
             if (hovered() === tab.sessionID) return theme.text.default
             return tint(theme.text.subdued, theme.text.default, selection())


### PR DESCRIPTION
## What

Apply the tab-edge title fade when a title exactly fills its available width, not only when it is truncated.

## Before / After

**Before:** An exact-fit title remained at full brightness through its final cell, making its boundary with the next tab visually ambiguous.

**After:** Exact-fit and truncated titles receive the same edge fade. Short titles with empty space before the edge remain unchanged.

## How

- Measure the original title with terminal-cell-aware `stringWidth`.
- Fade when that width fills or exceeds the available title area.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui` (`562 pass`, `5 skip`, `0 fail`)
- Push-hook workspace typecheck (`33` tasks passed)
- `bunx prettier --check packages/tui/src/component/session-tabs.tsx`
- `git diff --check`
