### PR TITLE
fix(session): retry HTTP 408 request timeouts

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -88,10 +88,12 @@ export function retryable(error: Err, provider: string) {
   if (SessionV1.APIError.isInstance(error)) {
     const status = error.data.statusCode
     // 5xx errors are transient server failures and should always be retried,
-    // even when the provider SDK doesn't explicitly mark them as retryable.
+    // even when the provider SDK doesn't explicitly mark them as retryable. 408 is the one 4xx
+    // that is transient in the same way: the request timed out before completing, so it is safe
+    // to send again.
     if (
       !error.data.isRetryable &&
-      !(status !== undefined && status >= 500) &&
+      !(status !== undefined && (status === 408 || status >= 500)) &&
       !matchesRetryableMessage(error.data.message) &&
       !matchesRetryableMessage(error.data.responseBody)
     )

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -309,6 +309,26 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "Service unavailable" })
   })
 
+  test("retries 408 request timeout errors", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "stream error: stream disconnected before completion",
+        isRetryable: false,
+        statusCode: 408,
+        responseBody: JSON.stringify({
+          type: "error",
+          sequence_number: 0,
+          code: "request_timeout",
+          message: "stream error: stream disconnected before completion",
+        }),
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "stream error: stream disconnected before completion",
+    })
+  })
+
   test("does not retry 4xx errors when isRetryable is false", () => {
     const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
       new SessionV1.APIError({


### PR DESCRIPTION
### Issue for this PR

Closes #39221

### Type of change

- [x] Bug fix

### What does this PR do?

`retryable()` only bypasses the provider SDK's `isRetryable` flag for `status >= 500`. An HTTP 408 that the SDK didn't mark retryable therefore falls through and ends the turn, so the user has to resend the prompt by hand. This shows up with OpenAI-compatible proxies that normalize an aborted upstream stream into `408 request_timeout`.

408 Request Timeout is the one 4xx that is transient in the same way a 5xx is — the request never completed, so sending it again is the defined behavior for that status. This adds 408 to the existing condition, so it takes exactly the same path as 5xx: same classification, same backoff, same `retry-after` handling. No new retry mechanism, and other 4xx statuses are unchanged.

### How did you verify your code works?

Added `retries 408 request timeout errors` to `test/session/retry.test.ts`, built from the payload in the issue (status 408, `isRetryable: false`, `code: request_timeout`), asserting it is now classified retryable. Ran the whole `retry.test.ts` suite so the neighbouring cases still hold — in particular `does not retry 4xx errors when isRetryable is false` (status 400) still passes, so this doesn't loosen 4xx generally. `bun typecheck` passes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
