### PR TITLE
fix(tui): remove dummy session placeholder causing --continue error

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -283,16 +283,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                             <ArgsProvider {...input.args}>
                               <KVProvider>
                                 <ToastProvider>
-                                  <RouteProvider
-                                    initialRoute={
-                                      input.args.continue
-                                        ? {
-                                            type: "session",
-                                            sessionID: "dummy",
-                                          }
-                                        : undefined
-                                    }
-                                  >
+                                  <RouteProvider initialRoute={undefined}>
                                     <TuiConfigProvider config={input.config}>
                                       <PluginRuntimeProvider value={pluginRuntime}>
                                         <SDKProvider


### PR DESCRIPTION
### Issue for this PR

Closes #34144, closes #28486, closes #29262

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

removes the "dummy" session placeholder causing error being printed to logs when `--continue` was passed.

### How did you verify your code works?

`tail -f ~/.local/share/opencode/log/opencode.log`

`bun run --cwd packages/opencode dev -- --continue`

No error message in logs.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
