### PR TITLE
fix(tui): restore visible tab pulse

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -169,7 +169,7 @@ export function SessionTabs() {
                 enabled={config.animations ?? true}
                 active={status().busy}
                 complete={status().complete}
-                color={accent()}
+                color={theme.text.default}
                 completionColor={accent()}
                 backgroundColor={pulseBackground()}
               />

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -132,7 +132,6 @@ export function SessionTabs() {
             return tint(base, theme.raise(theme.background.surface.offset), selection())
           }
           const pulseBackground = () => background()
-          const pulseColor = () => tint(pulseBackground(), theme.text.default, 0.45)
           const title = () => tab.title ?? "Untitled session"
           const availableTitleWidth = () => Math.max(1, width() - 3)
           const visibleTitle = createMemo(() => Locale.takeWidth(title(), availableTitleWidth()))
@@ -170,7 +169,7 @@ export function SessionTabs() {
                 enabled={config.animations ?? true}
                 active={status().busy}
                 complete={status().complete}
-                color={pulseColor()}
+                color={accent()}
                 completionColor={accent()}
                 backgroundColor={pulseBackground()}
               />

--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -17,6 +17,7 @@ const RUN_DURATION = 2_800
 const RUN_HEAD = 4
 const RUN_TAIL = 18
 const RUN_FADE_OUT = 500
+const RUN_OPACITY = 0.1
 const COMPLETION_DURATION = 900
 const COMPLETION_ATTACK = 0.16
 const intensityAt = (index: number, front: number, head: number, tail: number) => {
@@ -163,7 +164,7 @@ class TabPulseRenderable extends Renderable {
         intensityAt(index, front, RUN_HEAD, RUN_TAIL),
         intensityAt(index, secondFront, RUN_HEAD, RUN_TAIL),
       )
-      const running = tint(this._backgroundColor, this._color, intensity * 0.14 * runningOpacity)
+      const running = tint(this._backgroundColor, this._color, intensity * RUN_OPACITY * runningOpacity)
       buffer.setCell(
         this.screenX + index,
         this.screenY,


### PR DESCRIPTION
## What

Make the running session-tab sweep subtly visible across themes without assigning ordinary running work an accent/status color.

## Before / After

**Before:** The adaptive tab layout blended the pulse 45% toward neutral text before the pulse renderable applied its own 14% opacity. The resulting maximum was only about 6.3% toward the theme text color, making the movement disappear in some dark themes.

**After:** The running sweep blends directly toward each theme's default text color at 10%. It remains neutral and restrained while producing more predictable contrast on dark and light backgrounds. Completion feedback remains accent-colored.

## How

- `packages/tui/src/component/session-tabs.tsx`: use the theme's contrast-aware default text color for the running sweep while retaining accent for completion.
- `packages/tui/src/component/tab-pulse.tsx`: name and set the running blend strength at 10%.

## Scope

- Does not change busy-state detection, sweep timing or shape, fade-out timing, or completion animation behavior.

## Testing

- `bun typecheck` in `packages/tui`
- `bun run test` in `packages/tui`: 566 passed, 5 skipped
- Workspace push-hook typecheck: 33 packages passed
- `bunx prettier --check packages/tui/src/component/session-tabs.tsx packages/tui/src/component/tab-pulse.tsx`
- Isolated OpenCode Drive recordings with the same inactive busy tab in `opencode` and `tokyonight`

## Demo

The inactive second tab remains busy while the neutral 10% sweep moves across it. The left panel uses `opencode`; the right uses `tokyonight`.

https://github.com/user-attachments/assets/adcabd56-3106-4662-a267-1fdeb7d6ce61
