### PR TITLE
fix(tui): preserve session route on transient errors

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -25,15 +25,16 @@ import { Spinner, SPINNER_FRAMES } from "../../component/spinner"
 import { ThemeContextProvider, useTheme, useThemes } from "../../context/theme"
 import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, RGBA } from "@opentui/core"
 import { Prompt, type PromptRef } from "../../component/prompt"
-import type {
-  ModelInfo,
-  SessionMessageInfo,
-  SessionMessageAssistant,
-  SessionMessageAssistantReasoning,
-  SessionMessageAssistantText,
-  SessionMessageAssistantTool,
-  SessionMessageUser,
-  SessionInfo,
+import {
+  isSessionNotFoundError,
+  type ModelInfo,
+  type SessionMessageInfo,
+  type SessionMessageAssistant,
+  type SessionMessageAssistantReasoning,
+  type SessionMessageAssistantText,
+  type SessionMessageAssistantTool,
+  type SessionMessageUser,
+  type SessionInfo,
 } from "@opencode-ai/client"
 import { useLocal } from "../../context/local"
 import { Locale } from "../../util/locale"
@@ -282,7 +283,7 @@ export function Session() {
         variant: "error",
         duration: 5000,
       })
-      navigate({ type: "home" })
+      if (isSessionNotFoundError(error)) navigate({ type: "home" })
     })
   })
 


### PR DESCRIPTION
## What

Keep the selected session route when session hydration fails for a transient reason. Existing sessions remain navigable after the managed background service reconnects instead of appearing to disappear.

## Before / After

**Before:** Selecting an existing session started its hydration requests. If the background service was stopping or restarting, a transient transport error or undeclared `503` rejected hydration. The session route treated every rejection as if the session did not exist and immediately navigated home, so repeatedly selecting old sessions appeared to do nothing.

**After:** Only a decoded `SessionNotFoundError` navigates home. Other hydration failures still surface a toast, but the selected route remains intact. The existing connection-status effect can hydrate that same session when the event stream reconnects.

## How

- `packages/tui/src/routes/session/index.tsx` uses the generated `isSessionNotFoundError` guard before discarding the current route.
- The actual not-found path is unchanged.

## Scope

This PR does not retry arbitrary API mutations or change managed-service restart behavior. It only prevents transient session-load failures from being misclassified as missing sessions.

## Testing

- `bun typecheck` from `packages/tui`
- `bun run test test/cli/tui` from `packages/tui`: 129 passed, 1 skipped
- Push hook: `bun turbo typecheck --concurrency=3`: 33 packages passed

## Demo

No recording attached. The visible failure depends on hitting the managed-service replacement window; the change preserves the route at the exact error boundary without simulating a successful server response.

## Flow

```mermaid
sequenceDiagram
    participant User
    participant TUI
    participant Service

    User->>TUI: Select existing session
    TUI->>Service: Hydrate session
    Service-->>TUI: Transient failure during restart
    TUI->>TUI: Keep selected route and show error
    Service-->>TUI: Event stream reconnects
    TUI->>Service: Hydrate selected session again
    Service-->>TUI: Existing session
```
