### PR TITLE
docs: fix Italian enterprise typo

### DIFF
--- a/packages/web/src/content/docs/it/enterprise.mdx
+++ b/packages/web/src/content/docs/it/enterprise.mdx
@@ -21,7 +21,7 @@ Per iniziare con OpenCode Enterprise:
 
 ## Prova
 
-OpenCode e open source e non memorizza alcun tuo codice o dato di contesto, quindi i tuoi sviluppatori possono semplicemente [iniziare](/docs/) e fare una prova.
+OpenCode è open source e non memorizza alcun tuo codice o dato di contesto, quindi i tuoi sviluppatori possono semplicemente [iniziare](/docs/) e fare una prova.
 
 ---
 


### PR DESCRIPTION
## What

Correct the Italian enterprise documentation to use the accented verb `è` in “OpenCode è open source.”

Closes #39404.

## Scope

One translation typo only; no runtime or documentation structure changes.

## Testing

- `git diff --check`