### PR TITLE
fix(tui): always show session tab

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1197,7 +1197,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         <box flexGrow={1} minWidth={0} flexDirection="column">
           <Show when={plugins.ready()}>
             <box flexGrow={1} minHeight={0} flexDirection="column">
-              <Show when={sessionTabs.enabled() && sessionTabs.tabs().length > 1 && route.data.type !== "plugin"}>
+              <Show when={sessionTabs.enabled() && sessionTabs.tabs().length > 0 && route.data.type !== "plugin"}>
                 <SessionTabs />
               </Show>
               <Switch>


### PR DESCRIPTION
## What

Always render the session tab strip when at least one real tab is open.

## Before / After

**Before:** A single open session hid the tab strip, so tab navigation appeared only after opening a second session.

**After:** The first open session immediately appears as a capped-width tab. Home/New with no open tabs remains unchanged, and plugin routes still omit the strip.

## How

- `packages/tui/src/app.tsx`: change the tab-strip visibility threshold from more than one tab to at least one tab.
- Reuse the existing single-tab sizing behavior in the adaptive tab layout.

## Scope

- No changes to tab sizing, ordering, history, or persistence.

## Testing

- `bun typecheck` in `packages/tui`
- Workspace push-hook typecheck: 33 packages passed
- `bunx prettier --check src/app.tsx`
- `git diff --check`
