### PR TITLE
fix(tui): reduce tab pulse allocations

### DIFF
--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -1,6 +1,5 @@
 import { OptimizedBuffer, Renderable, RGBA, type RenderableOptions, type RenderContext } from "@opentui/core"
 import { extend } from "@opentui/solid"
-import { tint } from "../theme/color"
 
 type TabPulseOptions = RenderableOptions<TabPulseRenderable> & {
   enabled?: boolean
@@ -23,6 +22,7 @@ const COMPLETION_DURATION = 900
 const COMPLETION_ATTACK = 0.16
 const GLOW_TAIL = 12
 const GLOW_OPACITY = 0.16
+const DEFAULT_FOREGROUND = RGBA.defaultForeground()
 const intensityAt = (index: number, front: number, head: number, tail: number) => {
   const distance = front - index
   return distance < 0 ? smootherstep(clamp(1 + distance / head)) : smootherstep(clamp(1 - distance / tail))
@@ -41,6 +41,26 @@ export const unreadGlowIntensity = (index: number, width: number) => {
   const tail = Math.min(GLOW_TAIL, Math.max(1, width - 2))
   return smootherstep(clamp(1 - Math.max(0, index - 1) / tail))
 }
+export function blendTabPulseColor(
+  output: RGBA,
+  background: RGBA,
+  glowColor: RGBA,
+  runningColor: RGBA,
+  completionColor: RGBA,
+  glow: number,
+  running: number,
+  completion: number,
+) {
+  output.r = background.r + (glowColor.r - background.r) * glow
+  output.g = background.g + (glowColor.g - background.g) * glow
+  output.b = background.b + (glowColor.b - background.b) * glow
+  output.r += (runningColor.r - output.r) * running
+  output.g += (runningColor.g - output.g) * running
+  output.b += (runningColor.b - output.b) * running
+  output.r += (completionColor.r - output.r) * completion
+  output.g += (completionColor.g - output.g) * completion
+  output.b += (completionColor.b - output.b) * completion
+}
 class TabPulseRenderable extends Renderable {
   private _enabled: boolean
   private _active: boolean
@@ -54,6 +74,7 @@ class TabPulseRenderable extends Renderable {
   private fadeClock: number | undefined
   private completionClock: number | undefined
   private completionPending = false
+  private renderColor = RGBA.fromInts(0, 0, 0)
 
   constructor(ctx: RenderContext, options: TabPulseOptions = {}) {
     const enabled = options.enabled ?? true
@@ -191,17 +212,20 @@ class TabPulseRenderable extends Renderable {
         intensityAt(index, front, RUN_HEAD, RUN_TAIL),
         intensityAt(index, secondFront, RUN_HEAD, RUN_TAIL),
       )
-      const background = this._glow
-        ? tint(this._backgroundColor, this._glowColor, unreadGlowIntensity(index, this.width) * GLOW_OPACITY)
-        : this._backgroundColor
-      const running = tint(background, this._color, intensity * 0.14 * runningOpacity)
-      buffer.setCell(
-        this.screenX + index,
-        this.screenY,
-        " ",
-        RGBA.defaultForeground(),
-        tint(running, this._completionColor, completionOpacity * 0.18),
+      const glow = this._glow ? unreadGlowIntensity(index, this.width) * GLOW_OPACITY : 0
+      const running = intensity * 0.14 * runningOpacity
+      const completion = completionOpacity * 0.18
+      blendTabPulseColor(
+        this.renderColor,
+        this._backgroundColor,
+        this._glowColor,
+        this._color,
+        this._completionColor,
+        glow,
+        running,
+        completion,
       )
+      buffer.setCell(this.screenX + index, this.screenY, " ", DEFAULT_FOREGROUND, this.renderColor)
     }
   }
 }

--- a/packages/tui/test/component/tab-pulse.test.ts
+++ b/packages/tui/test/component/tab-pulse.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test"
-import { completionPulseOpacity, unreadGlowIntensity } from "../../src/component/tab-pulse"
+import { RGBA } from "@opentui/core"
+import { blendTabPulseColor, completionPulseOpacity, unreadGlowIntensity } from "../../src/component/tab-pulse"
+import { tint } from "../../src/theme/color"
 
 test("completion pulse rises quickly and fades over the remaining duration", () => {
   expect(completionPulseOpacity(0)).toBe(0)
@@ -23,4 +25,23 @@ test("unread glow peaks behind the tab number and fades to the normal background
 test("unread glow reaches the normal background on compact tabs", () => {
   expect(unreadGlowIntensity(0, 8)).toBe(1)
   expect(unreadGlowIntensity(7, 8)).toBe(0)
+})
+
+test("reuses a color while preserving the original glow and pulse blend stages", () => {
+  const output = RGBA.fromInts(0, 0, 0)
+  const background = RGBA.fromHex("#1a1b26")
+  const glowColor = RGBA.fromHex("#82aaff")
+  const runningColor = RGBA.fromHex("#c8d3f5")
+  const completionColor = RGBA.fromHex("#ff9e64")
+
+  for (const glow of [0, 0.08, 0.16]) {
+    for (const running of [0, 0.01, 0.07, 0.14]) {
+      for (const completion of [0, 0.03, 0.09, 0.18]) {
+        blendTabPulseColor(output, background, glowColor, runningColor, completionColor, glow, running, completion)
+        expect(output.buffer).toEqual(
+          tint(tint(tint(background, glowColor, glow), runningColor, running), completionColor, completion).buffer,
+        )
+      }
+    }
+  }
 })


### PR DESCRIPTION
## What

Reduce per-frame allocation pressure in the 60 FPS session-tab pulse without changing its timing, easing, colors, or render cadence.

The pulse previously constructed blended `RGBA` values for glow, running, and completion layers, plus a default foreground for every tab cell on every frame. At ten typical busy tabs, that produced tens of thousands of short-lived objects and typed arrays per second.

## Before / After

**Before:** Every rendered cell allocated its applicable glow, running, and completion blends plus a default foreground before crossing the native `setCell` boundary.

**After:** Each pulse reuses one explicitly RGB-typed output color and a module-level default foreground. The blend retains the original ordered quantization stages, including OpenTUI color-intent metadata. The animation remains live at 60 FPS.

Representative deterministic results with a 500-row static tree:

| Case | Before ms/frame | After ms/frame | Change |
| --- | ---: | ---: | ---: |
| 1 busy tab | 0.326 | 0.276 | -15% |
| 5 busy tabs | 0.371 | 0.292 | -21% |
| 10 busy tabs | 0.492 | 0.312 | -37% |

A five-second autonomous-renderer run with ten busy tabs retained effectively the same observed frame rate (54.0 before, 54.8 after) while process CPU fell from 15.27% to 11.66%, a 24% reduction. These numbers use OpenTUI's in-memory native test renderer and exclude terminal I/O.

## How

- `packages/tui/src/component/tab-pulse.tsx`: mutate one RGB scratch color through the same glow, running, and completion blend stages, then pass it synchronously to `setCell`.
- `packages/tui/test/component/tab-pulse.test.ts`: compare all packed output bytes against the previous nested `tint` behavior across representative running and completion strengths.

## Scope

- The pulse remains a 60 FPS animation.
- No scheduler, duration, easing, intensity, state lifecycle, terminal output primitive, or tab layout changes.
- Benchmark and experimental scaffolding is not included in the PR.

## Testing

- `bun run test` in `packages/tui`: 571 passed, 5 skipped
- `bun typecheck` in `packages/tui`
- Workspace push-hook typecheck: 33 packages passed
- `bun run lint -- <changed TypeScript files>`: 0 warnings, 0 errors
- Prettier and `git diff --check`
- Local uncommitted deterministic and autonomous OpenTUI benchmark harnesses
