### PR TITLE
fix(session-ui): enable text selection in patch accordion

### DIFF
--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -702,6 +702,7 @@
 [data-component="bash-output"],
 [data-component="edit-content"],
 [data-component="write-content"],
+[data-component="apply-patch-file-diff"],
 [data-component="todos"],
 [data-component="diagnostics"],
 .error-card {
@@ -1225,6 +1226,8 @@
     justify-content: space-between;
     width: 100%;
     gap: 20px;
+    -webkit-user-select: text;
+    user-select: text;
   }
 
   [data-slot="apply-patch-file-info"] {


### PR DESCRIPTION
### Issue for this PR

Closes #39218

### Type of change

- [x] Bug fix

### What does this PR do?

The apply-patch-file-diff area had user-select: none inherited from parent .card styles, preventing text selection. This change adds user-select: text and makes the component explicitly selectable by including it in the list of components that already allow selection (like bash-output, edit-content, etc.).

### How did you verify your code works?

Verified locally that text in the patch accordion diff area is now selectable via mouse drag.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
