### PR TITLE
feat(tui): add tab/shift-tab to cycle through timeline popup list

### DIFF
--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -473,7 +473,26 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                 cmd: () => moveAction(-1),
               },
             ]
-          : []),
+          : [
+              {
+                key: "tab",
+                desc: "Next item",
+                group: "Dialog",
+                cmd: () => {
+                  setStore("input", "keyboard")
+                  move(1)
+                },
+              },
+              {
+                key: "shift+tab",
+                desc: "Previous item",
+                group: "Dialog",
+                cmd: () => {
+                  setStore("input", "keyboard")
+                  move(-1)
+                },
+              },
+            ]),
         ...(props.bindings ?? []).filter((binding) => {
           if (typeof binding.cmd !== "string") return true
           return visible.some((item) => item.command === binding.cmd)


### PR DESCRIPTION
### Issue for this PR

Closes #39438

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the timeline popup (`/timeline` or `<leader>g`) has no footer actions, pressing `Tab` or `Shift+Tab` currently does nothing. This adds bindings to cycle through the list items — same wrapping behavior as up/down arrows. When action buttons are present, tab continues navigating between them as before.

### How did you verify your code works?

Ran `tsgo --noEmit` (typecheck passes). The change is in `DialogSelect`, a shared component — tested manually by running `bun dev` and opening the timeline popup.

### Screenshots / recordings

_This is a TUI change — tab/arrow behavior cannot be captured in a static screenshot._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR